### PR TITLE
[FEATURE] OpenSwathWorkflow: UIS & Site-Scoring

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MRM/ReactionMonitoringTransition.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MRM/ReactionMonitoringTransition.h
@@ -154,6 +154,12 @@ public:
 
     void setLibraryIntensity(double intensity);
 
+    bool isDetectingTransition() const;
+
+    bool isIdentifyingTransition() const;
+
+    bool isQuantifyingTransition() const;
+
     //@}
 
     /** @name Predicates

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.h
@@ -54,6 +54,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/unordered_map.hpp>
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -161,6 +162,82 @@ public:
     void prepareProteinPeptideMaps_(OpenSwath::LightTargetedExperiment& transition_exp);
     //@}
 
+    /** @brief Splits combined transition groups into detection transition groups
+     * 
+     * For standard assays, transition_group_detection is identical to transition_group and the others are empty.
+     *
+     * @param transition_group Containing all detecting, identifying and site-identifying transitions
+     * @param transition_group_detection To be filled with detecting transitions
+    */
+    void splitTransitionGroupsDetection_(MRMTransitionGroupType& transition_group, MRMTransitionGroupType& transition_group_detection);
+
+    /** @brief Splits combined transition groups into identification transition groups
+     * 
+     * For standard assays, transition_group_identification is empty. When UIS scoring
+     * is enabled, it contains the corresponding identification transitions.
+     *
+     * @param transition_group Containing all detecting, identifying and site-identifying transitions
+     * @param transition_group_identification To be filled with identifying transitions
+     * @param transition_group_identification_decoy To be filled with identifying decoy transitions
+    */
+    void splitTransitionGroupsIdentification_(MRMTransitionGroupType& transition_group, MRMTransitionGroupType& transition_group_identification, MRMTransitionGroupType& transition_group_identification_decoy);
+
+    /** @brief Splits combined transition groups into site-identification transition groups
+     * 
+     * For standard assays, transition_group_site_identification is empty. When UIS scoring
+     * is enabled, it contains the corresponding site-identification transitions.
+     *
+     * @param transition_group Containing all detecting, identifying and site-identifying transitions
+     * @param transition_group_site_identification To be filled with site-identifying transitions
+     * @param transition_group_site_identification_decoy To be filled with site-identifying decoy transitions
+     * @param site_identifying_index The index for site-identifying target transitions
+     * @param site_identifying_decoy_index The index for site-identifying decoy transitions
+    */
+    void splitTransitionGroupsSiteIdentification_(MRMTransitionGroupType& transition_group, MRMTransitionGroupType& transition_group_site_identification, MRMTransitionGroupType& transition_group_site_identification_decoy, std::map<size_t, std::map<String, std::vector<String> > >& site_identifying_index, std::map<size_t, std::map<String, std::vector<String> > >& site_identifying_decoy_index);
+
+    /** @brief Provides scoring for target and decoy identification against detecting transitions
+     * 
+     * The function is used twice, for target and decoy identification transitions. The results are
+     * reported analogously to the ones for detecting transitions but must be stored separately.
+     *
+     * @param transition_group Containing all detecting, identifying and site-identifying transitions
+     * @param transition_group_identification Containing all detecting and identifying transitions
+     * @param scorer An instance of OpenSwathScoring
+     * @param feature_idx The index of the current feature
+     * @param native_ids_detection The native IDs of the detecting transitions
+     * @param sn_win_len_ The signal to noise window length
+     * @param sn_bin_count_ The signal to noise bin count
+     * @param write_log_messages Whether to write signal to noise log messages
+     * @value a struct of type OpenSwath_Scores containing either target or decoy values
+    */
+    OpenSwath_Scores scoreIdentification_(MRMTransitionGroupType& transition_group_identification, OpenSwathScoring& scorer, const size_t feature_idx, const std::vector<std::string> native_ids_detection, const double sn_win_len_, const unsigned int sn_bin_count_, bool write_log_messages);
+
+    /** @brief Provides scoring for target and decoy site-identification against detecting transitions
+     * 
+     * The function is used twice, for target and decoy identification transitions. The results are
+     * reported analogously to the ones for detecting transitions but must be stored separately.
+     *
+     * Scores for different classes of site-identifying transitions are being generated:
+     * - fwddiag: a-, b- or c- fragment ions with ordinal at modified residue
+     * - fwdnext: a-, b- or c- fragment ions with ordinal one residue before modified residue
+     * - revdiag: x-, y- or z- fragment ions with ordinal at modified residue
+     * - revnext: x-, y- or z- fragment ions with ordinal one residue before modified residue
+     *
+     * Aggregated site-identifying scores of the raw scores are then being generated (_diag).
+     *
+     * @param transition_group Containing all detecting, identifying and site-identifying transitions
+     * @param transition_group_site_identification Containing all detecting and identifying transitions
+     * @param site_identifying_index The index for site-identifying target transitions
+     * @param scorer An instance of OpenSwathScoring
+     * @param feature_idx The index of the current feature
+     * @param native_ids_detection The native IDs of the detecting transitions
+     * @param sn_win_len_ The signal to noise window length
+     * @param sn_bin_count_ The signal to noise bin count
+     * @param write_log_messages Whether to write signal to noise log messages
+     * @value a map containing the aggregated scores for the scored sites
+    */
+    boost::unordered_map<String, String> scoreSiteIdentification_(MRMTransitionGroupType& transition_group_site_identification, std::map<size_t, std::map<String, std::vector<String> > >& site_identifying_index, OpenSwathScoring& scorer, const size_t feature_idx, const std::vector<std::string> native_ids_detection, const double sn_win_len_, const unsigned int sn_bin_count_, bool write_log_messages);
+
     /** @brief Score all peak groups of a transition group
      *
      * Iterate through all features found along the chromatograms of the
@@ -234,6 +311,7 @@ private:
     double rt_normalization_factor_;
     int add_up_spectra_;
     double spacing_for_spectra_resampling_;
+    size_t num_uis_transitions_;
 
     // members
     std::map<OpenMS::String, const PeptideType*> PeptideRefMap_;

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathScoring.h
@@ -83,6 +83,8 @@ namespace OpenMS
 
     bool use_ms1_correlation;
     bool use_ms1_fullscan;
+    bool use_uis_scores;
+    bool use_site_scores;
   };
 
   /** @brief A structure to hold the different scores computed by OpenSWATH
@@ -105,10 +107,13 @@ namespace OpenMS
     double isotope_overlap;
     double massdev_score;
     double xcorr_coelution_score;
+    double min_xcorr_coelution_score;
     double xcorr_shape_score;
+    double max_xcorr_shape_score;
     double yseries_score;
     double bseries_score;
     double log_sn_score;
+    int id_num_transitions;
 
     double weighted_coelution_score;
     double weighted_xcorr_shape;
@@ -145,10 +150,13 @@ namespace OpenMS
       isotope_overlap(0),
       massdev_score(0),
       xcorr_coelution_score(0),
+      min_xcorr_coelution_score(0),
       xcorr_shape_score(0),
+      max_xcorr_shape_score(0),
       yseries_score(0),
       bseries_score(0),
       log_sn_score(0),
+      id_num_transitions(0),
       weighted_coelution_score(0),
       weighted_xcorr_shape(0),
       weighted_massdev_score(0),
@@ -451,6 +459,31 @@ var_yseries_score   -0.0327896378737766
           OpenSwath::IMRMFeature* imrmfeature,
           const std::vector<std::string>& native_ids,
           const std::vector<double>& normalized_library_intensity,
+          std::vector<OpenSwath::ISignalToNoisePtr>& signal_noise_estimators,
+          OpenSwath_Scores & scores);
+
+    /** @brief Score identification transitions against detection transitions of a single peakgroup 
+     * in a chromatogram using only chromatographic properties.
+     *
+     * This function only uses the chromatographic properties (coelution,
+     * signal to noise, etc.) of a peakgroup in a chromatogram to compute
+     * scores. The scores are computed by scoring identification against detection
+     * transitions.
+     *
+     * The scores are returned in the OpenSwath_Scores object. Only those
+     * scores specified in the OpenSwath_Scores_Usage object are computed.
+     *
+     * @param imrmfeature The feature to be scored
+     * @param native_ids_identification The list of identification native ids (giving a canonical ordering of the transitions)
+     * @param native_ids_detection The list of detection native ids (giving a canonical ordering of the transitions)
+     * @param signal_noise_estimators The signal-to-noise estimators for each transition
+     * @param scores The object to store the result
+     *
+    */
+    void calculateChromatographicIdScores(
+          OpenSwath::IMRMFeature* imrmfeature,
+          const std::vector<std::string>& native_ids_identification,
+          const std::vector<std::string>& native_ids_detection,
           std::vector<OpenSwath::ISignalToNoisePtr>& signal_noise_estimators,
           OpenSwath_Scores & scores);
 

