### PR TITLE
[FIX] throw exception if tools are run on wrong peak type

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
@@ -414,13 +414,14 @@ public:
      *
      * @param input  input map in profile mode
      * @param output  output map with picked peaks
+     * @param check_spectrum_type  if set, checks spectrum type and throws an exception if a centoided spectrum is passed 
      */
     template <typename PeakType, typename ChromatogramPeakT>
-    void pickExperiment(const MSExperiment<PeakType, ChromatogramPeakT>& input, MSExperiment<PeakType, ChromatogramPeakT>& output) const
+    void pickExperiment(const MSExperiment<PeakType, ChromatogramPeakT>& input, MSExperiment<PeakType, ChromatogramPeakT>& output, const bool check_spectrum_type = true) const
     {
         std::vector<std::vector<PeakBoundary> > boundaries_spec;
         std::vector<std::vector<PeakBoundary> > boundaries_chrom;
-        pickExperiment(input, output, boundaries_spec, boundaries_chrom);
+        pickExperiment(input, output, boundaries_spec, boundaries_chrom, check_spectrum_type);
     }
 
     /**
@@ -432,6 +433,7 @@ public:
      * @param output  output map with picked peaks
      * @param boundaries_spec  boundaries of the picked peaks in spectra
      * @param boundaries_chrom  boundaries of the picked peaks in chromatograms
+     * @param check_spectrum_type  if set, checks spectrum type and throws an exception if a centoided spectrum is passed 
      */
     template <typename PeakType, typename ChromatogramPeakT>
     void pickExperiment(const MSExperiment<PeakType, ChromatogramPeakT>& input, MSExperiment<PeakType, ChromatogramPeakT>& output, std::vector<std::vector<PeakBoundary> >& boundaries_spec, std::vector<std::vector<PeakBoundary> >& boundaries_chrom, const bool check_spectrum_type = true) const

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
@@ -450,16 +450,8 @@ public:
       Size progress = 0;
       startProgress(0, input.size() + input.getChromatograms().size(), "picking peaks");
 
