### PR TITLE
[NOP] add heavy methyl SILAC labels to unimod.xml

### DIFF
--- a/share/OpenMS/CHEMISTRY/unimod.xml
+++ b/share/OpenMS/CHEMISTRY/unimod.xml
@@ -5224,6 +5224,8 @@ corrected by subtraction of a further -O at 8.6.2010</umod:misc_notes>
                 date_time_modified="2006-10-15 18:24:07"
                 approved="1"
                 record_id="199">
+         <umod:specificity hidden="1" site="R" position="Anywhere" classification="Isotopic label"
+                           spec_group="4"/>
          <umod:specificity hidden="1" site="N-term" position="Protein N-term"
                            classification="Isotopic label"
                            spec_group="3"/>
@@ -10185,6 +10187,8 @@ corrected by subtraction of a further -O at 8.6.2010</umod:misc_notes>
                 date_time_modified="2006-10-15 18:26:15"
                 approved="1"
                 record_id="510">
+         <umod:specificity hidden="1" site="R" position="Anywhere" classification="Isotopic label"
+                           spec_group="3"/>
          <umod:specificity hidden="1" site="N-term" position="Any N-term" classification="Isotopic label"
                            spec_group="2"/>
          <umod:specificity hidden="1" site="K" position="Anywhere" classification="Isotopic label"


### PR DESCRIPTION
Standard dimethyl chemical labelling modifies Lys and N-termini. In heavy methyl SILAC methabolic labelling [1] Arg can be modified as well. This site is not (yet) allowed for in unimod # 199 and # 510. The pull request adds the following two mods.

Dimethyl:2H(4) (R)
Dimethyl:2H(4)13C(2) (R)

[1] Ong, S.-E., Mittler, G. & Mann, M. Identifying and quantifying in vivo methylation sites by heavy methyl SILAC. Nat Methods 1, 119–126 (2004).
