### PR TITLE
[FIX, FEATURE] GaussFitter: return valid sigma values

### DIFF
--- a/src/openms/include/OpenMS/MATH/STATISTICS/GaussFitter.h
+++ b/src/openms/include/OpenMS/MATH/STATISTICS/GaussFitter.h
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Andreas Bertsch $
-// $Authors: $
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 //
 
@@ -46,12 +46,12 @@ namespace OpenMS
   namespace Math
   {
     /**
-        @brief Implements a fitter for gaussian functions
+        @brief Implements a fitter for Gaussian functions
 
-        This class fits a gaussian distribution to a number of data points.
+        This class fits a Gaussian distribution to a number of data points.
         The results as well as the initial guess are specified using the struct GaussFitResult.
 
-        The complete gaussian formula with the fitted parameters can be transformed into a
+        The complete Gaussian formula with the fitted parameters can be transformed into a
         gnuplot formula using getGnuplotFormula after fitting.
 
         @ingroup Math
@@ -60,7 +60,7 @@ namespace OpenMS
     {
 public:
 
-      /// struct of parameters of a gaussian distribution
+      /// struct of parameters of a Gaussian distribution
       struct GaussFitResult
       {
 public:
@@ -68,13 +68,14 @@ public:
         : A(-1.0), x0(-1.0), sigma(-1.0) {}
         GaussFitResult(double a, double x, double s)
         : A(a), x0(x), sigma(s) {}
-        /// parameter A of gaussian distribution (amplitude)
+
+        /// parameter A of Gaussian distribution (amplitude)
         double A;
 
-        /// parameter x0 of gaussian distribution (left/right shift)
+        /// parameter x0 of Gaussian distribution (center position)
         double x0;
 
-        /// parameter sigma of gaussian distribution (width)
+        /// parameter sigma of Gaussian distribution (width)
         double sigma;
       };
 
@@ -84,17 +85,27 @@ public:
       /// Destructor
       virtual ~GaussFitter();
 
-      /// sets the initial parameters used by the fit method as initial guess for the gaussian
-      void setInitialParameters(const GaussFitResult & result);
+      /// sets the initial parameters used by the fit method as initial guess for the Gaussian
+      void setInitialParameters(const GaussFitResult& result);
 
       /**
-          @brief Fits a gaussian distribution to the given data points
+          @brief Fits a Gaussian distribution to the given data points
 
-          @param points the data points used for the gaussian fitting
+          @param points the data points used for the Gaussian fitting
 
           @exception Exception::UnableToFit is thrown if fitting cannot be performed
       */
-      GaussFitResult fit(std::vector<DPosition<2> > & points);
+      GaussFitResult fit(std::vector<DPosition<2> > & points) const;
+
+      /**
+        @brief Evaluate the current Gaussian model at the specified points.
+
+        Returns the intensities (i.e. probabilities scaled by the factor 'A') of the PDF at the given positions.
+        This function can be called with any set of parameters, e.g. the initial parameters (to get a 'before-fit' status),
+        or after fitting.
+
+      */
+      static std::vector<double> eval(const std::vector<double>& evaluation_points, const GaussFitResult& model);
 
 protected:
 

--- a/src/tests/class_tests/openms/source/GaussFitter_test.cpp
+++ b/src/tests/class_tests/openms/source/GaussFitter_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // 
 // --------------------------------------------------------------------------
-// $Maintainer: Andreas Bertsch $
-// $Authors: Andreas Bertsch $
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>
@@ -64,7 +64,34 @@ START_SECTION((virtual ~GaussFitter()))
 }
 END_SECTION
 
-START_SECTION((GaussFitResult fit(std::vector< DPosition< 2 > >& points)))
+double mz[] = {
+  240.1000470172,
+  240.1002675493,
+  240.1004880817,
+  240.1007086145,
+  240.1009291475,
+  240.1011496808,
+  240.1013702145};
+
+double ints[] = {
+  61134.39453125,
+  111288.5390625,
+  163761.46875,
+  165861.4375,
+  162133.46875,
+  120060.5234375,
+  71102.1328125,
+};
+
+// initial guesses
+double max_peak_int = 168324;
+double max_peak_mz =  240.10051;
+double sigma = 0.000375375;
+
+Math::GaussFitter::GaussFitResult gfi(max_peak_int, max_peak_mz, sigma);
+
+
+START_SECTION((GaussFitResult fit(std::vector< DPosition< 2 > >& points) const))
 {
   DPosition<2> pos;
 	pos.setX(0.0);
@@ -90,10 +117,33 @@ START_SECTION((GaussFitResult fit(std::vector< DPosition< 2 > >& points)))
 	ptr = new GaussFitter;
 	GaussFitter::GaussFitResult result = ptr->fit(points);
 
-	TOLERANCE_ABSOLUTE(0.1)
-	TEST_REAL_SIMILAR(result.A, 1.0)
-	TEST_REAL_SIMILAR(result.x0, 0.3)
-	TEST_REAL_SIMILAR(result.sigma, 0.2)
+	//TOLERANCE_ABSOLUTE(0.1)
+	TEST_REAL_SIMILAR(result.A, 1.01898275662372)
+	TEST_REAL_SIMILAR(result.x0, 0.300612870901173)
+	TEST_REAL_SIMILAR(result.sigma, 0.136316330927453)
+
+  ////////////////////////////////////////
+  // second case which results in a negative sigma internally (requires using fabs())
+  ////////////////////////////////////////
+  std::vector< DPosition< 2 > > gp;
+  for (Size iii = 0; iii < 7; ++iii)
+  {
+    DPosition< 2 > d(mz[iii], ints[iii]);
+    gp.push_back(d);
+  }
+
+  Math::GaussFitter gf;
+  gf.setInitialParameters(gfi);
+  Math::GaussFitter::GaussFitResult gfr = gf.fit(gp);
+  /*
+  x0:      240.10051 --> 240.1007246725147
+  sigma: 0.000375375 --> 0.00046642320683761701
+  A:          168324 --> 175011.8930067491
+  */
+  TEST_REAL_SIMILAR(gfr.A, 175011.893006749)
+  TEST_REAL_SIMILAR(gfr.x0, 240.1007246725147)
+  TEST_REAL_SIMILAR(gfr.sigma, 0.00046642320683761701)
+
 }
 END_SECTION
 
@@ -107,6 +157,24 @@ START_SECTION((void setInitialParameters(const GaussFitResult& result)))
 }
 END_SECTION
 
+START_SECTION((static std::vector<double> eval(const std::vector<double>& evaluation_points, const GaussFitResult& model)))
+  GaussFitter f1;
+  std::vector<double> rnd = Math::GaussFitter::eval(std::vector<double>(&mz[0], &mz[0] + 7), gfi);
+
+  double int_fitted[] = {
+    78670.515322697669,
+    136633.77791868619,
+    168037.29915800504,
+    146337.00743127937,
+    90240.802825824489,
+    39405.008909696895,
+    12184.248044493703
+  };
+  for (Size i=0; i < rnd.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(int_fitted[i], rnd[i])
+  }
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
GaussFitter 
 - returns valid sigma values now (only positive) ... in some rare cases sigma was negative and thus invalid. Using fabs() solves this (and is the correct solution).
 - added an evaluation function, which uses the fitted model to predict data intensities
 - test extended
 - improved stopping criterion check of LevenbergMQ
 - fitting-speed improvement by ~10% by restructuring formulas

When reviewing this, please verify that the formula reconstruction is actually correct (I'm reasonably sure that this is the case, since the results are identical on a large dataset, but one never knows :) ).