--- a/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
+++ b/src/openms/source/ANALYSIS/MRM/ReactionMonitoringTransition.cpp
@@ -284,4 +284,52 @@ namespace OpenMS
     library_intensity_ = intensity;
   }
 
+  bool ReactionMonitoringTransition::isDetectingTransition() const
+  {
+    bool detecting = true;
+    if (this->metaValueExists("detecting_transition"))
+    {
+    if (!this->getMetaValue("detecting_transition").toBool()) {detecting = false;}
+    else if (this->getMetaValue("detecting_transition").toBool()) {detecting = true;}
+    }
+    else
+    {
+      detecting = true;
+    }
+
+    return detecting;
+  }
+
+  bool ReactionMonitoringTransition::isIdentifyingTransition() const
+  {
+    bool identifying = true;
+    if (this->metaValueExists("identifying_transition"))
+    {
+    if (!this->getMetaValue("identifying_transition").toBool()) {identifying = false;}
+    else if (this->getMetaValue("identifying_transition").toBool()) {identifying = true;}
+    }
+    else
+    {
+      identifying = false;
+    }
+
+    return identifying;
+  }
+
+  bool ReactionMonitoringTransition::isQuantifyingTransition() const
+  {
+    bool quantifying = true;
+    if (this->metaValueExists("quantifying_transition"))
+    {
+    if (!this->getMetaValue("quantifying_transition").toBool()) {quantifying = false;}
+    else if (this->getMetaValue("quantifying_transition").toBool()) {quantifying = true;}
+    }
+    else
+    {
+      quantifying = true;
+    }
+
+    return quantifying;
+  }
+
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -244,7 +244,7 @@ namespace OpenMS
     transition_group_detection.setTransitionGroupID(transition_group.getTransitionGroupID());
 
     std::vector<TransitionType> tr = transition_group.getTransitions();
