### PR TITLE
[PYOPENMS] changed extra methods on MSSpectrum

### DIFF
--- a/pyOpenMS/tests/unittests/test000.py
+++ b/pyOpenMS/tests/unittests/test000.py
@@ -2798,7 +2798,14 @@ def testMSSpectrum():
     assert spec == spec
     assert not spec != spec
 
-    assert spec.get_peaks().shape == (1,2), spec.get_peaks().shape
+    mz, ii = spec.get_peaks()
+    assert len(mz) == len(ii)
+    assert len(mz) == 1
+
+    spec.set_peaks((mz, ii))
+    mz0, ii0 = spec.get_peaks()
+    assert mz0 == mz
+    assert ii0 == ii
 
     assert int(spec.isSorted()) in  (0,1)
 


### PR DESCRIPTION
`MSSpectrum.get_peaks` and `MSSpectrum.set_peaks` now return and receive different precisions for mass/charge and intensity, so that we get better resolution for mass/charge.

m/z was float32 and is now float64
