### PR TITLE
[FIX] fix Swath window estimation

### DIFF
--- a/src/openswathalgo/include/OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/SwathMap.h
+++ b/src/openswathalgo/include/OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/SwathMap.h
@@ -48,6 +48,7 @@ namespace OpenSwath
     OpenSwath::SpectrumAccessPtr sptr;
     double lower;
     double upper;
+    double center;
     bool ms1;
   };
 

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -50,9 +50,6 @@
 #include <OpenMS/FORMAT/TransformationXMLFile.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
 #include <OpenMS/FORMAT/CachedMzML.h>
-#ifdef OPENMS_FORMAT_SWATHFILE_MZXMLSUPPORT
-#include "MSDataReader.h"
-#endif
 #include <OpenMS/FORMAT/SwathFile.h>
 
 // Kernel and implementations
@@ -1246,7 +1243,9 @@ protected:
       SwathWindowLoader::annotateSwathMapsFromFile(swath_windows_file, swath_maps, sort_swath_maps);
 
     for (Size i = 0; i < swath_maps.size(); i++)
-      LOG_DEBUG << "Found swath map " << i << " with lower " << swath_maps[i].lower << " and upper " << swath_maps[i].upper << std::endl;
+      LOG_DEBUG << "Found swath map " << i << " with lower " << swath_maps[i].lower 
+        << " and upper " << swath_maps[i].upper << " and " << swath_maps[i].sptr->getNrSpectra() 
+        << " spectra." << std::endl;
 
     ///////////////////////////////////
     // Get the transformation information (using iRT peptides)


### PR DESCRIPTION
fixes how the scans of a Swath experiment are assigned to their respective Swathes. This was necessary due to the fact that we encountered Swath files that had intermittent MS1 scans or missing/empty scans and thus simply counting did not work any more. This commit contains the following changes:
- store center of a window in a SwathMap
- allow reading of Swath windows in any random order (map read SWATH
  scans directly by their precursor m/z). This makes no more assumptions
  about the order in which the scans are stored.
  - allows for missing scans in between
  - allows for MS1 scans in between
- allows to provide a set of swath boundaries to the consumer
- [TEST] write tests for random order reading
