### PR TITLE
sorting mass shifts in FeatureFinderMultiplex

### DIFF
--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -818,13 +818,14 @@ public:
               // loop over peptides
               for (unsigned peptide = 0; peptide < patterns[pattern].getMassShiftCount(); ++peptide)
               {
-                profile_intensities[peptide].push_back(result_raw.getIntensities()[(isotopes_per_peptide_max_ + 1) * peptide + peak + 1]);                  // +1 due to zeroth peaks
-
-                std::pair<unsigned, unsigned> peptide_peak(peptide, peak);
-                double mz = result_raw.getMZ() + result_raw.getMZShifts()[(isotopes_per_peptide_max_ + 1) * peptide + peak + 1];
-                if (!(boost::math::isnan(mz)))
+                unsigned index = (isotopes_per_peptide_max_ + 1) * peptide + peak + 1;    // +1 due to zeroth peaks
+                profile_intensities[peptide].push_back(result_raw.getIntensities()[index]);    // Note that the intensity can be NaN. To be checked later.
+                
+                double mz_shift = result_raw.getMZShifts()[index];
+                if (!(boost::math::isnan(mz_shift)))
                 {
-                  mass_traces[peptide_peak].enlarge(rt, mz);
+                  std::pair<unsigned, unsigned> peptide_peak(peptide, peak);
+                  mass_traces[peptide_peak].enlarge(rt, result_raw.getMZ() + mz_shift);
                 }
               }
             }


### PR DESCRIPTION
The algorithm searches for a number of mass shift patterns in the data. Starting with with small mass shifts which correspond to no or few miscleavages i.e. a simpler explanation of the data.

The pull request also includes small changes in the generation of feature and consensus maps.
