### PR TITLE
fix #620

### DIFF
--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -878,6 +878,7 @@ namespace OpenMS
     for (Size i = 0; i < pkg.size(); ++i)
     {
       per_round_basenames.push_back(pkg[i].find(max_size_index)->second.filenames);
+      //String s = String(pkg[i].find(max_size_index)->second.filenames.join(" + "));
     }
 
     // maybe we find something more unique, e.g. last base directory if all filenames are equal
@@ -931,15 +932,14 @@ namespace OpenMS
       {
         // store edge for this param for all rounds
         output_files_[r][param_index] = vrp; // index by index of source-out param
-        QString fn = path;
 
         // check if tool consumes list and outputs single file (such as IDMerger or FileMerger)
         if (per_round_basenames[r].size() > 1 && out_params[param_index].type == IOInfo::IOT_FILE)
         {
-          fn += QString(QFileInfo(per_round_basenames[r].first()).fileName()
-                        + "_to_"
-                        + QFileInfo(per_round_basenames[r].last()).fileName()
-                        + "_merged");
+          QString fn = path + QString(QFileInfo(per_round_basenames[r].first()).fileName()
+                            + "_to_"
+                            + QFileInfo(per_round_basenames[r].last()).fileName()
+                            + "_merged");
           fn = fn.left(220); // allow max of 220 chars per path+filename (~NTFS limit)
           fn += "_tmp" + QString::number(uid_++);
           fn = QDir::toNativeSeparators(fn);
@@ -949,7 +949,7 @@ namespace OpenMS
         {
           foreach(const QString &input_file, per_round_basenames[r])
           {
-            fn += QFileInfo(input_file).fileName(); // discard directory
+            QString fn = path + QFileInfo(input_file).fileName(); // discard directory
             QRegExp rx("_tmp\\d+$"); // remove "_tmp<number>" if its a suffix
             int tmp_index = rx.indexIn(fn);
             if (tmp_index != -1)

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -236,7 +236,7 @@ namespace OpenMS
     {
       throw Exception::IndexOverflow(__FILE__, __LINE__, __PRETTY_FUNCTION__, param_index, rp.size());  // index could be larger (its a map, but nevertheless)
     }
-    //String s = String(rp[param_index].filenames.join("\" \""));
+    String s = String(rp[param_index].filenames.join("\" \""));
     return rp[param_index].filenames;
   }
 

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -228,10 +228,15 @@ namespace OpenMS
   QStringList TOPPASVertex::getFileNames(int param_index, int round) const
   {
     if ((Size)round >= output_files_.size())
+    {
       throw Exception::IndexOverflow(__FILE__, __LINE__, __PRETTY_FUNCTION__, round, output_files_.size());
+    }
     RoundPackage rp = output_files_[round];
     if (rp.find(param_index) == rp.end())
-      throw Exception::IndexOverflow(__FILE__, __LINE__, __PRETTY_FUNCTION__, param_index, rp.size());                                   // index could be larger (its a map, but nevertheless)
+    {
+      throw Exception::IndexOverflow(__FILE__, __LINE__, __PRETTY_FUNCTION__, param_index, rp.size());  // index could be larger (its a map, but nevertheless)
+    }
+    //String s = String(rp[param_index].filenames.join("\" \""));
     return rp[param_index].filenames;
   }
 


### PR DESCRIPTION
output file names are now (correctly) derived from input files for TOPPAS nodes which use lists

I used a minor example (input -> collector -> MapAlignerPoseClustering -> output).

Ideally, this is tested on a handful of other workflows beforehand (even though its a very minor change).

@hendrik Can you confirm this fixes #620?
