### PR TITLE
[FIX] disallow concurrent access to the static PRNG

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/SwathFile.h
+++ b/src/openms/include/OpenMS/FORMAT/SwathFile.h
@@ -79,7 +79,7 @@ public:
       {
 
 #ifdef _OPENMP
-#pragma omp critical (load)
+#pragma omp critical (OPENMS_SwathFile_loadSplit)
 #endif
         {
           std::cout << "Loading file " << i << " with name " << file_list[i] << " using readoptions " << readoptions << std::endl;
@@ -137,7 +137,7 @@ public:
         swath_map.upper = upper;
         swath_map.ms1 = ms1;
 #ifdef _OPENMP
-#pragma omp critical (load)
+#pragma omp critical (OPENMS_SwathFile_loadSplit)
 #endif
         {
           LOG_DEBUG << "Adding Swath file " << file_list[i] << " with " << swath_map.lower << " to " << swath_map.upper << std::endl;

--- a/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
+++ b/src/openms/source/CONCEPT/UniqueIdGenerator.cpp
@@ -46,7 +46,17 @@ namespace OpenMS
   UInt64 UniqueIdGenerator::getUniqueId()
   {
     UniqueIdGenerator& instance = getInstance_();
+#ifdef _OPENMP
+    UInt64 val;
+#pragma omp critical (OPENMS_UniqueIdGenerator_getUniqueId)
+    {
+      val = (*instance.dist_)(*instance.rng_);
+    }
+    // note: OpenMP can only work on a structured block, return needs to be outside that block
+    return val; 
+#else
     return (*instance.dist_)(*instance.rng_);
+#endif
   }
 
   UInt64 UniqueIdGenerator::getSeed()
@@ -56,32 +66,49 @@ namespace OpenMS
 
   void UniqueIdGenerator::setSeed(UInt64 seed)
   {
-    UniqueIdGenerator& instance = getInstance_();
-    instance.seed_ = seed;
-    instance.rng_->seed( instance.seed_ );
-    instance.dist_->reset();
+  // modifies static members
+#ifdef _OPENMP
+#pragma omp critical (OPENMS_UniqueIdGenerator_setSeed)
+#endif
+    {
+      UniqueIdGenerator& instance = getInstance_();
+      instance.seed_ = seed;
+      instance.rng_->seed( instance.seed_ );
+      instance.dist_->reset();
+    }
   }
 
   UniqueIdGenerator::UniqueIdGenerator()
   {
-
   }
 
   UniqueIdGenerator & UniqueIdGenerator::getInstance_()
   {
-    if (!instance_)
+  // modifies static members
+#ifdef _OPENMP
+#pragma omp critical (OPENMS_UniqueIdGenerator_getInstance_)
+#endif
     {
-      instance_ = new UniqueIdGenerator();
-      instance_->init_();
+      if (!instance_)
+      {
+        instance_ = new UniqueIdGenerator();
+        instance_->init_();
+      }
     }
     return *instance_;
   }
 
   void UniqueIdGenerator::init_()
   {
-    seed_ = std::time(0);
-    rng_ = new boost::mt19937_64 (seed_);
-    dist_ = new boost::uniform_int<UInt64> (0,std::numeric_limits<UInt64>::max());
+  // modifies static members
+#ifdef _OPENMP
+#pragma omp critical (OPENMS_UniqueIdGenerator_init_)
+#endif
+    {
+      seed_ = std::time(0);
+      rng_ = new boost::mt19937_64 (seed_);
+      dist_ = new boost::uniform_int<UInt64> (0,std::numeric_limits<UInt64>::max());
+    }
   }
 
   UniqueIdGenerator::~UniqueIdGenerator()

--- a/src/openms/source/FILTERING/DATAREDUCTION/ElutionPeakDetection.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/ElutionPeakDetection.cpp
@@ -448,7 +448,7 @@ namespace OpenMS
         // if (mt_quality >= 1.2)
         //      {
 #ifdef _OPENMP
-#pragma omp critical
+#pragma omp critical (OPENMS_ElutionPeakDetection_mtraces)
 #endif
         single_mtraces.push_back(mt);
 
@@ -539,7 +539,7 @@ namespace OpenMS
           // if ((new_mt_length >= min_trace_length_) && (new_mt_length <= max_trace_length_))
           //{
 #ifdef _OPENMP
-#pragma omp critical
+#pragma omp critical (OPENMS_ElutionPeakDetection_mtraces)
 #endif
           single_mtraces.push_back(new_mt);
         }


### PR DESCRIPTION
- otherwise the same random number might be produce twice which could
  lead to all kinds of apocalypses
- [FIX](re)-named critical blocks (should be namespaced with OPENMS_)
- proposed solution to issue #956
