### PR TITLE
additional dimethyl delta mods in unimod.xml

### DIFF
--- a/share/OpenMS/CHEMISTRY/unimod.xml
+++ b/share/OpenMS/CHEMISTRY/unimod.xml
@@ -24178,6 +24178,89 @@ M. Zimnicka, et al.  "Tunable Charge Tags for Electron-Based Methods of Peptide 
             <umod:url/>
          </umod:xref>
       </umod:mod>
+      <umod:mod title="Delta:2H(4)" full_name="mass difference between Dimthyl #36 and Dimethyl:2H(4) #199" username_of_poster="Lars"
+                group_of_poster="admin"
+                date_time_posted="2015-05-10 13:00:00"
+                date_time_modified="2015-05-10 13:00:00"
+                approved="0"
+                record_id="99988">
+         <umod:specificity hidden="1" site="N" position="Anywhere" classification="Post-translational"
+                           spec_group="4"/>
+         <umod:specificity hidden="1" site="N-term" position="Any N-term"
+                           classification="Chemical derivative"
+                           spec_group="3"/>
+         <umod:specificity hidden="1" site="R" position="Anywhere" classification="Post-translational"
+                           spec_group="2"/>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Post-translational"
+                           spec_group="1"/>
+         <umod:specificity hidden="1" site="P" position="Protein N-term"
+                           classification="Post-translational"
+                           spec_group="5"/>
+         <umod:delta mono_mass="4.025107" avge_mass="4.0246" composition="2H(4)">
+            <umod:element symbol="2H" number="4"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>none</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url/>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Delta:2H(4)13C(2)" full_name="mass difference between Dimthyl #36 and Dimethyl:2H(4)13C(2) #510" username_of_poster="Lars"
+                group_of_poster="admin"
+                date_time_posted="2015-05-10 13:00:00"
+                date_time_modified="2015-05-10 13:00:00"
+                approved="0"
+                record_id="99989">
+         <umod:specificity hidden="1" site="N" position="Anywhere" classification="Post-translational"
+                           spec_group="4"/>
+         <umod:specificity hidden="1" site="N-term" position="Any N-term"
+                           classification="Chemical derivative"
+                           spec_group="3"/>
+         <umod:specificity hidden="1" site="R" position="Anywhere" classification="Post-translational"
+                           spec_group="2"/>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Post-translational"
+                           spec_group="1"/>
+         <umod:specificity hidden="1" site="P" position="Protein N-term"
+                           classification="Post-translational"
+                           spec_group="5"/>
+         <umod:delta mono_mass="6.031817" avge_mass="6.0099" composition="2H(4) 13C(2)">
+            <umod:element symbol="2H" number="4"/>
+            <umod:element symbol="13C" number="2"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>none</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url/>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Delta:2H(6)13C(2)" full_name="mass difference between Dimthyl #36 and Dimethyl:2H(6)13C(2) #330" username_of_poster="Lars"
+                group_of_poster="admin"
+                date_time_posted="2015-05-10 13:00:00"
+                date_time_modified="2015-05-10 13:00:00"
+                approved="0"
+                record_id="99990">
+         <umod:specificity hidden="1" site="N" position="Anywhere" classification="Post-translational"
+                           spec_group="4"/>
+         <umod:specificity hidden="1" site="N-term" position="Any N-term"
+                           classification="Chemical derivative"
+                           spec_group="3"/>
+         <umod:specificity hidden="1" site="R" position="Anywhere" classification="Post-translational"
+                           spec_group="2"/>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Post-translational"
+                           spec_group="1"/>
+         <umod:specificity hidden="1" site="P" position="Protein N-term"
+                           classification="Post-translational"
+                           spec_group="5"/>
+         <umod:delta mono_mass="8.04437" avge_mass="8.0222" composition="2H(6) 13C(2)">
+            <umod:element symbol="2H" number="6"/>
+            <umod:element symbol="13C" number="2"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>none</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url/>
+         </umod:xref>
+      </umod:mod>
       <umod:mod title="RNPXlink1" full_name="Cysteine Adduct" username_of_poster="Timo"
                 group_of_poster="admin"
                 date_time_posted="2002-08-19 19:17:11"


### PR DESCRIPTION
Searches with variable dimethyl mods allow for totally unlabeled peptides. Multiple fixed searches often result in conflicting IDs for the same MS2 spectrum.

Searching with a fixed light dimethyl mod (Dimethyl, unimod id 36) plus one of the new variable dimethyl delta mods instead, ensures that all peptides are labeled and avoids ID conflicts.