### PR TITLE
[FIX] OpenSwathAssayGenerator: Compatibilty with VS10.0

### DIFF
--- a/src/topp/OpenSwathAssayGenerator.cpp
+++ b/src/topp/OpenSwathAssayGenerator.cpp
@@ -237,7 +237,8 @@ protected:
 
       if (enable_ms1_uis_scoring)
       {
-        for (int i = 0; i < Math::round((precursor_upper_mz_limit - precursor_lower_mz_limit) / precursor_mz_threshold); i++)
+        int num_precursor_windows = static_cast<int>(Math::round((precursor_upper_mz_limit - precursor_lower_mz_limit) / precursor_mz_threshold));
+        for (int i = 0; i < num_precursor_windows; i++)
         {
           uis_swathes.push_back(std::make_pair((precursor_lower_mz_limit+(i*precursor_mz_threshold)),(precursor_lower_mz_limit+((i+1)*precursor_mz_threshold))));
         }

--- a/src/topp/OpenSwathAssayGenerator.cpp
+++ b/src/topp/OpenSwathAssayGenerator.cpp
@@ -41,6 +41,7 @@
 #include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h>
+#include <OpenMS/MATH/MISC/MathFunctions.h>
 // #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 
 #include <iostream>
@@ -236,7 +237,7 @@ protected:
 
       if (enable_ms1_uis_scoring)
       {
-        for (int i = 0; i < round((precursor_upper_mz_limit - precursor_lower_mz_limit) / precursor_mz_threshold); i++)
+        for (int i = 0; i < Math::round((precursor_upper_mz_limit - precursor_lower_mz_limit) / precursor_mz_threshold); i++)
         {
           uis_swathes.push_back(std::make_pair((precursor_lower_mz_limit+(i*precursor_mz_threshold)),(precursor_lower_mz_limit+((i+1)*precursor_mz_threshold))));
         }


### PR DESCRIPTION
This pull request addresses the issue of missing std::round() functionality in VS10.0: https://github.com/OpenMS/OpenMS/commit/89945b7aa0996bbaa9c762054cd19195e405f76f#commitcomment-10688815