### PR TITLE
[FIX] fix for the write out of mzid

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -614,12 +614,12 @@ namespace OpenMS
           sid = String(it->getMetaValue("spectrum_id"));
           if (sid.empty())
           {
-            if (emz.empty())
+              if (it->getMZ() != it->getMZ())
             {
               emz = "nan";
               LOG_WARN << "Found no spectrum reference and no mz position of identified spectrum! You are probabliy converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
             }
-            if (ert.empty())
+            if (it->getRT() != it->getRT())
             {
               ert = "nan";
               LOG_WARN << "Found no spectrum reference and no RT position of identified spectrum! You are probabliy converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -614,6 +614,16 @@ namespace OpenMS
           sid = String(it->getMetaValue("spectrum_id"));
           if (sid.empty())
           {
+            if (emz.empty())
+            {
+              emz = "nan";
+              LOG_WARN << "Found no spectrum reference and no mz position of identified spectrum! You are probabliy converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
+            }
+            if (ert.empty())
+            {
+              ert = "nan";
+              LOG_WARN << "Found no spectrum reference and no RT position of identified spectrum! You are probabliy converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
+            }
             sid = String("MZ:") + emz + String("@RT:") + ert;
           }
         }


### PR DESCRIPTION
this considers conversion from old id formats with insufficient data provision 
- nan value for spectrumreferenceid now equal on all platforms (fixing TOPP_IDFileConverter_9_out1 fail on win8-VS10_)
- added warning if such replacement is necessary