### PR TITLE
fixes problems with ">>" generated in nested C++ templates

### DIFF
--- a/src/pyOpenMS/pxds/DBoundingBox.pxd
+++ b/src/pyOpenMS/pxds/DBoundingBox.pxd
@@ -6,7 +6,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/DBoundingBox.h>" namespace "OpenMS":
     # as an alternative one could use a similar ctypedef, but these can
     # not be renamed when cipmorting, which might cause trouble !
 
-    cdef cppclass DBoundingBox2 "OpenMS::DBoundingBox<2>":
+    cdef cppclass DBoundingBox2 "OpenMS::DBoundingBox<2> ":
         DBoundingBox2() nogil except +
         DBoundingBox2(DBoundingBox2) nogil except +
         DPosition2 minPosition() nogil except +

--- a/src/pyOpenMS/pxds/DPosition.pxd
+++ b/src/pyOpenMS/pxds/DPosition.pxd
@@ -14,7 +14,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/DPosition.h>" namespace "OpenMS":
     # as an alternative one could use a similar ctypedef, but these can
     # not be renamed when cipmorting, which might cause trouble !
 
-    cdef cppclass DPosition1 "OpenMS::DPosition<1>":
+    cdef cppclass DPosition1 "OpenMS::DPosition<1> ":
         # wrap-ignore
         DPosition1()  nogil except +
         DPosition1(DPosition1)  nogil except +
@@ -32,7 +32,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/DPosition.h>" namespace "OpenMS":
         void clear() nogil except +
         Size size() nogil except +
 
-    cdef cppclass DPosition2 "OpenMS::DPosition<2>":
+    cdef cppclass DPosition2 "OpenMS::DPosition<2> ":
         # wrap-ignore
         DPosition2()  nogil except +
         DPosition2(DPosition2)  nogil except +

--- a/src/pyOpenMS/pxds/DRange.pxd
+++ b/src/pyOpenMS/pxds/DRange.pxd
@@ -4,7 +4,7 @@ from libcpp cimport bool
 
 cdef extern from "<OpenMS/DATASTRUCTURES/DRange.h>" namespace "OpenMS":
     
-    cdef cppclass DRange1 "OpenMS::DRange<1>":
+    cdef cppclass DRange1 "OpenMS::DRange<1> ":
         DRange1() nogil except +
         DRange1(DRange1) nogil except +
         DRange1(DPosition1 lower, DPosition1 upper) nogil except +
@@ -15,7 +15,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/DRange.h>" namespace "OpenMS":
         bool isIntersected(DRange1 & range_) nogil except +
         bool isEmpty() nogil except +
 
-    cdef cppclass DRange2 "OpenMS::DRange<2>":
+    cdef cppclass DRange2 "OpenMS::DRange<2> ":
         DRange2() nogil except +
         DRange2(DRange2) nogil except +
         DRange2(DPosition2 lower, DPosition2 upper) nogil except +

--- a/src/pyOpenMS/pxds/SeedListGenerator.pxd
+++ b/src/pyOpenMS/pxds/SeedListGenerator.pxd
@@ -9,9 +9,10 @@ from Peak1D cimport *
 from PeptideIdentification cimport *
 from DefaultParamHandler cimport *
 from ProgressLogger cimport *
+from DPosition cimport DPosition2
 
 
-ctypedef libcpp_vector[ DPosition2] SeedList
+ctypedef libcpp_vector[DPosition2] SeedList
 
 cdef extern from "<OpenMS/TRANSFORMATIONS/FEATUREFINDER/SeedListGenerator.h>" namespace "OpenMS":
 


### PR DESCRIPTION
clang-503-0.40 refused to compile experssions like `std::vector<OpenMS::DRange<2>>` because of the `>>` at the end. This commit fixed this by creating the easier to parse form `std::vector<OpenMS::DRange<2> >`
