### PR TITLE
labels in consensusXML for knockouts added

### DIFF
--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -494,7 +494,7 @@ namespace OpenMS
     {
       if (stream != 0)
       {
-        *stream << "Map descriptions (file name + label) in ConsensusMap are are not unique:\n" << all_maps << std::endl;
+        *stream << "Map descriptions (file name + label) in ConsensusMap are not unique:\n" << all_maps << std::endl;
       }
       return false;
     }

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -494,7 +494,7 @@ namespace OpenMS
     {
       if (stream != 0)
       {
-        *stream << "ConsensusMap file descriptions are not unique:\n" << all_maps << std::endl;
+        *stream << "Map descriptions (file name + label) in ConsensusMap are are not unique:\n" << all_maps << std::endl;
       }
       return false;
     }

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -920,6 +920,8 @@ public:
         }
 
         consensus_map.push_back(consensus);
+        
+        consensus_map.getFileDescriptions()[0].label = "LABEL_ZERO";
       }
 
     }
@@ -1030,7 +1032,10 @@ public:
       if (knock_out_)
       {
         // With knock-outs present, the correct labels can only be determined during ID mapping.
-        desc.label = "";
+        // For now, we simply store a unique identifier.
+        std::stringstream stream;
+        stream << "label " << i;
+        desc.label = stream.str();
       }
       else
       {

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -920,8 +920,6 @@ public:
         }
 
         consensus_map.push_back(consensus);
-        
-        consensus_map.getFileDescriptions()[0].label = "LABEL_ZERO";
       }
 
     }


### PR DESCRIPTION
In the case of knockouts (one or more peptides missing), the labels can only be determined with the help of IDs. The labels in consensusXML were previously left empty. Now a unique identifier is used.