### PR TITLE
[BUILD] improved handling of boost in OpenMS build system

### DIFF
--- a/cmake/OpenMSBuildSystem_externalLibs.cmake
+++ b/cmake/OpenMSBuildSystem_externalLibs.cmake
@@ -107,18 +107,7 @@ endif()
 
 #------------------------------------------------------------------------------
 # BOOST
-option(BOOST_USE_STATIC "Use Boost static libraries." ON)
-set(Boost_USE_STATIC_LIBS ${BOOST_USE_STATIC})
-set(Boost_USE_MULTITHREADED  ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-add_definitions(/DBOOST_ALL_NO_LIB) ## disable auto-linking of boost libs (boost tends to guess wrong lib names)
-set(Boost_COMPILER "")
-
-# help boost finding it's packages
-set(Boost_ADDITIONAL_VERSIONS "1.47.0" "1.48.0" "1.49.0" "1.50.0" "1.51.0" "1.52.0" "1.53.0" "1.54.0")
-
-# 1st attempt does not explicitly requires boost to enable second check (see below)
-find_package(Boost 1.42.0 COMPONENTS iostreams date_time math_c99 regex)
+find_boost(iostreams date_time math_c99 regex)
 
 if(Boost_FOUND)
   message(STATUS "Found Boost version ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}" )
@@ -128,15 +117,6 @@ if(Boost_FOUND)
 	set(CF_OPENMS_BOOST_VERSION ${Boost_VERSION})
 else()
   message(FATAL_ERROR "Boost or one of its components not found!")
-endif()
-
-set(BOOST_MOC_ARGS "")
-
-# see: https://bugreports.qt-project.org/browse/QTBUG-22829
-# Confirmed only on mac os x and leads to problems on win32 and lnx
-# so we handle it for now only on mac os x
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	set(BOOST_MOC_ARGS "-DBOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION")
 endif()
 
 #------------------------------------------------------------------------------

--- a/cmake/OpenMSBuildSystem_macros.cmake
+++ b/cmake/OpenMSBuildSystem_macros.cmake
@@ -1,3 +1,4 @@
+#------------------------------------------------------------------------------
 ## fills ${varname} with the names of Debug and Release libraries (which usually only differ on MSVC)
 ## @param varname Name of the variable which will hold the result string (e.g. "optimized myLib.so debug myLibDebug.so")
 ## @param libnames   List of library names which are searched (release libs)
@@ -24,6 +25,7 @@ macro (OPENMS_CHECKLIB varname libnames libnames_d human_libname)
 	set(${varname} optimized ${${varname}_OPT} debug ${${varname}_DBG})
 endmacro (OPENMS_CHECKLIB)
 
+#------------------------------------------------------------------------------
 ## Copy the dll produced by the given target to the test/doc binary path.
 ## @param targetname The target to modify.
 ## @note This macro will do nothing with non MSVC generators.
@@ -50,3 +52,35 @@ macro(copy_dll_to_extern_bin targetname)
                       COMMAND ${CMAKE_COMMAND} -E copy ${DLL_SOURCE} ${DLL_DOC_TARGET})
   endif(MSVC)
 endmacro()
+
+#------------------------------------------------------------------------------
+## export a single option indicating if boost static libs should be preferred
+option(BOOST_USE_STATIC "Use Boost static libraries." ON)
+
+#------------------------------------------------------------------------------
+## Wraps the common find boost code into a single call
+## @param .. simply add all required components to the call
+## @note This macro will define BOOST_MOC_ARGS that should be added to all moc
+##       calls (see https://bugreports.qt-project.org/browse/QTBUG-22829)
+macro(find_boost)
+  set(Boost_USE_STATIC_LIBS ${BOOST_USE_STATIC})
+  set(Boost_USE_MULTITHREADED  ON)
+  set(Boost_USE_STATIC_RUNTIME OFF)
+  add_definitions(/DBOOST_ALL_NO_LIB) ## disable auto-linking of boost libs (boost tends to guess wrong lib names)
+  set(Boost_COMPILER "")
+
+  # help boost finding it's packages
+  set(Boost_ADDITIONAL_VERSIONS "1.47.0" "1.48.0" "1.49.0" "1.50.0" "1.51.0" "1.52.0" "1.53.0" "1.54.0")
+
+  # 1st attempt does not explicitly requires boost to enable second check (see below)
+  find_package(Boost 1.42.0 COMPONENTS ${ARGN})
+
+  set(BOOST_MOC_ARGS "")
+
+  # see: https://bugreports.qt-project.org/browse/QTBUG-22829
+  # Confirmed only on mac os x and leads to problems on win32 and lnx
+  # so we handle it for now only on mac os x and boost versions > 1.52
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR ${Boost_MINOR_VERSION} GREATER "52")
+  	set(BOOST_MOC_ARGS "-DBOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION")
+  endif()
+endmacro(find_boost)

