### PR TITLE
[FIX] IsobaricAnalyzer: set charge states of consensus features

### DIFF
--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
@@ -545,7 +545,7 @@ namespace OpenMS
         }
 
         // check featureHandles are not empty
-        if (!(overall_intensity > 0))
+        if (overall_intensity <= 0)
         {
           cf.setMetaValue("all_empty", String("true"));
         }
@@ -557,10 +557,10 @@ namespace OpenMS
 
         // embed the id of the scan from which the quantitative information was extracted
         cf.setMetaValue("scan_id", it->getNativeID());
-        // .. as well as additional meta information
+        // ...as well as additional meta information
         cf.setMetaValue("precursor_intensity", it->getPrecursors()[0].getIntensity());
-        cf.setMetaValue("precursor_charge", it->getPrecursors()[0].getCharge());
 
+        cf.setCharge(it->getPrecursors()[0].getCharge());
         cf.setIntensity(overall_intensity);
         consensus_map.push_back(cf);
 

--- a/src/tests/class_tests/openms/source/IsobaricChannelExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/IsobaricChannelExtractor_test.cpp
@@ -161,7 +161,7 @@ START_SECTION((void extractChannels(const MSExperiment<Peak1D>&ms_exp_data, Cons
     TEST_EQUAL(cm_out[0].size(), 4)
     TEST_EQUAL(cm_out[0].getMetaValue("scan_id"), "controllerType=0 controllerNumber=1 scan=2")
     TEST_REAL_SIMILAR(cm_out[0].getMetaValue("precursor_intensity"), 5251952.5)
-    TEST_REAL_SIMILAR(cm_out[0].getMetaValue("precursor_charge"), 2)
+    TEST_EQUAL(cm_out[0].getCharge(), 2)
     TEST_REAL_SIMILAR(cm_out[0].getIntensity(), 1490501.21)
     cf_it = cm_out[0].begin();
     TEST_REAL_SIMILAR(cf_it->getIntensity(), 643005.56)
@@ -178,7 +178,7 @@ START_SECTION((void extractChannels(const MSExperiment<Peak1D>&ms_exp_data, Cons
     TEST_EQUAL(cm_out[1].size(), 4)
     TEST_EQUAL(cm_out[1].getMetaValue("scan_id"), "controllerType=0 controllerNumber=1 scan=4")
     TEST_REAL_SIMILAR(cm_out[1].getMetaValue("precursor_intensity"), 7365030)
-    TEST_REAL_SIMILAR(cm_out[1].getMetaValue("precursor_charge"), 3)
+    TEST_EQUAL(cm_out[1].getCharge(), 3)
     TEST_REAL_SIMILAR(cm_out[1].getIntensity(), 2358063.25)
     cf_it = cm_out[1].begin();
     TEST_REAL_SIMILAR(cf_it->getIntensity(), 851248.38)
@@ -194,7 +194,7 @@ START_SECTION((void extractChannels(const MSExperiment<Peak1D>&ms_exp_data, Cons
     TEST_EQUAL(cm_out[2].size(), 4)
     TEST_EQUAL(cm_out[2].getMetaValue("scan_id"), "controllerType=0 controllerNumber=1 scan=6")
     TEST_REAL_SIMILAR(cm_out[2].getMetaValue("precursor_intensity"), 6835636)
-    TEST_REAL_SIMILAR(cm_out[2].getMetaValue("precursor_charge"), 3)
+    TEST_EQUAL(cm_out[2].getCharge(), 3)
     TEST_REAL_SIMILAR(cm_out[2].getIntensity(), 2623415.33)
     cf_it = cm_out[2].begin();
     TEST_REAL_SIMILAR(cf_it->getIntensity(), 898583.7)
@@ -210,7 +210,7 @@ START_SECTION((void extractChannels(const MSExperiment<Peak1D>&ms_exp_data, Cons
     TEST_EQUAL(cm_out[3].size(), 4)
     TEST_EQUAL(cm_out[3].getMetaValue("scan_id"), "controllerType=0 controllerNumber=1 scan=8")
     TEST_REAL_SIMILAR(cm_out[3].getMetaValue("precursor_intensity"), 6762358)
-    TEST_REAL_SIMILAR(cm_out[3].getMetaValue("precursor_charge"), 3)
+    TEST_EQUAL(cm_out[3].getCharge(), 3)
     TEST_REAL_SIMILAR(cm_out[3].getIntensity(), 1692679.37)
     cf_it = cm_out[3].begin();
     TEST_REAL_SIMILAR(cf_it->getIntensity(), 593009)
@@ -226,7 +226,7 @@ START_SECTION((void extractChannels(const MSExperiment<Peak1D>&ms_exp_data, Cons
     TEST_EQUAL(cm_out[4].size(), 4)
     TEST_EQUAL(cm_out[4].getMetaValue("scan_id"), "controllerType=0 controllerNumber=1 scan=10")
     TEST_REAL_SIMILAR(cm_out[4].getMetaValue("precursor_intensity"), 5464634.5)
-    TEST_REAL_SIMILAR(cm_out[4].getMetaValue("precursor_charge"), 2)
+    TEST_EQUAL(cm_out[4].getCharge(), 2)
     TEST_REAL_SIMILAR(cm_out[4].getIntensity(), 1746368)
     cf_it = cm_out[4].begin();
     TEST_REAL_SIMILAR(cf_it->getIntensity(), 648863)

--- a/src/tests/topp/IsobaricAnalyzer_output_1.consensusXML
+++ b/src/tests/topp/IsobaricAnalyzer_output_1.consensusXML
@@ -35,7 +35,7 @@
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_16627578304933075941" quality="0">
+		<consensusElement id="e_16627578304933075941" quality="0" charge="2">
 			<centroid rt="3611.09208" mz="769.393789466471" it="1.50524e+06"/>
 			<groupedElementList>
 				<element map="0" id="0" rt="3611.09208" mz="114.1112" it="682505"/>
@@ -46,9 +46,8 @@
 			<userParam type="float" name="precursor_purity" value="1"/>
 			<userParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=2"/>
 			<userParam type="float" name="precursor_intensity" value="5251952.5"/>
-			<userParam type="int" name="precursor_charge" value="2"/>
 		</consensusElement>
-		<consensusElement id="e_13229490167902618598" quality="0">
+		<consensusElement id="e_13229490167902618598" quality="0" charge="3">
 			<centroid rt="3611.39772" mz="421.558584883603" it="2.37883e+06"/>
 			<groupedElementList>
 				<element map="0" id="1" rt="3611.39772" mz="114.1112" it="897312"/>
@@ -59,9 +58,8 @@
 			<userParam type="float" name="precursor_purity" value="0.692433623198553"/>
 			<userParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=4"/>
 			<userParam type="float" name="precursor_intensity" value="7365030"/>
-			<userParam type="int" name="precursor_charge" value="3"/>
 		</consensusElement>
-		<consensusElement id="e_5024549519481199379" quality="0">
+		<consensusElement id="e_5024549519481199379" quality="0" charge="3">
 			<centroid rt="3611.7015" mz="447.907085078449" it="2.64587e+06"/>
 			<groupedElementList>
 				<element map="0" id="2" rt="3611.7015" mz="114.1112" it="946024"/>
@@ -72,9 +70,8 @@
 			<userParam type="float" name="precursor_purity" value="0.824560653224408"/>
 			<userParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=6"/>
 			<userParam type="float" name="precursor_intensity" value="6835636"/>
-			<userParam type="int" name="precursor_charge" value="3"/>
 		</consensusElement>
-		<consensusElement id="e_6211693768620736135" quality="0">
+		<consensusElement id="e_6211693768620736135" quality="0" charge="3">
 			<centroid rt="3612.0051" mz="407.579288484896" it="1.70608e+06"/>
 			<groupedElementList>
 				<element map="0" id="3" rt="3612.0051" mz="114.1112" it="623919"/>
@@ -85,9 +82,8 @@
 			<userParam type="float" name="precursor_purity" value="0.731295499808224"/>
 			<userParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=8"/>
 			<userParam type="float" name="precursor_intensity" value="6762358"/>
-			<userParam type="int" name="precursor_charge" value="3"/>
 		</consensusElement>
-		<consensusElement id="e_2727934422266510952" quality="0">
+		<consensusElement id="e_2727934422266510952" quality="0" charge="2">
 			<centroid rt="3612.31176" mz="748.901794746371" it="1.76225e+06"/>
 			<groupedElementList>
 				<element map="0" id="4" rt="3612.31176" mz="114.1112" it="684796"/>
@@ -98,7 +94,6 @@
 			<userParam type="float" name="precursor_purity" value="1"/>
 			<userParam type="string" name="scan_id" value="controllerType=0 controllerNumber=1 scan=10"/>
 			<userParam type="float" name="precursor_intensity" value="5464634.5"/>
-			<userParam type="int" name="precursor_charge" value="2"/>
 		</consensusElement>
 	</consensusElementList>
 </consensusXML>


### PR DESCRIPTION
Previously, IsobaricAnalyzer did not set the charge states of the consensus features it produced, but it stored the precursor charges as meta values ("precursor_charge"). However, since the centroid position (RT, m/z) of a consensus feature was already chosen to be the precursor position, it makes sense to also set the charge state to the precursor charge (and dispense with the meta value). This makes it possible to keep track of the charge information e.g. when using TextExporter, which is useful for post-processing.