### PR TITLE
Feature/base64 nowhitespacecheck

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -450,7 +450,7 @@ protected:
         typedef typename SpectrumType::PeakType PeakType;
 
         //decode all base64 arrays
-        MzMLHandlerHelper::decodeBase64Arrays(input_data);
+        MzMLHandlerHelper::decodeBase64Arrays(input_data, options_.getSkipXMLChecks());
 
         //look up the precision and the index of the intensity and m/z array
         bool mz_precision_64 = true;
@@ -630,7 +630,7 @@ protected:
         typedef typename ChromatogramType::PeakType ChromatogramPeakType;
 
         //decode all base64 arrays
-        MzMLHandlerHelper::decodeBase64Arrays(input_data);
+        MzMLHandlerHelper::decodeBase64Arrays(input_data, options_.getSkipXMLChecks());
 
         //look up the precision and the index of the intensity and m/z array
         bool int_precision_64 = true;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
@@ -84,7 +84,7 @@ namespace OpenMS
         std::vector< std::pair<std::string, long> > & chromatograms_offsets
       );
 
-      static void decodeBase64Arrays(std::vector<BinaryData> & data_);
+      static void decodeBase64Arrays(std::vector<BinaryData> & data_, bool skipXMLCheck = false);
 
       static void computeDataProperties_(std::vector<BinaryData>& data_, bool& precision_64, SignedSize& index, String index_name);
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSpectrumDecoder.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLSpectrumDecoder.h
@@ -65,6 +65,8 @@ namespace OpenMS
   {
   protected:
 
+    bool skip_xml_checks_;
+      
     typedef Internal::MzMLHandlerHelper::BinaryData BinaryData;
 
     /**
@@ -116,6 +118,12 @@ namespace OpenMS
 
   public:
 
+    MzMLSpectrumDecoder() :
+      skip_xml_checks_(false)
+    {}
+
+
+
     /**
       @brief Extract data from a string which contains a full mzML spectrum.
 
@@ -146,6 +154,8 @@ namespace OpenMS
     */
     void domParseChromatogram(const std::string& in, OpenMS::Interfaces::ChromatogramPtr & cptr);
 
+    ///sets whether to skip some XML checks and be fast instead
+    void setSkipXMLChecks(bool only);
   };
 }
 

--- a/src/openms/include/OpenMS/FORMAT/IndexedMzMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/IndexedMzMLFile.h
@@ -84,6 +84,8 @@ namespace OpenMS
       /// Whether parsing the indexedmzML file was successful
       bool parsing_success_;
 
+      bool skip_xml_checks_;
+
     /**
       @brief Try to parse the footer of the indexedmzML
 
@@ -155,6 +157,13 @@ namespace OpenMS
       @return The chromatogram at position id
     */
     OpenMS::Interfaces::ChromatogramPtr getChromatogramById(int id);
+
+    ///sets whether to skip some XML checks and be fast instead
+    void setSkipXMLChecks(bool skip)
+    {
+      skip_xml_checks_ = skip;
+    }
+
   };
 }
 

--- a/src/openms/include/OpenMS/FORMAT/OPTIONS/PeakFileOptions.h
+++ b/src/openms/include/OpenMS/FORMAT/OPTIONS/PeakFileOptions.h
@@ -148,6 +148,10 @@ public:
     void setFillData(bool only);
     ///returns whether to fill the actual data into the container (spectrum/chromatogram)
     bool getFillData() const;
+    ///sets whether to skip some XML checks and be fast instead
+    void setSkipXMLChecks(bool only);
+    ///returns whether to skip some XML checks and be fast instead
+    bool getSkipXMLChecks() const;
 
     /// @name sort peaks in spectra / chromatograms by position
     ///sets whether or not to sort peaks in spectra
@@ -220,6 +224,7 @@ private:
     bool zlib_compression_;
     bool size_only_;
     bool always_append_data_;
+    bool skip_xml_checks_;
     bool sort_spectra_by_mz_;
     bool sort_chromatograms_by_rt_;
     bool fill_data_;

--- a/src/openms/include/OpenMS/KERNEL/OnDiscMSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/OnDiscMSExperiment.h
@@ -239,6 +239,12 @@ public:
       return indexed_mzml_file_.getChromatogramById(id);
     }
 
+    ///sets whether to skip some XML checks and be fast instead
+    void setSkipXMLChecks(bool skip)
+    {
+      indexed_mzml_file_.setSkipXMLChecks(skip);
+    }
+
 private:
     /// Private Assignment operator -> we cannot copy file streams in IndexedMzMLFile
     OnDiscMSExperiment& operator=(const OnDiscMSExperiment& /* source */) {}

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -164,7 +164,9 @@ namespace OpenMS
       // NOTE: this may take up to 10% of reading time with a single thread,
       //       either omit it or make it more efficient
       if (!skipXMLCheck)
+      {
         data_[i].base64.removeWhitespaces();
+      }
 
       //decode data and check if the length of the decoded data matches the expected length
       if (data_[i].data_type == BinaryData::DT_FLOAT)

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -151,7 +151,7 @@ namespace OpenMS
     }
   }
 
