### PR TITLE
[FIX-#861,DOC] fixed eigen 3.2.1 problems with GammaDistributionFitter

### DIFF
--- a/src/openms/include/OpenMS/MATH/STATISTICS/GammaDistributionFitter.h
+++ b/src/openms/include/OpenMS/MATH/STATISTICS/GammaDistributionFitter.h
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Andreas Bertsch $
-// $Authors: $
+// $Maintainer: Stephan Aiche $
+// $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 //
 #ifndef OPENMS_MATH_STATISTICS_GAMMADISTRIBUTIONFITTER_H
@@ -50,13 +50,14 @@ namespace OpenMS
 
       This class fits a Gamma distribution to a number of data points.
       The results as well as the initial guess are specified using the struct
-          GammaDistributionFitResult.
+      GammaDistributionFitResult.
+     
+      @note We actually fit a slightly customized version of the gamma distribution
+      that is 0.0 if the parameters b or p are <= 0.0. With this modification we 
+      can still use an unconstrained optimization algorithm.
 
-      The formula with the fitted parameters can be transformed into a
-      gnuplot formula using getGnuplotFormula() after fitting.
-
-          @ingroup Math
-      */
+      @ingroup Math
+    */
     class OPENMS_DLLAPI GammaDistributionFitter
     {
 public:
@@ -85,7 +86,7 @@ public:
       virtual ~GammaDistributionFitter();
 
       /// sets the gamma distribution start parameters b and p for the fitting
-      void setInitialParameters(const GammaDistributionFitResult & result);
+      void setInitialParameters(const GammaDistributionFitResult& result);
 
       /**
           @brief Fits a gamma distribution to the given data points
@@ -94,7 +95,7 @@ public:
 
           @exception Exception::UnableToFit is thrown if fitting cannot be performed
       */
-      GammaDistributionFitResult fit(const std::vector<DPosition<2> > & points);
+      GammaDistributionFitResult fit(const std::vector<DPosition<2> >& points);
 
 protected:
 
@@ -102,9 +103,9 @@ protected:
 
 private:
       /// Copy constructor (not implemented to prevent usage)
-      GammaDistributionFitter(const GammaDistributionFitter & rhs);
+      GammaDistributionFitter(const GammaDistributionFitter& rhs);
       /// assignment operator (not implemented to prevent usage)
-      GammaDistributionFitter & operator=(const GammaDistributionFitter & rhs);
+      GammaDistributionFitter& operator=(const GammaDistributionFitter& rhs);
     };
   }
 }

--- a/src/openms/source/MATH/STATISTICS/GammaDistributionFitter.cpp
+++ b/src/openms/source/MATH/STATISTICS/GammaDistributionFitter.cpp
@@ -28,7 +28,7 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Andreas Bertsch $
+// $Maintainer: Stephan Aiche $
 // $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 //
