### PR TITLE
OPENMS_DLLAPI removed from GridBasedClustering

### DIFF
--- a/src/openms/include/OpenMS/COMPARISON/CLUSTERING/GridBasedClustering.h
+++ b/src/openms/include/OpenMS/COMPARISON/CLUSTERING/GridBasedClustering.h
@@ -116,7 +116,7 @@ class OPENMS_DLLAPI MinimumDistance
 * all properties B different.
 */
 template <typename Metric>
-class OPENMS_DLLAPI GridBasedClustering
+class GridBasedClustering
 {
     public:
     /**


### PR DESCRIPTION
OPENMS_DLLAPI in a template implementation leads to linker problems under Windows. It is now removed.
