### PR TITLE
[TEST] fix

### DIFF
--- a/src/tests/class_tests/openms/source/IndexedMzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/IndexedMzMLFile_test.cpp
@@ -207,24 +207,27 @@ START_SECTION(([EXTRA] load broken file))
   // Contains an value (2^63-1) in the indexListOffset field that should not
   // trigger an exception - however parsing will fail since the file is
   // actually shorter.
-  if (sizeof(std::streamsize)*8 > 32 )
+  if (sizeof(std::streampos)*8 > 32 )
   {
     IndexedMzMLFile file(OPENMS_GET_TEST_DATA_PATH("IndexedmzMLFile_3_broken.mzML"));
     TEST_EQUAL(file.getParsingSuccess(), false)
   }
   else
   {
-    // Most likely a 32 bit system, the value in the indexListOffset (2^63-1)
-    // will not fit into std::streampos -> this should throw an exception in
-    // the constructor.
+    // 
+    // On systems that use 32 bit or less to represent std::streampos, we
+    // cannot fit our value in the indexListOffset (2^63-1) into std::streampos
+    // -> this should throw an exception in the constructor which can test here
+    // instead when loading the file.
     //
-    // This code path is hard to test on other machines but one can cast the
-    // indexoffset variable to int to trigger this behavior 
-
-    // Apparently this does not do what I thought it would on a 32 bit system
-    // TEST_EXCEPTION_WITH_MESSAGE (Exception::ConversionError, 
-    //   new IndexedMzMLFile(OPENMS_GET_TEST_DATA_PATH("IndexedmzMLFile_3_broken.mzML")), 
-    //   "Could not convert string '9223372036854775807' to an integer on your system." )
+    // This code path is hard to test on most machines since almost all modern
+    // compilers and filesystems support file access for files > 2 GB 
+    // Manually, one can cast the indexoffset variable to int to trigger this
+    // behavior in IndexedMzMLDecoder.cpp
+    // 
+    TEST_EXCEPTION_WITH_MESSAGE (Exception::ConversionError, 
+      new IndexedMzMLFile(OPENMS_GET_TEST_DATA_PATH("IndexedmzMLFile_3_broken.mzML")), 
+      "Could not convert string '9223372036854775807' to an integer on your system." )
   }
 }
 END_SECTION


### PR DESCRIPTION
fixes IndexedMzMLFile test by testing the size of streampos instead of streamsize

fixes the issue on my 32 bit machine (still does not test the code path)