### PR TITLE
skip empty spectra in FeatureFinderMultiplex filtering step

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
@@ -126,6 +126,12 @@ namespace OpenMS
       // iterate over spectra
       for (MSExperiment<Peak1D>::Iterator it_rt_picked = exp_picked_.begin(); it_rt_picked < exp_picked_.end(); ++it_rt_picked)
       {
+        // skip empty spectra
+        if ((*it_rt_picked).size() == 0)
+        {
+          continue;
+        }
+
         setProgress(++progress);
 
         int spectrum = it_rt_picked - exp_picked_.begin(); // index of the spectrum in exp_picked_

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -145,6 +145,12 @@ namespace OpenMS
            it_rt_profile < exp_profile_.end() && it_rt_picked < exp_picked_.end() && it_rt_boundaries < boundaries_.end();
            ++it_rt_profile, ++it_rt_picked, ++it_rt_boundaries)
       {
+        // skip empty spectra
+        if ((*it_rt_profile).size() == 0 || (*it_rt_picked).size() == 0 || (*it_rt_boundaries).size() == 0)
+        {
+          continue;
+        }
+        
         if ((*it_rt_picked).size() != (*it_rt_boundaries).size())
         {
           throw Exception::IllegalArgument(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Number of peaks and number of peak boundaries differ.");


### PR DESCRIPTION
Empty spectra are now ignored and skipped in the filtering step of the FeatureFinderMultiplex algorithm.