### PR TITLE
Feature/speed improvements indexed

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
@@ -119,14 +119,6 @@ namespace OpenMS
       // This seems to be the fastest method to move the data (faster than copy or assign)
       x_array->data.insert(x_array->data.begin(), data_[x_index].floats_64.begin(), data_[x_index].floats_64.end());
       intensity_array->data.insert(intensity_array->data.begin(), data_[int_index].floats_32.begin(), data_[int_index].floats_32.end());
-
-      /*
-      std::copy(data_[x_index].floats_64.begin(), data_[x_index].floats_64.end(), std::back_inserter(x_array->data));
-      std::copy(data_[int_index].floats_32.begin(), data_[int_index].floats_32.end(), std::back_inserter(intensity_array->data));
-
-      x_array->data.assign(data_[x_index].floats_64.begin(), data_[x_index].floats_64.end());
-      intensity_array->data.assign(data_[int_index].floats_32.begin(), data_[int_index].floats_32.end());
-      */
     }
     else if (x_precision_64 && int_precision_64)
     {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
@@ -113,6 +113,8 @@ namespace OpenMS
 
     OpenMS::Interfaces::BinaryDataArrayPtr intensity_array(new OpenMS::Interfaces::BinaryDataArray);
     OpenMS::Interfaces::BinaryDataArrayPtr x_array(new OpenMS::Interfaces::BinaryDataArray);
+    x_array->data.reserve(default_array_length_);
+    intensity_array->data.reserve(default_array_length_);
     for (Size n = 0; n < default_array_length_; n++)
     {
       double xcoord = x_precision_64 ? data_[x_index].floats_64[n] : data_[x_index].floats_32[n];

--- a/src/openms/source/FORMAT/IndexedMzMLFile.cpp
+++ b/src/openms/source/FORMAT/IndexedMzMLFile.cpp
@@ -71,6 +71,7 @@ namespace OpenMS
     chromatograms_offsets_(source.chromatograms_offsets_),
     index_offset_(source.index_offset_),
     spectra_before_chroms_(source.spectra_before_chroms_),
+    // do not copy the filestream itself but open a new filestream using the same file
     filestream_(source.filename_.c_str()),
     parsing_success_(source.parsing_success_)
   {


### PR DESCRIPTION
a few performance improvements for the indexed mzML files

- reserve space
- copy data directly into output vectors using `vector::insert`