### PR TITLE
[FIX] fixed macosx version query

### DIFF
--- a/src/utils/OpenMSInfo.cpp
+++ b/src/utils/OpenMSInfo.cpp
@@ -41,6 +41,10 @@
 #include <QSysInfo>
 #include <QDir>
 
+#if defined(Q_WS_MAC)
+  #include <CoreServices/CoreServices.h>
+#endif
+
 #include <iostream>
 
 using namespace OpenMS;
@@ -97,62 +101,15 @@ namespace OpenMS
 
 // check if we can use QSysInfo
 #if defined(Q_WS_MAC)
-      // identify
-      switch (QSysInfo::MacintoshVersion)
-      {
-      case QSysInfo::MV_10_2:
-      {
-        info.os_version = "10.2 (Jaguar)";
-        break;
-      }
 
-      case QSysInfo::MV_10_3:
-      {
-        info.os_version = "10.3 (Panther)";
-        break;
-      }
-
-      case QSysInfo::MV_10_4:
-      {
-        info.os_version = "10.4 (Tiger)";
-        break;
-      }
-
-      case QSysInfo::MV_10_5:
-      {
-        info.os_version = "10.5 (Leopard)";
-        break;
-      }
-
-      case QSysInfo::MV_10_6:
-      {
-        info.os_version = "10.6 (Snow Leopard)";
-        break;
-      }
-
-      case QSysInfo::MV_10_7:
-      {
-        info.os_version = "10.7 (Lion)";
-        break;
-      }
-
-      case QSysInfo::MV_10_8:
-      {
-        info.os_version = "10.8 (Mountain Lion)";
-        break;
-      }
-
-      case QSysInfo::MV_10_9:
-      {
-        info.os_version = "10.9 (Mavericks)";
-        break;
-      }
-
-      default:
-      {
-        info.os_version = "unsupported";
-      }
-      }
+      // query gestalt for detailed osx version information
+      // NOTE: Gestalt will be deprecated at some point in the future where we
+      //       have to look for a better solution
+      SInt32 majorVersion,minorVersion,bugFixVersion;
+      Gestalt(gestaltSystemVersionMajor, &majorVersion);
+      Gestalt(gestaltSystemVersionMinor, &minorVersion);
+      Gestalt(gestaltSystemVersionBugFix, &bugFixVersion);
+      info.os_version = String(majorVersion) + "." + String(minorVersion) + String(".") + String(bugFixVersion);
 
       // identify architecture
       if (QSysInfo::WordSize == 32)


### PR DESCRIPTION
- `QSysInfo::MV_10_9` is not available in older Qt versions, which leads to a compile error for Qt < 4.8.6
- replaced QSysInfo with `Gestalt` a mac osx API to query system information
- this is a intermediate fix, as Gestalt will be deprecated in a future osx version, at some point we need to switch to [`sysctl`](https://developer.apple.com/library/mac/documentation/Darwin/Reference/Manpages/man3/sysctl.3.html) but this requires a manual mapping from kernel version to mac osx version
