### PR TITLE
New ConsensusID algorithm "worst"

### DIFF
--- a/doc/doxygen/parameters/DefaultParamHandlerDocumenter.cpp
+++ b/doc/doxygen/parameters/DefaultParamHandlerDocumenter.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmBest.h>
 #include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmPEPIons.h>
 #include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmRanks.h>
+#include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmWorst.h>
 #include <OpenMS/ANALYSIS/ID/PILISScoring.h>
 #include <OpenMS/ANALYSIS/ID/PILISModel.h>
 #include <OpenMS/ANALYSIS/ID/PILISModelGenerator.h>
@@ -361,6 +362,7 @@ int main(int argc, char** argv)
   DOCME(ConsensusIDAlgorithmPEPIons);
   DOCME(ConsensusIDAlgorithmPEPMatrix);
   DOCME(ConsensusIDAlgorithmRanks);
+  DOCME(ConsensusIDAlgorithmWorst);
   DOCME(DetectabilitySimulation);
   DOCME(DIAScoring);
   DOCME(DigestSimulation);

--- a/src/openms/include/OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmWorst.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmWorst.h
@@ -29,31 +29,42 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Hendrik Weisser $
-// $Authors: Sven Nahnsen, Hendrik Weisser $
+// $Authors: Andreas Bertsch, Marc Sturm, Sven Nahnsen, Hendrik Weisser $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmBest.h>
+#ifndef OPENMS_ANALYSIS_ID_CONSENSUSIDALGORITHMWORST_H
+#define OPENMS_ANALYSIS_ID_CONSENSUSIDALGORITHMWORST_H
 
-#include <cmath>
-
-using namespace std;
+#include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmIdentity.h>
 
 namespace OpenMS
 {
-  ConsensusIDAlgorithmBest::ConsensusIDAlgorithmBest()
-  {
-    setName("ConsensusIDAlgorithmBest"); // DefaultParamHandler
-  }
+  /**
+    @brief Calculates a consensus from multiple ID runs by taking the worst search score (conservative approach).
 
-
-  double ConsensusIDAlgorithmBest::getAggregateScore_(vector<double>& scores,
-                                                      bool higher_better)
+    @htmlinclude OpenMS_ConsensusIDAlgorithmWorst.parameters
+    
+    @ingroup Analysis_ID
+  */
+  class OPENMS_DLLAPI ConsensusIDAlgorithmWorst :
+    public ConsensusIDAlgorithmIdentity
   {
-    if (higher_better)
-    {
-      return *max_element(scores.begin(), scores.end());
-    }
-    return *min_element(scores.begin(), scores.end());
-  }
+  public:
+    /// Default constructor
+    ConsensusIDAlgorithmWorst();
+
+  private:
+    /// Not implemented
+    ConsensusIDAlgorithmWorst(const ConsensusIDAlgorithmWorst&);
+
+    /// Not implemented
+    ConsensusIDAlgorithmWorst& operator=(const ConsensusIDAlgorithmWorst&);
+
+    /// Aggregate peptide scores into one final score (by taking the worst score)
+    virtual double getAggregateScore_(std::vector<double>& scores,
+                                      bool higher_better);
+  };
 
 } // namespace OpenMS
+
+#endif // OPENMS_ANALYSIS_ID_CONSENSUSIDALGORITHMWORST_H

--- a/src/openms/include/OpenMS/ANALYSIS/ID/sources.cmake
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/sources.cmake
@@ -13,6 +13,7 @@ ConsensusIDAlgorithmPEPIons.h
 ConsensusIDAlgorithmPEPMatrix.h
 ConsensusIDAlgorithmRanks.h
 ConsensusIDAlgorithmSimilarity.h
+ConsensusIDAlgorithmWorst.h
 FalseDiscoveryRate.h
 HiddenMarkovModel.h
 IDDecoyProbability.h

--- a/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithmWorst.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithmWorst.cpp
@@ -32,7 +32,7 @@
 // $Authors: Sven Nahnsen, Hendrik Weisser $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmBest.h>
+#include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmWorst.h>
 
 #include <cmath>
 
