### PR TITLE
[PYOPENMS,FIX] fixed streampos->long conversion

### DIFF
--- a/pyOpenMS/addons/streampos.pyx
+++ b/pyOpenMS/addons/streampos.pyx
@@ -1,4 +1,8 @@
 
 
     def __long__(self):
-        return <long>(deref(self.inst.get()))
+        # <long> calls c++ conversion streampos -> c++ long value
+        # long(..) converts this value to a Python long.
+        # value. else this method may return an int or long, depending on the magnitude of
+        # the value !
+        return long(<long>(deref(self.inst.get())))

--- a/pyOpenMS/tests/unittests/test000.py
+++ b/pyOpenMS/tests/unittests/test000.py
@@ -4020,6 +4020,6 @@ def testIndexedMzMLDecoder():
 
 
 def test_streampos():
-    p = pyopenms.streampos()
-    assert isinstance(int(p), int)
+    p = long(pyopenms.streampos())
+    assert isinstance(p, long), "got %r" % p
 


### PR DESCRIPTION
Repairs dangerous fix in https://github.com/OpenMS/OpenMS/pull/734 for converting `streampos` instance to Python `long` value.
