### PR TITLE
TOPPAS tool progress

### DIFF
--- a/doc/TOPP_tutorial/TOPPAS.doxygen
+++ b/doc/TOPP_tutorial/TOPPAS.doxygen
@@ -139,11 +139,11 @@
       temporary files that are passed from tool to tool within the pipeline.
 			Both folders contain further sub-directories which are named after the number in the top-left corner of the node they
 			belong to (plus the name of the tool for temporary files). During pipeline execution, the status lights in the top-right corner of the
-			tools indicate if the tool has finished successfully (green), is currently running (yellow), has not done anything so far (gray), or has crashed (red).
+			tools indicate if the tool has finished successfully (green), is currently running (yellow), has not done anything so far (gray), is scheduled to run next (blue), or has crashed (red).
 			The numbers in the bottom-right corner of every tool show how many files have already been processed and
 			the overall number of files to be processed by this tool.
 			When the execution has finished, you can check the generated output files of every node quickly by selecting
-			@a Open @a files @a in @a TOPPView from its context menu (right click on the node).
+			"@a Open @a files @a in @a TOPPView" or "@a Open @a contaning @a folder" from the context menu (right click on the node).
 			
 			
 			@section TOPPAS_interface_mk Mouse and keyboard

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -152,6 +152,7 @@ namespace OpenMS
       arguments << "-type";
       arguments << type_.toQString();
     }
+    // allow for update using old parameters
     if (old_ini_file != "")
     {
       if (!File::exists(old_ini_file))
@@ -164,6 +165,7 @@ namespace OpenMS
       arguments << old_ini_file;
     }
 
+    // actually request the INI
     QProcess p;
     p.start(program, arguments);
     if (!p.waitForFinished(-1))
@@ -181,8 +183,12 @@ namespace OpenMS
 
     ParamXMLFile paramFile;
     paramFile.load(String(ini_file).c_str(), tmp_param);
-    param_ = tmp_param.copy(name_ + ":1:", true);
+    // remember the parameters of this tool
+    param_ = tmp_param.copy(name_ + ":1:", true); // get first instance (we never use more -- this is a legacy layer in paramXML)
+    param_.setValue("no_progress", "true"); // by default, we do not want each tool to report loading/status statistics (would clutter the log window)
+    // the user is free however, to re-enable it for individual nodes
 
+    // write to disk to see if anything has changed
     writeParam_(param_, ini_file);
     bool changed = false;
     if (old_ini_file != "")
@@ -541,7 +547,6 @@ namespace OpenMS
     round_counter_ = 0; // once round_counter_ reaches round_total_, we are done
 
     QStringList shared_args;
-    shared_args << "-no_progress";
     if (type_ != "")
       shared_args << "-type" << type_.toQString();
 


### PR DESCRIPTION
TOPPAS used to call each tool with --no_progress, i.e. the user had no option of seeing the status of a tool, no matter how -no_progress was set in the parameters.

This PR gives user control over -no_progress for each TOPP tool; progress is disabled by default

Plus:
Some minor documentation fix.