### PR TITLE
[FIX, INTERNAL]

### DIFF
--- a/source/METADATA/DocumentIdentifier.C
+++ b/source/METADATA/DocumentIdentifier.C
@@ -35,6 +35,7 @@
 #include <OpenMS/METADATA/DocumentIdentifier.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 
+#include <QDir>
 
 namespace OpenMS
 {
@@ -83,7 +84,18 @@ namespace OpenMS
 
   void DocumentIdentifier::setLoadedFilePath(const String & file_name)
   {
-    file_path_ = File::absolutePath(file_name);
+    // only change the path if we need to, otherwise low and upper case might be altered by Qt, making comparison in tests more tricky
+    // i.e., a call to this will report unmatched strings
+    //   FeatureXMLFile().load(OPENMS_GET_TEST_DATA_PATH("FeatureXMLFile_1.featureXML"), e);
+    //   TEST_STRING_EQUAL(e.getLoadedFilePath(), OPENMS_GET_TEST_DATA_PATH("FeatureXMLFile_1.featureXML"));
+    if (QDir::isRelativePath(file_name.toQString()))
+    {
+      file_path_ = File::absolutePath(file_name);
+    }
+    else
+    {
+      file_path_ = file_name;
+    }
   }
 
   const String & DocumentIdentifier::getLoadedFilePath() const

--- a/source/TEST/DocumentIdentifier_test.C
+++ b/source/TEST/DocumentIdentifier_test.C
@@ -71,7 +71,7 @@ START_SECTION((DocumentIdentifier(const DocumentIdentifier &source)))
 
 	DocumentIdentifier di2(di1);
 	TEST_EQUAL(di2.getIdentifier(), "this is a test");
-	TEST_EQUAL(di2.getLoadedFilePath() == File::absolutePath( OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
+	TEST_EQUAL(di2.getLoadedFilePath(), OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt"))
   TEST_EQUAL(FileTypes::typeToName(di2.getLoadedFileType()) == "unknown", true)
 }
 END_SECTION
@@ -85,7 +85,7 @@ START_SECTION((DocumentIdentifier& operator=(const DocumentIdentifier &source)))
 
 	DocumentIdentifier di2 = di1;
 	TEST_EQUAL(di2.getIdentifier(), "this is a test");
-	TEST_EQUAL(di2.getLoadedFilePath() == File::absolutePath( OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
+	TEST_EQUAL(di2.getLoadedFilePath(), OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt"))
   TEST_EQUAL(FileTypes::typeToName(di2.getLoadedFileType()) == "unknown", true)
 }
 END_SECTION
@@ -133,7 +133,7 @@ START_SECTION((void setLoadedFilePath(const String &file_name)))
 {
   DocumentIdentifier di1;
 	di1.setLoadedFilePath( OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt"));
-	TEST_EQUAL(di1.getLoadedFilePath(), File::absolutePath( OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")))
+	TEST_EQUAL(di1.getLoadedFilePath(), OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt"))
 }
 END_SECTION
 
@@ -156,7 +156,7 @@ START_SECTION((void swap(DocumentIdentifier& from)))
 	TEST_EQUAL(di1.getIdentifier() == "", true)
 	TEST_EQUAL(di1.getIdentifier() == "", true)
 	TEST_EQUAL(di2.getIdentifier() == "this is a test", true)
-  TEST_EQUAL(di2.getLoadedFilePath() == File::absolutePath( OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
+  TEST_EQUAL(di2.getLoadedFilePath(), OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt"))
   TEST_EQUAL(FileTypes::typeToName(di2.getLoadedFileType()) == "unknown", true)
 
 }


### PR DESCRIPTION
on Windows the tests below might fail when OpenMS is configured with a
OPENMS_GET_TEST_DATA_PATH which contains a small device letter, e.g.

//#define OPENMS_GET_TEST_DATA_PATH(filename) (std::string("c:/dev/oms/source/TEST/data/") + filename).c_str()

since getLoadedFilePath() used to call Qt to create absolute paths and
this changes "c" to "C", making the string comparison like

TEST_EQUAL(di2.getLoadedFilePath(), OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt"))

fail. The fix here is to modify/fix the path only if its not absolute,
thus for our tests it will stay untouched since OPENMS_GET_TEST_DATA_PATH
is always absolute.

Alternatively, one could modify each(!) test (e.g. convert to lower case
before comparing),
but this creates invalid paths on unix and is error prone (since the next
developer will surely forget to use it).

Failing tests are

123 - ConsensusXMLFile_test (Failed)
126 - DTA2DFile_test (Failed)
130 - FeatureXMLFile_test (Failed)
142 - MS2File_test (Failed)
143 - MSPFile_test (Failed)
149 - MzDataFile_test (Failed)
153 - MzMLFile_test (Failed)
158 - MzXMLFile_test (Failed)
