### PR TITLE
IDFilter reports empty results

### DIFF
--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -210,7 +210,7 @@ protected:
 
     registerTOPPSubsection_("mz", "Filtering by mz");
     registerDoubleOption_("mz:error", "<float>", -1, "Filtering by deviation to theoretical mass (disabled for negative values).", false);
-    registerStringOption_("mz:unit", "<String>", "ppm", "Absolute or relativ error.", false);
+    registerStringOption_("mz:unit", "<String>", "ppm", "Absolute or relative error.", false);
     setValidStrings_("mz:unit", ListUtils::create<String>("Da,ppm"));
 
     registerTOPPSubsection_("best", "Filtering best hits per spectrum (for peptides) or from proteins");
@@ -385,7 +385,7 @@ protected:
     }
 
     // Filtering peptide identification according to set criteria
-    for (Size i = 0; i < identifications.size(); i++)
+    for (Size i = 0; i < identifications.size(); ++i)
     {
       if (unique_per_protein)
       {
@@ -395,9 +395,10 @@ protected:
         {
           if (!it->metaValueExists("protein_references"))
           {
-            writeLog_("IDFilter: Warning, filtering with 'unique_per_protein' can only be done after indexing the file with 'PeptideIndexer' first.");
+            LOG_ERROR << "Error: Filtering with 'unique_per_protein' can only be done after indexing the file with 'PeptideIndexer'." << std::endl;
+            return INCOMPATIBLE_INPUT_DATA;
           }
-          if (it->metaValueExists("protein_references") && (String)it->getMetaValue("protein_references") == "unique")
+          else if ((String)it->getMetaValue("protein_references") == "unique")
           {
             hits.push_back(*it);
           }
@@ -634,6 +635,7 @@ protected:
     if (filtered_protein_identifications.size() == 0) LOG_INFO << "0 / 0";
     else LOG_INFO << filtered_protein_identifications[0].getHits().size() << " / " << protein_identifications[0].getHits().size();
     LOG_INFO << std::endl;
+    
     //-------------------------------------------------------------
     // writing output
     //-------------------------------------------------------------


### PR DESCRIPTION
if used as filter for uniqueness without the input having been run through 'PeptideIndexer'.
All you get is:
IDFilter: Warning, filtering with 'unique_per_protein' can only be done after indexing the file with 'PeptideIndexer' first.
This can be easily overlooked.

Elevated warning to Error.

@lars20070 : can you check if this fixes your issue?