@@ -51,8 +51,8 @@ namespace OpenMS
 {
   namespace Math
   {
-    GammaDistributionFitter::GammaDistributionFitter()
-    : init_param_(1.0, 5.0)
+    GammaDistributionFitter::GammaDistributionFitter() :
+      init_param_(1.0, 5.0)
     {
     }
 
@@ -60,7 +60,7 @@ namespace OpenMS
     {
     }
 
-    void GammaDistributionFitter::setInitialParameters(const GammaDistributionFitResult & param)
+    void GammaDistributionFitter::setInitialParameters(const GammaDistributionFitResult& param)
     {
       init_param_ = param;
     }
@@ -70,45 +70,71 @@ namespace OpenMS
       int inputs() const { return m_inputs; }
       int values() const { return m_values; }
 
-      GammaFunctor(unsigned dimensions, const std::vector<DPosition<2> >* data)
-      : m_inputs(dimensions), m_values(data->size()), m_data(data) {}
+      GammaFunctor(unsigned dimensions, const std::vector<DPosition<2> >* data) :
+        m_inputs(dimensions), m_values(data->size()), m_data(data) {}
 
-      int operator()(const Eigen::VectorXd &x, Eigen::VectorXd &fvec)
+      int operator()(const Eigen::VectorXd& x, Eigen::VectorXd& fvec)
       {
 
         double b = x(0);
         double p = x(1);
 
         UInt i = 0;
-        for (std::vector<DPosition<2> >::const_iterator it = m_data->begin(); it != m_data->end(); ++it, ++i)
+
+        // gamma distribution is only defined for positive parameter values
+        if (b > 0.0 && p > 0.0)
         {
-          double the_x = it->getX();
-          fvec(i) =  std::pow(b, p) / boost::math::tgamma(p) * std::pow(the_x, p - 1) * std::exp(-b * the_x) - it->getY();
+          for (std::vector<DPosition<2> >::const_iterator it = m_data->begin(); it != m_data->end(); ++it, ++i)
+          {
+            double the_x = it->getX();
+            fvec(i) =  std::pow(b, p) / boost::math::tgamma(p) * std::pow(the_x, p - 1) * std::exp(-b * the_x) - it->getY();
+          }
         }
+        else
+        {
+          for (std::vector<DPosition<2> >::const_iterator it = m_data->begin(); it != m_data->end(); ++it, ++i)
+          {
+            fvec(i) = -it->getY();
+          }
+        }
+
 
         return 0;
       }
+
       // compute Jacobian matrix for the different parameters
-      int df(const Eigen::VectorXd &x, Eigen::MatrixXd &J)
+      int df(const Eigen::VectorXd& x, Eigen::MatrixXd& J)
       {
 
         double b = x(0);
         double p = x(1);
 
         UInt i = 0;
-        for (std::vector<DPosition<2> >::const_iterator it = m_data->begin(); it != m_data->end(); ++it, ++i)
+        // gamma distribution is only defined for positive parameter values
+        if (b > 0.0 && p > 0.0)
         {
-          double the_x = it->getX();
+          for (std::vector<DPosition<2> >::const_iterator it = m_data->begin(); it != m_data->end(); ++it, ++i)
+          {
+            double the_x = it->getX();
 
-          // partial deviation regarding b
-          double part_dev_b = std::pow(the_x, p - 1) * std::exp(-the_x * b) / boost::math::tgamma(p) * (p * std::pow(b, p - 1) - the_x * std::pow(b, p));
-          J(i,0) = part_dev_b;
+            // partial deviation regarding b
+            double part_dev_b = std::pow(the_x, p - 1) * std::exp(-the_x * b) / boost::math::tgamma(p) * (p * std::pow(b, p - 1) - the_x * std::pow(b, p));
+            J(i, 0) = part_dev_b;
 
-          // partial deviation regarding p
-          double factor = std::exp(-b * the_x) * std::pow(the_x, p - 1) * std::pow(b, p) / std::pow(boost::math::tgamma(p), 2);
-          double argument = (std::log(b) + std::log(the_x)) * boost::math::tgamma(p) - boost::math::tgamma(p) * boost::math::digamma(p);
-          double part_dev_p = factor * argument;
-          J(i,1) = part_dev_p;
+            // partial deviation regarding p
+            double factor = std::exp(-b * the_x) * std::pow(the_x, p - 1) * std::pow(b, p) / std::pow(boost::math::tgamma(p), 2);
+            double argument = (std::log(b) + std::log(the_x)) * boost::math::tgamma(p) - boost::math::tgamma(p) * boost::math::digamma(p);
+            double part_dev_p = factor * argument;
+            J(i, 1) = part_dev_p;
+          }
+        }
+        else
+        {
+          for (std::vector<DPosition<2> >::const_iterator it = m_data->begin(); it != m_data->end(); ++it, ++i)
+          {
+            J(i, 0) = 0.0;
+            J(i, 1) = 0.0;
+          }
         }
         return 0;
       }
@@ -117,12 +143,12 @@ namespace OpenMS
       const std::vector<DPosition<2> >* m_data;
     };
 
-    GammaDistributionFitter::GammaDistributionFitResult GammaDistributionFitter::fit(const std::vector<DPosition<2> > & input)
+    GammaDistributionFitter::GammaDistributionFitResult GammaDistributionFitter::fit(const std::vector<DPosition<2> >& input)
     {
-      Eigen::VectorXd x_init (2);
-      x_init << init_param_.b, init_param_.p ;
-      GammaFunctor functor (2, &input);
-      Eigen::LevenbergMarquardt<GammaFunctor> lmSolver (functor);
+      Eigen::VectorXd x_init(2);
+      x_init << init_param_.b, init_param_.p;
+      GammaFunctor functor(2, &input);
+      Eigen::LevenbergMarquardt<GammaFunctor> lmSolver(functor);
       Eigen::LevenbergMarquardtSpace::Status status = lmSolver.minimize(x_init);
 
       //the states are poorly documented. after checking the source, we believe that
@@ -135,12 +161,12 @@ namespace OpenMS
 
 #ifdef GAMMA_DISTRIBUTION_FITTER_VERBOSE
       std::stringstream formula;
-      formula << "f(x)=" << "(" << result.b << " ** " << result.p << ") / gamma(" << result.p << ") * x ** (" << result.p << " - 1) * exp(- " << result.b << " * x)";
-      std::cout << formular.str() << std::endl;
+      formula << "f(x)=" << "(" << x_init(0) << " ** " << x_init(1) << ") / gamma(" << x_init(1) << ") * x ** (" << x_init(1) << " - 1) * exp(- " << x_init(0) << " * x)";
+      std::cout << formula.str() << std::endl;
 #endif
 
-      return GammaDistributionFitResult (x_init(0), x_init(1));
+      return GammaDistributionFitResult(x_init(0), x_init(1));
     }
 
-  }   //namespace Math
+  } //namespace Math
 } // namespace OpenMS

