### PR TITLE
[FIX] Ammend to #1284

### DIFF
--- a/cmake/knime/binaries_mac.ini
+++ b/cmake/knime/binaries_mac.ini
@@ -1,3 +1,3 @@
 OPENMS_DATA_PATH=$ROOT/share/OpenMS
-PATH=$ROOT/bin/:$ROOT/bin/Fido:$ROOT/bin/OMSSA:$ROOT/bin/XTandem:$ROOT/../../../jre/bin/java
+PATH=$ROOT/bin/:$ROOT/bin/Fido:$ROOT/bin/OMSSA:$ROOT/bin/XTandem:$ROOT/../../../jre/Home/bin
 MSGFPLUS_PATH=$ROOT/bin/MSGFPlus/MSGFPlus.jar


### PR DESCRIPTION
Shipped jre in KNIME is located in a subfolder on Mac.