### PR TITLE
extended blacklisting in FeatureFinderMultiplex

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
@@ -208,8 +208,6 @@ protected:
      */
     void blacklistPeaks(MultiplexPeakPattern pattern, int spectrum, const std::vector<int>& mz_shifts_actual_indices, int peaks_found_in_all_peptides_spline);
 
-    void blacklistPeaks2(MultiplexPeakPattern pattern, int spectrum, const std::vector<int>& mz_shifts_actual_indices, int peaks_found_in_all_peptides_spline);
-
     /**
      * @brief returns the index of a peak at m/z
      * (finds not only a valid peak, i.e. within certain m/z deviation, but the best of the valid peaks)

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
@@ -208,6 +208,8 @@ protected:
      */
     void blacklistPeaks(MultiplexPeakPattern pattern, int spectrum, const std::vector<int>& mz_shifts_actual_indices, int peaks_found_in_all_peptides_spline);
 
+    void blacklistPeaks2(MultiplexPeakPattern pattern, int spectrum, const std::vector<int>& mz_shifts_actual_indices, int peaks_found_in_all_peptides_spline);
+
     /**
      * @brief returns the index of a peak at m/z
      * (finds not only a valid peak, i.e. within certain m/z deviation, but the best of the valid peaks)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -329,6 +329,76 @@ namespace OpenMS
     }
   }
 
+  void MultiplexFiltering::blacklistPeaks2(MultiplexPeakPattern pattern, int spectrum, const vector<int>& mz_shifts_actual_indices, int peaks_found_in_all_peptides_spline)
+  {
+    for (unsigned peptide = 0; peptide < pattern.getMassShiftCount(); ++peptide)
+    {
+      for (int isotope = 0; isotope < peaks_found_in_all_peptides_spline; ++isotope)
+      {
+        int mz_position = peptide * (peaks_per_peptide_max_ + 1) + isotope + 1; // index in m/z shift list
+        int peak_index;
+
+        // blacklist peaks in this spectrum
+        peak_index = mz_shifts_actual_indices[mz_position];
+        if (peak_index != -1 && !blacklist_[spectrum][peak_index].black)
+        {
+          blacklist_[spectrum][peak_index].black = true;
+          blacklist_[spectrum][peak_index].black_exception_mass_shift_index = pattern.getMassShiftIndex();
+          blacklist_[spectrum][peak_index].black_exception_charge = pattern.getCharge();
+          blacklist_[spectrum][peak_index].black_exception_mz_position = mz_position;
+        }
+
+        // blacklist peaks in previous spectrum
+        peak_index = registry_[spectrum][mz_shifts_actual_indices[mz_position]].index_in_previous_spectrum;
+        if (peak_index != -1 && !blacklist_[spectrum - 1][peak_index].black)
+        {
+          blacklist_[spectrum - 1][peak_index].black = true;
+          blacklist_[spectrum - 1][peak_index].black_exception_mass_shift_index = pattern.getMassShiftIndex();
+          blacklist_[spectrum - 1][peak_index].black_exception_charge = pattern.getCharge();
+          blacklist_[spectrum - 1][peak_index].black_exception_mz_position = mz_position;
+        }
+        
+        // blacklist peaks in spectrum -2
+        if (peak_index != -1 && spectrum > 1)
+        {
+          int peak_index2 = registry_[spectrum - 1][peak_index].index_in_previous_spectrum;
+          if (peak_index2 != -1 && !blacklist_[spectrum - 2][peak_index2].black)
+          {
+            blacklist_[spectrum - 2][peak_index2].black = true;
+            blacklist_[spectrum - 2][peak_index2].black_exception_mass_shift_index = pattern.getMassShiftIndex();
+            blacklist_[spectrum - 2][peak_index2].black_exception_charge = pattern.getCharge();
+            blacklist_[spectrum - 2][peak_index2].black_exception_mz_position = mz_position;
+          }
+        }
+        
+        // blacklist peaks in next spectrum
+        peak_index = registry_[spectrum][mz_shifts_actual_indices[mz_position]].index_in_next_spectrum;
+        if (peak_index != -1 && !blacklist_[spectrum + 1][peak_index].black)
+        {
+          blacklist_[spectrum + 1][peak_index].black = true;
+          blacklist_[spectrum + 1][peak_index].black_exception_mass_shift_index = pattern.getMassShiftIndex();
+          blacklist_[spectrum + 1][peak_index].black_exception_charge = pattern.getCharge();
+          blacklist_[spectrum + 1][peak_index].black_exception_mz_position = mz_position;
+        }
+        
+        // blacklist peaks in spectrum +2
+        if (peak_index != -1 && spectrum + 2 < (int) blacklist_.size())
+        {
+          int peak_index2 = registry_[spectrum + 1][peak_index].index_in_next_spectrum;
+          if (peak_index2 != -1 && !blacklist_[spectrum + 2][peak_index2].black)
+          {
+            blacklist_[spectrum + 2][peak_index2].black = true;
+            blacklist_[spectrum + 2][peak_index2].black_exception_mass_shift_index = pattern.getMassShiftIndex();
+            blacklist_[spectrum + 2][peak_index2].black_exception_charge = pattern.getCharge();
+            blacklist_[spectrum + 2][peak_index2].black_exception_mz_position = mz_position;
+          }
+        }
+
+
+      }
+    }
+  }
+
   int MultiplexFiltering::getPeakIndex(std::vector<double> peak_position, int start, double mz, double scaling) const
   {
     vector<int> valid_index; // indices of valid peaks that lie within the ppm range of the expected peak

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -314,60 +314,17 @@ namespace OpenMS
           blacklist_[spectrum - 1][peak_index].black_exception_charge = pattern.getCharge();
           blacklist_[spectrum - 1][peak_index].black_exception_mz_position = mz_position;
         }
-
-        // blacklist peaks in next spectrum
-        peak_index = registry_[spectrum][mz_shifts_actual_indices[mz_position]].index_in_next_spectrum;
-        if (peak_index != -1 && !blacklist_[spectrum + 1][peak_index].black)
-        {
-          blacklist_[spectrum + 1][peak_index].black = true;
-          blacklist_[spectrum + 1][peak_index].black_exception_mass_shift_index = pattern.getMassShiftIndex();
-          blacklist_[spectrum + 1][peak_index].black_exception_charge = pattern.getCharge();
-          blacklist_[spectrum + 1][peak_index].black_exception_mz_position = mz_position;
-        }
-
-      }
-    }
-  }
-
-  void MultiplexFiltering::blacklistPeaks2(MultiplexPeakPattern pattern, int spectrum, const vector<int>& mz_shifts_actual_indices, int peaks_found_in_all_peptides_spline)
-  {
-    for (unsigned peptide = 0; peptide < pattern.getMassShiftCount(); ++peptide)
-    {
-      for (int isotope = 0; isotope < peaks_found_in_all_peptides_spline; ++isotope)
-      {
-        int mz_position = peptide * (peaks_per_peptide_max_ + 1) + isotope + 1; // index in m/z shift list
-        int peak_index;
-
-        // blacklist peaks in this spectrum
-        peak_index = mz_shifts_actual_indices[mz_position];
-        if (peak_index != -1 && !blacklist_[spectrum][peak_index].black)
-        {
-          blacklist_[spectrum][peak_index].black = true;
-          blacklist_[spectrum][peak_index].black_exception_mass_shift_index = pattern.getMassShiftIndex();
-          blacklist_[spectrum][peak_index].black_exception_charge = pattern.getCharge();
-          blacklist_[spectrum][peak_index].black_exception_mz_position = mz_position;
-        }
-
-        // blacklist peaks in previous spectrum
-        peak_index = registry_[spectrum][mz_shifts_actual_indices[mz_position]].index_in_previous_spectrum;
-        if (peak_index != -1 && !blacklist_[spectrum - 1][peak_index].black)
-        {
-          blacklist_[spectrum - 1][peak_index].black = true;
-          blacklist_[spectrum - 1][peak_index].black_exception_mass_shift_index = pattern.getMassShiftIndex();
-          blacklist_[spectrum - 1][peak_index].black_exception_charge = pattern.getCharge();
-          blacklist_[spectrum - 1][peak_index].black_exception_mz_position = mz_position;
-        }
         
-        // blacklist peaks in spectrum -2
+        // blacklist peaks in spectrum before previous one
         if (peak_index != -1 && spectrum > 1)
         {
-          int peak_index2 = registry_[spectrum - 1][peak_index].index_in_previous_spectrum;
-          if (peak_index2 != -1 && !blacklist_[spectrum - 2][peak_index2].black)
+          int peak_index_2 = registry_[spectrum - 1][peak_index].index_in_previous_spectrum;
+          if (peak_index_2 != -1 && !blacklist_[spectrum - 2][peak_index_2].black)
           {
-            blacklist_[spectrum - 2][peak_index2].black = true;
-            blacklist_[spectrum - 2][peak_index2].black_exception_mass_shift_index = pattern.getMassShiftIndex();
-            blacklist_[spectrum - 2][peak_index2].black_exception_charge = pattern.getCharge();
-            blacklist_[spectrum - 2][peak_index2].black_exception_mz_position = mz_position;
+            blacklist_[spectrum - 2][peak_index_2].black = true;
+            blacklist_[spectrum - 2][peak_index_2].black_exception_mass_shift_index = pattern.getMassShiftIndex();
+            blacklist_[spectrum - 2][peak_index_2].black_exception_charge = pattern.getCharge();
+            blacklist_[spectrum - 2][peak_index_2].black_exception_mz_position = mz_position;
           }
         }
         
@@ -381,19 +338,18 @@ namespace OpenMS
           blacklist_[spectrum + 1][peak_index].black_exception_mz_position = mz_position;
         }
         
-        // blacklist peaks in spectrum +2
+        // blacklist peaks in spectrum after next one
         if (peak_index != -1 && spectrum + 2 < (int) blacklist_.size())
         {
-          int peak_index2 = registry_[spectrum + 1][peak_index].index_in_next_spectrum;
-          if (peak_index2 != -1 && !blacklist_[spectrum + 2][peak_index2].black)
+          int peak_index_2 = registry_[spectrum + 1][peak_index].index_in_next_spectrum;
+          if (peak_index_2 != -1 && !blacklist_[spectrum + 2][peak_index_2].black)
           {
-            blacklist_[spectrum + 2][peak_index2].black = true;
-            blacklist_[spectrum + 2][peak_index2].black_exception_mass_shift_index = pattern.getMassShiftIndex();
-            blacklist_[spectrum + 2][peak_index2].black_exception_charge = pattern.getCharge();
-            blacklist_[spectrum + 2][peak_index2].black_exception_mz_position = mz_position;
+            blacklist_[spectrum + 2][peak_index_2].black = true;
+            blacklist_[spectrum + 2][peak_index_2].black_exception_mass_shift_index = pattern.getMassShiftIndex();
+            blacklist_[spectrum + 2][peak_index_2].black_exception_charge = pattern.getCharge();
+            blacklist_[spectrum + 2][peak_index_2].black_exception_mz_position = mz_position;
           }
         }
-
 
       }
     }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -134,6 +134,16 @@ namespace OpenMS
     // loop over patterns
     for (unsigned pattern = 0; pattern < patterns_.size(); ++pattern)
     {
+      std::vector<double> mshifts = patterns_[pattern].getMassShifts();
+      if (mshifts.size() > 1)
+      {
+        std::cout << "pattern: " << pattern << "   charge: " << patterns_[pattern].getCharge() << "   mass shift 1: " << patterns_[pattern].getMassShifts()[1] << "\n";
+      }
+      else
+      {
+        std::cout << "pattern: " << pattern << "   charge: " << patterns_[pattern].getCharge() << "\n";
+      }
+      
       // data structure storing peaks which pass all filters
       MultiplexFilterResult result;
 
@@ -261,11 +271,15 @@ namespace OpenMS
             // add raw data point to list that passed all filters
             MultiplexFilterResultRaw result_raw(mz, mz_shifts_actual, intensities_actual);
             results_raw.push_back(result_raw);
+            
+            std::cout << "Found something.   RT = " << rt_picked << "\n";
 
             // blacklist peaks in the current spectrum and the two neighbouring ones
             if (!blacklisted)
             {
-              blacklistPeaks(patterns_[pattern], spectrum, mz_shifts_actual_indices, peaks_found_in_all_peptides_spline);
+              std::cout << "Now blacklisting.   RT = " << rt_picked << "   mz = " << mz <<  "   index = " << mz_shifts_actual_indices[1] << "\n";
+              
+              blacklistPeaks2(patterns_[pattern], spectrum, mz_shifts_actual_indices, peaks_found_in_all_peptides_spline);
               blacklisted = true;
             }
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -133,17 +133,7 @@ namespace OpenMS
 
     // loop over patterns
     for (unsigned pattern = 0; pattern < patterns_.size(); ++pattern)
-    {
-      std::vector<double> mshifts = patterns_[pattern].getMassShifts();
-      if (mshifts.size() > 1)
-      {
-        std::cout << "pattern: " << pattern << "   charge: " << patterns_[pattern].getCharge() << "   mass shift 1: " << patterns_[pattern].getMassShifts()[1] << "\n";
-      }
-      else
-      {
-        std::cout << "pattern: " << pattern << "   charge: " << patterns_[pattern].getCharge() << "\n";
-      }
-      
+    {      
       // data structure storing peaks which pass all filters
       MultiplexFilterResult result;
 
@@ -272,14 +262,10 @@ namespace OpenMS
             MultiplexFilterResultRaw result_raw(mz, mz_shifts_actual, intensities_actual);
             results_raw.push_back(result_raw);
             
-            std::cout << "Found something.   RT = " << rt_picked << "\n";
-
             // blacklist peaks in the current spectrum and the two neighbouring ones
             if (!blacklisted)
             {
-              std::cout << "Now blacklisting.   RT = " << rt_picked << "   mz = " << mz <<  "   index = " << mz_shifts_actual_indices[1] << "\n";
-              
-              blacklistPeaks2(patterns_[pattern], spectrum, mz_shifts_actual_indices, peaks_found_in_all_peptides_spline);
+              blacklistPeaks(patterns_[pattern], spectrum, mz_shifts_actual_indices, peaks_found_in_all_peptides_spline);
               blacklisted = true;
             }
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -133,7 +133,7 @@ namespace OpenMS
 
     // loop over patterns
     for (unsigned pattern = 0; pattern < patterns_.size(); ++pattern)
-    {      
+    {
       // data structure storing peaks which pass all filters
       MultiplexFilterResult result;
 


### PR DESCRIPTION
If a data point passes all filters, the corresponding peaks in the spectrum and the two neighbouring ones are blacklisted. In this pull request, the blacklisting is extended to +/-2 spectra. The FP detection rate should thereby be reduced.