### PR TITLE
Improvements to SpectraFilterNormalizer

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/Normalizer.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/Normalizer.h
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Mathias Walzer $
-// $Authors: $
+// $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 //
 #ifndef OPENMS_FILTERING_TRANSFORMERS_NORMALIZER_H
@@ -44,11 +44,13 @@
 namespace OpenMS
 {
   /**
-    @brief Normalizer normalizes the peak intensities
+    @brief Normalizes the peak intensities spectrum-wise.
 
-        @htmlinclude OpenMS_Normalizer.parameters
+    Either to a total intensity-sum of one or to a maximum intensity of one.
 
-        @ingroup SpectraPreprocessers
+    @htmlinclude OpenMS_Normalizer.parameters
+
+    @ingroup SpectraPreprocessers
   */
   class OPENMS_DLLAPI Normalizer :
     public DefaultParamHandler
@@ -72,43 +74,31 @@ public:
     // @name Accessors
     // @{
 
-    ///
+    /**
+      Workhorse of this class.
+
+      @param spectrum Input/output spectrum containing peaks
+      @throws Exception::InvalidValue if 'method_' has unknown value
+    */
     template <typename SpectrumType>
-    void filterSpectrum(SpectrumType & spectrum)
+    void filterSpectrum(SpectrumType& spectrum) const
     {
+      if (spectrum.empty()) return;
+
       typedef typename SpectrumType::Iterator Iterator;
       typedef typename SpectrumType::ConstIterator ConstIterator;
 
-      method_ = param_.getValue("method");
-
-      // normalizes the max peak to 1 and the rest of the peaks to values relative to max
+      double divisor(0);
+      // find divisor      
       if (method_ == "to_one")
-      {
-        double max(0);
-        for (ConstIterator it = spectrum.begin(); it != spectrum.end(); ++it)
-        {
-          if (max < it->getIntensity())
-          {
-            max = it->getIntensity();
-          }
-        }
-        for (Iterator it = spectrum.begin(); it != spectrum.end(); ++it)
-        {
-          it->setIntensity(it->getIntensity() / max);
-        }
+      { // normalizes the max peak to 1 and the rest of the peaks to values relative to max
+        divisor = std::max_element(spectrum.begin(), spectrum.end(), SpectrumType::PeakType::IntensityLess())->getIntensity();
       }
-      // normalizes the peak intensities to the TIC
       else if (method_ == "to_TIC")
-      {
-        double sum(0);
+      { // normalizes the peak intensities to the TIC
         for (ConstIterator it = spectrum.begin(); it != spectrum.end(); ++it)
         {
-          sum += it->getIntensity();
-        }
-
-        for (Iterator it = spectrum.begin(); it != spectrum.end(); ++it)
-        {
-          it->setIntensity(it->getIntensity() / sum);
+          divisor += it->getIntensity();
         }
       }
       // method unknown
@@ -116,22 +106,28 @@ public:
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Method not known", method_);
       }
+
+      // normalize
+      for (Iterator it = spectrum.begin(); it != spectrum.end(); ++it)
+      {
+        it->setIntensity(it->getIntensity() / divisor);
+      }
+
       return;
 
     }
 
     ///
-    void filterPeakSpectrum(PeakSpectrum & spectrum);
+    void filterPeakSpectrum(PeakSpectrum & spectrum) const;
     ///
-    void filterPeakMap(PeakMap & exp);
+    void filterPeakMap(PeakMap & exp) const;
 
-    //TODO reimplement DefaultParamHandler::updateMembers_()
+    virtual void updateMembers_();
 
     // @}
 
 private:
     String method_;
-
   };
 
 

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/Normalizer.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/Normalizer.h
@@ -46,7 +46,7 @@ namespace OpenMS
   /**
     @brief Normalizes the peak intensities spectrum-wise.
 
-    Either to a total intensity-sum of one or to a maximum intensity of one.
+    Either to a total intensity-sum of one (i.e. to total-ion-count; TIC) or to a maximum intensity of one.
 
     @htmlinclude OpenMS_Normalizer.parameters
 
@@ -91,8 +91,12 @@ public:
       double divisor(0);
       // find divisor      
       if (method_ == "to_one")
-      { // normalizes the max peak to 1 and the rest of the peaks to values relative to max
-        divisor = std::max_element(spectrum.begin(), spectrum.end(), SpectrumType::PeakType::IntensityLess())->getIntensity();
+      { // normalizes the max peak to 1 and the remaining peaks to values relative to max
+        divisor = spectrum.begin()->getIntensity(); // safety measure: if all intensities are negative, divisor would stay 0 (as constructed)
+        for (ConstIterator it = spectrum.begin(); it != spectrum.end(); ++it)
+        {
+          if (divisor < it->getIntensity()) divisor = it->getIntensity();
+        }
       }
       else if (method_ == "to_TIC")
       { // normalizes the peak intensities to the TIC

--- a/src/openms/source/FILTERING/TRANSFORMERS/Normalizer.cpp
+++ b/src/openms/source/FILTERING/TRANSFORMERS/Normalizer.cpp
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Mathias Walzer $
-// $Authors: $
+// $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 //
 
@@ -44,7 +44,7 @@ namespace OpenMS
   Normalizer::Normalizer() :
     DefaultParamHandler("Normalizer")
   {
-    defaults_.setValue("method", "to_one", "Normalize by deviding though the TIC ('to_TIC') or normalize to max intensity of one ('to_one').");
+    defaults_.setValue("method", "to_one", "Normalize via dividing by TIC ('to_TIC') per spectrum or normalize to max. intensity of one ('to_one') per spectrum.");
     defaults_.setValidStrings("method", ListUtils::create<String>("to_one,to_TIC"));
     defaultsToParam_();
   }
@@ -67,17 +67,22 @@ namespace OpenMS
     return *this;
   }
 
-  void Normalizer::filterPeakSpectrum(PeakSpectrum & spectrum)
+  void Normalizer::filterPeakSpectrum(PeakSpectrum& spectrum) const
   {
     filterSpectrum(spectrum);
   }
 
-  void Normalizer::filterPeakMap(PeakMap & exp)
+  void Normalizer::filterPeakMap(PeakMap& exp) const
   {
     for (PeakMap::Iterator it = exp.begin(); it != exp.end(); ++it)
     {
       filterSpectrum(*it);
     }
+  }
+
+  void Normalizer::updateMembers_()
+  {
+    method_ = param_.getValue("method");
   }
 
 }

--- a/src/tests/class_tests/openms/source/Normalizer_test.cpp
+++ b/src/tests/class_tests/openms/source/Normalizer_test.cpp
@@ -78,19 +78,16 @@ START_SECTION((Normalizer& operator = (const Normalizer& source)))
 	TEST_EQUAL(copy.getName(), e_ptr->getName())
 END_SECTION
 
-START_SECTION((template<typename SpectrumType> void filterSpectrum(SpectrumType& spectrum)))
-	DTAFile dta_file;
-	PeakSpectrum spec;
-	dta_file.load(OPENMS_GET_TEST_DATA_PATH("Transformers_tests.dta"), spec);
 
-	spec.sortByIntensity();
+DTAFile dta_file;
+PeakSpectrum spec_ref;
+dta_file.load(OPENMS_GET_TEST_DATA_PATH("Transformers_tests.dta"), spec_ref);
+spec_ref.sortByIntensity();
 
+START_SECTION((template<typename SpectrumType> void filterSpectrum(SpectrumType& spectrum) const))
+	PeakSpectrum spec = spec_ref;
 	TEST_EQUAL(spec.rbegin()->getIntensity(), 46)
-
 	e_ptr->filterSpectrum(spec);
-
-	spec.sortByIntensity();
-	
 	TEST_EQUAL(spec.rbegin()->getIntensity(), 1)
 
 	Param p(e_ptr->getParameters());
@@ -107,24 +104,18 @@ START_SECTION((template<typename SpectrumType> void filterSpectrum(SpectrumType&
 	TEST_REAL_SIMILAR(sum, 1.0);	
 END_SECTION
 	
-START_SECTION((void filterPeakMap(PeakMap& exp)))
+START_SECTION((void filterPeakMap(PeakMap& exp) const))
 	delete e_ptr;
 	e_ptr = new Normalizer();
 
-	DTAFile dta_file;
-  PeakSpectrum spec;
-  dta_file.load(OPENMS_GET_TEST_DATA_PATH("Transformers_tests.dta"), spec);
+  PeakSpectrum spec = spec_ref;
 
 	PeakMap pm;
 	pm.addSpectrum(spec);
 
-  pm.begin()->sortByIntensity();
-
   TEST_EQUAL(pm.begin()->rbegin()->getIntensity(), 46)
 
   e_ptr->filterPeakMap(pm);
-
-  pm.begin()->sortByIntensity();
 
   TEST_EQUAL(pm.begin()->rbegin()->getIntensity(), 1)
 
@@ -138,26 +129,14 @@ START_SECTION((void filterPeakMap(PeakMap& exp)))
   {
     sum += it->getIntensity();
   }
-
   TEST_REAL_SIMILAR(sum, 1.0);	
 END_SECTION
 
-START_SECTION((void filterPeakSpectrum(PeakSpectrum& spectrum)))
+START_SECTION((void filterPeakSpectrum(PeakSpectrum& spectrum) const))
 	delete e_ptr;
 	e_ptr = new Normalizer();
-
-	DTAFile dta_file;
-  PeakSpectrum spec;
-  dta_file.load(OPENMS_GET_TEST_DATA_PATH("Transformers_tests.dta"), spec);
-
-  spec.sortByIntensity();
-
-  TEST_EQUAL(spec.rbegin()->getIntensity(), 46)
-
+  PeakSpectrum spec = spec_ref;
   e_ptr->filterPeakSpectrum(spec);
-
-  spec.sortByIntensity();
-
   TEST_EQUAL(spec.rbegin()->getIntensity(), 1)
 
 	Param p(e_ptr->getParameters());
@@ -170,7 +149,6 @@ START_SECTION((void filterPeakSpectrum(PeakSpectrum& spectrum)))
   {
     sum += it->getIntensity();
   }
-
   TEST_REAL_SIMILAR(sum, 1.0);	
 END_SECTION
 

--- a/src/topp/SpectraFilterNormalizer.cpp
+++ b/src/topp/SpectraFilterNormalizer.cpp
@@ -47,7 +47,7 @@ using namespace std;
 /**
   @page TOPP_SpectraFilterNormalizer SpectraFilterNormalizer
 
-  @brief Filters the top Peaks in the given spectra according to a given schema/thresholdset
+  @brief Normalizes intensity of peak spectra.
 
   <CENTER>
   <table>
@@ -62,6 +62,8 @@ using namespace std;
   </tr>
   </table>
   </CENTER>
+
+  Normalization is performed for each spectrum independently.
 
   <B>The command line parameters of this tool are:</B>
   @verbinclude TOPP_SpectraFilterNormalizer.cli
@@ -78,7 +80,7 @@ class TOPPSpectraFilterNormalizer :
 {
 public:
   TOPPSpectraFilterNormalizer() :
-    TOPPBase("SpectraFilterNormalizer", "Applies thresholdfilter to peak spectra.")
+    TOPPBase("SpectraFilterNormalizer", "Normalizes intensity of peak spectra.")
   {
   }
 
@@ -86,9 +88,9 @@ protected:
 
   void registerOptionsAndFlags_()
   {
-    registerInputFile_("in", "<file>", "", "input file ");
+    registerInputFile_("in", "<file>", "", "input file");
     setValidFormats_("in", ListUtils::create<String>("mzML"));
-    registerOutputFile_("out", "<file>", "", "output file ");
+    registerOutputFile_("out", "<file>", "", "output file");
     setValidFormats_("out", ListUtils::create<String>("mzML"));
 
     // register one section for each algorithm
@@ -119,14 +121,6 @@ protected:
     MzMLFile f;
     f.setLogType(log_type_);
     f.load(in, exp);
-
-    //-------------------------------------------------------------
-    // if meta data arrays are present, remove them and warn
-    //-------------------------------------------------------------
-    if (exp.clearMetaDataArrays())
-    {
-      writeLog_("Warning: Spectrum meta data arrays cannot be sorted. They are deleted.");
-    }
 
     //-------------------------------------------------------------
     // filter


### PR DESCRIPTION
 - remove unneccessary restriction which removes meta-values from input data
 - clean-up of main normalization method
 - faster class test
 - better doc