### PR TITLE
Fix toppview pen size in 2D View

### DIFF
--- a/doc/TOPP_tutorial/TOPPView_interface.doxygen
+++ b/doc/TOPP_tutorial/TOPPView_interface.doxygen
@@ -38,7 +38,7 @@
 /**
 	@page TOPPView_introduction Introduction
 
-	  TOPPView is a viewer for MS and HPLC-MS data. It can be used to inspect files in mzML, mzData, mzXML, ANDI/MS
+	  TOPPView is a viewer for MS and HPLC-MS data. It can be used to inspect files in mzML, mzData, mzXML
 	  and several other text-based file formats.
 
 	 	In each view, several datasets can be displayed using the layer concept. This allows visual comparison
@@ -366,7 +366,7 @@
 			<TR> <TD>CTRL</TD> <TD>Activate zoom mode</TD> </TR>
 			<TR> <TD>SHIFT</TD> <TD>Activate measurement mode</TD> </TR>
 			<TR> <TD>Arrow keys</TD> <TD>Translate currently shown data</TD> </TR>
-			<TR> <TD>CTRL+,CTRL-</TD> <TD>Move up and down in zoom history</TD> </TR>
+			<TR> <TD>CTRL+'+',CTRL+'-'</TD> <TD>Move up and down in zoom history</TD> </TR>
 			<TR> <TD>mouse wheel</TD> <TD>Move up and down in zoom history</TD> </TR>
 			<TR> <TD>CTRL+G</TD> <TD>Goto dialog</TD> </TR>
 			<TR> <TD>Backspace</TD> <TD>Reset zoom</TD> </TR>
@@ -381,6 +381,10 @@
 			<TR> <TD>S</TD> <TD>Intensity mode: Snap-to-maximum</TD> </TR>
 			<TR> <TD>I</TD> <TD>1D draw mode: peaks</TD> </TR>
 			<TR> <TD>R</TD> <TD>1D draw mode: raw data</TD> </TR>
+      <TR> <TD>CTRL+ALT+Home</TD> <TD>2D draw mode: increase minimum canvas coverage threshold (for raw peak scaling). 'Home' on MacOSX keyboards is also 'Fn+ArrowLeft'</TD> </TR>
+      <TR> <TD>CTRL+ALT+End</TD> <TD>2D draw mode: decrease minimum canvas coverage threshold (for raw peak scaling). 'End' on MacOSX keyboards is also 'Fn+ArrowRight'</TD> </TR>
+      <TR> <TD>CTRL+ALT+'+'</TD> <TD>2D draw mode: increase maximum point size (for raw peak scaling)</TD> </TR>
+      <TR> <TD>CTRL+ALT+'-'</TD> <TD>2D draw mode: decrease maximum point size (for raw peak scaling)</TD> </TR>
 
 			<TR> <TD colspan=2><B>Annotations in 1D view</B></TD> </TR>
 			<TR> <TD>CTRL+A</TD> <TD>Select all annotations of the current layer</TD> </TR>

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
@@ -336,6 +336,10 @@ protected:
       }
     }
 
+    /// for a certain dimension: computes the size a data point would need, such that the image
+    /// reaches a certain coverage
+    double getPenScaling_(double MIN_COVERAGE, double MAX_PEN_SIZE, double ratio_data2pixel, double& pen_size) const;
+    
     /// recalculates the dot gradient of a layer
     void recalculateDotGradient_(Size layer);
 

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
@@ -267,11 +267,6 @@ protected:
     // DOcu in base class
     virtual void recalculateSnapFactor_();
 
-    /// m/z projection data
-    ExperimentType projection_mz_;
-    /// RT projection data
-    ExperimentType projection_rt_;
-
     /**
       @brief Returns the position on color @p gradient associated with given intensity.
 
@@ -339,14 +334,15 @@ protected:
     /** 
       @brief For a certain dimension: computes the size a data point would need, such that the image
              reaches a certain coverage
+      
+      Internally, this function makes use of the members 'canvas_coverage_min_' (giving the fraction (e.g. 20%) of area which should be covered by data)
+      and 'pen_size_max_' (maximum allowed number of pixels per data point).
 
-      @param MIN_COVERAGE A constant, giving the fraction (e.g. 20%) of area which should be covered by data
-      @param MAX_PEN_SIZE The maximum allowed number of pixels per data point
       @param ratio_data2pixel The current ratio of #data points vs. # pixels of image
-      @param pen_size In/Out param: gives the initial pen size, and is increased (up to @p MAX_PEN_SIZE) to reach desired coverage @p MIN_COVERAGE
+      @param pen_size In/Out param: gives the initial pen size, and is increased (up to @p MAX_PEN_SIZE) to reach desired coverage given by 'canvas_coverage_min_'
       @return The factor by which @pen_size increased (gives a hint of how many data points should be merged to avoid overplotting)
     */
