### PR TITLE
[FIX] attempt to fix error C2332: 'struct' : missing tag name caused by

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.h
@@ -100,10 +100,11 @@ namespace OpenMS
 
        @returns True if the meta value was written, false if it already exists.
     */
-    static bool storeOriginalRT_(MetaInfoInterface& interface,
+    static bool storeOriginalRT_(MetaInfoInterface& meta_info,
                                  double original_rt);
 
   };
 } // namespace OpenMS
 
 #endif // OPENMS_ANALYSIS_MAPMATCHING_MAPALIGNMENTTRANSFORMER_H
+

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentTransformer.cpp
@@ -46,11 +46,11 @@ using std::vector;
 namespace OpenMS
 {
 
-  bool MapAlignmentTransformer::storeOriginalRT_(MetaInfoInterface& interface,
+  bool MapAlignmentTransformer::storeOriginalRT_(MetaInfoInterface& meta_info,
                                                  double original_rt)
   {
-    if (interface.metaValueExists("original_RT")) return false;
-    interface.setMetaValue("original_RT", original_rt);
+    if (meta_info.metaValueExists("original_RT")) return false;
+    meta_info.setMetaValue("original_RT", original_rt);
     return true;
   }
 


### PR DESCRIPTION
use of "interface" in our code as variable identifier