### PR TITLE
[DOC,TEST] for StablePairFinder / FeatureDistance

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureDistance.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureDistance.h
@@ -57,17 +57,31 @@ namespace OpenMS
 
      @f$ RT_i @f$, @f$ MZ_i @f$, and @f$ int_i @f$ are the RT, m/z, and intensity values of the respective feature.
 
-     @f$ {\Delta RT_{max}} @f$ and @f$ {\Delta MZ_{max}} @f$ are the maximum allowed differences in RT and m/z, respectively. They are specified by the parameters @p distance_RT:max_difference and @p distance_MZ:max_difference, and are used for normalization. If an absolute difference exceeds the specified maximum, the behavior depends on the value used for @p check_constraints in the constructor: If "false", the distance will be computed normally, but may become greater than 1; if "true", the fixed value @ref infinity is returned.
+     Constraints are: @f$ {\Delta RT_{max}}, {\Delta MZ_{max}}, int_{max}  @f$ and (optionally) @f$ charge @f$.
+     If an absolute difference exceeds the specified maximum, the behavior depends on the value used for @p check_constraints in the constructor: 
+     If "false" (i.e., no constraints), the distance in that dimension may become greater than 1; if "true", @ref infinity is returned as overall distance.
 
-     @f$ int_{max} @f$ is the maximum intensity that can occur for features compared by this distance function. It is not a parameter specified by the user, but depends on the data at hand and is thus set in the constructor (via parameter @p max_intensity).
+     @f$ {\Delta RT_{max}} @f$ and @f$ {\Delta MZ_{max}} @f$ are the maximum allowed differences in RT and m/z, respectively. 
+     They are specified by the parameters @p distance_RT:max_difference and @p distance_MZ:max_difference, and are used for normalization,
+     i.e., the observed RT or m/z differences of the feature pair are scaled relative to this value.
+     
+     @f$ int_{max} @f$ is the intensity which yields a normalized intensity of 1. This parameter is not settable via user params,
+     but is set in the constructor (via parameter @p max_intensity), since it depends on the data at hand.
 
-     @f$ w_X @f$ is the weight of distance component X, specified by the parameter @p distance_X:weight. The weights can be used to increase or decrease the contribution of RT, m/z, or intensity in the distance function. (Note that the default weight for the intensity component is zero, i.e. intensity is not considered by default.)
+     @f$ p_X @f$ is the exponent for the distance in dimension X, specified by the parameter @p distance_X:exponent. 
+     Normalized differences (between (0, 1) unless unconstrained) are taken to this power. This makes it possible to compare values using linear, quadratic, etc. distance.
 
-     @f$ p_X @f$ is the exponent for distance component X, specified by the parameter @p distance_X:exponent. Normalized differences are taken to this power. This makes it possible to compare values using linear, quadratic, etc. distance.
+     By default, two features are paired only if they have the same charge state (or at least one unknown charge '0') - otherwise, @ref infinity is returned. 
+     This behavior can be changed by the @p ignore_charge parameter.
 
