### PR TITLE
Some GUI convenience features

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASInputFilesDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPASInputFilesDialog.h
@@ -61,10 +61,13 @@ public:
     void dropEvent(QDropEvent *e);
 
     /// Constructor
-    TOPPASInputFilesDialog(const QStringList& list);
+    TOPPASInputFilesDialog(const QStringList& list, const QString& cwd);
 
     /// Stores the list of all filenames in the list widget in @p files
     void getFilenames(QStringList& files) const;
+
+    /// get the CWD (according to most recently added file)
+    const QString& getCWD() const;
 
     /// support Ctrl+C to copy currently selected items to clipboard
     virtual void keyPressEvent(QKeyEvent *e);
@@ -81,6 +84,10 @@ public slots:
     void editCurrentItem();
     /// Moves the current item up/downwards
     void moveCurrentItem();
+
+protected:
+    /// current working dir, i.e. the last position a file was added from
+    QString cwd_;
 
   };
 

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASInputFileListVertex.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASInputFileListVertex.h
@@ -96,6 +96,9 @@ protected:
     /// The key of this input node (for applying resources from a resource file)
     QString key_;
 
+    /// current working dir, i.e. the last position a file was added from
+    QString cwd_;
+
     ///@name reimplemented Qt events
     //@{
     void mouseDoubleClickEvent(QGraphicsSceneMouseEvent * e);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1799,30 +1799,31 @@ namespace OpenMS
 
   void TOPPViewBase::updateLayerBar()
   {
-    //reset
+    // reset
     layer_manager_->clear();
     SpectrumCanvas* cc = getActiveCanvas();
     if (cc == 0)
+    {
       return;
+    }
 
-    //determine if this is a 1D view (for text color)
-    bool is_1d_view = false;
-    if (dynamic_cast<Spectrum1DCanvas*>(cc))
-      is_1d_view = true;
+    // determine if this is a 1D view (for text color)
+    bool is_1d_view = (dynamic_cast<Spectrum1DCanvas*>(cc) != 0);
 
     layer_manager_->blockSignals(true);
-    QString name;
     for (Size i = 0; i < cc->getLayerCount(); ++i)
     {
       const LayerData& layer = cc->getLayer(i);
-      //add item
+      // add item
       QListWidgetItem* item = new QListWidgetItem(layer_manager_);
-      name = layer.name.toQString();
+      QString name = layer.name.toQString();
       if (layer.flipped)
       {
         name += " [flipped]";
       }
       item->setText(name);
+      item->setToolTip(layer.filename.toQString());
+
       if (is_1d_view && cc->getLayerCount() > 1)
       {
         QPixmap icon(7, 7);
@@ -1841,7 +1842,7 @@ namespace OpenMS
       {
         item->setText(item->text() + '*');
       }
-      //highlight active item
+      // highlight active item
       if (i == cc->activeLayerIndex())
       {
         layer_manager_->setCurrentItem(item);
@@ -1928,24 +1929,6 @@ namespace OpenMS
     updateViewBar();
   }
 
-  /*
-  void TOPPViewBase::updateDataBar()
-  {
-    const set<String> filenames = getFilenamesOfOpenFiles();
-    //reset
-    data_manager_view_->clear();
-    data_manager_view_->blockSignals(true);
-    QTreeWidgetItem* item = 0;
-    for (set<String>::const_iterator it = filenames.begin(); it != filenames.end(); ++it)
-    {
-      item = new QTreeWidgetItem(data_manager_view_);
-      QString name = it->toQString();
-      QFileInfo fi(name);
-      item->setText(0, fi.fileName());
-    }
-    layer_manager_->blockSignals(false);
-  }
-*/
   void TOPPViewBase::layerSelectionChange(int i)
   {
     // after adding a layer i is -1. TODO: check if this is the correct behaviour

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPASInputFilesDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPASInputFilesDialog.cpp
@@ -36,6 +36,8 @@
 #include <OpenMS/VISUAL/DIALOGS/TOPPASInputFilesDialog.h>
 #include <OpenMS/VISUAL/DIALOGS/TOPPASInputFileDialog.h>
 
+#include <OpenMS/SYSTEM/File.h>
+
 #include <QtGui/QFileDialog>
 #include <QApplication>
 #include <QClipboard>
@@ -46,7 +48,8 @@
 
 namespace OpenMS
 {
-  TOPPASInputFilesDialog::TOPPASInputFilesDialog(const QStringList & list)
+  TOPPASInputFilesDialog::TOPPASInputFilesDialog(const QStringList & list, const QString& cwd)
+    : cwd_(cwd)
   {
     setupUi(this);
 
@@ -69,7 +72,8 @@ namespace OpenMS
   void TOPPASInputFilesDialog::dragEnterEvent(QDragEnterEvent* e)
   {
     // file dropped from a window manager come as URLs
-    if (e->mimeData()->hasUrls()) {
+    if (e->mimeData()->hasUrls())
+    {
       e->acceptProposedAction();
     }
   }
@@ -104,10 +108,13 @@ namespace OpenMS
 
   void TOPPASInputFilesDialog::showFileDialog()
   {
-    QStringList file_names = QFileDialog::getOpenFileNames(this, tr("Select input file(s)"), tr(""), tr(/*valid filetypes*/ ""));
+    QStringList file_names = QFileDialog::getOpenFileNames(this,
+                                                           tr("Select input file(s)"), 
+                                                           cwd_);
     if (!file_names.isEmpty())
     {
       input_file_list->addItems(file_names);
+      cwd_ = File::path(file_names.back()).toQString();
     }
   }
 
@@ -134,6 +141,11 @@ namespace OpenMS
     }
     if (flag_sort_list->isChecked())
       files.sort();
+  }
+
+  const QString& TOPPASInputFilesDialog::getCWD() const
+  {
+    return cwd_;
   }
 
   void TOPPASInputFilesDialog::editCurrentItem()

--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -100,7 +100,7 @@ namespace OpenMS
 
   void TOPPASInputFileListVertex::showFilesDialog()
   {
-    TOPPASInputFilesDialog tifd(getFileNames());
+    TOPPASInputFilesDialog tifd(getFileNames(), cwd_);
     if (tifd.exec())
     {
       QStringList updated_filelist;
@@ -109,6 +109,10 @@ namespace OpenMS
       { // files were changed
         setFilenames(updated_filelist); // to correct filenames (separators etc)
         qobject_cast<TOPPASScene *>(scene())->updateEdgeColors();
+
+        // update cwd
+        cwd_ = tifd.getCWD();
+
         emit parameterChanged(true); // aborts the pipeline (if running) and resets downstream nodes
       }
     }
@@ -253,6 +257,9 @@ namespace OpenMS
   void TOPPASInputFileListVertex::setFilenames(const QStringList& files)
   {
     output_files_.clear();
+
+    if (files.empty()) return;
+
     output_files_.resize(files.size()); // for now, assume one file per round (we could later extend that)
     for (int f = 0; f < files.size(); ++f)
     {
@@ -260,6 +267,9 @@ namespace OpenMS
     }
 
     setToolTip(files.join("\n"));
+
+    // set current working dir when opening files to the last file
+    cwd_ = File::path(files.back()).toQString();
   }
 
   void TOPPASInputFileListVertex::outEdgeHasChanged()

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -262,7 +262,9 @@ namespace OpenMS
           else // update the target parameters
           {
             tv_target->setParam(to);
-            changedParameter(TOPPASToolVertex::TOOL_READY); // show *, indicating changed params
+            abortPipeline();
+            setChanged(true); // to allow "Store" of pipeline
+            resetDownstream(target);
           }
           //ss << "test test";
           my_log << " ---------------------------------- " << std::endl; // this will cause a flush... removing this line might cause loss(!) of log content!


### PR DESCRIPTION
this PR collects three minor improvements to TOPPAS and TOPPView:

[TOPPView] add Tooltip in Layer Window, giving the full file path (helpful for duplicate layers with identical filename)

[TOPPAS] remember most recent directory when adding files to an Input-Vertex -- makes browsing easier

and somewhat a bugfix:
[TOPPAS] reset downstream pipeline when transferred params between nodes
