### PR TITLE
Added Deuterium and Tritium to Elements.xml, as LIPIDMAPS contains sum f...

### DIFF
--- a/share/OpenMS/CHEMISTRY/Elements.xml
+++ b/share/OpenMS/CHEMISTRY/Elements.xml
@@ -20,6 +20,28 @@
         </NODE>
       </NODE>
     </NODE>    
+    <NODE name="Deuterium">
+      <ITEM name="Name" value="Deuterium" type="string" />
+      <ITEM name="Symbol" value="D" type="string" />
+      <ITEM name="AtomicNumber" value="1" type="int" />
+      <NODE name="Isotopes">
+        <NODE name="1">
+          <ITEM name="RelativeAbundance" value="1" type="float" />
+          <ITEM name="AtomicMass" value="2.01410178" type="float" />
+        </NODE>
+      </NODE>
+    </NODE>    
+    <NODE name="Tritium">
+      <ITEM name="Name" value="Tritium" type="string" />
+      <ITEM name="Symbol" value="T" type="string" />
+      <ITEM name="AtomicNumber" value="1" type="int" />
+      <NODE name="Isotopes">
+        <NODE name="1">
+          <ITEM name="RelativeAbundance" value="1" type="float" />
+          <ITEM name="AtomicMass" value="3.01604927" type="float" />
+        </NODE>
+      </NODE>
+    </NODE>    
     <NODE name="Helium">
       <ITEM name="Name" value="Helium" type="string"/>
       <ITEM name="Symbol" value="He" type="string"/>

--- a/share/OpenMS/CHEMISTRY/Elements.xml
+++ b/share/OpenMS/CHEMISTRY/Elements.xml
@@ -26,7 +26,7 @@
       <ITEM name="AtomicNumber" value="1" type="int" />
       <NODE name="Isotopes">
         <NODE name="1">
-          <ITEM name="RelativeAbundance" value="1" type="float" />
+          <ITEM name="RelativeAbundance" value="100.0" type="float" />
           <ITEM name="AtomicMass" value="2.01410178" type="float" />
         </NODE>
       </NODE>
@@ -37,7 +37,7 @@
       <ITEM name="AtomicNumber" value="1" type="int" />
       <NODE name="Isotopes">
         <NODE name="1">
-          <ITEM name="RelativeAbundance" value="1" type="float" />
+          <ITEM name="RelativeAbundance" value="100.0" type="float" />
           <ITEM name="AtomicMass" value="3.01604927" type="float" />
         </NODE>
       </NODE>


### PR DESCRIPTION
...ormulas with these isotopes using their abbreviations (D and T). AMS crashed because "D" was not supported as element. Critical fix for me, as I need AccurateMassSearch using LIPID MAPS, and we also have to expect ppl to sometimes use D or T in their sum formulas.

All tests passed, with the exception of   474 - TwoDOptimization_test