-     By default, two features are only compared if they have the same charge state (or charge state 0 for "undefined") - otherwise, @ref infinity is returned. This behavior can be changed by the @p ignore_charge parameter.
+     @f$ w_X @f$ is the weight of final distance in dimension X, specified by the parameter @p distance_X:weight. The weights can be used to increase or decrease 
+     the contribution of RT, m/z, or intensity in the distance function. 
+     (The default weight for the intensity dimension is zero, i.e. intensity is not considered by default. However, @f$ int_{max} @f$ is still a constraint and
+      should be set sensibly in the c'tor.)
 
-     @note Peptide identifications annotated to features are not taken into account here, because they are stored in a format that is not suitable for rapid comparison.
+
+     @note Peptide identifications annotated to features are not taken into account here, 
+           because they are stored in a format that is not suitable for rapid comparison.
 
    @htmlinclude OpenMS_FeatureDistance.parameters
 

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureDistance.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/FeatureDistance.h
@@ -57,7 +57,7 @@ namespace OpenMS
 
      @f$ RT_i @f$, @f$ MZ_i @f$, and @f$ int_i @f$ are the RT, m/z, and intensity values of the respective feature.
 
-     Constraints are: @f$ {\Delta RT_{max}}, {\Delta MZ_{max}}, int_{max}  @f$ and (optionally) @f$ charge @f$.
+     Constraints are: @f$ {\Delta RT_{max}}, {\Delta MZ_{max}} @f$ and @f$ int_{max} @f$.
      If an absolute difference exceeds the specified maximum, the behavior depends on the value used for @p check_constraints in the constructor: 
      If "false" (i.e., no constraints), the distance in that dimension may become greater than 1; if "true", @ref infinity is returned as overall distance.
 
@@ -71,13 +71,13 @@ namespace OpenMS
      @f$ p_X @f$ is the exponent for the distance in dimension X, specified by the parameter @p distance_X:exponent. 
      Normalized differences (between (0, 1) unless unconstrained) are taken to this power. This makes it possible to compare values using linear, quadratic, etc. distance.
 
-     By default, two features are paired only if they have the same charge state (or at least one unknown charge '0') - otherwise, @ref infinity is returned. 
-     This behavior can be changed by the @p ignore_charge parameter.
-
      @f$ w_X @f$ is the weight of final distance in dimension X, specified by the parameter @p distance_X:weight. The weights can be used to increase or decrease 
      the contribution of RT, m/z, or intensity in the distance function. 
      (The default weight for the intensity dimension is zero, i.e. intensity is not considered by default. However, @f$ int_{max} @f$ is still a constraint and
       should be set sensibly in the c'tor.)
+
+     By default, two features are paired only if they have the same charge state (or at least one unknown charge '0') - otherwise, @ref infinity is returned. 
+     This behavior can be changed by the @p ignore_charge parameter.
 
 
      @note Peptide identifications annotated to features are not taken into account here, 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureDistance.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureDistance.cpp
@@ -50,31 +50,31 @@ namespace OpenMS
     params_rt_(), params_mz_(), params_intensity_(),
     max_intensity_(max_intensity), force_constraints_(force_constraints)
   {
-    defaults_.setValue("distance_RT:max_difference", 100.0, "Maximum allowed difference in RT in seconds");
+    defaults_.setValue("distance_RT:max_difference", 100.0, "Never pair features with a larger RT distance (in seconds).");
     defaults_.setMinFloat("distance_RT:max_difference", 0.0);
-    defaults_.setValue("distance_RT:exponent", 1.0, "Normalized RT differences are raised to this power (using 1 or 2 will be fast, everything else is REALLY slow)", ListUtils::create<String>("advanced"));
+    defaults_.setValue("distance_RT:exponent", 1.0, "Normalized RT differences ([0-1], relative to 'max_difference') are raised to this power (using 1 or 2 will be fast, everything else is REALLY slow)", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("distance_RT:exponent", 0.0);
-    defaults_.setValue("distance_RT:weight", 1.0, "RT distances are weighted by this factor", ListUtils::create<String>("advanced"));
+    defaults_.setValue("distance_RT:weight", 1.0, "Final RT distances are weighted by this factor", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("distance_RT:weight", 0.0);
     defaults_.setSectionDescription("distance_RT", "Distance component based on RT differences");
 
-    defaults_.setValue("distance_MZ:max_difference", 0.3, "Maximum allowed difference in m/z (unit defined by 'unit')");
+    defaults_.setValue("distance_MZ:max_difference", 0.3, "Never pair features with larger m/z distance (unit defined by 'unit')");
     defaults_.setMinFloat("distance_MZ:max_difference", 0.0);
     defaults_.setValue("distance_MZ:unit", "Da", "Unit of the 'max_difference' parameter");
     defaults_.setValidStrings("distance_MZ:unit", ListUtils::create<String>("Da,ppm"));
-    defaults_.setValue("distance_MZ:exponent", 2.0, "Normalized m/z differences are raised to this power (using 1 or 2 will be fast, everything else is REALLY slow)", ListUtils::create<String>("advanced"));
+    defaults_.setValue("distance_MZ:exponent", 2.0, "Normalized ([0-1], relative to 'max_difference') m/z differences are raised to this power (using 1 or 2 will be fast, everything else is REALLY slow)", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("distance_MZ:exponent", 0.0);
-    defaults_.setValue("distance_MZ:weight", 1.0, "m/z distances are weighted by this factor", ListUtils::create<String>("advanced"));
+    defaults_.setValue("distance_MZ:weight", 1.0, "Final m/z distances are weighted by this factor", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("distance_MZ:weight", 0.0);
     defaults_.setSectionDescription("distance_MZ", "Distance component based on m/z differences");
 
-    defaults_.setValue("distance_intensity:exponent", 1.0, "Differences in relative intensity are raised to this power (using 1 or 2 will be fast, everything else is REALLY slow)", ListUtils::create<String>("advanced"));
+    defaults_.setValue("distance_intensity:exponent", 1.0, "Differences in relative intensity ([0-1]) are raised to this power (using 1 or 2 will be fast, everything else is REALLY slow)", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("distance_intensity:exponent", 0.0);
-    defaults_.setValue("distance_intensity:weight", 0.0, "Distances based on relative intensity are weighted by this factor", ListUtils::create<String>("advanced"));
+    defaults_.setValue("distance_intensity:weight", 0.0, "Final intensity distances are weighted by this factor", ListUtils::create<String>("advanced"));
     defaults_.setMinFloat("distance_intensity:weight", 0.0);
-    defaults_.setSectionDescription("distance_intensity", "Distance component based on differences in relative intensity");
+    defaults_.setSectionDescription("distance_intensity", "Distance component based on differences in relative intensity (usually relative to highest peak in the whole data set)");
 
-    defaults_.setValue("ignore_charge", "false", "Compare features normally even if their charge states are different");
+    defaults_.setValue("ignore_charge", "false", "false [default]: pairing requires equal charge state (or at least one unknown charge '0'); true: Pairing irrespective of charge state");
     defaults_.setValidStrings("ignore_charge", ListUtils::create<String>("true,false"));
 
     defaultsToParam_();

--- a/src/openms/source/ANALYSIS/MAPMATCHING/StablePairFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/StablePairFinder.cpp
@@ -59,10 +59,10 @@ namespace OpenMS
     //set the name for DefaultParamHandler error messages
     Base::setName(getProductName());
 
-    defaults_.setValue("second_nearest_gap", 2.0, "The distance to the second nearest neighbors must be larger by this factor than the distance to the matching element itself.");
+    defaults_.setValue("second_nearest_gap", 2.0, "Only link features whose distance to the second nearest neighbors (for both sides) is larger by 'second_nearest_gap' than the distance between the matched pair itself.");
     defaults_.setMinFloat("second_nearest_gap", 1.0);
 
-    defaults_.setValue("use_identifications", "false", "Never link features that are annotated with different peptides (only the best hit per peptide identification is taken into account).");
+    defaults_.setValue("use_identifications", "false", "Never link features that are annotated with different peptides (features without ID's always match; only the best hit per peptide identification is considered).");
     defaults_.setValidStrings("use_identifications", ListUtils::create<String>("true,false"));
 
     defaults_.insert("", FeatureDistance().getDefaults());
@@ -143,7 +143,8 @@ namespace OpenMS
         double distance = result.second;
         // we only care if distance constraints are satisfied for "best
         // matches", not for second-best; this means that second-best distances
-        // can become smaller than best distances!
+        // can become smaller than best distances
+        // (e.g. the RT is larger than allowed (->invalid pair), but m/z is perfect and has the most weight --> better score!)
         bool valid = result.first;
 
         // update entries for map 0:

--- a/src/tests/class_tests/openms/source/FeatureDistance_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureDistance_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // 
 // --------------------------------------------------------------------------
-// $Maintainer: Hendrik Weisser $
-// $Authors: Hendrik Weisser $
+// $Maintainer: Hendrik Weisser
+// $Authors: Clemens Groepl, Hendrik Weisser, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>
@@ -105,6 +105,55 @@ START_SECTION((std::pair<bool, double> operator()(const BaseFeature& left, const
 	result = dist2(left, right);
 	TEST_EQUAL(result.first, false);
 	TEST_EQUAL(result.second, FeatureDistance::infinity);
+
+  // ppm for m/z
+	param.setValue("distance_intensity:weight", 0.0);
+	param.setValue("distance_RT:weight", 0.0);
+	param.setValue("distance_MZ:weight", 1.0);
+  param.setValue("distance_MZ:max_difference", 10.0);
+  param.setValue("distance_MZ:unit", "ppm");
+  dist.setParameters(param);
+  left.setRT(100.0);
+  left.setIntensity(100.0);
+  left.setMZ(100.0);
+  right.setRT(110.0);
+  right.setIntensity(200.0);
+  right.setMZ(100.0 + 100.0/1e6 * 5); // 5ppm off
+  result = dist(left, right);
+  TEST_EQUAL(result.first, true);
+  TEST_REAL_SIMILAR(result.second, 0.5);
+
+  right.setMZ(100.0 + 100.0/1e6 * 20); // 20ppm off
+  result = dist(left, right);
+  TEST_EQUAL(result.first, false);
+  TEST_REAL_SIMILAR(result.second, 2);
+
+  // charge
+  param.setValue("ignore_charge", "false");
+  dist.setParameters(param);
+  right.setMZ(100.0 + 100.0/1e6 * 5); // 5ppm off --> valid in m/z
+  // charges differ
+  right.setCharge(1);
+  left.setCharge(2);
+  result = dist(left, right);
+  TEST_EQUAL(result.first, false); // --> invalid
+  TEST_REAL_SIMILAR(result.second, FeatureDistance::infinity);
+  // one charge 0 -- pass filter
+  right.setCharge(1);
+  left.setCharge(0);
+  result = dist(left, right);
+  TEST_EQUAL(result.first, true); // --> valid
+  TEST_REAL_SIMILAR(result.second, 0.5);
+  // ignore charge
+  param.setValue("ignore_charge", "true");
+  dist.setParameters(param);
+  // charges differ, but we don't care
+  right.setCharge(1);
+  left.setCharge(2);
+  result = dist(left, right);
+  TEST_EQUAL(result.first, true); // --> valid
+  TEST_REAL_SIMILAR(result.second, 0.5);
+
 }
 END_SECTION
 


### PR DESCRIPTION
Docs were somewhat confusing, and tests not very exhaustive. Fixed.

TOPP: affects FeatureLinkerUnlabeled