### PR TITLE
[FIX] fixed warnings in CONCEPTS

### DIFF
--- a/src/openms/source/CONCEPT/Constants.cpp
+++ b/src/openms/source/CONCEPT/Constants.cpp
@@ -42,115 +42,115 @@ namespace OpenMS
     double EPSILON = 1e-6;
 
     // PI
-    const double  PI = 3.14159265358979323846L;
+    const double PI = 3.14159265358979323846;
 
     // Euler's number - base of the natural logarithm
-    const double  E  = 2.718281828459045235L;
+    const double E = 2.718281828459045235;
 
     // Elementary charge
-    const double    ELEMENTARY_CHARGE = 1.60217738E-19L;         // C
+    const double ELEMENTARY_CHARGE = 1.60217738E-19; // C
 
     // Elementary charge (alias)
-    const double    e0                              =   ELEMENTARY_CHARGE;
+    const double e0 = ELEMENTARY_CHARGE;
 
     // Electron mass
-    const double    ELECTRON_MASS       = 9.1093897E-31L;            // kg
+    const double ELECTRON_MASS = 9.1093897E-31; // kg
 
     // Electron mass in units
-    const double  ELECTRON_MASS_U   = 1.0 / 1822.8885020477;     // u
+    const double ELECTRON_MASS_U = 1.0 / 1822.8885020477; // u
 
     // Proton mass
-    const double    PROTON_MASS         = 1.6726230E-27L;            // kg
+    const double PROTON_MASS = 1.6726230E-27; // kg
 
     // Proton mass in units
-    const double  PROTON_MASS_U         = 1.0072764667710;         // u
+    const double  PROTON_MASS_U = 1.0072764667710;// u
 
     // Mass difference between Carbon-13 and Carbon-12 in units
     const double C13C12_MASSDIFF_U = 1.0033548; // u
 
     // Neutron mass
-    const double    NEUTRON_MASS        = 1.6749286E-27L;            // kg
+    const double NEUTRON_MASS = 1.6749286E-27; // kg
 
     // Neutron mass in units
-    const double NEUTRON_MASS_U     = 1.00866491566;                    // u
+    const double NEUTRON_MASS_U = 1.00866491566; // u
 
     // Avogadro constant
-    const double    AVOGADRO            = 6.0221367E+23L;            // 1 / mol
+    const double AVOGADRO = 6.0221367E+23; // 1 / mol
 
     // Avogadro constant (alias)
-    const double    NA                              = AVOGADRO;
+    const double NA = AVOGADRO;
 
     // Avogadro constant (alias)
-    const double    MOL                 = AVOGADRO;
+    const double MOL = AVOGADRO;
 
     // Boltzmann constant
-    const double    BOLTZMANN           = 1.380657E-23L;           // J / K
+    const double BOLTZMANN = 1.380657E-23; // J / K
 
     // Boltzmann constant (alias)
-    const double    k                           = BOLTZMANN;
+    const double k = BOLTZMANN;
 
     // Planck constant
-    const double    PLANCK              = 6.6260754E-34L;          // J * sec
+    const double PLANCK = 6.6260754E-34; // J * sec
 
     // Planck constant (alias)
-    const double    h                       = PLANCK;
+    const double h = PLANCK;
 
     // Gas constant (= NA * k)
-    const double    GAS_CONSTANT        = NA * k;
+    const double GAS_CONSTANT = NA * k;
 
     // Gas constant (alias)
-    const double R                              = GAS_CONSTANT;
+    const double R = GAS_CONSTANT;
 
     // Faraday constant (= NA * e0)
-    const double    FARADAY             = NA * e0;
+    const double FARADAY = NA * e0;
 
     // Faraday constant (alias)
-    const double    F                               = FARADAY;
+    const double F = FARADAY;
 
     // Bohr radius
-    const double    BOHR_RADIUS         = 5.29177249E-11L;         // m
+    const double BOHR_RADIUS = 5.29177249E-11; // m
 
     // Bohr radius (alias)
-    const double    a0                          = BOHR_RADIUS;
+    const double a0 = BOHR_RADIUS;
 
     //  the following values from:
     //  P.W.Atkins: Physical Chemistry, 5th ed., Oxford University Press, 1995
 
     // Vacuum permittivity
-    const double    VACUUM_PERMITTIVITY     = 8.85419E-12L;         // C^2 / (J * m)
+    const double VACUUM_PERMITTIVITY = 8.85419E-12; // C^2 / (J * m)
 
     // Vacuum permeability
-    const double    VACUUM_PERMEABILITY     = (4 * PI * 1E-7L);     // J s^2 / (C^2 * m)
+    const double VACUUM_PERMEABILITY = (4 * PI * 1E-7); // J s^2 / (C^2 * m)
 
     // Speed of light
-    const double    SPEED_OF_LIGHT          = 2.99792458E+8L;         // m / s
+    const double SPEED_OF_LIGHT = 2.99792458E+8; // m / s
 
     // Speed of Light (alias)
-    const double    c                                               = SPEED_OF_LIGHT;
+    const double c = SPEED_OF_LIGHT;
 
     // Gravitational constant
-    const double    GRAVITATIONAL_CONSTANT  = 6.67259E-11L;         // N m^2 / kg^2
+    const double GRAVITATIONAL_CONSTANT  = 6.67259E-11; // N m^2 / kg^2
 
     // Fine structure constant
-    const double    FINE_STRUCTURE_CONSTANT = 7.29735E-3L;              // 1
+    const double FINE_STRUCTURE_CONSTANT = 7.29735E-3; // 1
 
     // Degree per rad
-    const double    DEG_PER_RAD             = 57.2957795130823209L;
+    const double DEG_PER_RAD = 57.2957795130823209;
 
     // Rad per degree
-    const double    RAD_PER_DEG             = 0.0174532925199432957L;
+    const double RAD_PER_DEG = 0.0174532925199432957;
 
     // mm per inch
-    const double    MM_PER_INCH             = 25.4L;
+    const double MM_PER_INCH = 25.4;
 
     // m per foot
-    const double    M_PER_FOOT              = 3.048L;
+    const double M_PER_FOOT = 3.048;
 
     // Joule per calorie
-    const double    JOULE_PER_CAL     = 4.184;
+    const double JOULE_PER_CAL  = 4.184;
 
     // Calories per Joule
-    const double    CAL_PER_JOULE     = (1 / 4.184);
+    const double CAL_PER_JOULE = (1 / 4.184);
 
   }
 }


### PR DESCRIPTION
Fixed warinings caused by assigning long double values (generated with the prefix 'L' attach to a number) to a double variable.
