### PR TITLE
[FIX] fixed compilation error on vs2013

### DIFF
--- a/src/openms/source/FORMAT/ConsensusXMLFile.cpp
+++ b/src/openms/source/FORMAT/ConsensusXMLFile.cpp
@@ -589,7 +589,7 @@ namespace OpenMS
       throw Exception::UnableToCreateFile(__FILE__, __LINE__, __PRETTY_FUNCTION__, filename);
     }
 
-    os.precision(writtenDigits<DoubleReal>());
+    os.precision(writtenDigits<DoubleReal>(0.0));
 
     setProgress(++progress_);
     os << "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n";

--- a/src/openms/source/FORMAT/FeatureXMLFile.cpp
+++ b/src/openms/source/FORMAT/FeatureXMLFile.cpp
@@ -160,7 +160,7 @@ namespace OpenMS
       throw;
     }
 
-    os.precision(writtenDigits<DoubleReal>());
+    os.precision(writtenDigits<DoubleReal>(0.0));
 
     os << "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n"
        << "<featureMap version=\"" << version_ << "\"";

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -99,7 +99,7 @@ namespace OpenMS
     {
       throw Exception::UnableToCreateFile(__FILE__, __LINE__, __PRETTY_FUNCTION__, filename);
     }
-    os.precision(writtenDigits<DoubleReal>());
+    os.precision(writtenDigits<DoubleReal>(0.0));
 
     //write header
     os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";

--- a/src/openms/source/FORMAT/ParamXMLFile.cpp
+++ b/src/openms/source/FORMAT/ParamXMLFile.cpp
@@ -83,7 +83,7 @@ namespace OpenMS
 
     ostream& os = *os_ptr;
 
-    os.precision(writtenDigits<DoubleReal>());
+    os.precision(writtenDigits<DoubleReal>(0.0));
 
     os << "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n";
     os << "<PARAMETERS version=\"" << getVersion() << "\" xsi:noNamespaceSchemaLocation=\"http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n";

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -88,7 +88,7 @@ namespace OpenMS
       search_engine_name = protein_ids.begin()->getSearchEngine();
     }
 
-    f.precision(writtenDigits<DoubleReal>());
+    f.precision(writtenDigits<DoubleReal>(0.0));
 
     f << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << "\n";
     f << "<msms_pipeline_analysis date=\"2007-12-05T17:49:46\" xmlns=\"http://regis-web.systemsbiology.net/pepXML\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://regis-web.systemsbiology.net/pepXML http://www.matrixscience.com/xmlns/schema/pepXML_v18/pepXML_v18.xsd\" summary_xml=\".xml\">" << "\n";

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -1065,7 +1065,7 @@ namespace OpenMS
       throw Exception::UnableToCreateFile(__FILE__, __LINE__, __PRETTY_FUNCTION__, filename);
     }
  
-    os.precision(writtenDigits<DoubleReal>());
+    os.precision(writtenDigits<DoubleReal>(0.0));
 
     //~ setProgress(++progress_);
     //header & xslt

--- a/src/openms/source/FORMAT/TransformationXMLFile.cpp
+++ b/src/openms/source/FORMAT/TransformationXMLFile.cpp
@@ -78,7 +78,7 @@ namespace OpenMS
     {
       throw Exception::UnableToCreateFile(__FILE__, __LINE__, __PRETTY_FUNCTION__, filename);
     }
-    os.precision(writtenDigits<DoubleReal>());
+    os.precision(writtenDigits<DoubleReal>(0.0));
 
     //write header
     os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << "\n";

--- a/src/openms/source/MATH/MISC/MSNumpress.cpp
+++ b/src/openms/source/MATH/MISC/MSNumpress.cpp
@@ -31,6 +31,7 @@
 */
 #include <iostream>
 #include <cmath>
+#include <algorithm>
 #include <OpenMS/MATH/MISC/MSNumpress.h>
 
 namespace ms {

--- a/src/openms/source/TRANSFORMATIONS/RAW2PEAK/OptimizePick.cpp
+++ b/src/openms/source/TRANSFORMATIONS/RAW2PEAK/OptimizePick.cpp
@@ -113,7 +113,7 @@ namespace OpenMS
             }
           }
 
-          std::cerr.precision(writtenDigits<DoubleReal>());
+          std::cerr.precision(writtenDigits<DoubleReal>(0.0));
 
           std::cerr << positions[0] + i * sw << " " << computed_signal << std::endl;
         }


### PR DESCRIPTION
Some include was missing in MSNumpress and writtenDigits template did not work without providing an actual double.
Compiles on Windows and Linux. Tests on Linux ran through. 
