### PR TITLE
[FEATURE] TOPPAS convenience functionality

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASInputFileDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASInputFileDialog.h
@@ -78,7 +78,7 @@ protected slots:
 protected:
 
     /// The parent
-    QObject * parent_;
+    QObject* parent_;
   };
 
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASInputFilesDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASInputFilesDialog.h
@@ -55,12 +55,19 @@ namespace OpenMS
     Q_OBJECT
 
 public:
+    /// support drag'n'drop of files from OS window manager
+    void dragEnterEvent(QDragEnterEvent *e);
+    /// support drag'n'drop of files from OS window manager
+    void dropEvent(QDropEvent *e);
 
     /// Constructor
-    TOPPASInputFilesDialog(const QStringList & list);
+    TOPPASInputFilesDialog(const QStringList& list);
 
     /// Stores the list of all filenames in the list widget in @p files
-    void getFilenames(QStringList & files);
+    void getFilenames(QStringList& files) const;
+
+    /// support Ctrl+C to copy currently selected items to clipboard
+    virtual void keyPressEvent(QKeyEvent *e);
 
 public slots:
 


### PR DESCRIPTION
TOPPAS InputNode:
 - support Ctrl+C for selected items in the InputList
 - support drag'n'drop of files from window manager (e.g. Windows Explorer)
 - close InputFile window when pressing 'Escape'

Minor cleanup.