### PR TITLE
force flag circumvents java time-outs in MSGFPlusAdapter

### DIFF
--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -417,10 +417,13 @@ protected:
       writeLog_("Warning: Modifications are defined ('fixed_modifications'/'variable_modifications'), but the number of allowed modifications is zero ('max_mods'). Is that intended?");
     }
 
-    if (!JavaInfo::canRun("java"))
+    if (!getFlag_("force"))
     {
-      writeLog_("Fatal error: Java not found, or the Java process timed out. Java is needed to run MS-GF+. Make sure that it can be executed by calling 'java', e.g. add the directory containing the Java binary to your PATH variable.");
-      return EXTERNAL_PROGRAM_ERROR;
+      if (!JavaInfo::canRun("java"))
+      {
+        writeLog_("Fatal error: Java not found, or the Java process timed out. Java is needed to run MS-GF+. Make sure that it can be executed by calling 'java', e.g. add the directory containing the Java binary to your PATH variable. If you are certain java is installed, please set the 'force' flag in order to avoid this error message.");
+        return EXTERNAL_PROGRAM_ERROR;
+      }
     }
 
     // create temporary directory (and modifications file, if necessary):

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -194,8 +194,6 @@ protected:
 
     registerIntOption_("java_memory", "<num>", 3500, "Maximum Java heap size (in MB)", false);
     registerIntOption_("java_permgen", "<num>", 0, "Maximum Java permanent generation space (in MB); only for Java 7 and below", false, true);
-    
-    registerFlag_("force", "New description for force flag.", true);
   }
 
   // The following sequence modification methods are used to modify the sequence stored in the TSV such that it can be used by AASequence

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -425,6 +425,10 @@ protected:
         return EXTERNAL_PROGRAM_ERROR;
       }
     }
+    else
+    {
+      writeLog_("The installation of Java was not checked.");
+    }
 
     // create temporary directory (and modifications file, if necessary):
     String temp_dir, mzid_temp, mod_file;

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -194,6 +194,8 @@ protected:
 
     registerIntOption_("java_memory", "<num>", 3500, "Maximum Java heap size (in MB)", false);
     registerIntOption_("java_permgen", "<num>", 0, "Maximum Java permanent generation space (in MB); only for Java 7 and below", false, true);
+    
+    registerFlag_("force", "New description for force flag.", true);
   }
 
   // The following sequence modification methods are used to modify the sequence stored in the TSV such that it can be used by AASequence


### PR DESCRIPTION
The installation of java is now only checked, if the `force` flag is not set. That allows to circumvent time-out crashes when the system is very busy. Resolves #1517.