### PR TITLE
[FIX] fixed misleading warning ('Removed x peptide identifications...

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
@@ -155,11 +155,6 @@ namespace OpenMS
       if (tag_ == "NumQueries")
       {
         id_data_.resize(character_buffer_.trim().toInt());
-        for (vector<PeptideIdentification>::iterator it = id_data_.begin();
-             it != id_data_.end(); ++it)
-        {
-          it->setIdentifier(identifier_);
-        }
       }
 
       else if (tag_ == "prot_score")
@@ -630,6 +625,7 @@ namespace OpenMS
         }
         if (!already_stored)
         {
+          id_data_[peptide_identification_index_].setIdentifier(identifier_);
           id_data_[peptide_identification_index_].setScoreType("Mascot");
           actual_peptide_hit_.addProteinAccession(actual_protein_hit_.getAccession());
           id_data_[peptide_identification_index_].insertHit(actual_peptide_hit_);

--- a/src/openms/source/FORMAT/MascotXMLFile.cpp
+++ b/src/openms/source/FORMAT/MascotXMLFile.cpp
@@ -79,6 +79,7 @@ namespace OpenMS
     // the identifications without any real peptide hit are removed
     vector<PeptideIdentification> filtered_hits;
     filtered_hits.reserve(id_data.size());
+    Size missing_sequence = 0; // counter
 
     for (vector<PeptideIdentification>::iterator id_it = id_data.begin();
          id_it != id_data.end(); ++id_it)
@@ -89,11 +90,11 @@ namespace OpenMS
       {
         filtered_hits.push_back(*id_it);
       }
+      else if (!id_it->empty()) ++missing_sequence;
     }
-    Size diff = id_data.size() - filtered_hits.size();
-    if (diff) 
+    if (missing_sequence) 
     {
-      LOG_WARN << "Warning: Removed " << diff 
+      LOG_WARN << "Warning: Removed " << missing_sequence 
                << " peptide identifications without sequence." << endl;
     }
     id_data.swap(filtered_hits);


### PR DESCRIPTION
... without sequence')

Cause of the problem: When parsing Mascot XML, blank PeptideIdentifications are created according to the number of search queries ("NumQueries" element in the XML). But potentially there are only results in the file for a fraction of those (e.g. due to filtering). The remaining blank IDs would be reported as "IDs without sequence" by the converter.

Fix: Make sure the blank IDs stay really empty, and don't count the empty ones for the "without sequence" number.
