### PR TITLE
[BUILD] fix 2 bugs in build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,11 @@ if (MSVC)
 	SET(CMAKE_DEBUG_POSTFIX d)
 endif()
 
+########################################################
+###    external libs (contrib or system)						 ###
+########################################################
+include(${OPENMS_HOST_DIRECTORY}/cmake/OpenMSBuildSystem_externalLibs.cmake)
+
 #------------------------------------------------------------------------------
 # The actual openms code
 #------------------------------------------------------------------------------

--- a/cmake/OpenMSBuildSystem_externalLibs.cmake
+++ b/cmake/OpenMSBuildSystem_externalLibs.cmake
@@ -36,7 +36,7 @@
 # This cmake file handles finding external libs for OpenMS
 
 set(CONTRIB_CUSTOM_DIR CACHE DOC "DEPRECATED: Please use CMAKE_FIND_ROOT_PATH instead! User defined location of contrib dir. If left empty we assume the contrib to be in OpenMS/contrib!")
-set(CONTRIB_DIR ${PROJECT_SOURCE_DIR}/contrib/ CACHE INTERNAL "Final contrib path after looking at CMAKE_FIND_ROOT_PATH. Defaults to OpenMS/contrib")
+set(CONTRIB_DIR ${OPENMS_HOST_DIRECTORY}/contrib/ CACHE INTERNAL "Final contrib path after looking at CMAKE_FIND_ROOT_PATH. Defaults to OpenMS/contrib")
 
 if("${CMAKE_FIND_ROOT_PATH}" STREQUAL "")
 	if(NOT "${CONTRIB_CUSTOM_DIR}" STREQUAL "")

--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -54,12 +54,6 @@ if (WITH_CRAWDAD)
   include_directories(${CRAWDAD_INCLUDE_DIRS})
 endif()
 
-########################################################
-###    external libs (contrib or system)						 ###
-########################################################
-
-include(${OPENMS_HOST_DIRECTORY}/cmake/OpenMSBuildSystem_externalLibs.cmake)
-
 # TODO: XERCESC and  CONTRIB are included only with the others
 # Expose OpenMS's public includes (including transitive dependencies)
 set(OPENMS_INCLUDE_DIRECTORIES ${PROJECT_SOURCE_DIR}/include


### PR DESCRIPTION
- use OpenMSBuildSystem_externalLibs.cmake on top level to find correct
  include paths not only for OpenMS but also for OpenSwathAlgo and other
  libraries
- use OPENMS_HOST_DIRECTORY instead of PROJECT_SOURCE_DIR to determine
  correct location of contrib

fixes #699
