### PR TITLE
Refactor PoseClustering: Redesign interface

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/PoseClusteringAffineSuperimposer.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/PoseClusteringAffineSuperimposer.h
@@ -37,6 +37,7 @@
 #define OPENMS_ANALYSIS_MAPMATCHING_POSECLUSTERINGAFFINESUPERIMPOSER_H
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/BaseSuperimposer.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/Peak2D.h>
 
 namespace OpenMS

--- a/src/openms/source/ANALYSIS/MAPMATCHING/PoseClusteringAffineSuperimposer.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/PoseClusteringAffineSuperimposer.cpp
@@ -35,7 +35,6 @@
 #include <OpenMS/ANALYSIS/MAPMATCHING/PoseClusteringAffineSuperimposer.h>
 #include <OpenMS/FILTERING/BASELINE/MorphologicalFilter.h>
 #include <OpenMS/MATH/STATISTICS/BasicStatistics.h>
-#include <OpenMS/DATASTRUCTURES/ConstRefVector.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/MATH/MISC/LinearInterpolation.h>
 
@@ -157,10 +156,6 @@ namespace OpenMS
 
   */
   void affineTransformationHashing(const bool do_dump_pairs,
-                                   /*
-                                   const ConstRefVector<ConsensusMap>& model_map,
-                                   const ConstRefVector<ConsensusMap>& scene_map,
-                                   */
                                    const std::vector<Peak2D> & model_map,
                                    const std::vector<Peak2D> & scene_map,
                                    Math::LinearInterpolation<double, double>& scaling_hash_1,
@@ -731,7 +726,6 @@ namespace OpenMS
     }
   }
 
-  //double computeIntensityRatio(const ConstRefVector<ConsensusMap>& model_map, const ConstRefVector<ConsensusMap>& scene_map)
   double computeIntensityRatio(const std::vector<Peak2D> & model_map, const std::vector<Peak2D> & scene_map)
   {
     double total_int_model_map = 0;
@@ -787,7 +781,6 @@ namespace OpenMS
     //**************************************************************************
     // Working variables
     //**************************************************************************
-    // typedef ConstRefVector<ConsensusMap> PeakPointerArray_;
     typedef Math::LinearInterpolation<double, double> LinearInterpolationType_;
     // these are a set of hashes that transform bins to actual RT values ...
     LinearInterpolationType_ scaling_hash_1; //scaling estimate from round 1 hashing


### PR DESCRIPTION
switch interface from `ConsensusMap` to `std::vector<Peak2D>` as this is a much cleaner interface and the algorithm only needs RT, m/z and int information. This potentially allows other code to use an easy interface for alignment that takes two simple 3D peaklist as input.

This should be merged after #1598