-    for (std::vector<TransitionType>::const_iterator tr_it = tr.begin(); tr_it != tr.end(); tr_it++)
+    for (std::vector<TransitionType>::const_iterator tr_it = tr.begin(); tr_it != tr.end(); ++tr_it)
     {
       if (tr_it->isDetectingTransition())
       {
@@ -254,18 +254,18 @@ namespace OpenMS
     }
 
     std::vector< MRMFeature > tgf = transition_group.getFeatures();
-    for (std::vector< MRMFeature >::iterator tgf_it = tgf.begin(); tgf_it != tgf.end(); tgf_it++)
+    for (std::vector< MRMFeature >::iterator tgf_it = tgf.begin(); tgf_it != tgf.end(); ++tgf_it)
     {
       MRMFeature mf;
       mf.setIntensity(tgf_it->getIntensity());
       mf.setRT(tgf_it->getRT());
       std::vector<String> metavalues;
       tgf_it->getKeys(metavalues);
-      for (std::vector<String>::iterator key_it = metavalues.begin(); key_it != metavalues.end(); key_it++)
+      for (std::vector<String>::iterator key_it = metavalues.begin(); key_it != metavalues.end(); ++key_it)
       {
         mf.setMetaValue(*key_it,tgf_it->getMetaValue(*key_it));
       }
-      for (std::vector<TransitionType>::iterator tr_it = tr.begin(); tr_it != tr.end(); tr_it++)
+      for (std::vector<TransitionType>::iterator tr_it = tr.begin(); tr_it != tr.end(); ++tr_it)
       {
         if (tr_it->isDetectingTransition())
         {
@@ -274,7 +274,7 @@ namespace OpenMS
       }
       std::vector<String> pf_ids;
       tgf_it->getPrecursorFeatureIDs(pf_ids);
-      for (std::vector<String>::iterator pf_ids_it = pf_ids.begin(); pf_ids_it != pf_ids.end(); pf_ids_it++)
+      for (std::vector<String>::iterator pf_ids_it = pf_ids.begin(); pf_ids_it != pf_ids.end(); ++pf_ids_it)
       {
         mf.addPrecursorFeature(tgf_it->getPrecursorFeature(*pf_ids_it),*pf_ids_it);
       }
@@ -288,14 +288,14 @@ namespace OpenMS
     transition_group_identification_decoy.setTransitionGroupID(transition_group.getTransitionGroupID());
 
     std::vector< MRMFeature > tgf = transition_group.getFeaturesMuteable();
-    for (std::vector< MRMFeature >::iterator tgf_it = tgf.begin(); tgf_it != tgf.end(); tgf_it++)
+    for (std::vector< MRMFeature >::iterator tgf_it = tgf.begin(); tgf_it != tgf.end(); ++tgf_it)
     {
       transition_group_identification.addFeature(*tgf_it);
       transition_group_identification_decoy.addFeature(*tgf_it);
     }
 
     std::vector<TransitionType> tr = transition_group.getTransitions();
-    for (std::vector<TransitionType>::iterator tr_it = tr.begin(); tr_it != tr.end(); tr_it++)
+    for (std::vector<TransitionType>::iterator tr_it = tr.begin(); tr_it != tr.end(); ++tr_it)
     {
       if (tr_it->identifying_transition)
       {
@@ -319,14 +319,14 @@ namespace OpenMS
     transition_group_site_identification_decoy.setTransitionGroupID(transition_group.getTransitionGroupID());
 
     std::vector< MRMFeature > tgf = transition_group.getFeaturesMuteable();
-    for (std::vector< MRMFeature >::iterator tgf_it = tgf.begin(); tgf_it != tgf.end(); tgf_it++)
+    for (std::vector< MRMFeature >::iterator tgf_it = tgf.begin(); tgf_it != tgf.end(); ++tgf_it)
     {
       transition_group_site_identification.addFeature(*tgf_it);
       transition_group_site_identification_decoy.addFeature(*tgf_it);
     }
 
     std::vector<TransitionType> tr = transition_group.getTransitions();
-    for (std::vector<TransitionType>::iterator tr_it = tr.begin(); tr_it != tr.end(); tr_it++)
+    for (std::vector<TransitionType>::iterator tr_it = tr.begin(); tr_it != tr.end(); ++tr_it)
     {
       std::vector<int> site_identifying_transition = tr_it->site_identifying_transition;
       std::vector<std::string> site_identifying_class = tr_it->site_identifying_class;
@@ -445,7 +445,7 @@ namespace OpenMS
       transition_group_site_identification_revnext.setTransitionGroupID(transition_group_site_identification.getTransitionGroupID());
   
       std::vector< MRMFeature > tgf = transition_group_site_identification.getFeaturesMuteable();
-      for (std::vector< MRMFeature >::iterator tgf_it = tgf.begin(); tgf_it != tgf.end(); tgf_it++)
+      for (std::vector< MRMFeature >::iterator tgf_it = tgf.begin(); tgf_it != tgf.end(); ++tgf_it)
       {
         transition_group_site_identification_fwddiag.addFeature(*tgf_it);
         transition_group_site_identification_fwdnext.addFeature(*tgf_it);
@@ -453,7 +453,7 @@ namespace OpenMS
         transition_group_site_identification_revnext.addFeature(*tgf_it);
       }
 
-      for (std::vector<String>::iterator n_it = site_identifying_index[key][String("fwddiag")].begin(); n_it != site_identifying_index[key][String("fwddiag")].end(); n_it++)
+      for (std::vector<String>::iterator n_it = site_identifying_index[key][String("fwddiag")].begin(); n_it != site_identifying_index[key][String("fwddiag")].end(); ++n_it)
       {
         OpenSwath::ISignalToNoisePtr snptr(new OpenMS::SignalToNoiseOpenMS< PeakT >(transition_group_site_identification.getChromatogram(*n_it), sn_win_len_, sn_bin_count_, write_log_messages));
 
@@ -465,7 +465,7 @@ namespace OpenMS
           transition_group_site_identification_fwddiag.addChromatogram(transition_group_site_identification.getChromatogram(*n_it), *n_it);
         }
       }   
-      for (std::vector<String>::iterator n_it = site_identifying_index[key][String("fwdnext")].begin(); n_it != site_identifying_index[key][String("fwdnext")].end(); n_it++)
+      for (std::vector<String>::iterator n_it = site_identifying_index[key][String("fwdnext")].begin(); n_it != site_identifying_index[key][String("fwdnext")].end(); ++n_it)
       {
         OpenSwath::ISignalToNoisePtr snptr(new OpenMS::SignalToNoiseOpenMS< PeakT >(transition_group_site_identification.getChromatogram(*n_it), sn_win_len_, sn_bin_count_, write_log_messages));
 
@@ -477,7 +477,7 @@ namespace OpenMS
           transition_group_site_identification_fwdnext.addChromatogram(transition_group_site_identification.getChromatogram(*n_it), *n_it);
         }
       }   
-      for (std::vector<String>::iterator n_it = site_identifying_index[key][String("revdiag")].begin(); n_it != site_identifying_index[key][String("revdiag")].end(); n_it++)
+      for (std::vector<String>::iterator n_it = site_identifying_index[key][String("revdiag")].begin(); n_it != site_identifying_index[key][String("revdiag")].end(); ++n_it)
       {
         OpenSwath::ISignalToNoisePtr snptr(new OpenMS::SignalToNoiseOpenMS< PeakT >(transition_group_site_identification.getChromatogram(*n_it), sn_win_len_, sn_bin_count_, write_log_messages));
 
@@ -489,7 +489,7 @@ namespace OpenMS
           transition_group_site_identification_revdiag.addChromatogram(transition_group_site_identification.getChromatogram(*n_it), *n_it);
         }
       }   
-      for (std::vector<String>::iterator n_it = site_identifying_index[key][String("revnext")].begin(); n_it != site_identifying_index[key][String("revnext")].end(); n_it++)
+      for (std::vector<String>::iterator n_it = site_identifying_index[key][String("revnext")].begin(); n_it != site_identifying_index[key][String("revnext")].end(); ++n_it)
       {
         OpenSwath::ISignalToNoisePtr snptr(new OpenMS::SignalToNoiseOpenMS< PeakT >(transition_group_site_identification.getChromatogram(*n_it), sn_win_len_, sn_bin_count_, write_log_messages));
 

--- a/src/openswathalgo/include/OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/ALGO/MRMScoring.h
+++ b/src/openswathalgo/include/OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/ALGO/MRMScoring.h
@@ -108,11 +108,18 @@ public:
     /// Initialize the cross-correlation vector with the MS1 trace
     void initializeMS1XCorr(OpenSwath::IMRMFeature* mrmfeature, std::vector<String> native_ids, std::string precursor_id);
 
+    /// Initialize the scoring object and building the cross-correlation matrix of identification vs detection chromatograms
+    void initializeXCorrIdMatrix(OpenSwath::IMRMFeature* mrmfeature, std::vector<String> native_ids_identification, std::vector<String> native_ids_detection);
+
     /// calculate the cross-correlation score
     double calcXcorrCoelutionScore();
+    double calcXcorrIdCoelutionScore();
+    double calcMinXcorrIdCoelutionScore();
 
     /// calculate the cross-correlation shape score
     double calcXcorrShape_score();
+    double calcXcorrIdShape_score();
+    double calcMaxXcorrIdShape_score();
 
     /// calculate the weighted cross-correlation shape score
     double calcXcorrShape_score_weighted(const std::vector<double>& normalized_library_intensity);

--- a/src/tests/class_tests/openms/data/OpenSwath_identification_input.TraML
+++ b/src/tests/class_tests/openms/data/OpenSwath_identification_input.TraML
@@ -38,8 +38,8 @@
       <Product>
        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="628.435" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
       </Product>
-      <userParam name="detecting_transition" type="xsd:integer" value="1"/>
-      <userParam name="identifying_transition" type="xsd:integer" value="0"/>
+      <userParam name="detecting_transition" type="xsd:string" value="true"/>
+      <userParam name="identifying_transition" type="xsd:string" value="false"/>
       <userParam name="site_identifying_transition" type="xsd:string" value=""/>
       <userParam name="site_identifying_class" type="xsd:string" value=""/>
     </Transition>
@@ -53,8 +53,8 @@
       <Product>
        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="654.38" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
       </Product>
-      <userParam name="detecting_transition" type="xsd:integer" value="1"/>
-      <userParam name="identifying_transition" type="xsd:integer" value="0"/>
+      <userParam name="detecting_transition" type="xsd:string" value="true"/>
+      <userParam name="identifying_transition" type="xsd:string" value="false"/>
       <userParam name="site_identifying_transition" type="xsd:string" value=""/>
       <userParam name="site_identifying_class" type="xsd:string" value=""/>
     </Transition>
@@ -68,8 +68,8 @@
       <Product>
        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="618.31" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
       </Product>
-      <userParam name="detecting_transition" type="xsd:integer" value="1"/>
-      <userParam name="identifying_transition" type="xsd:integer" value="0"/>
+      <userParam name="detecting_transition" type="xsd:string" value="true"/>
+      <userParam name="identifying_transition" type="xsd:string" value="false"/>
       <userParam name="site_identifying_transition" type="xsd:string" value=""/>
       <userParam name="site_identifying_class" type="xsd:string" value=""/>
     </Transition>
@@ -83,25 +83,40 @@
       <Product>
        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="628.435" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
       </Product>
-      <userParam name="detecting_transition" type="xsd:integer" value="1"/>
-      <userParam name="identifying_transition" type="xsd:integer" value="0"/>
-      <userParam name="site_identifying_transition" type="xsd:string" value=""/>
-      <userParam name="site_identifying_class" type="xsd:string" value=""/>
+      <userParam name="detecting_transition" type="xsd:string" value="true"/>
+      <userParam name="identifying_transition" type="xsd:string" value="false"/>
+      <userParam name="site_identifying_transition" type="xsd:string" value="3"/>
+      <userParam name="site_identifying_class" type="xsd:string" value="revdiag"/>
+    </Transition>
+    <Transition id="tr5" peptideRef="tr_gr2" >
+      <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="1"/>
+      <cvParam cvRef="MS" accession="MS:1001226" name="product ion intensity" value="4300"/>
+      <cvParam cvRef="MS" accession="decoy" name="decoy" value="0"/>
+      <Precursor>
+       <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="501" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+      </Precursor>
+      <Product>
+       <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="651.3" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+      </Product>
+      <userParam name="detecting_transition" type="xsd:string" value="true"/>
+      <userParam name="identifying_transition" type="xsd:string" value="true"/>
+      <userParam name="site_identifying_transition" type="xsd:string" value="3,4"/>
+      <userParam name="site_identifying_class" type="xsd:string" value="revnext,revdiag"/>
     </Transition>
     <Transition id="tr2" peptideRef="tr_gr2" >
       <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="1"/>
       <cvParam cvRef="MS" accession="MS:1001226" name="product ion intensity" value="2"/>
       <cvParam cvRef="MS" accession="decoy" name="decoy" value="0"/>
       <Precursor>
-       <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="501" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+       <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="500" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
       </Precursor>
       <Product>
        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="654.38" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
       </Product>
-      <userParam name="detecting_transition" type="xsd:integer" value="0"/>
-      <userParam name="identifying_transition" type="xsd:integer" value="1"/>
-      <userParam name="site_identifying_transition" type="xsd:string" value=""/>
-      <userParam name="site_identifying_class" type="xsd:string" value=""/>
+      <userParam name="detecting_transition" type="xsd:string" value="false"/>
+      <userParam name="identifying_transition" type="xsd:string" value="true"/>
+      <userParam name="site_identifying_transition" type="xsd:string" value="3,4"/>
+      <userParam name="site_identifying_class" type="xsd:string" value="fwddiag,fwdnext"/>
     </Transition>
   </TransitionList>
 </TraML>

--- a/src/tests/class_tests/openms/source/MRMFeatureFinderScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFinderScoring_test.cpp
@@ -164,6 +164,194 @@ START_SECTION(void pickExperiment(OpenSwath::SpectrumAccessPtr input, FeatureMap
 
 }
 END_SECTION
+
+START_SECTION(void pickExperiment(OpenSwath::SpectrumAccessPtr input, FeatureMap< Feature > &output, OpenSwath::LightTargetedExperiment &transition_exp, TransformationDescription trafo, OpenSwath::SpectrumAccessPtr swath_map, TransitionGroupMapType &transition_group_map))
+{ 
+  MRMFeatureFinderScoring ff;
+  Param ff_param = MRMFeatureFinderScoring().getDefaults();
+  Param scores_to_use;
+  scores_to_use.setValue("use_uis_scores", "true", "Use UIS scores for proteoform identification ", ListUtils::create<String>("advanced"));
+  scores_to_use.setValidStrings("use_uis_scores", ListUtils::create<String>("true,false"));
+  ff_param.insert("Scores:", scores_to_use);
+  ff.setParameters(ff_param);
+
+  MRMFeature feature;
+  FeatureMap featureFile;
+  TransformationDescription trafo;
+  boost::shared_ptr<PeakMap> swath_map (new PeakMap);
+  TransitionGroupMapType transition_group_map;
+  MRMFeatureFinderScoring::MRMTransitionGroupType transition_group;
+
+  // Load the chromatograms (mzML) and the meta-information (TraML)
+  boost::shared_ptr<PeakMap> exp (new PeakMap);
+  OpenSwath::LightTargetedExperiment transitions;
+  MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("OpenSwath_generic_input.mzML"), *exp);
+  { 
+    TargetedExperiment transition_exp_;
+    TraMLFile().load(OPENMS_GET_TEST_DATA_PATH("OpenSwath_identification_input.TraML"), transition_exp_);
+    OpenSwathDataAccessHelper::convertTargetedExp(transition_exp_, transitions);
+  }
+
+  // Pick features in the experiment
+#ifdef USE_SP_INTERFACE
+  OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
+  OpenSwath::SpectrumAccessPtr chromatogram_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp);
+  ff.pickExperiment(chromatogram_ptr, featureFile, transitions, trafo, swath_ptr, transition_group_map);
+#else
+  ff.pickExperiment(exp, featureFile, transitions, trafo, *swath_map, transition_group_map);
+#endif
+
+  // Test the number of features found 
+  TEST_EQUAL(transition_group_map.size(), 2)
+
+  ///////////////////////////////////////////////////////////////////////////
+  //// Scores for the second group
+  transition_group = transition_group_map["tr_gr2"];
+  TEST_EQUAL(transition_group.size(), 3)
+  TEST_EQUAL(transition_group.getFeatures().size(), 2)
+  TEST_EQUAL(featureFile.size(), 3)
+
+  // Look closely at the feature we found in the second group
+  feature = transition_group.getFeatures()[0];
+  TOLERANCE_ABSOLUTE(0.1);
+  TEST_REAL_SIMILAR(feature.getRT(), 3119.092);
+  TEST_REAL_SIMILAR(feature.getIntensity(), 1034.55);
+
+  // feature attributes
+  TEST_REAL_SIMILAR(feature.getMetaValue("leftWidth" ), 3099.7);
+  TEST_REAL_SIMILAR(feature.getMetaValue("rightWidth"), 3147.68);
+  TEST_REAL_SIMILAR(feature.getMetaValue("total_xic"), 1610.27);
+
+  // feature scores
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_xcorr_coelution"), 2.265);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_xcorr_shape"), 0.7245);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_library_rmsd"), 0.43566);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_library_corr"), -0.784);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_elution_model_fit_score"), 0.902);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_intensity_score"), 0.642);
+  TEST_REAL_SIMILAR(feature.getMetaValue("sn_ratio"), 30.18);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_log_sn_score"), 3.40718216971789);
+
+  // feature identification scores
+  TEST_REAL_SIMILAR(feature.getMetaValue("id_target_num_transitions"), 2);
+  TEST_REAL_SIMILAR(feature.getMetaValue("id_target_xcorr_coelution"), 2.544);
+  TEST_REAL_SIMILAR(feature.getMetaValue("id_target_min_xcorr_coelution"), 1);
+  TEST_REAL_SIMILAR(feature.getMetaValue("id_target_xcorr_shape"), 0.688);
+  TEST_REAL_SIMILAR(feature.getMetaValue("id_target_max_xcorr_shape"), 0.690);
+  TEST_REAL_SIMILAR(feature.getMetaValue("id_target_log_sn_score"), 3.794);
+  TEST_REAL_SIMILAR(feature.getMetaValue("id_target_elution_model_fit_score"), 0.974);
+
+}
+END_SECTION
+
+START_SECTION(void pickExperiment(OpenSwath::SpectrumAccessPtr input, FeatureMap< Feature > &output, OpenSwath::LightTargetedExperiment &transition_exp, TransformationDescription trafo, OpenSwath::SpectrumAccessPtr swath_map, TransitionGroupMapType &transition_group_map))
+{ 
+  MRMFeatureFinderScoring ff;
+  Param ff_param = MRMFeatureFinderScoring().getDefaults();
+  Param scores_to_use;
+  scores_to_use.setValue("use_site_scores", "true", "Use site-specific scores for proteoform identification ", ListUtils::create<String>("advanced"));
+  scores_to_use.setValidStrings("use_site_scores", ListUtils::create<String>("true,false"));
+  ff_param.insert("Scores:", scores_to_use);
+  ff.setParameters(ff_param);
+
+  MRMFeature feature;
+  FeatureMap featureFile;
+  TransformationDescription trafo;
+  boost::shared_ptr<PeakMap> swath_map (new PeakMap);
+  TransitionGroupMapType transition_group_map;
+  MRMFeatureFinderScoring::MRMTransitionGroupType transition_group;
+
+  // Load the chromatograms (mzML) and the meta-information (TraML)
+  boost::shared_ptr<PeakMap> exp (new PeakMap);
+  OpenSwath::LightTargetedExperiment transitions;
+  MzMLFile().load(OPENMS_GET_TEST_DATA_PATH("OpenSwath_generic_input.mzML"), *exp);
+  { 
+    TargetedExperiment transition_exp_;
+    TraMLFile().load(OPENMS_GET_TEST_DATA_PATH("OpenSwath_identification_input.TraML"), transition_exp_);
+    OpenSwathDataAccessHelper::convertTargetedExp(transition_exp_, transitions);
+  }
+
+  // Pick features in the experiment
+#ifdef USE_SP_INTERFACE
+  OpenSwath::SpectrumAccessPtr swath_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(swath_map);
+  OpenSwath::SpectrumAccessPtr chromatogram_ptr = SimpleOpenMSSpectraFactory::getSpectrumAccessOpenMSPtr(exp);
+  ff.pickExperiment(chromatogram_ptr, featureFile, transitions, trafo, swath_ptr, transition_group_map);
+#else
+  ff.pickExperiment(exp, featureFile, transitions, trafo, *swath_map, transition_group_map);
+#endif
+
+  // Test the number of features found 
+  TEST_EQUAL(transition_group_map.size(), 2)
+
+  ///////////////////////////////////////////////////////////////////////////
+  //// Scores for the second group
+  transition_group = transition_group_map["tr_gr2"];
+  TEST_EQUAL(transition_group.size(), 3)
+  TEST_EQUAL(transition_group.getFeatures().size(), 2)
+  TEST_EQUAL(featureFile.size(), 3)
+
+  // Look closely at the feature we found in the second group
+  feature = transition_group.getFeatures()[0];
+  TOLERANCE_ABSOLUTE(0.1);
+  TEST_REAL_SIMILAR(feature.getRT(), 3119.092);
+  TEST_REAL_SIMILAR(feature.getIntensity(), 1034.55);
+
+  // feature attributes
+  TEST_REAL_SIMILAR(feature.getMetaValue("leftWidth" ), 3099.7);
+  TEST_REAL_SIMILAR(feature.getMetaValue("rightWidth"), 3147.68);
+  TEST_REAL_SIMILAR(feature.getMetaValue("total_xic"), 1610.27);
+
+  // feature scores
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_xcorr_coelution"), 2.265);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_xcorr_shape"), 0.7245);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_library_rmsd"), 0.43566);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_library_corr"), -0.784);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_elution_model_fit_score"), 0.902);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_intensity_score"), 0.642);
+  TEST_REAL_SIMILAR(feature.getMetaValue("sn_ratio"), 30.18);
+  TEST_REAL_SIMILAR(feature.getMetaValue("var_log_sn_score"), 3.40718216971789);
+
+  // feature identification scores
+  TEST_EQUAL(feature.getMetaValue("sid_target_num_transitions"), "3:1_0_1_1;4:0_1_1_0;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_coelution"), "3:5;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_coelution_diag"), "3:6.38838379663723;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_coelution_fwddiag"), "3:3.19419189831861;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_coelution_fwdnext"), "3:;4:3.19419189831861;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_coelution_revdiag"), "3:3.19419189831861;4:2;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_coelution_revnext"), "3:2;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_min_xcorr_coelution"), "3:2;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_min_xcorr_coelution_diag"), "3:3.33333333333333;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_min_xcorr_coelution_fwddiag"), "3:1.66666666666667;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_min_xcorr_coelution_fwdnext"), "3:;4:1.66666666666667;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_min_xcorr_coelution_revdiag"), "3:1.66666666666667;4:1;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_min_xcorr_coelution_revnext"), "3:1;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_shape"), "3:1.38256468013869;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_shape_diag"), "3:1.38256468013869;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_shape_fwddiag"), "3:0.690493679584138;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_shape_fwdnext"), "3:;4:0.690493679584138;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_shape_revdiag"), "3:0.692071000554549;4:0.686309833886937;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_xcorr_shape_revnext"), "3:0.686309833886937;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_max_xcorr_shape"), "3:1.38256468013869;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_max_xcorr_shape_diag"), "3:1.38256468013869;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_max_xcorr_shape_fwddiag"), "3:0.690493679584138;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_max_xcorr_shape_fwdnext"), "3:;4:0.690493679584138;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_max_xcorr_shape_revdiag"), "3:0.692071000554549;4:0.686309833886937;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_max_xcorr_shape_revnext"), "3:0.686309833886937;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_log_sn"), "3:8.90877224487829;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_log_sn_diag"), "3:8.90877224487829;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_log_sn_fwddiag"), "3:4.45007591150298;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_log_sn_fwdnext"), "3:;4:4.45007591150298;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_log_sn_revdiag"), "3:4.45869633337531;4:1.16692266163571;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_log_sn_revnext"), "3:1.16692266163571;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_elution_model_fit"), "3:1.97080624103546;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_elution_model_fit_diag"), "3:1.97080624103546;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_elution_model_fit_fwddiag"), "3:0.987985491752625;4:;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_elution_model_fit_fwdnext"), "3:;4:0.987985491752625;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_elution_model_fit_revdiag"), "3:0.982820749282837;4:0.960665225982666;");
+  TEST_EQUAL(feature.getMetaValue("sid_target_elution_model_fit_revnext"), "3:0.960665225982666;4:;");
+
+}
+END_SECTION
     
 START_SECTION(void mapExperimentToTransitionList(OpenSwath::SpectrumAccessPtr input, OpenSwath::LightTargetedExperiment &transition_exp, TransitionGroupMapType &transition_group_map, TransformationDescription trafo, double rt_extraction_window))
 {

--- a/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
@@ -85,6 +85,8 @@ sum(datapoints[3:10])
 
   // Transition trace 1
   {
+  ReactionMonitoringTransition transition;
+  transition.setNativeID("1");
   RichPeakChromatogram chromatogram;
   for (int k = 0; k < 18; k++)
   {   
@@ -96,10 +98,13 @@ sum(datapoints[3:10])
   chromatogram.setMetaValue("product_mz", 618.31);
   chromatogram.setNativeID("1");
   transition_group.addChromatogram(chromatogram, chromatogram.getNativeID());
+  transition_group.addTransition(transition, transition.getNativeID());
   }
 
   // Transition trace 2
   {
+  ReactionMonitoringTransition transition;
+  transition.setNativeID("2");
   RichPeakChromatogram chromatogram;
   for (int k = 0; k < 18; k++)
   {   
@@ -111,6 +116,7 @@ sum(datapoints[3:10])
   chromatogram.setMetaValue("product_mz", 619.31);
   chromatogram.setNativeID("2");
   transition_group.addChromatogram(chromatogram, chromatogram.getNativeID());
+  transition_group.addTransition(transition, transition.getNativeID());
   }
 
   // MS1 trace
@@ -236,6 +242,7 @@ START_SECTION((template <typename SpectrumT, typename TransitionT> MRMFeature cr
     picked_chrom.getFloatDataArrays()[0].push_back(1000.0);
     picked_chrom.getFloatDataArrays()[1].push_back(left_start);
     picked_chrom.getFloatDataArrays()[2].push_back(right_end);
+    picked_chrom.setNativeID(transition_group.getChromatograms()[k].getNativeID());
 
     picked_chroms.push_back(picked_chrom);
   }

--- a/src/tests/class_tests/openms/source/OpenSwathScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathScoring_test.cpp
@@ -88,6 +88,13 @@ START_SECTION((void calculateChromatographicScores( OpenSwath::IMRMFeature* imrm
 }
 END_SECTION
 
+START_SECTION((void calculateChromatographicIdScores( OpenSwath::IMRMFeature* imrmfeature, const std::vector<std::string>& native_ids_identification,, const std::vector<std::string>& native_ids_detection, std::vector<OpenSwath::ISignalToNoisePtr>& signal_noise_estimators, OpenSwath_Scores & idscores) ))
+{
+  NOT_TESTABLE // see MRMFeatureFinderScoring_test.cpp
+  // - the OpenSwathScoring is a facade and thus does not need testing on its own
+}
+END_SECTION
+
 START_SECTION((void calculateLibraryScores( OpenSwath::IMRMFeature* imrmfeature, const std::vector<TransitionType> & transitions, const PeptideType& pep, const double normalized_feature_rt, OpenSwath_Scores & scores)))
 {
   NOT_TESTABLE // see MRMFeatureFinderScoring_test.cpp

--- a/src/tests/class_tests/openswathalgo/MRMScoring_test.cpp
+++ b/src/tests/class_tests/openswathalgo/MRMScoring_test.cpp
@@ -230,6 +230,43 @@ BOOST_AUTO_TEST_CASE(initializeMS1XCorr)
 }
 END_SECTION
 
+BOOST_AUTO_TEST_CASE(initializeXCorrIdMatrix)
+{
+  MockMRMFeature * imrmfeature = new MockMRMFeature();
+  MRMScoring mrmscore;
+
+  std::vector<std::string> native_ids;
+  fill_mock_objects(imrmfeature, native_ids);
+
+  //initialize the XCorr Matrix
+  mrmscore.initializeXCorrIdMatrix(imrmfeature, native_ids, native_ids);
+
+  TEST_EQUAL(mrmscore.getXCorrMatrix().size(), 2)
+  TEST_EQUAL(mrmscore.getXCorrMatrix()[0].size(), 2)
+  TEST_EQUAL(mrmscore.getXCorrMatrix()[0][0].size(), 23)
+
+  // test auto-correlation = xcorrmatrix_0_0
+  const std::map<int, double> auto_correlation =
+      mrmscore.getXCorrMatrix()[0][0];
+  TEST_REAL_SIMILAR(auto_correlation.find(0)->second, 1)
+  TEST_REAL_SIMILAR(auto_correlation.find(1)->second, -0.227352707759245)
+  TEST_REAL_SIMILAR(auto_correlation.find(-1)->second, -0.227352707759245)
+  TEST_REAL_SIMILAR(auto_correlation.find(2)->second, -0.07501116)
+  TEST_REAL_SIMILAR(auto_correlation.find(-2)->second, -0.07501116)
+
+  // test cross-correlation = xcorrmatrix_0_1
+  const std::map<int, double> cross_correlation =
+      mrmscore.getXCorrMatrix()[0][1];
+  TEST_REAL_SIMILAR(cross_correlation.find(2)->second, -0.31165141)
+  TEST_REAL_SIMILAR(cross_correlation.find(1)->second, -0.35036919)
+  TEST_REAL_SIMILAR(cross_correlation.find(0)->second, 0.03129565)
+  TEST_REAL_SIMILAR(cross_correlation.find(-1)->second, 0.30204049)
+  TEST_REAL_SIMILAR(cross_correlation.find(-2)->second, 0.13012441)
+  TEST_REAL_SIMILAR(cross_correlation.find(-3)->second, 0.39698322)
+  TEST_REAL_SIMILAR(cross_correlation.find(-4)->second, 0.16608774)
+}
+END_SECTION
+
 BOOST_AUTO_TEST_CASE(test_calcXcorrCoelutionScore)
 {
   MockMRMFeature * imrmfeature = new MockMRMFeature();
@@ -238,6 +275,28 @@ BOOST_AUTO_TEST_CASE(test_calcXcorrCoelutionScore)
   fill_mock_objects(imrmfeature, native_ids);
   mrmscore.initializeXCorrMatrix(imrmfeature, native_ids);
   TEST_REAL_SIMILAR(mrmscore.calcXcorrCoelutionScore(), 1 + std::sqrt(3.0)) // mean + std deviation
+}
+END_SECTION
+
+BOOST_AUTO_TEST_CASE(test_calcXcorrIdCoelutionScore)
+{ 
+  MockMRMFeature * imrmfeature = new MockMRMFeature();
+  MRMScoring mrmscore;
+  std::vector<std::string> native_ids;
+  fill_mock_objects(imrmfeature, native_ids);
+  mrmscore.initializeXCorrIdMatrix(imrmfeature, native_ids, native_ids);
+  TEST_REAL_SIMILAR(mrmscore.calcXcorrIdCoelutionScore(), 1.5 + std::sqrt(3.0)) // mean + std deviation
+}
+END_SECTION
+
+BOOST_AUTO_TEST_CASE(test_calcMinXcorrIdCoelutionScore)
+{ 
+  MockMRMFeature * imrmfeature = new MockMRMFeature();
+  MRMScoring mrmscore;
+  std::vector<std::string> native_ids;
+  fill_mock_objects(imrmfeature, native_ids);
+  mrmscore.initializeXCorrIdMatrix(imrmfeature, native_ids, native_ids);
+  TEST_EQUAL(mrmscore.calcMinXcorrIdCoelutionScore(), 1.5) // min
 }
 END_SECTION
 
@@ -265,6 +324,28 @@ BOOST_AUTO_TEST_CASE(test_calcXcorrShape_score)
   fill_mock_objects(imrmfeature, native_ids);
   mrmscore.initializeXCorrMatrix(imrmfeature, native_ids);
   TEST_REAL_SIMILAR(mrmscore.calcXcorrShape_score(), (1.0 + 0.3969832 + 1.0)/3.0) // mean + std deviation
+}
+END_SECTION
+
+BOOST_AUTO_TEST_CASE(test_calcXcorrIdShape_score)
+{
+  MockMRMFeature * imrmfeature = new MockMRMFeature();
+  MRMScoring mrmscore;
+  std::vector<std::string> native_ids;
+  fill_mock_objects(imrmfeature, native_ids);
+  mrmscore.initializeXCorrIdMatrix(imrmfeature, native_ids, native_ids);
+  TEST_REAL_SIMILAR(mrmscore.calcXcorrIdShape_score(), (1+0.3969832+0.3969832+1)/4.0) // mean + std deviation
+}
+END_SECTION
+
+BOOST_AUTO_TEST_CASE(test_calcMaxXcorrIdShape_score)
+{ 
+  MockMRMFeature * imrmfeature = new MockMRMFeature();
+  MRMScoring mrmscore;
+  std::vector<std::string> native_ids;
+  fill_mock_objects(imrmfeature, native_ids);
+  mrmscore.initializeXCorrIdMatrix(imrmfeature, native_ids, native_ids);
+  TEST_REAL_SIMILAR(mrmscore.calcMaxXcorrIdShape_score(), 0.6984916) // max
 }
 END_SECTION
 

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -88,14 +88,18 @@ namespace OpenMS
     String input_filename_;
     bool doWrite_;
     bool use_ms1_traces_;
+    bool enable_uis_scoring_;
+    bool enable_site_scoring_;
 
   public:
 
-    OpenSwathTSVWriter(String output_filename, String input_filename = "inputfile", bool ms1_scores = false) :
+    OpenSwathTSVWriter(String output_filename, String input_filename = "inputfile", bool ms1_scores = false, bool uis_scores = false, bool site_scores = false) :
       ofs(output_filename.c_str()),
       input_filename_(input_filename),
       doWrite_(!output_filename.empty()),
-      use_ms1_traces_(ms1_scores)
+      use_ms1_traces_(ms1_scores),
+      enable_uis_scoring_(uis_scores),
+      enable_site_scoring_(site_scores)
       {}
 
     bool isActive() 
@@ -124,7 +128,18 @@ namespace OpenMS
       {
         ofs << "\taggr_prec_Peak_Area\taggr_prec_Peak_Apex\taggr_prec_Fragment_Annotation";
       }
-      ofs << "\taggr_Peak_Area\taggr_Peak_Apex\taggr_Fragment_Annotation\n";
+      ofs << "\taggr_Peak_Area\taggr_Peak_Apex\taggr_Fragment_Annotation";
+      if (enable_uis_scoring_)
+      {
+        ofs << "\tid_target_num_transitions\tid_target_var_xcorr_coelution\tid_target_var_min_xcorr_coelution\tid_target_var_xcorr_shape\tid_target_var_max_xcorr_shape\tid_target_main_var_log_sn_score\tid_target_var_elution_model_fit_score" <<
+        "\tid_decoy_num_transitions\tid_decoy_var_xcorr_coelution\tid_decoy_var_min_xcorr_coelution\tid_decoy_var_xcorr_shape\tid_decoy_var_max_xcorr_shape\tid_decoy_main_var_log_sn_score\tid_decoy_var_elution_model_fit_score";
+      }
+      if (enable_site_scoring_)
+      {
+        ofs << "\tsid_target_num_transitions\tsid_target_var_xcorr_coelution\tsid_target_var_xcorr_coelution_diag\tsid_target_var_min_xcorr_coelution\tsid_target_var_min_xcorr_coelution_diag\tsid_target_var_xcorr_shape\tsid_target_var_xcorr_shape_diag\tsid_target_var_max_xcorr_shape\tsid_target_var_max_xcorr_shape_diag\tsid_target_var_log_sn\tsid_target_main_var_log_sn_diag\tsid_target_var_elution_model_fit\tsid_target_var_elution_model_fit_diag" <<
+        "\tsid_decoy_num_transitions\tsid_decoy_var_xcorr_coelution\tsid_decoy_var_xcorr_coelution_diag\tsid_decoy_var_min_xcorr_coelution\tsid_decoy_var_min_xcorr_coelution_diag\tsid_decoy_var_xcorr_shape\tsid_decoy_var_xcorr_shape_diag\tsid_decoy_var_max_xcorr_shape\tsid_decoy_var_max_xcorr_shape_diag\tsid_decoy_var_log_sn\tsid_decoy_main_var_log_sn_diag\tsid_decoy_var_elution_model_fit\tsid_decoy_var_elution_model_fit_diag";       
+      }
+      ofs << "\n";
     }
 
     String prepareLine(const OpenSwath::LightPeptide& pep,
@@ -262,8 +277,54 @@ namespace OpenMS
             {
               line += "\t" + aggr_prec_Peak_Area + "\t" + aggr_prec_Peak_Apex + "\t" + aggr_prec_Fragment_Annotation;
             }
-            line += "\t" + aggr_Peak_Area + "\t" + aggr_Peak_Apex + "\t" + aggr_Fragment_Annotation + "\n";
-          result += line;
+            line += "\t" + aggr_Peak_Area + "\t" + aggr_Peak_Apex + "\t" + aggr_Fragment_Annotation;
+            if (enable_uis_scoring_)
+            {
+              line += "\t" + (String)feature_it->getMetaValue("id_target_num_transitions")
+              + "\t" + (String)feature_it->getMetaValue("id_target_xcorr_coelution")
+              + "\t" + (String)feature_it->getMetaValue("id_target_min_xcorr_coelution")
+              + "\t" + (String)feature_it->getMetaValue("id_target_xcorr_shape")
+              + "\t" + (String)feature_it->getMetaValue("id_target_max_xcorr_shape")
+              + "\t" + (String)feature_it->getMetaValue("id_target_log_sn_score")
+              + "\t" + (String)feature_it->getMetaValue("id_target_elution_model_fit_score")
+              + "\t" + (String)feature_it->getMetaValue("id_decoy_num_transitions")
+              + "\t" + (String)feature_it->getMetaValue("id_decoy_xcorr_coelution")
+              + "\t" + (String)feature_it->getMetaValue("id_decoy_min_xcorr_coelution")
+              + "\t" + (String)feature_it->getMetaValue("id_decoy_xcorr_shape")
+              + "\t" + (String)feature_it->getMetaValue("id_decoy_max_xcorr_shape")
+              + "\t" + (String)feature_it->getMetaValue("id_decoy_log_sn_score")
+              + "\t" + (String)feature_it->getMetaValue("id_decoy_elution_model_fit_score");
+            }
+            if (enable_site_scoring_)
+            {
+              line += "\t" + (String)feature_it->getMetaValue("sid_target_num_transitions")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_xcorr_coelution")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_xcorr_coelution_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_min_xcorr_coelution")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_min_xcorr_coelution_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_xcorr_shape")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_xcorr_shape_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_max_xcorr_shape")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_max_xcorr_shape_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_log_sn")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_log_sn_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_elution_model_fit")
+              + "\t" + (String)feature_it->getMetaValue("sid_target_elution_model_fit_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_num_transitions")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_xcorr_coelution")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_xcorr_coelution_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_min_xcorr_coelution")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_min_xcorr_coelution_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_xcorr_shape")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_xcorr_shape_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_max_xcorr_shape")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_max_xcorr_shape_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_log_sn")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_log_sn_diag")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_elution_model_fit")
+              + "\t" + (String)feature_it->getMetaValue("sid_decoy_elution_model_fit_diag");
+            }
+            line += "\n";          result += line;
         } // end of iteration
       return result;
     }
