### PR TITLE
ConsensusID: avoid warning message

### DIFF
--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -358,9 +358,14 @@ protected:
         if (!it->getPeptideIdentifications().empty())
         {
           PeptideIdentification& pep_id = it->getPeptideIdentifications()[0];
-          pep_id.setRT(it->getRT());
-          pep_id.setMZ(it->getMZ());
-          pep_ids.push_back(pep_id);
+          // hits may be empty due to filtering (parameter "min_support");
+          // in that case skip to a avoid warning from "IDXMLFile::store":
+          if (!pep_id.getHits().empty())
+          {
+            pep_id.setRT(it->getRT());
+            pep_id.setMZ(it->getMZ());
+            pep_ids.push_back(pep_id);
+          }
         }
       }
 

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -359,7 +359,7 @@ protected:
         {
           PeptideIdentification& pep_id = it->getPeptideIdentifications()[0];
           // hits may be empty due to filtering (parameter "min_support");
-          // in that case skip to a avoid warning from "IDXMLFile::store":
+          // in that case skip to avoid a warning from "IDXMLFile::store":
           if (!pep_id.getHits().empty())
           {
             pep_id.setRT(it->getRT());


### PR DESCRIPTION
When the "filter:min_support" option is used in ConsensusID, peptide identifications without any peptide hits can be generated (if none of the hits pass the filter). Storing the resulting IdXML file would then produce this message:
> Omitted writing of ... peptide identifications due to empty hits.

To avoid this message (indicating a problem where there isn't one), peptide IDs with empty hits are now skipped when the final list of IDs is generated.