### PR TITLE
[FEATURE] track base name when reading pep.xml files

### DIFF
--- a/pyOpenMS/pxds/PeptideIdentification.pxd
+++ b/pyOpenMS/pxds/PeptideIdentification.pxd
@@ -33,6 +33,9 @@ cdef extern from "<OpenMS/METADATA/PeptideIdentification.h>" namespace "OpenMS":
         String     getIdentifier() nogil except +
         void       setIdentifier(String) nogil except +
 
+        String     getBaseName() nogil except +
+        void       setBaseName(String) nogil except +
+
         void       assignRanks() nogil except +
         void       sort() nogil except +
         bool       empty() nogil except +

--- a/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
@@ -210,6 +210,9 @@ private:
     /// Have we checked the "base_name" attribute in the "msms_run_summary" element?
     bool checked_base_name_;
 
+    /// current base name
+    String current_base_name_;
+
     /// References to currently active ProteinIdentifications
     std::vector<std::vector<ProteinIdentification>::iterator> current_proteins_;
 

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -113,6 +113,11 @@ public:
     /// sets the identifier
     void setIdentifier(const String & id);
 
+    /// returns the base name which links to underlying peak map
+    const String & getBaseName() const;
+    /// sets the base name which links to underlying peak map
+    void setBaseName(const String & base_name);
+
     /// Sorts the hits by score and assigns ranks according to the scores
     void assignRanks();
 
@@ -150,6 +155,7 @@ protected:
     DoubleReal significance_threshold_;              ///< the peptide significance threshold
     String score_type_;                                      ///< The score type (Mascot, Sequest, e-value, p-value)
     bool higher_score_better_;                       ///< The score orientation
+    String base_name_;
   };
 
 } //namespace OpenMS

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -626,6 +626,8 @@ namespace OpenMS
       current_peptide_ = PeptideIdentification();
       current_peptide_.setMetaValue("RT", rt_);
       current_peptide_.setMetaValue("MZ", mz_);
+      current_peptide_.setBaseName(current_base_name_);
+
       search_id_ = 1; // references "search_summary"
       optionalAttributeAsUInt_(search_id_, attributes, "search_id");
       current_peptide_.setIdentifier(current_proteins_[search_id_ - 1]->getIdentifier());
@@ -868,11 +870,11 @@ namespace OpenMS
     }
     else if (element == "search_summary") // parent: "msms_run_summary"
     { // creates a new ProteinIdentification (usually)
+      current_base_name_ = "";
+      optionalAttributeAsString_(current_base_name_, attributes, "base_name");
       if (!checked_base_name_) // work-around for files exported by Mascot
       {
-        String base_name = "";
-        optionalAttributeAsString_(base_name, attributes, "base_name");
-        if (base_name.hasSuffix(exp_name_))
+        if (current_base_name_.hasSuffix(exp_name_))
         {
           seen_experiment_ = true;
         }

--- a/src/openms/source/METADATA/PeptideIdentification.cpp
+++ b/src/openms/source/METADATA/PeptideIdentification.cpp
@@ -48,7 +48,8 @@ namespace OpenMS
     hits_(),
     significance_threshold_(0.0),
     score_type_(),
-    higher_score_better_(true)
+    higher_score_better_(true),
+    base_name_()
   {
   }
 
@@ -58,7 +59,8 @@ namespace OpenMS
     hits_(rhs.hits_),
     significance_threshold_(rhs.significance_threshold_),
     score_type_(rhs.score_type_),
-    higher_score_better_(rhs.higher_score_better_)
+    higher_score_better_(rhs.higher_score_better_),
+    base_name_(rhs.base_name_)
   {
   }
 
@@ -79,6 +81,7 @@ namespace OpenMS
     significance_threshold_ = rhs.significance_threshold_;
     score_type_ = rhs.score_type_;
     higher_score_better_ = rhs.higher_score_better_;
+    base_name_ = rhs.base_name_;
 
     return *this;
   }
@@ -91,7 +94,8 @@ namespace OpenMS
            && hits_ == rhs.getHits()
            && significance_threshold_ == rhs.getSignificanceThreshold()
            && score_type_ == rhs.score_type_
-           && higher_score_better_ == rhs.higher_score_better_;
+           && higher_score_better_ == rhs.higher_score_better_
+           && base_name_ == rhs.base_name_;
   }
 
   // Inequality operator
@@ -159,6 +163,17 @@ namespace OpenMS
   {
     id_ = id;
   }
+
+  const String & PeptideIdentification::getBaseName() const
+  {
+    return base_name_;
+  }
+
+  void PeptideIdentification::setBaseName(const String & base_name)
+  {
+    base_name_ = base_name;
+  }
+
 
   void PeptideIdentification::assignRanks()
   {


### PR DESCRIPTION
PeptideIdentifcation has a new attribute base_name_ including the  corresponding accessor methods,
this is set when reading .pep.xml files. pyopenms is extended accordingly.
