### PR TITLE
[FIX] TOPPView: add margins around data range (2%)

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/DRange.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DRange.h
@@ -53,7 +53,7 @@ namespace OpenMS
       The two limiting points are accessed as minPosition() and maxPosition().
 
       A range denotes a semi-open interval. A lower coordinate of each
-      dimension is part the range, the higher coordinate is not.
+      dimension is part of the range, the higher coordinate is not.
 
       @ingroup Datastructures
   */
@@ -75,7 +75,7 @@ public:
     typedef typename Base::PositionType PositionType;
     /// Coordinate type of the positions
     typedef typename Base::CoordinateType CoordinateType;
-    ///Types that describe the kind of intersection between two ranges
+    /// Types that describe the kind of intersection between two ranges
     enum DRangeIntersection
     {
       Disjoint, ///< No intersection
@@ -118,7 +118,7 @@ public:
     {
     }
 
-    ///Convenient constructor for DRange<2>
+    /// Convenient constructor for DRange<2>
     DRange(CoordinateType minx, CoordinateType miny, CoordinateType maxx, CoordinateType maxy)
     {
       OPENMS_PRECONDITION(D == 2, "DRange<D>:DRange(minx, miny, maxx, maxy): index overflow!");
@@ -302,6 +302,33 @@ public:
       }
       return false;
     }
+
+    /**
+         @brief Extends the range in all dimensions by a certain multiplier.
+
+         Extends the range, while maintaining the original center position.
+
+         Examples (for D=1):
+           factor = 1.01 extends the range by 1% in total, i.e. 0.5% left and right.
+           factor = 2.00 doubles the total range, e.g. from [0,100] to [-50,150]
+
+         @param factor Multiplier (allowed is [0, inf)).
+    */
+    void extend(double factor)
+    {
+      if (factor < 0)
+      {
+        throw Exception::InvalidParameter(__FILE__, __LINE__, __PRETTY_FUNCTION__, "DRange::extend(): factor must not be negative!");
+      }
+
+      for (UInt i = 0; i != D; ++i)
+      {
+        Internal::DIntervalBase<1>::CoordinateType extra = (max_[i] - min_[i]) / 2.0 * (factor - 1);
+        min_[i] -= extra;
+        max_[i] += extra;
+      }
+    }
+
 
     //@}
   };

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -546,13 +546,11 @@ namespace OpenMS
         }
       }
     }
-    //Add 1% margin to RT in order to display all the data
-    double margin = 0.01 * max(1.0, m_max[rt_dim] - m_min[rt_dim]);
-    m_min[rt_dim] -= margin;
-    m_max[rt_dim] += margin;
-
     overall_data_range_.setMin(m_min);
     overall_data_range_.setMax(m_max);
+
+    // add 4% margin (2% left, 2% right) to RT, m/z and intensity
+    overall_data_range_.extend(1.04);
   }
 
   double SpectrumCanvas::getSnapFactor()

--- a/src/tests/class_tests/openms/source/DRange_test.cpp
+++ b/src/tests/class_tests/openms/source/DRange_test.cpp
@@ -53,7 +53,7 @@ DPosition<2> p1,p2,p3,one,two;
 p1[0]=-1.0f;
 p1[1]=-2.0f;
 p2[0]=3.0f;
-p2[1]=4.0f;	
+p2[1]=4.0f;
 p3[0]=-10.0f;
 p3[1]=20.0f;
 one[0]=1;
@@ -420,6 +420,22 @@ START_SECTION(bool isEmpty() const)
 	TEST_EQUAL(tmp.isEmpty(), false);
 END_SECTION
 
+
+START_SECTION(void extend(double factor))
+  DRange<2> r(p1,p2);
+/*
+p1[0]=-1.0f;
+p1[1]=-2.0f;
+p2[0]=3.0f;
+p2[1]=4.0f;
+*/
+  TEST_EXCEPTION(Exception::InvalidParameter, r.extend(-0.01))
+  r.extend(2.0);
+	TEST_REAL_SIMILAR(r.minPosition()[0],-3.0f);
+	TEST_REAL_SIMILAR(r.maxPosition()[0], 5.0f);
+	TEST_REAL_SIMILAR(r.minPosition()[1],-5.0f);
+	TEST_REAL_SIMILAR(r.maxPosition()[1], 7.0f); 
+END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST


### PR DESCRIPTION
solves #1528 

![image](https://cloud.githubusercontent.com/assets/6008722/9931314/ed1e870c-5d3a-11e5-8813-cd675239986e.png)
