### PR TITLE
[FIX, DOC, INTERNAL] Fix enzymesDB

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/EnzymesDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EnzymesDB.h
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Xiao Liang $
-// $Authors: Xiao Liang $
+// $Authors: Xiao Liang, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_CHEMISTRY_ENZYMESDB_H
@@ -47,10 +47,10 @@ namespace OpenMS
 
   /** @ingroup Chemistry
 
-          @brief enzyme database which holds enzymes
+    @brief enzyme database which holds enzymes
 
-          The enzymes stored in this DB are defined in a
-          XML file under share/CHEMISTRY/Enzymes.xml
+    The enzymes stored in this DB are defined in a
+    XML file under share/CHEMISTRY/Enzymes.xml
 
   */
   class OPENMS_DLLAPI EnzymesDB
@@ -60,12 +60,12 @@ public:
     /** @name Typedefs
     */
     //@{
-    typedef std::set<Enzyme *>::iterator EnzymeIterator;
-    typedef std::set<const Enzyme *>::const_iterator EnzymeConstIterator;
+    typedef std::set<const Enzyme *>::const_iterator ConstEnzymeIterator;
+    typedef std::set<const Enzyme *>::iterator EnzymeIterator;
     //@}
 
     /// this member function serves as a replacement of the constructor
-    inline static EnzymesDB * getInstance()
+    inline static EnzymesDB* getInstance()
     {
       static EnzymesDB * db_ = 0;
       if (db_ == 0)
@@ -85,93 +85,84 @@ public:
     /** @name Accessors
     */
     //@{
-    /// returns a pointer to the enzyme with name
-    /// @throw Exception::ElementNotFound if enzyme is unkown
-    const Enzyme * getEnzyme(const String & name) const;
+    /// returns a pointer to the enzyme with name (supports synonym names)
+    /// @throw Exception::ElementNotFound if enzyme is unknown
+    const Enzyme* getEnzyme(const String & name) const;
 
     /// returns a pointer to the enzyme with cleavage regex
     /// @throw Exception::IllegalArgument if enzyme regex  is unregistered.
-    const Enzyme * getEnzymeByRegEx(const String & cleavage_regex) const;
+    const Enzyme* getEnzymeByRegEx(const String & cleavage_regex) const;
 
-    /// sets the enzymes from given file
-    void setEnzymes(const String & filename);
+    /// load enzymes from given file
+    void setEnzymes(const String& filename);
 
-    /// adds an enzyme, i.e. a new enzyme, where only the cleavage regex is known
-    void addEnzyme(const Enzyme & enzyme);
+    /// adds a new enzyme, e.g. a new enzyme, where only the cleavage regex is known
+    void addEnzyme(const Enzyme& enzyme);
 
-    /// returns all the enzyme names
-    void getAllNames(std::vector<String> & all_names) const;
+    /// deletes all enzymes, resulting in an empty database
+    void clear();
+
+    /// returns all the enzyme names (does NOT include synonym names)
+    void getAllNames(std::vector<String>& all_names) const;
 
     /// returns all the enzyme names available for XTandem
-    void getAllXTandemNames(std::vector<String> & all_names) const;
+    void getAllXTandemNames(std::vector<String>& all_names) const;
     
     /// returns all the enzyme names available for OMSSA
-    void getAllOMSSANames(std::vector<String> & all_names) const;
+    void getAllOMSSANames(std::vector<String>& all_names) const;
+
+
     //@}
 
 
     /** @name Predicates
     */
     //@{
-    /// returns true if the db contains a enzyme with the given name
-    bool hasEnzyme(const String & name) const;
+    /// returns true if the db contains a enzyme with the given name (supports synonym names)
+    bool hasEnzyme(const String& name) const;
 
     /// returns true if the db contains a enzyme with the given regex
-    bool hasRegEx(const String & cleavage_regex) const;
+    bool hasRegEx(const String& cleavage_regex) const;
     
     /// returns true if the db contains the enzyme of the given pointer
-    bool hasEnzyme(const Enzyme * enzyme) const;
+    bool hasEnzyme(const Enzyme* enzyme) const;
     //@}
 
     /** @name Iterators
     */
     //@{
-    inline EnzymeIterator beginEnzyme() { return enzymes_.begin(); }
+    inline ConstEnzymeIterator beginEnzyme() const { return const_enzymes_.begin(); }  // we only allow constant iterators -- this DB is not meant to be modifiable
+    inline ConstEnzymeIterator endEnzyme() const { return const_enzymes_.end(); }
 
-    inline EnzymeIterator endEnzyme() { return enzymes_.end(); }
-
-    inline EnzymeConstIterator beginEnzyme() const { return const_enzymes_.begin(); }
-
-    inline EnzymeConstIterator endEnzyme() const { return const_enzymes_.end(); }
     //@}
 protected:
     EnzymesDB();
     
     ///copy constructor
-    EnzymesDB(const EnzymesDB & enzyme_db);
+    EnzymesDB(const EnzymesDB& enzyme_db);
     //@}
 
     /** @name Assignment
     */
     //@{
     /// assignment operator
-    EnzymesDB & operator=(const EnzymesDB & enzymes_db);
+    EnzymesDB & operator=(const EnzymesDB& enzymes_db);
     //@}
 
     /// reads enzymes from the given file
-    void readEnzymesFromFile_(const String & filename);
+    void readEnzymesFromFile_(const String& filename);
 
     /// parses a enzyme, given the key/value pairs from i.e. an XML file
-    Enzyme * parseEnzyme_(Map<String, String> & values);
+    const Enzyme* parseEnzyme_(Map<String, String>& values) const;
 
-    /// deletes all sub-instances of the stored data like enzymes
-    void clear_();
+    // add to internal data; also update indices for search by name and regex
+    void addEnzyme_(const Enzyme* enzyme);
 
-    /// clears the enzymes
-    void clearEnzymes_();
+    boost::unordered_map<String, const Enzyme*> enzyme_names_;  // index by names
 
-    /// builds an index of enzyme names for fast access, synonyms are also considered
-    void buildEnzymeNames_();
+    Map<String, const Enzyme*> enzyme_regex_; // index by regex
 
-    void addEnzyme_(Enzyme * enzyme);
-
-    boost::unordered_map<String, Enzyme *> enzyme_names_;
-
-    Map<String, Enzyme *> enzyme_regex_;
-
-    std::set<Enzyme *> enzymes_;
-
-    std::set<const Enzyme *> const_enzymes_;
+    std::set<const Enzyme*> const_enzymes_; // set of enzymes
 
   };
 }

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -220,6 +220,11 @@ namespace OpenMS
 
   String File::find(const String& filename, StringList directories)
   {
+    // maybe we do not need to do anything?!
+    // This check is required since calling File::find(File::find("CHEMISTRY/Elements.xml")) will otherwise fail
+    // because the outer call receives an absolute path already
+    if (exists(filename)) return filename;
+
     String filename_new = filename;
 
     // empty string cannot be found, so throw Exception.

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -100,9 +100,12 @@ START_SECTION((static bool writable(const String &file)))
 END_SECTION
 
 START_SECTION((static String find(const String &filename, StringList directories=StringList())))
-	TEST_EXCEPTION(Exception::FileNotFound,File::find("File.h"))
-  TEST_NOT_EQUAL(File::find("CV/psi-ms.obo"),"");
-  TEST_EXCEPTION(Exception::FileNotFound,File::find(""))
+	TEST_EXCEPTION(Exception::FileNotFound, File::find("File.h"))
+  String s_obo = File::find("CV/psi-ms.obo");
+  TEST_EQUAL(s_obo.empty(), false);
+  TEST_EQUAL(File::find(s_obo), s_obo); // iterative finding should return the identical file
+  
+  TEST_EXCEPTION(Exception::FileNotFound, File::find(""))
 END_SECTION
 
 START_SECTION((static String findDoc(const String& filename)))

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -349,11 +349,11 @@ namespace OpenMS
           exp.setChromatograms(irt_chromatograms);
           MzMLFile().store("debug_irts.mzML", exp);
         }
-        catch (OpenMS::Exception::UnableToCreateFile& e)
+        catch (OpenMS::Exception::UnableToCreateFile& /*e*/)
         {
           LOG_DEBUG << "Error creating file 'debug_irts.mzML', not writing out iRT chromatogram file"  << std::endl;
         }
-        catch (OpenMS::Exception::BaseException& e)
+        catch (OpenMS::Exception::BaseException& /*e*/)
         {
           LOG_DEBUG << "Error writint to file 'debug_irts.mzML', not writing out iRT chromatogram file"  << std::endl;
         }


### PR DESCRIPTION
fixed EnzymesDB:
 - synonyms were not indexed correctly
 - adding new enzymes was incomplete
 - constness and double bookkeeping fixed
 - extended tests (incomplete before)

While doing this, I found an inconvenience in File::find(), which could not be called recursively (as it happens here when using ::setEnyzmes(filename). Fixed as well (see test).
