### PR TITLE
Fix/lp wrapper param file

### DIFF
--- a/src/tests/class_tests/openms/data/LPWrapper_test.mps
+++ b/src/tests/class_tests/openms/data/LPWrapper_test.mps
@@ -5,7 +5,6 @@ ROWS
  L  Const_2 
  L  Const_3 
 COLUMNS
-    MARK0000  'MARKER'                 'INTORG'
     y         OBJROW                          1
     y         Const_1                         1
     y         Const_2                         2
@@ -13,11 +12,10 @@ COLUMNS
     x         Const_1                        -1
     x         Const_2                         3
     x         Const_3                         2
-    MARK0001  'MARKER'                 'INTEND'
 RHS
     rhs       Const_2                        12
     rhs       Const_3                        12
 BOUNDS
- LI bnd       y         0
- LI bnd       x         0
+ BV BOUND       y
+ BV BOUND       x
 ENDATA

--- a/src/tests/class_tests/openms/data/LPWrapper_test_integer.mps
+++ b/src/tests/class_tests/openms/data/LPWrapper_test_integer.mps
@@ -1,0 +1,25 @@
+NAME          LPWrapper_test.lp
+ROWS
+ N  OBJROW  
+ L  Const_1 
+ L  Const_2 
+ L  Const_3 
+COLUMNS
+    MARK0000  'MARKER'                 'INTORG'
+    y         OBJROW                          1
+    y         Const_1                         1
+    y         Const_2                         2
+    y         Const_3                         3
+    x         Const_1                        -1
+    x         Const_2                         3
+    x         Const_3                         2
+    MARK0001  'MARKER'                 'INTEND'
+RHS
+    rhs       Const_2                        12
+    rhs       Const_3                        12
+BOUNDS
+ LI BOUND       y       0
+ LI BOUND       x       0
+ UI BOUND       y       5
+ UI BOUND       x       5
+ENDATA

--- a/src/tests/class_tests/openms/source/LPWrapper_test.cpp
+++ b/src/tests/class_tests/openms/source/LPWrapper_test.cpp
@@ -358,6 +358,13 @@ START_SECTION((Int solve(SolverParam &solver_param, const Size verbose_level=0))
   lp2.solve(param);
   TEST_EQUAL(lp2.getColumnValue(0),1)
   TEST_EQUAL(lp2.getColumnValue(1),1)
+
+  // Test an integer problem
+  lp2.readProblem(OPENMS_GET_TEST_DATA_PATH("LPWrapper_test_integer.mps"),"MPS");
+  lp2.setObjectiveSense(LPWrapper::MAX);
+  lp2.solve(param);
+  TEST_EQUAL(lp2.getColumnValue(0),2)
+  TEST_EQUAL(lp2.getColumnValue(1),2)
 }
 END_SECTION
 


### PR DESCRIPTION
fixes #1200 and addresses the issue in #1030 

this PR now creates two MPS files, one clearly containing a binary problem and one clearly containing the integer problem. It solves both and checks that the results are correct (at least I expect them to be correct, I did not actually calculate it on pen and paper)