### PR TITLE
IsobaricAnalyzer: documentation, warning fix

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.h
@@ -96,14 +96,14 @@ private:
       @brief Small struct to capture the current state of the purity computation.
 
       It basically contains two iterators pointing to the current potential
-      ms1 precursor scan of an ms2 scan and the ms1 scan immediately
-      following the current ms2 scan.
+      MS1 precursor scan of an MS2 scan and the MS1 scan immediately
+      following the current MS2 scan.
     */
     struct PuritySate_
     {
-      /// Iterator pointing to the potential ms1 precursor scan
+      /// Iterator pointing to the potential MS1 precursor scan
       MSExperiment<Peak1D>::ConstIterator precursorScan;
-      /// Iterator pointing to the potential follow up ms1 scan
+      /// Iterator pointing to the potential follow up MS1 scan
       MSExperiment<Peak1D>::ConstIterator followUpScan;
 
       /// Indicates if a follow up scan was found
@@ -119,7 +119,7 @@ private:
       PuritySate_(const MSExperiment<>& targetExp);
 
       /**
-        @brief Searches the experiment for the next ms1 spectrum with a retention time bigger then @p rt.
+        @brief Searches the experiment for the next MS1 spectrum with a retention time bigger then @p rt.
 
         @param rt The next follow up scan should have a retention bigger then this value.
       */
@@ -160,7 +160,7 @@ private:
     /// Max. allowed deviation between theoretical and observed isotopic peaks of the precursor peak in the isolation window to be counted as part of the precursor.
     double max_precursor_isotope_deviation_;
 
-    /// Flag if precursor purity will solely be computed based on the precursor scan (false), or interpolated between the precursor- and the following ms1 scan.
+    /// Flag if precursor purity will solely be computed based on the precursor scan (false), or interpolated between the precursor- and the following MS1 scan.
     bool interpolate_precursor_purity_;
 
     /// add channel information to the map after it has been filled
@@ -185,7 +185,7 @@ private:
     /**
       @brief Computes the purity of the precursor given an iterator pointing to the MS/MS spectrum and one to the precursor spectrum.
 
-      @param ms2_spec Iterator pointing to the ms2 spectrum.
+      @param ms2_spec Iterator pointing to the MS2 spectrum.
       @param precursor Iterator pointing to the precursor spectrum of ms2_spec.
       @return Fraction of the total intensity in the isolation window of the precursor spectrum that was assigned to the precursor.
     */
@@ -194,7 +194,7 @@ private:
     /**
       @brief Computes the purity of the precursor given an iterator pointing to the MS/MS spectrum and a reference to the potential precursor spectrum.
 
-      @param ms2_spec Iterator pointing to the ms2 spectrum.
+      @param ms2_spec Iterator pointing to the MS2 spectrum.
       @param precursor Iterator pointing to the precursor spectrum of ms2_spec.
       @return Fraction of the total intensity in the isolation window of the precursor spectrum that was assigned to the precursor.
     */

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
@@ -159,17 +159,17 @@ namespace OpenMS
     defaults_.setValue("keep_unannotated_precursor", "true", "Flag if precursor with missing intensity value or missing precursor spectrum should be included or not.");
     defaults_.setValidStrings("keep_unannotated_precursor", ListUtils::create<String>("true,false"));
 
-    defaults_.setValue("min_reporter_intensity", 0.0, "Minimum intensity of the individual reporter ions to be used extracted.");
+    defaults_.setValue("min_reporter_intensity", 0.0, "Minimum intensity of the individual reporter ions to be extracted.");
     defaults_.setMinFloat("min_reporter_intensity", 0.0);
 
-    defaults_.setValue("discard_low_intensity_quantifications", "false", "Remove all reporter intensities if a single reporter is below the threshold given in min_reporter_intensity.");
+    defaults_.setValue("discard_low_intensity_quantifications", "false", "Remove all reporter intensities if a single reporter is below the threshold given in 'min_reporter_intensity'.");
     defaults_.setValidStrings("discard_low_intensity_quantifications", ListUtils::create<String>("true,false"));
 
     defaults_.setValue("min_precursor_purity", 0.0, "Minimum fraction of the total intensity in the isolation window of the precursor spectrum attributable to the selected precursor.");
     defaults_.setMinFloat("min_precursor_purity", 0.0);
     defaults_.setMaxFloat("min_precursor_purity", 1.0);
 
-    defaults_.setValue("precursor_isotope_deviation", 10.0, "Maximum allowed deviation in ppm between theoretical and observed isotopic peaks of the precursor peak in the isolation window to be counted as part of the precursor.");
+    defaults_.setValue("precursor_isotope_deviation", 10.0, "Maximum allowed deviation (in ppm) between theoretical and observed isotopic peaks of the precursor peak in the isolation window to be counted as part of the precursor.");
     defaults_.setMinFloat("precursor_isotope_deviation", 0.0);
     defaults_.addTag("precursor_isotope_deviation", "advanced");
 

--- a/src/openms/source/ANALYSIS/QUANTITATION/ItraqEightPlexQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/ItraqEightPlexQuantitationMethod.cpp
@@ -117,7 +117,7 @@ namespace OpenMS
                                                                "0.09/4.71/1.88/0.00,"
                                                                "0.14/5.66/0.87/0.00,"
                                                                "0.27/7.44/0.18/0.00"), //121
