### PR TITLE
Speedup (x 3-4) cubic spline 2d

### DIFF
--- a/src/openms/include/OpenMS/MATH/MISC/CubicSpline2d.h
+++ b/src/openms/include/OpenMS/MATH/MISC/CubicSpline2d.h
@@ -43,9 +43,13 @@
 namespace OpenMS
 {
   /**
-   * @brief cubic spline interpolation
-   * as described in R.L. Burden, J.D. Faires, Numerical Analysis, 4th ed.
-   * PWS-Kent, 1989, ISBN 0-53491-585-X, pp. 126-131.
+    @brief cubic spline interpolation
+    as described in R.L. Burden, J.D. Faires, Numerical Analysis, 4th ed.
+    PWS-Kent, 1989, ISBN 0-53491-585-X, pp. 126-131.
+    
+    Construction of the spline takes by far the most time. Evaluating it is rather fast 
+    (one evaluation is about 50x faster than construction -- depending on number of points etc.).
+   
    */
   class OPENMS_DLLAPI CubicSpline2d
   {
@@ -61,11 +65,12 @@ public:
     /**
      * @brief constructor of spline interpolation
      *
-     * @param x x-coordinates of input data points (knots)
-     * @param y y-coordinates of input data points
      * The coordinates must match by index. Both vectors must be
      * the same size and sorted in x. Sortedness in x is required
      * for @see SplinePackage.
+     *
+     * @param x x-coordinates of input data points (knots)
+     * @param y y-coordinates of input data points
      */
     CubicSpline2d(const std::vector<double>& x, const std::vector<double>& y);
 

--- a/src/openms/source/MATH/MISC/CubicSpline2d.cpp
+++ b/src/openms/source/MATH/MISC/CubicSpline2d.cpp
@@ -73,6 +73,9 @@ namespace OpenMS
     std::vector<double> x;
     std::vector<double> y;
 
+    x.reserve(m.size());
+    y.reserve(m.size());
+
     std::map<double, double>::const_iterator map_it;
     for (map_it = m.begin(); map_it != m.end(); ++map_it)
     {
@@ -85,42 +88,42 @@ namespace OpenMS
 
   double CubicSpline2d::eval(double x) const
   {
-    if (x < x_[0] || x > x_[x_.size() - 1])
+    if (x < x_.front() || x > x_.back())
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Argument out of range of spline interpolation.");
     }
 
     // determine index of closest node left of (or exactly at) x
     unsigned i = std::lower_bound(x_.begin(), x_.end(), x) - x_.begin();
-    if (x_[i] > x || x_[x_.size() - 1] == x)
+    if (x_[i] > x || x_.back() == x)
     {
         --i;
     }
     
-    double xx = x - x_[i];
+    const double xx = x - x_[i];
     return ((d_[i] * xx + c_[i]) * xx + b_[i]) * xx + a_[i];
   }
 
   double CubicSpline2d::derivatives(double x, unsigned order) const
   {
-    if (x < x_[0] || x > x_[x_.size() - 1])
+    if (x < x_.front() || x > x_.back())
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Argument out of range of spline interpolation.");
     }
 
-    if (order != 1 && order != 2 && order != 3)
+    if (order < 1 || order > 3)
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Only first, second and third derivative defined on cubic spline");
     }
 
     // determine index of closest node left of (or exactly at) x
     unsigned i = std::lower_bound(x_.begin(), x_.end(), x) - x_.begin();
-    if (x_[i] > x || x_[x_.size() - 1] == x)
+    if (x_[i] > x || x_.back() == x) // also, i must not point to last index in 'x_', since all other vectors are one element shorter
     {
-        --i;
+      --i;
     }
     
-    double xx = x - x_[i];
+    const double xx = x - x_[i];
     if (order == 1)
     {
       return b_[i] + 2 * c_[i] * xx + 3 * d_[i] * xx * xx;
@@ -139,39 +142,41 @@ namespace OpenMS
   {
     const size_t n = x.size() - 1;
 
-    std::vector<double> h(n, 0.0);
+    std::vector<double> h;
+    h.reserve(n);
     for (unsigned i = 0; i < n; ++i)
     {
-      h[i] = x[i + 1] - x[i];
+      h.push_back(x[i + 1] - x[i]);
     }
 
     std::vector<double> mu(n, 0.0);
-    std::vector<double> z(n + 1, 0.0);
+    std::vector<double> z(n, 0.0);
     for (unsigned i = 1; i < n; ++i)
     {
-      double l = 2 * (x[i + 1] - x[i - 1]) - h[i - 1] * mu[i - 1];
+      const double l = 2 * (x[i + 1] - x[i - 1]) - h[i - 1] * mu[i - 1];
       mu[i] = h[i] / l;
       z[i] = (3 * (y[i + 1] * h[i - 1] - y[i] * (x[i + 1] - x[i - 1]) + y[i - 1] * h[i]) / (h[i - 1] * h[i]) - h[i - 1] * z[i - 1]) / l;
     }
 
-    std::vector<double> b(n, 0.0);
-    std::vector<double> c(n + 1, 0.0);
-    std::vector<double> d(n, 0.0);
+    b_.resize(n); 
+    d_.resize(n);
+    c_.resize(n+1);
+    c_.back() = 0;
     for (int j = n - 1; j >= 0; --j)
     {
-      c[j] = z[j] - mu[j] * c[j + 1];
-      b[j] = (y[j + 1] - y[j]) / h[j] - h[j] * (c[j + 1] + 2 * c[j]) / 3;
-      d[j] = (c[j + 1] - c[j]) / (3 * h[j]);
+      c_[j] = z[j] - mu[j] * c_[j + 1];
+      b_[j] = (y[j + 1] - y[j]) / h[j] - h[j] * (c_[j + 1] + 2 * c_[j]) / 3;
+      d_[j] = (c_[j + 1] - c_[j]) / (3 * h[j]);
     }
 
+    a_.reserve(n);
+    x_.reserve(n+1);
     for (unsigned i = 0; i < n; ++i)
     {
       a_.push_back(y[i]);
-      b_.push_back(b[i]);
-      c_.push_back(c[i]);
-      d_.push_back(d[i]);
       x_.push_back(x[i]);
     }
+    // 'x' needs to be full length (all other vectors are one shorter)
     x_.push_back(x[n]);
   }
 


### PR DESCRIPTION
Construction of the spline is especially slow, compared to evaluating it.

This PR allows a speedup of ~3-4x for construction, and a minor speedup in evaluating (5%).

10 million constructions:
old: 46s
new: 13s  (3.5x faster)

This also speeds up downstream tools, e.g. PeakPickerHiRes' picking step:
6.52s vs 8.22s (26% speedup)