### PR TITLE
GenericWrapper doc has minor quirks

### DIFF
--- a/src/topp/GenericWrapper.cpp
+++ b/src/topp/GenericWrapper.cpp
@@ -121,12 +121,12 @@ using namespace std;
   All tokens therein will be replaced and the result will be patched into the <tt>cloptions</tt> string.
   Allowed tokens are:
   <ul>
-  <li>%TMP  --> The current temp directory, fetched using File::getTempDirectory()
-  <li>%DIR --> directory prefix, e.g.:, c:/tmp/mzfile.mzML gives 'c:/tmp'
-  <li>%BASENAME[file] --> the basename of a file, e.g. c:/tmp/myfile.mzML gives 'myfile'
-  <li>%RND --> generates a long random number, which can be used to generate unique filenames in a &lt;file_pre&gt; tag
-  <li>%WORKINGDIR --> expands to the current working directory (default is '.'), settable by &lt;workingdirectory&gt; tag in the .ttd file.
-  <li>%%&lt;param&gt; --> any param registered in the ini_param section, e.g. '%%in'
+  <li>\%TMP  --> The current temp directory, fetched using File::getTempDirectory()
+  <li>\%DIR --> directory prefix, e.g.:, c:/tmp/mzfile.mzML gives 'c:/tmp'
+  <li>\%BASENAME[file] --> the basename of a file, e.g. c:/tmp/myfile.mzML gives 'myfile'
+  <li>\%RND --> generates a long random number, which can be used to generate unique filenames in a &lt;file_pre&gt; tag
+  <li>\%WORKINGDIR --> expands to the current working directory (default is '.'), settable by &lt;workingdirectory&gt; tag in the .ttd file.
+  <li>\%\%&lt;param&gt; --> any param registered in the ini_param section, e.g. '\%\%in'
   </ul>
 
   Example:


### PR DESCRIPTION
escape percent sign to fix usage documentation,
see http://www.stack.nl/~dimitri/doxygen/manual/commands.html  --> \%
