### PR TITLE
[PARAM] SpectraMerger default params changed

### DIFF
--- a/src/openms/source/FILTERING/TRANSFORMERS/SpectraMerger.cpp
+++ b/src/openms/source/FILTERING/TRANSFORMERS/SpectraMerger.cpp
@@ -45,10 +45,10 @@ namespace OpenMS
     DefaultParamHandler("SpectraMerger")
   {
     // common
-    defaults_.setValue("mz_binning_width", 10e-5, "Max m/z distance of two peaks to be merged.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("mz_binning_width", 5, "minimum m/z distance for two data points (profile data) or peaks (centroided data) to be considered distinct. Closer data points or peaks will be merged.", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("mz_binning_width", 0);
 
-    defaults_.setValue("mz_binning_width_unit", "Da", "Unit in which the distance between two peaks is given.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("mz_binning_width_unit", "ppm", "Unit in which the distance between two data points or peaks is given.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("mz_binning_width_unit", ListUtils::create<String>("Da,ppm"));
 
     defaults_.setValue("sort_blocks", "RT_ascending", "Sort blocks by <?> before merging them (useful for precursor order)", ListUtils::create<String>("advanced"));

--- a/src/openms/source/FILTERING/TRANSFORMERS/SpectraMerger.cpp
+++ b/src/openms/source/FILTERING/TRANSFORMERS/SpectraMerger.cpp
@@ -45,8 +45,8 @@ namespace OpenMS
     DefaultParamHandler("SpectraMerger")
   {
     // common
-    defaults_.setValue("mz_binning_width", 5, "minimum m/z distance for two data points (profile data) or peaks (centroided data) to be considered distinct. Closer data points or peaks will be merged.", ListUtils::create<String>("advanced"));
-    defaults_.setMinFloat("mz_binning_width", 0);
+    defaults_.setValue("mz_binning_width", 5.0, "minimum m/z distance for two data points (profile data) or peaks (centroided data) to be considered distinct. Closer data points or peaks will be merged.", ListUtils::create<String>("advanced"));
+    defaults_.setMinFloat("mz_binning_width", 0.0);
 
     defaults_.setValue("mz_binning_width_unit", "ppm", "Unit in which the distance between two data points or peaks is given.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("mz_binning_width_unit", ListUtils::create<String>("Da,ppm"));

--- a/src/tests/class_tests/openms/source/SpectraMerger_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectraMerger_test.cpp
@@ -84,6 +84,9 @@ START_SECTION((template < typename MapType > void mergeSpectraBlockWise(MapType 
 
 	SpectraMerger merger;
   Param p;
+  p.setValue("mz_binning_width", 0.0001, "Max m/z distance of two peaks to be merged.", ListUtils::create<String>("advanced"));
+  p.setValue("mz_binning_width_unit", "Da", "Unit in which the distance between two peaks is given.", ListUtils::create<String>("advanced"));
+
   p.setValue("block_method:rt_block_size", 5);
   p.setValue("block_method:ms_levels", ListUtils::create<Int>("1"));
   merger.setParameters(p);


### PR DESCRIPTION
On modern mass spectrometry machines (e.g. Q Exactive) two peaks can be considered distinct if they are roughly 5 ppm apart. The default params in SpectraMerger have been changed.

Resolves #1461.