### PR TITLE
[FEATURE] substantially faster indexed mzML access

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
@@ -265,7 +265,6 @@ namespace OpenMS
           currentNode->getNodeType() == xercesc::DOMNode::ELEMENT_NODE) // is element
       {
         std::vector<std::pair<std::string, std::streampos> > result;
-        xercesc::DOMNodeList* offset_elems = currentNode->getChildNodes();
 
         xercesc::DOMNode* firstChild = currentNode->getFirstChild();
         xercesc::DOMNode* lastChild = currentNode->getLastChild();

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
@@ -215,7 +215,8 @@ namespace OpenMS
     //-------------------------------------------------------------
     // Create parser from input string using MemBufInputSource
     //-------------------------------------------------------------
-    xercesc::MemBufInputSource myxml_buf(reinterpret_cast<const unsigned char*>(in.c_str()), in.length(), "myxml (in memory)");
+    xercesc::MemBufInputSource myxml_buf(
+        reinterpret_cast<const unsigned char*>(in.c_str()), in.length(), "myxml (in memory)");
     xercesc::XercesDOMParser* parser = new xercesc::XercesDOMParser();
     parser->setDoNamespaces(false);
     parser->setDoSchema(false);
@@ -233,25 +234,27 @@ namespace OpenMS
     xercesc::DOMElement* elementRoot = doc->getDocumentElement();
     if (!elementRoot)
     {
-      std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: No root element found:" << std::endl << std::endl << in << std::endl;
+      std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: " <<
+        "No root element found:" << std::endl << std::endl << in << std::endl;
       delete parser;
       return -1;
     }
 
     // Extract the indexList tag (there should only be one)
-    XMLCh* tag = xercesc::XMLString::transcode("indexList");
-    xercesc::DOMNodeList* li = elementRoot->getElementsByTagName(tag);
-    xercesc::XMLString::release(&tag);
+    XMLCh* x_tag = xercesc::XMLString::transcode("indexList");
+    xercesc::DOMNodeList* li = elementRoot->getElementsByTagName(x_tag);
+    xercesc::XMLString::release(&x_tag);
     if (li->getLength() != 1)
     {
-      std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: no indexList element found:" << std::endl << std::endl << in << std::endl;
+      std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: "
+        << "no indexList element found:" << std::endl << std::endl << in << std::endl;
       delete parser;
       return -1;
     }
     xercesc::DOMNode* indexListNode = li->item(0);
 
-    XMLCh* idref_tag = xercesc::XMLString::transcode("idRef");
-    XMLCh* name_tag = xercesc::XMLString::transcode("name");
+    XMLCh* x_idref_tag = xercesc::XMLString::transcode("idRef");
+    XMLCh* x_name_tag = xercesc::XMLString::transcode("name");
 
     xercesc::DOMNodeList* index_elems = indexListNode->getChildNodes();
     const  XMLSize_t nodeCount_ = index_elems->getLength();
@@ -286,7 +289,7 @@ namespace OpenMS
           {
             xercesc::DOMElement* currentElement = dynamic_cast<xercesc::DOMElement*>(currentONode);
 
-            char* x_name = xercesc::XMLString::transcode(currentElement->getAttribute(idref_tag));
+            char* x_name = xercesc::XMLString::transcode(currentElement->getAttribute(x_idref_tag));
             char* x_offset = xercesc::XMLString::transcode(currentONode->getTextContent());
 
             std::streampos thisOffset = OpenMS::IndexedMzMLUtils::stringToStreampos( String(x_offset) );
@@ -299,7 +302,7 @@ namespace OpenMS
 
         // should be either spectrum or chromatogram ...
         xercesc::DOMElement* currentElement = dynamic_cast<xercesc::DOMElement*>(currentNode);
-        char* x_indexName = xercesc::XMLString::transcode(currentElement->getAttribute(name_tag));
+        char* x_indexName = xercesc::XMLString::transcode(currentElement->getAttribute(x_name_tag));
         std::string name(x_indexName);
         xercesc::XMLString::release(&x_indexName);
 
@@ -314,16 +317,17 @@ namespace OpenMS
         else
         {
           std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: expected only " <<
-            "'spectrum' or 'chromatogram' below indexList but found instead '" << name << "'." << std::endl;
-          xercesc::XMLString::release(&idref_tag);
-          xercesc::XMLString::release(&name_tag);
+            "'spectrum' or 'chromatogram' below indexList but found instead '" << 
+            name << "'." << std::endl;
+          xercesc::XMLString::release(&x_idref_tag);
+          xercesc::XMLString::release(&x_name_tag);
           delete parser;
           return -1;
         }
       }
     }
-    xercesc::XMLString::release(&idref_tag);
-    xercesc::XMLString::release(&name_tag);
+    xercesc::XMLString::release(&x_idref_tag);
+    xercesc::XMLString::release(&x_name_tag);
 
 
     delete parser;

--- a/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/IndexedMzMLDecoder.cpp
@@ -217,11 +217,11 @@ namespace OpenMS
     //-------------------------------------------------------------
     xercesc::MemBufInputSource myxml_buf(
         reinterpret_cast<const unsigned char*>(in.c_str()), in.length(), "myxml (in memory)");
-    xercesc::XercesDOMParser* parser = new xercesc::XercesDOMParser();
-    parser->setDoNamespaces(false);
-    parser->setDoSchema(false);
-    parser->setLoadExternalDTD(false);
-    parser->parse(myxml_buf);
+    xercesc::XercesDOMParser parser;
+    parser.setDoNamespaces(false);
+    parser.setDoSchema(false);
+    parser.setLoadExternalDTD(false);
+    parser.parse(myxml_buf);
 
     //-------------------------------------------------------------
     // Start parsing
@@ -229,14 +229,13 @@ namespace OpenMS
     //-------------------------------------------------------------
 
     // no need to free this pointer - owned by the parent parser object
-    xercesc::DOMDocument* doc =  parser->getDocument();
+    xercesc::DOMDocument* doc =  parser.getDocument();
     // Get the top-level element ("indexedmzML")
     xercesc::DOMElement* elementRoot = doc->getDocumentElement();
     if (!elementRoot)
     {
       std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: " <<
         "No root element found:" << std::endl << std::endl << in << std::endl;
-      delete parser;
       return -1;
     }
 
@@ -248,7 +247,6 @@ namespace OpenMS
     {
       std::cerr << "IndexedMzMLDecoder::domParseIndexedEnd Error: "
         << "no indexList element found:" << std::endl << std::endl << in << std::endl;
-      delete parser;
       return -1;
     }
     xercesc::DOMNode* indexListNode = li->item(0);
@@ -321,7 +319,6 @@ namespace OpenMS
             name << "'." << std::endl;
           xercesc::XMLString::release(&x_idref_tag);
           xercesc::XMLString::release(&x_name_tag);
-          delete parser;
           return -1;
         }
       }
@@ -329,8 +326,6 @@ namespace OpenMS
     xercesc::XMLString::release(&x_idref_tag);
     xercesc::XMLString::release(&x_name_tag);
 
-
-    delete parser;
     return 0;
   }
 


### PR DESCRIPTION
- instead of iterating through all <offset> elements using an algorithm with
  O(n^2) complexity, use one that has O(n) complexity
- removes a major bottleneck in parsing large indexed files that have thousands of spectra
- resolves #1301

this improves parsing a large XML file and calculating its TIC substantially. Before this patch it took 75 minutes to parse through 78 000 spectra, now it takes 90 seconds