-    double adaptPenScaling_(double MIN_COVERAGE, double MAX_PEN_SIZE, double ratio_data2pixel, double& pen_size) const;
+    double adaptPenScaling_(double ratio_data2pixel, double& pen_size) const;
     
     /// recalculates the dot gradient of a layer
     void recalculateDotGradient_(Size layer);
@@ -359,11 +355,6 @@ protected:
 
     /// Paints a peak icon for feature and consensus feature peaks
     void paintIcon_(const QPoint& pos, const QRgb& color, const String& icon, Size s, QPainter& p) const;
-
-    /// the nearest peak/feature to the mouse cursor
-    PeakIndex selected_peak_;
-    /// start peak/feature of measuring mode
-    PeakIndex measurement_start_;
 
     /// translates the visible area by a given offset specified in fractions of current visible area
     virtual void translateVisibleArea_(double mzShiftRel, double rtShiftRel);
@@ -379,6 +370,25 @@ protected:
 
     /// Finishes context menu after customization to peaks, features or consensus features
     void finishContextMenu_(QMenu* context_menu, QMenu* settings_menu);
+
+    /// m/z projection data
+    ExperimentType projection_mz_;
+    /// RT projection data
+    ExperimentType projection_rt_;
+    
+    /// the nearest peak/feature to the mouse cursor
+    PeakIndex selected_peak_;
+    /// start peak/feature of measuring mode
+    PeakIndex measurement_start_;
+    
+    double pen_size_min_; //< minimum number of pixels for one data point
+    double pen_size_max_; //< maximum number of pixels for one data point
+    double canvas_coverage_min_; //< minimum coverage of the canvas required; if lower, points are upscaled in size
+
+  private:
+    /// Default C'tor hidden
+    Spectrum2DCanvas();
+
   };
 }
 

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
@@ -336,9 +336,17 @@ protected:
       }
     }
 
