### PR TITLE
change MzTabExporter output format from csv to tsv

### DIFF
--- a/src/topp/MzTabExporter.cpp
+++ b/src/topp/MzTabExporter.cpp
@@ -116,7 +116,7 @@ protected:
       registerInputFile_("in_id", "<file>", "", "Identifications used to generate the mzTab file.", false);
       setValidFormats_("in_id", ListUtils::create<String>("idXML"));
       registerOutputFile_("out", "<file>", "", "Output file (mzTab)", true);
-      setValidFormats_("out", ListUtils::create<String>("csv"));
+      setValidFormats_("out", ListUtils::create<String>("tsv"));
     }
 
     map<Size, MzTabModificationMetaData> generateMzTabStringFromModifications(const vector<String>& mods)


### PR DESCRIPTION
Minute change csv to tsv for MzTabExporter output format. Excel and other programs now automatically recognize the format.