### PR TITLE
[FEATURE] ModificationsDB: Use custom UniMod & PSI-MOD XML

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -70,17 +70,7 @@ namespace OpenMS
   {
 public:
 
-    inline static ModificationsDB * getInstance()
-    {
-      static ModificationsDB * db_ = 0;
-      if (db_ == 0)
-      {
-        db_ = new ModificationsDB;
-      }
-      return db_;
-    }
-
-    inline static ModificationsDB * getCustomInstance(OpenMS::String unimod_file, OpenMS::String psimod_file)
+    inline static ModificationsDB * getInstance(OpenMS::String unimod_file = "CHEMISTRY/unimod.xml", OpenMS::String psimod_file = "CHEMISTRY/PSI-MOD.obo")
     {
       static ModificationsDB * db_ = 0;
       if (db_ == 0)
@@ -199,9 +189,7 @@ private:
 */
     //@{
     /// default constructor
-    ModificationsDB();
-
-    ModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file);
+    ModificationsDB(OpenMS::String unimod_file = "CHEMISTRY/unimod.xml", OpenMS::String psimod_file = "CHEMISTRY/PSI-MOD.obo");
 
     ///copy constructor
     ModificationsDB(const ModificationsDB & residue_db);

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -80,6 +80,16 @@ public:
       return db_;
     }
 
+    inline static ModificationsDB * getCustomInstance(OpenMS::String unimod_file, OpenMS::String psimod_file)
+    {
+      static ModificationsDB * db_ = 0;
+      if (db_ == 0)
+      {
+        db_ = new ModificationsDB(unimod_file, psimod_file);
+      }
+      return db_;
+    }
+
     /// returns the number of modifications read from the unimod.xml file
     Size getNumberOfModifications() const;
 
@@ -190,6 +200,8 @@ private:
     //@{
     /// default constructor
     ModificationsDB();
+
+    ModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file);
 
     ///copy constructor
     ModificationsDB(const ModificationsDB & residue_db);

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -50,19 +50,13 @@ using namespace std;
 
 namespace OpenMS
 {
-  ModificationsDB::ModificationsDB()
-  {
-    readFromUnimodXMLFile("CHEMISTRY/unimod.xml");
-    readFromOBOFile("CHEMISTRY/PSI-MOD.obo");
-  }
-
   ModificationsDB::ModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file)
   {
-    if (unimod_file != OpenMS::String(""))
+    if (!unimod_file.empty())
     {
       readFromUnimodXMLFile(unimod_file);
     }
-    if (psimod_file != OpenMS::String(""))
+    if (!psimod_file.empty())
     {
       readFromOBOFile(psimod_file);
     }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -56,6 +56,18 @@ namespace OpenMS
     readFromOBOFile("CHEMISTRY/PSI-MOD.obo");
   }
 
+  ModificationsDB::ModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file)
+  {
+    if (unimod_file != OpenMS::String(""))
+    {
+      readFromUnimodXMLFile(unimod_file);
+    }
+    if (psimod_file != OpenMS::String(""))
+    {
+      readFromOBOFile(psimod_file);
+    }
+  }
+
   ModificationsDB::~ModificationsDB()
   {
     modification_names_.clear();

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -220,6 +220,11 @@ namespace OpenMS
 
   String File::find(const String& filename, StringList directories)
   {
+    if (exists(filename))
+    {
+        return String(QDir::cleanPath(filename.toQString()));
+    }
+
     String filename_new = filename;
 
     // empty string cannot be found, so throw Exception.
@@ -228,12 +233,6 @@ namespace OpenMS
 
     //add data dir in OpenMS data path
     directories.push_back(getOpenMSDataPath());
-
-    //add root dir
-    directories.push_back('/');
-
-    //add relative dir
-    directories.push_back('./');
 
     //add path suffix to all specified directories
     String path = File::path(filename);

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -229,6 +229,12 @@ namespace OpenMS
     //add data dir in OpenMS data path
     directories.push_back(getOpenMSDataPath());
 
+    //add root dir
+    directories.push_back('/');
+
+    //add relative dir
+    directories.push_back('./');
+
     //add path suffix to all specified directories
     String path = File::path(filename);
     if (path != "")


### PR DESCRIPTION
For some applications, it would be very convenient to use ModificationsDB instances based on custom UniMod XML & PSI-MOD OBO files. This pull requests suggests the function ModificationsDB::getCustomInstance() and changes in File::find() to support loading of these files using absolute and relative pathes.