-    /// for a certain dimension: computes the size a data point would need, such that the image
-    /// reaches a certain coverage
-    double getPenScaling_(double MIN_COVERAGE, double MAX_PEN_SIZE, double ratio_data2pixel, double& pen_size) const;
+    /** 
+      @brief For a certain dimension: computes the size a data point would need, such that the image
+             reaches a certain coverage
+
+      @param MIN_COVERAGE A constant, giving the fraction (e.g. 20%) of area which should be covered by data
+      @param MAX_PEN_SIZE The maximum allowed number of pixels per data point
+      @param ratio_data2pixel The current ratio of #data points vs. # pixels of image
+      @param pen_size In/Out param: gives the initial pen size, and is increased (up to @p MAX_PEN_SIZE) to reach desired coverage @p MIN_COVERAGE
+      @return The factor by which @pen_size increased (gives a hint of how many data points should be merged to avoid overplotting)
+    */
+    double adaptPenScaling_(double MIN_COVERAGE, double MAX_PEN_SIZE, double ratio_data2pixel, double& pen_size) const;
     
     /// recalculates the dot gradient of a layer
     void recalculateDotGradient_(Size layer);

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -630,68 +630,53 @@ namespace OpenMS
 
   void SpectrumCanvas::keyPressEvent(QKeyEvent * e)
   {
-    // Alt/Shift pressed => change action mode
     if (e->key() == Qt::Key_Control)
-    {
-      e->accept();
+    { // Ctrl pressed => change action mode
       action_mode_ = AM_ZOOM;
       emit actionModeChange();
     }
     else if (e->key() == Qt::Key_Shift)
-    {
-      e->accept();
+    { // Shift pressed => change action mode
       action_mode_ = AM_MEASURE;
       emit actionModeChange();
     }
-
-    // CTRL+/CTRL- => Zoom stack
-    if ((e->modifiers() & Qt::ControlModifier) && (e->key() == Qt::Key_Plus))
-    {
-      e->accept();
+    else if ((e->modifiers() & Qt::ControlModifier) && (e->key() == Qt::Key_Plus)) // do not use (e->modifiers() == Qt::ControlModifier) to target Ctrl exclusively, since +/- might(!) also trigger the Qt::KeypadModifier
+    { // CTRL+Plus => Zoom stack
       zoomForward_();
     }
     else if ((e->modifiers() & Qt::ControlModifier) && (e->key() == Qt::Key_Minus))
-    {
-      e->accept();
+    { // CTRL+Minus => Zoom stack
       zoomBack_();
     }
     // Arrow keys => translate
     else if (e->key() == Qt::Key_Left)
     {
-      e->accept();
       translateLeft_();
     }
     else if (e->key() == Qt::Key_Right)
     {
-      e->accept();
       translateRight_();
     }
     else if (e->key() == Qt::Key_Up)
     {
-      e->accept();
       translateForward_();
     }
     else if (e->key() == Qt::Key_Down)
     {
-      e->accept();
       translateBackward_();
     }
-    //Backspace to reset zoom
     else if (e->key() == Qt::Key_Backspace)
-    {
-      e->accept();
+    { // Backspace to reset zoom
       resetZoom();
     }
-
-    // CTRL+ALT+T => activate timing mode
-    if ((e->modifiers() & Qt::ControlModifier) && (e->modifiers() & Qt::AltModifier) && (e->key() == Qt::Key_T))
-    {
-      e->accept();
+    else if ((e->modifiers() == (Qt::ControlModifier | Qt::AltModifier)) && (e->key() == Qt::Key_T))
+    { // CTRL+ALT+T => activate timing mode
       show_timing_ = !show_timing_;
     }
-
-    releaseKeyboard();    // ensure that the key event is passed on to parent widget
-    e->ignore();
+    else
+    { // call the keyPressEvent() of the parent widget
+      e->ignore();
+    }
   }
 
   void SpectrumCanvas::translateLeft_()


### PR DESCRIPTION
TOPPView's data point size estimation for 2D data is not very good:
it will show huge squares when only a handful of data are within the visible area,
but on the other hand will use the most tiny pixels when there is lots of data in one dimension, but almost none in the other (i.e. showing only a handful of scans over the whole RT range).

This PR fixes:
 * point size estimation for the above scenarios by computing a 'coverage' for each dimension: if there is lots of blank background, the pixel size is increased until reaching a sensible maximum (here: 20 pixel).
 * speedup of plotting: when plotting lots of data, there was a bug that collected (and maximised over) all RT scans, irrespective of whether they are visible. This can have tremendious speed implications when viewing only partial data (plotting is now in linear time for the RT range shown).
 * hotkeys to change the minimum desired coverage before upscaling
 * hotkeys for the maximum point size
 * performance issue when drawing precursor positions of MS2 spectra (crosses) (25k precursors now take 50ms instead of 2000ms)
 * lots of cleanup


Comparison of old/new view:
![2015-04-06 -- 2d pointsize optimization](https://cloud.githubusercontent.com/assets/6008722/7006539/495176ea-dc82-11e4-944a-2a70dc6cff6c.png)