-                       "Override default values (see Documentation); use the following format: <-2Da>/<-1Da>/<+1Da>/<+2Da> ; e.g. '0/0.3/4/0' , '0.1/0.3/3/0.2'");
+                       "Correction matrix for isotope distributions (see documentation); use the following format: <-2Da>/<-1Da>/<+1Da>/<+2Da>; e.g. '0/0.3/4/0', '0.1/0.3/3/0.2'");
 
     defaultsToParam_();
   }

--- a/src/openms/source/ANALYSIS/QUANTITATION/ItraqFourPlexQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/ItraqFourPlexQuantitationMethod.cpp
@@ -79,7 +79,7 @@ namespace OpenMS
                                                                "0.0/2.0/5.6/0.1,"
                                                                "0.0/3.0/4.5/0.1,"
                                                                "0.1/4.0/3.5/0.1"),
-                       "Override default values (see Documentation); use the following format: <-2Da>/<-1Da>/<+1Da>/<+2Da> ; e.g. '0/0.3/4/0' , '0.1/0.3/3/0.2'");
+                       "Correction matrix for isotope distributions (see documentation); use the following format: <-2Da>/<-1Da>/<+1Da>/<+2Da>; e.g. '0/0.3/4/0', '0.1/0.3/3/0.2'");
 
     defaultsToParam_();
   }

--- a/src/openms/source/ANALYSIS/QUANTITATION/TMTSixPlexQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/TMTSixPlexQuantitationMethod.cpp
@@ -85,7 +85,7 @@ namespace OpenMS
                                                                "0.0/0.0/0.0/0.0,"
                                                                "0.0/0.0/0.0/0.0,"
                                                                "0.0/0.0/0.0/0.0"),
-                       "Override default values (see Documentation); use the following format: <-2Da>/<-1Da>/<+1Da>/<+2Da> ; e.g. '0/0.3/4/0' , '0.1/0.3/3/0.2'");
+                       "Correction matrix for isotope distributions (see documentation); use the following format: <-2Da>/<-1Da>/<+1Da>/<+2Da>; e.g. '0/0.3/4/0', '0.1/0.3/3/0.2'");
 
     defaultsToParam_();
   }

--- a/src/openms/source/ANALYSIS/QUANTITATION/TMTTenPlexQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/TMTTenPlexQuantitationMethod.cpp
@@ -104,7 +104,7 @@ namespace OpenMS
                                                                "0.0/0.0/0.0/0.0,"
                                                                "0.0/0.0/0.0/0.0,"
                                                                "0.0/0.0/0.0/0.0"),
-                       "Override default values (see Documentation); use the following format: <-2Da>/<-1Da>/<+1Da>/<+2Da> ; e.g. '0/0.3/4/0' , '0.1/0.3/3/0.2'");
+                       "Correction matrix for isotope distributions (see documentation); use the following format: <-2Da>/<-1Da>/<+1Da>/<+2Da>; e.g. '0/0.3/4/0', '0.1/0.3/3/0.2'");
 
     defaultsToParam_();
   }

