### PR TITLE
[FEATURE] added meta info interface to featuremap

### DIFF
--- a/share/OpenMS/SCHEMAS/FeatureXML_1_7.xsd
+++ b/share/OpenMS/SCHEMAS/FeatureXML_1_7.xsd
@@ -1,0 +1,679 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2007 sp2 (http://www.altova.com) by Oliver Kohlbacher (Universität Tübingen) -->
+<!-- Mit XMLSpy v2007 sp1 bearbeitet (http://www.altova.com) von Oliver Kohlbacher (Universität Tübingen) -->
+<!-- edited with gvim by Clemens Groepl, 2009-10-07. -->
+<!-- edited with notepad++ by Chris Bielow, 2011-10-27. -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:element name="featureMap">
+		<xs:annotation>
+			<xs:documentation>Base node of the FeatureXML format.</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>user parameters</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dataProcessing" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>data processing applied to this file</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="software">
+								<xs:annotation>
+									<xs:documentation>processing software</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:attribute name="name" type="xs:string" use="required">
+										<xs:annotation>
+											<xs:documentation>software name</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="version" type="xs:string" use="required">
+										<xs:annotation>
+											<xs:documentation>software version</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="processingAction" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>processing actions applied by the software</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:attribute name="name" type="xs:string" use="required">
+										<xs:annotation>
+											<xs:documentation>action name</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="userParam" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>user parameters</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:complexContent>
+										<xs:extension base="userParam"/>
+									</xs:complexContent>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="completion_time" type="xs:dateTime" use="required">
+							<xs:annotation>
+								<xs:documentation>end time of processing</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="IdentificationRun" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Identification runs mapped to this feature map.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="SearchParameters">
+								<xs:annotation>
+									<xs:documentation>Search parameters that can be used for several identification runs</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="FixedModification" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>fixed modifications for the search</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence minOccurs="0">
+													<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+												</xs:sequence>
+												<xs:attribute name="name" use="required">
+													<xs:annotation>
+														<xs:documentation>modification name</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:attribute>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="VariableModification" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>variable modifications for the search</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence minOccurs="0">
+													<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+												</xs:sequence>
+												<xs:attribute name="name" use="required">
+													<xs:annotation>
+														<xs:documentation>modification name</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:attribute>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+									</xs:sequence>
+									<xs:attribute name="db" type="xs:string" use="required">
+										<xs:annotation>
+											<xs:documentation>protein sequence database name</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="db_version" type="xs:string" use="required">
+										<xs:annotation>
+											<xs:documentation>database version</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="taxonomy" type="xs:string">
+										<xs:annotation>
+											<xs:documentation>taxonomy restriction</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="mass_type" type="MassType" use="required">
+										<xs:annotation>
+											<xs:documentation>mass type ('monoisotopic' or 'average')</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="charges" type="xs:string" use="required">
+										<xs:annotation>
+											<xs:documentation>searched for charges. If you want these charges to be automatically processed use the following format: '+1,+2,+3'</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="enzyme" type="DigestionEnzyme">
+										<xs:annotation>
+											<xs:documentation>digestion enzyme ('trypsin','pepsin_a','chymotrypsin','proteinase_k','no_enzyme' or 'unknown_enzyme')</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="missed_cleavages" type="xs:unsignedInt">
+										<xs:annotation>
+											<xs:documentation>number of allowed missed cleavages</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="precursor_peak_tolerance" type="xs:float" use="required">
+										<xs:annotation>
+											<xs:documentation>peak mass tolerance of precursor peak in Da</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="peak_mass_tolerance" type="xs:float" use="required">
+										<xs:annotation>
+											<xs:documentation>peak mass tolerance of fragment ions in Da</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="ProteinIdentification" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Collection of identified proteins</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="ProteinHit" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Single reported protein hit</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence minOccurs="0">
+													<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+												</xs:sequence>
+												<xs:attribute name="id" type="xs:ID" use="required">
+													<xs:annotation>
+														<xs:documentation>'id' of the protein hit. Is referenced by peptide hits.</xs:documentation>
+													</xs:annotation>
+												</xs:attribute>
+												<xs:attribute name="accession" type="xs:string" use="required">
+													<xs:annotation>
+														<xs:documentation>accession of the protein in the used database.</xs:documentation>
+													</xs:annotation>
+												</xs:attribute>
+												<xs:attribute name="score" type="xs:float" use="required">
+													<xs:annotation>
+														<xs:documentation>score of the hit</xs:documentation>
+													</xs:annotation>
+												</xs:attribute>
+												<xs:attribute name="sequence" type="xs:string">
+													<xs:annotation>
+														<xs:documentation>protein sequences, if known</xs:documentation>
+													</xs:annotation>
+												</xs:attribute>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+									</xs:sequence>
+									<xs:attribute name="score_type" type="xs:string" use="required">
+										<xs:annotation>
+											<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+										<xs:annotation>
+											<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="significance_threshold" type="xs:float">
+										<xs:annotation>
+											<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="id" type="xs:ID" use="required">
+							<xs:annotation>
+								<xs:documentation>Identifier of the identification run, which is referenced by the peptide identifications in order to relate them to the run.</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="search_engine" type="xs:string" use="required">
+							<xs:annotation>
+								<xs:documentation>search engine name, e.g. 'Mascot', 'Sequest'</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="search_engine_version" type="xs:string" use="required">
+							<xs:annotation>
+								<xs:documentation>search engine version</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="date" type="xs:dateTime" use="required">
+							<xs:annotation>
+								<xs:documentation>date, when the search was performed (Format: yyyy-mm-ddThh:mm:ss)</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UnassignedPeptideIdentification" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Peptide identifications not mapped to any feature.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="PeptideHit" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>single reported peptide hit</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence minOccurs="0">
+										<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+									</xs:sequence>
+									<xs:attribute name="sequence" type="xs:string" use="required">
+										<xs:annotation>
+											<xs:documentation>peptide sequence</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="charge" type="xs:integer" use="required">
+										<xs:annotation>
+											<xs:documentation>charge of the peptide</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="score" type="xs:float" use="required">
+										<xs:annotation>
+											<xs:documentation>score of the hit</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+									<xs:attribute name="aa_before">
+										<xs:annotation>
+											<xs:documentation>amino acid before the sequence (for DB search)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:minLength value="0"/>
+												<xs:maxLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:attribute>
+									<xs:attribute name="aa_after">
+										<xs:annotation>
+											<xs:documentation>amino acid after the sequence (for DB search)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:minLength value="0"/>
+												<xs:maxLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:attribute>
+									<xs:attribute name="protein_refs" type="xs:IDREFS">
+										<xs:annotation>
+											<xs:documentation>References to proteins hits, this peptide occurs in.</xs:documentation>
+										</xs:annotation>
+									</xs:attribute>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+						<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
+							<xs:annotation>
+								<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="score_type" type="xs:string" use="required">
+							<xs:annotation>
+								<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+							<xs:annotation>
+								<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="significance_threshold" type="xs:float">
+							<xs:annotation>
+								<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
+							<xs:annotation>
+								<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="RT" type="xs:float">
+							<xs:annotation>
+								<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="MZ" type="xs:float">
+							<xs:annotation>
+								<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="featureList">
+					<xs:annotation>
+						<xs:documentation>A list of several features</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="feature" type="featureType" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>a single feature</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="count" type="xs:integer" use="required">
+							<xs:annotation>
+								<xs:documentation>number of feature to expect in the list</xs:documentation>
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:float">
+				<xs:annotation>
+					<xs:documentation>Schema version, e.g. '1.1'. If it is missing, version 1.0 is assumed.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="document_id" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>An optional id for the document. It is recommended to use LSIDs when possible.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="id" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>An optional unique_id for the document, for internal use by OpenMS.</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="userParam">
+		<xs:annotation>
+			<xs:documentation>Type-Name-Value type for annotations</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="type" type="UserParamType" use="required">
+			<xs:annotation>
+				<xs:documentation>value type ('int', 'float' or 'string')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>name of the annotation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="value" type="xs:anySimpleType" use="required">
+			<xs:annotation>
+				<xs:documentation>actual value of the annotation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="featureType">
+		<xs:sequence>
+			<xs:element name="position" minOccurs="2" maxOccurs="2">
+				<xs:annotation>
+					<xs:documentation>position in the map</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:anySimpleType">
+							<xs:attribute name="dim" use="required">
+								<xs:annotation>
+									<xs:documentation>Dimension 0 for retention time and 1 for m/z</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="intensity" type="xs:double">
+				<xs:annotation>
+					<xs:documentation>Intensity of the feature (the sum of all the peak intensities that belong to it)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="quality" minOccurs="0" maxOccurs="2">
+				<xs:annotation>
+					<xs:documentation>model fitting quality for one dimension</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:simpleContent>
+						<xs:extension base="xs:anySimpleType">
+							<xs:attribute name="dim" use="required">
+								<xs:annotation>
+									<xs:documentation>Dimension 0 for retention time and 1 for m/z</xs:documentation>
+								</xs:annotation>
+							</xs:attribute>
+						</xs:extension>
+					</xs:simpleContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="overallquality" type="xs:double" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>overall model fitting quality of both dimension</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="charge" type="xs:double" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>charge of the feature</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="model" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Description of the model that was fitted to the feature</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="param" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>Model parameters</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:attribute name="name" use="required">
+									<xs:annotation>
+										<xs:documentation>name of the parameter</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="value" use="required">
+									<xs:annotation>
+										<xs:documentation>value of the prameter</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="name" use="required">
+						<xs:annotation>
+							<xs:documentation>Model name</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="convexhull" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>convex hulls of the feature in map coordinates. Points must be stored count-clockwise! Normally there is only one hull, but for high resolution data, each isotope pattern can have its own hull.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:choice>
+						<xs:element name="hullpoint" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>A single point in the convex hull</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="hposition" minOccurs="2" maxOccurs="2">
+										<xs:annotation>
+											<xs:documentation>coordinate position of a point</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:simpleContent>
+												<xs:extension base="xs:anySimpleType">
+													<xs:attribute name="dim" use="required">
+														<xs:annotation>
+															<xs:documentation>Dimension 0 for retention time and 1 for m/z</xs:documentation>
+														</xs:annotation>
+													</xs:attribute>
+												</xs:extension>
+											</xs:simpleContent>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="pt" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>short form of hullpoint - since v1.5 due to filesize considerations</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:attribute name="x" type="xs:double" use="required"/>
+								<xs:attribute name="y" type="xs:double" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:choice>
+					<xs:attribute name="nr">
+						<xs:annotation>
+							<xs:documentation>number of hull points to expect</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="subordinate" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="feature" type="featureType" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="PeptideIdentification" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Peptide identifications mapped to this feature.</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="PeptideHit" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation>single reported peptide hit</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence minOccurs="0">
+									<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:sequence>
+								<xs:attribute name="sequence" type="xs:string" use="required">
+									<xs:annotation>
+										<xs:documentation>peptide sequence</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="charge" type="xs:integer" use="required">
+									<xs:annotation>
+										<xs:documentation>charge of the peptide</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="score" type="xs:float" use="required">
+									<xs:annotation>
+										<xs:documentation>score of the hit</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="aa_before">
+									<xs:annotation>
+										<xs:documentation>amino acid before the sequence (for DB search)</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:minLength value="0"/>
+											<xs:maxLength value="1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="aa_after">
+									<xs:annotation>
+										<xs:documentation>amino acid after the sequence (for DB search)</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:minLength value="0"/>
+											<xs:maxLength value="1"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+								<xs:attribute name="protein_refs" type="xs:IDREFS">
+									<xs:annotation>
+										<xs:documentation>References to proteins hits, this peptide occurs in.</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
+						<xs:annotation>
+							<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="score_type" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+						<xs:annotation>
+							<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="significance_threshold" type="xs:float">
+						<xs:annotation>
+							<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
+						<xs:annotation>
+							<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="RT" type="xs:float">
+						<xs:annotation>
+							<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="MZ" type="xs:float">
+						<xs:annotation>
+							<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="userParam" type="userParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:ID" use="required" form="unqualified">
+			<xs:annotation>
+				<xs:documentation>Unique identifier for the feature.  OpenMS uses unsigned 64 bit integers as unique ids.  As an xs:id cannot be an integer number, the values are typically prefixed with 'f_'.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="UserParamType">
+		<xs:annotation>
+			<xs:documentation>Enumeration of types</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="int"/>
+			<xs:enumeration value="float"/>
+			<xs:enumeration value="string"/>
+			<xs:enumeration value="intList"/>
+			<xs:enumeration value="floatList"/>
+			<xs:enumeration value="stringList"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MassType">
+		<xs:annotation>
+			<xs:documentation>Enumeration of mass types</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="average"/>
+			<xs:enumeration value="monoisotopic"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DigestionEnzyme">
+		<xs:annotation>
+			<xs:documentation>Enumeration of digestion enzymes</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="pepsin_a"/>
+			<xs:enumeration value="chymotrypsin"/>
+			<xs:enumeration value="proteinase_k"/>
+			<xs:enumeration value="trypsin"/>
+			<xs:enumeration value="no_enzyme"/>
+			<xs:enumeration value="unknown_enzyme"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/openms/include/OpenMS/KERNEL/FeatureMap.h
+++ b/src/openms/include/OpenMS/KERNEL/FeatureMap.h
@@ -38,6 +38,7 @@
 #include <OpenMS/KERNEL/Feature.h>
 #include <OpenMS/KERNEL/RangeManager.h>
 #include <OpenMS/METADATA/DocumentIdentifier.h>
+#include <OpenMS/METADATA/MetaInfoInterface.h>
 
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/CONCEPT/UniqueIdInterface.h>
@@ -92,6 +93,7 @@ namespace OpenMS
   */
   class FeatureMap :
     private std::vector<Feature>,
+    public MetaInfoInterface,
     public RangeManager<2>,
     public DocumentIdentifier,
     public UniqueIdInterface,

--- a/src/openms/source/FORMAT/FeatureXMLFile.cpp
+++ b/src/openms/source/FORMAT/FeatureXMLFile.cpp
@@ -44,8 +44,8 @@ using namespace std;
 namespace OpenMS
 {
   FeatureXMLFile::FeatureXMLFile() :
-    Internal::XMLHandler("", "1.6"),
-    Internal::XMLFile("/SCHEMAS/FeatureXML_1_6.xsd", "1.6")
+    Internal::XMLHandler("", "1.7"),
+    Internal::XMLFile("/SCHEMAS/FeatureXML_1_7.xsd", "1.7")
   {
     resetMembers_();
   }
@@ -175,7 +175,10 @@ namespace OpenMS
     {
       os << " id=\"fm_" << feature_map.getUniqueId() << "\"";
     }
-    os << " xsi:noNamespaceSchemaLocation=\"http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n";
+    os << " xsi:noNamespaceSchemaLocation=\"http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n";
+
+    // user param
+    writeUserParam_("userParam", os, feature_map, 1);
 
     //write data processing
     for (Size i = 0; i < feature_map.getDataProcessing().size(); ++i)
@@ -488,6 +491,7 @@ namespace OpenMS
       {
         map_->setUniqueId(unique_id);
       }
+      last_meta_ = map_;
     }
     else if (tag == "dataProcessing")
     {

--- a/src/openms/source/KERNEL/FeatureMap.cpp
+++ b/src/openms/source/KERNEL/FeatureMap.cpp
@@ -105,6 +105,7 @@ namespace OpenMS
 
   FeatureMap::FeatureMap() :
     Base(),
+    MetaInfoInterface(),
     RangeManagerType(),
     DocumentIdentifier(),
     UniqueIdInterface(),
@@ -117,6 +118,7 @@ namespace OpenMS
 
   FeatureMap::FeatureMap(const FeatureMap& source) :
     Base(source),
+    MetaInfoInterface(source),
     RangeManagerType(source),
     DocumentIdentifier(source),
     UniqueIdInterface(source),
@@ -136,6 +138,7 @@ namespace OpenMS
     if (&rhs == this) return *this;
 
     Base::operator=(rhs);
+    MetaInfoInterface::operator=(rhs);
     RangeManagerType::operator=(rhs);
     DocumentIdentifier::operator=(rhs);
     UniqueIdInterface::operator=(rhs);
@@ -149,6 +152,7 @@ namespace OpenMS
   bool FeatureMap::operator==(const FeatureMap& rhs) const
   {
     return std::operator==(*this, rhs) &&
+           MetaInfoInterface::operator==(rhs) &&
            RangeManagerType::operator==(rhs) &&
            DocumentIdentifier::operator==(rhs) &&
            UniqueIdInterface::operator==(rhs) &&
@@ -360,6 +364,7 @@ namespace OpenMS
 
     if (clear_meta_data)
     {
+      clearMetaInfo();
       clearRanges();
       this->DocumentIdentifier::operator=(DocumentIdentifier()); // no "clear" method
       clearUniqueId();

--- a/src/tests/class_tests/openms/data/AccurateMassSearchEngine_input1.featureXML
+++ b/src/tests/class_tests/openms/data/AccurateMassSearchEngine_input1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="10">
 		<feature id="f_6565892897288149707">
 			<position dim="0">281.25</position>

--- a/src/tests/class_tests/openms/data/AccurateMassSearchEngine_output1.featureXML
+++ b/src/tests/class_tests/openms/data/AccurateMassSearchEngine_output1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<IdentificationRun id="PI_0" date="2015-02-04T16:32:07" search_engine="AccurateMassSearch" search_engine_version="">
 		<SearchParameters db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" peak_mass_tolerance="0" >
 		</SearchParameters>

--- a/src/tests/class_tests/openms/data/EDTAFile_test_out_1.featureXML
+++ b/src/tests/class_tests/openms/data/EDTAFile_test_out_1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_15667592293696986630" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_15667592293696986630" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="2611">
 		<feature id="f_9516781838073177046">
 			<position dim="0">1459.88352377641</position>

--- a/src/tests/class_tests/openms/data/FeatureFindingMetabo_output1.featureXML
+++ b/src/tests/class_tests/openms/data/FeatureFindingMetabo_output1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_16237515440356837086" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_16237515440356837086" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="91">
 		<feature id="f_3525220823171556399">
 			<position dim="0">283.75</position>

--- a/src/tests/class_tests/openms/data/FeatureXMLFile_1.featureXML
+++ b/src/tests/class_tests/openms/data/FeatureXMLFile_1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" document_id="lsid" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" document_id="lsid" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="2001-02-03T04:05:07">
 		<software name="Software1" version="0.91a" />
 		<processingAction name="Deisotoping" />

--- a/src/tests/class_tests/openms/data/RawTandemMSSignalSimulation_no_ms2.featureXML
+++ b/src/tests/class_tests/openms/data/RawTandemMSSignalSimulation_no_ms2.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_10989935207240663916" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_10989935207240663916" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<IdentificationRun id="PI_0" date="0000-00-00T00:00:00" search_engine="" search_engine_version="">
 		<SearchParameters db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" peak_mass_tolerance="0" >
 		</SearchParameters>

--- a/src/tests/class_tests/openms/source/FeatureMap_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureMap_test.cpp
@@ -197,28 +197,31 @@ START_SECTION((void updateRanges()))
 END_SECTION
 
 START_SECTION((FeatureMap(const FeatureMap &source)))
-	FeatureMap map1;
-	map1.push_back(feature1);
-	map1.push_back(feature2);
-	map1.push_back(feature3);
-	map1.updateRanges();
-	map1.setIdentifier("lsid");;
-	map1.getDataProcessing().resize(1);
-	map1.getProteinIdentifications().resize(1);
-	map1.getUnassignedPeptideIdentifications().resize(1);
+  FeatureMap map1;
+  map1.setMetaValue("meta",String("value"));
+  map1.push_back(feature1);
+  map1.push_back(feature2);
+  map1.push_back(feature3);
+  map1.updateRanges();
+  map1.setIdentifier("lsid");;
+  map1.getDataProcessing().resize(1);
+  map1.getProteinIdentifications().resize(1);
+  map1.getUnassignedPeptideIdentifications().resize(1);
 
-	FeatureMap map2(map1);
+  FeatureMap map2(map1);
 
-	TEST_EQUAL(map2.size(),3);
+  TEST_EQUAL(map2.size(),3);
+  TEST_EQUAL(map2.getMetaValue("meta").toString(),"value")
   TEST_REAL_SIMILAR(map2.getMaxInt(),1.0)
   TEST_STRING_EQUAL(map2.getIdentifier(),"lsid")
   TEST_EQUAL(map2.getDataProcessing().size(),1)
-	TEST_EQUAL(map2.getProteinIdentifications().size(),1);
-	TEST_EQUAL(map2.getUnassignedPeptideIdentifications().size(),1);
+  TEST_EQUAL(map2.getProteinIdentifications().size(),1);
+  TEST_EQUAL(map2.getUnassignedPeptideIdentifications().size(),1);
 END_SECTION
 
 START_SECTION((FeatureMap& operator = (const FeatureMap& rhs)))
 	FeatureMap map1;
+  map1.setMetaValue("meta",String("value"));
 	map1.push_back(feature1);
 	map1.push_back(feature2);
 	map1.push_back(feature3);
@@ -233,6 +236,7 @@ START_SECTION((FeatureMap& operator = (const FeatureMap& rhs)))
 	map2 = map1;
 
 	TEST_EQUAL(map2.size(),3);
+  TEST_EQUAL(map2.getMetaValue("meta").toString(),"value")
   TEST_REAL_SIMILAR(map2.getMaxInt(),1.0)
   TEST_STRING_EQUAL(map2.getIdentifier(),"lsid")
   TEST_EQUAL(map2.getDataProcessing().size(),1)

--- a/src/tests/topp/AdditiveSeries_1_feat34.featureXML
+++ b/src/tests/topp/AdditiveSeries_1_feat34.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.4" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.4" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="2">
 		<feature id="f_0">
 			<position dim="0">1253.79</position>

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -334,6 +334,10 @@ set_tests_properties("TOPP_FileConverter_18_out1" PROPERTIES DEPENDS "TOPP_FileC
 add_test("TOPP_FileConverter_19" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA_DIR_TOPP}/FileFilter_1_input.mzML -out FileConverter_19.tmp  -write_mzML_index -process_lowmemory -in_type mzML -out_type mzML)
 add_test("TOPP_FileConverter_19_out" ${DIFF} -in1 FileConverter_19.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_19_output.mzML )
 set_tests_properties("TOPP_FileConverter_19_out" PROPERTIES DEPENDS "TOPP_FileConverter_19")
+# Purpose: test the writing and reading back the same featureXML 
+add_test("TOPP_FileConverter_20" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA_DIR_TOPP}/FileConverter_20_input.featureXML -out FileConverter_20.tmp -in_type featureXML -out_type featureXML)
+add_test("TOPP_FileConverter_20_out" ${DIFF} -in1 FileConverter_20.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_20_output.featureXML )
+set_tests_properties("TOPP_FileConverter_20_out" PROPERTIES DEPENDS "TOPP_FileConverter_20")
 
 #------------------------------------------------------------------------------
 # FileFilter tests

--- a/src/tests/topp/ConsensusID_2_output.featureXML
+++ b/src/tests/topp/ConsensusID_2_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<IdentificationRun id="PI_0" date="2010-09-16T09:49:46" search_engine="OpenMS/ConsensusID_average" search_engine_version="1.7.0">
 		<SearchParameters db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" peak_mass_tolerance="0" >
 		</SearchParameters>

--- a/src/tests/topp/FeatureFinderCentroided_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderCentroided_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderCentroided" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureFinderIdentification_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderIdentification_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_4906628401344677738" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_4906628401344677738" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderIdentification" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureFinderMRM_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderMRM_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderMRM" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureFinderMetabo_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderMetabo_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderMetabo" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureFinderMetabo_2_noEPD_output.featureXML
+++ b/src/tests/topp/FeatureFinderMetabo_2_noEPD_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderMetabo" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureFinderMultiplex_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderMultiplex_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_7804704400743266335" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_7804704400743266335" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="4">
 		<feature id="f_15004869347769368353">
 			<position dim="0">1481.78192813311</position>

--- a/src/tests/topp/FeatureFinderRaw_1.featureXML
+++ b/src/tests/topp/FeatureFinderRaw_1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_16237515440356837086" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_16237515440356837086" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="5">
 		<feature id="f_3525220823171556399">
 			<position dim="0">653</position>

--- a/src/tests/topp/FeatureFinderSuperHirn_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderSuperHirn_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderSuperHirn" version="version_string" />
 		<processingAction name="Peak picking" />

--- a/src/tests/topp/FeatureFinderSuperHirn_2_output.featureXML
+++ b/src/tests/topp/FeatureFinderSuperHirn_2_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderSuperHirn" version="version_string" />
 		<processingAction name="Peak picking" />

--- a/src/tests/topp/FeatureFinder_1_output.featureXML
+++ b/src/tests/topp/FeatureFinder_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_3314940832964417861" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_3314940832964417861" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="2012-09-16T18:04:00">
 		<software name="FeatureFinderMetabo" version="1.10.0" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_3_input1.featureXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_3_input1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_8706403922746272921" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_8706403922746272921" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="2013-06-20T18:17:07">
 		<software name="MassTraceExtractor" version="1.11.0" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_3_input2.featureXML
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_3_input2.featureXML
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_10253060449047408476" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_10253060449047408476" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<userParam type="string" name="user_param_1" value="User Param 1"/>
+	<userParam type="string" name="user_param_2" value="User Param 2"/>
 	<dataProcessing completion_time="2013-06-20T16:35:04">
 		<software name="MassTraceExtractor" version="1.11.0" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FileConverter_10_output.featureXML
+++ b/src/tests/topp/FileConverter_10_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileConverter" version="version_string" />
 		<processingAction name="File format conversion" />

--- a/src/tests/topp/FileConverter_11_output.featureXML
+++ b/src/tests/topp/FileConverter_11_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileConverter" version="version_string" />
 		<processingAction name="File format conversion" />

--- a/src/tests/topp/FileConverter_12_output.featureXML
+++ b/src/tests/topp/FileConverter_12_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileConverter" version="version_string" />
 		<processingAction name="File format conversion" />

--- a/src/tests/topp/FileConverter_13_output.featureXML
+++ b/src/tests/topp/FileConverter_13_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileConverter" version="version_string" />
 		<processingAction name="File format conversion" />

--- a/src/tests/topp/FileConverter_20_input.featureXML
+++ b/src/tests/topp/FileConverter_20_input.featureXML
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.7" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<userParam type="float" name="test_float" value="1234.5"/>
+	<userParam type="string" name="test_string" value="mystring"/>	
+	<featureList count="10">
+		<feature id="f_8152">
+			<position dim="0">537.4101</position>
+			<position dim="1">648.388</position>
+			<intensity>2393</intensity>
+			<quality dim="0">50.8404</quality>
+			<quality dim="1">0.727776</quality>
+			<overallquality>0.746627</overallquality>
+			<charge>2</charge>
+		</feature>
+		<feature id="f_8153">
+			<position dim="0">537.4567</position>
+			<position dim="1">432.599</position>
+			<intensity>5206</intensity>
+			<quality dim="0">50.8084</quality>
+			<quality dim="1">0.77485</quality>
+			<overallquality>0.85423</overallquality>
+			<charge>3</charge>
+		</feature>
+		<feature id="f_8154">
+			<position dim="0">537.6243</position>
+			<position dim="1">431.263</position>
+			<intensity>4103</intensity>
+			<quality dim="0">50.8795</quality>
+			<quality dim="1">0.742337</quality>
+			<overallquality>0.825227</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="537.1567" y="432.599" />
+				<pt x="537.3243" y="431.263" />
+				<pt x="537.6243" y="430.963" />
+				<pt x="537.9243" y="431.263" />
+				<pt x="537.7567" y="432.599" />
+				<pt x="537.4567" y="432.899" />
+			</convexhull>
+		</feature>
+		<feature id="f_8155">
+			<position dim="0">537.7869</position>
+			<position dim="1">646.367</position>
+			<intensity>1376</intensity>
+			<quality dim="0">50.8336</quality>
+			<quality dim="1">0.692032</quality>
+			<overallquality>0.757107</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="537.1101" y="648.388" />
+				<pt x="537.4869" y="646.367" />
+				<pt x="537.7869" y="646.067" />
+				<pt x="538.0869" y="646.367" />
+				<pt x="537.7101" y="648.388" />
+				<pt x="537.4101" y="648.688" />
+			</convexhull>
+		</feature>
+		<feature id="f_8156">
+			<position dim="0">538.7912</position>
+			<position dim="1">612.852</position>
+			<intensity>1881</intensity>
+			<quality dim="0">50.7999</quality>
+			<quality dim="1">0.707839</quality>
+			<overallquality>0.749841</overallquality>
+			<charge>2</charge>
+		</feature>
+		<feature id="f_8157">
+			<position dim="0">538.8625</position>
+			<position dim="1">533.968</position>
+			<intensity>6403</intensity>
+			<quality dim="0">50.9139</quality>
+			<quality dim="1">0.661723</quality>
+			<overallquality>0.797495</overallquality>
+			<charge>3</charge>
+		</feature>
+		<feature id="f_8158">
+			<position dim="0">539.0525</position>
+			<position dim="1">532.619</position>
+			<intensity>6712</intensity>
+			<quality dim="0">50.8424</quality>
+			<quality dim="1">0.752286</quality>
+			<overallquality>0.883375</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="538.5625" y="533.968" />
+				<pt x="538.7525" y="532.619" />
+				<pt x="539.0525" y="532.319" />
+				<pt x="539.3525" y="532.619" />
+				<pt x="539.1625" y="533.968" />
+				<pt x="538.8625" y="534.268" />
+			</convexhull>
+		</feature>
+		<feature id="f_8159">
+			<position dim="0">539.1095</position>
+			<position dim="1">408.916</position>
+			<intensity>2803</intensity>
+			<quality dim="0">50.7882</quality>
+			<quality dim="1">0.778111</quality>
+			<overallquality>0.803365</overallquality>
+			<charge>3</charge>
+		</feature>
+		<feature id="f_8160">
+			<position dim="0">539.1152</position>
+			<position dim="1">407.581</position>
+			<intensity>3295</intensity>
+			<quality dim="0">50.8859</quality>
+			<quality dim="1">0.677578</quality>
+			<overallquality>0.802009</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="538.8095" y="408.916" />
+				<pt x="538.8152" y="407.581" />
+				<pt x="539.1152" y="407.281" />
+				<pt x="539.4152" y="407.581" />
+				<pt x="539.4095" y="408.916" />
+				<pt x="539.1095" y="409.216" />
+			</convexhull>
+		</feature>
+		<feature id="f_8161">
+			<position dim="0">539.2316</position>
+			<position dim="1">610.838</position>
+			<intensity>2567</intensity>
+			<quality dim="0">50.8642</quality>
+			<quality dim="1">0.700694</quality>
+			<overallquality>0.766224</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="538.4912" y="612.852" />
+				<pt x="538.9316" y="610.838" />
+				<pt x="539.2316" y="610.538" />
+				<pt x="539.5316" y="610.838" />
+				<pt x="539.0912" y="612.852" />
+				<pt x="538.7912" y="613.152" />
+			</convexhull>
+		</feature>
+	</featureList>
+</featureMap>

--- a/src/tests/topp/FileConverter_20_output.featureXML
+++ b/src/tests/topp/FileConverter_20_output.featureXML
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.7" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<userParam type="float" name="test_float" value="1234.5"/>
+	<userParam type="string" name="test_string" value="mystring"/>
+	<dataProcessing completion_time="1999-12-31T23:59:59">
+		<software name="FileConverter" version="version_string" />
+		<processingAction name="File format conversion" />
+		<userParam type="string" name="parameter: mode" value="test_mode"/>
+	</dataProcessing>
+	<featureList count="10">
+		<feature id="f_8152">
+			<position dim="0">537.4101</position>
+			<position dim="1">648.388</position>
+			<intensity>2393</intensity>
+			<quality dim="0">50.8404</quality>
+			<quality dim="1">0.727776</quality>
+			<overallquality>0.746627</overallquality>
+			<charge>2</charge>
+		</feature>
+		<feature id="f_8153">
+			<position dim="0">537.4567</position>
+			<position dim="1">432.599</position>
+			<intensity>5206</intensity>
+			<quality dim="0">50.8084</quality>
+			<quality dim="1">0.77485</quality>
+			<overallquality>0.85423</overallquality>
+			<charge>3</charge>
+		</feature>
+		<feature id="f_8154">
+			<position dim="0">537.6243</position>
+			<position dim="1">431.263</position>
+			<intensity>4103</intensity>
+			<quality dim="0">50.8795</quality>
+			<quality dim="1">0.742337</quality>
+			<overallquality>0.825227</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="537.1567" y="432.599" />
+				<pt x="537.3243" y="431.263" />
+				<pt x="537.6243" y="430.963" />
+				<pt x="537.9243" y="431.263" />
+				<pt x="537.7567" y="432.599" />
+				<pt x="537.4567" y="432.899" />
+			</convexhull>
+		</feature>
+		<feature id="f_8155">
+			<position dim="0">537.7869</position>
+			<position dim="1">646.367</position>
+			<intensity>1376</intensity>
+			<quality dim="0">50.8336</quality>
+			<quality dim="1">0.692032</quality>
+			<overallquality>0.757107</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="537.1101" y="648.388" />
+				<pt x="537.4869" y="646.367" />
+				<pt x="537.7869" y="646.067" />
+				<pt x="538.0869" y="646.367" />
+				<pt x="537.7101" y="648.388" />
+				<pt x="537.4101" y="648.688" />
+			</convexhull>
+		</feature>
+		<feature id="f_8156">
+			<position dim="0">538.7912</position>
+			<position dim="1">612.852</position>
+			<intensity>1881</intensity>
+			<quality dim="0">50.7999</quality>
+			<quality dim="1">0.707839</quality>
+			<overallquality>0.749841</overallquality>
+			<charge>2</charge>
+		</feature>
+		<feature id="f_8157">
+			<position dim="0">538.8625</position>
+			<position dim="1">533.968</position>
+			<intensity>6403</intensity>
+			<quality dim="0">50.9139</quality>
+			<quality dim="1">0.661723</quality>
+			<overallquality>0.797495</overallquality>
+			<charge>3</charge>
+		</feature>
+		<feature id="f_8158">
+			<position dim="0">539.0525</position>
+			<position dim="1">532.619</position>
+			<intensity>6712</intensity>
+			<quality dim="0">50.8424</quality>
+			<quality dim="1">0.752286</quality>
+			<overallquality>0.883375</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="538.5625" y="533.968" />
+				<pt x="538.7525" y="532.619" />
+				<pt x="539.0525" y="532.319" />
+				<pt x="539.3525" y="532.619" />
+				<pt x="539.1625" y="533.968" />
+				<pt x="538.8625" y="534.268" />
+			</convexhull>
+		</feature>
+		<feature id="f_8159">
+			<position dim="0">539.1095</position>
+			<position dim="1">408.916</position>
+			<intensity>2803</intensity>
+			<quality dim="0">50.7882</quality>
+			<quality dim="1">0.778111</quality>
+			<overallquality>0.803365</overallquality>
+			<charge>3</charge>
+		</feature>
+		<feature id="f_8160">
+			<position dim="0">539.1152</position>
+			<position dim="1">407.581</position>
+			<intensity>3295</intensity>
+			<quality dim="0">50.8859</quality>
+			<quality dim="1">0.677578</quality>
+			<overallquality>0.802009</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="538.8095" y="408.916" />
+				<pt x="538.8152" y="407.581" />
+				<pt x="539.1152" y="407.281" />
+				<pt x="539.4152" y="407.581" />
+				<pt x="539.4095" y="408.916" />
+				<pt x="539.1095" y="409.216" />
+			</convexhull>
+		</feature>
+		<feature id="f_8161">
+			<position dim="0">539.2316</position>
+			<position dim="1">610.838</position>
+			<intensity>2567</intensity>
+			<quality dim="0">50.8642</quality>
+			<quality dim="1">0.700694</quality>
+			<overallquality>0.766224</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="538.4912" y="612.852" />
+				<pt x="538.9316" y="610.838" />
+				<pt x="539.2316" y="610.538" />
+				<pt x="539.5316" y="610.838" />
+				<pt x="539.0912" y="612.852" />
+				<pt x="538.7912" y="613.152" />
+			</convexhull>
+		</feature>
+	</featureList>
+</featureMap>

--- a/src/tests/topp/FileConverter_7_output.featureXML
+++ b/src/tests/topp/FileConverter_7_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_123456789012345" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_123456789012345" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileConverter" version="version_string" />
 		<processingAction name="File format conversion" />

--- a/src/tests/topp/FileConverter_9_output.featureXML
+++ b/src/tests/topp/FileConverter_9_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_7765414056999294261" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_7765414056999294261" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileConverter" version="version_string" />
 		<processingAction name="File format conversion" />

--- a/src/tests/topp/FileFilter_13_output.featureXML
+++ b/src/tests/topp/FileFilter_13_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_16627578304933075941" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileFilter" version="version_string" />
 		<processingAction name="Data filtering" />

--- a/src/tests/topp/FileFilter_15_output.featureXML
+++ b/src/tests/topp/FileFilter_15_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileFilter" version="version_string" />
 		<processingAction name="Data filtering" />

--- a/src/tests/topp/FileFilter_16_output.featureXML
+++ b/src/tests/topp/FileFilter_16_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileFilter" version="version_string" />
 		<processingAction name="Data filtering" />

--- a/src/tests/topp/FileFilter_17_output.featureXML
+++ b/src/tests/topp/FileFilter_17_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileFilter" version="version_string" />
 		<processingAction name="Data filtering" />

--- a/src/tests/topp/FileFilter_20_output.featureXML
+++ b/src/tests/topp/FileFilter_20_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileFilter" version="version_string" />
 		<processingAction name="Data filtering" />

--- a/src/tests/topp/FileFilter_21_output.featureXML
+++ b/src/tests/topp/FileFilter_21_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_7478034797829266976" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileFilter" version="version_string" />
 		<processingAction name="Data filtering" />

--- a/src/tests/topp/FileFilter_5_out.featureXML
+++ b/src/tests/topp/FileFilter_5_out.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileFilter" version="version_string" />
 		<processingAction name="Data filtering" />

--- a/src/tests/topp/FileFilter_6_out.featureXML
+++ b/src/tests/topp/FileFilter_6_out.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FileFilter" version="version_string" />
 		<processingAction name="Data filtering" />

--- a/src/tests/topp/FileMerger_7_output.featureXML
+++ b/src/tests/topp/FileMerger_7_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="2001-02-03T04:05:07">
 		<software name="Software1" version="0.91a" />
 		<processingAction name="Deisotoping" />

--- a/src/tests/topp/HighResPrecursorMassCorrector_1035_1178_4.featureXML
+++ b/src/tests/topp/HighResPrecursorMassCorrector_1035_1178_4.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="1">
 		<feature id="f_11817803992392522689">
 			<position dim="0">1031.39064576375</position>

--- a/src/tests/topp/HighResPrecursorMassCorrector_2538_1091_2.featureXML
+++ b/src/tests/topp/HighResPrecursorMassCorrector_2538_1091_2.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="1">
 		<feature id="f_15871072107436603275">
 			<position dim="0">2538.83463437242</position>

--- a/src/tests/topp/HighResPrecursorMassCorrector_2810_1091_3.featureXML
+++ b/src/tests/topp/HighResPrecursorMassCorrector_2810_1091_3.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="1">
 		<feature id="f_1367168138228622435">
 			<position dim="0">2812.2764415743</position>

--- a/src/tests/topp/HighResPrecursorMassCorrector_2860_1103_3.featureXML
+++ b/src/tests/topp/HighResPrecursorMassCorrector_2860_1103_3.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="1">
 		<feature id="f_7689343597569623311">
 			<position dim="0">2857.74452384369</position>

--- a/src/tests/topp/HighResPrecursorMassCorrector_3070_1191_3.featureXML
+++ b/src/tests/topp/HighResPrecursorMassCorrector_3070_1191_3.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="1">
 		<feature id="f_7189417617113947780">
 			<position dim="0">3065.78396581567</position>

--- a/src/tests/topp/IDConflictResolver_1_output.featureXML
+++ b/src/tests/topp/IDConflictResolver_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_15407585427843071297" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_15407585427843071297" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="2011-08-08T19:31:37">
 		<software name="FeatureFinder" version="1.9.0" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/IDMapper_1_output.featureXML
+++ b/src/tests/topp/IDMapper_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_10835979930765915373" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_10835979930765915373" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="IDMapper" version="version_string" />
 		<processingAction name="Identification mapping" />

--- a/src/tests/topp/IDMapper_3_output.featureXML
+++ b/src/tests/topp/IDMapper_3_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="IDMapper" version="version_string" />
 		<processingAction name="Identification mapping" />

--- a/src/tests/topp/IDSplitter_1_output.featureXML
+++ b/src/tests/topp/IDSplitter_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_10835979930765915373" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_10835979930765915373" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="IDMapper" version="version_string" />
 		<processingAction name="Identification mapping" />

--- a/src/tests/topp/MRMTransitionGroupPicker_1_output.featureXML
+++ b/src/tests/topp/MRMTransitionGroupPicker_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_11399299100673837381" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_11399299100673837381" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="72">
 		<feature id="f_5233264595117471314">
 			<position dim="0">4003.6575404948</position>

--- a/src/tests/topp/MapAlignerIdentification_1_output1.featureXML
+++ b/src/tests/topp/MapAlignerIdentification_1_output1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_3412380066310033627" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_3412380066310033627" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="MapAlignerIdentification" version="version_string" />
 		<processingAction name="Retention time alignment" />

--- a/src/tests/topp/MapAlignerIdentification_1_output2.featureXML
+++ b/src/tests/topp/MapAlignerIdentification_1_output2.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_3412380066310033627" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_3412380066310033627" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="MapAlignerIdentification" version="version_string" />
 		<processingAction name="Retention time alignment" />

--- a/src/tests/topp/MapAlignerIdentification_2_output1.featureXML
+++ b/src/tests/topp/MapAlignerIdentification_2_output1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_3412380066310033627" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_3412380066310033627" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="MapAlignerIdentification" version="version_string" />
 		<processingAction name="Retention time alignment" />

--- a/src/tests/topp/MapAlignerIdentification_3_output1.featureXML
+++ b/src/tests/topp/MapAlignerIdentification_3_output1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_3412380066310033627" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_3412380066310033627" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="MapAlignerIdentification" version="version_string" />
 		<processingAction name="Retention time alignment" />

--- a/src/tests/topp/MapAlignerPoseClustering_1_output1.featureXML
+++ b/src/tests/topp/MapAlignerPoseClustering_1_output1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5235077110101051705" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5235077110101051705" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="MapAlignerPoseClustering" version="version_string" />
 		<processingAction name="Retention time alignment" />

--- a/src/tests/topp/MapAlignerPoseClustering_1_output2.featureXML
+++ b/src/tests/topp/MapAlignerPoseClustering_1_output2.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_6211775903316680671" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_6211775903316680671" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="MapAlignerPoseClustering" version="version_string" />
 		<processingAction name="Retention time alignment" />

--- a/src/tests/topp/MapAlignerPoseClustering_1_output3.featureXML
+++ b/src/tests/topp/MapAlignerPoseClustering_1_output3.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_15371720830477971505" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_15371720830477971505" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="MapAlignerPoseClustering" version="version_string" />
 		<processingAction name="Retention time alignment" />

--- a/src/tests/topp/MapRTTransformer_1_output1.featureXML
+++ b/src/tests/topp/MapRTTransformer_1_output1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="2001-02-03T04:05:07">
 		<software name="Software1" version="0.91a" />
 		<processingAction name="Deisotoping" />

--- a/src/tests/topp/MapRTTransformer_1_output2.featureXML
+++ b/src/tests/topp/MapRTTransformer_1_output2.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="2001-02-03T04:05:07">
 		<software name="Software1" version="0.91a" />
 		<processingAction name="Deisotoping" />

--- a/src/tests/topp/MassTraceExtractor_1_output.featureXML
+++ b/src/tests/topp/MassTraceExtractor_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5233264595117471314" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="MassTraceExtractor" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/OpenSwathAnalyzer_1_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathAnalyzer" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/OpenSwathAnalyzer_2_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_2_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathAnalyzer" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/OpenSwathAnalyzer_5_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_5_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathAnalyzer" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/OpenSwathAnalyzer_6_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_6_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathAnalyzer" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/OpenSwathAnalyzer_7_output.featureXML
+++ b/src/tests/topp/OpenSwathAnalyzer_7_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_12999979801269632061" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathAnalyzer" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/OpenSwathConfidenceScoring_1_output.featureXML
+++ b/src/tests/topp/OpenSwathConfidenceScoring_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5545122449014130491" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5545122449014130491" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathConfidenceScoring" version="version_string" />
 		<processingAction name="Data processing action" />

--- a/src/tests/topp/OpenSwathFeatureXMLToTSV_input.featureXML
+++ b/src/tests/topp/OpenSwathFeatureXMLToTSV_input.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_5545122449014130491" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_5545122449014130491" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<IdentificationRun id="PI_0" date="0000-00-00T00:00:00" search_engine="" search_engine_version="">
 		<SearchParameters db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" peak_mass_tolerance="0" >
 		</SearchParameters>

--- a/src/tests/topp/OpenSwathWorkflow_1_output.featureXML
+++ b/src/tests/topp/OpenSwathWorkflow_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_15050004366391181853" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_15050004366391181853" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathWorkflow" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/OpenSwathWorkflow_2_output.featureXML
+++ b/src/tests/topp/OpenSwathWorkflow_2_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_12524258085768770586" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_12524258085768770586" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathWorkflow" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/OpenSwathWorkflow_3_output.featureXML
+++ b/src/tests/topp/OpenSwathWorkflow_3_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_11115414975438642789" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_11115414975438642789" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="OpenSwathWorkflow" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/PrecursorIonSelector_2_output.featureXML
+++ b/src/tests/topp/PrecursorIonSelector_2_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" id="fm_7675317259246054802" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" id="fm_7675317259246054802" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<IdentificationRun id="PI_0" date="2008-08-18T14:30:01" search_engine="Mascot" search_engine_version="2.2.03">
 		<SearchParameters db="SwissProt" db_version="SwissProt_54.5.fasta" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" peak_mass_tolerance="0" >
 		</SearchParameters>

--- a/src/tests/topp/SeedListGenerator_1_output.featureXML
+++ b/src/tests/topp/SeedListGenerator_1_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="SeedListGenerator" version="version_string" />
 		<processingAction name="Data processing action" />

--- a/src/tests/topp/SeedListGenerator_2_output.featureXML
+++ b/src/tests/topp/SeedListGenerator_2_output.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="SeedListGenerator" version="version_string" />
 		<processingAction name="Data processing action" />

--- a/src/tests/topp/SeedListGenerator_3_output1.featureXML
+++ b/src/tests/topp/SeedListGenerator_3_output1.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="SeedListGenerator" version="version_string" />
 		<processingAction name="Data processing action" />

--- a/src/tests/topp/SeedListGenerator_3_output2.featureXML
+++ b/src/tests/topp/SeedListGenerator_3_output2.featureXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.6" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_6.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.7" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="SeedListGenerator" version="version_string" />
 		<processingAction name="Data processing action" />


### PR DESCRIPTION
In order to store essential meta data (ms run location etc.) in featureMaps the metainfointerface is added.
FeatureXML version is bumped up to 1.7 but should be fully backward compatible.
Tests have been added and adapted.