### PR TITLE
FileInfo, field renamed

### DIFF
--- a/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+++ b/src/openms/source/FORMAT/MascotRemoteQuery.cpp
@@ -722,7 +722,6 @@ namespace OpenMS
 
   Int MascotRemoteQuery::getSearchNumberFromFilePath_(const String& path) const
   {
-    Int search_number = 0;
     int pos = path.find_last_of("/\\");
     String tmp = path.substr(pos + 1);
     pos = tmp.find_last_of(".");

--- a/src/tests/topp/FileInfo_10_output.txt
+++ b/src/tests/topp/FileInfo_10_output.txt
@@ -9,7 +9,8 @@ Number of:
   non-redundant protein hits: 0
   (only hits that differ in the accession)
 
-  spectra:                    0
+  peptide identifications:    0
+  (number of spectra with peptide sequence information)
   peptide hits:               0
   modified top-hits:          0/0
   non-redundant peptide hits: 0

--- a/src/tests/topp/FileInfo_10_output.txt
+++ b/src/tests/topp/FileInfo_10_output.txt
@@ -9,8 +9,7 @@ Number of:
   non-redundant protein hits: 0
   (only hits that differ in the accession)
 
-  peptide identifications:    0
-  (number of spectra with peptide sequence information)
+  matched spectra:            0
   peptide hits:               0
   modified top-hits:          0/0
   non-redundant peptide hits: 0

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -550,7 +550,8 @@ protected:
       os << "  non-redundant protein hits: " << proteins.size() << "\n";
       os << "  (only hits that differ in the accession)" << "\n";
       os << "\n";
-      os << "  spectra:                    " << spectrum_count << "\n";
+      os << "  peptide identifications:    " << spectrum_count << "\n";
+      os << "  (number of spectra with peptide sequence information)" << "\n";
       os << "  peptide hits:               " << peptide_hit_count << "\n";
       os << "  modified top-hits:          " << modified_peptide_count << "/" << spectrum_count << (spectrum_count > 0 ? String(" (") + (modified_peptide_count * 100.0 / spectrum_count) + "%)" : "") << "\n";
       os << "  non-redundant peptide hits: " << peptides.size() << "\n";

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -550,8 +550,7 @@ protected:
       os << "  non-redundant protein hits: " << proteins.size() << "\n";
       os << "  (only hits that differ in the accession)" << "\n";
       os << "\n";
-      os << "  peptide identifications:    " << spectrum_count << "\n";
-      os << "  (number of spectra with peptide sequence information)" << "\n";
+      os << "  matched spectra:    " << spectrum_count << "\n";
       os << "  peptide hits:               " << peptide_hit_count << "\n";
       os << "  modified top-hits:          " << modified_peptide_count << "/" << spectrum_count << (spectrum_count > 0 ? String(" (") + (modified_peptide_count * 100.0 / spectrum_count) + "%)" : "") << "\n";
       os << "  non-redundant peptide hits: " << peptides.size() << "\n";


### PR DESCRIPTION
One of the fields in FileInfo output renamed. Now in line with the name of the corresponding class (PeptideIdentification).