### PR TITLE
Meta value export for TextExporter

### DIFF
--- a/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
@@ -37,6 +37,7 @@
 
 #include <OpenMS/OpenMSConfig.h>
 #include <vector>
+#include <vector>
 
 namespace OpenMS
 {
@@ -70,6 +71,9 @@ public:
     template<typename T_In, typename T_Out>
     static typename T_Out findCommonMetaKeys(const typename T_In::const_iterator& it_start, const typename T_In::const_iterator& it_end, float min_frequency)
     {
+      // make sure min_frequency is within [0,100]
+      min_frequency = std::min((float)100.0, std::max((float)0.0, min_frequency));
+
       std::map<String, uint> counter;
       typedef std::vector<String> KeysType;
       KeysType keys;

--- a/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
@@ -1,0 +1,107 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2015.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#ifndef OPENMS_METADATA_METAINFOINTERFACEUTILS_H
+#define OPENMS_METADATA_METAINFOINTERFACEUTILS_H
+
+#include <OpenMS/OpenMSConfig.h>
+#include <vector>
+
+namespace OpenMS
+{
+
+  /**
+    @brief Utilities operating on containers inheriting from MetaInfoInterface
+
+    @ingroup MetaData
+  */
+  class /*OPENMS_DLLAPI -- disabled since it's template code only */ MetaInfoInterfaceUtils
+  {
+public:
+    
+    ///@name Methods to find key sets
+    //@{
+    /**
+      @brief Find keys in a collection of MetaInfoInterface objects which occur with a certain frequency.
+
+      Searches the given iterator range for the keys of each element's MetaInfoInterface keys and returns those keys, which
+      occur with a certain frequency. Common use cases 
+      are @p min_frequency = 0 (i.e. take any key which occurs)
+      and @p min_frequency = 100 (i.e. take only keys which are common to all elements in the iterator range).
+
+      @tparam T_In Input container (e.g. std::vector or alike)
+      @tparam T_Out Output container of type T<String>
+      @param start Iterator pointing to the initial position to search. (note: that this does not need to correspond to the beginning of the container)
+      @param end Iterator pointing to the end final position to search.
+      @param min_frequency Minimum required frequency (in percent). Must be between 0-100. Other values are corrected to the closest value allowed.
+      @return Returns a vector/list/set of keys passing the frequency criterion.
+    */
+    template<typename T_In, typename T_Out>
+    static typename T_Out findCommonMetaKeys(const typename T_In::const_iterator& it_start, const typename T_In::const_iterator& it_end, float min_frequency)
+    {
+      std::map<String, uint> counter;
+      typedef std::vector<String> KeysType;
+      KeysType keys;
+      for (T_In::const_iterator it = it_start; it != it_end; ++it)
+      {
+        it->getKeys(keys);
+        for (KeysType::const_iterator itk = keys.begin(); itk != keys.end(); ++itk)
+        {
+          ++counter[*itk];
+        }
+      }
+      // pick the keys which occur often enough
+      const uint required_counts = uint(min_frequency / 100.0 * std::distance(it_start, it_end));
+      T_Out common_keys;
+      for (std::map<String, uint>::const_iterator it = counter.begin(); it != counter.end(); ++it)
+      {
+        if (it->second >= required_counts) 
+        {
+          common_keys.insert(common_keys.end(), it->first);
+        }
+      }
+      return common_keys;
+    }
+
+private:
+    /// hide c'tors to avoid instantiation of utils class
+    MetaInfoInterfaceUtils();
+    MetaInfoInterfaceUtils(const MetaInfoInterfaceUtils&);
+    MetaInfoInterfaceUtils& operator=(MetaInfoInterfaceUtils&);
+  
+  }; // class
+
+} // namespace OPENMS
+
+#endif // OPENMS_METADATA_METAINFOINTERFACEUTILS_H

--- a/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
@@ -36,8 +36,11 @@
 #define OPENMS_METADATA_METAINFOINTERFACEUTILS_H
 
 #include <OpenMS/OpenMSConfig.h>
-#include <vector>
+#include <OpenMS/DATASTRUCTURES/String.h>
+
 #include <algorithm>
+#include <map>
+#include <vector>
 
 namespace OpenMS
 {
@@ -69,7 +72,7 @@ public:
       @return Returns a vector/list/set of keys passing the frequency criterion.
     */
     template<typename T_In, typename T_Out>
-    static typename T_Out findCommonMetaKeys(const typename T_In::const_iterator& it_start, const typename T_In::const_iterator& it_end, float min_frequency)
+    static T_Out findCommonMetaKeys(const typename T_In::const_iterator& it_start, const typename T_In::const_iterator& it_end, float min_frequency)
     {
       // make sure min_frequency is within [0,100]
       min_frequency = std::min((float)100.0, std::max((float)0.0, min_frequency));
@@ -77,7 +80,7 @@ public:
       std::map<String, uint> counter;
       typedef std::vector<String> KeysType;
       KeysType keys;
-      for (T_In::const_iterator it = it_start; it != it_end; ++it)
+      for (typename T_In::const_iterator it = it_start; it != it_end; ++it)
       {
         it->getKeys(keys);
         for (KeysType::const_iterator itk = keys.begin(); itk != keys.end(); ++itk)

--- a/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
@@ -37,7 +37,7 @@
 
 #include <OpenMS/OpenMSConfig.h>
 #include <vector>
-#include <vector>
+#include <algorithm>
 
 namespace OpenMS
 {
@@ -54,16 +54,16 @@ public:
     ///@name Methods to find key sets
     //@{
     /**
-      @brief Find keys in a collection of MetaInfoInterface objects which occur with a certain frequency.
+      @brief Find keys in a collection of MetaInfoInterface objects which reach a certain frequency threshold.
 
       Searches the given iterator range for the keys of each element's MetaInfoInterface keys and returns those keys, which
-      occur with a certain frequency. Common use cases 
+      reach a certain frequency threshold. Common use cases 
       are @p min_frequency = 0 (i.e. take any key which occurs)
       and @p min_frequency = 100 (i.e. take only keys which are common to all elements in the iterator range).
 
-      @tparam T_In Input container (e.g. std::vector or alike)
-      @tparam T_Out Output container of type T<String>
-      @param start Iterator pointing to the initial position to search. (note: that this does not need to correspond to the beginning of the container)
+      @tparam T_In Input container (e.g. std::vector or alike), containing objects which implement the MetaInfoInterface (i.e. support 'getKeys()')
+      @tparam T_Out Output container of type T<String> (e.g. std::set<String>)
+      @param start Iterator pointing to the initial position to search. (note: this does not need to correspond to the beginning of the container)
       @param end Iterator pointing to the end final position to search.
       @param min_frequency Minimum required frequency (in percent). Must be between 0-100. Other values are corrected to the closest value allowed.
       @return Returns a vector/list/set of keys passing the frequency criterion.

--- a/src/openms/include/OpenMS/METADATA/sources.cmake
+++ b/src/openms/include/OpenMS/METADATA/sources.cmake
@@ -21,6 +21,7 @@ MassAnalyzer.h
 MetaInfo.h
 MetaInfoDescription.h
 MetaInfoInterface.h
+MetaInfoInterfaceUtils.h
 MetaInfoRegistry.h
 Modification.h
 MSQuantifications.h

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -86,6 +86,7 @@ set(metadata_executables_list
   MassAnalyzer_test
   MetaInfoDescription_test
   MetaInfoInterface_test
+  MetaInfoInterfaceUtils_test
   MetaInfoRegistry_test
   MetaInfo_test
   Modification_test

--- a/src/tests/class_tests/openms/source/MetaInfoInterfaceUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaInfoInterfaceUtils_test.cpp
@@ -71,6 +71,10 @@ START_SECTION((template<typename T_In, T_Out> static T_Out findCommonMetaKeys(co
     ABORT_IF(common.size() != 2);
     TEST_EQUAL(common[0], "commonMeta1");
     TEST_EQUAL(common[1], "commonMeta2");
+    
+    // exceeds 100% --> should be corrected to 100% internally
+    std::vector<String> common2 = MetaInfoInterfaceUtils::findCommonMetaKeys<std::vector<PeptideHit>, std::vector<String> >(hits.begin(), hits.end(), 1110.0);
+    TEST_EQUAL(common==common2, true);
   }
   
   // occurrence of at least 50 (i.e. 50% min_frequency)
@@ -96,6 +100,10 @@ START_SECTION((template<typename T_In, T_Out> static T_Out findCommonMetaKeys(co
     set0_expected.insert("meta50pc");
     set0_expected.insert("metaSingle");
     TEST_EQUAL(set0==set0_expected, true);
+
+    // exceeds 0% --> should be corrected to 0% internally
+    std::set<String> set0_2 = MetaInfoInterfaceUtils::findCommonMetaKeys<std::vector<PeptideHit>, std::set<String> >(hits.begin(), hits.end(), -10.0);
+    TEST_EQUAL(set0==set0_2, true);
   }
   
 

--- a/src/tests/class_tests/openms/source/MetaInfoInterfaceUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaInfoInterfaceUtils_test.cpp
@@ -1,0 +1,111 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry               
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2015.
+// 
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution 
+//    may be used to endorse or promote products derived from this software 
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS. 
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING 
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// --------------------------------------------------------------------------
+// $Maintainer: Chris Bielow $
+// $Authors: Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+#include <OpenMS/METADATA/MetaInfoInterfaceUtils.h>
+#include <OpenMS/METADATA/PeptideHit.h>
+///////////////////////////
+
+using namespace OpenMS;
+using namespace std;
+
+START_TEST(MetaInfoInterfaceUtils, "$Id$")
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+
+START_SECTION((template<typename T_In, T_Out> static T_Out findCommonMetaKeys(const T::const_iterator& start, const T::const_iterator& end, const float min_frequency = 100.0)))
+{
+  vector<PeptideHit> hits; // some class derived from MetaInfoInterface
+  for (Size i = 0; i < 10; ++i)
+  {
+    PeptideHit h;
+    h.setMetaValue("commonMeta1", i);
+    h.setMetaValue("commonMeta2", i);
+    if (i % 2 == 0) 
+    {
+      h.setMetaValue("meta50pc", i);
+    }
+    hits.push_back(h);
+  }
+  hits.back().setMetaValue("metaSingle", "single");
+  
+  // common keys for ALL entries (i.e. 100% min_frequency)
+  {
+    std::vector<String> common = MetaInfoInterfaceUtils::findCommonMetaKeys<std::vector<PeptideHit>, std::vector<String> >(hits.begin(), hits.end(), 100.0);
+    TEST_EQUAL(common.size(), 2);
+    ABORT_IF(common.size() != 2);
+    TEST_EQUAL(common[0], "commonMeta1");
+    TEST_EQUAL(common[1], "commonMeta2");
+  }
+  
+  // occurrence of at least 50 (i.e. 50% min_frequency)
+  {
+    std::set<String> set50 = MetaInfoInterfaceUtils::findCommonMetaKeys<std::vector<PeptideHit>, std::set<String> >(hits.begin(), hits.end(), 50.0);
+    TEST_EQUAL(set50.size(), 3);
+    ABORT_IF(set50.size() != 3);
+    std::set<String> set50_expected;
+    set50_expected.insert("commonMeta1");
+    set50_expected.insert("commonMeta2");
+    set50_expected.insert("meta50pc");
+    TEST_EQUAL(set50==set50_expected, true);
+  }
+
+  // ALL keys (i.e. 0% min_frequency)
+  {
+    std::set<String> set0 = MetaInfoInterfaceUtils::findCommonMetaKeys<std::vector<PeptideHit>, std::set<String> >(hits.begin(), hits.end(), 0.0);
+    TEST_EQUAL(set0.size(), 4);
+    ABORT_IF(set0.size() != 4);
+    std::set<String> set0_expected;
+    set0_expected.insert("commonMeta1");
+    set0_expected.insert("commonMeta2");
+    set0_expected.insert("meta50pc");
+    set0_expected.insert("metaSingle");
+    TEST_EQUAL(set0==set0_expected, true);
+  }
+  
+
+}
+END_SECTION
+
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST
+
+
+

--- a/src/topp/TextExporter.cpp
+++ b/src/topp/TextExporter.cpp
@@ -43,6 +43,7 @@
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/SVOutStream.h>
+#include <OpenMS/METADATA/MetaInfoInterfaceUtils.h>
 
 #include <boost/math/special_functions/fpclassify.hpp>
 
@@ -238,6 +239,37 @@ namespace OpenMS
         << "sequence" << nl;
     out.modifyStrings(old);
   }
+
+
+  void writeMetaValuesHeader(SVOutStream& output, const StringList& meta_keys)
+  {
+    if (!meta_keys.empty())
+    {
+      for (StringList::const_iterator its = meta_keys.begin(); its != meta_keys.end(); ++its)
+      {
+        output << *its;
+      }
+    }
+  }
+
+  void writeMetaValues(SVOutStream& output, const FeatureMap::const_iterator& it, const StringList& meta_keys)
+  {
+    if (!meta_keys.empty())
+    {
+      for (StringList::const_iterator its = meta_keys.begin(); its != meta_keys.end(); ++its)
+      {
+        if (it->metaValueExists(*its))
+        {
+          output << it->getMetaValue(*its);
+        }
+        else
+        {
+          output << "";
+        }
+      }
+    }
+  }
+
 
   // stream output operator for a ProteinHit
   SVOutStream& operator<<(SVOutStream& out, const ProteinHit& hit)
@@ -447,11 +479,14 @@ protected:
       registerStringOption_("replacement", "<string>", "_", "Used to replace occurrences of the separator in strings before writing, if 'quoting' is 'none'", false);
       registerStringOption_("quoting", "<method>", "none", "Method for quoting of strings: 'none' for no quoting, 'double' for quoting with doubling of embedded quotes,\n'escape' for quoting with backslash-escaping of embedded quotes", false);
       setValidStrings_("quoting", ListUtils::create<String>("none,double,escape"));
-      registerFlag_("no_ids", "Supresses output of identification data.");
+      registerFlag_("no_ids", "Suppresses output of identification data.");
       addEmptyLine_();
 
       registerTOPPSubsection_("feature", "Options for featureXML input files");
       registerFlag_("feature:minimal", "Set this flag to write only three attributes: RT, m/z, and intensity.");
+      registerIntOption_("feature:add_metavalues", "<min_frequency>", -1, "Add columns for meta values which occur with a certain frequency (0-100%). Set to -1 to omit meta values (default).", false);
+      setMinInt_("feature:add_metavalues", -1);
+      setMaxInt_("feature:add_metavalues", 100);
       addEmptyLine_();
 
       registerTOPPSubsection_("id", "Options for idXML input files");
@@ -482,6 +517,7 @@ protected:
       String out = getStringOption_("out");
       bool no_ids = getFlag_("no_ids");
       bool first_dim_rt = getFlag_("id:first_dim_rt");
+      int add_metavalues = getIntOption_("feature:add_metavalues");
 
       // separator etc.
       String sep = getStringOption_("separator");
@@ -504,6 +540,8 @@ protected:
         return PARSE_ERROR;
       }
 
+      StringList meta_keys;
+
       if (in_type == FileTypes::FEATUREXML)
       {
         //-------------------------------------------------------------
@@ -513,6 +551,11 @@ protected:
         FeatureMap feature_map;
         FeatureXMLFile f;
         f.load(in, feature_map);
+
+        if (add_metavalues >= 0) 
+        {
+          meta_keys = MetaInfoInterfaceUtils::findCommonMetaKeys<FeatureMap, StringList>(feature_map.begin(), feature_map.end(), add_metavalues);
+        }
 
         // compute protein coverage
         vector<ProteinIdentification> prot_ids = feature_map.getProteinIdentifications();
@@ -562,6 +605,7 @@ protected:
           writeFeatureHeader(output, "", true, comment);
           output << "rt_quality" << "mz_quality" << "rt_start" << "rt_end";
         }
+        writeMetaValuesHeader(output, meta_keys);
         output << nl;
         if (!no_ids)
         {
@@ -602,18 +646,18 @@ protected:
             output << *citer << citer->getQuality(0) << citer->getQuality(1);
             if (citer->getConvexHulls().size() > 0)
             {
-              output << citer->getConvexHulls().begin()->
-                getBoundingBox().minX() << citer->getConvexHulls().begin()->
-                getBoundingBox().maxX();
+              output << citer->getConvexHulls().begin()->getBoundingBox().minX() 
+                     << citer->getConvexHulls().begin()->getBoundingBox().maxX();
             }
             else
             {
               output << "-1" << "-1";
             }
           }
+          writeMetaValues(output, citer, meta_keys);
           output << nl;
 
-          //peptide ids
+          // peptide ids
           if (!no_ids)
           {
             for (vector<PeptideIdentification>::const_iterator pit =


### PR DESCRIPTION
Metavalues with a certain user defined frequency (0-100%) can now be exported as additional columns for featureXML.

Some GUI code was adapted to use the new functionality.

This should also enable the export of Fido scores via TextExporter, as mentioned in #1381 (although support for idXML needs to be added in TextExporter).