@@ -40,20 +40,20 @@ using namespace std;
 
 namespace OpenMS
 {
-  ConsensusIDAlgorithmBest::ConsensusIDAlgorithmBest()
+  ConsensusIDAlgorithmWorst::ConsensusIDAlgorithmWorst()
   {
-    setName("ConsensusIDAlgorithmBest"); // DefaultParamHandler
+    setName("ConsensusIDAlgorithmWorst"); // DefaultParamHandler
   }
 
 
-  double ConsensusIDAlgorithmBest::getAggregateScore_(vector<double>& scores,
-                                                      bool higher_better)
+  double ConsensusIDAlgorithmWorst::getAggregateScore_(vector<double>& scores,
+                                                       bool higher_better)
   {
     if (higher_better)
     {
-      return *max_element(scores.begin(), scores.end());
+      return *min_element(scores.begin(), scores.end());
     }
-    return *min_element(scores.begin(), scores.end());
+    return *max_element(scores.begin(), scores.end());
   }
 
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/ID/sources.cmake
+++ b/src/openms/source/ANALYSIS/ID/sources.cmake
@@ -13,6 +13,7 @@ ConsensusIDAlgorithmPEPIons.cpp
 ConsensusIDAlgorithmPEPMatrix.cpp
 ConsensusIDAlgorithmRanks.cpp
 ConsensusIDAlgorithmSimilarity.cpp
+ConsensusIDAlgorithmWorst.cpp
 FalseDiscoveryRate.cpp
 HiddenMarkovModel.cpp
 IDMapper.cpp

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -392,6 +392,7 @@ set(analysis_executables_list
   ConsensusIDAlgorithmPEPIons_test
   ConsensusIDAlgorithmPEPMatrix_test
   ConsensusIDAlgorithmRanks_test
+  ConsensusIDAlgorithmWorst_test
   ConsensusMapNormalizerAlgorithmThreshold_test
   ConsensusMapNormalizerAlgorithmMedian_test
   ConsensusMapNormalizerAlgorithmQuantile_test

--- a/src/tests/class_tests/openms/source/ConsensusIDAlgorithmWorst_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusIDAlgorithmWorst_test.cpp
@@ -1,0 +1,188 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2015.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hendrik Weisser $
+// $Authors: Marc Sturm, Andreas Bertsch, Sven Nahnsen, Hendrik Weisser $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmWorst.h>
+
+using namespace OpenMS;
+using namespace std;
+
+///////////////////////////
+
+START_TEST(ConsensusIDAlgorithmWorst, "$Id$")
+
+/////////////////////////////////////////////////////////////
+
+ConsensusIDAlgorithm* ptr = 0;
+ConsensusIDAlgorithm* null_pointer = 0;
+START_SECTION(ConsensusIDAlgorithmWorst())
+{
+  ptr = new ConsensusIDAlgorithmWorst();
+  TEST_NOT_EQUAL(ptr, null_pointer);
+}
+END_SECTION
+
+START_SECTION(~ConsensusIDAlgorithmWorst())
+{
+  delete(ptr);
+}
+END_SECTION
+
+// create 3 ID runs:
+PeptideIdentification temp;
+temp.setScoreType("Posterior Error Probability");
+temp.setHigherScoreBetter(false);
+vector<PeptideIdentification> ids(3, temp);
+vector<PeptideHit> hits;
+// the first ID has 5 hits
+hits.resize(5);
+hits[0].setSequence(AASequence::fromString("A"));
+hits[0].setScore(0.1);
+hits[1].setSequence(AASequence::fromString("B"));
+hits[1].setScore(0.2);
+hits[2].setSequence(AASequence::fromString("C"));
+hits[2].setScore(0.3);
+hits[3].setSequence(AASequence::fromString("D"));
+hits[3].setScore(0.4);
+hits[4].setSequence(AASequence::fromString("E"));
+hits[4].setScore(0.5);
+ids[0].setHits(hits);
+// the second ID has 3 hits
+hits.resize(3);
+hits[0].setSequence(AASequence::fromString("C"));
+hits[0].setScore(0.2);
+hits[1].setSequence(AASequence::fromString("A"));
+hits[1].setScore(0.4);
+hits[2].setSequence(AASequence::fromString("B"));
+hits[2].setScore(0.6);
+ids[1].setHits(hits);
+// the third ID has 10 hits
+hits.resize(10);
+hits[0].setSequence(AASequence::fromString("F"));
+hits[0].setScore(0.0);
+hits[1].setSequence(AASequence::fromString("C"));
+hits[1].setScore(0.1);
+hits[2].setSequence(AASequence::fromString("G"));
+hits[2].setScore(0.2);
+hits[3].setSequence(AASequence::fromString("D"));
+hits[3].setScore(0.3);
+hits[4].setSequence(AASequence::fromString("B"));
+hits[4].setScore(0.4);
+hits[5].setSequence(AASequence::fromString("E"));
+hits[5].setScore(0.5);
+hits[6].setSequence(AASequence::fromString("H"));
+hits[6].setScore(0.6);
+hits[7].setSequence(AASequence::fromString("I"));
+hits[7].setScore(0.7);
+hits[8].setSequence(AASequence::fromString("J"));
+hits[8].setScore(0.8);
+hits[9].setSequence(AASequence::fromString("K"));
+hits[9].setScore(0.9);
+ids[2].setHits(hits);
+
+START_SECTION(void apply(std::vector<PeptideIdentification>& ids))
+{
+  TOLERANCE_ABSOLUTE(0.01)
+
+  ConsensusIDAlgorithmWorst consensus;
+  // define parameters:
+  Param param;
+  param.setValue("filter:considered_hits", 0);
+  consensus.setParameters(param);
+  // apply:
+  vector<PeptideIdentification> f = ids;
+  consensus.apply(f);
+
+  TEST_EQUAL(f.size(), 1);
+  hits = f[0].getHits();
+  TEST_EQUAL(hits.size(), 11);
+
+  TEST_EQUAL(hits[0].getRank(), 1);
+  TEST_EQUAL(hits[0].getSequence(), AASequence::fromString("F"));
+  TEST_REAL_SIMILAR(hits[0].getScore(), 0.0);
+
+  TEST_EQUAL(hits[1].getRank(), 2);
+  TEST_EQUAL(hits[1].getSequence(), AASequence::fromString("G"));
+  TEST_REAL_SIMILAR(hits[1].getScore(), 0.2);
+
+  TEST_EQUAL(hits[2].getRank(), 3);
+  TEST_EQUAL(hits[2].getSequence(), AASequence::fromString("C"));
+  TEST_REAL_SIMILAR(hits[2].getScore(), 0.3);
+
+  // hits with the same score get assigned the same rank:
+  TEST_EQUAL(hits[3].getRank(), 4);
+  TEST_EQUAL(hits[3].getSequence(), AASequence::fromString("A"));
+  TEST_REAL_SIMILAR(hits[3].getScore(), 0.4);
+
+  TEST_EQUAL(hits[4].getRank(), 4);
+  TEST_EQUAL(hits[4].getSequence(), AASequence::fromString("D"));
+  TEST_REAL_SIMILAR(hits[4].getScore(), 0.4);
+
+  TEST_EQUAL(hits[5].getRank(), 5);
+  TEST_EQUAL(hits[5].getSequence(), AASequence::fromString("E"));
+  TEST_REAL_SIMILAR(hits[5].getScore(), 0.5);
+
+  TEST_EQUAL(hits[6].getRank(), 6);
+  TEST_EQUAL(hits[6].getSequence(), AASequence::fromString("B"));
+  TEST_REAL_SIMILAR(hits[6].getScore(), 0.6);
+
+  TEST_EQUAL(hits[7].getRank(), 6);
+  TEST_EQUAL(hits[7].getSequence(), AASequence::fromString("H"));
+  TEST_REAL_SIMILAR(hits[7].getScore(), 0.6);
+
+  TEST_EQUAL(hits[8].getRank(), 7);
+  TEST_EQUAL(hits[8].getSequence(), AASequence::fromString("I"));
+  TEST_REAL_SIMILAR(hits[8].getScore(), 0.7);
+
+  TEST_EQUAL(hits[9].getRank(), 8);
+  TEST_EQUAL(hits[9].getSequence(), AASequence::fromString("J"));
+  TEST_REAL_SIMILAR(hits[9].getScore(), 0.8);
+
+  TEST_EQUAL(hits[10].getRank(), 9);
+  TEST_EQUAL(hits[10].getSequence(), AASequence::fromString("K"));
+  TEST_REAL_SIMILAR(hits[10].getScore(), 0.9);
+
+
+  ids[2].setHigherScoreBetter(true);
+  TEST_EXCEPTION(Exception::InvalidValue, consensus.apply(ids));
+}
+END_SECTION
+
+/////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////
+END_TEST


### PR DESCRIPTION
Added a new ConsensusID algorithm that, when combining ID runs, uses the worst score among all runs for each PSM. This is the opposite of the existing "best" strategy and allows for conservative merging.