### PR TITLE
[FIX] fixed uninitialized pointer warning

### DIFF
--- a/src/tests/class_tests/openms/source/FASTAFile_test.cpp
+++ b/src/tests/class_tests/openms/source/FASTAFile_test.cpp
@@ -56,7 +56,7 @@ START_TEST(FASTAFile, "$Id$")
 using namespace OpenMS;
 using namespace std;
 
-FASTAFile* ptr;
+FASTAFile* ptr = 0;
 START_SECTION((FASTAFile()))
   ptr = new FASTAFile();
   TEST_EQUAL(ptr == 0, false)


### PR DESCRIPTION
Small fix for a warning that caused the build to fail after the recent change to the compiler options ("-Werror") in the build system.