-      if (!input.getNrSpectra() == 0)
+      if (input.getNrSpectra() > 0)
       {
-        // determine type of spectral data (profile or centroided)
-        SpectrumSettings::SpectrumType original_spectrum_type = input[0].getType();
-
-        if (original_spectrum_type == SpectrumSettings::PEAKS && check_spectrum_type)
-        {
-          throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Centroided data provided but profile spectra expected.");
-        }
-
         for (Size scan_idx = 0; scan_idx != input.size(); ++scan_idx)
         {
           if (!ListUtils::contains(ms_levels_, input[scan_idx].getMSLevel()))
@@ -469,6 +461,15 @@ public:
           else
           {
             std::vector<PeakBoundary> boundaries_s; // peak boundaries of a single spectrum
+
+            // determine type of spectral data (profile or centroided)
+            SpectrumSettings::SpectrumType spectrum_type = input[scan_idx].getType();
+
+            if (spectrum_type == SpectrumSettings::PEAKS && check_spectrum_type)
+            {
+              throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Centroided data provided but profile spectra expected.");
+            }
+
             pick(input[scan_idx], output[scan_idx], boundaries_s);
             boundaries_spec.push_back(boundaries_s);
           }
@@ -510,15 +511,8 @@ public:
       Size progress = 0;
       startProgress(0, input.size() + input.getNrChromatograms(), "picking peaks");
 
-      if (!input.getNrSpectra() == 0)
+      if (input.getNrSpectra() > 0)
       {
-        // determine type of spectral data (profile or centroided)
-        SpectrumSettings::SpectrumType spectrum_type = input[0].getType();
-
-        if (spectrum_type == SpectrumSettings::PEAKS && check_spectrum_type)
-        {
-          throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Centroided data provided but profile spectra expected.");
-        }
 
         // resize output with respect to input
         output.resize(input.size());
@@ -533,6 +527,15 @@ public:
           {
             MSSpectrum<PeakType> s = input[scan_idx];
             s.sortByPosition();
+
+            // determine type of spectral data (profile or centroided)
+            SpectrumSettings::SpectrumType spectrum_type = s.getType();
+
+            if (spectrum_type == SpectrumSettings::PEAKS && check_spectrum_type)
+            {
+              throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Centroided data provided but profile spectra expected.");
+            }
+
             pick(s, output[scan_idx]);
           }
           setProgress(++progress);

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h
@@ -434,7 +434,7 @@ public:
      * @param boundaries_chrom  boundaries of the picked peaks in chromatograms
      */
     template <typename PeakType, typename ChromatogramPeakT>
-    void pickExperiment(const MSExperiment<PeakType, ChromatogramPeakT>& input, MSExperiment<PeakType, ChromatogramPeakT>& output, std::vector<std::vector<PeakBoundary> >& boundaries_spec, std::vector<std::vector<PeakBoundary> >& boundaries_chrom) const
+    void pickExperiment(const MSExperiment<PeakType, ChromatogramPeakT>& input, MSExperiment<PeakType, ChromatogramPeakT>& output, std::vector<std::vector<PeakBoundary> >& boundaries_spec, std::vector<std::vector<PeakBoundary> >& boundaries_chrom, const bool check_spectrum_type = true) const
     {
       // make sure that output is clear
       output.clear(true);
@@ -453,7 +453,7 @@ public:
         // determine type of spectral data (profile or centroided)
         SpectrumSettings::SpectrumType original_spectrum_type = input[0].getType();
 
-        if (original_spectrum_type == SpectrumSettings::PEAKS)
+        if (original_spectrum_type == SpectrumSettings::PEAKS && check_spectrum_type)
         {
           throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Centroided data provided but profile spectra expected.");
         }
@@ -497,7 +497,7 @@ public:
       Currently we have to give up const-correctness but we know that everything on disc is constant
     */
     template <typename PeakType, typename ChromatogramPeakT>
-    void pickExperiment(/* const */ OnDiscMSExperiment<PeakType, ChromatogramPeakT>& input, MSExperiment<PeakType, ChromatogramPeakT>& output) const
+    void pickExperiment(/* const */ OnDiscMSExperiment<PeakType, ChromatogramPeakT>& input, MSExperiment<PeakType, ChromatogramPeakT>& output, const bool check_spectrum_type = true) const
     {
       // make sure that output is clear
       output.clear(true);
@@ -513,7 +513,7 @@ public:
         // determine type of spectral data (profile or centroided)
         SpectrumSettings::SpectrumType spectrum_type = input[0].getType();
 
-        if (spectrum_type == SpectrumSettings::PEAKS)
+        if (spectrum_type == SpectrumSettings::PEAKS && check_spectrum_type)
         {
           throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Centroided data provided but profile spectra expected.");
         }

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -169,6 +169,7 @@ namespace OpenMS
     registerStringOption_("write_ctd", "<out_dir>", "", "Writes the common tool description file(s) (Toolname(s).ctd) to <out_dir>", false, true);
     registerStringOption_("write_wsdl", "<file>", "", "Writes the default WSDL file", false, true);
     registerFlag_("no_progress", "Disables progress logging to command line", true);
+    registerFlag_("force", "Overwrite tool specific checks.", true);
     if (id_tag_support_)
     {
       registerStringOption_("id_pool", "<file>", "", String("ID pool file to DocumentID's for all generated output files. Disabled by default. (Set to 'main' to use ") + String() + id_tagger_.getPoolFile() + ")", false);

--- a/src/tests/class_tests/openms/data/PeakPickerHiRes_spectrum_selection.mzML
+++ b/src/tests/class_tests/openms/data/PeakPickerHiRes_spectrum_selection.mzML
@@ -214,7 +214,7 @@
 		<userParam name="mzml_id" type="xsd:string" value="LiSt20140228_H5M8_044_V12_Lysat_E1_R3"/>
 		<spectrumList count="16" defaultDataProcessingRef="dp_sp_0">
 			<spectrum id="controllerType=0 controllerNumber=1 scan=5529" index="0" defaultArrayLength="3238" dataProcessingRef="dp_sp_0">
-				<cvParam cvRef="MS" accession="MS:1000127" name="centroid spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" />
 				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
 				<cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" />
 				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />

--- a/src/tests/class_tests/openms/source/TOPPBase_test.cpp
+++ b/src/tests/class_tests/openms/source/TOPPBase_test.cpp
@@ -473,6 +473,7 @@ START_SECTION(([EXTRA]String getStringOption_(const String& name) const))
 	p2.setValue("TOPPBaseTest:1:debug",0,"Sets the debug level");
 	p2.setValue("TOPPBaseTest:1:threads",1, "Sets the number of threads allowed to be used by the TOPP tool");
 	p2.setValue("TOPPBaseTest:1:no_progress","false","Disables progress logging to command line");
+	p2.setValue("TOPPBaseTest:1:force","false","Overwrite tool specific checks.");
 	p2.setValue("TOPPBaseTest:1:test","false","Enables the test mode (needed for software testing only)");
 	//with restriction
   p2.setValue("TOPPBaseTest:1:stringlist2", ListUtils::create<String>("hopla,dude"),"stringlist with restrictions");

--- a/src/tests/topp/INIUpdater_1_noupdate.toppas
+++ b/src/tests/topp/INIUpdater_1_noupdate.toppas
@@ -34,6 +34,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+        <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
         <NODE name="algorithm" description="Algorithm section">
           <ITEM name="debug" value="false" type="string" description="When debug mode is activated, several files with intermediate results are written to the folder &apos;debug&apos; (do not use in parallel mode)." required="false" advanced="false" restrictions="true,false" />
@@ -115,6 +116,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+        <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
         <NODE name="feature" description="Additional options for featureXML input">
           <ITEM name="use_centroid_rt" value="false" type="string" description="Use the RT coordinates of the feature centroids for matching, instead of the RT ranges of the features/mass traces." required="false" advanced="false" restrictions="true,false" />
@@ -141,6 +143,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+        <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
         <NODE name="algorithm" description="Algorithm parameters section">
           <ITEM name="second_nearest_gap" value="2" type="double" description="The distance to the second nearest neighbors must be larger by this factor than the distance to the matching element itself." required="false" advanced="false" restrictions="1:" />

--- a/src/tests/topp/INIUpdater_3_old_out.toppas
+++ b/src/tests/topp/INIUpdater_3_old_out.toppas
@@ -26,14 +26,15 @@
       <ITEM name="x_pos" value="-140" type="double" description="" required="false" advanced="false" />
       <ITEM name="y_pos" value="-40" type="double" description="" required="false" advanced="false" />
       <NODE name="parameters" description="Instance &apos;1&apos; section for &apos;FeatureFinderCentroided&apos;">
-        <ITEM name="in" value="" type="input-file" description="input file" required="true" advanced="false"  supported_formats="*.mzML" />
-        <ITEM name="out" value="" type="output-file" description="output file" required="true" advanced="false"  supported_formats="*.featureXML" />
-        <ITEM name="seeds" value="" type="input-file" description="User specified seed list" required="false" advanced="false"  supported_formats="*.featureXML" />
+        <ITEM name="in" value="" type="input-file" description="input file" required="true" advanced="false" supported_formats="*.mzML" />
+        <ITEM name="out" value="" type="output-file" description="output file" required="true" advanced="false" supported_formats="*.featureXML" />
+        <ITEM name="seeds" value="" type="input-file" description="User specified seed list" required="false" advanced="false" supported_formats="*.featureXML" />
         <ITEM name="out_mzq" value="" type="output-file" description="Optional output file of MzQuantML." required="false" advanced="true" supported_formats="*.mzq" />
         <ITEM name="log" value="TOPP.log" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+        <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
         <NODE name="algorithm" description="Algorithm section">
           <ITEM name="debug" value="false" type="string" description="When debug mode is activated, several files with intermediate results are written to the folder &apos;debug&apos; (do not use in parallel mode)." required="false" advanced="false" restrictions="true,false" />
@@ -115,6 +116,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+        <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
         <NODE name="feature" description="Additional options for featureXML input">
           <ITEM name="use_centroid_rt" value="false" type="string" description="Use the RT coordinates of the feature centroids for matching, instead of the RT ranges of the features/mass traces." required="false" advanced="false" restrictions="true,false" />
@@ -141,6 +143,7 @@
         <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
         <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
         <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+        <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
         <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
         <NODE name="algorithm" description="Algorithm parameters section">
           <ITEM name="second_nearest_gap" value="2" type="double" description="The distance to the second nearest neighbors must be larger by this factor than the distance to the matching element itself." required="false" advanced="false" restrictions="1:" />

--- a/src/tests/topp/WRITE_INI_OUT.ini
+++ b/src/tests/topp/WRITE_INI_OUT.ini
@@ -10,6 +10,7 @@
       <ITEM name="debug" value="4" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">
         <ITEM name="signal_to_noise" value="1" type="double" description="Minimal signal to noise ratio for a peak to be picked." required="false" advanced="false" restrictions="0:" />
@@ -50,8 +51,8 @@
           <ITEM name="scaling" value="0.12" type="double" description="Initial scaling of the cwt used in the seperation of heavily overlapping peaks. The initial value is used for charge 1, for higher charges it is adapted to scaling/charge." required="false" advanced="true" restrictions="0:" />
           <NODE name="fitting" description="">
             <ITEM name="fwhm_threshold" value="0.7" type="double" description="If the fwhm of a peak is higher than fwhm_thresholds it is assumed that it consists of more than one peak and the deconvolution procedure is started." required="false" advanced="true" restrictions="0:" />
-            <ITEM name="eps_abs" value="9.99999974737875e-006" type="double" description="if the absolute error gets smaller than this value the fitting is stopped." required="false" advanced="true" restrictions="0:" />
-            <ITEM name="eps_rel" value="9.99999974737875e-006" type="double" description="if the relative error gets smaller than this value the fitting is stopped." required="false" advanced="true" restrictions="0:" />
+            <ITEM name="eps_abs" value="9.99999974737875e-06" type="double" description="if the absolute error gets smaller than this value the fitting is stopped." required="false" advanced="true" restrictions="0:" />
+            <ITEM name="eps_rel" value="9.99999974737875e-06" type="double" description="if the relative error gets smaller than this value the fitting is stopped." required="false" advanced="true" restrictions="0:" />
             <ITEM name="max_iteration" value="10" type="int" description="maximal number of iterations for the fitting step" required="false" advanced="true" restrictions="1:" />
             <NODE name="penalties" description="">
               <ITEM name="position" value="0" type="double" description="penalty term for the fitting of the peak position:If the position changes more than 0.5Da during the fitting it can be penalized as well as discrepancies of the peptide mass rule." required="false" advanced="true" restrictions="0:" />
@@ -70,7 +71,7 @@
           <ITEM name="bin_count" value="30" type="int" description="number of bins for intensity values" required="false" advanced="true" restrictions="3:" />
           <ITEM name="stdev_mp" value="3" type="double" description="multiplier for stdev" required="false" advanced="true" restrictions="0.01:999" />
           <ITEM name="min_required_elements" value="10" type="int" description="minimum number of elements required in a window (otherwise it is considered sparse)" required="false" advanced="true" restrictions="1:" />
-          <ITEM name="noise_for_empty_window" value="1e+020" type="double" description="noise value used for sparse windows" required="false" advanced="true" />
+          <ITEM name="noise_for_empty_window" value="1e+20" type="double" description="noise value used for sparse windows" required="false" advanced="true" />
         </NODE>
       </NODE>
     </NODE>

--- a/src/tests/topp/WSDL_out.wsdl
+++ b/src/tests/topp/WSDL_out.wsdl
@@ -91,6 +91,17 @@
                 </xs:restriction>
               </xs:simpleType>
             </xs:element>
+            <xs:element name="force" default="false">
+              <xs:annotation>
+                <xs:documentation>Overwrite tool specific checks.</xs:documentation>
+              </xs:annotation>
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="true"/>
+                  <xs:enumeration value="false"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:element>
             <xs:element name="test" default="false">
               <xs:annotation>
                 <xs:documentation>Enables the test mode (needed for internal use only)</xs:documentation>

--- a/src/topp/FeatureFinderCentroided.cpp
+++ b/src/topp/FeatureFinderCentroided.cpp
@@ -196,7 +196,10 @@ protected:
 
     if (spectrum_type == SpectrumSettings::RAWDATA)
     {
-      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected.");
+      if (!getFlag_("force"))
+      {
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected.");
+      }
     }
 
     //load seeds

--- a/src/topp/FeatureFinderCentroided.cpp
+++ b/src/topp/FeatureFinderCentroided.cpp
@@ -173,7 +173,6 @@ protected:
     String out = getStringOption_("out");
     String out_mzq = getStringOption_("out_mzq");
 
-
     //prevent loading of fragment spectra
     PeakFileOptions options;
     options.setMSLevels(vector<Int>(1, 1));
@@ -186,6 +185,19 @@ protected:
     PeakMap exp;
     f.load(in, exp);
     exp.updateRanges();
+
+    if (exp.getSpectra().empty())
+    {
+      throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: No MS1 spectra in input file.");
+    }
+
+    // determine type of spectral data (profile or centroided)
+    SpectrumSettings::SpectrumType  spectrum_type = exp[0].getType();
+
+    if (spectrum_type == SpectrumSettings::RAWDATA)
+    {
+      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected.");
+    }
 
     //load seeds
     FeatureMap seeds;

--- a/src/topp/FeatureFinderCentroided.cpp
+++ b/src/topp/FeatureFinderCentroided.cpp
@@ -198,7 +198,7 @@ protected:
     {
       if (!getFlag_("force"))
       {
-        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected.");
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected. To enforce processing of the data set the -force flag.");
       }
     }
 

--- a/src/topp/FeatureFinderMetabo.cpp
+++ b/src/topp/FeatureFinderMetabo.cpp
@@ -179,7 +179,7 @@ protected:
     {
       if (!getFlag_("force"))
       {
-        throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected.");
+        throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected. To enforce processing of the data set the -force flag.");
       }
     }
 

--- a/src/topp/FeatureFinderMetabo.cpp
+++ b/src/topp/FeatureFinderMetabo.cpp
@@ -177,7 +177,10 @@ protected:
 
     if (spectrum_type == SpectrumSettings::RAWDATA)
     {
-      throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected.");
+      if (!getFlag_("force"))
+      {
+        throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected.");
+      }
     }
 
     // make sure the spectra are sorted by m/z

--- a/src/topp/FeatureFinderMetabo.cpp
+++ b/src/topp/FeatureFinderMetabo.cpp
@@ -162,7 +162,7 @@ protected:
     mz_data_file.setLogType(log_type_);
     MSExperiment<Peak1D> ms_peakmap;
     std::vector<Int> ms_level(1, 1);
-    (mz_data_file.getOptions()).setMSLevels(ms_level);
+    mz_data_file.getOptions().setMSLevels(ms_level);
     mz_data_file.load(in, ms_peakmap);
 
     if (ms_peakmap.empty())
@@ -170,6 +170,14 @@ protected:
       LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
+    }
+
+    // determine type of spectral data (profile or centroided)
+    SpectrumSettings::SpectrumType spectrum_type = ms_peakmap[0].getType();
+
+    if (spectrum_type == SpectrumSettings::RAWDATA)
+    {
+      throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided spectra expected.");
     }
 
     // make sure the spectra are sorted by m/z

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -1224,6 +1224,11 @@ private:
     file.setLogType(log_type_);
     file.load(in_, exp);
 
+    if (exp.getSpectra().empty())
+    {
+      throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: No MS1 spectra in input file.");
+    }
+
     // update m/z and RT ranges
     exp.updateRanges();
 
@@ -1231,7 +1236,13 @@ private:
     exp.sortSpectra();
 
     // determine type of spectral data (profile or centroided)
-    bool centroided = (PeakTypeEstimator().estimateType(exp[0].begin(), exp[0].end()) == SpectrumSettings::PEAKS);
+    SpectrumSettings::SpectrumType spectrum_type = exp[0].getType();
+    if (spectrum_type == SpectrumSettings::UNKNOWN)
+    {
+      spectrum_type = PeakTypeEstimator().estimateType(exp[0].begin(), exp[0].end());
+    }
+
+    bool centroided = spectrum_type == SpectrumSettings::PEAKS;
 
     /**
      * pick peaks
@@ -1239,6 +1250,7 @@ private:
     MSExperiment<Peak1D> exp_picked;
     std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > boundaries_exp_s; // peak boundaries for spectra
     std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > boundaries_exp_c; // peak boundaries for chromatograms
+
     if (!centroided)
     {
       PeakPickerHiRes picker;

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -300,7 +300,10 @@ protected:
 
       if (spectrum_type == SpectrumSettings::RAWDATA)
       {
-        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+        if (!getFlag_("force"))
+        {
+          throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+        }
       }
 
       for (PeakMap::iterator it = exp.begin(); it != exp.end(); ++it)

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -302,7 +302,7 @@ protected:
       {
         if (!getFlag_("force"))
         {
-          throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+          throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected. To enforce processing of the data set the -force flag.");
         }
       }
 

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -290,6 +290,19 @@ protected:
       f.getOptions().addMSLevel(2);
       f.load(exp_name, exp);
 
+      if (exp.getSpectra().empty())
+      {
+        throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: No MS2 spectra in input file.");
+      }
+
+      // determine type of spectral data (profile or centroided)
+      SpectrumSettings::SpectrumType spectrum_type = exp[0].getType();
+
+      if (spectrum_type == SpectrumSettings::RAWDATA)
+      {
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+      }
+
       for (PeakMap::iterator it = exp.begin(); it != exp.end(); ++it)
       {
         String id = it->getNativeID(); // expected format: "... scan=#"

--- a/src/topp/MascotAdapterOnline.cpp
+++ b/src/topp/MascotAdapterOnline.cpp
@@ -168,6 +168,19 @@ protected:
     fh.loadExperiment(in, exp, in_type, log_type_);
     writeDebug_(String("Spectra loaded: ") + exp.size(), 2);
 
+    if (exp.getSpectra().empty())
+    {
+      throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: No MS2 spectra in input file.");
+    }
+
+    // determine type of spectral data (profile or centroided)
+    SpectrumSettings::SpectrumType spectrum_type = exp[0].getType();
+
+    if (spectrum_type == SpectrumSettings::RAWDATA)
+    {
+      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+    }
+
     //-------------------------------------------------------------
     // calculations
     //-------------------------------------------------------------

--- a/src/topp/MascotAdapterOnline.cpp
+++ b/src/topp/MascotAdapterOnline.cpp
@@ -178,7 +178,10 @@ protected:
 
     if (spectrum_type == SpectrumSettings::RAWDATA)
     {
-      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+      if (!getFlag_("force"))
+      {
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+      }
     }
 
     //-------------------------------------------------------------

--- a/src/topp/MascotAdapterOnline.cpp
+++ b/src/topp/MascotAdapterOnline.cpp
@@ -180,7 +180,7 @@ protected:
     {
       if (!getFlag_("force"))
       {
-        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected. To enforce processing of the data set the -force flag.");
       }
     }
 

--- a/src/topp/OMSSAAdapter.cpp
+++ b/src/topp/OMSSAAdapter.cpp
@@ -764,6 +764,19 @@ protected:
       ms2_spec_count = map.size();
       writeDebug_("Read " + String(ms2_spec_count) + " spectra from file", 5);
 
+      if (map.getSpectra().empty())
+      {
+        throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: No MS2 spectra in input file.");
+      }
+
+      // determine type of spectral data (profile or centroided)
+      SpectrumSettings::SpectrumType spectrum_type = map[0].getType();
+
+      if (spectrum_type == SpectrumSettings::RAWDATA)
+      {
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+      }
+
       int chunk(0);
       int chunk_size(getIntOption_("chunk_size"));
       if (chunk_size <= 0)

--- a/src/topp/OMSSAAdapter.cpp
+++ b/src/topp/OMSSAAdapter.cpp
@@ -774,7 +774,10 @@ protected:
 
       if (spectrum_type == SpectrumSettings::RAWDATA)
       {
-        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+        if (!getFlag_("force"))
+        {
+          throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+        }
       }
 
       int chunk(0);

--- a/src/topp/OMSSAAdapter.cpp
+++ b/src/topp/OMSSAAdapter.cpp
@@ -776,7 +776,7 @@ protected:
       {
         if (!getFlag_("force"))
         {
-          throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+          throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected. To enforce processing of the data set the -force flag.");
         }
       }
 

--- a/src/topp/PeakPickerHiRes.cpp
+++ b/src/topp/PeakPickerHiRes.cpp
@@ -231,12 +231,6 @@ protected:
       return INCOMPATIBLE_INPUT_DATA;
     }
 
-    //check for peak type (profile data required)
-    if (!ms_exp_raw.empty() && PeakTypeEstimator().estimateType(ms_exp_raw[0].begin(), ms_exp_raw[0].end()) == SpectrumSettings::PEAKS)
-    {
-      writeLog_("Warning: OpenMS peak type estimation indicates that this is not profile data!");
-    }
-
     //check if spectra are sorted
     for (Size i = 0; i < ms_exp_raw.size(); ++i)
     {
@@ -257,12 +251,12 @@ protected:
       }
     }
 
-
     //-------------------------------------------------------------
     // pick
     //-------------------------------------------------------------
     MSExperiment<> ms_exp_peaks;
-    pp.pickExperiment(ms_exp_raw, ms_exp_peaks);
+    bool check_spectrum_type = !getFlag_("force");
+    pp.pickExperiment(ms_exp_raw, ms_exp_peaks, check_spectrum_type);
 
     //-------------------------------------------------------------
     // writing output

--- a/src/topp/PeakPickerHiRes.cpp
+++ b/src/topp/PeakPickerHiRes.cpp
@@ -90,6 +90,9 @@ using namespace std;
 
   For the parameters of the algorithm section see the algorithm documentation: @ref OpenMS::PeakPickerHiRes "PeakPickerHiRes"
 
+  Be aware that applying the algorithm to already picked data results in an error message and program exit or corrupted output data.
+  Advanced users may skip the check for already centroided data using the flag "-force" (useful e.g. if spectrum annotations in the data files are wrong).
+
   In the following table you, can find example values of the most important algorithm parameters for
   different instrument types. @n These parameters are not valid for all instruments of that type,
   but can be used as a starting point for finding suitable parameters.

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -246,6 +246,19 @@ protected:
     mzml_file.setLogType(log_type_);
     mzml_file.load(inputfile_name, exp);
 
+    if (exp.getSpectra().empty())
+    {
+      throw OpenMS::Exception::FileEmpty(__FILE__, __LINE__, __FUNCTION__, "Error: No MS2 spectra in input file.");
+    }
+
+    // determine type of spectral data (profile or centroided)
+    SpectrumSettings::SpectrumType spectrum_type = exp[0].getType();
+
+    if (spectrum_type == SpectrumSettings::RAWDATA)
+    {
+      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+    }
+
     // we need to replace the native id with a simple numbering schema, to be able to
     // map the IDs back to the spectra (RT, and MZ information)
     Size native_id(0);

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -256,7 +256,10 @@ protected:
 
     if (spectrum_type == SpectrumSettings::RAWDATA)
     {
-      throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+      if (!getFlag_("force"))
+      {
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+      }
     }
 
     // we need to replace the native id with a simple numbering schema, to be able to

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -258,7 +258,7 @@ protected:
     {
       if (!getFlag_("force"))
       {
-        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected.");
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected. To enforce processing of the data set the -force flag.");
       }
     }
 


### PR DESCRIPTION
Selected tools now throw an exception in the case an unexpected spectrum type is encountered (e.g. picked spectrum in HighResPeakPicker or profile spectrum in FeatureFinderCentroided). If the spectrum type is UNKNOWN, behavior is as before. This should allow to detect many otherwise hard to discover configuration errors that resulted in pipelines running through but producing results that were inferior (e.g. no ids). In other cases pipelines crashed because of extensive memory consumption.
To be conservative, no additional attempts to deduce spectrum type (e.g. from DataProcessing information or by PeakTypeEstimator is done). 