### PR TITLE
[FIX] consistent use of wildmagic: TransformationModelLinear

### DIFF
--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModelLinear.cpp
@@ -34,8 +34,8 @@
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
 
-#include <WildMagic/Wm5Vector2.h>
-#include <WildMagic/Wm5ApprLineFit2.h>
+#include <Wm5Vector2.h>
+#include <Wm5ApprLineFit2.h>
 
 namespace OpenMS
 {


### PR DESCRIPTION
In #1098, TransformationModelLinear seems to have been forgotten to be reverted to the fixed WildMagic include conventions.