### PR TITLE
Feature/uids fileconverter

### DIFF
--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -307,7 +307,9 @@ add_test("TOPP_FileConverter_13" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA
 add_test("TOPP_FileConverter_13_out1" ${DIFF} -in1 FileConverter_13.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_13_output.featureXML )
 set_tests_properties("TOPP_FileConverter_13_out1" PROPERTIES DEPENDS "TOPP_FileConverter_13")
 # featureXML to consensusXML
-add_test("TOPP_FileConverter_14" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA_DIR_TOPP}/FileConverter_9_output.featureXML -no_progress -out FileConverter_14.tmp -out_type consensusXML)
+add_test("TOPP_FileConverter_14" ${TOPP_BIN_PATH}/FileConverter -test -in
+${DATA_DIR_TOPP}/FileConverter_9_output.featureXML -UID_postprocessing
+reassign -no_progress -out FileConverter_14.tmp -out_type consensusXML)
 add_test("TOPP_FileConverter_14_out1" ${DIFF} -in1 FileConverter_14.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_14_output.consensusXML )
 set_tests_properties("TOPP_FileConverter_14_out1" PROPERTIES DEPENDS "TOPP_FileConverter_14")
 # EDTA to consensusXML

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -134,6 +134,10 @@ protected:
     String formats("mzData,mzXML,mzML,dta,dta2d,mgf,featureXML,consensusXML,ms2,fid,tsv,peplist,kroenik,edta");
     setValidFormats_("in", ListUtils::create<String>(formats));
     setValidStrings_("in_type", ListUtils::create<String>(formats));
+    
+    registerStringOption_("UID_postprocessing", "<method>", "ensure", "unique id post-processing for output data.\n none keeps current ids even if invalid.\n ensure keeps current ids but reassigns invalid ones.\n reassign assigns new unique ids.", false);
+    String method("none,ensure,reassign");
+    setValidStrings_("UID_postprocessing", ListUtils::create<String>(method));
 
     formats = "mzData,mzXML,mzML,dta2d,mgf,featureXML,consensusXML,edta,csv";
     registerOutputFile_("out", "<file>", "", "Output file");
@@ -188,6 +192,7 @@ protected:
 
     writeDebug_(String("Output file type: ") + FileTypes::typeToName(out_type), 1);
 
+    String uid_postprocessing = getStringOption_("UID_postprocessing");
     //-------------------------------------------------------------
     // reading input
     //-------------------------------------------------------------
@@ -318,7 +323,13 @@ protected:
       if ((in_type == FileTypes::FEATUREXML) || (in_type == FileTypes::TSV) ||
           (in_type == FileTypes::PEPLIST) || (in_type == FileTypes::KROENIK))
       {
-        fm.applyMemberFunction(&UniqueIdInterface::setUniqueId);
+        if (uid_postprocessing == "ensure")
+        {
+          fm.applyMemberFunction(&UniqueIdInterface::ensureUniqueId);
+        } else if (uid_postprocessing == "reassign")
+        {
+          fm.applyMemberFunction(&UniqueIdInterface::setUniqueId);
+        }
       }
       else if (in_type == FileTypes::CONSENSUSXML || in_type == FileTypes::EDTA)
       {
@@ -364,7 +375,13 @@ protected:
       if ((in_type == FileTypes::FEATUREXML) || (in_type == FileTypes::TSV) ||
           (in_type == FileTypes::PEPLIST) || (in_type == FileTypes::KROENIK))
       {
-        fm.applyMemberFunction(&UniqueIdInterface::setUniqueId);
+        if (uid_postprocessing == "ensure")
+        {
+          fm.applyMemberFunction(&UniqueIdInterface::ensureUniqueId);
+        } else if (uid_postprocessing == "reassign")
+        {
+          fm.applyMemberFunction(&UniqueIdInterface::setUniqueId);
+        }
         ConsensusMap::convert(0, fm, cm);
       }
       // nothing to do for consensus input


### PR DESCRIPTION
[FIX] improved unique ID handling in featureXML files. Now one can choose between  'none', 'ensure' (default) and 'reassign' for UID handling in FileConverter.