--- a/src/tests/topp/IsobaricAnalyzer_output_1.consensusXML
+++ b/src/tests/topp/IsobaricAnalyzer_output_1.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="file:////Users/aiche/dev/openms/openms-head/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.5" experiment_type="labeled_MS2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<consensusXML version="1.5" id="12345" experiment_type="labeled_MS2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<userParam type="int" name="isoquant:scans_noquant" value="0"/>
 	<userParam type="int" name="isoquant:scans_total" value="5"/>
 	<dataProcessing completion_time="1999-12-31T23:59:59">

--- a/src/topp/IsobaricAnalyzer.cpp
+++ b/src/topp/IsobaricAnalyzer.cpp
@@ -68,7 +68,7 @@ using namespace std;
 /**
     @page TOPP_IsobaricAnalyzer IsobaricAnalyzer
 
-    @brief Extracts and normalizes isobaric labeling information from an MS experiment.
+    @brief Extracts and normalizes isobaric labeling information from an LC-MS/MS experiment.
 
 <CENTER>
     <table>
@@ -87,32 +87,21 @@ using namespace std;
     </table>
 </CENTER>
 
-  Extract the isobaric reporter ion intensities (currently iTRAQ 4plex and 8plex and TMT 6plex are supported)
-  from raw MS2 data, does isotope corrections and stores the resulting quantitation as
-  consensusXML, where each consensus centroid corresponds to one isobaric MS2 scan (e.g., HCD).
-  The position of the centroid is the precursor position, its sub-elements are the channels (thus having
-  m/z's of 113-121 for iTRAQ 126-131 for TMT respectively).
+  This tool currently supports iTRAQ 4-plex and 8-plex, and TMT 6-plex and 10-plex as labeling methods.
+  It extracts the isobaric reporter ion intensities from raw MS2 data, performs isotope correction and stores the resulting quantitation in a consensus map, in which each consensus feature represents one relevant MS2 scan (e.g. HCD; see parameters @p select_activation and @p min_precursor_intensity).
+  The position (RT, m/z) of the consensus centroid is the precursor position; the sub-elements correspond to the channels (with m/z values of 113-121 for iTRAQ and 126-131 for TMT, respectively).
+  
+  @note If none of the reporter ions can be detected in an MS2 scan, a consensus feature will still be generated, but the intensities of the overall feature and of all its sub-elements will be zero.
+  
+  Isotope correction is done using non-negative least squares (NNLS), i.e.:@n
+  Minimize ||Ax - b||, subject to x >= 0, where b is the vector of observed reporter intensities (with "contaminating" isotope species), A is a correction matrix (as supplied by the manufacturer of the labeling kit) and x is the desired vector of corrected (real) reporter intensities.
+  Other software tools solve this problem by using an inverse matrix multiplication, but this can yield entries in x which are negative. In a real sample, this solution cannot possibly be true, so usually negative values (= negative reporter intensities) are set to zero.
+  However, a negative result usually means that noise was not properly accounted for in the calculation. We thus use NNLS to get a non-negative solution, without the need to truncate negative values. In the (usual) case that inverse matrix multiplication yields only positive values, our NNLS will give the exact same optimal solution.
 
-  Isotope correction is done using non-negative least squares (NNLS), i.e.,
+  The correction matrices can be found (and changed) in the INI file (parameter @p correction_matrix of the corresponding labeling method). However, these matrices for both 4-plex and 8-plex iTRAQ are now stable, and every kit delivered should have the same isotope correction values. Thus, there should be no need to change them, but feel free to compare the values in the INI file with your kit's certificate. For TMT (6-plex and 10-plex) the values have to be adapted for each kit.
 
-  Minimize ||Ax - b||, subject to x >= 0, where b is the vector of observed reporter intensities (with 'contaminating'
-  isotope species), A is a correction matrix (as supplied by the manufacturer AB Sciex) and x is the desired vector of corrected (real)
-  reporter intensities.
-  Other software solves this problem using an inverse matrix multiplication, but this can yield entries in x which are negative. In a real sample,
-  this solution cannot possibly be true, so usually negative values (= negative reporter intensities) are set to 0.
-  However, a negative result usually means, that noise was not accounted for thus we use NNLS to get a non-negative solution, without the need to
-  truncate negative values. In (the usual) case that inverse matrix multiplication yields only positive values, our NNLS will give
-  the exact same optimal solution.
-
-  The correction matrices can be found (and changed) in the INI file. However, these matrices for both 4plex and 8plex iTRAQ are now stable, and every
-  kit delivered should have the same isotope correction values. Thus, there should be no need to change them, but feel free to compare the values in the
-  INI file with your kit's Certificate.
-  For TMT 6plex the values have to be adapted for each kit.
-
-  After this quantitation step, you might want to annotate the consensus elements with the respective identifications, obtained from
-  an identification pipeline.
-  Note that quantification is solely on peptide level at this stage. In order to obtain protein quantifications, you can try @ref TOPP_TextExporter
-  to obtain a simple text format which you can feed to other software tools (e.g., R), or you can try @ref TOPP_ProteinQuantifier.
+  After the quantitation, you may want to annotate the consensus features with corresponding peptide identifications, obtained from an identification pipeline. Use @ref TOPP_IDMapper to perform the annotation, but make sure to set suitably small RT and m/z tolerances for the mapping, since the identifications will come from the very same MS2 scans that are now represented by consensus features. In general it should be possible to achieve a perfect one-to-one matching of every identification to a single consensus feature.@n
+  Note that quantification will be solely on peptide level after this stage. In order to obtain protein quantities, you can use @ref TOPP_TextExporter to obtain a simple text format which you can feed to other software tools (e.g., R), or you can apply @ref TOPP_ProteinQuantifier.
 
     <B>The command line parameters of this tool are:</B>
     @verbinclude TOPP_IsobaricAnalyzer.cli
@@ -128,6 +117,7 @@ class TOPPIsobaricAnalyzer :
 {
 private:
   std::map<String, IsobaricQuantitationMethod*> quant_methods_;
+  std::map<String, String> quant_method_names_;
 
 public:
   TOPPIsobaricAnalyzer() :
@@ -141,6 +131,10 @@ public:
     quant_methods_[itraq8plex->getName()] = itraq8plex;
     quant_methods_[tmt6plex->getName()] = tmt6plex;
     quant_methods_[tmt10plex->getName()] = tmt10plex;
+    quant_method_names_[itraq4plex->getName()] = "iTRAQ 4-plex";
+    quant_method_names_[itraq8plex->getName()] = "iTRAQ 8-plex";
+    quant_method_names_[tmt6plex->getName()] = "TMT 6-plex";
+    quant_method_names_[tmt10plex->getName()] = "TMT 10-plex";
   }
 
   ~TOPPIsobaricAnalyzer()
@@ -179,7 +173,7 @@ protected:
          it != quant_methods_.end();
          ++it)
     {
-      registerSubsection_(it->second->getName(), String("Algorithm parameters for ") + it->second->getName());
+      registerSubsection_(it->second->getName(), String("Algorithm parameters for ") + quant_method_names_[it->second->getName()]);
     }
   }
 

--- a/src/topp/IsobaricAnalyzer.cpp
+++ b/src/topp/IsobaricAnalyzer.cpp
@@ -247,7 +247,7 @@ protected:
 
     quantifier.quantify(consensus_map_raw, consensus_map_quant);
 
-    // assign unique ID to output file (this might throw an exception.. but thats ok, as we want the program to quit then)
+    // assign unique ID to output file (this might throw an exception... but that's ok, as we want the program to quit then)
     if (getStringOption_("id_pool").trim().length() > 0) getDocumentIDTagger_().tag(consensus_map_quant);
 
     //-------------------------------------------------------------
@@ -265,8 +265,8 @@ protected:
       it->second.filename = in;
     }
 
-    ConsensusXMLFile cm_file;
-    cm_file.store(out, consensus_map_quant);
+    consensus_map_quant.ensureUniqueId();
+    ConsensusXMLFile().store(out, consensus_map_quant);
 
     return EXECUTION_OK;
   }


### PR DESCRIPTION
Extended documentation of IsobaricAnalyzer (e.g. added TMT 10-plex, note about zero-intensity features, ID mapping hints) and fixed the "1 invalid unique ids" warning.