### PR TITLE
Toppas filename generation

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASEdge.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASEdge.h
@@ -46,6 +46,7 @@ namespace OpenMS
   class TOPPASToolVertex;
   class TOPPASInputFileListVertex;
 
+  class String;
 
   /**
       @brief An edge representing a data flow in TOPPAS
@@ -88,6 +89,9 @@ public:
     virtual ~TOPPASEdge();
     /// Assignment operator
     TOPPASEdge & operator=(const TOPPASEdge & rhs);
+
+    /// for debug output
+    String toString();
 
     /// Returns the bounding rectangle of this item
     QRectF boundingRect() const;

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPASOutputFilesDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPASOutputFilesDialog.cpp
@@ -71,6 +71,9 @@ namespace OpenMS
     connect(browse_button, SIGNAL(clicked()), this, SLOT(showFileDialog()));
     connect(ok_button, SIGNAL(clicked()), this, SLOT(checkValidity_()));
     connect(cancel_button, SIGNAL(clicked()), this, SLOT(reject()));
+    
+    // make Ok the default (just pressing Enter will run the workflow)
+    ok_button->setFocus();
   }
 
   void TOPPASOutputFilesDialog::showFileDialog()

--- a/src/openms_gui/source/VISUAL/TOPPASEdge.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASEdge.cpp
@@ -89,6 +89,11 @@ namespace OpenMS
     setFlag(QGraphicsItem::ItemIsSelectable, true);
   }
 
+  String TOPPASEdge::toString()
+  {
+    String s = String("Edge: ") + getSourceOutParamName() + " target-in: " + getTargetInParamName() + "\n";
+    return s;
+  }
   TOPPASEdge & TOPPASEdge::operator=(const TOPPASEdge & rhs)
   {
     from_ = rhs.from_;

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -55,6 +55,31 @@
 
 namespace OpenMS
 {
+
+
+  struct NameComponent
+  {
+    String prefix, suffix;
+    int counter;
+    NameComponent()
+      : counter(-1)
+    {}
+
+    NameComponent(const String& r_prefix, const String& r_suffix)
+      : prefix(r_prefix),
+      suffix(r_suffix),
+      counter(-1)
+    {}
+
+    String toString() const
+    {
+      String s_counter;
+      if (counter != -1) s_counter = String(counter).fillLeft('0', 3) + ".";
+      return (prefix + s_counter + suffix);
+    }
+
+  };
+
   UInt TOPPASToolVertex::uid_ = 1;
 
   TOPPASToolVertex::TOPPASToolVertex() :
@@ -776,29 +801,6 @@ namespace OpenMS
   {
     // get all output names
     QStringList files = this->getFileNames();
-    
-    struct NameComponent
-    {
-      String prefix, suffix;
-      int counter;
-      NameComponent()
-        : counter(-1)
-      {}
-
-      NameComponent(const String& r_prefix, const String& r_suffix)
-       : prefix(r_prefix),
-         suffix(r_suffix),
-         counter(-1)
-      {}
-      
-      String toString() const
-      {
-        String s_counter;
-        if (counter != -1) s_counter = String(counter).fillLeft('0', 3) + ".";
-        return (prefix + s_counter + suffix);
-      }
-
-    };
 
     std::map<String, NameComponent> name_old_to_new;
     Map<String, int> name_new_count, name_new_idx; // count occurrence (for optional counter infix)

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -902,7 +902,7 @@ namespace OpenMS
         //std::cerr << "Edge: " << (it->second.edge->toString()) << "\n";
         if ((it->second.filenames.size() > max_size) ||   // either just larger 
             // ... or it's from '-in' (which we prefer as naming source).. only for non-recycling -in though
-            (it->second.filenames.size () == max_size) && (it->second.edge->getTargetInParamName() == "in") && (use_recycling == 0))
+            ((it->second.filenames.size () == max_size) && (it->second.edge->getTargetInParamName() == "in") && (use_recycling == 0)))
         {
           max_size_index = it->first;
           max_size       = it->second.filenames.size();

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -899,6 +899,8 @@ namespace OpenMS
     // maybe we find something more unique, e.g. last base directory if all filenames are equal
     smartFileNames_(per_round_basenames);
 
+    QRegExp rx_tmp_suffix("_tmp\\d+$"); // regex to remove "_tmp<number>" if its a suffix
+
     // clear output file list
     output_files_.clear();
     output_files_.resize(pkg.size()); // #rounds
@@ -964,9 +966,8 @@ namespace OpenMS
         {
           foreach(const QString &input_file, per_round_basenames[r])
           {
-            QString fn = path + QFileInfo(input_file).fileName(); // discard directory
-            QRegExp rx("_tmp\\d+$"); // remove "_tmp<number>" if its a suffix
-            int tmp_index = rx.indexIn(fn);
+            QString fn = path + QFileInfo(input_file).fileName(); // out_path + filename
+            int tmp_index = rx_tmp_suffix.indexIn(fn);
             if (tmp_index != -1)
             {
               fn = fn.left(tmp_index);

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -885,8 +885,8 @@ namespace OpenMS
 
     // look for the input with the most files in round 0 (as this is the maximal number of output files we can produce)
     // we assume the number of files is equal in all rounds...
-    // however, we delay using nodes which use 'recycling' of input, as the names will always be the same
-    //          only iff a recycling node gives the most input files we use its names
+    // However, we delay using nodes which use 'recycling' of input, as the names will always be the same.
+    //          Only if a recycling node gives the most input files we use its names
     int max_size_index = -1;
     int max_size = -1;
     for (int use_recycling = 0; use_recycling < 2; ++use_recycling)
@@ -899,7 +899,10 @@ namespace OpenMS
         { // first test all input nodes with disabled recycling
           continue;
         }
-        if (it->second.filenames.size() > max_size)
+        //std::cerr << "Edge: " << (it->second.edge->toString()) << "\n";
+        if ((it->second.filenames.size() > max_size) ||   // either just larger 
+            // ... or it's from '-in' (which we prefer as naming source).. only for non-recycling -in though
+            (it->second.filenames.size () == max_size) && (it->second.edge->getTargetInParamName() == "in") && (use_recycling == 0))
         {
           max_size_index = it->first;
           max_size       = it->second.filenames.size();
@@ -908,8 +911,8 @@ namespace OpenMS
 
       if (max_size_index == -1)
       {
-        error_msg = "Did not find upstream nodes with unrecycled names. Something is fishy!\n";
-        std::cerr << error_msg;
+        error_msg = "Did not find upstream nodes with un-recycled names. Something is fishy!\n";
+        LOG_ERROR << error_msg;
         return false;
       }
     }

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -893,6 +893,7 @@ namespace OpenMS
     for (Size i = 0; i < pkg.size(); ++i)
     {
       per_round_basenames.push_back(pkg[i].find(max_size_index)->second.filenames);
+      //String s = String(pkg[i].find(max_size_index)->second.filenames.join(" + "));
     }
 
     // maybe we find something more unique, e.g. last base directory if all filenames are equal
@@ -946,15 +947,14 @@ namespace OpenMS
       {
         // store edge for this param for all rounds
         output_files_[r][param_index] = vrp; // index by index of source-out param
-        QString fn = path;
 
         // check if tool consumes list and outputs single file (such as IDMerger or FileMerger)
         if (per_round_basenames[r].size() > 1 && out_params[param_index].type == IOInfo::IOT_FILE)
         {
-          fn += QString(QFileInfo(per_round_basenames[r].first()).fileName()
-                        + "_to_"
-                        + QFileInfo(per_round_basenames[r].last()).fileName()
-                        + "_merged");
+          QString fn = path + QString(QFileInfo(per_round_basenames[r].first()).fileName()
+                            + "_to_"
+                            + QFileInfo(per_round_basenames[r].last()).fileName()
+                            + "_merged");
           fn = fn.left(220); // allow max of 220 chars per path+filename (~NTFS limit)
           fn += "_tmp" + QString::number(uid_++);
           fn = QDir::toNativeSeparators(fn);
@@ -964,7 +964,7 @@ namespace OpenMS
         {
           foreach(const QString &input_file, per_round_basenames[r])
           {
-            fn += QFileInfo(input_file).fileName(); // discard directory
+            QString fn = path + QFileInfo(input_file).fileName(); // discard directory
             QRegExp rx("_tmp\\d+$"); // remove "_tmp<number>" if its a suffix
             int tmp_index = rx.indexIn(fn);
             if (tmp_index != -1)

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -37,6 +37,7 @@
 #include <OpenMS/VISUAL/TOPPASScene.h>
 
 #include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <iostream>
 
@@ -138,12 +139,12 @@ namespace OpenMS
     return true;
   }
 
-  bool TOPPASVertex::buildRoundPackages(RoundPackages & pkg, String & error_msg) // check all incoming edges for this node and construct the package
+  bool TOPPASVertex::buildRoundPackages(RoundPackages& pkg, String& error_msg) // check all incoming edges for this node and construct the package
   {
     if (inEdgesBegin() == inEdgesEnd())
     {
       error_msg = "buildRoundPackages() called on vertex with no input edges!\n";
-      std::cerr << error_msg;
+      LOG_ERROR << error_msg;
       return false;
     }
 
@@ -154,11 +155,15 @@ namespace OpenMS
     {
       TOPPASVertex * tv = (*it)->getSourceVertex();
       if (tv->allow_output_recycling_)
+      {
         continue;
+      }
 
       ++no_recycle_count;
       if (round_common == -1)
+      {
         round_common = tv->round_total_;                       // first non-recycler sets the pace
+      }
 
       if (round_common != tv->round_total_)
       {

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -228,10 +228,15 @@ namespace OpenMS
   QStringList TOPPASVertex::getFileNames(int param_index, int round) const
   {
     if ((Size)round >= output_files_.size())
+    {
       throw Exception::IndexOverflow(__FILE__, __LINE__, __PRETTY_FUNCTION__, round, output_files_.size());
+    }
     RoundPackage rp = output_files_[round];
     if (rp.find(param_index) == rp.end())
-      throw Exception::IndexOverflow(__FILE__, __LINE__, __PRETTY_FUNCTION__, param_index, rp.size());                                   // index could be larger (its a map, but nevertheless)
+    {
+      throw Exception::IndexOverflow(__FILE__, __LINE__, __PRETTY_FUNCTION__, param_index, rp.size());  // index could be larger (its a map, but nevertheless)
+    }
+    //String s = String(rp[param_index].filenames.join("\" \""));
     return rp[param_index].filenames;
   }
 


### PR DESCRIPTION
when working with input file lists, TOPPAS will now:

 - use source filenames 1:1 if possible (new suffix if applicable)
 - use a 0-filled counter if filenames are duplicated (from different directories), e.g. fileX.001.mzML

When possible TOPPAS will now also prefer input filenames from "-in" (this usually only affects workflows with multiple input edges, but a single round (ie file) only).

This fixes #620 and #1480.