### PR TITLE
PeakPickerHiRes docu updated

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.cpp
+++ b/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.cpp
@@ -48,13 +48,13 @@ namespace OpenMS
     defaults_.setValue("signal_to_noise", 1.0, "Minimal signal-to-noise ratio for a peak to be picked (0.0 disables SNT estimation!)");
     defaults_.setMinFloat("signal_to_noise", 0.0);
 
-    defaults_.setValue("spacing_difference_gap", 4.0, "The extension of a peak is stopped, if the spacing between two subsequent data points exceeds (spacing_difference_gap * min_spacing). min_spacing is the smaller of the two spacing from the peak seed to its two neighbouring points.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("spacing_difference_gap", 4.0, "The extension of a peak is stopped if the spacing between two subsequent data points exceeds (spacing_difference_gap * min_spacing). 'min_spacing' is the smaller of the two spacings from the peak apex to its two neighboring points.", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("spacing_difference_gap", std::numeric_limits<unsigned>::min()); //must be > 0
 
-    defaults_.setValue("spacing_difference", 1.5, "Maximum allowed distance between peaks in multiples of the minimal difference (min_spacing). A higher value is implies a less stringent peak definition since individual signals within the peaks are allowed to further apart. E.g. if the value is set to 1.5 and in a peak the minimal spacing between peaks is 10 mDa, then only signals at most 15 mDa apart will be added to the peak.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("spacing_difference", 1.5, "Maximum allowed difference between points during peak extension, in multiples of the minimal difference between the peak apex and its two neighboring points. If this difference is exceeded a missing point is assumed (see parameter 'missing'). A higher value implies a less stringent peak definition, since individual signals within the peak are allowed to be further apart.", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("spacing_difference", std::numeric_limits<unsigned>::min()); //must be > 0
 
-    defaults_.setValue("missing", 1, "Maximum number of missing points allowed when extending the peak to the left or the right. A missing data point occurs, if the spacing between two subsequent data points exceeds (spacing_difference * min_spacing). min_spacing is the smaller of the two spacing from the peak seed to its two neighbouring points.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("missing", 1, "Maximum number of missing points allowed when extending a peak to the left or to the right. A missing data point occurs if the spacing between two subsequent data points exceeds (spacing_difference * min_spacing). 'min_spacing' is the smaller of the two spacings from the peak apex to its two neighboring points.", ListUtils::create<String>("advanced"));
     defaults_.setMinInt("missing", 0);
 
     defaults_.setValue("ms_levels", ListUtils::create<Int>("1,2"), "List of MS levels for which the peak picking is applied. Other scans are copied to the output without changes.");


### PR DESCRIPTION
The documentation for PeakPickerHiRes paramters is updated. As @hendrikweisser pointed out, the descriptions of missing, spacing_difference and spacing_difference_gap were not clear.

min_distance is defined as the smaller of the two spacing to the left and right from the seed. This distance serves as scale. Small gaps (> spacing_difference \* min_distance) define a missing data point and are allowed (if missing > 0). Large gaps (> spacing_difference_gap \* min_distance) immediately lead to an end of the peak extension.

IMO, all three parameters require the data to be roughly equidistant. Otherwise the concept of 'missing data point' or 'large gap' is ill defined.
