### PR TITLE
[FIX] fix RAM usage when adding dataprocessing to chromatograms

### DIFF
--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -838,12 +838,10 @@ protected:
       {
         map[i].getDataProcessing().push_back(dp);
       }
-      std::vector<MSChromatogram<CT> > chromatograms = map.getChromatograms();
-      for (Size i = 0; i < chromatograms.size(); ++i)
+      for (Size i = 0; i < map.getNrChromatograms(); ++i)
       {
-        chromatograms[i].getDataProcessing().push_back(dp);
+        map.getChromatogram(i).getDataProcessing().push_back(dp);
       }
-      map.setChromatograms(chromatograms);
     }
 
     ///Returns the data processing information


### PR DESCRIPTION
- instead of copying all chromatograms, add the dataprocessing directly
  to each chromatogram
