### PR TITLE
remove OS X specific code for opening folders

### DIFF
--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -211,36 +211,17 @@ namespace OpenMS
       QFileInfo fi(fl[i]);
       directories.insert(String(QFileInfo(fi.canonicalFilePath()).path()));
     }
-
+    
     // open them
     for (std::set<String>::const_iterator it = directories.begin(); it != directories.end(); ++it)
     {
       QString path = QDir::toNativeSeparators(it->toQString());
-#if defined(__APPLE__)
       
-      //QProcess* p = new QProcess();
-      //p->setProcessChannelMode(QProcess::ForwardedChannels);
-      //QStringList app_args;
-      //app_args.append(path);
-      //p->start("/usr/bin/open", app_args);
-      
-      QProcess p;
-      p.start("/usr/bin/open", QStringList() << path, QIODevice::ReadOnly);
-      p.waitForFinished();
-
-      if (!p.waitForStarted())
-      {
-        // execution failed
-        QMessageBox::warning(0, "Open Folder Error", "The folder " + path + " could not be opened!");
-        LOG_ERROR << "Failed to open folder " << path.toStdString() << std::endl;
-        LOG_ERROR << p.errorString().toStdString() << std::endl;
-      }
-#else
       if (!QDir(path).exists() || (!QDesktopServices::openUrl(QUrl("file:///" + path, QUrl::TolerantMode))))
       {
         QMessageBox::warning(0, "Open Folder Error", String("The folder " + path + " could not be opened!").toQString());
       }
-#endif
+
     }
   }
 

--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -217,17 +217,23 @@ namespace OpenMS
     {
       QString path = QDir::toNativeSeparators(it->toQString());
 #if defined(__APPLE__)
-      QProcess* p = new QProcess();
-      p->setProcessChannelMode(QProcess::ForwardedChannels);
-      QStringList app_args;
-      app_args.append(path);
-      p->start("/usr/bin/open", app_args);
-      if (!p->waitForStarted())
+      
+      //QProcess* p = new QProcess();
+      //p->setProcessChannelMode(QProcess::ForwardedChannels);
+      //QStringList app_args;
+      //app_args.append(path);
+      //p->start("/usr/bin/open", app_args);
+      
+      QProcess p;
+      p.start("/usr/bin/open", QStringList() << path, QIODevice::ReadOnly);
+      p.waitForFinished();
+
+      if (!p.waitForStarted())
       {
         // execution failed
         QMessageBox::warning(0, "Open Folder Error", "The folder " + path + " could not be opened!");
         LOG_ERROR << "Failed to open folder " << path.toStdString() << std::endl;
-        LOG_ERROR << p->errorString().toStdString() << std::endl;
+        LOG_ERROR << p.errorString().toStdString() << std::endl;
       }
 #else
       if (!QDir(path).exists() || (!QDesktopServices::openUrl(QUrl("file:///" + path, QUrl::TolerantMode))))

--- a/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
@@ -301,25 +301,12 @@ namespace OpenMS
   void TOPPASOutputFileListVertex::openContainingFolder()
   {
     QString path = getFullOutputDirectory().toQString();
-#if defined(__APPLE__)
-    QProcess p;
-    p.setProcessChannelMode(QProcess::ForwardedChannels);
-    QStringList app_args;
-    app_args.append(path);
-    p.start("/usr/bin/open", app_args);
-    if (!p.waitForStarted())
-    {
-      // execution failed
-      QMessageBox::warning(0, "Open Folder Error", "The folder '" + path + "' could not be opened!");
-      LOG_ERROR << "Failed to open folder " << path.toStdString() << "\n"
-                << p.errorString().toStdString() << std::endl;
-    }
-#else
+
     if (!QDir(path).exists() || (!QDesktopServices::openUrl(QUrl("file:///" + path, QUrl::TolerantMode))))
     {
       QMessageBox::warning(0, "Open Folder Error", "The folder '" + path + "' could not be opened!");
     }
-#endif
+
   }
 
   String TOPPASOutputFileListVertex::getFullOutputDirectory() const

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -1085,25 +1085,10 @@ namespace OpenMS
   void TOPPASToolVertex::openContainingFolder()
   {
     QString path = getFullOutputDirectory().toQString();
-#if defined(__APPLE__)
-    QProcess* p = new QProcess();
-    p->setProcessChannelMode(QProcess::ForwardedChannels);
-    QStringList app_args;
-    app_args.append(path);
-    p->start("/usr/bin/open", app_args);
-    if (!p->waitForStarted())
-    {
-      // execution failed
-      QMessageBox::warning(0, "Open Folder Error", "The folder " + path + " could not be opened!");
-      LOG_ERROR << "Failed to open folder " << path.toStdString() << std::endl;
-      LOG_ERROR << p->errorString().toStdString() << std::endl;
-    }
-#else
     if (!QDir(path).exists() || (!QDesktopServices::openUrl(QUrl("file:///" + path, QUrl::TolerantMode))))
     {
       QMessageBox::warning(0, "Open Folder Error", "The folder " + path + " could not be opened!");
     }
-#endif
   }
 
   String TOPPASToolVertex::getFullOutputDirectory() const


### PR DESCRIPTION
This pull request removes OS X specific code for opening folders. It resolves the TOPPAS issue #1299.