### PR TITLE
[FIX] fix inclusion of subdirectories for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ matrix:
   include:
     - env: ENABLE_STYLE_TESTING=ON WITH_GUI=ON
       compiler: gcc
-## split class vs. TOPP tests for GCC (otherwise it will run into time limit of 50min)      
-    - env: ENABLE_STYLE_TESTING=OFF ENABLE_TOPP_TESTING=ON  ENABLE_CLASS_TESTING=OFF WITH_GUI=ON
+## split class vs. TOPP tests for GCC (otherwise it will run into time limit of 50min)
+    - env: ENABLE_STYLE_TESTING=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=OFF WITH_GUI=ON
       compiler: gcc
     - env: ENABLE_STYLE_TESTING=OFF ENABLE_TOPP_TESTING=OFF ENABLE_CLASS_TESTING=ON  WITH_GUI=ON
       compiler: gcc
-## clang can run both class+TOPP tests since its faster      
+## clang can run both class+TOPP tests since it's faster
     - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF
       compiler: clang
     - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ script:
   ./tools/travis/lnx-cibuild.sh
 matrix:
   include:
-    - env: ENABLE_STYLE_TESTING=On WITH_GUI=On
+    - env: ENABLE_STYLE_TESTING=ON WITH_GUI=ON
       compiler: gcc
-## split class vs TOPP tests for GCC (otherwise it will run into time limit of 50min)      
-    - env: ENABLE_STYLE_TESTING=Off ENABLE_TOPP_TESTING=On  ENABLE_CLASS_TESTING=Off WITH_GUI=On
+## split class vs. TOPP tests for GCC (otherwise it will run into time limit of 50min)      
+    - env: ENABLE_STYLE_TESTING=OFF ENABLE_TOPP_TESTING=ON  ENABLE_CLASS_TESTING=OFF WITH_GUI=ON
       compiler: gcc
-    - env: ENABLE_STYLE_TESTING=Off ENABLE_TOPP_TESTING=Off ENABLE_CLASS_TESTING=On  WITH_GUI=On
+    - env: ENABLE_STYLE_TESTING=OFF ENABLE_TOPP_TESTING=OFF ENABLE_CLASS_TESTING=ON  WITH_GUI=ON
       compiler: gcc
 ## clang can run both class+TOPP tests since its faster      
-    - env: ENABLE_STYLE_TESTING=Off WITH_GUI=Off
+    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF
       compiler: clang
-    - env: ENABLE_STYLE_TESTING=Off WITH_GUI=On
+    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=ON
       compiler: clang

--- a/tools/travis/lnx-cibuild.cmake
+++ b/tools/travis/lnx-cibuild.cmake
@@ -2,7 +2,7 @@
 ## this script is invoked by lnx-cibuild.sh during the main "script:" section in .travis.yml
 ##
 
-# define build name&co for easier identification on cdash
+# define build name&co for easier identification on CDash
 set(CTEST_BUILD_NAME "$ENV{BUILD_NAME}")
 
 set(CTEST_SITE "travis-ci-build-server")
@@ -53,12 +53,12 @@ endif()
 # we want makefiles
 set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
-# run the classical ctest suite without update
+# run the classical CTest suite without update
 # travis-ci handles this for us
 ctest_start     (Continuous)
 ctest_configure (BUILD "${CTEST_BINARY_DIRECTORY}" RETURN_VALUE _configure_ret)
 # we only build when we do non-style testing
-if("$ENV{ENABLE_STYLE_TESTING}" STREQUAL "Off")
+if("$ENV{ENABLE_STYLE_TESTING}" STREQUAL "OFF")
 	ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors)
 else()
 	set(_build_errors 0)
@@ -66,7 +66,7 @@ endif()
 
 ## build lib&executables, run tests
 ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" PARALLEL_LEVEL 3)
-## send to cdash
+## send to CDash
 ctest_submit()
 
 # indicate errors

--- a/tools/travis/lnx-cibuild.sh
+++ b/tools/travis/lnx-cibuild.sh
@@ -45,7 +45,7 @@ if [ "${WITH_GUI}" = "OFF" ]; then
   _build_name=${_build_name}"-noGUI"
 fi
 
-# we will use this in the cmake script
+# we will use this in the CMake script
 export BUILD_NAME=${_build_name}
 
 # we need an X-server for building the documentation and some tests
@@ -53,7 +53,7 @@ export BUILD_NAME=${_build_name}
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
-# add thirdparty binaries (e.g. search engines) to PATH
+# add third-party binaries (e.g. search engines) to PATH
 export PATH=${SOURCE_DIRECTORY}/_thirdparty/MyriMatch:$PATH
 export PATH=${SOURCE_DIRECTORY}/_thirdparty/OMSSA:$PATH
 export PATH=${SOURCE_DIRECTORY}/_thirdparty/XTandem:$PATH
@@ -71,7 +71,7 @@ ctest -V -S tools/travis/lnx-cibuild.cmake
 echo "Please check the build results at: http://cdash.openms.de/index.php?project=OpenMS&date="$(date +"%y-%m-%d")"#Continuous"
 echo "This build has the name: ${BUILD_NAME}"
 
-# we indicate build failures if ctest experienced any errors
+# we indicate build failures if CTest experienced any errors
 if [ -f ${SOURCE_DIRECTORY}/failed ]; then
   echo "Configure/Build failed"
   exit -1
@@ -84,5 +84,5 @@ if [ "$FAILED_TEST" -gt "0" ]; then
   exit -1
 fi
 
-# it seems like everything worked
+# seems like everything worked
 exit 0

--- a/tools/travis/lnx-cibuild.sh
+++ b/tools/travis/lnx-cibuild.sh
@@ -27,21 +27,21 @@ fi
 _build_name=${_build_name}"-"${CXX}
 
 # add style to build name if requested
-if [ "${ENABLE_STYLE_TESTING}" = "On" ]; then
+if [ "${ENABLE_STYLE_TESTING}" = "ON" ]; then
   _build_name=${_build_name}"-codingStyle"
 fi
 
 # add class-testing to build name if requested
-if [ "${ENABLE_CLASS_TESTING}" = "On" ]; then
+if [ "${ENABLE_CLASS_TESTING}" = "ON" ]; then
   _build_name=${_build_name}"-testClass"
 fi
 # add TOPP-testing to build name if requested
-if [ "${ENABLE_TOPP_TESTING}" = "On" ]; then
+if [ "${ENABLE_TOPP_TESTING}" = "ON" ]; then
   _build_name=${_build_name}"-testTOPP"
 fi
 
 # add GUI to build name if requested
-if [ "${WITH_GUI}" = "Off" ]; then
+if [ "${WITH_GUI}" = "OFF" ]; then
   _build_name=${_build_name}"-noGUI"
 fi
 
@@ -61,7 +61,7 @@ export PATH=${SOURCE_DIRECTORY}/_thirdparty/MSGFPlus:$PATH
 export PATH=${SOURCE_DIRECTORY}/_thirdparty/Fido:$PATH
 
 # if we perform style tests, add cppcheck to path
-if [ $ENABLE_STYLE_TESTING == "On" ]; then
+if [ $ENABLE_STYLE_TESTING == "ON" ]; then
   export PATH=${SOURCE_DIRECTORY}/cppcheck:$PATH
 fi
 


### PR DESCRIPTION
adresses #1543

(reason for specific failure of clang is the different test pattern compared to gcc, i.e. different combination of [invalid] flags are used)

"ON" != "On" especially within CMAKE-statements like 'if(ENABLE_CLASS_TESTING) ...'