### PR TITLE
fixed 32bit memory limitation of OMSSA by chunking input data

### DIFF
--- a/src/topp/OMSSAAdapter.cpp
+++ b/src/topp/OMSSAAdapter.cpp
@@ -381,7 +381,7 @@ protected:
   ExitCodes main_(int, const char **)
   {
     StringList parameters;
-    // path to the log filea
+    // path to the log file
     String logfile(getStringOption_("log"));
     String omssa_executable(getStringOption_("omssa_executable"));
     String unique_name = QDir::toNativeSeparators(String(File::getTempDirectory() + "/" + File::getUniqueName()).toQString());   // body for the tmp files


### PR DESCRIPTION
processing large datasets (>30k MS2 spectra) with OMSSA might fail when using 32bit (which is the only available arch on Windows) due to memory allocation issues (4GB limit, generally speaking -- its even less in practice).

To fix, OMSSAAdapter now splits the MS2 spectra into chunks of 10k, such that arbitrary files can be searched now. At the expense of discarding protein IDs, since their OMSSA scores are invalid when evidence is spread across chunks (if the user requires prot scores, the chunk size needs to be increased in the parameters to include all spectra -- which might not work on all systems due to reasons mentioned above).
Also, processing gets a little faster, probably because protein scoring is faster within OMSSA when using less data.
