### PR TITLE
index variable change in MapAlignerPoseClustering

### DIFF
--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -210,7 +210,7 @@ protected:
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1)
 #endif
-    for (Size i = 0; i < in_files.size(); ++i)
+    for (int i = 0; i < (int) in_files.size(); ++i)
     {
       TransformationDescription trafo;
       if (in_type == FileTypes::FEATUREXML)
@@ -220,7 +220,7 @@ protected:
         FeatureXMLFile f_fxml_tmp; // do not use OMP-firstprivate, since FeatureXMLFile has no copy c'tor
         f_fxml_tmp.getOptions() = f_fxml.getOptions();
         f_fxml_tmp.load(in_files[i], map);
-        if (i == reference_index) trafo.fitModel("identity");
+        if (i == (int) reference_index) trafo.fitModel("identity");
         else algorithm.align(map, trafo);
         if (out_files.size())
         {
@@ -234,7 +234,7 @@ protected:
       {
         MSExperiment<> map;
         MzMLFile().load(in_files[i], map);
-        if (i == reference_index) trafo.fitModel("identity");
+        if (i == (int) reference_index) trafo.fitModel("identity");
         else algorithm.align(map, trafo);
         if (out_files.size())
         {

--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -210,7 +210,7 @@ protected:
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic, 1)
 #endif
-    for (int i = 0; i < (int) in_files.size(); ++i)
+    for (int i = 0; i < static_cast<int>(in_files.size()); ++i)
     {
       TransformationDescription trafo;
       if (in_type == FileTypes::FEATUREXML)
@@ -220,7 +220,7 @@ protected:
         FeatureXMLFile f_fxml_tmp; // do not use OMP-firstprivate, since FeatureXMLFile has no copy c'tor
         f_fxml_tmp.getOptions() = f_fxml.getOptions();
         f_fxml_tmp.load(in_files[i], map);
-        if (i == (int) reference_index) trafo.fitModel("identity");
+        if (i == static_cast<int>(reference_index)) trafo.fitModel("identity");
         else algorithm.align(map, trafo);
         if (out_files.size())
         {
@@ -234,7 +234,7 @@ protected:
       {
         MSExperiment<> map;
         MzMLFile().load(in_files[i], map);
-        if (i == (int) reference_index) trafo.fitModel("identity");
+        if (i == static_cast<int>(reference_index)) trafo.fitModel("identity");
         else algorithm.align(map, trafo);
         if (out_files.size())
         {


### PR DESCRIPTION
Index variable changed from `Size` to `int` in  MapAlignerPoseClustering for OpenMP.
Attempt to fix #1566 by correcting #1531.