### PR TITLE
[FIX] add setOptions method for FileHandler

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/FileHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/FileHandler.h
@@ -103,6 +103,9 @@ public:
     /// Non-mutable access to the options for loading/storing
     const PeakFileOptions& getOptions() const;
 
+    /// set options for loading/storing
+    void setOptions(const PeakFileOptions &);
+
     /**
       @brief Loads a file into an MSExperiment
 

--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -390,6 +390,11 @@ if (first_line.hasSubstring("File	First Scan	Last Scan	Num of Scans	Charge	Monoi
     return options_;
   }
 
+  void FileHandler::setOptions(const PeakFileOptions & options)
+  {
+      options_ = options;
+  }
+
   String FileHandler::computeFileHash_(const String& filename) const
   {
     QCryptographicHash crypto(QCryptographicHash::Sha1);

--- a/src/pyOpenMS/pxds/FileHandler.pxd
+++ b/src/pyOpenMS/pxds/FileHandler.pxd
@@ -17,6 +17,8 @@ cdef extern from "<OpenMS/FORMAT/FileHandler.h>" namespace "OpenMS":
         bool loadFeatures(libcpp_string, FeatureMap[Feature] &) nogil except +
 
         PeakFileOptions  getOptions() nogil except +
+        void setOptions(PeakFileOptions) nogil except +
+
 #
 # wrap static method:
 #


### PR DESCRIPTION
pyOpenMS needs explicit setters and getters (and C++ code should in theory too to be clean)
