### PR TITLE
[FIX] intermediate fix for win32 systems

### DIFF
--- a/src/openswathalgo/source/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/Transitions.cpp
+++ b/src/openswathalgo/source/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/Transitions.cpp
@@ -36,11 +36,5 @@
 
 namespace OpenSwath
 {
-	/*
-  TargetedExperiment::TargetedExperiment()
-  {}
-	
-  TargetedExperiment::~TargetedExperiment() 
-  {}
-  */
 }
+

--- a/src/openswathalgo/source/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/Transitions.cpp
+++ b/src/openswathalgo/source/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/Transitions.cpp
@@ -28,67 +28,19 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Witold Wolski $
-// $Authors: Witold Wolski  $
+// $Maintainer: Hannes Roest $
+// $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
 
-#include "OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/ALGO/StatsHelpers.h"
-
-#include <algorithm>
-#include <numeric>
-#include <functional>
-#include <stdexcept>
+#include <OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/Transitions.h>
 
 namespace OpenSwath
 {
-  void normalize(
-    const std::vector<double> & intensities,
-    double normalizer,
-    std::vector<double> & normalized_intensities)
-  {
-    //compute total intensities
-    //normalize intensities
-    normalized_intensities.resize(intensities.size());
-    if (normalizer > 0)
-    {
-      std::transform(intensities.begin(), intensities.end(), normalized_intensities.begin(), std::bind2nd(std::divides<double>(), normalizer));
-    }
-  }
-
-
-  double dotprodScoring(std::vector<double> intExp, std::vector<double> theorint)
-  {
-    for (unsigned int i = 0; i < intExp.size(); ++i)
-    {
-      intExp[i] = sqrt(intExp[i]);
-      theorint[i] = sqrt(theorint[i]);
-    }
-
-    double intExptotal = norm(intExp.begin(), intExp.end());
-    double intTheorTotal = norm(theorint.begin(), theorint.end());
-    OpenSwath::normalize(intExp, intExptotal, intExp);
-    OpenSwath::normalize(theorint, intTheorTotal, theorint);
-    double score2 = OpenSwath::dotProd(intExp.begin(), intExp.end(), theorint.begin());
-    return score2;
-  }
-
-  double manhattanScoring(std::vector<double> intExp, std::vector<double> theorint)
-  {
-
-    for (unsigned int i = 0; i < intExp.size(); ++i)
-    {
-      intExp[i] = sqrt(intExp[i]);
-      theorint[i] = sqrt(theorint[i]);
-      //std::transform(intExp.begin(), intExp.end(), intExp.begin(), sqrt);
-      //std::transform(theorint.begin(), theorint.end(), theorint.begin(), sqrt);
-    }
-
-    double intExptotal = std::accumulate(intExp.begin(), intExp.end(), 0.0);
-    double intTheorTotal = std::accumulate(theorint.begin(), theorint.end(), 0.0);
-    OpenSwath::normalize(intExp, intExptotal, intExp);
-    OpenSwath::normalize(theorint, intTheorTotal, theorint);
-    double score2 = OpenSwath::manhattanDist(intExp.begin(), intExp.end(), theorint.begin());
-    return score2;
-  }
-
+	/*
+  TargetedExperiment::TargetedExperiment()
+  {}
+	
+  TargetedExperiment::~TargetedExperiment() 
+  {}
+  */
 }

--- a/src/openswathalgo/source/ANALYSIS/OPENSWATH/OPENSWATHALGO/OpenSwathAlgoFiles.cmake
+++ b/src/openswathalgo/source/ANALYSIS/OPENSWATH/OPENSWATHALGO/OpenSwathAlgoFiles.cmake
@@ -37,17 +37,17 @@ set(directory source/ANALYSIS/OPENSWATH/OPENSWATHALGO)
 
 ### list all files of the directory here
 set(sources_algo_list
-  ALGO/Scoring.cpp
   ALGO/MRMScoring.cpp
+  ALGO/Scoring.cpp
   ALGO/StatsHelpers.cpp
 )
 
 set(sources_dataaccess_list
-  DATAACCESS/SpectrumHelpers.cpp
-  DATAACCESS/ISpectrumAccess.cpp
-  DATAACCESS/TransitionHelper.cpp
-  DATAACCESS/MockObjects.cpp
   DATAACCESS/DataFrameWriter.cpp
+  DATAACCESS/ISpectrumAccess.cpp
+  DATAACCESS/MockObjects.cpp
+  DATAACCESS/SpectrumHelpers.cpp
+  DATAACCESS/TransitionHelper.cpp
   DATAACCESS/Transitions.cpp
 )
 
@@ -82,11 +82,11 @@ set(header_dataaccess_list
   DATAACCESS/DataFrameWriter.h
   DATAACCESS/DataStructures.h
   DATAACCESS/ISpectrumAccess.h
-  DATAACCESS/TransitionHelper.h
   DATAACCESS/ITransition.h
   DATAACCESS/MockObjects.h
   DATAACCESS/SpectrumHelpers.h
   DATAACCESS/TransitionExperiment.h
+  DATAACCESS/TransitionHelper.h
   DATAACCESS/Transitions.h
 )
 

--- a/src/openswathalgo/source/ANALYSIS/OPENSWATH/OPENSWATHALGO/OpenSwathAlgoFiles.cmake
+++ b/src/openswathalgo/source/ANALYSIS/OPENSWATH/OPENSWATHALGO/OpenSwathAlgoFiles.cmake
@@ -44,10 +44,11 @@ set(sources_algo_list
 
 set(sources_dataaccess_list
   DATAACCESS/SpectrumHelpers.cpp
-	DATAACCESS/ISpectrumAccess.cpp
-	DATAACCESS/TransitionHelper.cpp
-	DATAACCESS/MockObjects.cpp
-	DATAACCESS/DataFrameWriter.cpp
+  DATAACCESS/ISpectrumAccess.cpp
+  DATAACCESS/TransitionHelper.cpp
+  DATAACCESS/MockObjects.cpp
+  DATAACCESS/DataFrameWriter.cpp
+  DATAACCESS/Transitions.cpp
 )
 
 ### add path to the filenames


### PR DESCRIPTION
This fixes the win32 compile issues from last nights win8 test builds. In general we should consider removing `DATAACCESS/Transitions.h` and `TestConvert.cpp` since it is not used anywhere else and the test itself is not a real test.

```
BOOST_AUTO_TEST_CASE(initializeXCorrMatrix)
{
  OpenSwath::LightTargetedExperiment  lte;
  OpenSwath::TargetedExperiment  te;
  //OpenSwath::convert(lte, te);
  //TODO (wolski): write tests
}
END_SECTION
```