### PR TITLE
TOPPAS: allow for custom output folder names 

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASVertexNameDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASVertexNameDialog.h
@@ -43,7 +43,7 @@
 namespace OpenMS
 {
   /**
-      @brief Dialog which allows to change the name of an input vertex
+      @brief Dialog which allows to change the name of an input/output vertex
 
       @ingroup TOPPAS_elements
       @ingroup Dialogs
@@ -57,7 +57,7 @@ namespace OpenMS
 public:
 
     /// Constructor
-    TOPPASVertexNameDialog(const QString & name);
+    TOPPASVertexNameDialog(const QString& name, const QString& input_regex = QString());
 
     /// Returns the name
     QString getName();

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASOutputFileListVertex.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASOutputFileListVertex.h
@@ -84,6 +84,11 @@ public:
     virtual void setTopoNr(UInt nr);
     /// Opens the folders of the output files
     void openContainingFolder();
+    /// Sets a custom output folder name, which will be integrated into 'getOutputDir()' and 'getFullOutputDirectory()' calls.
+    /// @note The string is not checked for validity (avoid characters which are not allowed in directories, e.g. '{')
+    void setOutputFolderName(const QString& name);
+    /// return the output folder where results are written
+    const QString& getOutputFolderName() const;
 
 public slots:
 
@@ -92,9 +97,16 @@ public slots:
 
 signals:
     /// Emitted when an output file was written
-    void outputFileWritten(const String & file);
+    void outputFileWritten(const String& file);
+
+    /// Emitted when user has changed the output folder name (i.e. output dir needs to be newly created and packages updates)
+    void outputFolderNameChanged();
 
 protected:
+
+    // custom output folder name
+    QString output_folder_name_;
+
     static bool copy_(const QString & from, const QString & to); //< STATIC(!) function which calls QFile::copy(); needs to be static, since we need to pass a function pointer (which does not work on member functions)
     // convenience members, not required for operation, but for progress during copying
     int files_written_;       //< files that were already written

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASScene.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASScene.h
@@ -270,6 +270,8 @@ public slots:
     void setPipelineRunning(bool b = true);
     /// Invoked by TTV or other vertices if a parameter was edited
     void changedParameter(const bool invalidates_running_pipeline);
+    /// Invoked by OutfilelistVertex of user changed the folder name
+    void changedOutputFolder();
     /// Called by a finished QProcess to indicate that we are free to start a new one
     void processFinished();
     /// dirty solution: when using ExecutePipeline this slot is called when the pipeline crashes. This will quit the app

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPASVertexNameDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPASVertexNameDialog.cpp
@@ -38,9 +38,16 @@
 
 namespace OpenMS
 {
-  TOPPASVertexNameDialog::TOPPASVertexNameDialog(const QString & name)
+  TOPPASVertexNameDialog::TOPPASVertexNameDialog(const QString& name, const QString& input_regex)
   {
     setupUi(this);
+    
+    if (!input_regex.isEmpty())
+    {
+      QRegExp rx(input_regex);
+      QRegExpValidator* v = new QRegExpValidator(rx, line_edit);
+      line_edit->setValidator(v);
+    }
 
     line_edit->setText(name);
     connect(ok_button, SIGNAL(clicked()), this, SLOT(accept()));
@@ -49,6 +56,7 @@ namespace OpenMS
 
   QString TOPPASVertexNameDialog::getName()
   {
+    
     return line_edit->text();
   }
 

--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -259,17 +259,17 @@ namespace OpenMS
     }
   }
 
-  void TOPPASInputFileListVertex::setKey(const QString & key)
+  void TOPPASInputFileListVertex::setKey(const QString& key)
   {
     key_ = key;
   }
 
-  const QString & TOPPASInputFileListVertex::getKey()
+  const QString& TOPPASInputFileListVertex::getKey()
   {
     return key_;
   }
 
-  void TOPPASInputFileListVertex::setFilenames(const QStringList & files)
+  void TOPPASInputFileListVertex::setFilenames(const QStringList& files)
   {
     output_files_.clear();
     output_files_.resize(files.size()); // for now, assume one file per round (we could later extend that)

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -698,6 +698,7 @@ namespace OpenMS
         save_param.setValue("vertices:" + id + ":toppas_type", DataValue("output file list"));
         save_param.setValue("vertices:" + id + ":x_pos", DataValue(tv->x()));
         save_param.setValue("vertices:" + id + ":y_pos", DataValue(tv->y()));
+        save_param.setValue("vertices:" + id + ":output_folder_name", oflv->getOutputFolderName());
         continue;
       }
 
@@ -771,7 +772,7 @@ namespace OpenMS
       ++counter;
     }
 
-    //save file
+    // save file
     ParamXMLFile paramFile;
     paramFile.store(file, save_param);
     setChanged(false);
@@ -875,7 +876,7 @@ namespace OpenMS
     QVector<TOPPASVertex*> vertex_vector;
     vertex_vector.resize((Size)(int)load_param.getValue("info:num_vertices"));
 
-    //load all vertices
+    // load all vertices
     for (Param::ParamIterator it = vertices_param.begin(); it != vertices_param.end(); ++it)
     {
       StringList substrings;
@@ -907,7 +908,12 @@ namespace OpenMS
         else if (current_type == "output file list")
         {
           TOPPASOutputFileListVertex* oflv = new TOPPASOutputFileListVertex();
-
+          // custom output folder
+          if (vertices_param.exists(current_id + ":output_folder_name"))
+          {
+            oflv->setOutputFolderName(vertices_param.getValue(current_id + ":output_folder_name").toQString());
+          }
+          
           connectOutputVertexSignals(oflv);
 
           current_vertex = oflv;
@@ -986,7 +992,7 @@ namespace OpenMS
       }
     }
 
-    //load all edges
+    // load all edges
     for (Param::ParamIterator it = edges_param.begin(); it != edges_param.end(); ++it)
     {
       const String& edge = (it->value).toString();
@@ -1753,6 +1759,7 @@ namespace OpenMS
 
       if (found_output)
       {
+        action.insert("Set output folder name");
         action.insert("Open files in TOPPView");
         action.insert("Open containing folder");
       }
@@ -1823,7 +1830,7 @@ namespace OpenMS
         return;
       }
 
-      foreach(QGraphicsItem * gi, selectedItems())
+      foreach(QGraphicsItem* gi, selectedItems())
       {
 
         if (text == "Toggle recycling mode")
@@ -1923,7 +1930,14 @@ namespace OpenMS
           {
             ofv->openContainingFolder();
           }
-
+          else if (text == "Set output folder name")
+          {
+            TOPPASVertexNameDialog dlg(ofv->getOutputFolderName(), "[a-zA-Z0-9_-]*");
+            if (dlg.exec())
+            {
+              ofv->setOutputFolderName(dlg.getName());
+            }
+          }
           continue;
         }
       }
@@ -2182,7 +2196,8 @@ namespace OpenMS
 
   void TOPPASScene::connectOutputVertexSignals(TOPPASOutputFileListVertex* oflv)
   {
-    connect(oflv, SIGNAL(outputFileWritten(const String &)), this, SLOT(logOutputFileWritten(const String &)));
+    connect(oflv, SIGNAL(outputFileWritten(const String &)), this, SLOT(logOutputFileWritten(const String&)));
+    connect(oflv, SIGNAL(outputFolderNameChanged()), this, SLOT(changedOutputFolder()));
   }
 
   void TOPPASScene::connectEdgeSignals(TOPPASEdge* e)
@@ -2192,6 +2207,12 @@ namespace OpenMS
     connect(e, SIGNAL(somethingHasChanged()), source, SLOT(outEdgeHasChanged()));
     connect(e, SIGNAL(somethingHasChanged()), target, SLOT(inEdgeHasChanged()));
     connect(e, SIGNAL(somethingHasChanged()), this, SLOT(abortPipeline()));
+  }
+
+  void TOPPASScene::changedOutputFolder()
+  {
+    abortPipeline();
+    setChanged(true); // to allow "Store" of pipeline
   }
 
   void TOPPASScene::changedParameter(const bool invalidates_running_pipeline)

--- a/src/tests/topp/INIUpdater_1_noupdate.toppas
+++ b/src/tests/topp/INIUpdater_1_noupdate.toppas
@@ -173,6 +173,7 @@
       <ITEM name="toppas_type" value="output file list" type="string" description="" required="false" advanced="false" />
       <ITEM name="x_pos" value="-120" type="double" description="" required="false" advanced="false" />
       <ITEM name="y_pos" value="260" type="double" description="" required="false" advanced="false" />
+      <ITEM name="output_folder_name" value="" type="string" description="" required="false" advanced="false" />
     </NODE>
     <NODE name="4" description="">
       <ITEM name="recycle_output" value="false" type="string" description="" required="false" advanced="false" />

--- a/src/tests/topp/INIUpdater_3_old_out.toppas
+++ b/src/tests/topp/INIUpdater_3_old_out.toppas
@@ -173,6 +173,7 @@
       <ITEM name="toppas_type" value="output file list" type="string" description="" required="false" advanced="false" />
       <ITEM name="x_pos" value="-120" type="double" description="" required="false" advanced="false" />
       <ITEM name="y_pos" value="260" type="double" description="" required="false" advanced="false" />
+      <ITEM name="output_folder_name" value="" type="string" description="" required="false" advanced="false" />
     </NODE>
     <NODE name="4" description="">
       <ITEM name="recycle_output" value="false" type="string" description="" required="false" advanced="false" />


### PR DESCRIPTION
I've been thinking about this for quite some time, because the output folder keeps changing when new nodes are inserted into a pipeline.

Howto:
right-click on output vertices -> 'Set output folder name'

Restriction: allowed output characters are:  A-Z, 0-9, underscore and hypen. Nothing else -- ensuring that the output folder is valid on all supported platforms (e.g. Windows forbids ", <, >, ... see https://msdn.microsoft.com/en-us/library/aa365247?f=255&MSPPError=-2147217396)

Caveat/Feature: naming two folders equally will result in merged/overwritten output. Use at own risk :)

solves #1415