### PR TITLE
[FIX] fix dereference of iterator

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/CachedMzML.h
+++ b/src/openms/include/OpenMS/FORMAT/CachedMzML.h
@@ -142,8 +142,12 @@ public:
 
       data1->data.resize(spec_size);
       data2->data.resize(spec_size);
-      ifs.read((char*) &(data1->data)[0], spec_size * sizeof(double));
-      ifs.read((char*) &(data2->data)[0], spec_size * sizeof(double));
+
+      if (spec_size > 0)
+      {
+        ifs.read((char*) &(data1->data)[0], spec_size * sizeof(double));
+        ifs.read((char*) &(data2->data)[0], spec_size * sizeof(double));
+      }
     }
 
     /**

--- a/src/openms/source/FORMAT/CachedMzML.cpp
+++ b/src/openms/source/FORMAT/CachedMzML.cpp
@@ -241,8 +241,12 @@ namespace OpenMS
 
     data1.resize(spec_size);
     data2.resize(spec_size);
-    ifs.read((char*)&data1[0], spec_size * sizeof(DatumSingleton));
-    ifs.read((char*)&data2[0], spec_size * sizeof(DatumSingleton));
+
+    if (spec_size > 0)
+    {
+      ifs.read((char*)&data1[0], spec_size * sizeof(DatumSingleton));
+      ifs.read((char*)&data2[0], spec_size * sizeof(DatumSingleton));
+    }
   }
 
   void CachedmzML::readChromatogram_(Datavector& data1, Datavector& data2, std::ifstream& ifs) const
@@ -251,8 +255,12 @@ namespace OpenMS
     ifs.read((char*)&spec_size, sizeof(spec_size));
     data1.resize(spec_size);
     data2.resize(spec_size);
-    ifs.read((char*)&data1[0], spec_size * sizeof(DatumSingleton));
-    ifs.read((char*)&data2[0], spec_size * sizeof(DatumSingleton));
+
+    if (spec_size > 0)
+    {
+      ifs.read((char*)&data1[0], spec_size * sizeof(DatumSingleton));
+      ifs.read((char*)&data2[0], spec_size * sizeof(DatumSingleton));
+    }
   }
 
   void CachedmzML::readSpectrum_(SpectrumType& spectrum, std::ifstream& ifs) const


### PR DESCRIPTION
- vector iterator front() is not dereferencable if vector is empty
- thanks to @aiche for finding the error!
