### PR TITLE
[BUILD,PYOPENMS] fix pyOpenMS build

### DIFF
--- a/pyOpenMS/pxds/ConsensusMap.pxd
+++ b/pyOpenMS/pxds/ConsensusMap.pxd
@@ -97,24 +97,4 @@ cdef extern from "<OpenMS/KERNEL/ConsensusMap.h>" namespace "OpenMS":
         # wrapped in ../addons/ConsensusMap.pyx:
         void setFileDescriptions(FileDescriptions &)   #wrap-ignore
         FileDescriptions & getFileDescriptions()       #wrap-ignore
-
-
-        void convert(UInt64 input_map_index,
-                     FeatureMap[Feature] input_map,
-                     ConsensusMap & output_map,
-                     Size n) nogil except +
-  
-        void convert(UInt64 input_map_index,
-                     MSExperiment[Peak1D, ChromatogramPeak] & input_map,
-                     ConsensusMap & output_map,
-                     Size n) nogil except +
-  
-        void convert(UInt64 input_map_index,
-                     libcpp_vector[Peak2D] & input_map,
-                     ConsensusMap & output_map,
-                     Size n) nogil except +
-  
-        void convert(ConsensusMap input_map,
-                     bool keep_uids,
-                     FeatureMap[Feature] & output_map) nogil except +
   

--- a/pyOpenMS/pxds/ConversionHelper.pxd
+++ b/pyOpenMS/pxds/ConversionHelper.pxd
@@ -1,0 +1,25 @@
+from libcpp cimport bool
+from libcpp.vector cimport vector as libcpp_vector
+from libcpp.map cimport map as libcpp_map
+from ConsensusMap cimport *
+from FeatureMap cimport *
+from MSExperiment cimport *
+
+cdef extern from "<OpenMS/KERNEL/ConversionHelper.h>" namespace "OpenMS":
+
+    cdef cppclass MapConversion:
+
+      void convert(UInt64 input_map_index,
+                   FeatureMap[Feature] input_map,
+                   ConsensusMap & output_map,
+                   Size n) nogil except +
+    
+      void convert(UInt64 input_map_index,
+                   MSExperiment[Peak1D, ChromatogramPeak] & input_map,
+                   ConsensusMap & output_map,
+                   Size n) nogil except +
+    
+      void convert(ConsensusMap input_map,
+                   bool keep_uids,
+                   FeatureMap[Feature] & output_map) nogil except +
+

--- a/pyOpenMS/tests/unittests/test000.py
+++ b/pyOpenMS/tests/unittests/test000.py
@@ -4004,3 +4004,38 @@ def test_streampos():
     p = pyopenms.streampos()
     assert isinstance(int(p), int)
 
+def test_MapConversion():
+
+    feature = pyopenms.Feature()
+    feature.setRT(99)
+
+    cmap = pyopenms.ConsensusMap()
+    fmap = pyopenms.FeatureMap()
+    fmap.push_back(feature)
+    pyopenms.MapConversion().convert(0, fmap, cmap, 1)
+
+    assert(cmap.size() == 1)
+    assert(cmap[0].getRT() == 99.0)
+
+    fmap = pyopenms.FeatureMap()
+    pyopenms.MapConversion().convert(cmap, True, fmap)
+
+    assert(fmap.size() == 1)
+    assert(fmap[0].getRT() == 99.0)
+
+    exp = pyopenms.MSExperiment()
+    sp = pyopenms.MSSpectrum()
+    peak = pyopenms.Peak1D()
+    peak.setIntensity(10)
+    peak.setMZ(20)
+    sp.push_back(peak)
+    exp.addSpectrum(sp)
+    exp.addSpectrum(sp)
+
+    cmap = pyopenms.ConsensusMap()
+    pyopenms.MapConversion().convert(0, exp, cmap, 2)
+
+    assert(cmap.size() == 2)
+    assert(cmap[0].getIntensity() == 10.0)
+    assert(cmap[0].getMZ() == 20.0)
+

--- a/src/openms/include/OpenMS/KERNEL/ConversionHelper.h
+++ b/src/openms/include/OpenMS/KERNEL/ConversionHelper.h
@@ -42,8 +42,10 @@
 namespace OpenMS
 {
 
-  namespace MapConversion
+  class OPENMS_DLLAPI MapConversion
   {
+public:
+
     /**
       @brief Similar to @p convert for FeatureMaps.
 
@@ -57,10 +59,10 @@ namespace OpenMS
       @param output_map The resulting ConsensusMap.
       @param n The maximum number of elements to be copied.
     */
-    void OPENMS_DLLAPI convert(UInt64 const input_map_index,
-                               MSExperiment<> & input_map,
-                               ConsensusMap & output_map,
-                               Size n = -1);
+    static void convert(UInt64 const input_map_index,
+                                      MSExperiment<> & input_map,
+                                      ConsensusMap & output_map,
+                                      Size n = -1);
 
     /**
       @brief Convert a ConsensusMap to a FeatureMap (of any feature type).
@@ -118,10 +120,10 @@ namespace OpenMS
       @param n The maximum number of elements to be copied.
     */
     template <typename FeatureT>
-    void convert(UInt64 const input_map_index,
-                 FeatureMap<FeatureT> const & input_map,
-                 ConsensusMap & output_map,
-                 Size n = -1)
+    static void convert(UInt64 const input_map_index,
+                        FeatureMap<FeatureT> const & input_map,
+                        ConsensusMap & output_map,
+                        Size n = -1)
     {
       if (n > input_map.size())
       {
@@ -143,7 +145,8 @@ namespace OpenMS
       output_map.setUnassignedPeptideIdentifications(input_map.getUnassignedPeptideIdentifications());
       output_map.updateRanges();
     }
-  } // namespace MapConversion
+
+  };
 } // namespace OpenMS
 
 #endif // OPENMS_KERNEL_CONSENSUSMAP_H

--- a/src/openms/include/OpenMS/KERNEL/sources.cmake
+++ b/src/openms/include/OpenMS/KERNEL/sources.cmake
@@ -9,6 +9,7 @@ ChromatogramPeak.h
 ChromatogramTools.h
 ComparatorUtils.h
 ConsensusFeature.h
+ConversionHelper.h
 ConsensusMap.h
 ConversionHelper.h
 DPeak.h

--- a/src/openms/source/KERNEL/ConversionHelper.cpp
+++ b/src/openms/source/KERNEL/ConversionHelper.cpp
@@ -36,9 +36,7 @@
 
 namespace OpenMS
 {
-  namespace MapConversion
-  {
-    void convert(UInt64 const input_map_index,
+    void MapConversion::convert(UInt64 const input_map_index,
                  MSExperiment<> & input_map,
                  ConsensusMap & output_map,
                  Size n)
@@ -75,6 +73,5 @@ namespace OpenMS
       output_map.getFileDescriptions()[input_map_index].size = n;
       output_map.updateRanges();
     }
-  } // namespace MapConversion
 } // namespace OpenMS
 


### PR DESCRIPTION
- move overloaded functions into a class (pyOpenMS currently cannot deal
  with overloaded global functions)
- write tests for conversion

fixes errors after #761 