@@ -1194,6 +1255,8 @@ protected:
     registerFlag_("sort_swath_maps", "Sort of input SWATH files when matching to SWATH windows from swath_windows_file", true);
 
     registerFlag_("use_ms1_traces", "Extract the precursor ion trace(s) and use for scoring", true);
+    registerFlag_("enable_uis_scoring", "Enable additional scoring uf UIS identification assays", true);
+    registerFlag_("enable_site_scoring", "Enable additional scoring uf site-specific identification assays", true);
 
     // one of the following two needs to be set
     registerOutputFile_("out_features", "<file>", "", "output file", false);
@@ -1278,6 +1341,7 @@ protected:
       // remove these parameters
       feature_finder_param.remove("add_up_spectra");
       feature_finder_param.remove("spacing_for_spectra_resampling");
+      feature_finder_param.remove("num_uis_transitions");
       feature_finder_param.remove("EMGScoring:statistics:mean");
       feature_finder_param.remove("EMGScoring:statistics:variance");
       return feature_finder_param;
@@ -1413,6 +1477,8 @@ protected:
     bool use_emg_score = getFlag_("use_elution_model_score");
     bool sort_swath_maps = getFlag_("sort_swath_maps");
     bool use_ms1_traces = getFlag_("use_ms1_traces");
