### PR TITLE
[FIX] fix Cython 0.20 compatibility issue

### DIFF
--- a/pyOpenMS/addons/EmgFitter1D.pyx
+++ b/pyOpenMS/addons/EmgFitter1D.pyx
@@ -1,8 +1,3 @@
 
 
 
-    def fit1d(libcpp_vector[Peak1D] range_, InterpolationModel model):
-        # assert isinstance(spectrum, MSSpectrum), 'arg spec wrong type'
-        pass
-
-        # ctypedef libcpp_vector[Peak1D] RawDataArrayType


### PR DESCRIPTION
- This patch makes the code work also for Cython 0.20
- Cython 0.20 seems to be pickier with empty functions (e.g. still parses them
  instead of skipping them entirely)
- This patch removes an old, unfinished implementation of fit1d in EmgFitter1D
