### PR TITLE
TOPPView: fix vertical scrollbar behaviour

### DIFF
--- a/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
@@ -1475,43 +1475,41 @@ namespace OpenMS
   void Spectrum2DCanvas::horizontalScrollBarChange(int value)
   {
     AreaType new_area = visible_area_;
-    if (isMzToXAxis())
+    if (!isMzToXAxis())
     {
-      new_area.setMinX(value);
-      new_area.setMaxX(value + (visible_area_.maxX() - visible_area_.minX()));
-      //cout << __PRETTY_FUNCTION__ << endl;
-      changeVisibleArea_(new_area);
-      emit layerZoomChanged(this);
+      new_area.setMinY(value);
+      new_area.setMaxY(value + (visible_area_.height()));
     }
     else
     {
-      new_area.setMinY(value);
-      new_area.setMaxY(value + (visible_area_.maxY() - visible_area_.minY()));
-      //cout << __PRETTY_FUNCTION__ << endl;
-      changeVisibleArea_(new_area);
-      emit layerZoomChanged(this);
+      new_area.setMinX(value);
+      new_area.setMaxX(value + (visible_area_.width()));
     }
+    //cout << __PRETTY_FUNCTION__ << endl;
+    changeVisibleArea_(new_area);
+    emit layerZoomChanged(this);
   }
 
   void Spectrum2DCanvas::verticalScrollBarChange(int value)
   {
+    // invert 'value' (since the VERTICAL(!) scrollbar's range is negative -- see SpectrumWidget::updateVScrollbar())
+    // this is independent on isMzToXAxis()!
+    value *= -1;
+    
     AreaType new_area = visible_area_;
     if (!isMzToXAxis())
     {
       new_area.setMinX(value);
-      new_area.setMaxX(value + (visible_area_.maxX() - visible_area_.minX()));
-      //cout << __PRETTY_FUNCTION__ << endl;
-      changeVisibleArea_(new_area);
-      emit layerZoomChanged(this);
+      new_area.setMaxX(value + visible_area_.width());
     }
     else
     {
       new_area.setMinY(value);
-      new_area.setMaxY(value + (visible_area_.maxY() - visible_area_.minY()));
-      //cout << __PRETTY_FUNCTION__ << endl;
-      changeVisibleArea_(new_area);
-      emit layerZoomChanged(this);
+      new_area.setMaxY(value + (visible_area_.height()));
     }
+    //cout << __PRETTY_FUNCTION__ << endl;
+    changeVisibleArea_(new_area);
+    emit layerZoomChanged(this);
   }
 
   void Spectrum2DCanvas::paintEvent(QPaintEvent * e)

--- a/src/openms_gui/source/VISUAL/SpectrumWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumWidget.cpp
@@ -79,9 +79,14 @@ namespace OpenMS
     connect(canvas_, SIGNAL(recalculateAxes()), this, SLOT(updateAxes()));
     connect(canvas_, SIGNAL(changeLegendVisibility()), this, SLOT(changeLegendVisibility()));
     //scrollbars
-    x_scrollbar_ = new QScrollBar(Qt::Horizontal, this);
-    y_scrollbar_ = new QScrollBar(Qt::Vertical, this);
-    y_scrollbar_->setInvertedAppearance(true);
+    x_scrollbar_ = new QScrollBar(Qt::Horizontal, this); // left is small value, right is high value
+    y_scrollbar_ = new QScrollBar(Qt::Vertical, this); // top is low value, bottom is high value (however, our coordinate system is inverse for the y-Axis!)
+    // We achieve the desired behavior by setting negative min/max ranges within the scrollbar when updateVScrollbar() is called.
+    // Thus, y_scrollbar_->valueChanged() will report negative values (which you need to multiply by -1 to get the correct value).
+    // Remember this when implementing verticalScrollBarChange() in your canvas class (currently only used in Spectrum2DCanvas)
+    // Do NOT use the build-in functions to invert a scrollbar, since implementation can be incomplete depending on style and platform
+    //y_scrollbar_->setInvertedAppearance(true);
+    //y_scrollbar_->setInvertedControls(true);
     grid_->addWidget(y_scrollbar_, row, col - 2);
     grid_->addWidget(x_scrollbar_, row + 2, col);
     x_scrollbar_->hide();
@@ -288,9 +293,11 @@ namespace OpenMS
       int local_max = max(f_max, disp_max);
       y_scrollbar_->blockSignals(true);
       y_scrollbar_->show();
-      y_scrollbar_->setMinimum(static_cast<int>(local_min));
-      y_scrollbar_->setMaximum(static_cast<int>(std::ceil(local_max - disp_max + disp_min)));
-      y_scrollbar_->setValue(static_cast<int>(disp_min));
+      // we use negative min/max here, because our coordinate system is inverted (small values are the bottom, higher values at the top)
+      // and we want the scrollbar to move correctly when clicking it
+      y_scrollbar_->setMaximum(static_cast<int>(-local_min));
+      y_scrollbar_->setMinimum(static_cast<int>(-std::ceil(local_max - (disp_max - disp_min))));
+      y_scrollbar_->setValue(static_cast<int>(-disp_min)); // 'disp_min' would be expected, but we invert, since our coordinate system is bottom to top
       y_scrollbar_->setPageStep(static_cast<int>(disp_max - disp_min));
       y_scrollbar_->blockSignals(false);
     }


### PR DESCRIPTION
Issue reported by Ana.Villar-Garea@vkl.uni-regensburg.de
 If one clicks on the most right-side of the bar for the  rt axis (x-axis), the window is scrolled to the area with higher rt values, as expected. Consequently, if one clicks on the most left-side, it scrolls to lower rt values. However, for the m/z axis (y-axis), if one clicks on the most upper part of the scroll bar (higher m/z values), the window slides towards smaller m/z values (although one would expect the contrary). If one clicks on the most lower part of the bar, then the window slides to higher m/z values.

This PR fixes the scrollbar behaviour.