+    bool enable_uis_scoring = getFlag_("enable_uis_scoring");
+    bool enable_site_scoring = getFlag_("enable_site_scoring");
     double min_upper_edge_dist = getDoubleOption_("min_upper_edge_dist");
     double mz_extraction_window = getDoubleOption_("mz_extraction_window");
     double rt_extraction_window = getDoubleOption_("rt_extraction_window");
@@ -1482,6 +1548,14 @@ protected:
     {
       feature_finder_param.setValue("Scores:use_ms1_correlation", "true");
       feature_finder_param.setValue("Scores:use_ms1_fullscan", "true");
+    }
+    if (enable_uis_scoring)
+    {
+      feature_finder_param.setValue("Scores:use_uis_scores", "true");
+    }
+    if (enable_site_scoring)
+    {
+      feature_finder_param.setValue("Scores:use_site_scores", "true");
     }
 
     ///////////////////////////////////
@@ -1553,7 +1627,7 @@ protected:
     ///////////////////////////////////
     FeatureMap out_featureFile;
 
-    OpenSwathTSVWriter tsvwriter(out_tsv, file_list[0], use_ms1_traces);
+    OpenSwathTSVWriter tsvwriter(out_tsv, file_list[0], use_ms1_traces, enable_uis_scoring, enable_site_scoring);
     OpenSwathWorkflow wf(use_ms1_traces);
     wf.setLogType(log_type_);
 


### PR DESCRIPTION
This pull request introduces support in OpenSwathWorkflow and the associated peak-picking and peak group scoring classes for UIS and site-specific scoring. The default behavior is to produce identical results as before; activation of the scores is done by setting flags and requires annotated input assay libraries.