-  void MzMLHandlerHelper::decodeBase64Arrays(std::vector<BinaryData>& data_)
+  void MzMLHandlerHelper::decodeBase64Arrays(std::vector<BinaryData> & data_, bool skipXMLCheck)
   {
     /// Decoder/Encoder for Base64-data in MzML
     Base64 decoder_;
@@ -161,7 +161,10 @@ namespace OpenMS
     {
       //remove whitespaces from binary data
       //this should not be necessary, but linebreaks inside the base64 data are unfortunately no exception
-      data_[i].base64.removeWhitespaces();
+      // NOTE: this may take up to 10% of reading time with a single thread,
+      //       either omit it or make it more efficient
+      if (!skipXMLCheck)
+        data_[i].base64.removeWhitespaces();
 
       //decode data and check if the length of the decoded data matches the expected length
       if (data_[i].data_type == BinaryData::DT_FLOAT)

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
@@ -78,7 +78,7 @@ namespace OpenMS
 
   OpenMS::Interfaces::SpectrumPtr MzMLSpectrumDecoder::decodeBinaryDataSpectrum_(std::vector<BinaryData>& data_)
   {
-    Internal::MzMLHandlerHelper::decodeBase64Arrays(data_);
+    Internal::MzMLHandlerHelper::decodeBase64Arrays(data_, skip_xml_checks_); 
     OpenMS::Interfaces::SpectrumPtr sptr(new OpenMS::Interfaces::Spectrum);
 
     //look up the precision and the index of the intensity and m/z array
@@ -130,7 +130,7 @@ namespace OpenMS
 
   OpenMS::Interfaces::ChromatogramPtr MzMLSpectrumDecoder::decodeBinaryDataChrom_(std::vector<BinaryData>& data_)
   {
-    Internal::MzMLHandlerHelper::decodeBase64Arrays(data_);
+    Internal::MzMLHandlerHelper::decodeBase64Arrays(data_, skip_xml_checks_);
     OpenMS::Interfaces::ChromatogramPtr sptr(new OpenMS::Interfaces::Chromatogram);
 
     //look up the precision and the index of the intensity and m/z array
@@ -322,6 +322,11 @@ namespace OpenMS
     std::vector<BinaryData> data_;
     domParseString_(in, data_);
     sptr = decodeBinaryDataChrom_(data_);
+  }
+
+  void MzMLSpectrumDecoder::setSkipXMLChecks(bool skip)
+  {
+    skip_xml_checks_ = skip;
   }
 
 }

--- a/src/openms/source/FORMAT/IndexedMzMLFile.cpp
+++ b/src/openms/source/FORMAT/IndexedMzMLFile.cpp
@@ -158,7 +158,9 @@ namespace OpenMS
 #endif
 
     OpenMS::Interfaces::SpectrumPtr sptr(new OpenMS::Interfaces::Spectrum);
-    MzMLSpectrumDecoder().domParseSpectrum(text, sptr);
+    MzMLSpectrumDecoder d;
+    d.setSkipXMLChecks(skip_xml_checks_ );
+    d.domParseSpectrum(text, sptr);
 
 #ifdef DEBUG_READER
     std::cout << sptr->getIntensityArray()->data.size() << " int and mz : " << sptr->getMZArray()->data.size() << std::endl;
@@ -219,7 +221,9 @@ namespace OpenMS
 #endif
 
     OpenMS::Interfaces::ChromatogramPtr sptr(new OpenMS::Interfaces::Chromatogram);
-    MzMLSpectrumDecoder().domParseChromatogram(text, sptr);
+    MzMLSpectrumDecoder d;
+    d.setSkipXMLChecks(skip_xml_checks_ );
+    d.domParseChromatogram(text, sptr);
 
 #ifdef DEBUG_READER
     std::cout << sptr->getIntensityArray()->data.size() << " int and time : " << sptr->getTimeArray()->data.size() << std::endl;

--- a/src/openms/source/FORMAT/OPTIONS/PeakFileOptions.cpp
+++ b/src/openms/source/FORMAT/OPTIONS/PeakFileOptions.cpp
@@ -56,6 +56,7 @@ namespace OpenMS
     zlib_compression_(false),
     size_only_(false),
     always_append_data_(false),
+    skip_xml_checks_(false),
     sort_spectra_by_mz_(true),
     sort_chromatograms_by_rt_(true),
     fill_data_(true),
@@ -81,6 +82,7 @@ namespace OpenMS
     zlib_compression_(options.zlib_compression_),
     size_only_(options.size_only_),
     always_append_data_(options.always_append_data_),
+    skip_xml_checks_(options.skip_xml_checks_),
     sort_spectra_by_mz_(options.sort_spectra_by_mz_),
     sort_chromatograms_by_rt_(options.sort_chromatograms_by_rt_),
     fill_data_(options.fill_data_),
@@ -226,6 +228,16 @@ namespace OpenMS
   bool PeakFileOptions::getFillData() const
   {
     return fill_data_;
+  }
+
+  void PeakFileOptions::setSkipXMLChecks(bool skip)
+  {
+    skip_xml_checks_ = skip;
+  }
+
+  bool PeakFileOptions::getSkipXMLChecks() const
+  {
+    return skip_xml_checks_;
   }
 
   void PeakFileOptions::setSortSpectraByMZ(bool sort)


### PR DESCRIPTION
- add skipXMLCheck option which will skip the `removeWhitespaces` call. 
- This gives about 10 % speed gain in a critical section of the code and can be turned on/off by the user