### PR TITLE
[TEST] fix test

### DIFF
--- a/src/tests/class_tests/openms/source/IndexedMzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/IndexedMzMLFile_test.cpp
@@ -220,9 +220,11 @@ START_SECTION(([EXTRA] load broken file))
     //
     // This code path is hard to test on other machines but one can cast the
     // indexoffset variable to int to trigger this behavior 
-    TEST_EXCEPTION_WITH_MESSAGE (Exception::ConversionError, 
-      new IndexedMzMLFile(OPENMS_GET_TEST_DATA_PATH("IndexedmzMLFile_3_broken.mzML")), 
-      "Could not convert string '9223372036854775807' to an integer on your system." )
+
+    // Apparently this does not do what I thought it would on a 32 bit system
+    // TEST_EXCEPTION_WITH_MESSAGE (Exception::ConversionError, 
+    //   new IndexedMzMLFile(OPENMS_GET_TEST_DATA_PATH("IndexedmzMLFile_3_broken.mzML")), 
+    //   "Could not convert string '9223372036854775807' to an integer on your system." )
   }
 }
 END_SECTION


### PR DESCRIPTION
- comment out test that doesnt really do what we want
- apparently it is not that easy to test the overflow of the position on
  32 bit systems

disable test, I thought I was testing something for 32 bit systems but when I run it actually on a 32 bit system, it fails. Well so much for testing stuff on 64 bit systems and trying to be smart