--- a/src/tests/class_tests/openms/source/GammaDistributionFitter_test.cpp
+++ b/src/tests/class_tests/openms/source/GammaDistributionFitter_test.cpp
@@ -1,34 +1,34 @@
 // --------------------------------------------------------------------------
-//                   OpenMS -- Open-Source Mass Spectrometry               
+//                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
 // ETH Zurich, and Freie Universitaet Berlin 2002-2013.
-// 
+//
 // This software is released under a three-clause BSD license:
 //  * Redistributions of source code must retain the above copyright
 //    notice, this list of conditions and the following disclaimer.
 //  * Redistributions in binary form must reproduce the above copyright
 //    notice, this list of conditions and the following disclaimer in the
 //    documentation and/or other materials provided with the distribution.
-//  * Neither the name of any author or any participating institution 
-//    may be used to endorse or promote products derived from this software 
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
 //    without specific prior written permission.
-// For a full list of authors, refer to the file AUTHORS. 
+// For a full list of authors, refer to the file AUTHORS.
 // --------------------------------------------------------------------------
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING 
-// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
-// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // --------------------------------------------------------------------------
-// $Maintainer: Andreas Bertsch$
+// $Maintainer: Stephan Aiche $
 // $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 
@@ -126,7 +126,7 @@ START_SECTION((void setInitialParameters(const GammaDistributionFitResult & resu
   GammaDistributionFitter f1;
   GammaDistributionFitter::GammaDistributionFitResult result (1.0, 5.0);
   f1.setInitialParameters(result);
-	
+
 	NOT_TESTABLE //implicitly tested in fit method
 }
 END_SECTION
@@ -135,6 +135,3 @@ END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-
-
-


### PR DESCRIPTION
- redefined gamma distribution to be 0.0 if parameters are <= 0.0, while this
  violated basic assumptions on statistical distributions it allows the usage of
  an unconstrained optimisation algorithm (like eigen's lm)
- assigned myself as maintainer
- updated documentation
- fixed error in `GAMMA_DISTRIBUTION_FITTER_VERBOSE` code path
- applied uncrustify

fixes #861