--- a/src/openms_gui/CMakeLists.txt
+++ b/src/openms_gui/CMakeLists.txt
@@ -50,6 +50,14 @@ include(${QT_USE_FILE})
 #include(qt_wrap_ui.cmake)
 include(qt_wrap_ui.cmake)
 
+#------------------------------------------------------------------------------
+# we need to handle boost > 1.52 when moc-ing so we explicitely find boost here
+find_boost()
+
+if(NOT Boost_FOUND)
+  message(FATAL_ERROR "Boost was not found!")
+endif()
+
 # --------------------------------------------------------------------------
 # big include file for headers and cpp files
 include (${PROJECT_SOURCE_DIR}/includes.cmake)

--- a/src/openswathalgo/CMakeLists.txt
+++ b/src/openswathalgo/CMakeLists.txt
@@ -38,17 +38,7 @@ cmake_minimum_required(VERSION 2.8.3 FATAL_ERROR)
 #------------------------------------------------------------------------------
 # Find Boost lib
 #------------------------------------------------------------------------------
-set(Boost_USE_STATIC_LIBS ${BOOST_USE_STATIC})
-set(Boost_USE_MULTITHREADED  ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-add_definitions(/DBOOST_ALL_NO_LIB) ## disable auto-linking of boost libs (boost tends to guess wrong lib names)
-set(Boost_COMPILER "")
-
-# help boost finding it's packages
-set(Boost_ADDITIONAL_VERSIONS "1.47.0" "1.48.0" "1.49.0" "1.50.0" "1.51.0" "1.52.0" "1.53.0" "1.54.0")
-
-# 1st attempt does not explicitly requires boost to enable second check (see below)
-find_package(Boost 1.42.0)
+find_boost()
 
 if(NOT Boost_FOUND)
   message(FATAL_ERROR "Boost was not found!")

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -43,25 +43,10 @@ configure_file(${PROJECT_SOURCE_DIR}/include/OpenMS/test_config.h.in ${CONFIGURE
 
 #------------------------------------------------------------------------------
 # Some tests have a link dependency to boost so we find our own boost here
-set(Boost_USE_STATIC_LIBS ${BOOST_USE_STATIC})
-set(Boost_USE_MULTITHREADED  ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-add_definitions(/DBOOST_ALL_NO_LIB) ## disable auto-linking of boost libs (boost tends to guess wrong lib names)
-set(Boost_COMPILER "")
+find_boost(math_c99)
 
-# help boost finding it's packages
-set(Boost_ADDITIONAL_VERSIONS "1.47.0" "1.48.0" "1.49.0" "1.50.0" "1.51.0" "1.52.0" "1.53.0" "1.54.0")
-
-# 1st attempt does not explicitly requires boost to enable second check (see below)
-find_package(Boost 1.42.0 COMPONENTS math_c99)
-
-set(BOOST_MOC_ARGS "")
-
-# see: https://bugreports.qt-project.org/browse/QTBUG-22829
-# Confirmed only on mac os x and leads to problems on win32 and lnx
-# so we handle it for now only on mac os x
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	set(BOOST_MOC_ARGS "-DBOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION")
+if(NOT Boost_FOUND)
+  message(FATAL_ERROR "Boost was not found!")
 endif()
 
 #------------------------------------------------------------------------------
@@ -164,13 +149,6 @@ foreach(_class_test ${TEST_executables})
 		set_target_properties(${_class_test} PROPERTIES LINK_FLAGS ${OpenMP_CXX_FLAGS})
 	endif()
 endforeach(_class_test)
-
-#------------------------------------------------------------------------------
-# Tests with extra dependencies
-#------------------------------------------------------------------------------
-if(NOT Boost_FOUND)
-  message(FATAL_ERROR "Boost was not found!")
-endif()
 
 #------------------------------------------------------------------------------
 # 2 - add link dependency

--- a/src/tests/class_tests/openms_gui/CMakeLists.txt
+++ b/src/tests/class_tests/openms_gui/CMakeLists.txt
@@ -81,6 +81,11 @@ endif()
 include(${QT_USE_FILE})
 
 #------------------------------------------------------------------------------
+# We need some special treatments of boost in moc, hence we search for boost
+# here
+find_boost()
+
+#------------------------------------------------------------------------------
 # Add GUI tests
 foreach(_gui_test ${GUI_executables_list})
 	# moc the test file

--- a/src/tests/class_tests/openms_gui/source/GUI/TOPPView_test.cpp
+++ b/src/tests/class_tests/openms_gui/source/GUI/TOPPView_test.cpp
@@ -38,10 +38,12 @@
 #include <QTimer>
 #include <QQueue>
 
+// see https://bugreports.qt-project.org/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
 #include <OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/VISUAL/EnhancedTabBar.h>
-
+#endif
 
 namespace OpenMS
 {

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -767,6 +767,7 @@ if(NOT DISABLE_OPENSWATH)
 
   ADD_TEST("UTILS_MRMTransitionGroupPicker_test_1" ${TOPP_BIN_PATH}/MRMTransitionGroupPicker -in ${DATA_DIR_TOPP}/MRMTransitionGroupPicker_1_input.mzML -tr ${DATA_DIR_TOPP}/MRMTransitionGroupPicker_1_input.TraML -out MRMTransitionGroupPicker_test_1.featureXML.tmp -test -algorithm:PeakPickerMRM:remove_overlapping_peaks true -algorithm:PeakPickerMRM:method legacy)
   ADD_TEST("UTILS_MRMTransitionGroupPicker_test_1_out" ${DIFF} -in1 MRMTransitionGroupPicker_test_1.featureXML.tmp -in2 ${DATA_DIR_TOPP}/MRMTransitionGroupPicker_1_output.featureXML)
+  set_tests_properties("UTILS_MRMTransitionGroupPicker_test_1_out" PROPERTIES DEPENDS "UTILS_MRMTransitionGroupPicker_test_1")
 
   ADD_TEST("TOPP_OpenSwathWorkflow_1" ${TOPP_BIN_PATH}/OpenSwathWorkflow -in ${DATA_DIR_TOPP}/OpenSwathWorkflow_1_input.mzML -tr ${DATA_DIR_TOPP}/OpenSwathWorkflow_1_input.TraML -rt_norm ${DATA_DIR_TOPP}/OpenSwathWorkflow_1_input.trafoXML -out_chrom OpenSwathWorkflow_1.chrom.mzML.tmp -out_features OpenSwathWorkflow_1.featureXML.tmp  -test) ## -ini ${DATA_DIR_TOPP}/OpenSwathAnalyzer_7_backgroundSubtraction.ini
   ADD_TEST("TOPP_OpenSwathWorkflow_1_out1" ${DIFF} -in1 OpenSwathWorkflow_1.featureXML.tmp -in2 ${DATA_DIR_TOPP}/OpenSwathWorkflow_1_output.featureXML)


### PR DESCRIPTION
This pull request restructures and refactors the build system code that finds boost. Since different parts of OpenMS find boost independently I bundled the corresponding code into a macro.

This commit should .. 
- fix boost compiler errors from boost1.54
- fix boost/moc error in TOPPView_test since BOOST_MOC_ARGS didn't work with a combination of boost 1.54, cmake 2.8.7, qt 4.8.1

Unrelated but occurred while testing
-  added proper dependency for MRMTransitionGroupPicker topp tests
