### PR TITLE
[DOC] merged License.txt and LICENSE for more complete description

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,5 +1,32 @@
-OpenMS is released under a 3 clause BSD license.
-The respective license file can be found in the LICENSE file 
+--------------------------------------------------------------------------
+                  OpenMS -- Open-Source Mass Spectrometry
+--------------------------------------------------------------------------
+Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+ETH Zurich, and Freie Universitaet Berlin 2002-2015.
+
+This software is released under a three-clause BSD license:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of any author or any participating institution
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+For a full list of authors, refer to the file AUTHORS.
+--------------------------------------------------------------------------
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 The source code of OpenMS is available via our homepage http://www.OpenMS.de
 
 OpenMS depends on third party libraries which are listed below.


### PR DESCRIPTION
see #1214. Added the content of LICENSE to License.txt (shown while installing). But we keep LICENSE for Linux packages.
