### PR TITLE
enable individual temp directory in file_post tags of TTD files

### DIFF
--- a/share/OpenMS/TOOLS/EXTERNAL/msconvert.ttd
+++ b/share/OpenMS/TOOLS/EXTERNAL/msconvert.ttd
@@ -15,9 +15,9 @@
 		  <cloptions>-o "%1" --mzML "%2"</cloptions>
 		  <path>msconvert</path>
 		  <mappings>
-			<mapping id="1" cl="%TMP" />
+			<mapping id="1" cl="%TMP/GenericWrapper_%RND" />
 			<mapping id="2" cl="%%in" />
-			<file_post location="%TMP/%BASENAME[%%in].mzML" target="out" />
+			<file_post location="%1/%BASENAME[%%in].mzML" target="out" />
 		  </mappings>
 		  <ini_param>
 			<ITEM name="in" value="" type="string" description="input file in RAW format(valid formats: &apos;RAW&apos;)" tags="input file" />

--- a/src/topp/GenericWrapper.cpp
+++ b/src/topp/GenericWrapper.cpp
@@ -124,7 +124,7 @@ using namespace std;
   <li>\%TMP  --> The current temp directory, fetched using File::getTempDirectory()
   <li>\%DIR --> directory prefix, e.g.:, c:/tmp/mzfile.mzML gives 'c:/tmp'
   <li>\%BASENAME[file] --> the basename of a file, e.g. c:/tmp/myfile.mzML gives 'myfile'
-  <li>\%RND --> generates a long random number, which can be used to generate unique filenames in a &lt;file_pre&gt; tag
+  <li>\%RND --> generates a long random number, which can be used to generate unique directory or file names in a &lt;file_pre&gt; tag
   <li>\%WORKINGDIR --> expands to the current working directory (default is '.'), settable by &lt;workingdirectory&gt; tag in the .ttd file.
   <li>\%\%&lt;param&gt; --> any param registered in the ini_param section, e.g. '\%\%in'
   </ul>
@@ -212,7 +212,7 @@ protected:
   };
 
 
-  void createFragment_(String & fragment, const Param & param)
+  void createFragment_(String & fragment, const Param & param, const std::map<int, string>& optional_mappings = std::map<int, string>())
   {
 
     //std::cerr << "FRAGMENT: " << fragment << "\n\n";
@@ -223,7 +223,7 @@ protected:
     // to sort the param names by length, otherwise we have a
     // problem with parameter substitution
     // i.e., if A is a prefix of B and gets replaced first, the
-    // suffix of B remains and will cause trouble!
+    // suffix of B remains and will cause trouble, e.g.: "%%out" vs. "%%out_fm"
     vector<String> param_names;
     param_names.reserve(param.size());
     for (Param::ParamIterator it = param.begin(); it != param.end(); ++it)
@@ -245,6 +245,17 @@ protected:
       fragment.substitute("%%" + *it, s_new);
     }
     if (fragment.hasSubstring("%%")) throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Invalid '%%' found in '" + fragment + "' after replacing all parameters!", fragment);
+
+    // mapping replace> e.g.: %2
+    // do it reverse, since %10 should precede %1
+    for (std::map<int, string>::const_reverse_iterator it = optional_mappings.rbegin(); it != optional_mappings.rend(); ++it)
+    {
+      String m = String("%") + it->first;
+      if (fragment.hasSubstring(m)) {
+        writeDebug_(String("Replacing '") + m + "' in '" + fragment + "' by '" + it->second + "'\n", 10);
+        fragment.substitute(m, it->second);
+      }
+    }
 
     // %TMP replace:
     fragment.substitute("%TMP", File::getTempDirectory());
@@ -434,6 +445,7 @@ protected:
     }
 
     ///// construct the command line:
+    std::map<int, string> mappings;  // remember the values for each mapping (for file_post substitution later on)
     // go through mappings (reverse because replacing %10 must come before %1):
     for (std::map<Int, String>::reverse_iterator it = tde_.tr_table.mapping.rbegin(); it != tde_.tr_table.mapping.rend(); ++it)
     {
@@ -445,6 +457,9 @@ protected:
       // replace fragment in cl
       //std::cout << "replace : " << "%"+String(it->first) << " with '" << fragment << "\n";
       command_args.substitute("%" + String(it->first), fragment);
+
+      // cache mapping
+      mappings[it->first] = fragment;
     }
 
     QProcess builder;
@@ -466,18 +481,18 @@ protected:
     LOG_INFO << ("External tool output:\n" + String(QString(builder.readAll())));
 
 
-    // post processing (file moving via 'file' command)
+    // post processing (file moving via 'file_post' command)
     for (Size i = 0; i < tde_.tr_table.post_moves.size(); ++i)
     {
       const Internal::FileMapping & fm = tde_.tr_table.post_moves[i];
       // find target param:
       Param p = tool_param.copy("ETool:", true);
-      String target = fm.target;
-      if (!p.exists(target)) throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Cannot find target parameter '" + target + "' being mapped from external tools output!", target);
       String source = fm.location;
       // fragment's placeholder evaluation:
-      createFragment_(source, p);
+      createFragment_(source, p, mappings);
       // check if target already exists:
+      String target = fm.target;
+      if (!p.exists(target)) throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Cannot find target parameter '" + target + "' being mapped from external tools output!", target);
       String target_file = (String)p.getValue(target);
 
       if (target_file.trim().empty())   // if target was not given, we skip the copying step (usually for optional parameters)
@@ -485,6 +500,7 @@ protected:
         LOG_INFO << "Parameter '" + target + "' not given. Skipping forwarding of files.\n";
         continue;
       }
+      // check if the target exists already (should not; if yes, delete it before overwriting it)
       if (File::exists(target_file))
       {
         if (!File::remove(target_file))


### PR DESCRIPTION
Individual mappings can now be used in the file_post tag, i.e.
a mapping can used to generate a unique temp directory name, which can then be reused
multiple times. RawFileConvert.tdd was adapted accordingly.

Addressing #1386