### PR TITLE
Fidoadapter: improved PEP handling, removed "prob_param"

### DIFF
--- a/src/tests/topp/THIRDPARTY/FidoAdapter_4_input.idXML
+++ b/src/tests/topp/THIRDPARTY/FidoAdapter_4_input.idXML
@@ -590,8814 +590,9695 @@
 				<UserParam type="float" name="XTandem_score" value="0"/>
 			</ProteinHit>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.889923095703" RT="1090.50499999998" >
-			<PeptideHit score="0" sequence="QSPVDIDTHTAK" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.889923095703" RT="1090.50499999998" >
+			<PeptideHit score="0.994116771387973" sequence="QSPVDIDTHTAK" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.7"/>
 				<UserParam type="float" name="E-Value" value="0.00023"/>
 				<UserParam type="float" name="nextscore" value="19.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994116771387973"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="483.763641357422" RT="1156.08949999998" >
-			<PeptideHit score="0.0331695331695332" sequence="GNVMVPPPR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_104" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="483.763641357422" RT="1156.08949999998" >
+			<PeptideHit score="0.185169102173804" sequence="GNVMVPPPR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_104" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="14.8"/>
 				<UserParam type="float" name="E-Value" value="0.5"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.185169102173804"/>
+				<UserParam type="float" name="q-value" value="0.0331695331695332"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="516.271240234375" RT="1210.42249999998" >
-			<PeptideHit score="0.0434782608695652" sequence="LKELSWYHTAGNK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_7" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="516.271240234375" RT="1210.42249999998" >
+			<PeptideHit score="0.111148168009872" sequence="LKELSWYHTAGNK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_7" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23.5"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.239532470703" RT="1214.31880000002" >
-			<PeptideHit score="0.0363636363636364" sequence="LVIESTK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_112" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="395.239532470703" RT="1214.31880000002" >
+			<PeptideHit score="0.175225488597367" sequence="LVIESTK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_112" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.7"/>
 				<UserParam type="float" name="E-Value" value="0.54"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.175225488597367"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="468.232666015625" RT="1436.92990000002" >
-			<PeptideHit score="0" sequence="GGPLDGTYR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="468.232666015625" RT="1436.92990000002" >
+			<PeptideHit score="0.835623332778618" sequence="GGPLDGTYR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.8"/>
 				<UserParam type="float" name="E-Value" value="0.015"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.835623332778618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="617.966247558594" RT="1698.3102" >
-			<PeptideHit score="0" sequence="FSTVAGESGSADTVRDPR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="617.966247558594" RT="1698.3102" >
+			<PeptideHit score="0.998339553383431" sequence="FSTVAGESGSADTVRDPR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.4"/>
 				<UserParam type="float" name="E-Value" value="4.6e-05"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998339553383431"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="617.966674804688" RT="1703.68000000002" >
-			<PeptideHit score="0" sequence="FSTVAGESGSADTVRDPR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="617.966674804688" RT="1703.68000000002" >
+			<PeptideHit score="0.994947495670415" sequence="FSTVAGESGSADTVRDPR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.3"/>
 				<UserParam type="float" name="E-Value" value="0.00019"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994947495670415"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.810363769531" RT="1822.72999999998" >
-			<PeptideHit score="0" sequence="LSQEDPDYGIR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="646.810363769531" RT="1822.72999999998" >
+			<PeptideHit score="0.97469904242467" sequence="LSQEDPDYGIR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29"/>
 				<UserParam type="float" name="E-Value" value="0.0014"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97469904242467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="493.222991943359" RT="1942.25059999998" >
-			<PeptideHit score="0" sequence="GGPFSDSYR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="493.222991943359" RT="1942.25059999998" >
+			<PeptideHit score="0.999128598342253" sequence="GGPFSDSYR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38"/>
 				<UserParam type="float" name="E-Value" value="2e-05"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999128598342253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="510.58251953125" RT="1957.51120000002" >
-			<PeptideHit score="0" sequence="VGAHAGEYGAEALER" charge="3" aa_before="K" aa_after="M" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="510.58251953125" RT="1957.51120000002" >
+			<PeptideHit score="0.984762202246869" sequence="VGAHAGEYGAEALER" charge="3" aa_before="K" aa_after="M" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.4"/>
 				<UserParam type="float" name="E-Value" value="0.00075"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984762202246869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="421.758819580078" RT="2073.8349" >
-			<PeptideHit score="0.00651890482398957" sequence="GLISSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_46" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="421.758819580078" RT="2073.8349" >
+			<PeptideHit score="0.429088420832665" sequence="GLISSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_46" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23.6"/>
 				<UserParam type="float" name="E-Value" value="0.13"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.429088420832665"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="510.582763671875" RT="2089.84360000002" >
-			<PeptideHit score="0" sequence="VGAHAGEYGAEALER" charge="3" aa_before="K" aa_after="M" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="510.582763671875" RT="2089.84360000002" >
+			<PeptideHit score="0.967570696734317" sequence="VGAHAGEYGAEALER" charge="3" aa_before="K" aa_after="M" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.2"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="17.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="605.268920898438" RT="2414.29000000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="605.268920898438" RT="2414.29000000002" >
+			<PeptideHit score="0.996958329726846" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.6"/>
 				<UserParam type="float" name="E-Value" value="0.0001"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996958329726846"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="605.268981933594" RT="2506.08" >
-			<PeptideHit score="0" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="605.268981933594" RT="2506.08" >
+			<PeptideHit score="0.999914455690938" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.2"/>
 				<UserParam type="float" name="E-Value" value="1e-06"/>
 				<UserParam type="float" name="nextscore" value="9.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999914455690938"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="605.268737792969" RT="2507.70520000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="605.268737792969" RT="2507.70520000002" >
+			<PeptideHit score="0.998626449672608" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-05"/>
 				<UserParam type="float" name="nextscore" value="10.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998626449672608"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="605.269592285156" RT="2599.578" >
-			<PeptideHit score="0" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="605.269592285156" RT="2599.578" >
+			<PeptideHit score="0.99865607372492" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.2"/>
 				<UserParam type="float" name="E-Value" value="3.5e-05"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99865607372492"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="409.539703369141" RT="2615.55409999998" >
-			<PeptideHit score="0.00134408602150538" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="409.539703369141" RT="2615.55409999998" >
+			<PeptideHit score="0.771058061136823" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.7"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="409.539764404297" RT="2708.12569999998" >
-			<PeptideHit score="0" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="409.539764404297" RT="2708.12569999998" >
+			<PeptideHit score="0.994528455081984" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.3"/>
 				<UserParam type="float" name="E-Value" value="0.00021"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994528455081984"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="398.562957763672" RT="2744.98789999998" >
-			<PeptideHit score="0.0224159402241594" sequence="VLVHGAASGNLR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_92" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="398.562957763672" RT="2744.98789999998" >
+			<PeptideHit score="0.224392094485239" sequence="VLVHGAASGNLR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_92" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.38"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.224392094485239"/>
+				<UserParam type="float" name="q-value" value="0.0224159402241594"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="409.539886474609" RT="2804.22019999998" >
-			<PeptideHit score="0.0139416983523447" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="409.539886474609" RT="2804.22019999998" >
+			<PeptideHit score="0.28827458994223" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.8"/>
 				<UserParam type="float" name="E-Value" value="0.26"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.28827458994223"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="825.765747070313" RT="3150.4548" >
-			<PeptideHit score="0.0139416983523447" sequence="ILNLVCLDSEKEIGCNSLIGDVK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_107" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="825.765747070313" RT="3150.4548" >
+			<PeptideHit score="0.28827458994223" sequence="ILNLVCLDSEKEIGCNSLIGDVK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_107" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22"/>
 				<UserParam type="float" name="E-Value" value="0.26"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.28827458994223"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="825.762023925781" RT="3152.79910000002" >
-			<PeptideHit score="0" sequence="TSETKHDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="825.762023925781" RT="3152.79910000002" >
+			<PeptideHit score="0.999999720662806" sequence="TSETKHDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.1"/>
 				<UserParam type="float" name="E-Value" value="6.2e-10"/>
 				<UserParam type="float" name="nextscore" value="20.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999720662806"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.249633789063" RT="3163.0461" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.249633789063" RT="3163.0461" >
+			<PeptideHit score="0.883199475322235" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.4"/>
 				<UserParam type="float" name="E-Value" value="0.0095"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.883199475322235"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="538.266723632813" RT="3170.8569" >
-			<PeptideHit score="0.00134408602150538" sequence="YSAELHVAHWNSAK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="538.266723632813" RT="3170.8569" >
+			<PeptideHit score="0.569404203070947" sequence="YSAELHVAHWNSAK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.3"/>
 				<UserParam type="float" name="E-Value" value="0.069"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.569404203070947"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250946044922" RT="3202.84870000002" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250946044922" RT="3202.84870000002" >
+			<PeptideHit score="0.99772509132693" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="6.9e-05"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99772509132693"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250518798828" RT="3204.64669999998" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250518798828" RT="3204.64669999998" >
+			<PeptideHit score="0.967570696734317" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.2"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="483.936645507813" RT="3205.10680000002" >
-			<PeptideHit score="0.00526315789473684" sequence="VVAGVANALAHKYH" charge="3" aa_before="K" aa_after="]" protein_refs="PH_19 PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="483.936645507813" RT="3205.10680000002" >
+			<PeptideHit score="0.487163428094098" sequence="VVAGVANALAHKYH" charge="3" aa_before="K" aa_after="]" protein_refs="PH_19 PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.5"/>
 				<UserParam type="float" name="E-Value" value="0.1"/>
 				<UserParam type="float" name="nextscore" value="11.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.487163428094098"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.248046875" RT="3205.6221" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.248046875" RT="3205.6221" >
+			<PeptideHit score="0.980753850169904" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.4"/>
 				<UserParam type="float" name="E-Value" value="0.001"/>
 				<UserParam type="float" name="nextscore" value="10.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980753850169904"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="628.834045410156" RT="3288.15850000002" >
-			<PeptideHit score="0" sequence="VNVDAVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_19" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="628.834045410156" RT="3288.15850000002" >
+			<PeptideHit score="0.99999280475604" sequence="VNVDAVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_19" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.2"/>
 				<UserParam type="float" name="E-Value" value="4.1e-08"/>
 				<UserParam type="float" name="nextscore" value="17.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999280475604"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854125976563" RT="3289.3056" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854125976563" RT="3289.3056" >
+			<PeptideHit score="0.99919687311191" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="1.8e-05"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99919687311191"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250122070313" RT="3295.31419999998" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250122070313" RT="3295.31419999998" >
+			<PeptideHit score="0.930401463762626" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0049"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.930401463762626"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250091552734" RT="3296.93110000002" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250091552734" RT="3296.93110000002" >
+			<PeptideHit score="0.936125892868832" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0044"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.936125892868832"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.248657226563" RT="3300.80089999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.248657226563" RT="3300.80089999998" >
+			<PeptideHit score="0.977679598036381" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.5"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.248229980469" RT="3302.4882" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.248229980469" RT="3302.4882" >
+			<PeptideHit score="0.967570696734317" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.2"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854431152344" RT="3380.66650000002" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854431152344" RT="3380.66650000002" >
+			<PeptideHit score="0.999876865375483" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.5"/>
 				<UserParam type="float" name="E-Value" value="1.6e-06"/>
 				<UserParam type="float" name="nextscore" value="9.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999876865375483"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854736328125" RT="3382.77349999998" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854736328125" RT="3382.77349999998" >
+			<PeptideHit score="0.992145529169711" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.8"/>
 				<UserParam type="float" name="E-Value" value="0.00033"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992145529169711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250366210938" RT="3387.79480000002" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250366210938" RT="3387.79480000002" >
+			<PeptideHit score="0.960802305355011" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0024"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.960802305355011"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250183105469" RT="3389.475" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250183105469" RT="3389.475" >
+			<PeptideHit score="0.934969044635626" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.3"/>
 				<UserParam type="float" name="E-Value" value="0.0045"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.934969044635626"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.249267578125" RT="3393.22720000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.249267578125" RT="3393.22720000002" >
+			<PeptideHit score="0.85204760460282" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.6"/>
 				<UserParam type="float" name="E-Value" value="0.013"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.85204760460282"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="492.760528564453" RT="3405.76999999998" >
-			<PeptideHit score="0.0259259259259259" sequence="AFDITYVR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_38" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="492.760528564453" RT="3405.76999999998" >
+			<PeptideHit score="0.20599231767492" sequence="AFDITYVR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_38" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.1"/>
 				<UserParam type="float" name="E-Value" value="0.43"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.20599231767492"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.249450683594" RT="3406.39279999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.249450683594" RT="3406.39279999998" >
+			<PeptideHit score="0.99046445524595" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.3"/>
 				<UserParam type="float" name="E-Value" value="0.00042"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99046445524595"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="492.761566162109" RT="3407.66449999998" >
-			<PeptideHit score="0.0363636363636364" sequence="AFDITYVR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_38" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="492.761566162109" RT="3407.66449999998" >
+			<PeptideHit score="0.166398718169042" sequence="AFDITYVR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_38" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="17.5"/>
 				<UserParam type="float" name="E-Value" value="0.58"/>
 				<UserParam type="float" name="nextscore" value="12.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.166398718169042"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="564.853759765625" RT="3444.5115" >
-			<PeptideHit score="0.00134408602150538" sequence="KQTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="564.853759765625" RT="3444.5115" >
+			<PeptideHit score="0.61801152613314" sequence="KQTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.6"/>
 				<UserParam type="float" name="E-Value" value="0.055"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.61801152613314"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="564.852600097656" RT="3446.40319999998" >
-			<PeptideHit score="0.00134408602150538" sequence="KQTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="564.852600097656" RT="3446.40319999998" >
+			<PeptideHit score="0.614224838611314" sequence="KQTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.6"/>
 				<UserParam type="float" name="E-Value" value="0.056"/>
 				<UserParam type="float" name="nextscore" value="11.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.614224838611314"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.853881835938" RT="3473.1654" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.853881835938" RT="3473.1654" >
+			<PeptideHit score="0.999759292017249" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.4"/>
 				<UserParam type="float" name="E-Value" value="3.8e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999759292017249"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854431152344" RT="3474.81490000002" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854431152344" RT="3474.81490000002" >
+			<PeptideHit score="0.999375797281708" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.7"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="376.904693603516" RT="3477.13660000002" >
-			<PeptideHit score="0.00134408602150538" sequence="KQTALVELVK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="376.904693603516" RT="3477.13660000002" >
+			<PeptideHit score="0.752250699877261" sequence="KQTALVELVK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.027"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.752250699877261"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265014648438" RT="3478.28800000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265014648438" RT="3478.28800000002" >
+			<PeptideHit score="0.991765444794236" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.2"/>
 				<UserParam type="float" name="E-Value" value="0.00035"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991765444794236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="657.836181640625" RT="3478.9176" >
-			<PeptideHit score="0" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="657.836181640625" RT="3478.9176" >
+			<PeptideHit score="0.998066166732661" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39"/>
 				<UserParam type="float" name="E-Value" value="5.6e-05"/>
 				<UserParam type="float" name="nextscore" value="18.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998066166732661"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250732421875" RT="3480.07210000002" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250732421875" RT="3480.07210000002" >
+			<PeptideHit score="0.91192835386055" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.6"/>
 				<UserParam type="float" name="E-Value" value="0.0066"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.91192835386055"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.249938964844" RT="3481.7598" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.249938964844" RT="3481.7598" >
+			<PeptideHit score="0.908807506017045" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0069"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.908807506017045"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="657.835205078125" RT="3483.06229999998" >
-			<PeptideHit score="0" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="657.835205078125" RT="3483.06229999998" >
+			<PeptideHit score="0.999992266429207" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.9"/>
 				<UserParam type="float" name="E-Value" value="4.5e-08"/>
 				<UserParam type="float" name="nextscore" value="19.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999992266429207"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="376.904327392578" RT="3483.56239999998" >
-			<PeptideHit score="0.00906735751295337" sequence="KQTALVELVK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="376.904327392578" RT="3483.56239999998" >
+			<PeptideHit score="0.371664142581344" sequence="KQTALVELVK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.5"/>
 				<UserParam type="float" name="E-Value" value="0.17"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.371664142581344"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.248107910156" RT="3507.93889999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.248107910156" RT="3507.93889999998" >
+			<PeptideHit score="0.963472366227381" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.1"/>
 				<UserParam type="float" name="E-Value" value="0.0022"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.963472366227381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.249328613281" RT="3511.7673" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.249328613281" RT="3511.7673" >
+			<PeptideHit score="0.916150345988615" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.4"/>
 				<UserParam type="float" name="E-Value" value="0.0062"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.916150345988615"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.853759765625" RT="3567.91069999998" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.853759765625" RT="3567.91069999998" >
+			<PeptideHit score="0.998900658395066" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264343261719" RT="3569.5548" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264343261719" RT="3569.5548" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264953613281" RT="3571.23700000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264953613281" RT="3571.23700000002" >
+			<PeptideHit score="0.999997404727025" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-08"/>
 				<UserParam type="float" name="nextscore" value="23.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997404727025"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="657.835998535156" RT="3572.91289999998" >
-			<PeptideHit score="0" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="657.835998535156" RT="3572.91289999998" >
+			<PeptideHit score="0.999999996474288" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="70.2"/>
 				<UserParam type="float" name="E-Value" value="2.2e-12"/>
 				<UserParam type="float" name="nextscore" value="22.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999996474288"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="657.836608886719" RT="3574.58830000002" >
-			<PeptideHit score="0" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="657.836608886719" RT="3574.58830000002" >
+			<PeptideHit score="0.999999916768411" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="70.3"/>
 				<UserParam type="float" name="E-Value" value="1.3e-10"/>
 				<UserParam type="float" name="nextscore" value="22.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999916768411"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="653.323913574219" RT="3593.61490000002" >
-			<PeptideHit score="0.0139416983523447" sequence="GSDPTGVTELSNK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_6" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="653.323913574219" RT="3593.61490000002" >
+			<PeptideHit score="0.28827458994223" sequence="GSDPTGVTELSNK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_6" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.26"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.28827458994223"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674377441406" RT="3595.29310000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674377441406" RT="3595.29310000002" >
+			<PeptideHit score="0.999998273774991" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.2"/>
 				<UserParam type="float" name="E-Value" value="6.5e-09"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998273774991"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673583984375" RT="3596.97379999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673583984375" RT="3596.97379999998" >
+			<PeptideHit score="0.999961245837018" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="3.6e-07"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999961245837018"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.247985839844" RT="3614.20939999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.247985839844" RT="3614.20939999998" >
+			<PeptideHit score="0.887940558151255" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.6"/>
 				<UserParam type="float" name="E-Value" value="0.009"/>
 				<UserParam type="float" name="nextscore" value="10.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.887940558151255"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265319824219" RT="3664.29160000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265319824219" RT="3664.29160000002" >
+			<PeptideHit score="0.999973542219251" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="2.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999973542219251"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854614257813" RT="3683.31340000002" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854614257813" RT="3683.31340000002" >
+			<PeptideHit score="0.999029002284869" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.2"/>
 				<UserParam type="float" name="E-Value" value="2.3e-05"/>
 				<UserParam type="float" name="nextscore" value="9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999029002284869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.305603027344" RT="3683.74009999998" >
-			<PeptideHit score="0" sequence="TIAQDYGVLK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="554.305603027344" RT="3683.74009999998" >
+			<PeptideHit score="0.976178644666495" sequence="TIAQDYGVLK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="19.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674499511719" RT="3687.39460000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674499511719" RT="3687.39460000002" >
+			<PeptideHit score="0.999999176872642" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.2"/>
 				<UserParam type="float" name="E-Value" value="2.5e-09"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999176872642"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674377441406" RT="3689.17159999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674377441406" RT="3689.17159999998" >
+			<PeptideHit score="0.999978334497071" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.6"/>
 				<UserParam type="float" name="E-Value" value="1.7e-07"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999978334497071"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="448.735076904297" RT="3703.11280000002" >
-			<PeptideHit score="0.00134408602150538" sequence="FLFEGQR" charge="2" aa_before="R" aa_after="I" protein_refs="PH_64" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="448.735076904297" RT="3703.11280000002" >
+			<PeptideHit score="0.575812066423463" sequence="FLFEGQR" charge="2" aa_before="R" aa_after="I" protein_refs="PH_64" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.3"/>
 				<UserParam type="float" name="E-Value" value="0.067"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.575812066423463"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="363.213470458984" RT="3707.03860000002" >
-			<PeptideHit score="0.00134408602150538" sequence="LRVDPVNFK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="363.213470458984" RT="3707.03860000002" >
+			<PeptideHit score="0.734542296491698" sequence="LRVDPVNFK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.1"/>
 				<UserParam type="float" name="E-Value" value="0.03"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.734542296491698"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="448.734985351563" RT="3713.2695" >
-			<PeptideHit score="0" sequence="FLFEGQR" charge="2" aa_before="R" aa_after="I" protein_refs="PH_64" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="448.734985351563" RT="3713.2695" >
+			<PeptideHit score="0.920445521361603" sequence="FLFEGQR" charge="2" aa_before="R" aa_after="I" protein_refs="PH_64" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.0058"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.920445521361603"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="363.213592529297" RT="3717.3747" >
-			<PeptideHit score="0.0151133501259446" sequence="LRVDPVNFK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="363.213592529297" RT="3717.3747" >
+			<PeptideHit score="0.262904122502352" sequence="LRVDPVNFK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.3"/>
 				<UserParam type="float" name="E-Value" value="0.3"/>
 				<UserParam type="float" name="nextscore" value="11.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.262904122502352"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785552978516" RT="3739.52020000002" >
-			<PeptideHit score="0.00134408602150538" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785552978516" RT="3739.52020000002" >
+			<PeptideHit score="0.771058061136823" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.5"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="20.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785125732422" RT="3741.72580000002" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785125732422" RT="3741.72580000002" >
+			<PeptideHit score="0.89569987641038" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.0082"/>
 				<UserParam type="float" name="nextscore" value="20.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.89569987641038"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674438476563" RT="3779.79280000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674438476563" RT="3779.79280000002" >
+			<PeptideHit score="0.999999932083572" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.1"/>
 				<UserParam type="float" name="E-Value" value="1e-10"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999932083572"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.305603027344" RT="3780.825" >
-			<PeptideHit score="0.02" sequence="TIAQDYGVLK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="554.305603027344" RT="3780.825" >
+			<PeptideHit score="0.237298523258975" sequence="TIAQDYGVLK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.6"/>
 				<UserParam type="float" name="E-Value" value="0.35"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.237298523258975"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674560546875" RT="3781.96690000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674560546875" RT="3781.96690000002" >
+			<PeptideHit score="0.999999857568655" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.1"/>
 				<UserParam type="float" name="E-Value" value="2.6e-10"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999857568655"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785186767578" RT="3832.4361" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785186767578" RT="3832.4361" >
+			<PeptideHit score="0.991389286083067" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.9"/>
 				<UserParam type="float" name="E-Value" value="0.00037"/>
 				<UserParam type="float" name="nextscore" value="24.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991389286083067"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784790039063" RT="3834.10480000002" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784790039063" RT="3834.10480000002" >
+			<PeptideHit score="0.977679598036381" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.9"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="590.814453125" RT="3834.363" >
-			<PeptideHit score="0" sequence="ISGLIYEETR" charge="2" aa_before="R" aa_after="G" protein_refs="PH_59" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="590.814453125" RT="3834.363" >
+			<PeptideHit score="0.973239129162826" sequence="ISGLIYEETR" charge="2" aa_before="R" aa_after="G" protein_refs="PH_59" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.9"/>
 				<UserParam type="float" name="E-Value" value="0.0015"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.973239129162826"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="590.814880371094" RT="3838.54390000002" >
-			<PeptideHit score="0" sequence="ISGLIYEETR" charge="2" aa_before="R" aa_after="G" protein_refs="PH_59" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="590.814880371094" RT="3838.54390000002" >
+			<PeptideHit score="0.984269703140117" sequence="ISGLIYEETR" charge="2" aa_before="R" aa_after="G" protein_refs="PH_59" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.8"/>
 				<UserParam type="float" name="E-Value" value="0.00078"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984269703140117"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.6748046875" RT="3876.85000000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.6748046875" RT="3876.85000000002" >
+			<PeptideHit score="0.998256357655817" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.8"/>
 				<UserParam type="float" name="E-Value" value="4.9e-05"/>
 				<UserParam type="float" name="nextscore" value="16.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998256357655817"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784942626953" RT="3889.4232" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784942626953" RT="3889.4232" >
+			<PeptideHit score="0.954315536242781" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.3"/>
 				<UserParam type="float" name="E-Value" value="0.0029"/>
 				<UserParam type="float" name="nextscore" value="20.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.954315536242781"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.617492675781" RT="3889.7091" >
-			<PeptideHit score="0" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.617492675781" RT="3889.7091" >
+			<PeptideHit score="0.998597011971812" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44"/>
 				<UserParam type="float" name="E-Value" value="3.7e-05"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998597011971812"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785614013672" RT="3891.18259999998" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785614013672" RT="3891.18259999998" >
+			<PeptideHit score="0.939634346039965" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.9"/>
 				<UserParam type="float" name="E-Value" value="0.0041"/>
 				<UserParam type="float" name="nextscore" value="24.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.939634346039965"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265014648438" RT="3900.3774" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265014648438" RT="3900.3774" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.917755126953" RT="3910.2657" >
-			<PeptideHit score="0.0489844683393071" sequence="SSHHVNPLSTETGR" charge="3" aa_before="[" aa_after="G" protein_refs="PH_122" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.917755126953" RT="3910.2657" >
+			<PeptideHit score="0.0969386199829794" sequence="SSHHVNPLSTETGR" charge="3" aa_before="[" aa_after="G" protein_refs="PH_122" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.61669921875" RT="3922.03789999998" >
-			<PeptideHit score="0" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.61669921875" RT="3922.03789999998" >
+			<PeptideHit score="0.982332435437406" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.7"/>
 				<UserParam type="float" name="E-Value" value="0.0009"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.982332435437406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.617736816406" RT="3923.80009999998" >
-			<PeptideHit score="0" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.617736816406" RT="3923.80009999998" >
+			<PeptideHit score="0.996488921991653" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.7"/>
 				<UserParam type="float" name="E-Value" value="0.00012"/>
 				<UserParam type="float" name="nextscore" value="17.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996488921991653"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674011230469" RT="3927.31900000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674011230469" RT="3927.31900000002" >
+			<PeptideHit score="0.984269703140117" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.4"/>
 				<UserParam type="float" name="E-Value" value="0.00078"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984269703140117"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673095703125" RT="3929.085" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673095703125" RT="3929.085" >
+			<PeptideHit score="0.917217114482157" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.5"/>
 				<UserParam type="float" name="E-Value" value="0.0061"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.917217114482157"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784515380859" RT="3967.38949999998" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784515380859" RT="3967.38949999998" >
+			<PeptideHit score="0.919364632593739" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="0.0059"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.919364632593739"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.78466796875" RT="3969.08869999998" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.78466796875" RT="3969.08869999998" >
+			<PeptideHit score="0.869435996707529" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.011"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.869435996707529"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265075683594" RT="3992.80369999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265075683594" RT="3992.80369999998" >
+			<PeptideHit score="0.999938007838369" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.2"/>
 				<UserParam type="float" name="E-Value" value="6.6e-07"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999938007838369"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.2646484375" RT="3994.56700000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.2646484375" RT="3994.56700000002" >
+			<PeptideHit score="0.99989516753533" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="1.3e-06"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99989516753533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673461914063" RT="4026.01870000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673461914063" RT="4026.01870000002" >
+			<PeptideHit score="0.999907897771499" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.8"/>
 				<UserParam type="float" name="E-Value" value="1.1e-06"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999907897771499"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673522949219" RT="4029.49069999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673522949219" RT="4029.49069999998" >
+			<PeptideHit score="0.99989516753533" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="1.3e-06"/>
 				<UserParam type="float" name="nextscore" value="20.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99989516753533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.314697265625" RT="4033.5678" >
-			<PeptideHit score="0.00134408602150538" sequence="IVRSSSSTGQK" charge="2" aa_before="K" aa_after="N" protein_refs="PH_5" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.314697265625" RT="4033.5678" >
+			<PeptideHit score="0.563155621027287" sequence="IVRSSSSTGQK" charge="2" aa_before="K" aa_after="N" protein_refs="PH_5" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27"/>
 				<UserParam type="float" name="E-Value" value="0.071"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.563155621027287"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784698486328" RT="4060.56400000002" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784698486328" RT="4060.56400000002" >
+			<PeptideHit score="0.869435996707529" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.2"/>
 				<UserParam type="float" name="E-Value" value="0.011"/>
 				<UserParam type="float" name="nextscore" value="21.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.869435996707529"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784576416016" RT="4062.2397" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784576416016" RT="4062.2397" >
+			<PeptideHit score="0.943202686631416" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.5"/>
 				<UserParam type="float" name="E-Value" value="0.0038"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.943202686631416"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="449.229156494141" RT="4067.7576" >
-			<PeptideHit score="0.0363636363636364" sequence="MEQFKSK" charge="2" aa_before="R" aa_after="L" protein_refs="PH_138" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="449.229156494141" RT="4067.7576" >
+			<PeptideHit score="0.160401285042504" sequence="MEQFKSK" charge="2" aa_before="R" aa_after="L" protein_refs="PH_138" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="18.5"/>
 				<UserParam type="float" name="E-Value" value="0.61"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.160401285042504"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264770507813" RT="4071.6372" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264770507813" RT="4071.6372" >
+			<PeptideHit score="0.999932970501854" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45"/>
 				<UserParam type="float" name="E-Value" value="7.3e-07"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999932970501854"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264770507813" RT="4073.17729999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264770507813" RT="4073.17729999998" >
+			<PeptideHit score="0.999934398186429" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="7.1e-07"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999934398186429"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673217773438" RT="4097.9523" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673217773438" RT="4097.9523" >
+			<PeptideHit score="0.998093027078404" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.6"/>
 				<UserParam type="float" name="E-Value" value="5.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998093027078404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784362792969" RT="4103.2089" >
-			<PeptideHit score="0.00526315789473684" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784362792969" RT="4103.2089" >
+			<PeptideHit score="0.500962368004618" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.3"/>
 				<UserParam type="float" name="E-Value" value="0.094"/>
 				<UserParam type="float" name="nextscore" value="27.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.500962368004618"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674499511719" RT="4104.97150000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674499511719" RT="4104.97150000002" >
+			<PeptideHit score="0.99998453888027" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-07"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998453888027"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311157226563" RT="4122.87259999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311157226563" RT="4122.87259999998" >
+			<PeptideHit score="0.999998908036975" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-09"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998908036975"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311767578125" RT="4124.64259999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311767578125" RT="4124.64259999998" >
+			<PeptideHit score="0.999870942238288" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="1.7e-06"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999870942238288"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.26416015625" RT="4128.171" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.26416015625" RT="4128.171" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264404296875" RT="4129.94170000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264404296875" RT="4129.94170000002" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.1"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673706054688" RT="4149.13249999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673706054688" RT="4149.13249999998" >
+			<PeptideHit score="0.999970786631432" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.7"/>
 				<UserParam type="float" name="E-Value" value="2.5e-07"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999970786631432"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673767089844" RT="4150.9557" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673767089844" RT="4150.9557" >
+			<PeptideHit score="0.99988897055048" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.4"/>
 				<UserParam type="float" name="E-Value" value="1.4e-06"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99988897055048"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785461425781" RT="4189.01980000002" >
-			<PeptideHit score="0.00402684563758389" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785461425781" RT="4189.01980000002" >
+			<PeptideHit score="0.510657972604375" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.4"/>
 				<UserParam type="float" name="E-Value" value="0.09"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.510657972604375"/>
+				<UserParam type="float" name="q-value" value="0.00402684563758389"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784271240234" RT="4195.44559999998" >
-			<PeptideHit score="0.00134408602150538" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784271240234" RT="4195.44559999998" >
+			<PeptideHit score="0.582385925569071" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="0.065"/>
 				<UserParam type="float" name="nextscore" value="22.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.582385925569071"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311279296875" RT="4220.3067" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311279296875" RT="4220.3067" >
+			<PeptideHit score="0.999998884600159" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="3.7e-09"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998884600159"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264953613281" RT="4220.67790000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264953613281" RT="4220.67790000002" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311340332031" RT="4221.97729999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311340332031" RT="4221.97729999998" >
+			<PeptideHit score="0.999999533975387" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.3"/>
 				<UserParam type="float" name="E-Value" value="1.2e-09"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999533975387"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264831542969" RT="4222.2387" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264831542969" RT="4222.2387" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="644.834838867188" RT="4245.59050000002" >
-			<PeptideHit score="0" sequence="ASAELIEEEVAK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="644.834838867188" RT="4245.59050000002" >
+			<PeptideHit score="0.999999307602226" sequence="ASAELIEEEVAK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.7"/>
 				<UserParam type="float" name="E-Value" value="2e-09"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999307602226"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="644.834899902344" RT="4254.37099999998" >
-			<PeptideHit score="0" sequence="ASAELIEEEVAK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="644.834899902344" RT="4254.37099999998" >
+			<PeptideHit score="0.99999349467219" sequence="ASAELIEEEVAK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.5"/>
 				<UserParam type="float" name="E-Value" value="3.6e-08"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999349467219"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.801696777344" RT="4269.96970000002" >
-			<PeptideHit score="0.00526315789473684" sequence="(Gln->pyro-Glu)QSQTEGAEILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_117" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.801696777344" RT="4269.96970000002" >
+			<PeptideHit score="0.505758287449657" sequence="(Gln->pyro-Glu)QSQTEGAEILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_117" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.092"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.505758287449657"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784606933594" RT="4287.4701" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784606933594" RT="4287.4701" >
+			<PeptideHit score="0.948061393923557" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="0.0034"/>
 				<UserParam type="float" name="nextscore" value="21.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.948061393923557"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784637451172" RT="4291.344" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784637451172" RT="4291.344" >
+			<PeptideHit score="0.97469904242467" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39"/>
 				<UserParam type="float" name="E-Value" value="0.0014"/>
 				<UserParam type="float" name="nextscore" value="18.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97469904242467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311279296875" RT="4313.8815" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311279296875" RT="4313.8815" >
+			<PeptideHit score="0.999999307602226" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.3"/>
 				<UserParam type="float" name="E-Value" value="2e-09"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999307602226"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264526367188" RT="4314.23290000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264526367188" RT="4314.23290000002" >
+			<PeptideHit score="0.999937281120465" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.2"/>
 				<UserParam type="float" name="E-Value" value="6.7e-07"/>
 				<UserParam type="float" name="nextscore" value="23.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999937281120465"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.31103515625" RT="4315.86250000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.31103515625" RT="4315.86250000002" >
+			<PeptideHit score="0.999996363252076" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="1.7e-08"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996363252076"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264709472656" RT="4316.16409999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264709472656" RT="4316.16409999998" >
+			<PeptideHit score="0.999973542219251" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.1"/>
 				<UserParam type="float" name="E-Value" value="2.2e-07"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999973542219251"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.6748046875" RT="4345.92700000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.6748046875" RT="4345.92700000002" >
+			<PeptideHit score="0.995160070637582" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.1"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674682617188" RT="4347.61069999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674682617188" RT="4347.61069999998" >
+			<PeptideHit score="0.999970786631432" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="2.5e-07"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999970786631432"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784912109375" RT="4381.86820000002" >
-			<PeptideHit score="0.00134408602150538" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784912109375" RT="4381.86820000002" >
+			<PeptideHit score="0.523385410522023" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.2"/>
 				<UserParam type="float" name="E-Value" value="0.085"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.523385410522023"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784698486328" RT="4385.62090000002" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784698486328" RT="4385.62090000002" >
+			<PeptideHit score="0.835623332778618" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.2"/>
 				<UserParam type="float" name="E-Value" value="0.015"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.835623332778618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311584472656" RT="4407.51670000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311584472656" RT="4407.51670000002" >
+			<PeptideHit score="0.999693069772492" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.4"/>
 				<UserParam type="float" name="E-Value" value="5.2e-06"/>
 				<UserParam type="float" name="nextscore" value="26.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999693069772492"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265319824219" RT="4407.9087" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265319824219" RT="4407.9087" >
+			<PeptideHit score="0.999998232748558" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="6.7e-09"/>
 				<UserParam type="float" name="nextscore" value="23.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998232748558"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311218261719" RT="4409.18239999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311218261719" RT="4409.18239999998" >
+			<PeptideHit score="0.999998315086412" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="6.3e-09"/>
 				<UserParam type="float" name="nextscore" value="23.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998315086412"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264465332031" RT="4409.53459999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264465332031" RT="4409.53459999998" >
+			<PeptideHit score="0.999997404727025" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-08"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997404727025"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673156738281" RT="4437.93979999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673156738281" RT="4437.93979999998" >
+			<PeptideHit score="0.99959657949333" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38"/>
 				<UserParam type="float" name="E-Value" value="7.4e-06"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99959657949333"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="505.920593261719" RT="4453.8546" >
-			<PeptideHit score="0.00134408602150538" sequence="IWHHTFYNELR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_0 PH_34 PH_35 PH_57 PH_65 PH_66 PH_67 PH_96 PH_130" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="505.920593261719" RT="4453.8546" >
+			<PeptideHit score="0.771058061136823" sequence="IWHHTFYNELR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_0 PH_34 PH_35 PH_57 PH_65 PH_66 PH_67 PH_96 PH_130" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.4"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674133300781" RT="4454.3895" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674133300781" RT="4454.3895" >
+			<PeptideHit score="0.999859324618151" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.5"/>
 				<UserParam type="float" name="E-Value" value="1.9e-06"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999859324618151"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.961486816406" RT="4477.93729999998" >
-			<PeptideHit score="0.00134408602150538" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.961486816406" RT="4477.93729999998" >
+			<PeptideHit score="0.536846435265042" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.7"/>
 				<UserParam type="float" name="E-Value" value="0.08"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.536846435265042"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310791015625" RT="4500.50569999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310791015625" RT="4500.50569999998" >
+			<PeptideHit score="0.999995403129308" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="2.3e-08"/>
 				<UserParam type="float" name="nextscore" value="26.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995403129308"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264465332031" RT="4500.8346" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264465332031" RT="4500.8346" >
+			<PeptideHit score="0.951788100541034" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.5"/>
 				<UserParam type="float" name="E-Value" value="0.0031"/>
 				<UserParam type="float" name="nextscore" value="22.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.951788100541034"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311340332031" RT="4502.22790000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311340332031" RT="4502.22790000002" >
+			<PeptideHit score="0.999997404727025" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-08"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997404727025"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265075683594" RT="4502.85949999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265075683594" RT="4502.85949999998" >
+			<PeptideHit score="0.999643869513167" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.3"/>
 				<UserParam type="float" name="E-Value" value="6.3e-06"/>
 				<UserParam type="float" name="nextscore" value="20.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999643869513167"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="816.938354492188" RT="4521.2373" >
-			<PeptideHit score="0.0363636363636364" sequence="VEADIPGHGQEVLIR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="816.938354492188" RT="4521.2373" >
+			<PeptideHit score="0.166398718169042" sequence="VEADIPGHGQEVLIR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.6"/>
 				<UserParam type="float" name="E-Value" value="0.58"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.166398718169042"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.300903320313" RT="4525.07209999998" >
-			<PeptideHit score="0" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.300903320313" RT="4525.07209999998" >
+			<PeptideHit score="0.991389286083067" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.9"/>
 				<UserParam type="float" name="E-Value" value="0.00037"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991389286083067"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.301391601563" RT="4526.74390000002" >
-			<PeptideHit score="0" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.301391601563" RT="4526.74390000002" >
+			<PeptideHit score="0.798085201014666" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28"/>
 				<UserParam type="float" name="E-Value" value="0.02"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.798085201014666"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="816.939819335938" RT="4528.4013" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="816.939819335938" RT="4528.4013" >
+			<PeptideHit score="0.995592056829865" sequence="VEADIPGHGQEVLIR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.9"/>
 				<UserParam type="float" name="E-Value" value="0.00016"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995592056829865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="555.248840332031" RT="4545.66490000002" >
-			<PeptideHit score="0" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="555.248840332031" RT="4545.66490000002" >
+			<PeptideHit score="0.966191334252643" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.9"/>
 				<UserParam type="float" name="E-Value" value="0.002"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.966191334252643"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="555.248413085938" RT="4547.33350000002" >
-			<PeptideHit score="0" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="555.248413085938" RT="4547.33350000002" >
+			<PeptideHit score="0.989024704232947" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.3"/>
 				<UserParam type="float" name="E-Value" value="0.0005"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989024704232947"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674743652344" RT="4551.0657" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674743652344" RT="4551.0657" >
+			<PeptideHit score="0.997471491901146" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.6"/>
 				<UserParam type="float" name="E-Value" value="7.9e-05"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997471491901146"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.961547851563" RT="4568.12590000002" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.961547851563" RT="4568.12590000002" >
+			<PeptideHit score="0.99955085527733" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="8.5e-06"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99955085527733"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.96142578125" RT="4569.86869999998" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.96142578125" RT="4569.86869999998" >
+			<PeptideHit score="0.827735811978521" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.8"/>
 				<UserParam type="float" name="E-Value" value="0.016"/>
 				<UserParam type="float" name="nextscore" value="10.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.827735811978521"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.340698242188" RT="4587.39619999998" >
-			<PeptideHit score="0.00526315789473684" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.340698242188" RT="4587.39619999998" >
+			<PeptideHit score="0.446677932430767" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.12"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.446677932430767"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.3408203125" RT="4589.17219999998" >
-			<PeptideHit score="0" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.3408203125" RT="4589.17219999998" >
+			<PeptideHit score="0.85204760460282" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.3"/>
 				<UserParam type="float" name="E-Value" value="0.013"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.85204760460282"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310424804688" RT="4592.9355" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310424804688" RT="4592.9355" >
+			<PeptideHit score="0.995160070637582" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.5"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="24.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.3115234375" RT="4594.60219999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.3115234375" RT="4594.60219999998" >
+			<PeptideHit score="0.99982061767054" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.8"/>
 				<UserParam type="float" name="E-Value" value="2.6e-06"/>
 				<UserParam type="float" name="nextscore" value="23.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99982061767054"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.300415039063" RT="4618.0851" >
-			<PeptideHit score="0" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.300415039063" RT="4618.0851" >
+			<PeptideHit score="0.954315536242781" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.6"/>
 				<UserParam type="float" name="E-Value" value="0.0029"/>
 				<UserParam type="float" name="nextscore" value="18.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.954315536242781"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="763.729614257813" RT="4625.2275" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIKTSETK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="763.729614257813" RT="4625.2275" >
+			<PeptideHit score="0.964825445057631" sequence="LYPIANGNNQSPVDIKTSETK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.9"/>
 				<UserParam type="float" name="E-Value" value="0.0021"/>
 				<UserParam type="float" name="nextscore" value="9.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.964825445057631"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="763.729553222656" RT="4627.66390000002" >
-			<PeptideHit score="0.0151133501259446" sequence="LYPIANGNNQSPVDIKTSETK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="763.729553222656" RT="4627.66390000002" >
+			<PeptideHit score="0.257305155260055" sequence="LYPIANGNNQSPVDIKTSETK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.3"/>
 				<UserParam type="float" name="E-Value" value="0.31"/>
 				<UserParam type="float" name="nextscore" value="8.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.257305155260055"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="555.247863769531" RT="4639.07959999998" >
-			<PeptideHit score="0" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="555.247863769531" RT="4639.07959999998" >
+			<PeptideHit score="0.991765444794236" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.3"/>
 				<UserParam type="float" name="E-Value" value="0.00035"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991765444794236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="555.247741699219" RT="4640.87140000002" >
-			<PeptideHit score="0" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="555.247741699219" RT="4640.87140000002" >
+			<PeptideHit score="0.970372889310467" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.2"/>
 				<UserParam type="float" name="E-Value" value="0.0017"/>
 				<UserParam type="float" name="nextscore" value="8.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.970372889310467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.96142578125" RT="4653.70030000002" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.96142578125" RT="4653.70030000002" >
+			<PeptideHit score="0.991765444794236" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.7"/>
 				<UserParam type="float" name="E-Value" value="0.00035"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991765444794236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.340942382813" RT="4679.9703" >
-			<PeptideHit score="0" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.340942382813" RT="4679.9703" >
+			<PeptideHit score="0.997906967138569" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="6.2e-05"/>
 				<UserParam type="float" name="nextscore" value="20.2"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997906967138569"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.340698242188" RT="4681.44010000002" >
-			<PeptideHit score="0" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.340698242188" RT="4681.44010000002" >
+			<PeptideHit score="0.996958329726846" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.5"/>
 				<UserParam type="float" name="E-Value" value="0.0001"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996958329726846"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.31103515625" RT="4685.1963" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.31103515625" RT="4685.1963" >
+			<PeptideHit score="0.999934398186429" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="7.1e-07"/>
 				<UserParam type="float" name="nextscore" value="26.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999934398186429"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.31103515625" RT="4686.8703" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.31103515625" RT="4686.8703" >
+			<PeptideHit score="0.999571462358373" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.6"/>
 				<UserParam type="float" name="E-Value" value="8e-06"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999571462358373"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264953613281" RT="4687.39840000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264953613281" RT="4687.39840000002" >
+			<PeptideHit score="0.999992941150764" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.1"/>
 				<UserParam type="float" name="E-Value" value="4e-08"/>
 				<UserParam type="float" name="nextscore" value="29.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999992941150764"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264282226563" RT="4688.5404" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264282226563" RT="4688.5404" >
+			<PeptideHit score="0.994321746497951" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="537.314086914063" RT="4716.7293" >
-			<PeptideHit score="0.00134408602150538" sequence="ATVQAVLGPLALETAR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_1 PH_89" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="537.314086914063" RT="4716.7293" >
+			<PeptideHit score="0.61801152613314" sequence="ATVQAVLGPLALETAR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_1 PH_89" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.2"/>
 				<UserParam type="float" name="E-Value" value="0.055"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.61801152613314"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="436.563751220703" RT="4729.95289999998" >
-			<PeptideHit score="0.0151133501259446" sequence="IKFEMEQNLR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_49" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="436.563751220703" RT="4729.95289999998" >
+			<PeptideHit score="0.262904122502352" sequence="IKFEMEQNLR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_49" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.8"/>
 				<UserParam type="float" name="E-Value" value="0.3"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.262904122502352"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="436.564361572266" RT="4745.04529999998" >
-			<PeptideHit score="0.00134408602150538" sequence="IKFEMEQNLR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_49" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="436.564361572266" RT="4745.04529999998" >
+			<PeptideHit score="0.654692624849357" sequence="IKFEMEQNLR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_49" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.2"/>
 				<UserParam type="float" name="E-Value" value="0.046"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.654692624849357"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.962463378906" RT="4750.05529999998" >
-			<PeptideHit score="0.0342298288508557" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.962463378906" RT="4750.05529999998" >
+			<PeptideHit score="0.180044603065486" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.9"/>
 				<UserParam type="float" name="E-Value" value="0.52"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.180044603065486"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.961181640625" RT="4752.36430000002" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.961181640625" RT="4752.36430000002" >
+			<PeptideHit score="0.918288520543892" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.4"/>
 				<UserParam type="float" name="E-Value" value="0.006"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.918288520543892"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.33984375" RT="4773.2196" >
-			<PeptideHit score="0.0444711538461538" sequence="SPQQSAALPRR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_94" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.33984375" RT="4773.2196" >
+			<PeptideHit score="0.103478204192389" sequence="SPQQSAALPRR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_94" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="17.3"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310913085938" RT="4778.391" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310913085938" RT="4778.391" >
+			<PeptideHit score="0.996721562845727" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.1"/>
 				<UserParam type="float" name="E-Value" value="0.00011"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996721562845727"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311218261719" RT="4780.10140000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311218261719" RT="4780.10140000002" >
+			<PeptideHit score="0.999657080608143" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="6e-06"/>
 				<UserParam type="float" name="nextscore" value="26.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999657080608143"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265014648438" RT="4780.73020000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265014648438" RT="4780.73020000002" >
+			<PeptideHit score="0.999998440846017" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.5"/>
 				<UserParam type="float" name="E-Value" value="5.7e-09"/>
 				<UserParam type="float" name="nextscore" value="22.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998440846017"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264465332031" RT="4782.51100000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264465332031" RT="4782.51100000002" >
+			<PeptideHit score="0.999930141176823" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45"/>
 				<UserParam type="float" name="E-Value" value="7.7e-07"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999930141176823"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="500.805084228516" RT="4801.3077" >
-			<PeptideHit score="0.00906735751295337" sequence="QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="500.805084228516" RT="4801.3077" >
+			<PeptideHit score="0.359831619897065" sequence="QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="16"/>
 				<UserParam type="float" name="E-Value" value="0.18"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.359831619897065"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310668945313" RT="4872.7377" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310668945313" RT="4872.7377" >
+			<PeptideHit score="0.998964248012865" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="2.5e-05"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998964248012865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.263977050781" RT="4873.3338" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.263977050781" RT="4873.3338" >
+			<PeptideHit score="0.999744693880245" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="4.1e-06"/>
 				<UserParam type="float" name="nextscore" value="23"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999744693880245"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.263916015625" RT="4876.77910000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.263916015625" RT="4876.77910000002" >
+			<PeptideHit score="0.999901472880047" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="1.2e-06"/>
 				<UserParam type="float" name="nextscore" value="20.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999901472880047"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.2900390625" RT="4882.82290000002" >
-			<PeptideHit score="0.0151133501259446" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.2900390625" RT="4882.82290000002" >
+			<PeptideHit score="0.262904122502352" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.7"/>
 				<UserParam type="float" name="E-Value" value="0.3"/>
 				<UserParam type="float" name="nextscore" value="11.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.262904122502352"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="500.805572509766" RT="4895.1642" >
-			<PeptideHit score="0.00134408602150538" sequence="QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="500.805572509766" RT="4895.1642" >
+			<PeptideHit score="0.752250699877261" sequence="QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="16.1"/>
 				<UserParam type="float" name="E-Value" value="0.027"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.752250699877261"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310913085938" RT="4965.444" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310913085938" RT="4965.444" >
+			<PeptideHit score="0.998715907376379" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="3.3e-05"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998715907376379"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311157226563" RT="4967.10649999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311157226563" RT="4967.10649999998" >
+			<PeptideHit score="0.994736999948131" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.4"/>
 				<UserParam type="float" name="E-Value" value="0.0002"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994736999948131"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264770507813" RT="4967.7381" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264770507813" RT="4967.7381" >
+			<PeptideHit score="0.999973542219251" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.1"/>
 				<UserParam type="float" name="E-Value" value="2.2e-07"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999973542219251"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264465332031" RT="4968.87850000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264465332031" RT="4968.87850000002" >
+			<PeptideHit score="0.999997404727025" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-08"/>
 				<UserParam type="float" name="nextscore" value="26"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997404727025"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289367675781" RT="4981.9851" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289367675781" RT="4981.9851" >
+			<PeptideHit score="0.998900658395066" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289093017578" RT="4983.65029999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289093017578" RT="4983.65029999998" >
+			<PeptideHit score="0.999789303075987" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="3.2e-06"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999789303075987"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.641723632813" RT="4985.32219999998" >
-			<PeptideHit score="0.00526315789473684" sequence="KYAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.641723632813" RT="4985.32219999998" >
+			<PeptideHit score="0.465947082204611" sequence="KYAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.11"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.465947082204611"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.642150878906" RT="4987.07440000002" >
-			<PeptideHit score="0.0342298288508557" sequence="KYAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.642150878906" RT="4987.07440000002" >
+			<PeptideHit score="0.180044603065486" sequence="KYAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.6"/>
 				<UserParam type="float" name="E-Value" value="0.52"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.180044603065486"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763519287109" RT="5031.44959999998" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763519287109" RT="5031.44959999998" >
+			<PeptideHit score="0.976178644666495" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.3"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.318054199219" RT="5038.92850000002" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.318054199219" RT="5038.92850000002" >
+			<PeptideHit score="0.998228864915851" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.3"/>
 				<UserParam type="float" name="E-Value" value="5e-05"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998228864915851"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.315307617188" RT="5040.5739" >
-			<PeptideHit score="0.029520295202952" sequence="LFIESLFTISQITK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_108" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.315307617188" RT="5040.5739" >
+			<PeptideHit score="0.193496525438801" sequence="LFIESLFTISQITK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_108" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311889648438" RT="5059.29460000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311889648438" RT="5059.29460000002" >
+			<PeptideHit score="0.999490594071398" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.4"/>
 				<UserParam type="float" name="E-Value" value="1e-05"/>
 				<UserParam type="float" name="nextscore" value="24"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999490594071398"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="820.471618652344" RT="5073.9501" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="820.471618652344" RT="5073.9501" >
+			<PeptideHit score="0.999413322128202" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.9"/>
 				<UserParam type="float" name="E-Value" value="1.2e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999413322128202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290283203125" RT="5076.25099999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290283203125" RT="5076.25099999998" >
+			<PeptideHit score="0.881325320475085" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.2"/>
 				<UserParam type="float" name="E-Value" value="0.0097"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.881325320475085"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289794921875" RT="5079.9057" >
-			<PeptideHit score="0.00134408602150538" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289794921875" RT="5079.9057" >
+			<PeptideHit score="0.69188890216611" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.2"/>
 				<UserParam type="float" name="E-Value" value="0.038"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.69188890216611"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.287261962891" RT="5081.14189999998" >
-			<PeptideHit score="0.00134408602150538" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="501.287261962891" RT="5081.14189999998" >
+			<PeptideHit score="0.534092302192569" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.6"/>
 				<UserParam type="float" name="E-Value" value="0.081"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.534092302192569"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.286651611328" RT="5082.92020000002" >
-			<PeptideHit score="0" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="501.286651611328" RT="5082.92020000002" >
+			<PeptideHit score="0.820048379204749" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.7"/>
 				<UserParam type="float" name="E-Value" value="0.017"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.820048379204749"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763916015625" RT="5104.194" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763916015625" RT="5104.194" >
+			<PeptideHit score="0.979203874797132" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.6"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763336181641" RT="5105.94670000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763336181641" RT="5105.94670000002" >
+			<PeptideHit score="0.991576891487535" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.3"/>
 				<UserParam type="float" name="E-Value" value="0.00036"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991576891487535"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317565917969" RT="5107.70740000002" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317565917969" RT="5107.70740000002" >
+			<PeptideHit score="0.999999474833695" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56"/>
 				<UserParam type="float" name="E-Value" value="1.4e-09"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999474833695"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.318115234375" RT="5109.8472" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.318115234375" RT="5109.8472" >
+			<PeptideHit score="0.999998253226817" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.2"/>
 				<UserParam type="float" name="E-Value" value="6.6e-09"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998253226817"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.760894775391" RT="5110.11289999998" >
-			<PeptideHit score="0.00651890482398957" sequence="TPLDVLSR" charge="2" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.760894775391" RT="5110.11289999998" >
+			<PeptideHit score="0.398109626639983" sequence="TPLDVLSR" charge="2" >
 				<UserParam type="string" name="target_decoy" value=""/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.15"/>
 				<UserParam type="float" name="nextscore" value="22"/>
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.398109626639983"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="820.473693847656" RT="5111.67139999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="820.473693847656" RT="5111.67139999998" >
+			<PeptideHit score="0.999999926876528" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.1"/>
 				<UserParam type="float" name="E-Value" value="1.1e-10"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999926876528"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="820.473693847656" RT="5113.4319" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="820.473693847656" RT="5113.4319" >
+			<PeptideHit score="0.999998635280842" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.8"/>
 				<UserParam type="float" name="E-Value" value="4.8e-09"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998635280842"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.76171875" RT="5143.0005" >
-			<PeptideHit score="0.0224159402241594" sequence="TPLDVLSR" charge="2" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.76171875" RT="5143.0005" >
+			<PeptideHit score="0.220425809510344" sequence="TPLDVLSR" charge="2" >
 				<UserParam type="string" name="target_decoy" value=""/>
 				<UserParam type="float" name="XTandem_score" value="21.4"/>
 				<UserParam type="float" name="E-Value" value="0.39"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.220425809510344"/>
+				<UserParam type="float" name="q-value" value="0.0224159402241594"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.764251708984" RT="5188.09630000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.764251708984" RT="5188.09630000002" >
+			<PeptideHit score="0.976178644666495" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.3"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310607910156" RT="5188.37209999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310607910156" RT="5188.37209999998" >
+			<PeptideHit score="0.991765444794236" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.6"/>
 				<UserParam type="float" name="E-Value" value="0.00035"/>
 				<UserParam type="float" name="nextscore" value="19.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991765444794236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763549804688" RT="5189.8194" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763549804688" RT="5189.8194" >
+			<PeptideHit score="0.977679598036381" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.8"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.3115234375" RT="5191.58449999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.3115234375" RT="5191.58449999998" >
+			<PeptideHit score="0.928151979218034" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="0.0051"/>
 				<UserParam type="float" name="nextscore" value="24.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.928151979218034"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.286590576172" RT="5192.08330000002" >
-			<PeptideHit score="0.0259259259259259" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="501.286590576172" RT="5192.08330000002" >
+			<PeptideHit score="0.209402044145386" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19"/>
 				<UserParam type="float" name="E-Value" value="0.42"/>
 				<UserParam type="float" name="nextscore" value="11.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.209402044145386"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317626953125" RT="5200.88119999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317626953125" RT="5200.88119999998" >
+			<PeptideHit score="0.999932970501854" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.1"/>
 				<UserParam type="float" name="E-Value" value="7.3e-07"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999932970501854"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317687988281" RT="5202.64699999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317687988281" RT="5202.64699999998" >
+			<PeptideHit score="0.999749532301869" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43"/>
 				<UserParam type="float" name="E-Value" value="4e-06"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999749532301869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.28955078125" RT="5208.29539999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.28955078125" RT="5208.29539999998" >
+			<PeptideHit score="0.945617006442802" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.7"/>
 				<UserParam type="float" name="E-Value" value="0.0036"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.945617006442802"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289733886719" RT="5222.41099999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289733886719" RT="5222.41099999998" >
+			<PeptideHit score="0.878537248230859" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.01"/>
 				<UserParam type="float" name="nextscore" value="12.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.878537248230859"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957641601563" RT="5240.41219999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957641601563" RT="5240.41219999998" >
+			<PeptideHit score="0.999999533975387" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.1"/>
 				<UserParam type="float" name="E-Value" value="1.2e-09"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999533975387"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.954772949219" RT="5242.1217" >
-			<PeptideHit score="0" sequence="RCAVLQATGGVEPAGWK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_103" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.954772949219" RT="5242.1217" >
+			<PeptideHit score="0.898667716126141" sequence="RCAVLQATGGVEPAGWK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_103" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="0.0079"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.898667716126141"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763519287109" RT="5273.4504" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763519287109" RT="5273.4504" >
+			<PeptideHit score="0.998012734633761" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.3"/>
 				<UserParam type="float" name="E-Value" value="5.8e-05"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998012734633761"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.639953613281" RT="5274.03229999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.639953613281" RT="5274.03229999998" >
+			<PeptideHit score="0.999302633161889" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.2"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763763427734" RT="5276.0064" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763763427734" RT="5276.0064" >
+			<PeptideHit score="0.995592056829865" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.2"/>
 				<UserParam type="float" name="E-Value" value="0.00016"/>
 				<UserParam type="float" name="nextscore" value="17"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995592056829865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311340332031" RT="5278.33819999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311340332031" RT="5278.33819999998" >
+			<PeptideHit score="0.979203874797132" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="21.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317993164063" RT="5283.1701" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317993164063" RT="5283.1701" >
+			<PeptideHit score="0.999996699477478" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.2"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317443847656" RT="5284.9389" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317443847656" RT="5284.9389" >
+			<PeptideHit score="0.99999147861159" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.2"/>
 				<UserParam type="float" name="E-Value" value="5.1e-08"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999147861159"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799774169922" RT="5299.64569999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799774169922" RT="5299.64569999998" >
+			<PeptideHit score="0.999923207531055" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="8.7e-07"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999923207531055"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800323486328" RT="5301.40390000002" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800323486328" RT="5301.40390000002" >
+			<PeptideHit score="0.982173192499341" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="0.00091"/>
 				<UserParam type="float" name="nextscore" value="19.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.982173192499341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="514.245422363281" RT="5303.1687" >
-			<PeptideHit score="0.0342298288508557" sequence="GETTSSETGLSTDVR" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_110" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="514.245422363281" RT="5303.1687" >
+			<PeptideHit score="0.182566859658893" sequence="GETTSSETGLSTDVR" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_110" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="19.6"/>
 				<UserParam type="float" name="E-Value" value="0.51"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.182566859658893"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958312988281" RT="5312.2761" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958312988281" RT="5312.2761" >
+			<PeptideHit score="0.99999994231739" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60"/>
 				<UserParam type="float" name="E-Value" value="8.1e-11"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999994231739"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957458496094" RT="5314.04359999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957458496094" RT="5314.04359999998" >
+			<PeptideHit score="0.999999763559957" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="62"/>
 				<UserParam type="float" name="E-Value" value="5e-10"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999763559957"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.764221191406" RT="5337.12220000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.764221191406" RT="5337.12220000002" >
+			<PeptideHit score="0.988320713282031" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.6"/>
 				<UserParam type="float" name="E-Value" value="0.00054"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.988320713282031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.640441894531" RT="5338.7985" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.640441894531" RT="5338.7985" >
+			<PeptideHit score="0.999983460247774" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.1"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="19.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.316711425781" RT="5346.891" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.316711425781" RT="5346.891" >
+			<PeptideHit score="0.999946176746281" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.5"/>
 				<UserParam type="float" name="E-Value" value="5.5e-07"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946176746281"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311828613281" RT="5349.4911" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311828613281" RT="5349.4911" >
+			<PeptideHit score="0.968964271876771" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.7"/>
 				<UserParam type="float" name="E-Value" value="0.0018"/>
 				<UserParam type="float" name="nextscore" value="26.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.968964271876771"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.95849609375" RT="5382.08479999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.95849609375" RT="5382.08479999998" >
+			<PeptideHit score="0.999999941216531" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.6"/>
 				<UserParam type="float" name="E-Value" value="8.3e-11"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999941216531"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="754.353881835938" RT="5385.58669999998" >
-			<PeptideHit score="0" sequence="GGDDLDPNYVLSSR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="754.353881835938" RT="5385.58669999998" >
+			<PeptideHit score="0.99977415246485" sequence="GGDDLDPNYVLSSR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44"/>
 				<UserParam type="float" name="E-Value" value="3.5e-06"/>
 				<UserParam type="float" name="nextscore" value="9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99977415246485"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.76318359375" RT="5389.5303" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.76318359375" RT="5389.5303" >
+			<PeptideHit score="0.95053753529317" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.4"/>
 				<UserParam type="float" name="E-Value" value="0.0032"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.95053753529317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264343261719" RT="5390.1459" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264343261719" RT="5390.1459" >
+			<PeptideHit score="0.993913437040977" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.9"/>
 				<UserParam type="float" name="E-Value" value="0.00024"/>
 				<UserParam type="float" name="nextscore" value="20.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993913437040977"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763793945313" RT="5395.3578" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763793945313" RT="5395.3578" >
+			<PeptideHit score="0.998147047632296" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="5.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998147047632296"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="578.850158691406" RT="5403.9255" >
-			<PeptideHit score="0.0102432778489117" sequence="AIAEAVIRNAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_132" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="578.850158691406" RT="5403.9255" >
+			<PeptideHit score="0.348796391782609" sequence="AIAEAVIRNAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_132" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.2"/>
 				<UserParam type="float" name="E-Value" value="0.19"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.348796391782609"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.640930175781" RT="5428.97659999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.640930175781" RT="5428.97659999998" >
+			<PeptideHit score="0.99999464603178" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.8"/>
 				<UserParam type="float" name="E-Value" value="2.8e-08"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999464603178"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.640625" RT="5430.67759999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.640625" RT="5430.67759999998" >
+			<PeptideHit score="0.997906967138569" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.3"/>
 				<UserParam type="float" name="E-Value" value="6.2e-05"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997906967138569"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="770.867004394531" RT="5434.2147" >
-			<PeptideHit score="0.0211970074812968" sequence="AYEDLEFQQLER" charge="2" aa_before="R" aa_after="E" protein_refs="PH_95" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="770.867004394531" RT="5434.2147" >
+			<PeptideHit score="0.228519335906576" sequence="AYEDLEFQQLER" charge="2" aa_before="R" aa_after="E" protein_refs="PH_95" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.7"/>
 				<UserParam type="float" name="E-Value" value="0.37"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.228519335906576"/>
+				<UserParam type="float" name="q-value" value="0.0211970074812968"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317321777344" RT="5437.76989999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317321777344" RT="5437.76989999998" >
+			<PeptideHit score="0.999935834951473" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.9"/>
 				<UserParam type="float" name="E-Value" value="6.9e-07"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999935834951473"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.316650390625" RT="5439.5409" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.316650390625" RT="5439.5409" >
+			<PeptideHit score="0.999970786631432" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.4"/>
 				<UserParam type="float" name="E-Value" value="2.5e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999970786631432"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="562.624816894531" RT="5441.30980000002" >
-			<PeptideHit score="0.00906735751295337" sequence="EIEIDIEPTDKVER" charge="3" aa_before="K" aa_after="I" protein_refs="PH_84" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="562.624816894531" RT="5441.30980000002" >
+			<PeptideHit score="0.359831619897065" sequence="EIEIDIEPTDKVER" charge="3" aa_before="K" aa_after="I" protein_refs="PH_84" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.9"/>
 				<UserParam type="float" name="E-Value" value="0.18"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.359831619897065"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800048828125" RT="5443.07779999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800048828125" RT="5443.07779999998" >
+			<PeptideHit score="0.993114935780985" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="0.00028"/>
 				<UserParam type="float" name="nextscore" value="21.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993114935780985"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.7998046875" RT="5444.86429999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.7998046875" RT="5444.86429999998" >
+			<PeptideHit score="0.999923207531055" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="8.7e-07"/>
 				<UserParam type="float" name="nextscore" value="20.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999923207531055"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311462402344" RT="5469.29350000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311462402344" RT="5469.29350000002" >
+			<PeptideHit score="0.97179748620208" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.7"/>
 				<UserParam type="float" name="E-Value" value="0.0016"/>
 				<UserParam type="float" name="nextscore" value="23.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97179748620208"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.3115234375" RT="5471.38000000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.3115234375" RT="5471.38000000002" >
+			<PeptideHit score="0.997006222645118" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.3"/>
 				<UserParam type="float" name="E-Value" value="9.8e-05"/>
 				<UserParam type="float" name="nextscore" value="26.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997006222645118"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.349792480469" RT="5519.45539999998" >
-			<PeptideHit score="0" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.349792480469" RT="5519.45539999998" >
+			<PeptideHit score="0.998093027078404" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.4"/>
 				<UserParam type="float" name="E-Value" value="5.5e-05"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998093027078404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763488769531" RT="5523.36850000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763488769531" RT="5523.36850000002" >
+			<PeptideHit score="0.993913437040977" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.3"/>
 				<UserParam type="float" name="E-Value" value="0.00024"/>
 				<UserParam type="float" name="nextscore" value="12"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993913437040977"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317504882813" RT="5530.809" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317504882813" RT="5530.809" >
+			<PeptideHit score="0.999981361280163" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.8"/>
 				<UserParam type="float" name="E-Value" value="1.4e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999981361280163"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763671875" RT="5531.20819999998" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763671875" RT="5531.20819999998" >
+			<PeptideHit score="0.997854601535419" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.1"/>
 				<UserParam type="float" name="E-Value" value="6.4e-05"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997854601535419"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800262451172" RT="5536.78009999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800262451172" RT="5536.78009999998" >
+			<PeptideHit score="0.999915784628098" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.5"/>
 				<UserParam type="float" name="E-Value" value="9.8e-07"/>
 				<UserParam type="float" name="nextscore" value="23.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999915784628098"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799896240234" RT="5538.432" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799896240234" RT="5538.432" >
+			<PeptideHit score="0.999923892492664" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="8.6e-07"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999923892492664"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="481.920867919922" RT="5566.38220000002" >
-			<PeptideHit score="0.0444711538461538" sequence="GDSPWQVVLLDSK" charge="3" aa_before="R" aa_after="K" protein_refs="PH_25" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="481.920867919922" RT="5566.38220000002" >
+			<PeptideHit score="0.103478204192389" sequence="GDSPWQVVLLDSK" charge="3" aa_before="R" aa_after="K" protein_refs="PH_25" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.3"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.350830078125" RT="5609.03410000002" >
-			<PeptideHit score="0" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.350830078125" RT="5609.03410000002" >
+			<PeptideHit score="0.981539358864782" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.4"/>
 				<UserParam type="float" name="E-Value" value="0.00095"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.981539358864782"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.350891113281" RT="5611.27759999998" >
-			<PeptideHit score="0" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.350891113281" RT="5611.27759999998" >
+			<PeptideHit score="0.994321746497951" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.7"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.425537109375" RT="5618.94979999998" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.425537109375" RT="5618.94979999998" >
+			<PeptideHit score="0.999992941150764" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.8"/>
 				<UserParam type="float" name="E-Value" value="4e-08"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999992941150764"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317932128906" RT="5623.44769999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317932128906" RT="5623.44769999998" >
+			<PeptideHit score="0.869435996707529" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.011"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.869435996707529"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317687988281" RT="5625.11149999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317687988281" RT="5625.11149999998" >
+			<PeptideHit score="0.996721562845727" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.6"/>
 				<UserParam type="float" name="E-Value" value="0.00011"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996721562845727"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="508.600341796875" RT="5625.99190000002" >
-			<PeptideHit score="0.02" sequence="LLRDYQELMNTK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="508.600341796875" RT="5625.99190000002" >
+			<PeptideHit score="0.237298523258975" sequence="LLRDYQELMNTK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.35"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.237298523258975"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800048828125" RT="5631.5175" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800048828125" RT="5631.5175" >
+			<PeptideHit score="0.99988897055048" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="1.4e-06"/>
 				<UserParam type="float" name="nextscore" value="26.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99988897055048"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="557.834289550781" RT="5631.88780000002" >
-			<PeptideHit score="0.00134408602150538" sequence="IQILEGWKK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="557.834289550781" RT="5631.88780000002" >
+			<PeptideHit score="0.551111338013726" sequence="IQILEGWKK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.6"/>
 				<UserParam type="float" name="E-Value" value="0.075"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.551111338013726"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="557.834167480469" RT="5636.07550000002" >
-			<PeptideHit score="0.00134408602150538" sequence="IQILEGWKK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="557.834167480469" RT="5636.07550000002" >
+			<PeptideHit score="0.629701467241458" sequence="IQILEGWKK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.052"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.629701467241458"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265197753906" RT="5636.5257" >
-			<PeptideHit score="0.00134408602150538" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265197753906" RT="5636.5257" >
+			<PeptideHit score="0.707171902639713" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="0.035"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.707171902639713"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="372.225860595703" RT="5645.3274" >
-			<PeptideHit score="0.0139416983523447" sequence="IQILEGWKK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="372.225860595703" RT="5645.3274" >
+			<PeptideHit score="0.281438322829347" sequence="IQILEGWKK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.1"/>
 				<UserParam type="float" name="E-Value" value="0.27"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.281438322829347"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="372.225860595703" RT="5646.99880000002" >
-			<PeptideHit score="0.00651890482398957" sequence="IQILEGWKK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="372.225860595703" RT="5646.99880000002" >
+			<PeptideHit score="0.429088420832665" sequence="IQILEGWKK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19"/>
 				<UserParam type="float" name="E-Value" value="0.13"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.429088420832665"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="538.27685546875" RT="5652.80479999998" >
-			<PeptideHit score="0.0489844683393071" sequence="VYNIEFYK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_87" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="538.27685546875" RT="5652.80479999998" >
+			<PeptideHit score="0.0969386199829794" sequence="VYNIEFYK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_87" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="18.2"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="12"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.31103515625" RT="5659.9092" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.31103515625" RT="5659.9092" >
+			<PeptideHit score="0.910883820050366" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="0.0067"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.910883820050366"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.819152832031" RT="5667.3357" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.819152832031" RT="5667.3357" >
+			<PeptideHit score="0.997828542200326" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46"/>
 				<UserParam type="float" name="E-Value" value="6.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997828542200326"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.819274902344" RT="5669.00080000002" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.819274902344" RT="5669.00080000002" >
+			<PeptideHit score="0.999901472880047" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-06"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999901472880047"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="504.618713378906" RT="5685.76660000002" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="504.618713378906" RT="5685.76660000002" >
+			<PeptideHit score="0.999375797281708" sequence="VPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.5"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.425598144531" RT="5716.77799999998" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.425598144531" RT="5716.77799999998" >
+			<PeptideHit score="0.999999999857634" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="75.9"/>
 				<UserParam type="float" name="E-Value" value="3.5e-14"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999857634"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="546.6259765625" RT="5717.04469999998" >
-			<PeptideHit score="0.00134408602150538" sequence="TFIIGELHPDDRPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_12" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="546.6259765625" RT="5717.04469999998" >
+			<PeptideHit score="0.557059990676927" sequence="TFIIGELHPDDRPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_12" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.6"/>
 				<UserParam type="float" name="E-Value" value="0.073"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.557059990676927"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.944213867188" RT="5718.02179999998" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.944213867188" RT="5718.02179999998" >
+			<PeptideHit score="0.998964248012865" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.6"/>
 				<UserParam type="float" name="E-Value" value="2.5e-05"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998964248012865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.425964355469" RT="5719.25029999998" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.425964355469" RT="5719.25029999998" >
+			<PeptideHit score="0.999999999893731" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="76"/>
 				<UserParam type="float" name="E-Value" value="2.4e-14"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999893731"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="546.626647949219" RT="5719.52509999998" >
-			<PeptideHit score="0.00134408602150538" sequence="TFIIGELHPDDRPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_12" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="546.626647949219" RT="5719.52509999998" >
+			<PeptideHit score="0.663546675058494" sequence="TFIIGELHPDDRPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_12" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.6"/>
 				<UserParam type="float" name="E-Value" value="0.044"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.663546675058494"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799743652344" RT="5723.8161" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799743652344" RT="5723.8161" >
+			<PeptideHit score="0.860612864765694" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.012"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.860612864765694"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310974121094" RT="5757.36559999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310974121094" RT="5757.36559999998" >
+			<PeptideHit score="0.993913437040977" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36"/>
 				<UserParam type="float" name="E-Value" value="0.00024"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993913437040977"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.819274902344" RT="5759.1375" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.819274902344" RT="5759.1375" >
+			<PeptideHit score="0.999959587384417" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.9"/>
 				<UserParam type="float" name="E-Value" value="3.8e-07"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999959587384417"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.819213867188" RT="5760.8133" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.819213867188" RT="5760.8133" >
+			<PeptideHit score="0.99955085527733" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.3"/>
 				<UserParam type="float" name="E-Value" value="8.5e-06"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99955085527733"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="505.936309814453" RT="5793.14299999998" >
-			<PeptideHit score="0.00134408602150538" sequence="TEWLDGKHVVFGK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="505.936309814453" RT="5793.14299999998" >
+			<PeptideHit score="0.633712555194939" sequence="TEWLDGKHVVFGK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.051"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.633712555194939"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="505.936218261719" RT="5795.07070000002" >
-			<PeptideHit score="0.00526315789473684" sequence="TEWLDGKHVVFGK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="505.936218261719" RT="5795.07070000002" >
+			<PeptideHit score="0.489404251795088" sequence="TEWLDGKHVVFGK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.2"/>
 				<UserParam type="float" name="E-Value" value="0.099"/>
 				<UserParam type="float" name="nextscore" value="11.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.489404251795088"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763031005859" RT="5807.40310000002" >
-			<PeptideHit score="0.00134408602150538" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763031005859" RT="5807.40310000002" >
+			<PeptideHit score="0.752250699877261" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.9"/>
 				<UserParam type="float" name="E-Value" value="0.027"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.752250699877261"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.425354003906" RT="5810.7987" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.425354003906" RT="5810.7987" >
+			<PeptideHit score="0.9999993618971" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.4"/>
 				<UserParam type="float" name="E-Value" value="1.8e-09"/>
 				<UserParam type="float" name="nextscore" value="12.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.9999993618971"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317199707031" RT="5811.32569999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317199707031" RT="5811.32569999998" >
+			<PeptideHit score="0.999932970501854" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.2"/>
 				<UserParam type="float" name="E-Value" value="7.3e-07"/>
 				<UserParam type="float" name="nextscore" value="18.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999932970501854"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.3173828125" RT="5813.5506" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.3173828125" RT="5813.5506" >
+			<PeptideHit score="0.999946936748021" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.42529296875" RT="5813.89579999998" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.42529296875" RT="5813.89579999998" >
+			<PeptideHit score="0.999999999326381" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.8"/>
 				<UserParam type="float" name="E-Value" value="2.6e-13"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999326381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799835205078" RT="5817.4488" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799835205078" RT="5817.4488" >
+			<PeptideHit score="0.999876865375483" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="1.6e-06"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999876865375483"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="474.759765625" RT="5818.07389999998" >
-			<PeptideHit score="0.02" sequence="RTTAAAETK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_45" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="474.759765625" RT="5818.07389999998" >
+			<PeptideHit score="0.246856676048891" sequence="RTTAAAETK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_45" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="17.7"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="11.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310363769531" RT="5851.7934" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310363769531" RT="5851.7934" >
+			<PeptideHit score="0.980753850169904" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.4"/>
 				<UserParam type="float" name="E-Value" value="0.001"/>
 				<UserParam type="float" name="nextscore" value="23.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980753850169904"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302612304688" RT="5888.80270000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302612304688" RT="5888.80270000002" >
+			<PeptideHit score="0.999986879993158" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.3"/>
 				<UserParam type="float" name="E-Value" value="8.9e-08"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999986879993158"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.762939453125" RT="5894.10280000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.762939453125" RT="5894.10280000002" >
+			<PeptideHit score="0.791101298057872" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.1"/>
 				<UserParam type="float" name="E-Value" value="0.021"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.791101298057872"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317932128906" RT="5905.08649999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317932128906" RT="5905.08649999998" >
+			<PeptideHit score="0.99998033748685" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.9"/>
 				<UserParam type="float" name="E-Value" value="1.5e-07"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998033748685"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.31787109375" RT="5907.26269999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.31787109375" RT="5907.26269999998" >
+			<PeptideHit score="0.999928040886378" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.1"/>
 				<UserParam type="float" name="E-Value" value="8e-07"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999928040886378"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.42529296875" RT="5908.9323" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.42529296875" RT="5908.9323" >
+			<PeptideHit score="0.999996699477478" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799896240234" RT="5910.60730000002" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799896240234" RT="5910.60730000002" >
+			<PeptideHit score="0.999231648451313" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="1.7e-05"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999231648451313"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.424743652344" RT="5913.5607" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.424743652344" RT="5913.5607" >
+			<PeptideHit score="0.999956327890147" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.1"/>
 				<UserParam type="float" name="E-Value" value="4.2e-07"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999956327890147"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="477.304840087891" RT="5926.6005" >
-			<PeptideHit score="0.00906735751295337" sequence="ILLLEAGPK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_144" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="477.304840087891" RT="5926.6005" >
+			<PeptideHit score="0.359831619897065" sequence="ILLLEAGPK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_144" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.18"/>
 				<UserParam type="float" name="nextscore" value="22.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.359831619897065"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290100097656" RT="5940.9147" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290100097656" RT="5940.9147" >
+			<PeptideHit score="0.976178644666495" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.6"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303070068359" RT="5952.74140000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303070068359" RT="5952.74140000002" >
+			<PeptideHit score="0.999999911847758" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="1.4e-10"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999911847758"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302642822266" RT="5954.45689999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302642822266" RT="5954.45689999998" >
+			<PeptideHit score="0.999999812773505" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="3.7e-10"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999812773505"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.818481445313" RT="5966.1795" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.818481445313" RT="5966.1795" >
+			<PeptideHit score="0.980753850169904" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34"/>
 				<UserParam type="float" name="E-Value" value="0.001"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980753850169904"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.80029296875" RT="5974.55260000002" >
-			<PeptideHit score="0.0259259259259259" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.80029296875" RT="5974.55260000002" >
+			<PeptideHit score="0.20599231767492" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.5"/>
 				<UserParam type="float" name="E-Value" value="0.43"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.20599231767492"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317016601563" RT="5975.50219999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317016601563" RT="5975.50219999998" >
+			<PeptideHit score="0.999266889838404" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38"/>
 				<UserParam type="float" name="E-Value" value="1.6e-05"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999266889838404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317749023438" RT="5979.24220000002" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317749023438" RT="5979.24220000002" >
+			<PeptideHit score="0.999769168223274" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.8"/>
 				<UserParam type="float" name="E-Value" value="3.6e-06"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999769168223274"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800079345703" RT="5980.7133" >
-			<PeptideHit score="0.0224159402241594" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800079345703" RT="5980.7133" >
+			<PeptideHit score="0.220425809510344" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.9"/>
 				<UserParam type="float" name="E-Value" value="0.39"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.220425809510344"/>
+				<UserParam type="float" name="q-value" value="0.0224159402241594"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="351.18896484375" RT="5986.8858" >
-			<PeptideHit score="0.02" sequence="IVPEHDVSR" charge="3" aa_before="R" aa_after="I" protein_refs="PH_106" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="351.18896484375" RT="5986.8858" >
+			<PeptideHit score="0.241973740416827" sequence="IVPEHDVSR" charge="3" aa_before="R" aa_after="I" protein_refs="PH_106" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="17.8"/>
 				<UserParam type="float" name="E-Value" value="0.34"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.241973740416827"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="477.304565429688" RT="5993.72440000002" >
-			<PeptideHit score="0" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="477.304565429688" RT="5993.72440000002" >
+			<PeptideHit score="0.90572411537101" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.5"/>
 				<UserParam type="float" name="E-Value" value="0.0072"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.90572411537101"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800720214844" RT="5995.99639999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800720214844" RT="5995.99639999998" >
+			<PeptideHit score="0.894717809051713" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.8"/>
 				<UserParam type="float" name="E-Value" value="0.0083"/>
 				<UserParam type="float" name="nextscore" value="23.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.894717809051713"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800048828125" RT="5997.76039999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800048828125" RT="5997.76039999998" >
+			<PeptideHit score="0.979203874797132" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.4"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289276123047" RT="6019.9695" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289276123047" RT="6019.9695" >
+			<PeptideHit score="0.997347108654437" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="8.4e-05"/>
 				<UserParam type="float" name="nextscore" value="9.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997347108654437"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.28955078125" RT="6021.663" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.28955078125" RT="6021.663" >
+			<PeptideHit score="0.998119986595388" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="5.4e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998119986595388"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="477.305358886719" RT="6029.81359999998" >
-			<PeptideHit score="0.0102432778489117" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="477.305358886719" RT="6029.81359999998" >
+			<PeptideHit score="0.348796391782609" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.8"/>
 				<UserParam type="float" name="E-Value" value="0.19"/>
 				<UserParam type="float" name="nextscore" value="25.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.348796391782609"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302368164063" RT="6031.33120000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302368164063" RT="6031.33120000002" >
+			<PeptideHit score="0.999999978259312" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="2.3e-11"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999978259312"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="477.305206298828" RT="6035.6352" >
-			<PeptideHit score="0.00651890482398957" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="477.305206298828" RT="6035.6352" >
+			<PeptideHit score="0.412959460251658" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.8"/>
 				<UserParam type="float" name="E-Value" value="0.14"/>
 				<UserParam type="float" name="nextscore" value="22.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.412959460251658"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="558.32470703125" RT="6045.273" >
-			<PeptideHit score="0.02" sequence="IEINKSAVNK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="558.32470703125" RT="6045.273" >
+			<PeptideHit score="0.246856676048891" sequence="IEINKSAVNK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="27.2"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="18.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317810058594" RT="6047.28199999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317810058594" RT="6047.28199999998" >
+			<PeptideHit score="0.999960414089089" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.8"/>
 				<UserParam type="float" name="E-Value" value="3.7e-07"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999960414089089"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="518.293579101563" RT="6048.46369999998" >
-			<PeptideHit score="0.0363636363636364" sequence="VLPSRNHGR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_54" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="518.293579101563" RT="6048.46369999998" >
+			<PeptideHit score="0.139151226014516" sequence="VLPSRNHGR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_54" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="18"/>
 				<UserParam type="float" name="E-Value" value="0.74"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.139151226014516"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.28955078125" RT="6068.74180000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.28955078125" RT="6068.74180000002" >
+			<PeptideHit score="0.997750839055042" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="6.8e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997750839055042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289184570313" RT="6070.49620000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289184570313" RT="6070.49620000002" >
+			<PeptideHit score="0.999901472880047" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="1.2e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999901472880047"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310607910156" RT="6072.70639999998" >
-			<PeptideHit score="0.00134408602150538" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310607910156" RT="6072.70639999998" >
+			<PeptideHit score="0.625748520080762" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.7"/>
 				<UserParam type="float" name="E-Value" value="0.053"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.625748520080762"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303131103516" RT="6078.28069999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303131103516" RT="6078.28069999998" >
+			<PeptideHit score="0.999999958478686" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="5.3e-11"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999958478686"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302947998047" RT="6080.26120000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302947998047" RT="6080.26120000002" >
+			<PeptideHit score="0.999995875058368" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.9"/>
 				<UserParam type="float" name="E-Value" value="2e-08"/>
 				<UserParam type="float" name="nextscore" value="9.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995875058368"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317321777344" RT="6100.2399" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317321777344" RT="6100.2399" >
+			<PeptideHit score="0.998626449672608" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42"/>
 				<UserParam type="float" name="E-Value" value="3.6e-05"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998626449672608"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799896240234" RT="6108.61219999998" >
-			<PeptideHit score="0.0236318407960199" sequence="IPSLLAAASK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_76" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799896240234" RT="6108.61219999998" >
+			<PeptideHit score="0.216611057630705" sequence="IPSLLAAASK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_76" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="16.9"/>
 				<UserParam type="float" name="E-Value" value="0.4"/>
 				<UserParam type="float" name="nextscore" value="12.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.216611057630705"/>
+				<UserParam type="float" name="q-value" value="0.0236318407960199"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="558.326171875" RT="6115.7283" >
-			<PeptideHit score="0.029520295202952" sequence="ELFEKPPKK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_131" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="558.326171875" RT="6115.7283" >
+			<PeptideHit score="0.193496525438801" sequence="ELFEKPPKK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_131" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="29.8"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="21.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289672851563" RT="6162.35329999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289672851563" RT="6162.35329999998" >
+			<PeptideHit score="0.997371865907272" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="8.3e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997371865907272"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302642822266" RT="6171.59470000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302642822266" RT="6171.59470000002" >
+			<PeptideHit score="0.999999126279445" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="2.7e-09"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999126279445"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302520751953" RT="6173.64199999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302520751953" RT="6173.64199999998" >
+			<PeptideHit score="0.999999774631398" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="4.7e-10"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999774631398"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.316772460938" RT="6197.32939999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.316772460938" RT="6197.32939999998" >
+			<PeptideHit score="0.977679598036381" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.9"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="12"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317565917969" RT="6198.651" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317565917969" RT="6198.651" >
+			<PeptideHit score="0.996721562845727" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.6"/>
 				<UserParam type="float" name="E-Value" value="0.00011"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996721562845727"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799713134766" RT="6200.5863" >
-			<PeptideHit score="0.00526315789473684" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799713134766" RT="6200.5863" >
+			<PeptideHit score="0.491668159923229" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.9"/>
 				<UserParam type="float" name="E-Value" value="0.098"/>
 				<UserParam type="float" name="nextscore" value="21.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.491668159923229"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.944091796875" RT="6201.82489999998" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.944091796875" RT="6201.82489999998" >
+			<PeptideHit score="0.992918683767341" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.7"/>
 				<UserParam type="float" name="E-Value" value="0.00029"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992918683767341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799957275391" RT="6205.22980000002" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799957275391" RT="6205.22980000002" >
+			<PeptideHit score="0.946835341093983" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="0.0035"/>
 				<UserParam type="float" name="nextscore" value="23.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.946835341093983"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.9580078125" RT="6212.0364" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.9580078125" RT="6212.0364" >
+			<PeptideHit score="0.998367552171115" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.9"/>
 				<UserParam type="float" name="E-Value" value="4.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998367552171115"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="551.616943359375" RT="6234.40930000002" >
-			<PeptideHit score="0.00651890482398957" sequence="ACAVFQIPPWHLDR" charge="3" aa_before="M" aa_after="K" protein_refs="PH_33" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="551.616943359375" RT="6234.40930000002" >
+			<PeptideHit score="0.429088420832665" sequence="ACAVFQIPPWHLDR" charge="3" aa_before="M" aa_after="K" protein_refs="PH_33" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.4"/>
 				<UserParam type="float" name="E-Value" value="0.13"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.429088420832665"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.2900390625" RT="6254.88" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.2900390625" RT="6254.88" >
+			<PeptideHit score="0.992723665442821" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.6"/>
 				<UserParam type="float" name="E-Value" value="0.0003"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992723665442821"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289398193359" RT="6256.39690000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289398193359" RT="6256.39690000002" >
+			<PeptideHit score="0.998869266957837" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.1"/>
 				<UserParam type="float" name="E-Value" value="2.8e-05"/>
 				<UserParam type="float" name="nextscore" value="11.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998869266957837"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.330322265625" RT="6260.0871" >
-			<PeptideHit score="0" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.330322265625" RT="6260.0871" >
+			<PeptideHit score="0.994321746497951" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.9"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="12.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.330261230469" RT="6263.76739999998" >
-			<PeptideHit score="0" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.330261230469" RT="6263.76739999998" >
+			<PeptideHit score="0.999996198517603" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="1.8e-08"/>
 				<UserParam type="float" name="nextscore" value="10.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996198517603"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302978515625" RT="6265.0806" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302978515625" RT="6265.0806" >
+			<PeptideHit score="0.999999689719728" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="7.1e-10"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999689719728"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302520751953" RT="6267.34489999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302520751953" RT="6267.34489999998" >
+			<PeptideHit score="0.999999564367445" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="1.1e-09"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999564367445"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="537.283386230469" RT="6278.87089999998" >
-			<PeptideHit score="0" sequence="AFYVNVLNEEQRK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="537.283386230469" RT="6278.87089999998" >
+			<PeptideHit score="0.929273950886146" sequence="AFYVNVLNEEQRK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.2"/>
 				<UserParam type="float" name="E-Value" value="0.005"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.929273950886146"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="537.282165527344" RT="6280.69579999998" >
-			<PeptideHit score="0.0236318407960199" sequence="AFYVNVLNEEQRK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="537.282165527344" RT="6280.69579999998" >
+			<PeptideHit score="0.212939146410455" sequence="AFYVNVLNEEQRK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.8"/>
 				<UserParam type="float" name="E-Value" value="0.41"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.212939146410455"/>
+				<UserParam type="float" name="q-value" value="0.0236318407960199"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.9443359375" RT="6290.99989999998" >
-			<PeptideHit score="0.0331695331695332" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.9443359375" RT="6290.99989999998" >
+			<PeptideHit score="0.185169102173804" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.9"/>
 				<UserParam type="float" name="E-Value" value="0.5"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.185169102173804"/>
+				<UserParam type="float" name="q-value" value="0.0331695331695332"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943420410156" RT="6292.61149999998" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943420410156" RT="6292.61149999998" >
+			<PeptideHit score="0.860612864765694" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27"/>
 				<UserParam type="float" name="E-Value" value="0.012"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.860612864765694"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310852050781" RT="6293.65759999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310852050781" RT="6293.65759999998" >
+			<PeptideHit score="0.943202686631416" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.2"/>
 				<UserParam type="float" name="E-Value" value="0.0038"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.943202686631416"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799743652344" RT="6296.46790000002" >
-			<PeptideHit score="0.0489844683393071" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799743652344" RT="6296.46790000002" >
+			<PeptideHit score="0.0969386199829794" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="19.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.273376464844" RT="6298.13959999998" >
-			<PeptideHit score="0" sequence="FSGTWYAMAK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_22" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.273376464844" RT="6298.13959999998" >
+			<PeptideHit score="0.982014267249911" sequence="FSGTWYAMAK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_22" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.2"/>
 				<UserParam type="float" name="E-Value" value="0.00092"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.982014267249911"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800598144531" RT="6299.0532" >
-			<PeptideHit score="0.0444711538461538" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800598144531" RT="6299.0532" >
+			<PeptideHit score="0.103478204192389" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="19.3"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.273803710938" RT="6300.18730000002" >
-			<PeptideHit score="0" sequence="FSGTWYAMAK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_22" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.273803710938" RT="6300.18730000002" >
+			<PeptideHit score="0.992723665442821" sequence="FSGTWYAMAK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_22" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.3"/>
 				<UserParam type="float" name="E-Value" value="0.0003"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992723665442821"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958129882813" RT="6311.74660000002" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958129882813" RT="6311.74660000002" >
+			<PeptideHit score="0.999999870479975" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.4"/>
 				<UserParam type="float" name="E-Value" value="2.3e-10"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999870479975"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290069580078" RT="6335.8014" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290069580078" RT="6335.8014" >
+			<PeptideHit score="0.998964248012865" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="2.5e-05"/>
 				<UserParam type="float" name="nextscore" value="9.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998964248012865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289703369141" RT="6337.49089999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289703369141" RT="6337.49089999998" >
+			<PeptideHit score="0.999302633161889" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.3"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.330078125" RT="6346.9293" >
-			<PeptideHit score="0" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.330078125" RT="6346.9293" >
+			<PeptideHit score="0.999994062235367" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.7"/>
 				<UserParam type="float" name="E-Value" value="3.2e-08"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999994062235367"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302886962891" RT="6348.714" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302886962891" RT="6348.714" >
+			<PeptideHit score="0.999506451073422" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="9.6e-06"/>
 				<UserParam type="float" name="nextscore" value="11.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999506451073422"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.329833984375" RT="6349.21729999998" >
-			<PeptideHit score="0" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.329833984375" RT="6349.21729999998" >
+			<PeptideHit score="0.99998033748685" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.1"/>
 				<UserParam type="float" name="E-Value" value="1.5e-07"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998033748685"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303283691406" RT="6350.3682" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303283691406" RT="6350.3682" >
+			<PeptideHit score="0.999907897771499" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-06"/>
 				<UserParam type="float" name="nextscore" value="12.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999907897771499"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943481445313" RT="6358.9377" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943481445313" RT="6358.9377" >
+			<PeptideHit score="0.996034376504582" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.4"/>
 				<UserParam type="float" name="E-Value" value="0.00014"/>
 				<UserParam type="float" name="nextscore" value="9.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996034376504582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957336425781" RT="6359.20000000002" >
-			<PeptideHit score="0.00134408602150538" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957336425781" RT="6359.20000000002" >
+			<PeptideHit score="0.777594217720977" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26"/>
 				<UserParam type="float" name="E-Value" value="0.023"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.777594217720977"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="559.831909179688" RT="6367.34980000002" >
-			<PeptideHit score="0" sequence="EKVFDVIIR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="559.831909179688" RT="6367.34980000002" >
+			<PeptideHit score="0.930401463762626" sequence="EKVFDVIIR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.7"/>
 				<UserParam type="float" name="E-Value" value="0.0049"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.930401463762626"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.312561035156" RT="6368.65600000002" >
-			<PeptideHit score="0" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.312561035156" RT="6368.65600000002" >
+			<PeptideHit score="0.878537248230859" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.1"/>
 				<UserParam type="float" name="E-Value" value="0.01"/>
 				<UserParam type="float" name="nextscore" value="9.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.878537248230859"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.95654296875" RT="6372.8733" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.95654296875" RT="6372.8733" >
+			<PeptideHit score="0.999934398186429" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42"/>
 				<UserParam type="float" name="E-Value" value="7.1e-07"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999934398186429"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800689697266" RT="6373.53460000002" >
-			<PeptideHit score="0.0489844683393071" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800689697266" RT="6373.53460000002" >
+			<PeptideHit score="0.0969386199829794" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800323486328" RT="6374.78569999998" >
-			<PeptideHit score="0.0211970074812968" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800323486328" RT="6374.78569999998" >
+			<PeptideHit score="0.228519335906576" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22"/>
 				<UserParam type="float" name="E-Value" value="0.37"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.228519335906576"/>
+				<UserParam type="float" name="q-value" value="0.0211970074812968"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289245605469" RT="6394.90009999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289245605469" RT="6394.90009999998" >
+			<PeptideHit score="0.999600809559596" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="7.3e-06"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999600809559596"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="559.831848144531" RT="6395.7648" >
-			<PeptideHit score="0" sequence="EKVFDVIIR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="559.831848144531" RT="6395.7648" >
+			<PeptideHit score="0.979203874797132" sequence="EKVFDVIIR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.7"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289611816406" RT="6397.02760000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289611816406" RT="6397.02760000002" >
+			<PeptideHit score="0.999876865375483" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.3"/>
 				<UserParam type="float" name="E-Value" value="1.6e-06"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999876865375483"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.956604003906" RT="6400.67440000002" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.956604003906" RT="6400.67440000002" >
+			<PeptideHit score="0.997673817427177" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.5"/>
 				<UserParam type="float" name="E-Value" value="7.1e-05"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997673817427177"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958435058594" RT="6410.0121" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958435058594" RT="6410.0121" >
+			<PeptideHit score="0.992145529169711" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.7"/>
 				<UserParam type="float" name="E-Value" value="0.00033"/>
 				<UserParam type="float" name="nextscore" value="11.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992145529169711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="502.5869140625" RT="6410.67040000002" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="502.5869140625" RT="6410.67040000002" >
+			<PeptideHit score="0.899664339188683" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.0078"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.899664339188683"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="502.587097167969" RT="6415.02400000002" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="502.587097167969" RT="6415.02400000002" >
+			<PeptideHit score="0.784273217611407" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.8"/>
 				<UserParam type="float" name="E-Value" value="0.022"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.784273217611407"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303131103516" RT="6442.96990000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303131103516" RT="6442.96990000002" >
+			<PeptideHit score="0.999951566095295" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.8"/>
 				<UserParam type="float" name="E-Value" value="4.8e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999951566095295"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302825927734" RT="6444.96199999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302825927734" RT="6444.96199999998" >
+			<PeptideHit score="0.998900658395066" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.1"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="753.376342773438" RT="6445.58299999998" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="753.376342773438" RT="6445.58299999998" >
+			<PeptideHit score="0.999998294394401" sequence="VKEGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="6.4e-09"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998294394401"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943786621094" RT="6451.22179999998" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943786621094" RT="6451.22179999998" >
+			<PeptideHit score="0.998367552171115" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.6"/>
 				<UserParam type="float" name="E-Value" value="4.5e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998367552171115"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943786621094" RT="6452.9871" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943786621094" RT="6452.9871" >
+			<PeptideHit score="0.998538671479314" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.8"/>
 				<UserParam type="float" name="E-Value" value="3.9e-05"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998538671479314"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.311279296875" RT="6461.49109999998" >
-			<PeptideHit score="0.00134408602150538" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.311279296875" RT="6461.49109999998" >
+			<PeptideHit score="0.758391515615522" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.5"/>
 				<UserParam type="float" name="E-Value" value="0.026"/>
 				<UserParam type="float" name="nextscore" value="8.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.758391515615522"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.311828613281" RT="6463.28779999998" >
-			<PeptideHit score="0" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.311828613281" RT="6463.28779999998" >
+			<PeptideHit score="0.843722813291116" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24"/>
 				<UserParam type="float" name="E-Value" value="0.014"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.843722813291116"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289581298828" RT="6488.22799999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289581298828" RT="6488.22799999998" >
+			<PeptideHit score="0.998452416252365" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="4.2e-05"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998452416252365"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800659179688" RT="6490.5834" >
-			<PeptideHit score="0.00651890482398957" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800659179688" RT="6490.5834" >
+			<PeptideHit score="0.398109626639983" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.2"/>
 				<UserParam type="float" name="E-Value" value="0.15"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.398109626639983"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46240234375" RT="6491.84629999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46240234375" RT="6491.84629999998" >
+			<PeptideHit score="0.999915119404183" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.8"/>
 				<UserParam type="float" name="E-Value" value="9.9e-07"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999915119404183"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46032714844" RT="6495.8265" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46032714844" RT="6495.8265" >
+			<PeptideHit score="0.999870942238288" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48"/>
 				<UserParam type="float" name="E-Value" value="1.7e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999870942238288"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="502.586151123047" RT="6505.89310000002" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="502.586151123047" RT="6505.89310000002" >
+			<PeptideHit score="0.999937281120465" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.1"/>
 				<UserParam type="float" name="E-Value" value="6.7e-07"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999937281120465"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="502.586273193359" RT="6507.65410000002" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="502.586273193359" RT="6507.65410000002" >
+			<PeptideHit score="0.99331247569031" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35"/>
 				<UserParam type="float" name="E-Value" value="0.00027"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99331247569031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958068847656" RT="6508.00699999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958068847656" RT="6508.00699999998" >
+			<PeptideHit score="0.999302633161889" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="11.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="652.026428222656" RT="6520.32919999998" >
-			<PeptideHit score="0" sequence="VAPEEHPVLLTEAPLNPK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_57 PH_65" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="652.026428222656" RT="6520.32919999998" >
+			<PeptideHit score="0.940816934477305" sequence="VAPEEHPVLLTEAPLNPK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_57 PH_65" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.9"/>
 				<UserParam type="float" name="E-Value" value="0.004"/>
 				<UserParam type="float" name="nextscore" value="27.7"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.940816934477305"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="652.026062011719" RT="6523.8852" >
-			<PeptideHit score="0" sequence="VAPDEHPILLTEAPLNPK" charge="3" aa_before="R" aa_after="I" protein_refs="PH_90" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="652.026062011719" RT="6523.8852" >
+			<PeptideHit score="0.996259978029628" sequence="VAPDEHPILLTEAPLNPK" charge="3" aa_before="R" aa_after="I" protein_refs="PH_90" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.9"/>
 				<UserParam type="float" name="E-Value" value="0.00013"/>
 				<UserParam type="float" name="nextscore" value="28.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996259978029628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302520751953" RT="6535.89859999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302520751953" RT="6535.89859999998" >
+			<PeptideHit score="0.999870942238288" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.2"/>
 				<UserParam type="float" name="E-Value" value="1.7e-06"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999870942238288"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302825927734" RT="6537.66460000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302825927734" RT="6537.66460000002" >
+			<PeptideHit score="0.999735095835476" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.3"/>
 				<UserParam type="float" name="E-Value" value="4.3e-06"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999735095835476"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943481445313" RT="6544.7763" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943481445313" RT="6544.7763" >
+			<PeptideHit score="0.991202597624598" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.00038"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991202597624598"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943420410156" RT="6546.4455" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943420410156" RT="6546.4455" >
+			<PeptideHit score="0.995811820230489" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.9"/>
 				<UserParam type="float" name="E-Value" value="0.00015"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995811820230489"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="471.577819824219" RT="6548.1528" >
-			<PeptideHit score="0.0363636363636364" sequence="TFLTVYWTPER" charge="3" aa_before="K" aa_after="V" protein_refs="PH_28" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="471.577819824219" RT="6548.1528" >
+			<PeptideHit score="0.172921900962734" sequence="TFLTVYWTPER" charge="3" aa_before="K" aa_after="V" protein_refs="PH_28" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.6"/>
 				<UserParam type="float" name="E-Value" value="0.55"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.172921900962734"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.311645507813" RT="6553.7169" >
-			<PeptideHit score="0" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.311645507813" RT="6553.7169" >
+			<PeptideHit score="0.878537248230859" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.9"/>
 				<UserParam type="float" name="E-Value" value="0.01"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.878537248230859"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.311340332031" RT="6555.50899999998" >
-			<PeptideHit score="0.00526315789473684" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.311340332031" RT="6555.50899999998" >
+			<PeptideHit score="0.493955532339166" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.097"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.493955532339166"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="577.790771484375" RT="6576.8145" >
-			<PeptideHit score="0" sequence="FEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="577.790771484375" RT="6576.8145" >
+			<PeptideHit score="0.956880028363855" sequence="FEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.9"/>
 				<UserParam type="float" name="E-Value" value="0.0027"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.956880028363855"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289611816406" RT="6581.3118" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289611816406" RT="6581.3118" >
+			<PeptideHit score="0.996982252670564" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.3"/>
 				<UserParam type="float" name="E-Value" value="9.9e-05"/>
 				<UserParam type="float" name="nextscore" value="12"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996982252670564"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289459228516" RT="6584.20720000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289459228516" RT="6584.20720000002" >
+			<PeptideHit score="0.976178644666495" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="10.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46252441406" RT="6585.94720000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46252441406" RT="6585.94720000002" >
+			<PeptideHit score="0.998339553383431" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.5"/>
 				<UserParam type="float" name="E-Value" value="4.6e-05"/>
 				<UserParam type="float" name="nextscore" value="9.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998339553383431"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="663.025512695313" RT="6606.39370000002" >
-			<PeptideHit score="0.00134408602150538" sequence="TITLEVEPSDTIENVKAK" charge="3" aa_before="K" aa_after="I" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="663.025512695313" RT="6606.39370000002" >
+			<PeptideHit score="0.560089068277706" sequence="TITLEVEPSDTIENVKAK" charge="3" aa_before="K" aa_after="I" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.7"/>
 				<UserParam type="float" name="E-Value" value="0.072"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.560089068277706"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957702636719" RT="6607.98130000002" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957702636719" RT="6607.98130000002" >
+			<PeptideHit score="0.976178644666495" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.9"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302703857422" RT="6628.72630000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302703857422" RT="6628.72630000002" >
+			<PeptideHit score="0.999029002284869" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.6"/>
 				<UserParam type="float" name="E-Value" value="2.3e-05"/>
 				<UserParam type="float" name="nextscore" value="11.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999029002284869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303070068359" RT="6630.49930000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303070068359" RT="6630.49930000002" >
+			<PeptideHit score="0.99988897055048" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41"/>
 				<UserParam type="float" name="E-Value" value="1.4e-06"/>
 				<UserParam type="float" name="nextscore" value="11.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99988897055048"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="460.758209228516" RT="6631.00720000002" >
-			<PeptideHit score="0" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="460.758209228516" RT="6631.00720000002" >
+			<PeptideHit score="0.860612864765694" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="0.012"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.860612864765694"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="460.757904052734" RT="6636.24940000002" >
-			<PeptideHit score="0.00134408602150538" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="460.757904052734" RT="6636.24940000002" >
+			<PeptideHit score="0.646109382185005" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.7"/>
 				<UserParam type="float" name="E-Value" value="0.048"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.646109382185005"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957580566406" RT="6636.6414" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957580566406" RT="6636.6414" >
+			<PeptideHit score="0.999693069772492" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.8"/>
 				<UserParam type="float" name="E-Value" value="5.2e-06"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999693069772492"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976318359375" RT="6641.56609999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976318359375" RT="6641.56609999998" >
+			<PeptideHit score="0.999998356693945" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.4"/>
 				<UserParam type="float" name="E-Value" value="6.1e-09"/>
 				<UserParam type="float" name="nextscore" value="12.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998356693945"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="577.789428710938" RT="6669.97450000002" >
-			<PeptideHit score="0" sequence="FEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="577.789428710938" RT="6669.97450000002" >
+			<PeptideHit score="0.99865607372492" sequence="FEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="3.5e-05"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99865607372492"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.288940429688" RT="6675.74929999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.288940429688" RT="6675.74929999998" >
+			<PeptideHit score="0.999029002284869" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.6"/>
 				<UserParam type="float" name="E-Value" value="2.3e-05"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999029002284869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="920.466979980469" RT="6695.35519999998" >
-			<PeptideHit score="0" sequence="SLLSNVEGDNAVPMQHNNRPTQPLK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="920.466979980469" RT="6695.35519999998" >
+			<PeptideHit score="0.997396681935865" sequence="SLLSNVEGDNAVPMQHNNRPTQPLK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="8.2e-05"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997396681935865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303192138672" RT="6705.6033" >
-			<PeptideHit score="0.00526315789473684" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303192138672" RT="6705.6033" >
+			<PeptideHit score="0.503347576910457" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.6"/>
 				<UserParam type="float" name="E-Value" value="0.093"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.503347576910457"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="460.758178710938" RT="6727.15690000002" >
-			<PeptideHit score="0" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="460.758178710938" RT="6727.15690000002" >
+			<PeptideHit score="0.812550391896406" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="0.018"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.812550391896406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="460.7578125" RT="6728.79799999998" >
-			<PeptideHit score="0" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="460.7578125" RT="6728.79799999998" >
+			<PeptideHit score="0.943202686631416" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.7"/>
 				<UserParam type="float" name="E-Value" value="0.0038"/>
 				<UserParam type="float" name="nextscore" value="12.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.943202686631416"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.944396972656" RT="6730.5255" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.944396972656" RT="6730.5255" >
+			<PeptideHit score="0.999542689659901" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.9"/>
 				<UserParam type="float" name="E-Value" value="8.7e-06"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999542689659901"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976684570313" RT="6738.5571" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976684570313" RT="6738.5571" >
+			<PeptideHit score="0.999779168898944" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44"/>
 				<UserParam type="float" name="E-Value" value="3.4e-06"/>
 				<UserParam type="float" name="nextscore" value="8.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999779168898944"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943786621094" RT="6738.9579" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943786621094" RT="6738.9579" >
+			<PeptideHit score="0.820048379204749" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.6"/>
 				<UserParam type="float" name="E-Value" value="0.017"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.820048379204749"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="854.389221191406" RT="6739.3692" >
-			<PeptideHit score="0" sequence="GSLGGGFSSGGFSGGSFSR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_41" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="854.389221191406" RT="6739.3692" >
+			<PeptideHit score="0.99999999953763" sequence="GSLGGGFSSGGFSGGSFSR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_41" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="73.4"/>
 				<UserParam type="float" name="E-Value" value="1.6e-13"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999999953763"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.977355957031" RT="6741.28489999998" >
-			<PeptideHit score="0.00134408602150538" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.977355957031" RT="6741.28489999998" >
+			<PeptideHit score="0.712448020910727" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.7"/>
 				<UserParam type="float" name="E-Value" value="0.034"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.712448020910727"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289672851563" RT="6767.79970000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289672851563" RT="6767.79970000002" >
+			<PeptideHit score="0.999375797281708" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289611816406" RT="6769.65259999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289611816406" RT="6769.65259999998" >
+			<PeptideHit score="0.973239129162826" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.3"/>
 				<UserParam type="float" name="E-Value" value="0.0015"/>
 				<UserParam type="float" name="nextscore" value="10.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.973239129162826"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302612304688" RT="6800.48170000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302612304688" RT="6800.48170000002" >
+			<PeptideHit score="0.998964248012865" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.7"/>
 				<UserParam type="float" name="E-Value" value="2.5e-05"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998964248012865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302429199219" RT="6802.2528" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302429199219" RT="6802.2528" >
+			<PeptideHit score="0.999266889838404" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.4"/>
 				<UserParam type="float" name="E-Value" value="1.6e-05"/>
 				<UserParam type="float" name="nextscore" value="11.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999266889838404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.898315429688" RT="6821.85799999998" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.898315429688" RT="6821.85799999998" >
+			<PeptideHit score="0.999996530182202" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51"/>
 				<UserParam type="float" name="E-Value" value="1.6e-08"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996530182202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976623535156" RT="6832.87999999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976623535156" RT="6832.87999999998" >
+			<PeptideHit score="0.998932314583604" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.4"/>
 				<UserParam type="float" name="E-Value" value="2.6e-05"/>
 				<UserParam type="float" name="nextscore" value="10.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998932314583604"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.977294921875" RT="6834.0948" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.977294921875" RT="6834.0948" >
+			<PeptideHit score="0.999626472939553" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.8"/>
 				<UserParam type="float" name="E-Value" value="6.7e-06"/>
 				<UserParam type="float" name="nextscore" value="10.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999626472939553"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799713134766" RT="6844.94329999998" >
-			<PeptideHit score="0.00134408602150538" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799713134766" RT="6844.94329999998" >
+			<PeptideHit score="0.734542296491698" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.7"/>
 				<UserParam type="float" name="E-Value" value="0.03"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.734542296491698"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290283203125" RT="6861.13540000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290283203125" RT="6861.13540000002" >
+			<PeptideHit score="0.998626449672608" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="3.6e-05"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998626449672608"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.28955078125" RT="6863.2233" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.28955078125" RT="6863.2233" >
+			<PeptideHit score="0.98106717389803" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.8"/>
 				<UserParam type="float" name="E-Value" value="0.00098"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.98106717389803"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.4619140625" RT="6864.48580000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.4619140625" RT="6864.48580000002" >
+			<PeptideHit score="0.999988987733186" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="7.1e-08"/>
 				<UserParam type="float" name="nextscore" value="9.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999988987733186"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46252441406" RT="6866.25040000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46252441406" RT="6866.25040000002" >
+			<PeptideHit score="0.999810014670625" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.9"/>
 				<UserParam type="float" name="E-Value" value="2.8e-06"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999810014670625"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958435058594" RT="6885.6909" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958435058594" RT="6885.6909" >
+			<PeptideHit score="0.998093027078404" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.6"/>
 				<UserParam type="float" name="E-Value" value="5.5e-05"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998093027078404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302917480469" RT="6897.92029999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302917480469" RT="6897.92029999998" >
+			<PeptideHit score="0.999498504307823" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="9.8e-06"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999498504307823"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="697.71533203125" RT="6907.90930000002" >
-			<PeptideHit score="0.02" sequence="HIGISFTPKEVGEHVVSVR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_80" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="697.71533203125" RT="6907.90930000002" >
+			<PeptideHit score="0.246856676048891" sequence="HIGISFTPKEVGEHVVSVR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_80" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.8"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.899841308594" RT="6915.7185" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.899841308594" RT="6915.7185" >
+			<PeptideHit score="0.999999417569271" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.4"/>
 				<UserParam type="float" name="E-Value" value="1.6e-09"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999417569271"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.601806640625" RT="6919.4655" >
-			<PeptideHit score="0.00134408602150538" sequence="ESISVSSEQLAQFR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.601806640625" RT="6919.4655" >
+			<PeptideHit score="0.592573680193453" sequence="ESISVSSEQLAQFR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.7"/>
 				<UserParam type="float" name="E-Value" value="0.062"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.592573680193453"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976379394531" RT="6951.54040000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976379394531" RT="6951.54040000002" >
+			<PeptideHit score="0.97469904242467" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.6"/>
 				<UserParam type="float" name="E-Value" value="0.0014"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97469904242467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46203613281" RT="6957.507" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46203613281" RT="6957.507" >
+			<PeptideHit score="0.989380474210414" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.6"/>
 				<UserParam type="float" name="E-Value" value="0.00048"/>
 				<UserParam type="float" name="nextscore" value="14.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989380474210414"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46215820312" RT="6959.28340000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46215820312" RT="6959.28340000002" >
+			<PeptideHit score="0.999534566298792" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.5"/>
 				<UserParam type="float" name="E-Value" value="8.9e-06"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999534566298792"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289398193359" RT="6959.6262" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289398193359" RT="6959.6262" >
+			<PeptideHit score="0.95053753529317" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.1"/>
 				<UserParam type="float" name="E-Value" value="0.0032"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.95053753529317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.325927734375" RT="6960.126" >
-			<PeptideHit score="0.0434782608695652" sequence="VLPCIDFAKR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_16" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.325927734375" RT="6960.126" >
+			<PeptideHit score="0.111148168009872" sequence="VLPCIDFAKR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_16" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.5"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="525.284484863281" RT="6967.89130000002" >
-			<PeptideHit score="0" sequence="DLFNAIATGK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="525.284484863281" RT="6967.89130000002" >
+			<PeptideHit score="0.994321746497951" sequence="DLFNAIATGK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="525.284790039063" RT="6969.56419999998" >
-			<PeptideHit score="0" sequence="DLFNAIATGK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="525.284790039063" RT="6969.56419999998" >
+			<PeptideHit score="0.994736999948131" sequence="DLFNAIATGK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.3"/>
 				<UserParam type="float" name="E-Value" value="0.0002"/>
 				<UserParam type="float" name="nextscore" value="17.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994736999948131"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="482.266540527344" RT="6979.69060000002" >
-			<PeptideHit score="0.0489844683393071" sequence="ALRAEFEK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_143" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="482.266540527344" RT="6979.69060000002" >
+			<PeptideHit score="0.0969386199829794" sequence="ALRAEFEK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_143" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303497314453" RT="6988.5333" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303497314453" RT="6988.5333" >
+			<PeptideHit score="0.99984239932391" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.6"/>
 				<UserParam type="float" name="E-Value" value="2.2e-06"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99984239932391"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303527832031" RT="6992.40520000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303527832031" RT="6992.40520000002" >
+			<PeptideHit score="0.998119986595388" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.9"/>
 				<UserParam type="float" name="E-Value" value="5.4e-05"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998119986595388"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.899230957031" RT="7009.49710000002" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.899230957031" RT="7009.49710000002" >
+			<PeptideHit score="0.999999623909072" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.7"/>
 				<UserParam type="float" name="E-Value" value="9.1e-10"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999623909072"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.900268554688" RT="7011.8121" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.900268554688" RT="7011.8121" >
+			<PeptideHit score="0.999999504148436" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.4"/>
 				<UserParam type="float" name="E-Value" value="1.3e-09"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999504148436"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.318115234375" RT="7013.66449999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.318115234375" RT="7013.66449999998" >
+			<PeptideHit score="0.976178644666495" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.4"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="645.864196777344" RT="7028.3826" >
-			<PeptideHit score="0.0363636363636364" sequence="LLVHQRMHTR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_81" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="645.864196777344" RT="7028.3826" >
+			<PeptideHit score="0.168511319241557" sequence="LLVHQRMHTR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_81" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.7"/>
 				<UserParam type="float" name="E-Value" value="0.57"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.168511319241557"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46228027344" RT="7051.44730000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46228027344" RT="7051.44730000002" >
+			<PeptideHit score="0.996958329726846" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.2"/>
 				<UserParam type="float" name="E-Value" value="0.0001"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996958329726846"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976318359375" RT="7053.24370000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976318359375" RT="7053.24370000002" >
+			<PeptideHit score="0.916150345988615" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.5"/>
 				<UserParam type="float" name="E-Value" value="0.0062"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.916150345988615"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302917480469" RT="7084.75159999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302917480469" RT="7084.75159999998" >
+			<PeptideHit score="0.997446493984178" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37"/>
 				<UserParam type="float" name="E-Value" value="8e-05"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997446493984178"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.898254394531" RT="7102.17919999998" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.898254394531" RT="7102.17919999998" >
+			<PeptideHit score="0.999993918918339" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.9"/>
 				<UserParam type="float" name="E-Value" value="3.3e-08"/>
 				<UserParam type="float" name="nextscore" value="17.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993918918339"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943725585938" RT="7111.69510000002" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943725585938" RT="7111.69510000002" >
+			<PeptideHit score="0.860612864765694" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.7"/>
 				<UserParam type="float" name="E-Value" value="0.012"/>
 				<UserParam type="float" name="nextscore" value="12.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.860612864765694"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799682617188" RT="7114.52959999998" >
-			<PeptideHit score="0.029520295202952" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799682617188" RT="7114.52959999998" >
+			<PeptideHit score="0.193496525438801" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.1"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="19.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289245605469" RT="7121.15479999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289245605469" RT="7121.15479999998" >
+			<PeptideHit score="0.827735811978521" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.5"/>
 				<UserParam type="float" name="E-Value" value="0.016"/>
 				<UserParam type="float" name="nextscore" value="12.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.827735811978521"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289947509766" RT="7126.7025" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289947509766" RT="7126.7025" >
+			<PeptideHit score="0.90267681364214" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.1"/>
 				<UserParam type="float" name="E-Value" value="0.0075"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.90267681364214"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="700.844909667969" RT="7133.80969999998" >
-			<PeptideHit score="0" sequence="STDYGIFQINSR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_58" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="700.844909667969" RT="7133.80969999998" >
+			<PeptideHit score="0.999994498417026" sequence="STDYGIFQINSR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_58" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.8"/>
 				<UserParam type="float" name="E-Value" value="2.9e-08"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999994498417026"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303405761719" RT="7180.18549999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303405761719" RT="7180.18549999998" >
+			<PeptideHit score="0.993511362275586" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.6"/>
 				<UserParam type="float" name="E-Value" value="0.00026"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993511362275586"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="553.826843261719" RT="7181.3238" >
-			<PeptideHit score="0.029520295202952" sequence="ALSAKQNFVK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_75" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="553.826843261719" RT="7181.3238" >
+			<PeptideHit score="0.190629580961098" sequence="ALSAKQNFVK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_75" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="15.7"/>
 				<UserParam type="float" name="E-Value" value="0.48"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.190629580961098"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46130371094" RT="7187.32690000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46130371094" RT="7187.32690000002" >
+			<PeptideHit score="0.998423979561058" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="4.3e-05"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998423979561058"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46166992188" RT="7198.5582" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46166992188" RT="7198.5582" >
+			<PeptideHit score="0.989024704232947" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0005"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989024704232947"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290069580078" RT="7218.75220000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290069580078" RT="7218.75220000002" >
+			<PeptideHit score="0.989919202493546" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.4"/>
 				<UserParam type="float" name="E-Value" value="0.00045"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989919202493546"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="611.969055175781" RT="7240.7208" >
-			<PeptideHit score="0" sequence="TYFPHFDLSHGSAQVK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="611.969055175781" RT="7240.7208" >
+			<PeptideHit score="0.999413322128202" sequence="TYFPHFDLSHGSAQVK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.8"/>
 				<UserParam type="float" name="E-Value" value="1.2e-05"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999413322128202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="611.969116210938" RT="7242.46849999998" >
-			<PeptideHit score="0.00134408602150538" sequence="TYFPHFDLSHGSAQVK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="611.969116210938" RT="7242.46849999998" >
+			<PeptideHit score="0.672686395927008" sequence="TYFPHFDLSHGSAQVK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.2"/>
 				<UserParam type="float" name="E-Value" value="0.042"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.672686395927008"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289855957031" RT="7244.24959999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289855957031" RT="7244.24959999998" >
+			<PeptideHit score="0.985591053717679" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.8"/>
 				<UserParam type="float" name="E-Value" value="0.0007"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.985591053717679"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034790039063" RT="7279.36900000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034790039063" RT="7279.36900000002" >
+			<PeptideHit score="0.997880742629807" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.3"/>
 				<UserParam type="float" name="E-Value" value="6.3e-05"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997880742629807"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035705566406" RT="7281.12019999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035705566406" RT="7281.12019999998" >
+			<PeptideHit score="0.999990459802719" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="5.9e-08"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999990459802719"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.30322265625" RT="7285.21909999998" >
-			<PeptideHit score="0.00134408602150538" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.30322265625" RT="7285.21909999998" >
+			<PeptideHit score="0.572587814312497" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.7"/>
 				<UserParam type="float" name="E-Value" value="0.068"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.572587814312497"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46069335938" RT="7294.86280000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46069335938" RT="7294.86280000002" >
+			<PeptideHit score="0.997102585203685" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.8"/>
 				<UserParam type="float" name="E-Value" value="9.4e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997102585203685"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="741.373291015625" RT="7302.83800000002" >
-			<PeptideHit score="0" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="741.373291015625" RT="7302.83800000002" >
+			<PeptideHit score="0.999982401673567" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.3"/>
 				<UserParam type="float" name="E-Value" value="1.3e-07"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999982401673567"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="741.373474121094" RT="7304.56930000002" >
-			<PeptideHit score="0" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="741.373474121094" RT="7304.56930000002" >
+			<PeptideHit score="0.999999504148436" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.4"/>
 				<UserParam type="float" name="E-Value" value="1.3e-09"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999504148436"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="894.4677734375" RT="7354.18249999998" >
-			<PeptideHit score="0" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="894.4677734375" RT="7354.18249999998" >
+			<PeptideHit score="0.99999976723339" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.9"/>
 				<UserParam type="float" name="E-Value" value="4.9e-10"/>
 				<UserParam type="float" name="nextscore" value="20.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999976723339"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="691.667602539063" RT="7365.17449999998" >
-			<PeptideHit score="0.0102432778489117" sequence="(Glu->pyro-Glu)EASTQSSSAAASQGWVLPEGK" charge="3" aa_before="R" aa_after="I" protein_refs="PH_77 PH_102 PH_133 PH_134" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="691.667602539063" RT="7365.17449999998" >
+			<PeptideHit score="0.311171156417568" sequence="(Glu->pyro-Glu)EASTQSSSAAASQGWVLPEGK" charge="3" aa_before="R" aa_after="I" protein_refs="PH_77 PH_102 PH_133 PH_134" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.23"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.311171156417568"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035888671875" RT="7372.31200000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035888671875" RT="7372.31200000002" >
+			<PeptideHit score="0.999996871332784" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.8"/>
 				<UserParam type="float" name="E-Value" value="1.4e-08"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996871332784"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302673339844" RT="7375.6725" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302673339844" RT="7375.6725" >
+			<PeptideHit score="0.812550391896406" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.6"/>
 				<UserParam type="float" name="E-Value" value="0.018"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.812550391896406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46057128906" RT="7390.69669999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46057128906" RT="7390.69669999998" >
+			<PeptideHit score="0.999764215082746" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="3.7e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999764215082746"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="639.79443359375" RT="7391.27020000002" >
-			<PeptideHit score="0" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="639.79443359375" RT="7391.27020000002" >
+			<PeptideHit score="0.880392902346972" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27"/>
 				<UserParam type="float" name="E-Value" value="0.0098"/>
 				<UserParam type="float" name="nextscore" value="9.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.880392902346972"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="741.372802734375" RT="7422.1527" >
-			<PeptideHit score="0" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="741.372802734375" RT="7422.1527" >
+			<PeptideHit score="0.999859324618151" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.5"/>
 				<UserParam type="float" name="E-Value" value="1.9e-06"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999859324618151"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799743652344" RT="7432.2645" >
-			<PeptideHit score="0.0489844683393071" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799743652344" RT="7432.2645" >
+			<PeptideHit score="0.0969386199829794" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="17.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="894.468444824219" RT="7433.64190000002" >
-			<PeptideHit score="0" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="894.468444824219" RT="7433.64190000002" >
+			<PeptideHit score="0.999999981251654" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="70.1"/>
 				<UserParam type="float" name="E-Value" value="1.9e-11"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999981251654"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="626.861145019531" RT="7443.46930000002" >
-			<PeptideHit score="0" sequence="FLASVSTVLTSK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="626.861145019531" RT="7443.46930000002" >
+			<PeptideHit score="0.999907897771499" sequence="FLASVSTVLTSK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43"/>
 				<UserParam type="float" name="E-Value" value="1.1e-06"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999907897771499"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035461425781" RT="7464.34939999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035461425781" RT="7464.34939999998" >
+			<PeptideHit score="0.999999564367445" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-09"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999564367445"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036376953125" RT="7466.11420000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036376953125" RT="7466.11420000002" >
+			<PeptideHit score="0.999996699477478" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.7"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="22.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="639.7939453125" RT="7481.35249999998" >
-			<PeptideHit score="0" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="639.7939453125" RT="7481.35249999998" >
+			<PeptideHit score="0.954315536242781" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.9"/>
 				<UserParam type="float" name="E-Value" value="0.0029"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.954315536242781"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="639.794128417969" RT="7483.0311" >
-			<PeptideHit score="0" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="639.794128417969" RT="7483.0311" >
+			<PeptideHit score="0.967570696734317" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.9"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46252441406" RT="7485.51250000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46252441406" RT="7485.51250000002" >
+			<PeptideHit score="0.99999021009498" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.2"/>
 				<UserParam type="float" name="E-Value" value="6.1e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999021009498"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302642822266" RT="7489.43410000002" >
-			<PeptideHit score="0.00526315789473684" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302642822266" RT="7489.43410000002" >
+			<PeptideHit score="0.446677932430767" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.2"/>
 				<UserParam type="float" name="E-Value" value="0.12"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.446677932430767"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289581298828" RT="7518.09" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289581298828" RT="7518.09" >
+			<PeptideHit score="0.894717809051713" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.1"/>
 				<UserParam type="float" name="E-Value" value="0.0083"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.894717809051713"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="894.46826171875" RT="7528.3089" >
-			<PeptideHit score="0" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="894.46826171875" RT="7528.3089" >
+			<PeptideHit score="0.999993355049058" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.4"/>
 				<UserParam type="float" name="E-Value" value="3.7e-08"/>
 				<UserParam type="float" name="nextscore" value="19.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993355049058"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="626.861938476563" RT="7534.5417" >
-			<PeptideHit score="0" sequence="FLASVSTVLTSK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="626.861938476563" RT="7534.5417" >
+			<PeptideHit score="0.999266889838404" sequence="FLASVSTVLTSK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.9"/>
 				<UserParam type="float" name="E-Value" value="1.6e-05"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999266889838404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036193847656" RT="7570.4844" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036193847656" RT="7570.4844" >
+			<PeptideHit score="0.996259978029628" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="0.00013"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996259978029628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034973144531" RT="7578.81" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034973144531" RT="7578.81" >
+			<PeptideHit score="0.999943915092245" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="5.8e-07"/>
 				<UserParam type="float" name="nextscore" value="16.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999943915092245"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46118164062" RT="7582.2843" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46118164062" RT="7582.2843" >
+			<PeptideHit score="0.999983460247774" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="8.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303863525391" RT="7597.2018" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303863525391" RT="7597.2018" >
+			<PeptideHit score="0.966191334252643" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.8"/>
 				<UserParam type="float" name="E-Value" value="0.002"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.966191334252643"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46081542969" RT="7677.276" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46081542969" RT="7677.276" >
+			<PeptideHit score="0.999999958478686" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.6"/>
 				<UserParam type="float" name="E-Value" value="5.3e-11"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999958478686"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="493.786560058594" RT="7681.6461" >
-			<PeptideHit score="0.0139416983523447" sequence="IQILEGWK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="493.786560058594" RT="7681.6461" >
+			<PeptideHit score="0.281438322829347" sequence="IQILEGWK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.7"/>
 				<UserParam type="float" name="E-Value" value="0.27"/>
 				<UserParam type="float" name="nextscore" value="10.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.281438322829347"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.45971679688" RT="7687.98850000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.45971679688" RT="7687.98850000002" >
+			<PeptideHit score="0.999999956668419" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.5"/>
 				<UserParam type="float" name="E-Value" value="5.6e-11"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999956668419"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="894.468200683594" RT="7709.8992" >
-			<PeptideHit score="0" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="894.468200683594" RT="7709.8992" >
+			<PeptideHit score="0.943202686631416" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28"/>
 				<UserParam type="float" name="E-Value" value="0.0038"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.943202686631416"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.0361328125" RT="7730.41000000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.0361328125" RT="7730.41000000002" >
+			<PeptideHit score="0.999571462358373" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.7"/>
 				<UserParam type="float" name="E-Value" value="8e-06"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999571462358373"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46069335938" RT="7788.70540000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46069335938" RT="7788.70540000002" >
+			<PeptideHit score="0.987281990010137" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.0006"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.987281990010137"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="541.287536621094" RT="7805.7777" >
-			<PeptideHit score="0.00134408602150538" sequence="YDLTVPFAR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_39 PH_53" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="541.287536621094" RT="7805.7777" >
+			<PeptideHit score="0.771058061136823" sequence="YDLTVPFAR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_39 PH_53" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.7"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1063.00256347656" RT="7829.82109999998" >
-			<PeptideHit score="0.0102432778489117" sequence="(Gln->pyro-Glu)QSSMTVMEAQESPLFNNVK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_128" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1063.00256347656" RT="7829.82109999998" >
+			<PeptideHit score="0.319722467127969" sequence="(Gln->pyro-Glu)QSSMTVMEAQESPLFNNVK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_128" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.3"/>
 				<UserParam type="float" name="E-Value" value="0.22"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.319722467127969"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034606933594" RT="7870.8831" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034606933594" RT="7870.8831" >
+			<PeptideHit score="0.999997608236872" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="9.9e-09"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997608236872"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="602.814208984375" RT="7897.31719999998" >
-			<PeptideHit score="0" sequence="ELFDPIISDR" charge="2" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="602.814208984375" RT="7897.31719999998" >
+			<PeptideHit score="0.980753850169904" sequence="ELFDPIISDR" charge="2" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.2"/>
 				<UserParam type="float" name="E-Value" value="0.001"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980753850169904"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="541.286804199219" RT="7910.27320000002" >
-			<PeptideHit score="0" sequence="YDLTVPFAR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_39 PH_53" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="541.286804199219" RT="7910.27320000002" >
+			<PeptideHit score="0.784273217611407" sequence="YDLTVPFAR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_39 PH_53" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.022"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.784273217611407"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="602.813781738281" RT="7917.50449999998" >
-			<PeptideHit score="0" sequence="ELFDPIISDR" charge="2" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="602.813781738281" RT="7917.50449999998" >
+			<PeptideHit score="0.97179748620208" sequence="ELFDPIISDR" charge="2" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32"/>
 				<UserParam type="float" name="E-Value" value="0.0016"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97179748620208"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46203613281" RT="7934.478" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46203613281" RT="7934.478" >
+			<PeptideHit score="0.973239129162826" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.3"/>
 				<UserParam type="float" name="E-Value" value="0.0015"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.973239129162826"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.648315429688" RT="7946.60419999998" >
-			<PeptideHit score="0.0115089514066496" sequence="CTYQGQDEARVDAITLK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_111" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.648315429688" RT="7946.60419999998" >
+			<PeptideHit score="0.295486312650848" sequence="CTYQGQDEARVDAITLK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_111" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.7"/>
 				<UserParam type="float" name="E-Value" value="0.25"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.295486312650848"/>
+				<UserParam type="float" name="q-value" value="0.0115089514066496"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="837.382995605469" RT="7951.44439999998" >
-			<PeptideHit score="0" sequence="EIETYHNLLEGGQEDFESSGAGK" charge="3" aa_before="K" aa_after="I" protein_refs="PH_49" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="837.382995605469" RT="7951.44439999998" >
+			<PeptideHit score="0.999981361280163" sequence="EIETYHNLLEGGQEDFESSGAGK" charge="3" aa_before="K" aa_after="I" protein_refs="PH_49" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.9"/>
 				<UserParam type="float" name="E-Value" value="1.4e-07"/>
 				<UserParam type="float" name="nextscore" value="21.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999981361280163"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="825.745849609375" RT="7953.19870000002" >
-			<PeptideHit score="0.0489844683393071" sequence="MSCRESAPLTPSSAPVSQESLAVK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_145" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="825.745849609375" RT="7953.19870000002" >
+			<PeptideHit score="0.0969386199829794" sequence="MSCRESAPLTPSSAPVSQESLAVK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_145" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="752.685791015625" RT="7955.3595" >
-			<PeptideHit score="0" sequence="EIINVGHSFHVNFEDNDNR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="752.685791015625" RT="7955.3595" >
+			<PeptideHit score="0.97179748620208" sequence="EIINVGHSFHVNFEDNDNR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.0016"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97179748620208"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036376953125" RT="7961.30470000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036376953125" RT="7961.30470000002" >
+			<PeptideHit score="0.999999990410417" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="69.4"/>
 				<UserParam type="float" name="E-Value" value="8e-12"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999990410417"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035217285156" RT="7963.06789999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035217285156" RT="7963.06789999998" >
+			<PeptideHit score="0.999998151509767" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.5"/>
 				<UserParam type="float" name="E-Value" value="7.1e-09"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998151509767"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="738.37841796875" RT="8031.38770000002" >
-			<PeptideHit score="0" sequence="WELLQQVDTSTR" charge="2" aa_before="K" aa_after="T" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="738.37841796875" RT="8031.38770000002" >
+			<PeptideHit score="0.999999564367445" sequence="WELLQQVDTSTR" charge="2" aa_before="K" aa_after="T" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-09"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999564367445"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="738.378356933594" RT="8033.00500000002" >
-			<PeptideHit score="0" sequence="WELLQQVDTSTR" charge="2" aa_before="K" aa_after="T" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="738.378356933594" RT="8033.00500000002" >
+			<PeptideHit score="0.99989516753533" sequence="WELLQQVDTSTR" charge="2" aa_before="K" aa_after="T" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.6"/>
 				<UserParam type="float" name="E-Value" value="1.3e-06"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99989516753533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="752.686767578125" RT="8043.3462" >
-			<PeptideHit score="0" sequence="EIINVGHSFHVNFEDNDNR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="752.686767578125" RT="8043.3462" >
+			<PeptideHit score="0.995811820230489" sequence="EIINVGHSFHVNFEDNDNR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="0.00015"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995811820230489"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036071777344" RT="8046.85090000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036071777344" RT="8046.85090000002" >
+			<PeptideHit score="0.999302633161889" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.5"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1070.548828125" RT="8130.01390000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1070.548828125" RT="8130.01390000002" >
+			<PeptideHit score="0.99331247569031" sequence="YDPSLKPLSVSYDQATSLR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.7"/>
 				<UserParam type="float" name="E-Value" value="0.00027"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99331247569031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1070.54968261719" RT="8131.71490000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1070.54968261719" RT="8131.71490000002" >
+			<PeptideHit score="0.997297766960443" sequence="YDPSLKPLSVSYDQATSLR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.3"/>
 				<UserParam type="float" name="E-Value" value="8.6e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997297766960443"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.279144287109" RT="8181.26359999998" >
-			<PeptideHit score="0.0434782608695652" sequence="ELFEKPPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_131" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.279144287109" RT="8181.26359999998" >
+			<PeptideHit score="0.136426593016225" sequence="ELFEKPPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_131" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="26.4"/>
 				<UserParam type="float" name="E-Value" value="0.76"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.136426593016225"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.279144287109" RT="8183.02030000002" >
-			<PeptideHit score="0.0363636363636364" sequence="ELFEKPPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_131" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.279144287109" RT="8183.02030000002" >
+			<PeptideHit score="0.139151226014516" sequence="ELFEKPPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_131" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="26.4"/>
 				<UserParam type="float" name="E-Value" value="0.74"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.139151226014516"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.0361328125" RT="8195.21329999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.0361328125" RT="8195.21329999998" >
+			<PeptideHit score="0.999999943424381" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.6"/>
 				<UserParam type="float" name="E-Value" value="7.9e-11"/>
 				<UserParam type="float" name="nextscore" value="24.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999943424381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="604.978576660156" RT="8195.5044" >
-			<PeptideHit score="0.0151133501259446" sequence="ATFDEVLELMATGFLR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_139" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="604.978576660156" RT="8195.5044" >
+			<PeptideHit score="0.257305155260055" sequence="ATFDEVLELMATGFLR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_139" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.2"/>
 				<UserParam type="float" name="E-Value" value="0.31"/>
 				<UserParam type="float" name="nextscore" value="10.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.257305155260055"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="492.291656494141" RT="8227.67479999998" >
-			<PeptideHit score="0.0259259259259259" sequence="(Gln->pyro-Glu)QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="492.291656494141" RT="8227.67479999998" >
+			<PeptideHit score="0.209402044145386" sequence="(Gln->pyro-Glu)QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.4"/>
 				<UserParam type="float" name="E-Value" value="0.42"/>
 				<UserParam type="float" name="nextscore" value="11.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.209402044145386"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="584.321655273438" RT="8248.10560000002" >
-			<PeptideHit score="0" sequence="KQGGLGPMNIPLVSDPK" charge="3" aa_before="K" aa_after="R" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="584.321655273438" RT="8248.10560000002" >
+			<PeptideHit score="0.997322409292524" sequence="KQGGLGPMNIPLVSDPK" charge="3" aa_before="K" aa_after="R" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="8.5e-05"/>
 				<UserParam type="float" name="nextscore" value="22.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997322409292524"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="584.321350097656" RT="8252.14519999998" >
-			<PeptideHit score="0" sequence="KQGGLGPMNIPLVSDPK" charge="3" aa_before="K" aa_after="R" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="584.321350097656" RT="8252.14519999998" >
+			<PeptideHit score="0.999338919682092" sequence="KQGGLGPMNIPLVSDPK" charge="3" aa_before="K" aa_after="R" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="1.4e-05"/>
 				<UserParam type="float" name="nextscore" value="20.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999338919682092"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036437988281" RT="8289.3645" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036437988281" RT="8289.3645" >
+			<PeptideHit score="0.999999883776959" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="69.2"/>
 				<UserParam type="float" name="E-Value" value="2e-10"/>
 				<UserParam type="float" name="nextscore" value="21.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999883776959"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035583496094" RT="8291.07079999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035583496094" RT="8291.07079999998" >
+			<PeptideHit score="0.999999228385608" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.3"/>
 				<UserParam type="float" name="E-Value" value="2.3e-09"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999228385608"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952026367188" RT="8296.7532" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952026367188" RT="8296.7532" >
+			<PeptideHit score="0.999998483417254" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.5"/>
 				<UserParam type="float" name="E-Value" value="5.5e-09"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998483417254"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425231933594" RT="8332.5582" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425231933594" RT="8332.5582" >
+			<PeptideHit score="0.99984239932391" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.4"/>
 				<UserParam type="float" name="E-Value" value="2.2e-06"/>
 				<UserParam type="float" name="nextscore" value="11.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99984239932391"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425842285156" RT="8334.80089999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425842285156" RT="8334.80089999998" >
+			<PeptideHit score="0.999981361280163" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50"/>
 				<UserParam type="float" name="E-Value" value="1.4e-07"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999981361280163"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952239990234" RT="8364.04750000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952239990234" RT="8364.04750000002" >
+			<PeptideHit score="0.999935834951473" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.9"/>
 				<UserParam type="float" name="E-Value" value="6.9e-07"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999935834951473"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034851074219" RT="8364.2982" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034851074219" RT="8364.2982" >
+			<PeptideHit score="0.999995558807143" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.9"/>
 				<UserParam type="float" name="E-Value" value="2.2e-08"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995558807143"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952178955078" RT="8366.1249" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952178955078" RT="8366.1249" >
+			<PeptideHit score="0.999999926876528" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-10"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999926876528"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.424743652344" RT="8369.88469999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.424743652344" RT="8369.88469999998" >
+			<PeptideHit score="0.999810014670625" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.9"/>
 				<UserParam type="float" name="E-Value" value="2.8e-06"/>
 				<UserParam type="float" name="nextscore" value="11.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999810014670625"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.657836914063" RT="8371.1454" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.657836914063" RT="8371.1454" >
+			<PeptideHit score="0.931534620353677" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="0.0048"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.931534620353677"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425598144531" RT="8372.751" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425598144531" RT="8372.751" >
+			<PeptideHit score="0.999919808785286" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.3"/>
 				<UserParam type="float" name="E-Value" value="9.2e-07"/>
 				<UserParam type="float" name="nextscore" value="11.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999919808785286"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034729003906" RT="8381.82259999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034729003906" RT="8381.82259999998" >
+			<PeptideHit score="0.999995096243584" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.4"/>
 				<UserParam type="float" name="E-Value" value="2.5e-08"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995096243584"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035339355469" RT="8389.67500000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035339355469" RT="8389.67500000002" >
+			<PeptideHit score="0.999999474833695" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.6"/>
 				<UserParam type="float" name="E-Value" value="1.4e-09"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999474833695"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953033447266" RT="8391.4419" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953033447266" RT="8391.4419" >
+			<PeptideHit score="0.999999892890679" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.5"/>
 				<UserParam type="float" name="E-Value" value="1.8e-10"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999892890679"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952178955078" RT="8393.2023" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952178955078" RT="8393.2023" >
+			<PeptideHit score="0.999995403129308" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.1"/>
 				<UserParam type="float" name="E-Value" value="2.3e-08"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995403129308"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="601.843383789063" RT="8400.23869999998" >
-			<PeptideHit score="0.0139416983523447" sequence="YEILAANAIPK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_50" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="601.843383789063" RT="8400.23869999998" >
+			<PeptideHit score="0.28827458994223" sequence="YEILAANAIPK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_50" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.6"/>
 				<UserParam type="float" name="E-Value" value="0.26"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.28827458994223"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.6572265625" RT="8405.5359" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.6572265625" RT="8405.5359" >
+			<PeptideHit score="0.999948466346366" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.3"/>
 				<UserParam type="float" name="E-Value" value="5.2e-07"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999948466346366"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.42431640625" RT="8411.45620000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.42431640625" RT="8411.45620000002" >
+			<PeptideHit score="0.999413322128202" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.9"/>
 				<UserParam type="float" name="E-Value" value="1.2e-05"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999413322128202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425903320313" RT="8413.65730000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425903320313" RT="8413.65730000002" >
+			<PeptideHit score="0.999957135954253" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.7"/>
 				<UserParam type="float" name="E-Value" value="4.1e-07"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999957135954253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.280212402344" RT="8417.12140000002" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.280212402344" RT="8417.12140000002" >
+			<PeptideHit score="0.992145529169711" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.6"/>
 				<UserParam type="float" name="E-Value" value="0.00033"/>
 				<UserParam type="float" name="nextscore" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992145529169711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.281433105469" RT="8422.90099999998" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.281433105469" RT="8422.90099999998" >
+			<PeptideHit score="0.991954978966702" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.6"/>
 				<UserParam type="float" name="E-Value" value="0.00034"/>
 				<UserParam type="float" name="nextscore" value="8.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991954978966702"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952453613281" RT="8443.3758" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952453613281" RT="8443.3758" >
+			<PeptideHit score="0.999999990132854" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.8"/>
 				<UserParam type="float" name="E-Value" value="8.3e-12"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999990132854"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.95263671875" RT="8445.1419" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.95263671875" RT="8445.1419" >
+			<PeptideHit score="0.999998908036975" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-09"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998908036975"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="710.722961425781" RT="8461.26070000002" >
-			<PeptideHit score="0.00526315789473684" sequence="TLSDYNIQKESTLHLVLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="710.722961425781" RT="8461.26070000002" >
+			<PeptideHit score="0.503347576910457" sequence="TLSDYNIQKESTLHLVLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.4"/>
 				<UserParam type="float" name="E-Value" value="0.093"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.503347576910457"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.657958984375" RT="8490.31489999998" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.657958984375" RT="8490.31489999998" >
+			<PeptideHit score="0.999451560929756" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.7"/>
 				<UserParam type="float" name="E-Value" value="1.1e-05"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999451560929756"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="528.273681640625" RT="8498.51770000002" >
-			<PeptideHit score="0" sequence="VSFELFADK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="528.273681640625" RT="8498.51770000002" >
+			<PeptideHit score="0.989919202493546" sequence="VSFELFADK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="0.00045"/>
 				<UserParam type="float" name="nextscore" value="19.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989919202493546"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.280151367188" RT="8513.45950000002" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.280151367188" RT="8513.45950000002" >
+			<PeptideHit score="0.99331247569031" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.1"/>
 				<UserParam type="float" name="E-Value" value="0.00027"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99331247569031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425231933594" RT="8535.5481" >
-			<PeptideHit score="0.02" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425231933594" RT="8535.5481" >
+			<PeptideHit score="0.246856676048891" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.4"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952087402344" RT="8537.3286" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952087402344" RT="8537.3286" >
+			<PeptideHit score="0.999999445986628" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-09"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999445986628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951995849609" RT="8539.10290000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951995849609" RT="8539.10290000002" >
+			<PeptideHit score="0.999999907005607" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-10"/>
 				<UserParam type="float" name="nextscore" value="18.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999907005607"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036315917969" RT="8562.1803" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036315917969" RT="8562.1803" >
+			<PeptideHit score="0.999999307602226" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60"/>
 				<UserParam type="float" name="E-Value" value="2e-09"/>
 				<UserParam type="float" name="nextscore" value="19.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999307602226"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035827636719" RT="8565.71749999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035827636719" RT="8565.71749999998" >
+			<PeptideHit score="0.999998569625157" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.8"/>
 				<UserParam type="float" name="E-Value" value="5.1e-09"/>
 				<UserParam type="float" name="nextscore" value="19.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998569625157"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.2802734375" RT="8606.00800000002" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.2802734375" RT="8606.00800000002" >
+			<PeptideHit score="0.991576891487535" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.4"/>
 				<UserParam type="float" name="E-Value" value="0.00036"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991576891487535"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.2802734375" RT="8607.68029999998" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.2802734375" RT="8607.68029999998" >
+			<PeptideHit score="0.984269703140117" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.7"/>
 				<UserParam type="float" name="E-Value" value="0.00078"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984269703140117"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="609.814575195313" RT="8608.82569999998" >
-			<PeptideHit score="0.00402684563758389" sequence="ELQDSKEELK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_9" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="609.814575195313" RT="8608.82569999998" >
+			<PeptideHit score="0.51314785373008" sequence="ELQDSKEELK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_9" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="27.8"/>
 				<UserParam type="float" name="E-Value" value="0.089"/>
 				<UserParam type="float" name="nextscore" value="22.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.51314785373008"/>
+				<UserParam type="float" name="q-value" value="0.00402684563758389"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951812744141" RT="8630.12179999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951812744141" RT="8630.12179999998" >
+			<PeptideHit score="0.999999921775042" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.4"/>
 				<UserParam type="float" name="E-Value" value="1.2e-10"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999921775042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.9521484375" RT="8631.7935" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.9521484375" RT="8631.7935" >
+			<PeptideHit score="0.999999965328785" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64"/>
 				<UserParam type="float" name="E-Value" value="4.2e-11"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999965328785"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.0361328125" RT="8652.91000000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.0361328125" RT="8652.91000000002" >
+			<PeptideHit score="0.999999659649047" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.4"/>
 				<UserParam type="float" name="E-Value" value="8e-10"/>
 				<UserParam type="float" name="nextscore" value="19.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999659649047"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="528.273498535156" RT="8676.77320000002" >
-			<PeptideHit score="0.0259259259259259" sequence="VSFELFADK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="528.273498535156" RT="8676.77320000002" >
+			<PeptideHit score="0.20599231767492" sequence="VSFELFADK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21"/>
 				<UserParam type="float" name="E-Value" value="0.43"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.20599231767492"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="601.848388671875" RT="8687.31460000002" >
-			<PeptideHit score="0.02" sequence="NITVDPRLFK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_18" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="601.848388671875" RT="8687.31460000002" >
+			<PeptideHit score="0.246856676048891" sequence="NITVDPRLFK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_18" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.4"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952392578125" RT="8723.28379999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952392578125" RT="8723.28379999998" >
+			<PeptideHit score="0.999999993338167" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.7"/>
 				<UserParam type="float" name="E-Value" value="5e-12"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999993338167"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952270507813" RT="8724.94510000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952270507813" RT="8724.94510000002" >
+			<PeptideHit score="0.999999981251654" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.4"/>
 				<UserParam type="float" name="E-Value" value="1.9e-11"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999981251654"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.650268554688" RT="8736.46600000002" >
-			<PeptideHit score="0.029520295202952" sequence="LELYDSKQTQHDTFGK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_11" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.650268554688" RT="8736.46600000002" >
+			<PeptideHit score="0.196460921093246" sequence="LELYDSKQTQHDTFGK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_11" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.46"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.196460921093246"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.894470214844" RT="8745.05389999998" >
-			<PeptideHit score="0" sequence="EGEETGEGDKTPSSDGD" charge="3" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.894470214844" RT="8745.05389999998" >
+			<PeptideHit score="0.00951478018092533" sequence="EGEETGEGDKTPSSDGD" charge="3" >
 				<UserParam type="string" name="target_decoy" value=""/>
 				<UserParam type="float" name="XTandem_score" value="9.1"/>
 				<UserParam type="float" name="E-Value" value="530"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.00951478018092533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952270507813" RT="8793.76000000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952270507813" RT="8793.76000000002" >
+			<PeptideHit score="0.999999967916601" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.2"/>
 				<UserParam type="float" name="E-Value" value="3.8e-11"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999967916601"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="692.348876953125" RT="8811.97630000002" >
-			<PeptideHit score="0" sequence="SLNNQFASFIDK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="692.348876953125" RT="8811.97630000002" >
+			<PeptideHit score="0.999997933185207" sequence="SLNNQFASFIDK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.4"/>
 				<UserParam type="float" name="E-Value" value="8.2e-09"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997933185207"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="692.350524902344" RT="8813.775" >
-			<PeptideHit score="0.029520295202952" sequence="SILDQSISSFMR" charge="2" aa_before="K" aa_after="K" protein_refs="PH_3" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="692.350524902344" RT="8813.775" >
+			<PeptideHit score="0.193496525438801" sequence="SILDQSISSFMR" charge="2" aa_before="K" aa_after="K" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="728.694946289063" RT="8847.0489" >
-			<PeptideHit score="0" sequence="NFTEVHPDYGSHIQALLDK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="728.694946289063" RT="8847.0489" >
+			<PeptideHit score="0.960802305355011" sequence="NFTEVHPDYGSHIQALLDK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34"/>
 				<UserParam type="float" name="E-Value" value="0.0024"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.960802305355011"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035095214844" RT="8858.38039999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035095214844" RT="8858.38039999998" >
+			<PeptideHit score="0.999999051936364" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.8"/>
 				<UserParam type="float" name="E-Value" value="3e-09"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999051936364"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.03515625" RT="8863.54720000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.03515625" RT="8863.54720000002" >
+			<PeptideHit score="0.999975426201442" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.1"/>
 				<UserParam type="float" name="E-Value" value="2e-07"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999975426201442"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="788.767944335938" RT="8870.54599999998" >
-			<PeptideHit score="0" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="788.767944335938" RT="8870.54599999998" >
+			<PeptideHit score="0.99999999999095" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="87.5"/>
 				<UserParam type="float" name="E-Value" value="1e-15"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999999999095"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="788.768615722656" RT="8874.39529999998" >
-			<PeptideHit score="0" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="788.768615722656" RT="8874.39529999998" >
+			<PeptideHit score="0.99999999999095" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="86.8"/>
 				<UserParam type="float" name="E-Value" value="1e-15"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999999999095"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951934814453" RT="8885.76049999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951934814453" RT="8885.76049999998" >
+			<PeptideHit score="0.999999956668419" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.5"/>
 				<UserParam type="float" name="E-Value" value="5.6e-11"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999956668419"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953002929688" RT="8887.4292" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953002929688" RT="8887.4292" >
+			<PeptideHit score="0.999998591411326" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.7"/>
 				<UserParam type="float" name="E-Value" value="5e-09"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998591411326"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="788.768432617188" RT="8966.88199999998" >
-			<PeptideHit score="0" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="788.768432617188" RT="8966.88199999998" >
+			<PeptideHit score="0.999962082800366" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.8"/>
 				<UserParam type="float" name="E-Value" value="3.5e-07"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999962082800366"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036010742188" RT="8968.5414" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036010742188" RT="8968.5414" >
+			<PeptideHit score="0.99999995726936" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="68.9"/>
 				<UserParam type="float" name="E-Value" value="5.5e-11"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999995726936"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="788.768127441406" RT="8972.1195" >
-			<PeptideHit score="0" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="788.768127441406" RT="8972.1195" >
+			<PeptideHit score="0.999999999971969" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="83"/>
 				<UserParam type="float" name="E-Value" value="4.3e-15"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999971969"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952453613281" RT="8978.41630000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952453613281" RT="8978.41630000002" >
+			<PeptideHit score="0.999999993545645" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.8"/>
 				<UserParam type="float" name="E-Value" value="4.8e-12"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999993545645"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951995849609" RT="8980.19959999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951995849609" RT="8980.19959999998" >
+			<PeptideHit score="0.999997778551365" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.7"/>
 				<UserParam type="float" name="E-Value" value="9e-09"/>
 				<UserParam type="float" name="nextscore" value="16.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997778551365"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="877.921264648438" RT="8986.41949999998" >
-			<PeptideHit score="0.02" sequence="GTFGPCCRWALDTVTK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_135" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="877.921264648438" RT="8986.41949999998" >
+			<PeptideHit score="0.251961841294195" sequence="GTFGPCCRWALDTVTK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_135" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="21.7"/>
 				<UserParam type="float" name="E-Value" value="0.32"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.251961841294195"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.61328125" RT="9043.52029999998" >
-			<PeptideHit score="0.00134408602150538" sequence="GAGAFGYFEVTHDITK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.61328125" RT="9043.52029999998" >
+			<PeptideHit score="0.752250699877261" sequence="GAGAFGYFEVTHDITK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.1"/>
 				<UserParam type="float" name="E-Value" value="0.027"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.752250699877261"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="856.916931152344" RT="9068.28559999998" >
-			<PeptideHit score="0" sequence="GAGAFGYFEVTHDITK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="856.916931152344" RT="9068.28559999998" >
+			<PeptideHit score="0.999999921775042" sequence="GAGAFGYFEVTHDITK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.3"/>
 				<UserParam type="float" name="E-Value" value="1.2e-10"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999921775042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="9071.85199999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="9071.85199999998" >
+			<PeptideHit score="0.999999954879847" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.4"/>
 				<UserParam type="float" name="E-Value" value="5.9e-11"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999954879847"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952575683594" RT="9073.63519999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952575683594" RT="9073.63519999998" >
+			<PeptideHit score="0.999999936870942" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.7"/>
 				<UserParam type="float" name="E-Value" value="9.1e-11"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999936870942"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="611.308166503906" RT="9088.60519999998" >
-			<PeptideHit score="0.0444711538461538" sequence="SIYGEKFEDENFILK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="611.308166503906" RT="9088.60519999998" >
+			<PeptideHit score="0.103478204192389" sequence="SIYGEKFEDENFILK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="16.2"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="916.459655761719" RT="9116.55370000002" >
-			<PeptideHit score="0" sequence="SIYGEKFEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="916.459655761719" RT="9116.55370000002" >
+			<PeptideHit score="0.999997702404425" sequence="SIYGEKFEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61"/>
 				<UserParam type="float" name="E-Value" value="9.4e-09"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997702404425"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.613708496094" RT="9137.04859999998" >
-			<PeptideHit score="0" sequence="GAGAFGYFEVTHDITK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.613708496094" RT="9137.04859999998" >
+			<PeptideHit score="0.835623332778618" sequence="GAGAFGYFEVTHDITK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.1"/>
 				<UserParam type="float" name="E-Value" value="0.015"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.835623332778618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="661.677490234375" RT="9201.54049999998" >
-			<PeptideHit score="0" sequence="TIAQDYGVLKADEGISFR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="661.677490234375" RT="9201.54049999998" >
+			<PeptideHit score="0.812550391896406" sequence="TIAQDYGVLKADEGISFR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.018"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.812550391896406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="661.678466796875" RT="9203.3178" >
-			<PeptideHit score="0" sequence="TIAQDYGVLKADEGISFR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="661.678466796875" RT="9203.3178" >
+			<PeptideHit score="0.933818296789238" sequence="TIAQDYGVLKADEGISFR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.8"/>
 				<UserParam type="float" name="E-Value" value="0.0046"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.933818296789238"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951934814453" RT="9256.33729999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951934814453" RT="9256.33729999998" >
+			<PeptideHit score="0.9999998975322" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.6"/>
 				<UserParam type="float" name="E-Value" value="1.7e-10"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.9999998975322"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952606201172" RT="9257.7678" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952606201172" RT="9257.7678" >
+			<PeptideHit score="0.999996530182202" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64"/>
 				<UserParam type="float" name="E-Value" value="1.6e-08"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996530182202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="690.384704589844" RT="9258.41860000002" >
-			<PeptideHit score="0.0139416983523447" sequence="DQDNAIIRPLPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_10" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="690.384704589844" RT="9258.41860000002" >
+			<PeptideHit score="0.274948227693009" sequence="DQDNAIIRPLPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_10" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20"/>
 				<UserParam type="float" name="E-Value" value="0.28"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.274948227693009"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="690.382202148438" RT="9260.03419999998" >
-			<PeptideHit score="0" sequence="VSFELFADKVPK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="690.382202148438" RT="9260.03419999998" >
+			<PeptideHit score="0.999915119404183" sequence="VSFELFADKVPK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.4"/>
 				<UserParam type="float" name="E-Value" value="9.9e-07"/>
 				<UserParam type="float" name="nextscore" value="12.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999915119404183"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.7890625" RT="9312.14440000002" >
-			<PeptideHit score="0.00906735751295337" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.7890625" RT="9312.14440000002" >
+			<PeptideHit score="0.384387191798194" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.16"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.384387191798194"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.788024902344" RT="9313.90990000002" >
-			<PeptideHit score="0.0151133501259446" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.788024902344" RT="9313.90990000002" >
+			<PeptideHit score="0.262904122502352" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="21.1"/>
 				<UserParam type="float" name="E-Value" value="0.3"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.262904122502352"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035339355469" RT="9343.6032" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035339355469" RT="9343.6032" >
+			<PeptideHit score="0.999968991099384" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.3"/>
 				<UserParam type="float" name="E-Value" value="2.7e-07"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999968991099384"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952087402344" RT="9349.0917" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952087402344" RT="9349.0917" >
+			<PeptideHit score="0.999999916768411" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60"/>
 				<UserParam type="float" name="E-Value" value="1.3e-10"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999916768411"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952270507813" RT="9350.86240000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952270507813" RT="9350.86240000002" >
+			<PeptideHit score="0.999999921775042" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.3"/>
 				<UserParam type="float" name="E-Value" value="1.2e-10"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999921775042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="617.979614257813" RT="9382.46119999998" >
-			<PeptideHit score="0" sequence="TLNDMRQEYEQLIAK" charge="3" aa_before="K" aa_after="N" protein_refs="PH_49" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="617.979614257813" RT="9382.46119999998" >
+			<PeptideHit score="0.960802305355011" sequence="TLNDMRQEYEQLIAK" charge="3" aa_before="K" aa_after="N" protein_refs="PH_49" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.0024"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.960802305355011"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="509.94189453125" RT="9386.17339999998" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="509.94189453125" RT="9386.17339999998" >
+			<PeptideHit score="0.999061854320524" sequence="NVIQISNDLENLR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.4"/>
 				<UserParam type="float" name="E-Value" value="2.2e-05"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999061854320524"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="562.310180664063" RT="9400.54210000002" >
-			<PeptideHit score="0.0102432778489117" sequence="DPILFPSFIHSQKR" charge="3" aa_before="R" aa_after="N" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="562.310180664063" RT="9400.54210000002" >
+			<PeptideHit score="0.303106246021224" sequence="DPILFPSFIHSQKR" charge="3" aa_before="R" aa_after="N" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.4"/>
 				<UserParam type="float" name="E-Value" value="0.24"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.303106246021224"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="811.932739257813" RT="9402.3291" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="811.932739257813" RT="9402.3291" >
+			<PeptideHit score="0.999993635170618" sequence="QGGLGPMNIPLVSDPK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.2"/>
 				<UserParam type="float" name="E-Value" value="3.5e-08"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993635170618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.788208007813" RT="9404.10949999998" >
-			<PeptideHit score="0.00906735751295337" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.788208007813" RT="9404.10949999998" >
+			<PeptideHit score="0.384387191798194" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.4"/>
 				<UserParam type="float" name="E-Value" value="0.16"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.384387191798194"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.788146972656" RT="9405.88060000002" >
-			<PeptideHit score="0.00134408602150538" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.788146972656" RT="9405.88060000002" >
+			<PeptideHit score="0.777594217720977" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="24.8"/>
 				<UserParam type="float" name="E-Value" value="0.023"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.777594217720977"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="811.932189941406" RT="9406.3017" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="811.932189941406" RT="9406.3017" >
+			<PeptideHit score="0.999996699477478" sequence="QGGLGPMNIPLVSDPK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.9"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="411.580322265625" RT="9435.4674" >
-			<PeptideHit score="0.0102432778489117" sequence="ANRPFLVFIR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_15" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="411.580322265625" RT="9435.4674" >
+			<PeptideHit score="0.328807035189251" sequence="ANRPFLVFIR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_15" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.1"/>
 				<UserParam type="float" name="E-Value" value="0.21"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.328807035189251"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.410949707031" RT="9440.95399999998" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.410949707031" RT="9440.95399999998" >
+			<PeptideHit score="0.999999973980493" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.6"/>
 				<UserParam type="float" name="E-Value" value="2.9e-11"/>
 				<UserParam type="float" name="nextscore" value="22.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999973980493"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952209472656" RT="9441.21730000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952209472656" RT="9441.21730000002" >
+			<PeptideHit score="0.999998931620711" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.3"/>
 				<UserParam type="float" name="E-Value" value="3.5e-09"/>
 				<UserParam type="float" name="nextscore" value="18.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998931620711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.410583496094" RT="9442.8513" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.410583496094" RT="9442.8513" >
+			<PeptideHit score="0.999999982800186" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.6"/>
 				<UserParam type="float" name="E-Value" value="1.7e-11"/>
 				<UserParam type="float" name="nextscore" value="22.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999982800186"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.9189453125" RT="9460.11979999998" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.9189453125" RT="9460.11979999998" >
+			<PeptideHit score="0.968964271876771" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.5"/>
 				<UserParam type="float" name="E-Value" value="0.0018"/>
 				<UserParam type="float" name="nextscore" value="22.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.968964271876771"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="621.296691894531" RT="9514.19770000002" >
-			<PeptideHit score="0" sequence="YDGLVGMFDPK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_39 PH_53" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="621.296691894531" RT="9514.19770000002" >
+			<PeptideHit score="0.982173192499341" sequence="YDGLVGMFDPK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_39 PH_53" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.2"/>
 				<UserParam type="float" name="E-Value" value="0.00091"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.982173192499341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953155517578" RT="9535.70110000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953155517578" RT="9535.70110000002" >
+			<PeptideHit score="0.999964626875691" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.3"/>
 				<UserParam type="float" name="E-Value" value="3.2e-07"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999964626875691"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="656.375183105469" RT="9537.0171" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="656.375183105469" RT="9537.0171" >
+			<PeptideHit score="0.878537248230859" sequence="HPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.4"/>
 				<UserParam type="float" name="E-Value" value="0.01"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.878537248230859"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952362060547" RT="9537.28660000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952362060547" RT="9537.28660000002" >
+			<PeptideHit score="0.999999774631398" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.8"/>
 				<UserParam type="float" name="E-Value" value="4.7e-10"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999774631398"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.410766601563" RT="9537.84979999998" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.410766601563" RT="9537.84979999998" >
+			<PeptideHit score="0.999993216272323" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.6"/>
 				<UserParam type="float" name="E-Value" value="3.8e-08"/>
 				<UserParam type="float" name="nextscore" value="22.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993216272323"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.918304443359" RT="9554.40589999998" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.918304443359" RT="9554.40589999998" >
+			<PeptideHit score="0.999996699477478" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.918975830078" RT="9556.19440000002" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.918975830078" RT="9556.19440000002" >
+			<PeptideHit score="0.989559356772796" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.9"/>
 				<UserParam type="float" name="E-Value" value="0.00047"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989559356772796"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952087402344" RT="9629.43379999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952087402344" RT="9629.43379999998" >
+			<PeptideHit score="0.999999417569271" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.7"/>
 				<UserParam type="float" name="E-Value" value="1.6e-09"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999417569271"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="382.541900634766" RT="9629.95360000002" >
-			<PeptideHit score="0.00134408602150538" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="382.541900634766" RT="9629.95360000002" >
+			<PeptideHit score="0.637783228316437" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.3"/>
 				<UserParam type="float" name="E-Value" value="0.05"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.637783228316437"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.409423828125" RT="9630.58729999998" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.409423828125" RT="9630.58729999998" >
+			<PeptideHit score="0.999999957872764" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.6"/>
 				<UserParam type="float" name="E-Value" value="5.4e-11"/>
 				<UserParam type="float" name="nextscore" value="22"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999957872764"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="656.374633789063" RT="9631.86649999998" >
-			<PeptideHit score="0.00526315789473684" sequence="HPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="656.374633789063" RT="9631.86649999998" >
+			<PeptideHit score="0.446677932430767" sequence="HPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.4"/>
 				<UserParam type="float" name="E-Value" value="0.12"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.446677932430767"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.867065429688" RT="9633.0147" >
-			<PeptideHit score="0.00134408602150538" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.867065429688" RT="9633.0147" >
+			<PeptideHit score="0.728863619332872" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.9"/>
 				<UserParam type="float" name="E-Value" value="0.031"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.728863619332872"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="382.541809082031" RT="9636.5097" >
-			<PeptideHit score="0.00134408602150538" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="382.541809082031" RT="9636.5097" >
+			<PeptideHit score="0.603177103780716" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.4"/>
 				<UserParam type="float" name="E-Value" value="0.059"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.603177103780716"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.918334960938" RT="9655.66510000002" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.918334960938" RT="9655.66510000002" >
+			<PeptideHit score="0.979203874797132" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.1"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="20.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.918640136719" RT="9672.41239999998" >
-			<PeptideHit score="0.00651890482398957" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.918640136719" RT="9672.41239999998" >
+			<PeptideHit score="0.412959460251658" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35"/>
 				<UserParam type="float" name="E-Value" value="0.14"/>
 				<UserParam type="float" name="nextscore" value="25"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.412959460251658"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="573.308044433594" RT="9715.11469999998" >
-			<PeptideHit score="0" sequence="DLKWWELR" charge="2" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="573.308044433594" RT="9715.11469999998" >
+			<PeptideHit score="0.892764267514638" sequence="DLKWWELR" charge="2" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36"/>
 				<UserParam type="float" name="E-Value" value="0.0085"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.892764267514638"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="573.309265136719" RT="9716.9076" >
-			<PeptideHit score="0" sequence="DLKWWELR" charge="2" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="573.309265136719" RT="9716.9076" >
+			<PeptideHit score="0.937288968996664" sequence="DLKWWELR" charge="2" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="0.0043"/>
 				<UserParam type="float" name="nextscore" value="20.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.937288968996664"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866333007813" RT="9725.45599999998" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866333007813" RT="9725.45599999998" >
+			<PeptideHit score="0.994528455081984" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.6"/>
 				<UserParam type="float" name="E-Value" value="0.00021"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994528455081984"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="382.5419921875" RT="9727.8306" >
-			<PeptideHit score="0.00134408602150538" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="382.5419921875" RT="9727.8306" >
+			<PeptideHit score="0.542451678177793" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.5"/>
 				<UserParam type="float" name="E-Value" value="0.078"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.542451678177793"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.8662109375" RT="9728.15689999998" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.8662109375" RT="9728.15689999998" >
+			<PeptideHit score="0.999997664605406" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.6"/>
 				<UserParam type="float" name="E-Value" value="9.6e-09"/>
 				<UserParam type="float" name="nextscore" value="21.3"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997664605406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.409912109375" RT="9729.1245" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.409912109375" RT="9729.1245" >
+			<PeptideHit score="0.999998462088884" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.5"/>
 				<UserParam type="float" name="E-Value" value="5.6e-09"/>
 				<UserParam type="float" name="nextscore" value="21.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998462088884"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="382.5419921875" RT="9730.9296" >
-			<PeptideHit score="0.00526315789473684" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="382.5419921875" RT="9730.9296" >
+			<PeptideHit score="0.465947082204611" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.5"/>
 				<UserParam type="float" name="E-Value" value="0.11"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.465947082204611"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="557.301940917969" RT="9743.69830000002" >
-			<PeptideHit score="0.0363636363636364" sequence="VLGAFSDGLAHLDNLK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="557.301940917969" RT="9743.69830000002" >
+			<PeptideHit score="0.175225488597367" sequence="VLGAFSDGLAHLDNLK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="0.54"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.175225488597367"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="600.000061035156" RT="9775.02070000002" >
-			<PeptideHit score="0" sequence="KVLGAFSDGLAHLDNLK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="600.000061035156" RT="9775.02070000002" >
+			<PeptideHit score="0.999128598342253" sequence="KVLGAFSDGLAHLDNLK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.7"/>
 				<UserParam type="float" name="E-Value" value="2e-05"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999128598342253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="644.684631347656" RT="9814.5594" >
-			<PeptideHit score="0.0363636363636364" sequence="SQAQIWVSILQQLEMR" charge="3" aa_before="K" aa_after="A" protein_refs="PH_140" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="644.684631347656" RT="9814.5594" >
+			<PeptideHit score="0.175225488597367" sequence="SQAQIWVSILQQLEMR" charge="3" aa_before="K" aa_after="A" protein_refs="PH_140" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.7"/>
 				<UserParam type="float" name="E-Value" value="0.54"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.175225488597367"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866516113281" RT="9818.12290000002" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866516113281" RT="9818.12290000002" >
+			<PeptideHit score="0.999991092618655" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.6"/>
 				<UserParam type="float" name="E-Value" value="5.4e-08"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999991092618655"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952545166016" RT="9818.3883" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952545166016" RT="9818.3883" >
+			<PeptideHit score="0.999925958251218" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52"/>
 				<UserParam type="float" name="E-Value" value="8.3e-07"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999925958251218"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866455078125" RT="9820.87759999998" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866455078125" RT="9820.87759999998" >
+			<PeptideHit score="0.999999003306759" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.5"/>
 				<UserParam type="float" name="E-Value" value="3.2e-09"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999003306759"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.867065429688" RT="9911.84050000002" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.867065429688" RT="9911.84050000002" >
+			<PeptideHit score="0.999998547934873" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.6"/>
 				<UserParam type="float" name="E-Value" value="5.2e-09"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998547934873"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952301025391" RT="9912.15829999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952301025391" RT="9912.15829999998" >
+			<PeptideHit score="0.999882872506843" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-06"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999882872506843"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866882324219" RT="9913.60669999998" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866882324219" RT="9913.60669999998" >
+			<PeptideHit score="0.998996472288824" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.5"/>
 				<UserParam type="float" name="E-Value" value="2.4e-05"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998996472288824"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951812744141" RT="9913.9353" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951812744141" RT="9913.9353" >
+			<PeptideHit score="0.999784218688703" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.1"/>
 				<UserParam type="float" name="E-Value" value="3.3e-06"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999784218688703"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866455078125" RT="10004.6873" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866455078125" RT="10004.6873" >
+			<PeptideHit score="0.977679598036381" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.9"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951965332031" RT="10005.078" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951965332031" RT="10005.078" >
+			<PeptideHit score="0.999983460247774" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.4"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.8662109375" RT="10006.3346" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.8662109375" RT="10006.3346" >
+			<PeptideHit score="0.906747837131065" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="0.0071"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.906747837131065"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952178955078" RT="10006.9708" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952178955078" RT="10006.9708" >
+			<PeptideHit score="0.999999151466588" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.8"/>
 				<UserParam type="float" name="E-Value" value="2.6e-09"/>
 				<UserParam type="float" name="nextscore" value="19.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999151466588"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.408813476563" RT="10026.1521" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.408813476563" RT="10026.1521" >
+			<PeptideHit score="0.999933683228512" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.4"/>
 				<UserParam type="float" name="E-Value" value="7.2e-07"/>
 				<UserParam type="float" name="nextscore" value="20.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999933683228512"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866027832031" RT="10097.8358" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866027832031" RT="10097.8358" >
+			<PeptideHit score="0.933818296789238" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.2"/>
 				<UserParam type="float" name="E-Value" value="0.0046"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.933818296789238"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952392578125" RT="10098.3343" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952392578125" RT="10098.3343" >
+			<PeptideHit score="0.999375797281708" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.1"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952514648438" RT="10099.6339" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952514648438" RT="10099.6339" >
+			<PeptideHit score="0.997371865907272" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="8.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997371865907272"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="493.639282226563" RT="10137.6489" >
-			<PeptideHit score="0.00134408602150538" sequence="HGATVLTALGGILKK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="493.639282226563" RT="10137.6489" >
+			<PeptideHit score="0.771058061136823" sequence="HGATVLTALGGILKK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.6"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="9.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.408874511719" RT="10146.1742" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.408874511719" RT="10146.1742" >
+			<PeptideHit score="0.996259978029628" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.4"/>
 				<UserParam type="float" name="E-Value" value="0.00013"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996259978029628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951843261719" RT="10192.6241" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951843261719" RT="10192.6241" >
+			<PeptideHit score="0.999847979667845" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.3"/>
 				<UserParam type="float" name="E-Value" value="2.1e-06"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999847979667845"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952911376953" RT="10193.914" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952911376953" RT="10193.914" >
+			<PeptideHit score="0.999162532344856" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.6"/>
 				<UserParam type="float" name="E-Value" value="1.9e-05"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999162532344856"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.86669921875" RT="10197.89" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.86669921875" RT="10197.89" >
+			<PeptideHit score="0.812550391896406" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.3"/>
 				<UserParam type="float" name="E-Value" value="0.018"/>
 				<UserParam type="float" name="nextscore" value="8.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.812550391896406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.865844726563" RT="10201.9416" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.865844726563" RT="10201.9416" >
+			<PeptideHit score="0.98265189056406" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.4"/>
 				<UserParam type="float" name="E-Value" value="0.00088"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.98265189056406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="493.639923095703" RT="10252.761" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILKK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="493.639923095703" RT="10252.761" >
+			<PeptideHit score="0.967570696734317" sequence="HGATVLTALGGILKK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.2"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="11.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.408935546875" RT="10260.1498" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.408935546875" RT="10260.1498" >
+			<PeptideHit score="0.999946936748021" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.9"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="846.744445800781" RT="10297.0524" >
-			<PeptideHit score="0" sequence="LIQFHFHWGSLDGQGSEHTVDK" charge="3" aa_before="R" aa_after="K" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="846.744445800781" RT="10297.0524" >
+			<PeptideHit score="0.999957135954253" sequence="LIQFHFHWGSLDGQGSEHTVDK" charge="3" aa_before="R" aa_after="K" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="4.1e-07"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999957135954253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="10297.9818" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="10297.9818" >
+			<PeptideHit score="0.998746131332642" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.8"/>
 				<UserParam type="float" name="E-Value" value="3.2e-05"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998746131332642"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952941894531" RT="10368.2199" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952941894531" RT="10368.2199" >
+			<PeptideHit score="0.999749532301869" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49"/>
 				<UserParam type="float" name="E-Value" value="4e-06"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999749532301869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="453.938171386719" RT="10389.8785" >
-			<PeptideHit score="0.00526315789473684" sequence="GLFIIDDKGILR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="453.938171386719" RT="10389.8785" >
+			<PeptideHit score="0.487163428094098" sequence="GLFIIDDKGILR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.2"/>
 				<UserParam type="float" name="E-Value" value="0.1"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.487163428094098"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952880859375" RT="10390.3099" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952880859375" RT="10390.3099" >
+			<PeptideHit score="0.998174212639616" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="5.2e-05"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998174212639616"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="453.937835693359" RT="10392.1662" >
-			<PeptideHit score="0" sequence="GLFIIDDKGILR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="453.937835693359" RT="10392.1662" >
+			<PeptideHit score="0.995160070637582" sequence="GLFIIDDKGILR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.1"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="680.402526855469" RT="10396.0063" >
-			<PeptideHit score="0" sequence="GLFIIDDKGILR" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="680.402526855469" RT="10396.0063" >
+			<PeptideHit score="0.999999703356172" sequence="GLFIIDDKGILR" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.2"/>
 				<UserParam type="float" name="E-Value" value="6.7e-10"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999703356172"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="835.448181152344" RT="10408.5453" >
-			<PeptideHit score="0" sequence="VLGAFSDGLAHLDNLK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="835.448181152344" RT="10408.5453" >
+			<PeptideHit score="0.999999883776959" sequence="VLGAFSDGLAHLDNLK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.7"/>
 				<UserParam type="float" name="E-Value" value="2e-10"/>
 				<UserParam type="float" name="nextscore" value="17"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999883776959"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866943359375" RT="10466.1475" >
-			<PeptideHit score="0.00134408602150538" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866943359375" RT="10466.1475" >
+			<PeptideHit score="0.717819888667725" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.4"/>
 				<UserParam type="float" name="E-Value" value="0.033"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.717819888667725"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831481933594" RT="10478.977" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831481933594" RT="10478.977" >
+			<PeptideHit score="0.960802305355011" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.7"/>
 				<UserParam type="float" name="E-Value" value="0.0024"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.960802305355011"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="381.557189941406" RT="10484.3266" >
-			<PeptideHit score="0.0434782608695652" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="381.557189941406" RT="10484.3266" >
+			<PeptideHit score="0.111148168009872" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.5"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951934814453" RT="10488.2903" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951934814453" RT="10488.2903" >
+			<PeptideHit score="0.999622160834219" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="6.8e-06"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999622160834219"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821960449219" RT="10558.6428" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821960449219" RT="10558.6428" >
+			<PeptideHit score="0.999990085933915" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.7"/>
 				<UserParam type="float" name="E-Value" value="6.2e-08"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999990085933915"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831237792969" RT="10570.3483" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831237792969" RT="10570.3483" >
+			<PeptideHit score="0.999998440846017" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.5"/>
 				<UserParam type="float" name="E-Value" value="5.7e-09"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998440846017"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832458496094" RT="10572.1407" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832458496094" RT="10572.1407" >
+			<PeptideHit score="0.999946936748021" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.6"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="381.557678222656" RT="10576.8814" >
-			<PeptideHit score="0.0363636363636364" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="381.557678222656" RT="10576.8814" >
+			<PeptideHit score="0.166398718169042" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19"/>
 				<UserParam type="float" name="E-Value" value="0.58"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.166398718169042"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="10581.1537" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="10581.1537" >
+			<PeptideHit score="0.999095046374717" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.7"/>
 				<UserParam type="float" name="E-Value" value="2.1e-05"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999095046374717"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952392578125" RT="10594.3958" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952392578125" RT="10594.3958" >
+			<PeptideHit score="0.979203874797132" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.8"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821166992188" RT="10633.0791" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821166992188" RT="10633.0791" >
+			<PeptideHit score="0.99999997056655" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.4"/>
 				<UserParam type="float" name="E-Value" value="3.4e-11"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999997056655"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.82177734375" RT="10634.8285" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.82177734375" RT="10634.8285" >
+			<PeptideHit score="0.999999969233292" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="62.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-11"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999969233292"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832885742188" RT="10642.3779" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832885742188" RT="10642.3779" >
+			<PeptideHit score="0.999996871332784" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.9"/>
 				<UserParam type="float" name="E-Value" value="1.4e-08"/>
 				<UserParam type="float" name="nextscore" value="19.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996871332784"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.83251953125" RT="10644.0808" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.83251953125" RT="10644.0808" >
+			<PeptideHit score="0.999998031549755" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58"/>
 				<UserParam type="float" name="E-Value" value="7.7e-09"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998031549755"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="945.429443359375" RT="10694.4256" >
-			<PeptideHit score="0" sequence="SSPDPTSTLSNTVSYERSTDGSFQDR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_40" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="945.429443359375" RT="10694.4256" >
+			<PeptideHit score="0.937288968996664" sequence="SSPDPTSTLSNTVSYERSTDGSFQDR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_40" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.5"/>
 				<UserParam type="float" name="E-Value" value="0.0043"/>
 				<UserParam type="float" name="nextscore" value="14.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.937288968996664"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.8212890625" RT="10720.912" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.8212890625" RT="10720.912" >
+			<PeptideHit score="0.999999666262621" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.6"/>
 				<UserParam type="float" name="E-Value" value="7.8e-10"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999666262621"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821655273438" RT="10722.6374" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821655273438" RT="10722.6374" >
+			<PeptideHit score="0.999996871332784" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.8"/>
 				<UserParam type="float" name="E-Value" value="1.4e-08"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996871332784"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832092285156" RT="10735.0964" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832092285156" RT="10735.0964" >
+			<PeptideHit score="0.996958329726846" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.8"/>
 				<UserParam type="float" name="E-Value" value="0.0001"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996958329726846"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="381.557098388672" RT="10762.5068" >
-			<PeptideHit score="0.0363636363636364" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="381.557098388672" RT="10762.5068" >
+			<PeptideHit score="0.170684806755907" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.6"/>
 				<UserParam type="float" name="E-Value" value="0.56"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.170684806755907"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="599.815551757813" RT="10764.8166" >
-			<PeptideHit score="0" sequence="YWGVASFLQK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_22" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="599.815551757813" RT="10764.8166" >
+			<PeptideHit score="0.999413322128202" sequence="YWGVASFLQK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_22" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.5"/>
 				<UserParam type="float" name="E-Value" value="1.2e-05"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999413322128202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820922851563" RT="10813.58" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820922851563" RT="10813.58" >
+			<PeptideHit score="0.999994351943102" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.3"/>
 				<UserParam type="float" name="E-Value" value="3e-08"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999994351943102"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821594238281" RT="10815.3625" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821594238281" RT="10815.3625" >
+			<PeptideHit score="0.99999280475604" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.8"/>
 				<UserParam type="float" name="E-Value" value="4.1e-08"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999280475604"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952667236328" RT="10819.8723" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952667236328" RT="10819.8723" >
+			<PeptideHit score="0.999977353129764" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.6"/>
 				<UserParam type="float" name="E-Value" value="1.8e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999977353129764"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831237792969" RT="10830.1527" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831237792969" RT="10830.1527" >
+			<PeptideHit score="0.994116771387973" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="0.00023"/>
 				<UserParam type="float" name="nextscore" value="22.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994116771387973"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="754.403869628906" RT="10830.7796" >
-			<PeptideHit score="0" sequence="LSVEALNSLTGEFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="754.403869628906" RT="10830.7796" >
+			<PeptideHit score="0.999999921775042" sequence="LSVEALNSLTGEFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58"/>
 				<UserParam type="float" name="E-Value" value="1.2e-10"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999921775042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="546.9580078125" RT="10838.39" >
-			<PeptideHit score="0.0102432778489117" sequence="SLNNQFASFIDKVR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="546.9580078125" RT="10838.39" >
+			<PeptideHit score="0.328807035189251" sequence="SLNNQFASFIDKVR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.7"/>
 				<UserParam type="float" name="E-Value" value="0.21"/>
 				<UserParam type="float" name="nextscore" value="17.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.328807035189251"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="762.0625" RT="10845.8772" >
-			<PeptideHit score="0.00651890482398957" sequence="ASELHQRDVLLTELSNCTVR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_83" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="762.0625" RT="10845.8772" >
+			<PeptideHit score="0.412959460251658" sequence="ASELHQRDVLLTELSNCTVR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_83" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.1"/>
 				<UserParam type="float" name="E-Value" value="0.14"/>
 				<UserParam type="float" name="nextscore" value="18.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.412959460251658"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="548.610656738281" RT="10878.8077" >
-			<PeptideHit score="0.00134408602150538" sequence="SFLVWVNEEDHLR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="548.610656738281" RT="10878.8077" >
+			<PeptideHit score="0.637783228316437" sequence="SFLVWVNEEDHLR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.3"/>
 				<UserParam type="float" name="E-Value" value="0.05"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.637783228316437"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820068359375" RT="10906.5965" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820068359375" RT="10906.5965" >
+			<PeptideHit score="0.999990965036209" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.6"/>
 				<UserParam type="float" name="E-Value" value="5.5e-08"/>
 				<UserParam type="float" name="nextscore" value="11.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999990965036209"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821350097656" RT="10908.3694" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821350097656" RT="10908.3694" >
+			<PeptideHit score="0.999921163166508" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.8"/>
 				<UserParam type="float" name="E-Value" value="9e-07"/>
 				<UserParam type="float" name="nextscore" value="9.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999921163166508"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832092285156" RT="10928.734" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832092285156" RT="10928.734" >
+			<PeptideHit score="0.999688506246991" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.9"/>
 				<UserParam type="float" name="E-Value" value="5.3e-06"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999688506246991"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.83154296875" RT="10932.7183" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.83154296875" RT="10932.7183" >
+			<PeptideHit score="0.994321746497951" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.2"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="625.821899414063" RT="10935.2857" >
-			<PeptideHit score="0.0342298288508557" sequence="MLQDTVLAAGCK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_137" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="625.821899414063" RT="10935.2857" >
+			<PeptideHit score="0.182566859658893" sequence="MLQDTVLAAGCK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_137" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20"/>
 				<UserParam type="float" name="E-Value" value="0.51"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.182566859658893"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="639.02734375" RT="10936.4735" >
-			<PeptideHit score="0.00134408602150538" sequence="TFVNITPAEVGVLVGKDR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_31" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="639.02734375" RT="10936.4735" >
+			<PeptideHit score="0.723290649933401" sequence="TFVNITPAEVGVLVGKDR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_31" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.2"/>
 				<UserParam type="float" name="E-Value" value="0.032"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.723290649933401"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="758.906494140625" RT="10956.2658" >
-			<PeptideHit score="0.0434782608695652" sequence="ELMQLEKELVER" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_109" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="758.906494140625" RT="10956.2658" >
+			<PeptideHit score="0.111148168009872" sequence="ELMQLEKELVER" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_109" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.4"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="23.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821899414063" RT="11000.4961" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821899414063" RT="11000.4961" >
+			<PeptideHit score="0.999997589533166" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.5"/>
 				<UserParam type="float" name="E-Value" value="1e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997589533166"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820922851563" RT="11002.8139" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820922851563" RT="11002.8139" >
+			<PeptideHit score="0.999995403129308" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.5"/>
 				<UserParam type="float" name="E-Value" value="2.3e-08"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995403129308"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831665039063" RT="11026.5059" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831665039063" RT="11026.5059" >
+			<PeptideHit score="0.983780616446989" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.7"/>
 				<UserParam type="float" name="E-Value" value="0.00081"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.983780616446989"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="11039.2794" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="11039.2794" >
+			<PeptideHit score="0.988671489432927" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.1"/>
 				<UserParam type="float" name="E-Value" value="0.00052"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.988671489432927"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="851.456176757813" RT="11063.2" >
-			<PeptideHit score="0" sequence="AVFVDLEPTVIDEVR" charge="2" aa_before="R" aa_after="T" protein_refs="PH_68 PH_97 PH_127" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="851.456176757813" RT="11063.2" >
+			<PeptideHit score="0.999991349393745" sequence="AVFVDLEPTVIDEVR" charge="2" aa_before="R" aa_after="T" protein_refs="PH_68 PH_97 PH_127" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.9"/>
 				<UserParam type="float" name="E-Value" value="5.2e-08"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999991349393745"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821838378906" RT="11094.4943" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821838378906" RT="11094.4943" >
+			<PeptideHit score="0.999996530182202" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.4"/>
 				<UserParam type="float" name="E-Value" value="1.6e-08"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996530182202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821228027344" RT="11096.1463" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821228027344" RT="11096.1463" >
+			<PeptideHit score="0.999993355049058" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.4"/>
 				<UserParam type="float" name="E-Value" value="3.7e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993355049058"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370910644531" RT="11104.6555" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370910644531" RT="11104.6555" >
+			<PeptideHit score="0.980910367654004" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.3"/>
 				<UserParam type="float" name="E-Value" value="0.00099"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980910367654004"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369934082031" RT="11106.4405" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369934082031" RT="11106.4405" >
+			<PeptideHit score="0.995374869594322" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.4"/>
 				<UserParam type="float" name="E-Value" value="0.00017"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995374869594322"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1023.05206298828" RT="11114.6575" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1023.05206298828" RT="11114.6575" >
+			<PeptideHit score="0.999996035830139" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.1"/>
 				<UserParam type="float" name="E-Value" value="1.9e-08"/>
 				<UserParam type="float" name="nextscore" value="11.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996035830139"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.83251953125" RT="11118.0506" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.83251953125" RT="11118.0506" >
+			<PeptideHit score="0.998423979561058" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47"/>
 				<UserParam type="float" name="E-Value" value="4.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998423979561058"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="695.019165039063" RT="11121.5798" >
-			<PeptideHit score="0.0259259259259259" sequence="DYGTGLSAGPGTSRPASYVVK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_4" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="695.019165039063" RT="11121.5798" >
+			<PeptideHit score="0.209402044145386" sequence="DYGTGLSAGPGTSRPASYVVK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_4" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.4"/>
 				<UserParam type="float" name="E-Value" value="0.42"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.209402044145386"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="517.636291503906" RT="11129.829" >
-			<PeptideHit score="0.0434782608695652" sequence="YVIGIGVGAGAYVLAK" charge="3" aa_before="K" aa_after="F" protein_refs="PH_141" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="517.636291503906" RT="11129.829" >
+			<PeptideHit score="0.111148168009872" sequence="YVIGIGVGAGAYVLAK" charge="3" aa_before="K" aa_after="F" protein_refs="PH_141" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.4"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.941711425781" RT="11147.4383" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.941711425781" RT="11147.4383" >
+			<PeptideHit score="0.999955524143958" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="4.3e-07"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999955524143958"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.37060546875" RT="11155.3576" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.37060546875" RT="11155.3576" >
+			<PeptideHit score="0.999991608400688" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60"/>
 				<UserParam type="float" name="E-Value" value="5e-08"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999991608400688"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.909118652344" RT="11155.6377" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="675.909118652344" RT="11155.6377" >
+			<PeptideHit score="0.999999812773505" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.2"/>
 				<UserParam type="float" name="E-Value" value="3.7e-10"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999812773505"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="11157.1155" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="11157.1155" >
+			<PeptideHit score="0.999997223667326" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.6"/>
 				<UserParam type="float" name="E-Value" value="1.2e-08"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997223667326"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.909118652344" RT="11159.1848" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="675.909118652344" RT="11159.1848" >
+			<PeptideHit score="0.999999988776952" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.3"/>
 				<UserParam type="float" name="E-Value" value="9.8e-12"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999988776952"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1023.05230712891" RT="11165.0249" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1023.05230712891" RT="11165.0249" >
+			<PeptideHit score="0.999999417569271" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61"/>
 				<UserParam type="float" name="E-Value" value="1.6e-09"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999417569271"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1023.05126953125" RT="11166.6494" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1023.05126953125" RT="11166.6494" >
+			<PeptideHit score="0.999990085933915" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.3"/>
 				<UserParam type="float" name="E-Value" value="6.2e-08"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999990085933915"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831298828125" RT="11167.3857" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831298828125" RT="11167.3857" >
+			<PeptideHit score="0.991576891487535" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.4"/>
 				<UserParam type="float" name="E-Value" value="0.00036"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991576891487535"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.942047119141" RT="11172.1491" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.942047119141" RT="11172.1491" >
+			<PeptideHit score="0.999999991933441" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="62.3"/>
 				<UserParam type="float" name="E-Value" value="6.4e-12"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999991933441"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.941925048828" RT="11175.0736" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.941925048828" RT="11175.0736" >
+			<PeptideHit score="0.999993635170618" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.6"/>
 				<UserParam type="float" name="E-Value" value="3.5e-08"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993635170618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="11181.0511" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="11181.0511" >
+			<PeptideHit score="0.99999994231739" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="68.8"/>
 				<UserParam type="float" name="E-Value" value="8.1e-11"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999994231739"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.909484863281" RT="11182.8302" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="675.909484863281" RT="11182.8302" >
+			<PeptideHit score="0.999999926876528" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-10"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999926876528"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.908996582031" RT="11184.5948" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="675.908996582031" RT="11184.5948" >
+			<PeptideHit score="0.99999998931328" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.2"/>
 				<UserParam type="float" name="E-Value" value="9.2e-12"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999998931328"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="995.47119140625" RT="11185.6931" >
-			<PeptideHit score="0" sequence="FFDSFGNLSSASAIMGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="995.47119140625" RT="11185.6931" >
+			<PeptideHit score="0.999999999893731" sequence="FFDSFGNLSSASAIMGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="78"/>
 				<UserParam type="float" name="E-Value" value="2.4e-14"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999893731"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821228027344" RT="11251.4589" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821228027344" RT="11251.4589" >
+			<PeptideHit score="0.999986425241788" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55"/>
 				<UserParam type="float" name="E-Value" value="9.3e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999986425241788"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820434570313" RT="11253.2345" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820434570313" RT="11253.2345" >
+			<PeptideHit score="0.99998722407621" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54"/>
 				<UserParam type="float" name="E-Value" value="8.6e-08"/>
 				<UserParam type="float" name="nextscore" value="11.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998722407621"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370849609375" RT="11272.7042" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370849609375" RT="11272.7042" >
+			<PeptideHit score="0.999999836765708" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="68.3"/>
 				<UserParam type="float" name="E-Value" value="3.1e-10"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999836765708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.3701171875" RT="11274.4743" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.3701171875" RT="11274.4743" >
+			<PeptideHit score="0.999999990690331" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="74.4"/>
 				<UserParam type="float" name="E-Value" value="7.7e-12"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999990690331"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.829895019531" RT="11332.9605" >
-			<PeptideHit score="0.0259259259259259" sequence="DLKPTSIAAAR" charge="2" aa_before="K" aa_after="M" protein_refs="PH_74" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.829895019531" RT="11332.9605" >
+			<PeptideHit score="0.209402044145386" sequence="DLKPTSIAAAR" charge="2" aa_before="K" aa_after="M" protein_refs="PH_74" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.2"/>
 				<UserParam type="float" name="E-Value" value="0.42"/>
 				<UserParam type="float" name="nextscore" value="21.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.209402044145386"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820495605469" RT="11346.574" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820495605469" RT="11346.574" >
+			<PeptideHit score="0.999951566095295" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54"/>
 				<UserParam type="float" name="E-Value" value="4.8e-07"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999951566095295"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952117919922" RT="11348.3681" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952117919922" RT="11348.3681" >
+			<PeptideHit score="0.996488921991653" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.2"/>
 				<UserParam type="float" name="E-Value" value="0.00012"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996488921991653"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370910644531" RT="11366.1036" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370910644531" RT="11366.1036" >
+			<PeptideHit score="0.999999902235584" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.1"/>
 				<UserParam type="float" name="E-Value" value="1.6e-10"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999902235584"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370300292969" RT="11367.8875" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370300292969" RT="11367.8875" >
+			<PeptideHit score="0.999999984390352" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="72.2"/>
 				<UserParam type="float" name="E-Value" value="1.5e-11"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999984390352"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847045898438" RT="11403.308" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847045898438" RT="11403.308" >
+			<PeptideHit score="0.99998453888027" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.6"/>
 				<UserParam type="float" name="E-Value" value="1.1e-07"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998453888027"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.8466796875" RT="11405.1473" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.8466796875" RT="11405.1473" >
+			<PeptideHit score="0.999779168898944" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.5"/>
 				<UserParam type="float" name="E-Value" value="3.4e-06"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999779168898944"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820678710938" RT="11431.2577" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820678710938" RT="11431.2577" >
+			<PeptideHit score="0.999998483417254" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.8"/>
 				<UserParam type="float" name="E-Value" value="5.5e-09"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998483417254"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832885742188" RT="11456.7483" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832885742188" RT="11456.7483" >
+			<PeptideHit score="0.922621924276223" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.6"/>
 				<UserParam type="float" name="E-Value" value="0.0056"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.922621924276223"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.84716796875" RT="11495.2914" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.84716796875" RT="11495.2914" >
+			<PeptideHit score="0.999998955356525" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58"/>
 				<UserParam type="float" name="E-Value" value="3.4e-09"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998955356525"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847106933594" RT="11496.9184" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847106933594" RT="11496.9184" >
+			<PeptideHit score="0.999999964690663" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66"/>
 				<UserParam type="float" name="E-Value" value="4.3e-11"/>
 				<UserParam type="float" name="nextscore" value="17.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999964690663"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820068359375" RT="11523.7577" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820068359375" RT="11523.7577" >
+			<PeptideHit score="0.999764215082746" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.6"/>
 				<UserParam type="float" name="E-Value" value="3.7e-06"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999764215082746"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821411132813" RT="11525.5315" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821411132813" RT="11525.5315" >
+			<PeptideHit score="0.999993078314779" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52"/>
 				<UserParam type="float" name="E-Value" value="3.9e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993078314779"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="999.500915527344" RT="11526.1693" >
-			<PeptideHit score="0" sequence="FFDSFGNLSSPSAILGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_20" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="999.500915527344" RT="11526.1693" >
+			<PeptideHit score="0.999998356693945" sequence="FFDSFGNLSSPSAILGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_20" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.4"/>
 				<UserParam type="float" name="E-Value" value="6.1e-09"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998356693945"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="999.502075195313" RT="11527.4781" >
-			<PeptideHit score="0" sequence="FFDSFGNLSSPSAILGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_20" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="999.502075195313" RT="11527.4781" >
+			<PeptideHit score="0.999995875058368" sequence="FFDSFGNLSSPSAILGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_20" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.9"/>
 				<UserParam type="float" name="E-Value" value="2e-08"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995875058368"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952941894531" RT="11547.6119" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952941894531" RT="11547.6119" >
+			<PeptideHit score="0.995160070637582" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.2"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.903503417969" RT="11563.7497" >
-			<PeptideHit score="0" sequence="VDLLNQEIEFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_51" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.903503417969" RT="11563.7497" >
+			<PeptideHit score="0.999999254517236" sequence="VDLLNQEIEFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_51" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.8"/>
 				<UserParam type="float" name="E-Value" value="2.2e-09"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999254517236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.90380859375" RT="11572.1475" >
-			<PeptideHit score="0" sequence="VDLLNQEIEFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_51" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.90380859375" RT="11572.1475" >
+			<PeptideHit score="0.999998635280842" sequence="VDLLNQEIEFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_51" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.2"/>
 				<UserParam type="float" name="E-Value" value="4.8e-09"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998635280842"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="694.682922363281" RT="11576.1105" >
-			<PeptideHit score="0" sequence="MDQTLAVYQQILTSMPSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="694.682922363281" RT="11576.1105" >
+			<PeptideHit score="0.940816934477305" sequence="MDQTLAVYQQILTSMPSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.8"/>
 				<UserParam type="float" name="E-Value" value="0.004"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.940816934477305"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846984863281" RT="11588.8606" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846984863281" RT="11588.8606" >
+			<PeptideHit score="0.999999051936364" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.6"/>
 				<UserParam type="float" name="E-Value" value="3e-09"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999051936364"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847412109375" RT="11590.6018" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847412109375" RT="11590.6018" >
+			<PeptideHit score="0.999994062235367" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.8"/>
 				<UserParam type="float" name="E-Value" value="3.2e-08"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999994062235367"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820983886719" RT="11617.6404" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820983886719" RT="11617.6404" >
+			<PeptideHit score="0.999970786631432" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54"/>
 				<UserParam type="float" name="E-Value" value="2.5e-07"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999970786631432"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820861816406" RT="11619.4209" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820861816406" RT="11619.4209" >
+			<PeptideHit score="0.999907897771499" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50"/>
 				<UserParam type="float" name="E-Value" value="1.1e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999907897771499"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="940.09423828125" RT="11621.1977" >
-			<PeptideHit score="0.0331695331695332" sequence="TSSSAFEKRPYEPSSNGSSSGEYAHR" charge="3" aa_before="R" aa_after="T" protein_refs="PH_142" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="940.09423828125" RT="11621.1977" >
+			<PeptideHit score="0.187855272905827" sequence="TSSSAFEKRPYEPSSNGSSSGEYAHR" charge="3" aa_before="R" aa_after="T" protein_refs="PH_142" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22"/>
 				<UserParam type="float" name="E-Value" value="0.49"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.187855272905827"/>
+				<UserParam type="float" name="q-value" value="0.0331695331695332"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.83154296875" RT="11625.3879" >
-			<PeptideHit score="0.0259259259259259" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.83154296875" RT="11625.3879" >
+			<PeptideHit score="0.199527926792731" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.9"/>
 				<UserParam type="float" name="E-Value" value="0.45"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.199527926792731"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370666503906" RT="11637.9578" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370666503906" RT="11637.9578" >
+			<PeptideHit score="0.999993776575081" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.5"/>
 				<UserParam type="float" name="E-Value" value="3.4e-08"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993776575081"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846801757813" RT="11682.5972" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846801757813" RT="11682.5972" >
+			<PeptideHit score="0.999999741852381" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.6"/>
 				<UserParam type="float" name="E-Value" value="5.6e-10"/>
 				<UserParam type="float" name="nextscore" value="17"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999741852381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831665039063" RT="11686.5743" >
-			<PeptideHit score="0.00134408602150538" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831665039063" RT="11686.5743" >
+			<PeptideHit score="0.734542296491698" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.3"/>
 				<UserParam type="float" name="E-Value" value="0.03"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.734542296491698"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="651.86083984375" RT="11715.5111" >
-			<PeptideHit score="0" sequence="SLDLDSIIAEVK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="651.86083984375" RT="11715.5111" >
+			<PeptideHit score="0.999999969233292" sequence="SLDLDSIIAEVK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-11"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999969233292"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820495605469" RT="11717.2955" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820495605469" RT="11717.2955" >
+			<PeptideHit score="0.999999861833214" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.9"/>
 				<UserParam type="float" name="E-Value" value="2.5e-10"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999861833214"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820617675781" RT="11719.0615" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820617675781" RT="11719.0615" >
+			<PeptideHit score="0.999999745432481" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="5.5e-10"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999745432481"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370056152344" RT="11729.9001" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370056152344" RT="11729.9001" >
+			<PeptideHit score="0.999996035830139" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.5"/>
 				<UserParam type="float" name="E-Value" value="1.9e-08"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996035830139"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370361328125" RT="11731.6593" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370361328125" RT="11731.6593" >
+			<PeptideHit score="0.999988867709711" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58"/>
 				<UserParam type="float" name="E-Value" value="7.2e-08"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999988867709711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846618652344" RT="11774.5616" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846618652344" RT="11774.5616" >
+			<PeptideHit score="0.999998356693945" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.8"/>
 				<UserParam type="float" name="E-Value" value="6.1e-09"/>
 				<UserParam type="float" name="nextscore" value="9.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998356693945"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846618652344" RT="11776.3465" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846618652344" RT="11776.3465" >
+			<PeptideHit score="0.999985862936074" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57"/>
 				<UserParam type="float" name="E-Value" value="9.8e-08"/>
 				<UserParam type="float" name="nextscore" value="19.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999985862936074"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="758.906127929688" RT="11776.9792" >
-			<PeptideHit score="0.0444711538461538" sequence="ELMQLEKELVER" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_109" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="758.906127929688" RT="11776.9792" >
+			<PeptideHit score="0.103478204192389" sequence="ELMQLEKELVER" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_109" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.2"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="22.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="506.2724609375" RT="11793.3171" >
-			<PeptideHit score="0" sequence="ELMQLEKELVER" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_109" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="506.2724609375" RT="11793.3171" >
+			<PeptideHit score="0.949295381752261" sequence="ELMQLEKELVER" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_109" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33"/>
 				<UserParam type="float" name="E-Value" value="0.0033"/>
 				<UserParam type="float" name="nextscore" value="19.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.949295381752261"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820495605469" RT="11830.0419" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820495605469" RT="11830.0419" >
+			<PeptideHit score="0.999923892492664" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.1"/>
 				<UserParam type="float" name="E-Value" value="8.6e-07"/>
 				<UserParam type="float" name="nextscore" value="11.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999923892492664"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="808.423400878906" RT="11865.0132" >
-			<PeptideHit score="0" sequence="IGDYVQQHGGVSLVEQLLQDPK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="808.423400878906" RT="11865.0132" >
+			<PeptideHit score="0.999095046374717" sequence="IGDYVQQHGGVSLVEQLLQDPK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.8"/>
 				<UserParam type="float" name="E-Value" value="2.1e-05"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999095046374717"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="808.424438476563" RT="11873.4521" >
-			<PeptideHit score="0" sequence="IGDYVQQHGGVSLVEQLLQDPK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="808.424438476563" RT="11873.4521" >
+			<PeptideHit score="0.999986312247327" sequence="IGDYVQQHGGVSLVEQLLQDPK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.7"/>
 				<UserParam type="float" name="E-Value" value="9.4e-08"/>
 				<UserParam type="float" name="nextscore" value="21.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999986312247327"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846313476563" RT="11881.4266" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846313476563" RT="11881.4266" >
+			<PeptideHit score="0.999338919682092" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45"/>
 				<UserParam type="float" name="E-Value" value="1.4e-05"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999338919682092"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.970031738281" RT="11885.4044" >
-			<PeptideHit score="0.0139416983523447" sequence="AEFAEVSKLVTDLTK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.970031738281" RT="11885.4044" >
+			<PeptideHit score="0.268778038393828" sequence="AEFAEVSKLVTDLTK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.1"/>
 				<UserParam type="float" name="E-Value" value="0.29"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.268778038393828"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370239257813" RT="11939.8503" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370239257813" RT="11939.8503" >
+			<PeptideHit score="0.999779168898944" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.1"/>
 				<UserParam type="float" name="E-Value" value="3.4e-06"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999779168898944"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846069335938" RT="11979.9218" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846069335938" RT="11979.9218" >
+			<PeptideHit score="0.999992133559993" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.5"/>
 				<UserParam type="float" name="E-Value" value="4.6e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999992133559993"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="726.427856445313" RT="11990.928" >
-			<PeptideHit score="0" sequence="QKVTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="726.427856445313" RT="11990.928" >
+			<PeptideHit score="0.996034376504582" sequence="QKVTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.9"/>
 				<UserParam type="float" name="E-Value" value="0.00014"/>
 				<UserParam type="float" name="nextscore" value="9.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996034376504582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846496582031" RT="11993.8354" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846496582031" RT="11993.8354" >
+			<PeptideHit score="0.999946936748021" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.6"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369140625" RT="12030.5414" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369140625" RT="12030.5414" >
+			<PeptideHit score="0.999963773117924" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.9"/>
 				<UserParam type="float" name="E-Value" value="3.3e-07"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999963773117924"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="12032.5811" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="12032.5811" >
+			<PeptideHit score="0.998746131332642" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="3.2e-05"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998746131332642"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369750976563" RT="12122.8152" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369750976563" RT="12122.8152" >
+			<PeptideHit score="0.999928040886378" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.5"/>
 				<UserParam type="float" name="E-Value" value="8e-07"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999928040886378"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="12124.4913" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="12124.4913" >
+			<PeptideHit score="0.999999907005607" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-10"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999907005607"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847351074219" RT="12145.8654" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847351074219" RT="12145.8654" >
+			<PeptideHit score="0.999954724592998" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.4"/>
 				<UserParam type="float" name="E-Value" value="4.4e-07"/>
 				<UserParam type="float" name="nextscore" value="11.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999954724592998"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.04296875" RT="12158.1052" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.04296875" RT="12158.1052" >
+			<PeptideHit score="0.903688650931131" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.0074"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.903688650931131"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.043090820313" RT="12159.8759" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.043090820313" RT="12159.8759" >
+			<PeptideHit score="0.97469904242467" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.4"/>
 				<UserParam type="float" name="E-Value" value="0.0014"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97469904242467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="556.941650390625" RT="12209.9494" >
-			<PeptideHit score="0.0342298288508557" sequence="GKYSDDTPLPTPSYK" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_113" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="556.941650390625" RT="12209.9494" >
+			<PeptideHit score="0.180044603065486" sequence="GKYSDDTPLPTPSYK" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_113" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.7"/>
 				<UserParam type="float" name="E-Value" value="0.52"/>
 				<UserParam type="float" name="nextscore" value="18.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.180044603065486"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="12219.9087" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="12219.9087" >
+			<PeptideHit score="0.999997836161518" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.6"/>
 				<UserParam type="float" name="E-Value" value="8.7e-09"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997836161518"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952667236328" RT="12233.479" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952667236328" RT="12233.479" >
+			<PeptideHit score="0.993913437040977" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.2"/>
 				<UserParam type="float" name="E-Value" value="0.00024"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993913437040977"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.043273925781" RT="12250.79" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.043273925781" RT="12250.79" >
+			<PeptideHit score="0.946835341093983" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.9"/>
 				<UserParam type="float" name="E-Value" value="0.0035"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.946835341093983"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.04345703125" RT="12252.2493" >
-			<PeptideHit score="0.0102432778489117" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.04345703125" RT="12252.2493" >
+			<PeptideHit score="0.348796391782609" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.19"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.348796391782609"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847595214844" RT="12257.8923" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847595214844" RT="12257.8923" >
+			<PeptideHit score="0.999859324618151" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.5"/>
 				<UserParam type="float" name="E-Value" value="1.9e-06"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999859324618151"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.3701171875" RT="12310.77" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.3701171875" RT="12310.77" >
+			<PeptideHit score="0.999961245837018" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.1"/>
 				<UserParam type="float" name="E-Value" value="3.6e-07"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999961245837018"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.37060546875" RT="12312.2907" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.37060546875" RT="12312.2907" >
+			<PeptideHit score="0.995160070637582" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.5"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="966.086853027344" RT="12367.4332" >
-			<PeptideHit score="0" sequence="VTIAQGGVLPNIQAVLLPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_27 PH_32 PH_43 PH_85 PH_93 PH_98 PH_114 PH_120 PH_124 PH_129" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="966.086853027344" RT="12367.4332" >
+			<PeptideHit score="0.999999445986628" sequence="VTIAQGGVLPNIQAVLLPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_27 PH_32 PH_43 PH_85 PH_93 PH_98 PH_114 PH_120 PH_124 PH_129" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.4"/>
 				<UserParam type="float" name="E-Value" value="1.5e-09"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999445986628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="966.089477539063" RT="12371.0178" >
-			<PeptideHit score="0" sequence="VTIAQGGVLPNIQAVLLPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_27 PH_32 PH_43 PH_85 PH_93 PH_98 PH_114 PH_120 PH_124 PH_129" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="966.089477539063" RT="12371.0178" >
+			<PeptideHit score="0.999997223667326" sequence="VTIAQGGVLPNIQAVLLPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_27 PH_32 PH_43 PH_85 PH_93 PH_98 PH_114 PH_120 PH_124 PH_129" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-08"/>
 				<UserParam type="float" name="nextscore" value="10"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997223667326"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370788574219" RT="12499.1708" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370788574219" RT="12499.1708" >
+			<PeptideHit score="0.999128598342253" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.6"/>
 				<UserParam type="float" name="E-Value" value="2e-05"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999128598342253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369140625" RT="12504.8106" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369140625" RT="12504.8106" >
+			<PeptideHit score="0.99999280475604" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.4"/>
 				<UserParam type="float" name="E-Value" value="4.1e-08"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999280475604"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.044311523438" RT="12599.12" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.044311523438" RT="12599.12" >
+			<PeptideHit score="0.954315536242781" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.6"/>
 				<UserParam type="float" name="E-Value" value="0.0029"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.954315536242781"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370483398438" RT="12599.8651" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370483398438" RT="12599.8651" >
+			<PeptideHit score="0.999958765560895" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.1"/>
 				<UserParam type="float" name="E-Value" value="3.9e-07"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999958765560895"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.043212890625" RT="12601.1792" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.043212890625" RT="12601.1792" >
+			<PeptideHit score="0.997030240257234" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.5"/>
 				<UserParam type="float" name="E-Value" value="9.7e-05"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997030240257234"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369689941406" RT="12602.738" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369689941406" RT="12602.738" >
+			<PeptideHit score="0.999972614812384" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="2.3e-07"/>
 				<UserParam type="float" name="nextscore" value="14.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999972614812384"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952697753906" RT="12627.5154" >
-			<PeptideHit score="0.00134408602150538" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952697753906" RT="12627.5154" >
+			<PeptideHit score="0.777594217720977" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.6"/>
 				<UserParam type="float" name="E-Value" value="0.023"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.777594217720977"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="628.02001953125" RT="12653.2417" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMKVGEANPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="628.02001953125" RT="12653.2417" >
+			<PeptideHit score="0.984106302508389" sequence="ADGLAVIGVLMKVGEANPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.4"/>
 				<UserParam type="float" name="E-Value" value="0.00079"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984106302508389"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369873046875" RT="12695.2392" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369873046875" RT="12695.2392" >
+			<PeptideHit score="0.992918683767341" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="0.00029"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992918683767341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.3701171875" RT="12698.8891" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.3701171875" RT="12698.8891" >
+			<PeptideHit score="0.994528455081984" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.8"/>
 				<UserParam type="float" name="E-Value" value="0.00021"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994528455081984"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="922.138427734375" RT="12766.2569" >
-			<PeptideHit score="0.00134408602150538" sequence="LTYYEPNPLSWGDCVEKIISALPR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_119" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="922.138427734375" RT="12766.2569" >
+			<PeptideHit score="0.520783328476773" sequence="LTYYEPNPLSWGDCVEKIISALPR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_119" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="24.7"/>
 				<UserParam type="float" name="E-Value" value="0.086"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.520783328476773"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="922.138061523438" RT="12774.18" >
-			<PeptideHit score="0.02" sequence="LTYYEPNPLSWGDCVEKIISALPR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_119" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="922.138061523438" RT="12774.18" >
+			<PeptideHit score="0.246856676048891" sequence="LTYYEPNPLSWGDCVEKIISALPR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_119" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.7"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951934814453" RT="13016.0227" >
-			<PeptideHit score="0.00526315789473684" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951934814453" RT="13016.0227" >
+			<PeptideHit score="0.505758287449657" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25"/>
 				<UserParam type="float" name="E-Value" value="0.092"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.505758287449657"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951873779297" RT="13110.0707" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951873779297" RT="13110.0707" >
+			<PeptideHit score="0.976178644666495" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.7"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="589.989929199219" RT="13239.5817" >
-			<PeptideHit score="0.00906735751295337" sequence="(Gln->pyro-Glu)QLAGAMAYLGARGLVHR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_79" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="589.989929199219" RT="13239.5817" >
+			<PeptideHit score="0.384387191798194" sequence="(Gln->pyro-Glu)QLAGAMAYLGARGLVHR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_79" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.4"/>
 				<UserParam type="float" name="E-Value" value="0.16"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.384387191798194"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="589.990356445313" RT="13241.3679" >
-			<PeptideHit score="0.029520295202952" sequence="(Gln->pyro-Glu)QLAGAMAYLGARGLVHR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_79" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="589.990356445313" RT="13241.3679" >
+			<PeptideHit score="0.193496525438801" sequence="(Gln->pyro-Glu)QLAGAMAYLGARGLVHR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_79" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.4"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370544433594" RT="13318.4235" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370544433594" RT="13318.4235" >
+			<PeptideHit score="0.999302633161889" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.1"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="13407.5118" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="13407.5118" >
+			<PeptideHit score="0.951788100541034" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.6"/>
 				<UserParam type="float" name="E-Value" value="0.0031"/>
 				<UserParam type="float" name="nextscore" value="16.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.951788100541034"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="556.993957519531" RT="13451.6427" >
-			<PeptideHit score="0" sequence="AVQQPDGLAVLGIFLK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="556.993957519531" RT="13451.6427" >
+			<PeptideHit score="0.999964626875691" sequence="AVQQPDGLAVLGIFLK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.3"/>
 				<UserParam type="float" name="E-Value" value="3.2e-07"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999964626875691"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="556.994201660156" RT="13452.9542" >
-			<PeptideHit score="0" sequence="AVQQPDGLAVLGIFLK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="556.994201660156" RT="13452.9542" >
+			<PeptideHit score="0.999375797281708" sequence="AVQQPDGLAVLGIFLK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369995117188" RT="13520.5009" >
-			<PeptideHit score="0.00134408602150538" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369995117188" RT="13520.5009" >
+			<PeptideHit score="0.734542296491698" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.9"/>
 				<UserParam type="float" name="E-Value" value="0.03"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.734542296491698"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="834.98876953125" RT="13556.1474" >
-			<PeptideHit score="0" sequence="AVQQPDGLAVLGIFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="834.98876953125" RT="13556.1474" >
+			<PeptideHit score="0.999999996982134" sequence="AVQQPDGLAVLGIFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.5"/>
 				<UserParam type="float" name="E-Value" value="1.8e-12"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999996982134"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369873046875" RT="13616.3295" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369873046875" RT="13616.3295" >
+			<PeptideHit score="0.998900658395066" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.9"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="504.742309570313" RT="13643.9999" >
-			<PeptideHit score="0.0489844683393071" sequence="AAGSMSSLER" charge="2" aa_before="R" aa_after="E" protein_refs="PH_121" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="504.742309570313" RT="13643.9999" >
+			<PeptideHit score="0.0969386199829794" sequence="AAGSMSSLER" charge="2" aa_before="R" aa_after="E" protein_refs="PH_121" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="16.2"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952484130859" RT="13691.2799" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952484130859" RT="13691.2799" >
+			<PeptideHit score="0.998838128770909" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.2"/>
 				<UserParam type="float" name="E-Value" value="2.9e-05"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998838128770909"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369567871094" RT="13939.6" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369567871094" RT="13939.6" >
+			<PeptideHit score="0.953047340351405" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="0.003"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.953047340351405"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370483398438" RT="13972.8499" >
-			<PeptideHit score="0.00526315789473684" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370483398438" RT="13972.8499" >
+			<PeptideHit score="0.465947082204611" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.9"/>
 				<UserParam type="float" name="E-Value" value="0.11"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.465947082204611"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.95263671875" RT="14083.9204" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.95263671875" RT="14083.9204" >
+			<PeptideHit score="0.995811820230489" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="0.00015"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995811820230489"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953216552734" RT="14186.9672" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953216552734" RT="14186.9672" >
+			<PeptideHit score="0.949295381752261" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.6"/>
 				<UserParam type="float" name="E-Value" value="0.0033"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.949295381752261"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370422363281" RT="14220.2283" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370422363281" RT="14220.2283" >
+			<PeptideHit score="0.996488921991653" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38"/>
 				<UserParam type="float" name="E-Value" value="0.00012"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996488921991653"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952911376953" RT="14315.9501" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952911376953" RT="14315.9501" >
+			<PeptideHit score="0.996721562845727" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.1"/>
 				<UserParam type="float" name="E-Value" value="0.00011"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996721562845727"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.372253417969" RT="14447.5702" >
-			<PeptideHit score="0.0489844683393071" sequence="LNQESTAPKVLFTGVVDAR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_82" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.372253417969" RT="14447.5702" >
+			<PeptideHit score="0.0969386199829794" sequence="LNQESTAPKVLFTGVVDAR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_82" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.2"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370422363281" RT="14719.5142" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370422363281" RT="14719.5142" >
+			<PeptideHit score="0.990100202387883" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.00044"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.990100202387883"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952972412109" RT="14721.1148" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952972412109" RT="14721.1148" >
+			<PeptideHit score="0.970372889310467" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.9"/>
 				<UserParam type="float" name="E-Value" value="0.0017"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.970372889310467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.372131347656" RT="14875.4339" >
-			<PeptideHit score="0.0211970074812968" sequence="VFSVNVGVLPTGDTTVVQGR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_136" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.372131347656" RT="14875.4339" >
+			<PeptideHit score="0.228519335906576" sequence="VFSVNVGVLPTGDTTVVQGR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_136" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.37"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.228519335906576"/>
+				<UserParam type="float" name="q-value" value="0.0211970074812968"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370178222656" RT="15290.849" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370178222656" RT="15290.849" >
+			<PeptideHit score="0.994947495670415" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.7"/>
 				<UserParam type="float" name="E-Value" value="0.00019"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994947495670415"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369689941406" RT="15300.3902" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369689941406" RT="15300.3902" >
+			<PeptideHit score="0.903688650931131" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.9"/>
 				<UserParam type="float" name="E-Value" value="0.0074"/>
 				<UserParam type="float" name="nextscore" value="17.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.903688650931131"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952819824219" RT="15342.89" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952819824219" RT="15342.89" >
+			<PeptideHit score="0.99951844176704" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.8"/>
 				<UserParam type="float" name="E-Value" value="9.3e-06"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99951844176704"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952758789063" RT="15360.3901" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952758789063" RT="15360.3901" >
+			<PeptideHit score="0.999967225273061" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="2.9e-07"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999967225273061"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820556640625" RT="15394.85" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820556640625" RT="15394.85" >
+			<PeptideHit score="0.99989516753533" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.6"/>
 				<UserParam type="float" name="E-Value" value="1.3e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99989516753533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821166992188" RT="15413.6197" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821166992188" RT="15413.6197" >
+			<PeptideHit score="0.999579785920331" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.3"/>
 				<UserParam type="float" name="E-Value" value="7.8e-06"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999579785920331"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370910644531" RT="15429.8295" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370910644531" RT="15429.8295" >
+			<PeptideHit score="0.99331247569031" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.4"/>
 				<UserParam type="float" name="E-Value" value="0.00027"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99331247569031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952911376953" RT="15462.4923" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952911376953" RT="15462.4923" >
+			<PeptideHit score="0.910883820050366" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.3"/>
 				<UserParam type="float" name="E-Value" value="0.0067"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.910883820050366"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821899414063" RT="15510.8384" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821899414063" RT="15510.8384" >
+			<PeptideHit score="0.999995248967135" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.2"/>
 				<UserParam type="float" name="E-Value" value="2.4e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995248967135"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.3701171875" RT="15556.6064" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.3701171875" RT="15556.6064" >
+			<PeptideHit score="0.886985857691212" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.6"/>
 				<UserParam type="float" name="E-Value" value="0.0091"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.886985857691212"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952362060547" RT="15558.281" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952362060547" RT="15558.281" >
+			<PeptideHit score="0.998685890644916" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.1"/>
 				<UserParam type="float" name="E-Value" value="3.4e-05"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998685890644916"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866027832031" RT="15650.3902" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866027832031" RT="15650.3902" >
+			<PeptideHit score="0.820048379204749" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28"/>
 				<UserParam type="float" name="E-Value" value="0.017"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.820048379204749"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820251464844" RT="15651.9001" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820251464844" RT="15651.9001" >
+			<PeptideHit score="0.999986994393307" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.4"/>
 				<UserParam type="float" name="E-Value" value="8.8e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999986994393307"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953094482422" RT="15694.6148" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953094482422" RT="15694.6148" >
+			<PeptideHit score="0.999266889838404" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="1.6e-05"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999266889838404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821960449219" RT="15787.434" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821960449219" RT="15787.434" >
+			<PeptideHit score="0.999997045974291" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.2"/>
 				<UserParam type="float" name="E-Value" value="1.3e-08"/>
 				<UserParam type="float" name="nextscore" value="10.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997045974291"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370178222656" RT="15803.28" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370178222656" RT="15803.28" >
+			<PeptideHit score="0.999661517151359" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="5.9e-06"/>
 				<UserParam type="float" name="nextscore" value="14.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999661517151359"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370910644531" RT="15806.2892" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370910644531" RT="15806.2892" >
+			<PeptideHit score="0.996259978029628" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.9"/>
 				<UserParam type="float" name="E-Value" value="0.00013"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996259978029628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370849609375" RT="15898.1901" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370849609375" RT="15898.1901" >
+			<PeptideHit score="0.918288520543892" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.2"/>
 				<UserParam type="float" name="E-Value" value="0.006"/>
 				<UserParam type="float" name="nextscore" value="11.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.918288520543892"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821533203125" RT="15899.621" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821533203125" RT="15899.621" >
+			<PeptideHit score="0.999946936748021" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.5"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820678710938" RT="15913.6905" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820678710938" RT="15913.6905" >
+			<PeptideHit score="0.999983460247774" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.6"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847473144531" RT="16046.88" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847473144531" RT="16046.88" >
+			<PeptideHit score="0.97179748620208" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.5"/>
 				<UserParam type="float" name="E-Value" value="0.0016"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97179748620208"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821472167969" RT="16549.1195" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821472167969" RT="16549.1195" >
+			<PeptideHit score="0.999375797281708" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.5"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369995117188" RT="16561.4053" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369995117188" RT="16561.4053" >
+			<PeptideHit score="0.938458406649018" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.9"/>
 				<UserParam type="float" name="E-Value" value="0.0042"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.938458406649018"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952209472656" RT="16564.7626" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952209472656" RT="16564.7626" >
+			<PeptideHit score="0.999749532301869" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.7"/>
 				<UserParam type="float" name="E-Value" value="4e-06"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999749532301869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317932128906" RT="16571.1423" >
-			<PeptideHit score="0.00134408602150538" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317932128906" RT="16571.1423" >
+			<PeptideHit score="0.682127937096026" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="0.04"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.682127937096026"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832763671875" RT="16573.6894" >
-			<PeptideHit score="0.0139416983523447" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832763671875" RT="16573.6894" >
+			<PeptideHit score="0.274948227693009" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.9"/>
 				<UserParam type="float" name="E-Value" value="0.28"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.274948227693009"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951843261719" RT="16656.5309" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951843261719" RT="16656.5309" >
+			<PeptideHit score="0.998339553383431" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.5"/>
 				<UserParam type="float" name="E-Value" value="4.6e-05"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998339553383431"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369384765625" RT="16657.182" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369384765625" RT="16657.182" >
+			<PeptideHit score="0.999029002284869" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.9"/>
 				<UserParam type="float" name="E-Value" value="2.3e-05"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999029002284869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952026367188" RT="16659.8628" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952026367188" RT="16659.8628" >
+			<PeptideHit score="0.999779168898944" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51"/>
 				<UserParam type="float" name="E-Value" value="3.4e-06"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999779168898944"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370056152344" RT="16661.7031" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370056152344" RT="16661.7031" >
+			<PeptideHit score="0.992918683767341" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.5"/>
 				<UserParam type="float" name="E-Value" value="0.00029"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992918683767341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317016601563" RT="16672.2733" >
-			<PeptideHit score="0.0115089514066496" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317016601563" RT="16672.2733" >
+			<PeptideHit score="0.295486312650848" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.8"/>
 				<UserParam type="float" name="E-Value" value="0.25"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.295486312650848"/>
+				<UserParam type="float" name="q-value" value="0.0115089514066496"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310363769531" RT="16784.36" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310363769531" RT="16784.36" >
+			<PeptideHit score="0.951788100541034" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29"/>
 				<UserParam type="float" name="E-Value" value="0.0031"/>
 				<UserParam type="float" name="nextscore" value="22"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.951788100541034"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.95263671875" RT="16845.4006" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.95263671875" RT="16845.4006" >
+			<PeptideHit score="0.998900658395066" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.8"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369018554688" RT="16858.5801" >
-			<PeptideHit score="0.00651890482398957" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369018554688" RT="16858.5801" >
+			<PeptideHit score="0.412959460251658" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.2"/>
 				<UserParam type="float" name="E-Value" value="0.14"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.412959460251658"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370544433594" RT="16870.2984" >
-			<PeptideHit score="0.00134408602150538" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370544433594" RT="16870.2984" >
+			<PeptideHit score="0.74033038219602" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.5"/>
 				<UserParam type="float" name="E-Value" value="0.029"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.74033038219602"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311584472656" RT="16909.2503" >
-			<PeptideHit score="0.00134408602150538" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311584472656" RT="16909.2503" >
+			<PeptideHit score="0.557059990676927" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22"/>
 				<UserParam type="float" name="E-Value" value="0.073"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.557059990676927"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317810058594" RT="16910.7179" >
-			<PeptideHit score="0.0102432778489117" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317810058594" RT="16910.7179" >
+			<PeptideHit score="0.348796391782609" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.19"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.348796391782609"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952514648438" RT="16947.04" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952514648438" RT="16947.04" >
+			<PeptideHit score="0.997572119635703" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43"/>
 				<UserParam type="float" name="E-Value" value="7.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997572119635703"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317016601563" RT="17008.87" >
-			<PeptideHit score="0.0102432778489117" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317016601563" RT="17008.87" >
+			<PeptideHit score="0.303106246021224" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.6"/>
 				<UserParam type="float" name="E-Value" value="0.24"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.303106246021224"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/THIRDPARTY/FidoAdapter_4_output.idXML
+++ b/src/tests/topp/THIRDPARTY/FidoAdapter_4_output.idXML
@@ -3,7 +3,7 @@
 <IdXML version="1.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="/tmp/2014-11-26_134242_giraffe_14458_1/TOPPAS_tmp/Untitled_workflow/003_DecoyDatabase/out/uniprot-all.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="+1-+4" enzyme="unknown_enzyme" missed_cleavages="1" precursor_peak_tolerance="1.5" peak_mass_tolerance="0.3" >
 	</SearchParameters>
-	<IdentificationRun date="2015-05-28T11:36:50" search_engine="XTandem" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2015-10-02T14:54:12" search_engine="XTandem" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|A5A3E0|POTEF_HUMAN" score="0.724701523780823" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -843,8814 +843,9695 @@
 			<UserParam type="string" name="indistinguishable_proteins_102" value="0.6997149674,PH_143"/>
 			<UserParam type="string" name="indistinguishable_proteins_103" value="0.6997149674,PH_145"/>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.889923095703" RT="1090.50499999998" >
-			<PeptideHit score="0" sequence="QSPVDIDTHTAK" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.889923095703" RT="1090.50499999998" >
+			<PeptideHit score="0.994116771387973" sequence="QSPVDIDTHTAK" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.7"/>
 				<UserParam type="float" name="E-Value" value="0.00023"/>
 				<UserParam type="float" name="nextscore" value="19.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994116771387973"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="483.763641357422" RT="1156.08949999998" >
-			<PeptideHit score="0.0331695331695332" sequence="GNVMVPPPR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_104" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="483.763641357422" RT="1156.08949999998" >
+			<PeptideHit score="0.185169102173804" sequence="GNVMVPPPR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_104" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="14.8"/>
 				<UserParam type="float" name="E-Value" value="0.5"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.185169102173804"/>
+				<UserParam type="float" name="q-value" value="0.0331695331695332"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="516.271240234375" RT="1210.42249999998" >
-			<PeptideHit score="0.0434782608695652" sequence="LKELSWYHTAGNK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_7" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="516.271240234375" RT="1210.42249999998" >
+			<PeptideHit score="0.111148168009872" sequence="LKELSWYHTAGNK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_7" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23.5"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.239532470703" RT="1214.31880000002" >
-			<PeptideHit score="0.0363636363636364" sequence="LVIESTK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_112" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="395.239532470703" RT="1214.31880000002" >
+			<PeptideHit score="0.175225488597367" sequence="LVIESTK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_112" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.7"/>
 				<UserParam type="float" name="E-Value" value="0.54"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.175225488597367"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="468.232666015625" RT="1436.92990000002" >
-			<PeptideHit score="0" sequence="GGPLDGTYR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="468.232666015625" RT="1436.92990000002" >
+			<PeptideHit score="0.835623332778618" sequence="GGPLDGTYR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.8"/>
 				<UserParam type="float" name="E-Value" value="0.015"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.835623332778618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="617.966247558594" RT="1698.3102" >
-			<PeptideHit score="0" sequence="FSTVAGESGSADTVRDPR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="617.966247558594" RT="1698.3102" >
+			<PeptideHit score="0.998339553383431" sequence="FSTVAGESGSADTVRDPR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.4"/>
 				<UserParam type="float" name="E-Value" value="4.6e-05"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998339553383431"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="617.966674804688" RT="1703.68000000002" >
-			<PeptideHit score="0" sequence="FSTVAGESGSADTVRDPR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="617.966674804688" RT="1703.68000000002" >
+			<PeptideHit score="0.994947495670415" sequence="FSTVAGESGSADTVRDPR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.3"/>
 				<UserParam type="float" name="E-Value" value="0.00019"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994947495670415"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.810363769531" RT="1822.72999999998" >
-			<PeptideHit score="0" sequence="LSQEDPDYGIR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="646.810363769531" RT="1822.72999999998" >
+			<PeptideHit score="0.97469904242467" sequence="LSQEDPDYGIR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29"/>
 				<UserParam type="float" name="E-Value" value="0.0014"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97469904242467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="493.222991943359" RT="1942.25059999998" >
-			<PeptideHit score="0" sequence="GGPFSDSYR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="493.222991943359" RT="1942.25059999998" >
+			<PeptideHit score="0.999128598342253" sequence="GGPFSDSYR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38"/>
 				<UserParam type="float" name="E-Value" value="2e-05"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999128598342253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="510.58251953125" RT="1957.51120000002" >
-			<PeptideHit score="0" sequence="VGAHAGEYGAEALER" charge="3" aa_before="K" aa_after="M" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="510.58251953125" RT="1957.51120000002" >
+			<PeptideHit score="0.984762202246869" sequence="VGAHAGEYGAEALER" charge="3" aa_before="K" aa_after="M" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.4"/>
 				<UserParam type="float" name="E-Value" value="0.00075"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984762202246869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="421.758819580078" RT="2073.8349" >
-			<PeptideHit score="0.00651890482398957" sequence="GLISSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_46" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="421.758819580078" RT="2073.8349" >
+			<PeptideHit score="0.429088420832665" sequence="GLISSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_46" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23.6"/>
 				<UserParam type="float" name="E-Value" value="0.13"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.429088420832665"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="510.582763671875" RT="2089.84360000002" >
-			<PeptideHit score="0" sequence="VGAHAGEYGAEALER" charge="3" aa_before="K" aa_after="M" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="510.582763671875" RT="2089.84360000002" >
+			<PeptideHit score="0.967570696734317" sequence="VGAHAGEYGAEALER" charge="3" aa_before="K" aa_after="M" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.2"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="17.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="605.268920898438" RT="2414.29000000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="605.268920898438" RT="2414.29000000002" >
+			<PeptideHit score="0.996958329726846" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.6"/>
 				<UserParam type="float" name="E-Value" value="0.0001"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996958329726846"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="605.268981933594" RT="2506.08" >
-			<PeptideHit score="0" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="605.268981933594" RT="2506.08" >
+			<PeptideHit score="0.999914455690938" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.2"/>
 				<UserParam type="float" name="E-Value" value="1e-06"/>
 				<UserParam type="float" name="nextscore" value="9.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999914455690938"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="605.268737792969" RT="2507.70520000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="605.268737792969" RT="2507.70520000002" >
+			<PeptideHit score="0.998626449672608" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-05"/>
 				<UserParam type="float" name="nextscore" value="10.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998626449672608"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="605.269592285156" RT="2599.578" >
-			<PeptideHit score="0" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="605.269592285156" RT="2599.578" >
+			<PeptideHit score="0.99865607372492" sequence="(Acetyl)ADSRDPASDQMQHWK" charge="3" aa_before="M" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.2"/>
 				<UserParam type="float" name="E-Value" value="3.5e-05"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99865607372492"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="409.539703369141" RT="2615.55409999998" >
-			<PeptideHit score="0.00134408602150538" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="409.539703369141" RT="2615.55409999998" >
+			<PeptideHit score="0.771058061136823" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.7"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="409.539764404297" RT="2708.12569999998" >
-			<PeptideHit score="0" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="409.539764404297" RT="2708.12569999998" >
+			<PeptideHit score="0.994528455081984" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.3"/>
 				<UserParam type="float" name="E-Value" value="0.00021"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994528455081984"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="398.562957763672" RT="2744.98789999998" >
-			<PeptideHit score="0.0224159402241594" sequence="VLVHGAASGNLR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_92" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="398.562957763672" RT="2744.98789999998" >
+			<PeptideHit score="0.224392094485239" sequence="VLVHGAASGNLR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_92" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.38"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.224392094485239"/>
+				<UserParam type="float" name="q-value" value="0.0224159402241594"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="409.539886474609" RT="2804.22019999998" >
-			<PeptideHit score="0.0139416983523447" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="409.539886474609" RT="2804.22019999998" >
+			<PeptideHit score="0.28827458994223" sequence="FKDLGEENFK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.8"/>
 				<UserParam type="float" name="E-Value" value="0.26"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.28827458994223"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="825.765747070313" RT="3150.4548" >
-			<PeptideHit score="0.0139416983523447" sequence="ILNLVCLDSEKEIGCNSLIGDVK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_107" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="825.765747070313" RT="3150.4548" >
+			<PeptideHit score="0.28827458994223" sequence="ILNLVCLDSEKEIGCNSLIGDVK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_107" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22"/>
 				<UserParam type="float" name="E-Value" value="0.26"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.28827458994223"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="825.762023925781" RT="3152.79910000002" >
-			<PeptideHit score="0" sequence="TSETKHDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="825.762023925781" RT="3152.79910000002" >
+			<PeptideHit score="0.999999720662806" sequence="TSETKHDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.1"/>
 				<UserParam type="float" name="E-Value" value="6.2e-10"/>
 				<UserParam type="float" name="nextscore" value="20.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999720662806"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.249633789063" RT="3163.0461" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.249633789063" RT="3163.0461" >
+			<PeptideHit score="0.883199475322235" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.4"/>
 				<UserParam type="float" name="E-Value" value="0.0095"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.883199475322235"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="538.266723632813" RT="3170.8569" >
-			<PeptideHit score="0.00134408602150538" sequence="YSAELHVAHWNSAK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="538.266723632813" RT="3170.8569" >
+			<PeptideHit score="0.569404203070947" sequence="YSAELHVAHWNSAK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.3"/>
 				<UserParam type="float" name="E-Value" value="0.069"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.569404203070947"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250946044922" RT="3202.84870000002" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250946044922" RT="3202.84870000002" >
+			<PeptideHit score="0.99772509132693" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="6.9e-05"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99772509132693"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250518798828" RT="3204.64669999998" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250518798828" RT="3204.64669999998" >
+			<PeptideHit score="0.967570696734317" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.2"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="483.936645507813" RT="3205.10680000002" >
-			<PeptideHit score="0.00526315789473684" sequence="VVAGVANALAHKYH" charge="3" aa_before="K" aa_after="]" protein_refs="PH_19 PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="483.936645507813" RT="3205.10680000002" >
+			<PeptideHit score="0.487163428094098" sequence="VVAGVANALAHKYH" charge="3" aa_before="K" aa_after="]" protein_refs="PH_19 PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.5"/>
 				<UserParam type="float" name="E-Value" value="0.1"/>
 				<UserParam type="float" name="nextscore" value="11.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.487163428094098"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.248046875" RT="3205.6221" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.248046875" RT="3205.6221" >
+			<PeptideHit score="0.980753850169904" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.4"/>
 				<UserParam type="float" name="E-Value" value="0.001"/>
 				<UserParam type="float" name="nextscore" value="10.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980753850169904"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="628.834045410156" RT="3288.15850000002" >
-			<PeptideHit score="0" sequence="VNVDAVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_19" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="628.834045410156" RT="3288.15850000002" >
+			<PeptideHit score="0.99999280475604" sequence="VNVDAVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_19" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.2"/>
 				<UserParam type="float" name="E-Value" value="4.1e-08"/>
 				<UserParam type="float" name="nextscore" value="17.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999280475604"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854125976563" RT="3289.3056" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854125976563" RT="3289.3056" >
+			<PeptideHit score="0.99919687311191" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="1.8e-05"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99919687311191"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250122070313" RT="3295.31419999998" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250122070313" RT="3295.31419999998" >
+			<PeptideHit score="0.930401463762626" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0049"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.930401463762626"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250091552734" RT="3296.93110000002" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250091552734" RT="3296.93110000002" >
+			<PeptideHit score="0.936125892868832" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0044"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.936125892868832"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.248657226563" RT="3300.80089999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.248657226563" RT="3300.80089999998" >
+			<PeptideHit score="0.977679598036381" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.5"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.248229980469" RT="3302.4882" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.248229980469" RT="3302.4882" >
+			<PeptideHit score="0.967570696734317" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.2"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854431152344" RT="3380.66650000002" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854431152344" RT="3380.66650000002" >
+			<PeptideHit score="0.999876865375483" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.5"/>
 				<UserParam type="float" name="E-Value" value="1.6e-06"/>
 				<UserParam type="float" name="nextscore" value="9.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999876865375483"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854736328125" RT="3382.77349999998" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854736328125" RT="3382.77349999998" >
+			<PeptideHit score="0.992145529169711" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.8"/>
 				<UserParam type="float" name="E-Value" value="0.00033"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992145529169711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250366210938" RT="3387.79480000002" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250366210938" RT="3387.79480000002" >
+			<PeptideHit score="0.960802305355011" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0024"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.960802305355011"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250183105469" RT="3389.475" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250183105469" RT="3389.475" >
+			<PeptideHit score="0.934969044635626" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.3"/>
 				<UserParam type="float" name="E-Value" value="0.0045"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.934969044635626"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.249267578125" RT="3393.22720000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.249267578125" RT="3393.22720000002" >
+			<PeptideHit score="0.85204760460282" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.6"/>
 				<UserParam type="float" name="E-Value" value="0.013"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.85204760460282"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="492.760528564453" RT="3405.76999999998" >
-			<PeptideHit score="0.0259259259259259" sequence="AFDITYVR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_38" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="492.760528564453" RT="3405.76999999998" >
+			<PeptideHit score="0.20599231767492" sequence="AFDITYVR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_38" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.1"/>
 				<UserParam type="float" name="E-Value" value="0.43"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.20599231767492"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.249450683594" RT="3406.39279999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.249450683594" RT="3406.39279999998" >
+			<PeptideHit score="0.99046445524595" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.3"/>
 				<UserParam type="float" name="E-Value" value="0.00042"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99046445524595"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="492.761566162109" RT="3407.66449999998" >
-			<PeptideHit score="0.0363636363636364" sequence="AFDITYVR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_38" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="492.761566162109" RT="3407.66449999998" >
+			<PeptideHit score="0.166398718169042" sequence="AFDITYVR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_38" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="17.5"/>
 				<UserParam type="float" name="E-Value" value="0.58"/>
 				<UserParam type="float" name="nextscore" value="12.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.166398718169042"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="564.853759765625" RT="3444.5115" >
-			<PeptideHit score="0.00134408602150538" sequence="KQTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="564.853759765625" RT="3444.5115" >
+			<PeptideHit score="0.61801152613314" sequence="KQTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.6"/>
 				<UserParam type="float" name="E-Value" value="0.055"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.61801152613314"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="564.852600097656" RT="3446.40319999998" >
-			<PeptideHit score="0.00134408602150538" sequence="KQTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="564.852600097656" RT="3446.40319999998" >
+			<PeptideHit score="0.614224838611314" sequence="KQTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.6"/>
 				<UserParam type="float" name="E-Value" value="0.056"/>
 				<UserParam type="float" name="nextscore" value="11.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.614224838611314"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.853881835938" RT="3473.1654" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.853881835938" RT="3473.1654" >
+			<PeptideHit score="0.999759292017249" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.4"/>
 				<UserParam type="float" name="E-Value" value="3.8e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999759292017249"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854431152344" RT="3474.81490000002" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854431152344" RT="3474.81490000002" >
+			<PeptideHit score="0.999375797281708" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.7"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="376.904693603516" RT="3477.13660000002" >
-			<PeptideHit score="0.00134408602150538" sequence="KQTALVELVK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="376.904693603516" RT="3477.13660000002" >
+			<PeptideHit score="0.752250699877261" sequence="KQTALVELVK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.027"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.752250699877261"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265014648438" RT="3478.28800000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265014648438" RT="3478.28800000002" >
+			<PeptideHit score="0.991765444794236" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.2"/>
 				<UserParam type="float" name="E-Value" value="0.00035"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991765444794236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="657.836181640625" RT="3478.9176" >
-			<PeptideHit score="0" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="657.836181640625" RT="3478.9176" >
+			<PeptideHit score="0.998066166732661" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39"/>
 				<UserParam type="float" name="E-Value" value="5.6e-05"/>
 				<UserParam type="float" name="nextscore" value="18.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998066166732661"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250732421875" RT="3480.07210000002" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.250732421875" RT="3480.07210000002" >
+			<PeptideHit score="0.91192835386055" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.6"/>
 				<UserParam type="float" name="E-Value" value="0.0066"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.91192835386055"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.249938964844" RT="3481.7598" >
-			<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="464.249938964844" RT="3481.7598" >
+			<PeptideHit score="0.908807506017045" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0069"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.908807506017045"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="657.835205078125" RT="3483.06229999998" >
-			<PeptideHit score="0" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="657.835205078125" RT="3483.06229999998" >
+			<PeptideHit score="0.999992266429207" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.9"/>
 				<UserParam type="float" name="E-Value" value="4.5e-08"/>
 				<UserParam type="float" name="nextscore" value="19.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999992266429207"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="376.904327392578" RT="3483.56239999998" >
-			<PeptideHit score="0.00906735751295337" sequence="KQTALVELVK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="376.904327392578" RT="3483.56239999998" >
+			<PeptideHit score="0.371664142581344" sequence="KQTALVELVK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.5"/>
 				<UserParam type="float" name="E-Value" value="0.17"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.371664142581344"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.248107910156" RT="3507.93889999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.248107910156" RT="3507.93889999998" >
+			<PeptideHit score="0.963472366227381" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.1"/>
 				<UserParam type="float" name="E-Value" value="0.0022"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.963472366227381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.249328613281" RT="3511.7673" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.249328613281" RT="3511.7673" >
+			<PeptideHit score="0.916150345988615" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.4"/>
 				<UserParam type="float" name="E-Value" value="0.0062"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.916150345988615"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.853759765625" RT="3567.91069999998" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.853759765625" RT="3567.91069999998" >
+			<PeptideHit score="0.998900658395066" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264343261719" RT="3569.5548" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264343261719" RT="3569.5548" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264953613281" RT="3571.23700000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264953613281" RT="3571.23700000002" >
+			<PeptideHit score="0.999997404727025" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-08"/>
 				<UserParam type="float" name="nextscore" value="23.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997404727025"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="657.835998535156" RT="3572.91289999998" >
-			<PeptideHit score="0" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="657.835998535156" RT="3572.91289999998" >
+			<PeptideHit score="0.999999996474288" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="70.2"/>
 				<UserParam type="float" name="E-Value" value="2.2e-12"/>
 				<UserParam type="float" name="nextscore" value="22.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999996474288"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="657.836608886719" RT="3574.58830000002" >
-			<PeptideHit score="0" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="657.836608886719" RT="3574.58830000002" >
+			<PeptideHit score="0.999999916768411" sequence="VNVDEVGGEALGR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="70.3"/>
 				<UserParam type="float" name="E-Value" value="1.3e-10"/>
 				<UserParam type="float" name="nextscore" value="22.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999916768411"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="653.323913574219" RT="3593.61490000002" >
-			<PeptideHit score="0.0139416983523447" sequence="GSDPTGVTELSNK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_6" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="653.323913574219" RT="3593.61490000002" >
+			<PeptideHit score="0.28827458994223" sequence="GSDPTGVTELSNK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_6" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.26"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.28827458994223"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674377441406" RT="3595.29310000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674377441406" RT="3595.29310000002" >
+			<PeptideHit score="0.999998273774991" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.2"/>
 				<UserParam type="float" name="E-Value" value="6.5e-09"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998273774991"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673583984375" RT="3596.97379999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673583984375" RT="3596.97379999998" >
+			<PeptideHit score="0.999961245837018" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="3.6e-07"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999961245837018"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.247985839844" RT="3614.20939999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.247985839844" RT="3614.20939999998" >
+			<PeptideHit score="0.887940558151255" sequence="(Acetyl)ASPDWGYDDK" charge="2" aa_before="M" aa_after="N" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.6"/>
 				<UserParam type="float" name="E-Value" value="0.009"/>
 				<UserParam type="float" name="nextscore" value="10.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.887940558151255"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265319824219" RT="3664.29160000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265319824219" RT="3664.29160000002" >
+			<PeptideHit score="0.999973542219251" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="2.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999973542219251"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="689.854614257813" RT="3683.31340000002" >
-			<PeptideHit score="0" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="689.854614257813" RT="3683.31340000002" >
+			<PeptideHit score="0.999029002284869" sequence="EFTPPVQAAYQK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.2"/>
 				<UserParam type="float" name="E-Value" value="2.3e-05"/>
 				<UserParam type="float" name="nextscore" value="9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999029002284869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.305603027344" RT="3683.74009999998" >
-			<PeptideHit score="0" sequence="TIAQDYGVLK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="554.305603027344" RT="3683.74009999998" >
+			<PeptideHit score="0.976178644666495" sequence="TIAQDYGVLK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="19.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674499511719" RT="3687.39460000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674499511719" RT="3687.39460000002" >
+			<PeptideHit score="0.999999176872642" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.2"/>
 				<UserParam type="float" name="E-Value" value="2.5e-09"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999176872642"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674377441406" RT="3689.17159999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674377441406" RT="3689.17159999998" >
+			<PeptideHit score="0.999978334497071" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.6"/>
 				<UserParam type="float" name="E-Value" value="1.7e-07"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999978334497071"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="448.735076904297" RT="3703.11280000002" >
-			<PeptideHit score="0.00134408602150538" sequence="FLFEGQR" charge="2" aa_before="R" aa_after="I" protein_refs="PH_64" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="448.735076904297" RT="3703.11280000002" >
+			<PeptideHit score="0.575812066423463" sequence="FLFEGQR" charge="2" aa_before="R" aa_after="I" protein_refs="PH_64" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.3"/>
 				<UserParam type="float" name="E-Value" value="0.067"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.575812066423463"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="363.213470458984" RT="3707.03860000002" >
-			<PeptideHit score="0.00134408602150538" sequence="LRVDPVNFK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="363.213470458984" RT="3707.03860000002" >
+			<PeptideHit score="0.734542296491698" sequence="LRVDPVNFK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.1"/>
 				<UserParam type="float" name="E-Value" value="0.03"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.734542296491698"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="448.734985351563" RT="3713.2695" >
-			<PeptideHit score="0" sequence="FLFEGQR" charge="2" aa_before="R" aa_after="I" protein_refs="PH_64" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="448.734985351563" RT="3713.2695" >
+			<PeptideHit score="0.920445521361603" sequence="FLFEGQR" charge="2" aa_before="R" aa_after="I" protein_refs="PH_64" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.0058"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.920445521361603"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="363.213592529297" RT="3717.3747" >
-			<PeptideHit score="0.0151133501259446" sequence="LRVDPVNFK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="363.213592529297" RT="3717.3747" >
+			<PeptideHit score="0.262904122502352" sequence="LRVDPVNFK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.3"/>
 				<UserParam type="float" name="E-Value" value="0.3"/>
 				<UserParam type="float" name="nextscore" value="11.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.262904122502352"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785552978516" RT="3739.52020000002" >
-			<PeptideHit score="0.00134408602150538" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785552978516" RT="3739.52020000002" >
+			<PeptideHit score="0.771058061136823" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.5"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="20.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785125732422" RT="3741.72580000002" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785125732422" RT="3741.72580000002" >
+			<PeptideHit score="0.89569987641038" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.0082"/>
 				<UserParam type="float" name="nextscore" value="20.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.89569987641038"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674438476563" RT="3779.79280000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674438476563" RT="3779.79280000002" >
+			<PeptideHit score="0.999999932083572" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.1"/>
 				<UserParam type="float" name="E-Value" value="1e-10"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999932083572"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.305603027344" RT="3780.825" >
-			<PeptideHit score="0.02" sequence="TIAQDYGVLK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="554.305603027344" RT="3780.825" >
+			<PeptideHit score="0.237298523258975" sequence="TIAQDYGVLK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.6"/>
 				<UserParam type="float" name="E-Value" value="0.35"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.237298523258975"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674560546875" RT="3781.96690000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674560546875" RT="3781.96690000002" >
+			<PeptideHit score="0.999999857568655" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.1"/>
 				<UserParam type="float" name="E-Value" value="2.6e-10"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999857568655"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785186767578" RT="3832.4361" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785186767578" RT="3832.4361" >
+			<PeptideHit score="0.991389286083067" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.9"/>
 				<UserParam type="float" name="E-Value" value="0.00037"/>
 				<UserParam type="float" name="nextscore" value="24.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991389286083067"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784790039063" RT="3834.10480000002" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784790039063" RT="3834.10480000002" >
+			<PeptideHit score="0.977679598036381" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.9"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="590.814453125" RT="3834.363" >
-			<PeptideHit score="0" sequence="ISGLIYEETR" charge="2" aa_before="R" aa_after="G" protein_refs="PH_59" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="590.814453125" RT="3834.363" >
+			<PeptideHit score="0.973239129162826" sequence="ISGLIYEETR" charge="2" aa_before="R" aa_after="G" protein_refs="PH_59" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.9"/>
 				<UserParam type="float" name="E-Value" value="0.0015"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.973239129162826"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="590.814880371094" RT="3838.54390000002" >
-			<PeptideHit score="0" sequence="ISGLIYEETR" charge="2" aa_before="R" aa_after="G" protein_refs="PH_59" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="590.814880371094" RT="3838.54390000002" >
+			<PeptideHit score="0.984269703140117" sequence="ISGLIYEETR" charge="2" aa_before="R" aa_after="G" protein_refs="PH_59" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.8"/>
 				<UserParam type="float" name="E-Value" value="0.00078"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984269703140117"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.6748046875" RT="3876.85000000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.6748046875" RT="3876.85000000002" >
+			<PeptideHit score="0.998256357655817" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.8"/>
 				<UserParam type="float" name="E-Value" value="4.9e-05"/>
 				<UserParam type="float" name="nextscore" value="16.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998256357655817"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784942626953" RT="3889.4232" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784942626953" RT="3889.4232" >
+			<PeptideHit score="0.954315536242781" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.3"/>
 				<UserParam type="float" name="E-Value" value="0.0029"/>
 				<UserParam type="float" name="nextscore" value="20.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.954315536242781"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.617492675781" RT="3889.7091" >
-			<PeptideHit score="0" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.617492675781" RT="3889.7091" >
+			<PeptideHit score="0.998597011971812" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44"/>
 				<UserParam type="float" name="E-Value" value="3.7e-05"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998597011971812"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785614013672" RT="3891.18259999998" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785614013672" RT="3891.18259999998" >
+			<PeptideHit score="0.939634346039965" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.9"/>
 				<UserParam type="float" name="E-Value" value="0.0041"/>
 				<UserParam type="float" name="nextscore" value="24.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.939634346039965"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265014648438" RT="3900.3774" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265014648438" RT="3900.3774" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.917755126953" RT="3910.2657" >
-			<PeptideHit score="0.0489844683393071" sequence="SSHHVNPLSTETGR" charge="3" aa_before="[" aa_after="G" protein_refs="PH_122" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.917755126953" RT="3910.2657" >
+			<PeptideHit score="0.0969386199829794" sequence="SSHHVNPLSTETGR" charge="3" aa_before="[" aa_after="G" protein_refs="PH_122" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.61669921875" RT="3922.03789999998" >
-			<PeptideHit score="0" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.61669921875" RT="3922.03789999998" >
+			<PeptideHit score="0.982332435437406" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.7"/>
 				<UserParam type="float" name="E-Value" value="0.0009"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.982332435437406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.617736816406" RT="3923.80009999998" >
-			<PeptideHit score="0" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.617736816406" RT="3923.80009999998" >
+			<PeptideHit score="0.996488921991653" sequence="LNYKPEEEYPDLSK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.7"/>
 				<UserParam type="float" name="E-Value" value="0.00012"/>
 				<UserParam type="float" name="nextscore" value="17.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996488921991653"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674011230469" RT="3927.31900000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674011230469" RT="3927.31900000002" >
+			<PeptideHit score="0.984269703140117" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.4"/>
 				<UserParam type="float" name="E-Value" value="0.00078"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984269703140117"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673095703125" RT="3929.085" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673095703125" RT="3929.085" >
+			<PeptideHit score="0.917217114482157" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.5"/>
 				<UserParam type="float" name="E-Value" value="0.0061"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.917217114482157"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784515380859" RT="3967.38949999998" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784515380859" RT="3967.38949999998" >
+			<PeptideHit score="0.919364632593739" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="0.0059"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.919364632593739"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.78466796875" RT="3969.08869999998" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.78466796875" RT="3969.08869999998" >
+			<PeptideHit score="0.869435996707529" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.011"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.869435996707529"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265075683594" RT="3992.80369999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265075683594" RT="3992.80369999998" >
+			<PeptideHit score="0.999938007838369" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.2"/>
 				<UserParam type="float" name="E-Value" value="6.6e-07"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999938007838369"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.2646484375" RT="3994.56700000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.2646484375" RT="3994.56700000002" >
+			<PeptideHit score="0.99989516753533" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="1.3e-06"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99989516753533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673461914063" RT="4026.01870000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673461914063" RT="4026.01870000002" >
+			<PeptideHit score="0.999907897771499" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.8"/>
 				<UserParam type="float" name="E-Value" value="1.1e-06"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999907897771499"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673522949219" RT="4029.49069999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673522949219" RT="4029.49069999998" >
+			<PeptideHit score="0.99989516753533" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="1.3e-06"/>
 				<UserParam type="float" name="nextscore" value="20.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99989516753533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.314697265625" RT="4033.5678" >
-			<PeptideHit score="0.00134408602150538" sequence="IVRSSSSTGQK" charge="2" aa_before="K" aa_after="N" protein_refs="PH_5" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.314697265625" RT="4033.5678" >
+			<PeptideHit score="0.563155621027287" sequence="IVRSSSSTGQK" charge="2" aa_before="K" aa_after="N" protein_refs="PH_5" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27"/>
 				<UserParam type="float" name="E-Value" value="0.071"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.563155621027287"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784698486328" RT="4060.56400000002" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784698486328" RT="4060.56400000002" >
+			<PeptideHit score="0.869435996707529" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.2"/>
 				<UserParam type="float" name="E-Value" value="0.011"/>
 				<UserParam type="float" name="nextscore" value="21.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.869435996707529"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784576416016" RT="4062.2397" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784576416016" RT="4062.2397" >
+			<PeptideHit score="0.943202686631416" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.5"/>
 				<UserParam type="float" name="E-Value" value="0.0038"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.943202686631416"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="449.229156494141" RT="4067.7576" >
-			<PeptideHit score="0.0363636363636364" sequence="MEQFKSK" charge="2" aa_before="R" aa_after="L" protein_refs="PH_138" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="449.229156494141" RT="4067.7576" >
+			<PeptideHit score="0.160401285042504" sequence="MEQFKSK" charge="2" aa_before="R" aa_after="L" protein_refs="PH_138" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="18.5"/>
 				<UserParam type="float" name="E-Value" value="0.61"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.160401285042504"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264770507813" RT="4071.6372" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264770507813" RT="4071.6372" >
+			<PeptideHit score="0.999932970501854" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45"/>
 				<UserParam type="float" name="E-Value" value="7.3e-07"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999932970501854"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264770507813" RT="4073.17729999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264770507813" RT="4073.17729999998" >
+			<PeptideHit score="0.999934398186429" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="7.1e-07"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999934398186429"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673217773438" RT="4097.9523" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673217773438" RT="4097.9523" >
+			<PeptideHit score="0.998093027078404" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.6"/>
 				<UserParam type="float" name="E-Value" value="5.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998093027078404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784362792969" RT="4103.2089" >
-			<PeptideHit score="0.00526315789473684" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784362792969" RT="4103.2089" >
+			<PeptideHit score="0.500962368004618" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.3"/>
 				<UserParam type="float" name="E-Value" value="0.094"/>
 				<UserParam type="float" name="nextscore" value="27.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.500962368004618"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674499511719" RT="4104.97150000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674499511719" RT="4104.97150000002" >
+			<PeptideHit score="0.99998453888027" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-07"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998453888027"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311157226563" RT="4122.87259999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311157226563" RT="4122.87259999998" >
+			<PeptideHit score="0.999998908036975" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-09"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998908036975"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311767578125" RT="4124.64259999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311767578125" RT="4124.64259999998" >
+			<PeptideHit score="0.999870942238288" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="1.7e-06"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999870942238288"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.26416015625" RT="4128.171" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.26416015625" RT="4128.171" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264404296875" RT="4129.94170000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264404296875" RT="4129.94170000002" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.1"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673706054688" RT="4149.13249999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673706054688" RT="4149.13249999998" >
+			<PeptideHit score="0.999970786631432" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.7"/>
 				<UserParam type="float" name="E-Value" value="2.5e-07"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999970786631432"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673767089844" RT="4150.9557" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673767089844" RT="4150.9557" >
+			<PeptideHit score="0.99988897055048" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.4"/>
 				<UserParam type="float" name="E-Value" value="1.4e-06"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99988897055048"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.785461425781" RT="4189.01980000002" >
-			<PeptideHit score="0.00402684563758389" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.785461425781" RT="4189.01980000002" >
+			<PeptideHit score="0.510657972604375" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.4"/>
 				<UserParam type="float" name="E-Value" value="0.09"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.510657972604375"/>
+				<UserParam type="float" name="q-value" value="0.00402684563758389"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784271240234" RT="4195.44559999998" >
-			<PeptideHit score="0.00134408602150538" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784271240234" RT="4195.44559999998" >
+			<PeptideHit score="0.582385925569071" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="0.065"/>
 				<UserParam type="float" name="nextscore" value="22.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.582385925569071"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311279296875" RT="4220.3067" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311279296875" RT="4220.3067" >
+			<PeptideHit score="0.999998884600159" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="3.7e-09"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998884600159"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264953613281" RT="4220.67790000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264953613281" RT="4220.67790000002" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311340332031" RT="4221.97729999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311340332031" RT="4221.97729999998" >
+			<PeptideHit score="0.999999533975387" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.3"/>
 				<UserParam type="float" name="E-Value" value="1.2e-09"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999533975387"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264831542969" RT="4222.2387" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264831542969" RT="4222.2387" >
+			<PeptideHit score="0.999983460247774" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="22.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="644.834838867188" RT="4245.59050000002" >
-			<PeptideHit score="0" sequence="ASAELIEEEVAK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="644.834838867188" RT="4245.59050000002" >
+			<PeptideHit score="0.999999307602226" sequence="ASAELIEEEVAK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.7"/>
 				<UserParam type="float" name="E-Value" value="2e-09"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999307602226"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="644.834899902344" RT="4254.37099999998" >
-			<PeptideHit score="0" sequence="ASAELIEEEVAK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="644.834899902344" RT="4254.37099999998" >
+			<PeptideHit score="0.99999349467219" sequence="ASAELIEEEVAK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.5"/>
 				<UserParam type="float" name="E-Value" value="3.6e-08"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999349467219"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.801696777344" RT="4269.96970000002" >
-			<PeptideHit score="0.00526315789473684" sequence="(Gln->pyro-Glu)QSQTEGAEILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_117" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.801696777344" RT="4269.96970000002" >
+			<PeptideHit score="0.505758287449657" sequence="(Gln->pyro-Glu)QSQTEGAEILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_117" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.092"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.505758287449657"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784606933594" RT="4287.4701" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784606933594" RT="4287.4701" >
+			<PeptideHit score="0.948061393923557" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="0.0034"/>
 				<UserParam type="float" name="nextscore" value="21.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.948061393923557"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784637451172" RT="4291.344" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784637451172" RT="4291.344" >
+			<PeptideHit score="0.97469904242467" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39"/>
 				<UserParam type="float" name="E-Value" value="0.0014"/>
 				<UserParam type="float" name="nextscore" value="18.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97469904242467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311279296875" RT="4313.8815" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311279296875" RT="4313.8815" >
+			<PeptideHit score="0.999999307602226" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.3"/>
 				<UserParam type="float" name="E-Value" value="2e-09"/>
 				<UserParam type="float" name="nextscore" value="23.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999307602226"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264526367188" RT="4314.23290000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264526367188" RT="4314.23290000002" >
+			<PeptideHit score="0.999937281120465" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.2"/>
 				<UserParam type="float" name="E-Value" value="6.7e-07"/>
 				<UserParam type="float" name="nextscore" value="23.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999937281120465"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.31103515625" RT="4315.86250000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.31103515625" RT="4315.86250000002" >
+			<PeptideHit score="0.999996363252076" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="1.7e-08"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996363252076"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264709472656" RT="4316.16409999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264709472656" RT="4316.16409999998" >
+			<PeptideHit score="0.999973542219251" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.1"/>
 				<UserParam type="float" name="E-Value" value="2.2e-07"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999973542219251"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.6748046875" RT="4345.92700000002" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.6748046875" RT="4345.92700000002" >
+			<PeptideHit score="0.995160070637582" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.1"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674682617188" RT="4347.61069999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674682617188" RT="4347.61069999998" >
+			<PeptideHit score="0.999970786631432" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="2.5e-07"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999970786631432"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784912109375" RT="4381.86820000002" >
-			<PeptideHit score="0.00134408602150538" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784912109375" RT="4381.86820000002" >
+			<PeptideHit score="0.523385410522023" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.2"/>
 				<UserParam type="float" name="E-Value" value="0.085"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.523385410522023"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="480.784698486328" RT="4385.62090000002" >
-			<PeptideHit score="0" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="480.784698486328" RT="4385.62090000002" >
+			<PeptideHit score="0.835623332778618" sequence="FQNALLVR" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.2"/>
 				<UserParam type="float" name="E-Value" value="0.015"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.835623332778618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311584472656" RT="4407.51670000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311584472656" RT="4407.51670000002" >
+			<PeptideHit score="0.999693069772492" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.4"/>
 				<UserParam type="float" name="E-Value" value="5.2e-06"/>
 				<UserParam type="float" name="nextscore" value="26.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999693069772492"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265319824219" RT="4407.9087" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265319824219" RT="4407.9087" >
+			<PeptideHit score="0.999998232748558" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="6.7e-09"/>
 				<UserParam type="float" name="nextscore" value="23.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998232748558"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311218261719" RT="4409.18239999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311218261719" RT="4409.18239999998" >
+			<PeptideHit score="0.999998315086412" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="6.3e-09"/>
 				<UserParam type="float" name="nextscore" value="23.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998315086412"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264465332031" RT="4409.53459999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264465332031" RT="4409.53459999998" >
+			<PeptideHit score="0.999997404727025" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-08"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997404727025"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.673156738281" RT="4437.93979999998" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.673156738281" RT="4437.93979999998" >
+			<PeptideHit score="0.99959657949333" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38"/>
 				<UserParam type="float" name="E-Value" value="7.4e-06"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99959657949333"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="505.920593261719" RT="4453.8546" >
-			<PeptideHit score="0.00134408602150538" sequence="IWHHTFYNELR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_0 PH_34 PH_35 PH_57 PH_65 PH_66 PH_67 PH_96 PH_130" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="505.920593261719" RT="4453.8546" >
+			<PeptideHit score="0.771058061136823" sequence="IWHHTFYNELR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_0 PH_34 PH_35 PH_57 PH_65 PH_66 PH_67 PH_96 PH_130" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.4"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674133300781" RT="4454.3895" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674133300781" RT="4454.3895" >
+			<PeptideHit score="0.999859324618151" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.5"/>
 				<UserParam type="float" name="E-Value" value="1.9e-06"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999859324618151"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.961486816406" RT="4477.93729999998" >
-			<PeptideHit score="0.00134408602150538" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.961486816406" RT="4477.93729999998" >
+			<PeptideHit score="0.536846435265042" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.7"/>
 				<UserParam type="float" name="E-Value" value="0.08"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.536846435265042"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310791015625" RT="4500.50569999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310791015625" RT="4500.50569999998" >
+			<PeptideHit score="0.999995403129308" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="2.3e-08"/>
 				<UserParam type="float" name="nextscore" value="26.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995403129308"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264465332031" RT="4500.8346" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264465332031" RT="4500.8346" >
+			<PeptideHit score="0.951788100541034" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.5"/>
 				<UserParam type="float" name="E-Value" value="0.0031"/>
 				<UserParam type="float" name="nextscore" value="22.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.951788100541034"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311340332031" RT="4502.22790000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311340332031" RT="4502.22790000002" >
+			<PeptideHit score="0.999997404727025" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-08"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997404727025"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265075683594" RT="4502.85949999998" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265075683594" RT="4502.85949999998" >
+			<PeptideHit score="0.999643869513167" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.3"/>
 				<UserParam type="float" name="E-Value" value="6.3e-06"/>
 				<UserParam type="float" name="nextscore" value="20.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999643869513167"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="816.938354492188" RT="4521.2373" >
-			<PeptideHit score="0.0363636363636364" sequence="VEADIPGHGQEVLIR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="816.938354492188" RT="4521.2373" >
+			<PeptideHit score="0.166398718169042" sequence="VEADIPGHGQEVLIR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.6"/>
 				<UserParam type="float" name="E-Value" value="0.58"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.166398718169042"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.300903320313" RT="4525.07209999998" >
-			<PeptideHit score="0" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.300903320313" RT="4525.07209999998" >
+			<PeptideHit score="0.991389286083067" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.9"/>
 				<UserParam type="float" name="E-Value" value="0.00037"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991389286083067"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.301391601563" RT="4526.74390000002" >
-			<PeptideHit score="0" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.301391601563" RT="4526.74390000002" >
+			<PeptideHit score="0.798085201014666" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28"/>
 				<UserParam type="float" name="E-Value" value="0.02"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.798085201014666"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="816.939819335938" RT="4528.4013" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="816.939819335938" RT="4528.4013" >
+			<PeptideHit score="0.995592056829865" sequence="VEADIPGHGQEVLIR" charge="2" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.9"/>
 				<UserParam type="float" name="E-Value" value="0.00016"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995592056829865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="555.248840332031" RT="4545.66490000002" >
-			<PeptideHit score="0" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="555.248840332031" RT="4545.66490000002" >
+			<PeptideHit score="0.966191334252643" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.9"/>
 				<UserParam type="float" name="E-Value" value="0.002"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.966191334252643"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="555.248413085938" RT="4547.33350000002" >
-			<PeptideHit score="0" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="555.248413085938" RT="4547.33350000002" >
+			<PeptideHit score="0.989024704232947" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.3"/>
 				<UserParam type="float" name="E-Value" value="0.0005"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989024704232947"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="643.674743652344" RT="4551.0657" >
-			<PeptideHit score="0" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="643.674743652344" RT="4551.0657" >
+			<PeptideHit score="0.997471491901146" sequence="HDTSLKPISVSYNPATAK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.6"/>
 				<UserParam type="float" name="E-Value" value="7.9e-05"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997471491901146"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.961547851563" RT="4568.12590000002" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.961547851563" RT="4568.12590000002" >
+			<PeptideHit score="0.99955085527733" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="8.5e-06"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99955085527733"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.96142578125" RT="4569.86869999998" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.96142578125" RT="4569.86869999998" >
+			<PeptideHit score="0.827735811978521" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.8"/>
 				<UserParam type="float" name="E-Value" value="0.016"/>
 				<UserParam type="float" name="nextscore" value="10.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.827735811978521"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.340698242188" RT="4587.39619999998" >
-			<PeptideHit score="0.00526315789473684" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.340698242188" RT="4587.39619999998" >
+			<PeptideHit score="0.446677932430767" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.12"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.446677932430767"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.3408203125" RT="4589.17219999998" >
-			<PeptideHit score="0" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.3408203125" RT="4589.17219999998" >
+			<PeptideHit score="0.85204760460282" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.3"/>
 				<UserParam type="float" name="E-Value" value="0.013"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.85204760460282"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310424804688" RT="4592.9355" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310424804688" RT="4592.9355" >
+			<PeptideHit score="0.995160070637582" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.5"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="24.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.3115234375" RT="4594.60219999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.3115234375" RT="4594.60219999998" >
+			<PeptideHit score="0.99982061767054" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.8"/>
 				<UserParam type="float" name="E-Value" value="2.6e-06"/>
 				<UserParam type="float" name="nextscore" value="23.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99982061767054"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.300415039063" RT="4618.0851" >
-			<PeptideHit score="0" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.300415039063" RT="4618.0851" >
+			<PeptideHit score="0.954315536242781" sequence="NAIHTFVQSGSHLAAR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.6"/>
 				<UserParam type="float" name="E-Value" value="0.0029"/>
 				<UserParam type="float" name="nextscore" value="18.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.954315536242781"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="763.729614257813" RT="4625.2275" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIKTSETK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="763.729614257813" RT="4625.2275" >
+			<PeptideHit score="0.964825445057631" sequence="LYPIANGNNQSPVDIKTSETK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.9"/>
 				<UserParam type="float" name="E-Value" value="0.0021"/>
 				<UserParam type="float" name="nextscore" value="9.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.964825445057631"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="763.729553222656" RT="4627.66390000002" >
-			<PeptideHit score="0.0151133501259446" sequence="LYPIANGNNQSPVDIKTSETK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="763.729553222656" RT="4627.66390000002" >
+			<PeptideHit score="0.257305155260055" sequence="LYPIANGNNQSPVDIKTSETK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.3"/>
 				<UserParam type="float" name="E-Value" value="0.31"/>
 				<UserParam type="float" name="nextscore" value="8.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.257305155260055"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="555.247863769531" RT="4639.07959999998" >
-			<PeptideHit score="0" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="555.247863769531" RT="4639.07959999998" >
+			<PeptideHit score="0.991765444794236" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.3"/>
 				<UserParam type="float" name="E-Value" value="0.00035"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991765444794236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="555.247741699219" RT="4640.87140000002" >
-			<PeptideHit score="0" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="555.247741699219" RT="4640.87140000002" >
+			<PeptideHit score="0.970372889310467" sequence="DAEAWFNEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_41 PH_99 PH_100 PH_101" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.2"/>
 				<UserParam type="float" name="E-Value" value="0.0017"/>
 				<UserParam type="float" name="nextscore" value="8.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.970372889310467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.96142578125" RT="4653.70030000002" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.96142578125" RT="4653.70030000002" >
+			<PeptideHit score="0.991765444794236" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.7"/>
 				<UserParam type="float" name="E-Value" value="0.00035"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991765444794236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.340942382813" RT="4679.9703" >
-			<PeptideHit score="0" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.340942382813" RT="4679.9703" >
+			<PeptideHit score="0.997906967138569" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="6.2e-05"/>
 				<UserParam type="float" name="nextscore" value="20.2"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997906967138569"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.340698242188" RT="4681.44010000002" >
-			<PeptideHit score="0" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.340698242188" RT="4681.44010000002" >
+			<PeptideHit score="0.996958329726846" sequence="QITVNDLPVGR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_47 PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.5"/>
 				<UserParam type="float" name="E-Value" value="0.0001"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996958329726846"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.31103515625" RT="4685.1963" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.31103515625" RT="4685.1963" >
+			<PeptideHit score="0.999934398186429" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="7.1e-07"/>
 				<UserParam type="float" name="nextscore" value="26.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999934398186429"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.31103515625" RT="4686.8703" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.31103515625" RT="4686.8703" >
+			<PeptideHit score="0.999571462358373" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.6"/>
 				<UserParam type="float" name="E-Value" value="8e-06"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999571462358373"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264953613281" RT="4687.39840000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264953613281" RT="4687.39840000002" >
+			<PeptideHit score="0.999992941150764" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.1"/>
 				<UserParam type="float" name="E-Value" value="4e-08"/>
 				<UserParam type="float" name="nextscore" value="29.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999992941150764"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264282226563" RT="4688.5404" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264282226563" RT="4688.5404" >
+			<PeptideHit score="0.994321746497951" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="537.314086914063" RT="4716.7293" >
-			<PeptideHit score="0.00134408602150538" sequence="ATVQAVLGPLALETAR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_1 PH_89" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="537.314086914063" RT="4716.7293" >
+			<PeptideHit score="0.61801152613314" sequence="ATVQAVLGPLALETAR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_1 PH_89" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.2"/>
 				<UserParam type="float" name="E-Value" value="0.055"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.61801152613314"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="436.563751220703" RT="4729.95289999998" >
-			<PeptideHit score="0.0151133501259446" sequence="IKFEMEQNLR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_49" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="436.563751220703" RT="4729.95289999998" >
+			<PeptideHit score="0.262904122502352" sequence="IKFEMEQNLR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_49" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.8"/>
 				<UserParam type="float" name="E-Value" value="0.3"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.262904122502352"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="436.564361572266" RT="4745.04529999998" >
-			<PeptideHit score="0.00134408602150538" sequence="IKFEMEQNLR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_49" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="436.564361572266" RT="4745.04529999998" >
+			<PeptideHit score="0.654692624849357" sequence="IKFEMEQNLR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_49" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.2"/>
 				<UserParam type="float" name="E-Value" value="0.046"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.654692624849357"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.962463378906" RT="4750.05529999998" >
-			<PeptideHit score="0.0342298288508557" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.962463378906" RT="4750.05529999998" >
+			<PeptideHit score="0.180044603065486" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.9"/>
 				<UserParam type="float" name="E-Value" value="0.52"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.180044603065486"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="544.961181640625" RT="4752.36430000002" >
-			<PeptideHit score="0" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="544.961181640625" RT="4752.36430000002" >
+			<PeptideHit score="0.918288520543892" sequence="VEADIPGHGQEVLIR" charge="3" aa_before="K" aa_after="L" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.4"/>
 				<UserParam type="float" name="E-Value" value="0.006"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.918288520543892"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="606.33984375" RT="4773.2196" >
-			<PeptideHit score="0.0444711538461538" sequence="SPQQSAALPRR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_94" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="606.33984375" RT="4773.2196" >
+			<PeptideHit score="0.103478204192389" sequence="SPQQSAALPRR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_94" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="17.3"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310913085938" RT="4778.391" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310913085938" RT="4778.391" >
+			<PeptideHit score="0.996721562845727" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.1"/>
 				<UserParam type="float" name="E-Value" value="0.00011"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996721562845727"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311218261719" RT="4780.10140000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311218261719" RT="4780.10140000002" >
+			<PeptideHit score="0.999657080608143" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="6e-06"/>
 				<UserParam type="float" name="nextscore" value="26.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999657080608143"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265014648438" RT="4780.73020000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265014648438" RT="4780.73020000002" >
+			<PeptideHit score="0.999998440846017" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.5"/>
 				<UserParam type="float" name="E-Value" value="5.7e-09"/>
 				<UserParam type="float" name="nextscore" value="22.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998440846017"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264465332031" RT="4782.51100000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264465332031" RT="4782.51100000002" >
+			<PeptideHit score="0.999930141176823" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45"/>
 				<UserParam type="float" name="E-Value" value="7.7e-07"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999930141176823"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="500.805084228516" RT="4801.3077" >
-			<PeptideHit score="0.00906735751295337" sequence="QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="500.805084228516" RT="4801.3077" >
+			<PeptideHit score="0.359831619897065" sequence="QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="16"/>
 				<UserParam type="float" name="E-Value" value="0.18"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.359831619897065"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310668945313" RT="4872.7377" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310668945313" RT="4872.7377" >
+			<PeptideHit score="0.998964248012865" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="2.5e-05"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998964248012865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.263977050781" RT="4873.3338" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.263977050781" RT="4873.3338" >
+			<PeptideHit score="0.999744693880245" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="4.1e-06"/>
 				<UserParam type="float" name="nextscore" value="23"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999744693880245"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.263916015625" RT="4876.77910000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.263916015625" RT="4876.77910000002" >
+			<PeptideHit score="0.999901472880047" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="1.2e-06"/>
 				<UserParam type="float" name="nextscore" value="20.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999901472880047"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.2900390625" RT="4882.82290000002" >
-			<PeptideHit score="0.0151133501259446" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.2900390625" RT="4882.82290000002" >
+			<PeptideHit score="0.262904122502352" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.7"/>
 				<UserParam type="float" name="E-Value" value="0.3"/>
 				<UserParam type="float" name="nextscore" value="11.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.262904122502352"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="500.805572509766" RT="4895.1642" >
-			<PeptideHit score="0.00134408602150538" sequence="QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="500.805572509766" RT="4895.1642" >
+			<PeptideHit score="0.752250699877261" sequence="QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="16.1"/>
 				<UserParam type="float" name="E-Value" value="0.027"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.752250699877261"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310913085938" RT="4965.444" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310913085938" RT="4965.444" >
+			<PeptideHit score="0.998715907376379" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="3.3e-05"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998715907376379"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311157226563" RT="4967.10649999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311157226563" RT="4967.10649999998" >
+			<PeptideHit score="0.994736999948131" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.4"/>
 				<UserParam type="float" name="E-Value" value="0.0002"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994736999948131"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264770507813" RT="4967.7381" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264770507813" RT="4967.7381" >
+			<PeptideHit score="0.999973542219251" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.1"/>
 				<UserParam type="float" name="E-Value" value="2.2e-07"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999973542219251"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264465332031" RT="4968.87850000002" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264465332031" RT="4968.87850000002" >
+			<PeptideHit score="0.999997404727025" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-08"/>
 				<UserParam type="float" name="nextscore" value="26"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997404727025"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289367675781" RT="4981.9851" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289367675781" RT="4981.9851" >
+			<PeptideHit score="0.998900658395066" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289093017578" RT="4983.65029999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289093017578" RT="4983.65029999998" >
+			<PeptideHit score="0.999789303075987" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="3.2e-06"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999789303075987"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.641723632813" RT="4985.32219999998" >
-			<PeptideHit score="0.00526315789473684" sequence="KYAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.641723632813" RT="4985.32219999998" >
+			<PeptideHit score="0.465947082204611" sequence="KYAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.11"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.465947082204611"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.642150878906" RT="4987.07440000002" >
-			<PeptideHit score="0.0342298288508557" sequence="KYAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.642150878906" RT="4987.07440000002" >
+			<PeptideHit score="0.180044603065486" sequence="KYAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.6"/>
 				<UserParam type="float" name="E-Value" value="0.52"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.180044603065486"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763519287109" RT="5031.44959999998" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763519287109" RT="5031.44959999998" >
+			<PeptideHit score="0.976178644666495" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.3"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.318054199219" RT="5038.92850000002" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.318054199219" RT="5038.92850000002" >
+			<PeptideHit score="0.998228864915851" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.3"/>
 				<UserParam type="float" name="E-Value" value="5e-05"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998228864915851"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.315307617188" RT="5040.5739" >
-			<PeptideHit score="0.029520295202952" sequence="LFIESLFTISQITK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_108" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.315307617188" RT="5040.5739" >
+			<PeptideHit score="0.193496525438801" sequence="LFIESLFTISQITK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_108" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311889648438" RT="5059.29460000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311889648438" RT="5059.29460000002" >
+			<PeptideHit score="0.999490594071398" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.4"/>
 				<UserParam type="float" name="E-Value" value="1e-05"/>
 				<UserParam type="float" name="nextscore" value="24"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999490594071398"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="820.471618652344" RT="5073.9501" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="820.471618652344" RT="5073.9501" >
+			<PeptideHit score="0.999413322128202" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.9"/>
 				<UserParam type="float" name="E-Value" value="1.2e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999413322128202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290283203125" RT="5076.25099999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290283203125" RT="5076.25099999998" >
+			<PeptideHit score="0.881325320475085" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.2"/>
 				<UserParam type="float" name="E-Value" value="0.0097"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.881325320475085"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289794921875" RT="5079.9057" >
-			<PeptideHit score="0.00134408602150538" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289794921875" RT="5079.9057" >
+			<PeptideHit score="0.69188890216611" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.2"/>
 				<UserParam type="float" name="E-Value" value="0.038"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.69188890216611"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.287261962891" RT="5081.14189999998" >
-			<PeptideHit score="0.00134408602150538" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="501.287261962891" RT="5081.14189999998" >
+			<PeptideHit score="0.534092302192569" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.6"/>
 				<UserParam type="float" name="E-Value" value="0.081"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.534092302192569"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.286651611328" RT="5082.92020000002" >
-			<PeptideHit score="0" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="501.286651611328" RT="5082.92020000002" >
+			<PeptideHit score="0.820048379204749" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.7"/>
 				<UserParam type="float" name="E-Value" value="0.017"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.820048379204749"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763916015625" RT="5104.194" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763916015625" RT="5104.194" >
+			<PeptideHit score="0.979203874797132" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.6"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763336181641" RT="5105.94670000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763336181641" RT="5105.94670000002" >
+			<PeptideHit score="0.991576891487535" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.3"/>
 				<UserParam type="float" name="E-Value" value="0.00036"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991576891487535"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317565917969" RT="5107.70740000002" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317565917969" RT="5107.70740000002" >
+			<PeptideHit score="0.999999474833695" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56"/>
 				<UserParam type="float" name="E-Value" value="1.4e-09"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999474833695"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.318115234375" RT="5109.8472" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.318115234375" RT="5109.8472" >
+			<PeptideHit score="0.999998253226817" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.2"/>
 				<UserParam type="float" name="E-Value" value="6.6e-09"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998253226817"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.760894775391" RT="5110.11289999998" >
-			<PeptideHit score="0.00651890482398957" sequence="TPLDVLSR" charge="2" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.760894775391" RT="5110.11289999998" >
+			<PeptideHit score="0.398109626639983" sequence="TPLDVLSR" charge="2" >
 				<UserParam type="string" name="target_decoy" value=""/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.15"/>
 				<UserParam type="float" name="nextscore" value="22"/>
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.398109626639983"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="820.473693847656" RT="5111.67139999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="820.473693847656" RT="5111.67139999998" >
+			<PeptideHit score="0.999999926876528" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.1"/>
 				<UserParam type="float" name="E-Value" value="1.1e-10"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999926876528"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="820.473693847656" RT="5113.4319" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="820.473693847656" RT="5113.4319" >
+			<PeptideHit score="0.999998635280842" sequence="KVPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.8"/>
 				<UserParam type="float" name="E-Value" value="4.8e-09"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998635280842"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.76171875" RT="5143.0005" >
-			<PeptideHit score="0.0224159402241594" sequence="TPLDVLSR" charge="2" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.76171875" RT="5143.0005" >
+			<PeptideHit score="0.220425809510344" sequence="TPLDVLSR" charge="2" >
 				<UserParam type="string" name="target_decoy" value=""/>
 				<UserParam type="float" name="XTandem_score" value="21.4"/>
 				<UserParam type="float" name="E-Value" value="0.39"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.220425809510344"/>
+				<UserParam type="float" name="q-value" value="0.0224159402241594"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.764251708984" RT="5188.09630000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.764251708984" RT="5188.09630000002" >
+			<PeptideHit score="0.976178644666495" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.3"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310607910156" RT="5188.37209999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310607910156" RT="5188.37209999998" >
+			<PeptideHit score="0.991765444794236" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.6"/>
 				<UserParam type="float" name="E-Value" value="0.00035"/>
 				<UserParam type="float" name="nextscore" value="19.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991765444794236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763549804688" RT="5189.8194" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763549804688" RT="5189.8194" >
+			<PeptideHit score="0.977679598036381" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.8"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.3115234375" RT="5191.58449999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.3115234375" RT="5191.58449999998" >
+			<PeptideHit score="0.928151979218034" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="0.0051"/>
 				<UserParam type="float" name="nextscore" value="24.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.928151979218034"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.286590576172" RT="5192.08330000002" >
-			<PeptideHit score="0.0259259259259259" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="501.286590576172" RT="5192.08330000002" >
+			<PeptideHit score="0.209402044145386" sequence="DYPLIPVGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19"/>
 				<UserParam type="float" name="E-Value" value="0.42"/>
 				<UserParam type="float" name="nextscore" value="11.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.209402044145386"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317626953125" RT="5200.88119999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317626953125" RT="5200.88119999998" >
+			<PeptideHit score="0.999932970501854" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.1"/>
 				<UserParam type="float" name="E-Value" value="7.3e-07"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999932970501854"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317687988281" RT="5202.64699999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317687988281" RT="5202.64699999998" >
+			<PeptideHit score="0.999749532301869" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43"/>
 				<UserParam type="float" name="E-Value" value="4e-06"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999749532301869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.28955078125" RT="5208.29539999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.28955078125" RT="5208.29539999998" >
+			<PeptideHit score="0.945617006442802" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.7"/>
 				<UserParam type="float" name="E-Value" value="0.0036"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.945617006442802"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289733886719" RT="5222.41099999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289733886719" RT="5222.41099999998" >
+			<PeptideHit score="0.878537248230859" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.01"/>
 				<UserParam type="float" name="nextscore" value="12.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.878537248230859"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957641601563" RT="5240.41219999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957641601563" RT="5240.41219999998" >
+			<PeptideHit score="0.999999533975387" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.1"/>
 				<UserParam type="float" name="E-Value" value="1.2e-09"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999533975387"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.954772949219" RT="5242.1217" >
-			<PeptideHit score="0" sequence="RCAVLQATGGVEPAGWK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_103" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.954772949219" RT="5242.1217" >
+			<PeptideHit score="0.898667716126141" sequence="RCAVLQATGGVEPAGWK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_103" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="0.0079"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.898667716126141"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763519287109" RT="5273.4504" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763519287109" RT="5273.4504" >
+			<PeptideHit score="0.998012734633761" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.3"/>
 				<UserParam type="float" name="E-Value" value="5.8e-05"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998012734633761"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.639953613281" RT="5274.03229999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.639953613281" RT="5274.03229999998" >
+			<PeptideHit score="0.999302633161889" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.2"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763763427734" RT="5276.0064" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763763427734" RT="5276.0064" >
+			<PeptideHit score="0.995592056829865" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.2"/>
 				<UserParam type="float" name="E-Value" value="0.00016"/>
 				<UserParam type="float" name="nextscore" value="17"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995592056829865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311340332031" RT="5278.33819999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311340332031" RT="5278.33819999998" >
+			<PeptideHit score="0.979203874797132" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="21.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317993164063" RT="5283.1701" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317993164063" RT="5283.1701" >
+			<PeptideHit score="0.999996699477478" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.2"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317443847656" RT="5284.9389" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317443847656" RT="5284.9389" >
+			<PeptideHit score="0.99999147861159" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.2"/>
 				<UserParam type="float" name="E-Value" value="5.1e-08"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999147861159"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799774169922" RT="5299.64569999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799774169922" RT="5299.64569999998" >
+			<PeptideHit score="0.999923207531055" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="8.7e-07"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999923207531055"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800323486328" RT="5301.40390000002" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800323486328" RT="5301.40390000002" >
+			<PeptideHit score="0.982173192499341" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="0.00091"/>
 				<UserParam type="float" name="nextscore" value="19.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.982173192499341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="514.245422363281" RT="5303.1687" >
-			<PeptideHit score="0.0342298288508557" sequence="GETTSSETGLSTDVR" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_110" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="514.245422363281" RT="5303.1687" >
+			<PeptideHit score="0.182566859658893" sequence="GETTSSETGLSTDVR" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_110" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="19.6"/>
 				<UserParam type="float" name="E-Value" value="0.51"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.182566859658893"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958312988281" RT="5312.2761" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958312988281" RT="5312.2761" >
+			<PeptideHit score="0.99999994231739" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60"/>
 				<UserParam type="float" name="E-Value" value="8.1e-11"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999994231739"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957458496094" RT="5314.04359999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957458496094" RT="5314.04359999998" >
+			<PeptideHit score="0.999999763559957" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="62"/>
 				<UserParam type="float" name="E-Value" value="5e-10"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999763559957"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.764221191406" RT="5337.12220000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.764221191406" RT="5337.12220000002" >
+			<PeptideHit score="0.988320713282031" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.6"/>
 				<UserParam type="float" name="E-Value" value="0.00054"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.988320713282031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.640441894531" RT="5338.7985" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.640441894531" RT="5338.7985" >
+			<PeptideHit score="0.999983460247774" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.1"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="19.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.316711425781" RT="5346.891" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.316711425781" RT="5346.891" >
+			<PeptideHit score="0.999946176746281" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.5"/>
 				<UserParam type="float" name="E-Value" value="5.5e-07"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946176746281"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311828613281" RT="5349.4911" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311828613281" RT="5349.4911" >
+			<PeptideHit score="0.968964271876771" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.7"/>
 				<UserParam type="float" name="E-Value" value="0.0018"/>
 				<UserParam type="float" name="nextscore" value="26.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.968964271876771"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.95849609375" RT="5382.08479999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.95849609375" RT="5382.08479999998" >
+			<PeptideHit score="0.999999941216531" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.6"/>
 				<UserParam type="float" name="E-Value" value="8.3e-11"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999941216531"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="754.353881835938" RT="5385.58669999998" >
-			<PeptideHit score="0" sequence="GGDDLDPNYVLSSR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="754.353881835938" RT="5385.58669999998" >
+			<PeptideHit score="0.99977415246485" sequence="GGDDLDPNYVLSSR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44"/>
 				<UserParam type="float" name="E-Value" value="3.5e-06"/>
 				<UserParam type="float" name="nextscore" value="9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99977415246485"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.76318359375" RT="5389.5303" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.76318359375" RT="5389.5303" >
+			<PeptideHit score="0.95053753529317" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.4"/>
 				<UserParam type="float" name="E-Value" value="0.0032"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.95053753529317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.264343261719" RT="5390.1459" >
-			<PeptideHit score="0" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.264343261719" RT="5390.1459" >
+			<PeptideHit score="0.993913437040977" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.9"/>
 				<UserParam type="float" name="E-Value" value="0.00024"/>
 				<UserParam type="float" name="nextscore" value="20.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993913437040977"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763793945313" RT="5395.3578" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763793945313" RT="5395.3578" >
+			<PeptideHit score="0.998147047632296" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="5.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998147047632296"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="578.850158691406" RT="5403.9255" >
-			<PeptideHit score="0.0102432778489117" sequence="AIAEAVIRNAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_132" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="578.850158691406" RT="5403.9255" >
+			<PeptideHit score="0.348796391782609" sequence="AIAEAVIRNAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_132" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.2"/>
 				<UserParam type="float" name="E-Value" value="0.19"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.348796391782609"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.640930175781" RT="5428.97659999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.640930175781" RT="5428.97659999998" >
+			<PeptideHit score="0.99999464603178" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.8"/>
 				<UserParam type="float" name="E-Value" value="2.8e-08"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999464603178"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.640625" RT="5430.67759999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.640625" RT="5430.67759999998" >
+			<PeptideHit score="0.997906967138569" sequence="LYPIANGNNQSPVDIK" charge="3" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.3"/>
 				<UserParam type="float" name="E-Value" value="6.2e-05"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997906967138569"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="770.867004394531" RT="5434.2147" >
-			<PeptideHit score="0.0211970074812968" sequence="AYEDLEFQQLER" charge="2" aa_before="R" aa_after="E" protein_refs="PH_95" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="770.867004394531" RT="5434.2147" >
+			<PeptideHit score="0.228519335906576" sequence="AYEDLEFQQLER" charge="2" aa_before="R" aa_after="E" protein_refs="PH_95" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.7"/>
 				<UserParam type="float" name="E-Value" value="0.37"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.228519335906576"/>
+				<UserParam type="float" name="q-value" value="0.0211970074812968"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317321777344" RT="5437.76989999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317321777344" RT="5437.76989999998" >
+			<PeptideHit score="0.999935834951473" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.9"/>
 				<UserParam type="float" name="E-Value" value="6.9e-07"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999935834951473"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.316650390625" RT="5439.5409" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.316650390625" RT="5439.5409" >
+			<PeptideHit score="0.999970786631432" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.4"/>
 				<UserParam type="float" name="E-Value" value="2.5e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999970786631432"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="562.624816894531" RT="5441.30980000002" >
-			<PeptideHit score="0.00906735751295337" sequence="EIEIDIEPTDKVER" charge="3" aa_before="K" aa_after="I" protein_refs="PH_84" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="562.624816894531" RT="5441.30980000002" >
+			<PeptideHit score="0.359831619897065" sequence="EIEIDIEPTDKVER" charge="3" aa_before="K" aa_after="I" protein_refs="PH_84" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.9"/>
 				<UserParam type="float" name="E-Value" value="0.18"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.359831619897065"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800048828125" RT="5443.07779999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800048828125" RT="5443.07779999998" >
+			<PeptideHit score="0.993114935780985" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="0.00028"/>
 				<UserParam type="float" name="nextscore" value="21.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993114935780985"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.7998046875" RT="5444.86429999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.7998046875" RT="5444.86429999998" >
+			<PeptideHit score="0.999923207531055" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="8.7e-07"/>
 				<UserParam type="float" name="nextscore" value="20.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999923207531055"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311462402344" RT="5469.29350000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311462402344" RT="5469.29350000002" >
+			<PeptideHit score="0.97179748620208" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.7"/>
 				<UserParam type="float" name="E-Value" value="0.0016"/>
 				<UserParam type="float" name="nextscore" value="23.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97179748620208"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.3115234375" RT="5471.38000000002" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.3115234375" RT="5471.38000000002" >
+			<PeptideHit score="0.997006222645118" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.3"/>
 				<UserParam type="float" name="E-Value" value="9.8e-05"/>
 				<UserParam type="float" name="nextscore" value="26.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997006222645118"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.349792480469" RT="5519.45539999998" >
-			<PeptideHit score="0" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.349792480469" RT="5519.45539999998" >
+			<PeptideHit score="0.998093027078404" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.4"/>
 				<UserParam type="float" name="E-Value" value="5.5e-05"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998093027078404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763488769531" RT="5523.36850000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763488769531" RT="5523.36850000002" >
+			<PeptideHit score="0.993913437040977" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.3"/>
 				<UserParam type="float" name="E-Value" value="0.00024"/>
 				<UserParam type="float" name="nextscore" value="12"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993913437040977"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317504882813" RT="5530.809" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317504882813" RT="5530.809" >
+			<PeptideHit score="0.999981361280163" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.8"/>
 				<UserParam type="float" name="E-Value" value="1.4e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999981361280163"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763671875" RT="5531.20819999998" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763671875" RT="5531.20819999998" >
+			<PeptideHit score="0.997854601535419" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.1"/>
 				<UserParam type="float" name="E-Value" value="6.4e-05"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997854601535419"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800262451172" RT="5536.78009999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800262451172" RT="5536.78009999998" >
+			<PeptideHit score="0.999915784628098" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.5"/>
 				<UserParam type="float" name="E-Value" value="9.8e-07"/>
 				<UserParam type="float" name="nextscore" value="23.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999915784628098"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799896240234" RT="5538.432" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799896240234" RT="5538.432" >
+			<PeptideHit score="0.999923892492664" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="8.6e-07"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999923892492664"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="481.920867919922" RT="5566.38220000002" >
-			<PeptideHit score="0.0444711538461538" sequence="GDSPWQVVLLDSK" charge="3" aa_before="R" aa_after="K" protein_refs="PH_25" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="481.920867919922" RT="5566.38220000002" >
+			<PeptideHit score="0.103478204192389" sequence="GDSPWQVVLLDSK" charge="3" aa_before="R" aa_after="K" protein_refs="PH_25" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.3"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.350830078125" RT="5609.03410000002" >
-			<PeptideHit score="0" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.350830078125" RT="5609.03410000002" >
+			<PeptideHit score="0.981539358864782" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.4"/>
 				<UserParam type="float" name="E-Value" value="0.00095"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.981539358864782"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.350891113281" RT="5611.27759999998" >
-			<PeptideHit score="0" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.350891113281" RT="5611.27759999998" >
+			<PeptideHit score="0.994321746497951" sequence="KLVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.7"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.425537109375" RT="5618.94979999998" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.425537109375" RT="5618.94979999998" >
+			<PeptideHit score="0.999992941150764" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.8"/>
 				<UserParam type="float" name="E-Value" value="4e-08"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999992941150764"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317932128906" RT="5623.44769999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317932128906" RT="5623.44769999998" >
+			<PeptideHit score="0.869435996707529" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.011"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.869435996707529"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317687988281" RT="5625.11149999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317687988281" RT="5625.11149999998" >
+			<PeptideHit score="0.996721562845727" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.6"/>
 				<UserParam type="float" name="E-Value" value="0.00011"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996721562845727"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="508.600341796875" RT="5625.99190000002" >
-			<PeptideHit score="0.02" sequence="LLRDYQELMNTK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="508.600341796875" RT="5625.99190000002" >
+			<PeptideHit score="0.237298523258975" sequence="LLRDYQELMNTK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.35"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.237298523258975"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800048828125" RT="5631.5175" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800048828125" RT="5631.5175" >
+			<PeptideHit score="0.99988897055048" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="1.4e-06"/>
 				<UserParam type="float" name="nextscore" value="26.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99988897055048"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="557.834289550781" RT="5631.88780000002" >
-			<PeptideHit score="0.00134408602150538" sequence="IQILEGWKK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="557.834289550781" RT="5631.88780000002" >
+			<PeptideHit score="0.551111338013726" sequence="IQILEGWKK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.6"/>
 				<UserParam type="float" name="E-Value" value="0.075"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.551111338013726"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="557.834167480469" RT="5636.07550000002" >
-			<PeptideHit score="0.00134408602150538" sequence="IQILEGWKK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="557.834167480469" RT="5636.07550000002" >
+			<PeptideHit score="0.629701467241458" sequence="IQILEGWKK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.052"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.629701467241458"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="585.265197753906" RT="5636.5257" >
-			<PeptideHit score="0.00134408602150538" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="585.265197753906" RT="5636.5257" >
+			<PeptideHit score="0.707171902639713" sequence="SADFTNFDPR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="0.035"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.707171902639713"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="372.225860595703" RT="5645.3274" >
-			<PeptideHit score="0.0139416983523447" sequence="IQILEGWKK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="372.225860595703" RT="5645.3274" >
+			<PeptideHit score="0.281438322829347" sequence="IQILEGWKK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.1"/>
 				<UserParam type="float" name="E-Value" value="0.27"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.281438322829347"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="372.225860595703" RT="5646.99880000002" >
-			<PeptideHit score="0.00651890482398957" sequence="IQILEGWKK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="372.225860595703" RT="5646.99880000002" >
+			<PeptideHit score="0.429088420832665" sequence="IQILEGWKK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19"/>
 				<UserParam type="float" name="E-Value" value="0.13"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.429088420832665"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="538.27685546875" RT="5652.80479999998" >
-			<PeptideHit score="0.0489844683393071" sequence="VYNIEFYK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_87" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="538.27685546875" RT="5652.80479999998" >
+			<PeptideHit score="0.0969386199829794" sequence="VYNIEFYK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_87" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="18.2"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="12"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.31103515625" RT="5659.9092" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.31103515625" RT="5659.9092" >
+			<PeptideHit score="0.910883820050366" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="0.0067"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.910883820050366"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.819152832031" RT="5667.3357" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.819152832031" RT="5667.3357" >
+			<PeptideHit score="0.997828542200326" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46"/>
 				<UserParam type="float" name="E-Value" value="6.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997828542200326"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.819274902344" RT="5669.00080000002" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.819274902344" RT="5669.00080000002" >
+			<PeptideHit score="0.999901472880047" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-06"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999901472880047"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="504.618713378906" RT="5685.76660000002" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="504.618713378906" RT="5685.76660000002" >
+			<PeptideHit score="0.999375797281708" sequence="VPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.5"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.425598144531" RT="5716.77799999998" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.425598144531" RT="5716.77799999998" >
+			<PeptideHit score="0.999999999857634" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="75.9"/>
 				<UserParam type="float" name="E-Value" value="3.5e-14"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999857634"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="546.6259765625" RT="5717.04469999998" >
-			<PeptideHit score="0.00134408602150538" sequence="TFIIGELHPDDRPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_12" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="546.6259765625" RT="5717.04469999998" >
+			<PeptideHit score="0.557059990676927" sequence="TFIIGELHPDDRPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_12" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.6"/>
 				<UserParam type="float" name="E-Value" value="0.073"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.557059990676927"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.944213867188" RT="5718.02179999998" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.944213867188" RT="5718.02179999998" >
+			<PeptideHit score="0.998964248012865" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.6"/>
 				<UserParam type="float" name="E-Value" value="2.5e-05"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998964248012865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.425964355469" RT="5719.25029999998" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.425964355469" RT="5719.25029999998" >
+			<PeptideHit score="0.999999999893731" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="76"/>
 				<UserParam type="float" name="E-Value" value="2.4e-14"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999893731"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="546.626647949219" RT="5719.52509999998" >
-			<PeptideHit score="0.00134408602150538" sequence="TFIIGELHPDDRPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_12" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="546.626647949219" RT="5719.52509999998" >
+			<PeptideHit score="0.663546675058494" sequence="TFIIGELHPDDRPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_12" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.6"/>
 				<UserParam type="float" name="E-Value" value="0.044"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.663546675058494"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799743652344" RT="5723.8161" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799743652344" RT="5723.8161" >
+			<PeptideHit score="0.860612864765694" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.012"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.860612864765694"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310974121094" RT="5757.36559999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310974121094" RT="5757.36559999998" >
+			<PeptideHit score="0.993913437040977" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36"/>
 				<UserParam type="float" name="E-Value" value="0.00024"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993913437040977"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.819274902344" RT="5759.1375" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.819274902344" RT="5759.1375" >
+			<PeptideHit score="0.999959587384417" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.9"/>
 				<UserParam type="float" name="E-Value" value="3.8e-07"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999959587384417"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.819213867188" RT="5760.8133" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.819213867188" RT="5760.8133" >
+			<PeptideHit score="0.99955085527733" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.3"/>
 				<UserParam type="float" name="E-Value" value="8.5e-06"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99955085527733"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="505.936309814453" RT="5793.14299999998" >
-			<PeptideHit score="0.00134408602150538" sequence="TEWLDGKHVVFGK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="505.936309814453" RT="5793.14299999998" >
+			<PeptideHit score="0.633712555194939" sequence="TEWLDGKHVVFGK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.051"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.633712555194939"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="505.936218261719" RT="5795.07070000002" >
-			<PeptideHit score="0.00526315789473684" sequence="TEWLDGKHVVFGK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="505.936218261719" RT="5795.07070000002" >
+			<PeptideHit score="0.489404251795088" sequence="TEWLDGKHVVFGK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.2"/>
 				<UserParam type="float" name="E-Value" value="0.099"/>
 				<UserParam type="float" name="nextscore" value="11.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.489404251795088"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.763031005859" RT="5807.40310000002" >
-			<PeptideHit score="0.00134408602150538" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.763031005859" RT="5807.40310000002" >
+			<PeptideHit score="0.752250699877261" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.9"/>
 				<UserParam type="float" name="E-Value" value="0.027"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.752250699877261"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.425354003906" RT="5810.7987" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.425354003906" RT="5810.7987" >
+			<PeptideHit score="0.9999993618971" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.4"/>
 				<UserParam type="float" name="E-Value" value="1.8e-09"/>
 				<UserParam type="float" name="nextscore" value="12.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.9999993618971"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317199707031" RT="5811.32569999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317199707031" RT="5811.32569999998" >
+			<PeptideHit score="0.999932970501854" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.2"/>
 				<UserParam type="float" name="E-Value" value="7.3e-07"/>
 				<UserParam type="float" name="nextscore" value="18.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999932970501854"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.3173828125" RT="5813.5506" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.3173828125" RT="5813.5506" >
+			<PeptideHit score="0.999946936748021" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.42529296875" RT="5813.89579999998" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.42529296875" RT="5813.89579999998" >
+			<PeptideHit score="0.999999999326381" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.8"/>
 				<UserParam type="float" name="E-Value" value="2.6e-13"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999326381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799835205078" RT="5817.4488" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799835205078" RT="5817.4488" >
+			<PeptideHit score="0.999876865375483" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="1.6e-06"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999876865375483"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="474.759765625" RT="5818.07389999998" >
-			<PeptideHit score="0.02" sequence="RTTAAAETK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_45" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="474.759765625" RT="5818.07389999998" >
+			<PeptideHit score="0.246856676048891" sequence="RTTAAAETK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_45" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="17.7"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="11.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310363769531" RT="5851.7934" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310363769531" RT="5851.7934" >
+			<PeptideHit score="0.980753850169904" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.4"/>
 				<UserParam type="float" name="E-Value" value="0.001"/>
 				<UserParam type="float" name="nextscore" value="23.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980753850169904"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302612304688" RT="5888.80270000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302612304688" RT="5888.80270000002" >
+			<PeptideHit score="0.999986879993158" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.3"/>
 				<UserParam type="float" name="E-Value" value="8.9e-08"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999986879993158"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="466.762939453125" RT="5894.10280000002" >
-			<PeptideHit score="0" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="466.762939453125" RT="5894.10280000002" >
+			<PeptideHit score="0.791101298057872" sequence="SAVTALWGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.1"/>
 				<UserParam type="float" name="E-Value" value="0.021"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.791101298057872"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317932128906" RT="5905.08649999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317932128906" RT="5905.08649999998" >
+			<PeptideHit score="0.99998033748685" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.9"/>
 				<UserParam type="float" name="E-Value" value="1.5e-07"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998033748685"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.31787109375" RT="5907.26269999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.31787109375" RT="5907.26269999998" >
+			<PeptideHit score="0.999928040886378" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.1"/>
 				<UserParam type="float" name="E-Value" value="8e-07"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999928040886378"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.42529296875" RT="5908.9323" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.42529296875" RT="5908.9323" >
+			<PeptideHit score="0.999996699477478" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799896240234" RT="5910.60730000002" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799896240234" RT="5910.60730000002" >
+			<PeptideHit score="0.999231648451313" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="1.7e-05"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999231648451313"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="756.424743652344" RT="5913.5607" >
-			<PeptideHit score="0" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="756.424743652344" RT="5913.5607" >
+			<PeptideHit score="0.999956327890147" sequence="VPQVSTPTLVEVSR" charge="2" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.1"/>
 				<UserParam type="float" name="E-Value" value="4.2e-07"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999956327890147"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="477.304840087891" RT="5926.6005" >
-			<PeptideHit score="0.00906735751295337" sequence="ILLLEAGPK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_144" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="477.304840087891" RT="5926.6005" >
+			<PeptideHit score="0.359831619897065" sequence="ILLLEAGPK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_144" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.18"/>
 				<UserParam type="float" name="nextscore" value="22.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.359831619897065"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290100097656" RT="5940.9147" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290100097656" RT="5940.9147" >
+			<PeptideHit score="0.976178644666495" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.6"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303070068359" RT="5952.74140000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303070068359" RT="5952.74140000002" >
+			<PeptideHit score="0.999999911847758" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="1.4e-10"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999911847758"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302642822266" RT="5954.45689999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302642822266" RT="5954.45689999998" >
+			<PeptideHit score="0.999999812773505" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="3.7e-10"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999812773505"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="598.818481445313" RT="5966.1795" >
-			<PeptideHit score="0" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="598.818481445313" RT="5966.1795" >
+			<PeptideHit score="0.980753850169904" sequence="LVQAFQFTDK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34"/>
 				<UserParam type="float" name="E-Value" value="0.001"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980753850169904"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.80029296875" RT="5974.55260000002" >
-			<PeptideHit score="0.0259259259259259" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.80029296875" RT="5974.55260000002" >
+			<PeptideHit score="0.20599231767492" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.5"/>
 				<UserParam type="float" name="E-Value" value="0.43"/>
 				<UserParam type="float" name="nextscore" value="20.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.20599231767492"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317016601563" RT="5975.50219999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317016601563" RT="5975.50219999998" >
+			<PeptideHit score="0.999266889838404" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38"/>
 				<UserParam type="float" name="E-Value" value="1.6e-05"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999266889838404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317749023438" RT="5979.24220000002" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317749023438" RT="5979.24220000002" >
+			<PeptideHit score="0.999769168223274" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.8"/>
 				<UserParam type="float" name="E-Value" value="3.6e-06"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999769168223274"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800079345703" RT="5980.7133" >
-			<PeptideHit score="0.0224159402241594" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800079345703" RT="5980.7133" >
+			<PeptideHit score="0.220425809510344" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.9"/>
 				<UserParam type="float" name="E-Value" value="0.39"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.220425809510344"/>
+				<UserParam type="float" name="q-value" value="0.0224159402241594"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="351.18896484375" RT="5986.8858" >
-			<PeptideHit score="0.02" sequence="IVPEHDVSR" charge="3" aa_before="R" aa_after="I" protein_refs="PH_106" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="351.18896484375" RT="5986.8858" >
+			<PeptideHit score="0.241973740416827" sequence="IVPEHDVSR" charge="3" aa_before="R" aa_after="I" protein_refs="PH_106" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="17.8"/>
 				<UserParam type="float" name="E-Value" value="0.34"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.241973740416827"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="477.304565429688" RT="5993.72440000002" >
-			<PeptideHit score="0" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="477.304565429688" RT="5993.72440000002" >
+			<PeptideHit score="0.90572411537101" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.5"/>
 				<UserParam type="float" name="E-Value" value="0.0072"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.90572411537101"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800720214844" RT="5995.99639999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800720214844" RT="5995.99639999998" >
+			<PeptideHit score="0.894717809051713" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.8"/>
 				<UserParam type="float" name="E-Value" value="0.0083"/>
 				<UserParam type="float" name="nextscore" value="23.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.894717809051713"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800048828125" RT="5997.76039999998" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800048828125" RT="5997.76039999998" >
+			<PeptideHit score="0.979203874797132" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.4"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="20.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289276123047" RT="6019.9695" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289276123047" RT="6019.9695" >
+			<PeptideHit score="0.997347108654437" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="8.4e-05"/>
 				<UserParam type="float" name="nextscore" value="9.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997347108654437"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.28955078125" RT="6021.663" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.28955078125" RT="6021.663" >
+			<PeptideHit score="0.998119986595388" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="5.4e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998119986595388"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="477.305358886719" RT="6029.81359999998" >
-			<PeptideHit score="0.0102432778489117" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="477.305358886719" RT="6029.81359999998" >
+			<PeptideHit score="0.348796391782609" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.8"/>
 				<UserParam type="float" name="E-Value" value="0.19"/>
 				<UserParam type="float" name="nextscore" value="25.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.348796391782609"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302368164063" RT="6031.33120000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302368164063" RT="6031.33120000002" >
+			<PeptideHit score="0.999999978259312" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="2.3e-11"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999978259312"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="477.305206298828" RT="6035.6352" >
-			<PeptideHit score="0.00651890482398957" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="477.305206298828" RT="6035.6352" >
+			<PeptideHit score="0.412959460251658" sequence="LLLPGELAK" charge="2" aa_before="R" aa_after="H" protein_refs="PH_8 PH_30 PH_44 PH_48 PH_55 PH_56 PH_60 PH_86 PH_91 PH_105 PH_115 PH_116 PH_123 PH_125 PH_126" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.8"/>
 				<UserParam type="float" name="E-Value" value="0.14"/>
 				<UserParam type="float" name="nextscore" value="22.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.412959460251658"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="558.32470703125" RT="6045.273" >
-			<PeptideHit score="0.02" sequence="IEINKSAVNK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="558.32470703125" RT="6045.273" >
+			<PeptideHit score="0.246856676048891" sequence="IEINKSAVNK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="27.2"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="18.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317810058594" RT="6047.28199999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317810058594" RT="6047.28199999998" >
+			<PeptideHit score="0.999960414089089" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.8"/>
 				<UserParam type="float" name="E-Value" value="3.7e-07"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999960414089089"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="518.293579101563" RT="6048.46369999998" >
-			<PeptideHit score="0.0363636363636364" sequence="VLPSRNHGR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_54" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="518.293579101563" RT="6048.46369999998" >
+			<PeptideHit score="0.139151226014516" sequence="VLPSRNHGR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_54" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="18"/>
 				<UserParam type="float" name="E-Value" value="0.74"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.139151226014516"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.28955078125" RT="6068.74180000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.28955078125" RT="6068.74180000002" >
+			<PeptideHit score="0.997750839055042" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="6.8e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997750839055042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289184570313" RT="6070.49620000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289184570313" RT="6070.49620000002" >
+			<PeptideHit score="0.999901472880047" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="1.2e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999901472880047"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310607910156" RT="6072.70639999998" >
-			<PeptideHit score="0.00134408602150538" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310607910156" RT="6072.70639999998" >
+			<PeptideHit score="0.625748520080762" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.7"/>
 				<UserParam type="float" name="E-Value" value="0.053"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.625748520080762"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303131103516" RT="6078.28069999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303131103516" RT="6078.28069999998" >
+			<PeptideHit score="0.999999958478686" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="5.3e-11"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999958478686"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302947998047" RT="6080.26120000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302947998047" RT="6080.26120000002" >
+			<PeptideHit score="0.999995875058368" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.9"/>
 				<UserParam type="float" name="E-Value" value="2e-08"/>
 				<UserParam type="float" name="nextscore" value="9.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995875058368"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317321777344" RT="6100.2399" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317321777344" RT="6100.2399" >
+			<PeptideHit score="0.998626449672608" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42"/>
 				<UserParam type="float" name="E-Value" value="3.6e-05"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998626449672608"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799896240234" RT="6108.61219999998" >
-			<PeptideHit score="0.0236318407960199" sequence="IPSLLAAASK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_76" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799896240234" RT="6108.61219999998" >
+			<PeptideHit score="0.216611057630705" sequence="IPSLLAAASK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_76" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="16.9"/>
 				<UserParam type="float" name="E-Value" value="0.4"/>
 				<UserParam type="float" name="nextscore" value="12.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.216611057630705"/>
+				<UserParam type="float" name="q-value" value="0.0236318407960199"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="558.326171875" RT="6115.7283" >
-			<PeptideHit score="0.029520295202952" sequence="ELFEKPPKK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_131" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="558.326171875" RT="6115.7283" >
+			<PeptideHit score="0.193496525438801" sequence="ELFEKPPKK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_131" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="29.8"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="21.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289672851563" RT="6162.35329999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289672851563" RT="6162.35329999998" >
+			<PeptideHit score="0.997371865907272" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.3"/>
 				<UserParam type="float" name="E-Value" value="8.3e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997371865907272"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302642822266" RT="6171.59470000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302642822266" RT="6171.59470000002" >
+			<PeptideHit score="0.999999126279445" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="2.7e-09"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999126279445"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302520751953" RT="6173.64199999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302520751953" RT="6173.64199999998" >
+			<PeptideHit score="0.999999774631398" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="4.7e-10"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999774631398"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.316772460938" RT="6197.32939999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.316772460938" RT="6197.32939999998" >
+			<PeptideHit score="0.977679598036381" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.9"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="12"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317565917969" RT="6198.651" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317565917969" RT="6198.651" >
+			<PeptideHit score="0.996721562845727" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.6"/>
 				<UserParam type="float" name="E-Value" value="0.00011"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996721562845727"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799713134766" RT="6200.5863" >
-			<PeptideHit score="0.00526315789473684" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799713134766" RT="6200.5863" >
+			<PeptideHit score="0.491668159923229" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.9"/>
 				<UserParam type="float" name="E-Value" value="0.098"/>
 				<UserParam type="float" name="nextscore" value="21.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.491668159923229"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.944091796875" RT="6201.82489999998" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.944091796875" RT="6201.82489999998" >
+			<PeptideHit score="0.992918683767341" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.7"/>
 				<UserParam type="float" name="E-Value" value="0.00029"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992918683767341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799957275391" RT="6205.22980000002" >
-			<PeptideHit score="0" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799957275391" RT="6205.22980000002" >
+			<PeptideHit score="0.946835341093983" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="0.0035"/>
 				<UserParam type="float" name="nextscore" value="23.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.946835341093983"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.9580078125" RT="6212.0364" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.9580078125" RT="6212.0364" >
+			<PeptideHit score="0.998367552171115" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.9"/>
 				<UserParam type="float" name="E-Value" value="4.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998367552171115"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="551.616943359375" RT="6234.40930000002" >
-			<PeptideHit score="0.00651890482398957" sequence="ACAVFQIPPWHLDR" charge="3" aa_before="M" aa_after="K" protein_refs="PH_33" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="551.616943359375" RT="6234.40930000002" >
+			<PeptideHit score="0.429088420832665" sequence="ACAVFQIPPWHLDR" charge="3" aa_before="M" aa_after="K" protein_refs="PH_33" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.4"/>
 				<UserParam type="float" name="E-Value" value="0.13"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.429088420832665"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.2900390625" RT="6254.88" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.2900390625" RT="6254.88" >
+			<PeptideHit score="0.992723665442821" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.6"/>
 				<UserParam type="float" name="E-Value" value="0.0003"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992723665442821"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289398193359" RT="6256.39690000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289398193359" RT="6256.39690000002" >
+			<PeptideHit score="0.998869266957837" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.1"/>
 				<UserParam type="float" name="E-Value" value="2.8e-05"/>
 				<UserParam type="float" name="nextscore" value="11.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998869266957837"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.330322265625" RT="6260.0871" >
-			<PeptideHit score="0" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.330322265625" RT="6260.0871" >
+			<PeptideHit score="0.994321746497951" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.9"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="12.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.330261230469" RT="6263.76739999998" >
-			<PeptideHit score="0" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.330261230469" RT="6263.76739999998" >
+			<PeptideHit score="0.999996198517603" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="1.8e-08"/>
 				<UserParam type="float" name="nextscore" value="10.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996198517603"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302978515625" RT="6265.0806" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302978515625" RT="6265.0806" >
+			<PeptideHit score="0.999999689719728" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="7.1e-10"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999689719728"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302520751953" RT="6267.34489999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302520751953" RT="6267.34489999998" >
+			<PeptideHit score="0.999999564367445" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="1.1e-09"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999564367445"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="537.283386230469" RT="6278.87089999998" >
-			<PeptideHit score="0" sequence="AFYVNVLNEEQRK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="537.283386230469" RT="6278.87089999998" >
+			<PeptideHit score="0.929273950886146" sequence="AFYVNVLNEEQRK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.2"/>
 				<UserParam type="float" name="E-Value" value="0.005"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.929273950886146"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="537.282165527344" RT="6280.69579999998" >
-			<PeptideHit score="0.0236318407960199" sequence="AFYVNVLNEEQRK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="537.282165527344" RT="6280.69579999998" >
+			<PeptideHit score="0.212939146410455" sequence="AFYVNVLNEEQRK" charge="3" aa_before="R" aa_after="R" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.8"/>
 				<UserParam type="float" name="E-Value" value="0.41"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.212939146410455"/>
+				<UserParam type="float" name="q-value" value="0.0236318407960199"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.9443359375" RT="6290.99989999998" >
-			<PeptideHit score="0.0331695331695332" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.9443359375" RT="6290.99989999998" >
+			<PeptideHit score="0.185169102173804" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.9"/>
 				<UserParam type="float" name="E-Value" value="0.5"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.185169102173804"/>
+				<UserParam type="float" name="q-value" value="0.0331695331695332"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943420410156" RT="6292.61149999998" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943420410156" RT="6292.61149999998" >
+			<PeptideHit score="0.860612864765694" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27"/>
 				<UserParam type="float" name="E-Value" value="0.012"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.860612864765694"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310852050781" RT="6293.65759999998" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310852050781" RT="6293.65759999998" >
+			<PeptideHit score="0.943202686631416" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.2"/>
 				<UserParam type="float" name="E-Value" value="0.0038"/>
 				<UserParam type="float" name="nextscore" value="21"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.943202686631416"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799743652344" RT="6296.46790000002" >
-			<PeptideHit score="0.0489844683393071" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799743652344" RT="6296.46790000002" >
+			<PeptideHit score="0.0969386199829794" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="19.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.273376464844" RT="6298.13959999998" >
-			<PeptideHit score="0" sequence="FSGTWYAMAK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_22" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.273376464844" RT="6298.13959999998" >
+			<PeptideHit score="0.982014267249911" sequence="FSGTWYAMAK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_22" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.2"/>
 				<UserParam type="float" name="E-Value" value="0.00092"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.982014267249911"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800598144531" RT="6299.0532" >
-			<PeptideHit score="0.0444711538461538" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800598144531" RT="6299.0532" >
+			<PeptideHit score="0.103478204192389" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="19.3"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.273803710938" RT="6300.18730000002" >
-			<PeptideHit score="0" sequence="FSGTWYAMAK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_22" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.273803710938" RT="6300.18730000002" >
+			<PeptideHit score="0.992723665442821" sequence="FSGTWYAMAK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_22" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.3"/>
 				<UserParam type="float" name="E-Value" value="0.0003"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992723665442821"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958129882813" RT="6311.74660000002" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958129882813" RT="6311.74660000002" >
+			<PeptideHit score="0.999999870479975" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.4"/>
 				<UserParam type="float" name="E-Value" value="2.3e-10"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999870479975"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290069580078" RT="6335.8014" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290069580078" RT="6335.8014" >
+			<PeptideHit score="0.998964248012865" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="2.5e-05"/>
 				<UserParam type="float" name="nextscore" value="9.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998964248012865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289703369141" RT="6337.49089999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289703369141" RT="6337.49089999998" >
+			<PeptideHit score="0.999302633161889" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.3"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.330078125" RT="6346.9293" >
-			<PeptideHit score="0" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.330078125" RT="6346.9293" >
+			<PeptideHit score="0.999994062235367" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.7"/>
 				<UserParam type="float" name="E-Value" value="3.2e-08"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999994062235367"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302886962891" RT="6348.714" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302886962891" RT="6348.714" >
+			<PeptideHit score="0.999506451073422" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="9.6e-06"/>
 				<UserParam type="float" name="nextscore" value="11.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999506451073422"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.329833984375" RT="6349.21729999998" >
-			<PeptideHit score="0" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.329833984375" RT="6349.21729999998" >
+			<PeptideHit score="0.99998033748685" sequence="DMASNYKELGFQG" charge="2" aa_before="K" aa_after="]" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.1"/>
 				<UserParam type="float" name="E-Value" value="1.5e-07"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998033748685"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303283691406" RT="6350.3682" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303283691406" RT="6350.3682" >
+			<PeptideHit score="0.999907897771499" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-06"/>
 				<UserParam type="float" name="nextscore" value="12.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999907897771499"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943481445313" RT="6358.9377" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943481445313" RT="6358.9377" >
+			<PeptideHit score="0.996034376504582" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.4"/>
 				<UserParam type="float" name="E-Value" value="0.00014"/>
 				<UserParam type="float" name="nextscore" value="9.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996034376504582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957336425781" RT="6359.20000000002" >
-			<PeptideHit score="0.00134408602150538" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957336425781" RT="6359.20000000002" >
+			<PeptideHit score="0.777594217720977" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26"/>
 				<UserParam type="float" name="E-Value" value="0.023"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.777594217720977"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="559.831909179688" RT="6367.34980000002" >
-			<PeptideHit score="0" sequence="EKVFDVIIR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="559.831909179688" RT="6367.34980000002" >
+			<PeptideHit score="0.930401463762626" sequence="EKVFDVIIR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.7"/>
 				<UserParam type="float" name="E-Value" value="0.0049"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.930401463762626"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.312561035156" RT="6368.65600000002" >
-			<PeptideHit score="0" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.312561035156" RT="6368.65600000002" >
+			<PeptideHit score="0.878537248230859" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.1"/>
 				<UserParam type="float" name="E-Value" value="0.01"/>
 				<UserParam type="float" name="nextscore" value="9.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.878537248230859"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.95654296875" RT="6372.8733" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.95654296875" RT="6372.8733" >
+			<PeptideHit score="0.999934398186429" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42"/>
 				<UserParam type="float" name="E-Value" value="7.1e-07"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999934398186429"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800689697266" RT="6373.53460000002" >
-			<PeptideHit score="0.0489844683393071" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800689697266" RT="6373.53460000002" >
+			<PeptideHit score="0.0969386199829794" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800323486328" RT="6374.78569999998" >
-			<PeptideHit score="0.0211970074812968" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800323486328" RT="6374.78569999998" >
+			<PeptideHit score="0.228519335906576" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22"/>
 				<UserParam type="float" name="E-Value" value="0.37"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.228519335906576"/>
+				<UserParam type="float" name="q-value" value="0.0211970074812968"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289245605469" RT="6394.90009999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289245605469" RT="6394.90009999998" >
+			<PeptideHit score="0.999600809559596" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="7.3e-06"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999600809559596"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="559.831848144531" RT="6395.7648" >
-			<PeptideHit score="0" sequence="EKVFDVIIR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="559.831848144531" RT="6395.7648" >
+			<PeptideHit score="0.979203874797132" sequence="EKVFDVIIR" charge="2" aa_before="R" aa_after="C" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.7"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289611816406" RT="6397.02760000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289611816406" RT="6397.02760000002" >
+			<PeptideHit score="0.999876865375483" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.3"/>
 				<UserParam type="float" name="E-Value" value="1.6e-06"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999876865375483"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.956604003906" RT="6400.67440000002" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.956604003906" RT="6400.67440000002" >
+			<PeptideHit score="0.997673817427177" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.5"/>
 				<UserParam type="float" name="E-Value" value="7.1e-05"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997673817427177"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958435058594" RT="6410.0121" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958435058594" RT="6410.0121" >
+			<PeptideHit score="0.992145529169711" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.7"/>
 				<UserParam type="float" name="E-Value" value="0.00033"/>
 				<UserParam type="float" name="nextscore" value="11.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992145529169711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="502.5869140625" RT="6410.67040000002" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="502.5869140625" RT="6410.67040000002" >
+			<PeptideHit score="0.899664339188683" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.0078"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.899664339188683"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="502.587097167969" RT="6415.02400000002" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="502.587097167969" RT="6415.02400000002" >
+			<PeptideHit score="0.784273217611407" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.8"/>
 				<UserParam type="float" name="E-Value" value="0.022"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.784273217611407"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303131103516" RT="6442.96990000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303131103516" RT="6442.96990000002" >
+			<PeptideHit score="0.999951566095295" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.8"/>
 				<UserParam type="float" name="E-Value" value="4.8e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999951566095295"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302825927734" RT="6444.96199999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302825927734" RT="6444.96199999998" >
+			<PeptideHit score="0.998900658395066" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.1"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="753.376342773438" RT="6445.58299999998" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="753.376342773438" RT="6445.58299999998" >
+			<PeptideHit score="0.999998294394401" sequence="VKEGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="6.4e-09"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998294394401"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943786621094" RT="6451.22179999998" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943786621094" RT="6451.22179999998" >
+			<PeptideHit score="0.998367552171115" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.6"/>
 				<UserParam type="float" name="E-Value" value="4.5e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998367552171115"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943786621094" RT="6452.9871" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943786621094" RT="6452.9871" >
+			<PeptideHit score="0.998538671479314" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.8"/>
 				<UserParam type="float" name="E-Value" value="3.9e-05"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998538671479314"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.311279296875" RT="6461.49109999998" >
-			<PeptideHit score="0.00134408602150538" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.311279296875" RT="6461.49109999998" >
+			<PeptideHit score="0.758391515615522" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.5"/>
 				<UserParam type="float" name="E-Value" value="0.026"/>
 				<UserParam type="float" name="nextscore" value="8.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.758391515615522"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.311828613281" RT="6463.28779999998" >
-			<PeptideHit score="0" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.311828613281" RT="6463.28779999998" >
+			<PeptideHit score="0.843722813291116" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24"/>
 				<UserParam type="float" name="E-Value" value="0.014"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.843722813291116"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289581298828" RT="6488.22799999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289581298828" RT="6488.22799999998" >
+			<PeptideHit score="0.998452416252365" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="4.2e-05"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998452416252365"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.800659179688" RT="6490.5834" >
-			<PeptideHit score="0.00651890482398957" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.800659179688" RT="6490.5834" >
+			<PeptideHit score="0.398109626639983" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.2"/>
 				<UserParam type="float" name="E-Value" value="0.15"/>
 				<UserParam type="float" name="nextscore" value="21.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.398109626639983"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46240234375" RT="6491.84629999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46240234375" RT="6491.84629999998" >
+			<PeptideHit score="0.999915119404183" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.8"/>
 				<UserParam type="float" name="E-Value" value="9.9e-07"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999915119404183"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46032714844" RT="6495.8265" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46032714844" RT="6495.8265" >
+			<PeptideHit score="0.999870942238288" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48"/>
 				<UserParam type="float" name="E-Value" value="1.7e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999870942238288"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="502.586151123047" RT="6505.89310000002" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="502.586151123047" RT="6505.89310000002" >
+			<PeptideHit score="0.999937281120465" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.1"/>
 				<UserParam type="float" name="E-Value" value="6.7e-07"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999937281120465"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="502.586273193359" RT="6507.65410000002" >
-			<PeptideHit score="0" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="502.586273193359" RT="6507.65410000002" >
+			<PeptideHit score="0.99331247569031" sequence="VKEGMNIVEAMER" charge="3" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35"/>
 				<UserParam type="float" name="E-Value" value="0.00027"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99331247569031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958068847656" RT="6508.00699999998" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958068847656" RT="6508.00699999998" >
+			<PeptideHit score="0.999302633161889" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="11.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="652.026428222656" RT="6520.32919999998" >
-			<PeptideHit score="0" sequence="VAPEEHPVLLTEAPLNPK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_57 PH_65" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="652.026428222656" RT="6520.32919999998" >
+			<PeptideHit score="0.940816934477305" sequence="VAPEEHPVLLTEAPLNPK" charge="3" aa_before="R" aa_after="A" protein_refs="PH_57 PH_65" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.9"/>
 				<UserParam type="float" name="E-Value" value="0.004"/>
 				<UserParam type="float" name="nextscore" value="27.7"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.940816934477305"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="652.026062011719" RT="6523.8852" >
-			<PeptideHit score="0" sequence="VAPDEHPILLTEAPLNPK" charge="3" aa_before="R" aa_after="I" protein_refs="PH_90" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="652.026062011719" RT="6523.8852" >
+			<PeptideHit score="0.996259978029628" sequence="VAPDEHPILLTEAPLNPK" charge="3" aa_before="R" aa_after="I" protein_refs="PH_90" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.9"/>
 				<UserParam type="float" name="E-Value" value="0.00013"/>
 				<UserParam type="float" name="nextscore" value="28.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996259978029628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302520751953" RT="6535.89859999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302520751953" RT="6535.89859999998" >
+			<PeptideHit score="0.999870942238288" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.2"/>
 				<UserParam type="float" name="E-Value" value="1.7e-06"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999870942238288"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302825927734" RT="6537.66460000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302825927734" RT="6537.66460000002" >
+			<PeptideHit score="0.999735095835476" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.3"/>
 				<UserParam type="float" name="E-Value" value="4.3e-06"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999735095835476"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943481445313" RT="6544.7763" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943481445313" RT="6544.7763" >
+			<PeptideHit score="0.991202597624598" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.00038"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991202597624598"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943420410156" RT="6546.4455" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943420410156" RT="6546.4455" >
+			<PeptideHit score="0.995811820230489" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.9"/>
 				<UserParam type="float" name="E-Value" value="0.00015"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995811820230489"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="471.577819824219" RT="6548.1528" >
-			<PeptideHit score="0.0363636363636364" sequence="TFLTVYWTPER" charge="3" aa_before="K" aa_after="V" protein_refs="PH_28" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="471.577819824219" RT="6548.1528" >
+			<PeptideHit score="0.172921900962734" sequence="TFLTVYWTPER" charge="3" aa_before="K" aa_after="V" protein_refs="PH_28" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.6"/>
 				<UserParam type="float" name="E-Value" value="0.55"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.172921900962734"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.311645507813" RT="6553.7169" >
-			<PeptideHit score="0" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.311645507813" RT="6553.7169" >
+			<PeptideHit score="0.878537248230859" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.9"/>
 				<UserParam type="float" name="E-Value" value="0.01"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.878537248230859"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.311340332031" RT="6555.50899999998" >
-			<PeptideHit score="0.00526315789473684" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.311340332031" RT="6555.50899999998" >
+			<PeptideHit score="0.493955532339166" sequence="VWPHKDYPLIPVGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.097"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.493955532339166"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="577.790771484375" RT="6576.8145" >
-			<PeptideHit score="0" sequence="FEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="577.790771484375" RT="6576.8145" >
+			<PeptideHit score="0.956880028363855" sequence="FEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.9"/>
 				<UserParam type="float" name="E-Value" value="0.0027"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.956880028363855"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289611816406" RT="6581.3118" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289611816406" RT="6581.3118" >
+			<PeptideHit score="0.996982252670564" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.3"/>
 				<UserParam type="float" name="E-Value" value="9.9e-05"/>
 				<UserParam type="float" name="nextscore" value="12"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996982252670564"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289459228516" RT="6584.20720000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289459228516" RT="6584.20720000002" >
+			<PeptideHit score="0.976178644666495" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="10.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46252441406" RT="6585.94720000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46252441406" RT="6585.94720000002" >
+			<PeptideHit score="0.998339553383431" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.5"/>
 				<UserParam type="float" name="E-Value" value="4.6e-05"/>
 				<UserParam type="float" name="nextscore" value="9.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998339553383431"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="663.025512695313" RT="6606.39370000002" >
-			<PeptideHit score="0.00134408602150538" sequence="TITLEVEPSDTIENVKAK" charge="3" aa_before="K" aa_after="I" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="663.025512695313" RT="6606.39370000002" >
+			<PeptideHit score="0.560089068277706" sequence="TITLEVEPSDTIENVKAK" charge="3" aa_before="K" aa_after="I" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.7"/>
 				<UserParam type="float" name="E-Value" value="0.072"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.560089068277706"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957702636719" RT="6607.98130000002" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957702636719" RT="6607.98130000002" >
+			<PeptideHit score="0.976178644666495" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.9"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302703857422" RT="6628.72630000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302703857422" RT="6628.72630000002" >
+			<PeptideHit score="0.999029002284869" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.6"/>
 				<UserParam type="float" name="E-Value" value="2.3e-05"/>
 				<UserParam type="float" name="nextscore" value="11.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999029002284869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303070068359" RT="6630.49930000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303070068359" RT="6630.49930000002" >
+			<PeptideHit score="0.99988897055048" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41"/>
 				<UserParam type="float" name="E-Value" value="1.4e-06"/>
 				<UserParam type="float" name="nextscore" value="11.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99988897055048"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="460.758209228516" RT="6631.00720000002" >
-			<PeptideHit score="0" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="460.758209228516" RT="6631.00720000002" >
+			<PeptideHit score="0.860612864765694" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="0.012"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.860612864765694"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="460.757904052734" RT="6636.24940000002" >
-			<PeptideHit score="0.00134408602150538" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="460.757904052734" RT="6636.24940000002" >
+			<PeptideHit score="0.646109382185005" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.7"/>
 				<UserParam type="float" name="E-Value" value="0.048"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.646109382185005"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.957580566406" RT="6636.6414" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.957580566406" RT="6636.6414" >
+			<PeptideHit score="0.999693069772492" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.8"/>
 				<UserParam type="float" name="E-Value" value="5.2e-06"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999693069772492"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976318359375" RT="6641.56609999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976318359375" RT="6641.56609999998" >
+			<PeptideHit score="0.999998356693945" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.4"/>
 				<UserParam type="float" name="E-Value" value="6.1e-09"/>
 				<UserParam type="float" name="nextscore" value="12.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998356693945"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="577.789428710938" RT="6669.97450000002" >
-			<PeptideHit score="0" sequence="FEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="577.789428710938" RT="6669.97450000002" >
+			<PeptideHit score="0.99865607372492" sequence="FEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="3.5e-05"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99865607372492"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.288940429688" RT="6675.74929999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.288940429688" RT="6675.74929999998" >
+			<PeptideHit score="0.999029002284869" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.6"/>
 				<UserParam type="float" name="E-Value" value="2.3e-05"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999029002284869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="920.466979980469" RT="6695.35519999998" >
-			<PeptideHit score="0" sequence="SLLSNVEGDNAVPMQHNNRPTQPLK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="920.466979980469" RT="6695.35519999998" >
+			<PeptideHit score="0.997396681935865" sequence="SLLSNVEGDNAVPMQHNNRPTQPLK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="8.2e-05"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997396681935865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303192138672" RT="6705.6033" >
-			<PeptideHit score="0.00526315789473684" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303192138672" RT="6705.6033" >
+			<PeptideHit score="0.503347576910457" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.6"/>
 				<UserParam type="float" name="E-Value" value="0.093"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.503347576910457"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="460.758178710938" RT="6727.15690000002" >
-			<PeptideHit score="0" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="460.758178710938" RT="6727.15690000002" >
+			<PeptideHit score="0.812550391896406" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="0.018"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.812550391896406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="460.7578125" RT="6728.79799999998" >
-			<PeptideHit score="0" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="460.7578125" RT="6728.79799999998" >
+			<PeptideHit score="0.943202686631416" sequence="GLFIIDDK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.7"/>
 				<UserParam type="float" name="E-Value" value="0.0038"/>
 				<UserParam type="float" name="nextscore" value="12.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.943202686631416"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.944396972656" RT="6730.5255" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.944396972656" RT="6730.5255" >
+			<PeptideHit score="0.999542689659901" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.9"/>
 				<UserParam type="float" name="E-Value" value="8.7e-06"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999542689659901"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976684570313" RT="6738.5571" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976684570313" RT="6738.5571" >
+			<PeptideHit score="0.999779168898944" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44"/>
 				<UserParam type="float" name="E-Value" value="3.4e-06"/>
 				<UserParam type="float" name="nextscore" value="8.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999779168898944"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943786621094" RT="6738.9579" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943786621094" RT="6738.9579" >
+			<PeptideHit score="0.820048379204749" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.6"/>
 				<UserParam type="float" name="E-Value" value="0.017"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.820048379204749"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="854.389221191406" RT="6739.3692" >
-			<PeptideHit score="0" sequence="GSLGGGFSSGGFSGGSFSR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_41" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="854.389221191406" RT="6739.3692" >
+			<PeptideHit score="0.99999999953763" sequence="GSLGGGFSSGGFSGGSFSR" charge="2" aa_before="K" aa_after="G" protein_refs="PH_41" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="73.4"/>
 				<UserParam type="float" name="E-Value" value="1.6e-13"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999999953763"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.977355957031" RT="6741.28489999998" >
-			<PeptideHit score="0.00134408602150538" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.977355957031" RT="6741.28489999998" >
+			<PeptideHit score="0.712448020910727" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.7"/>
 				<UserParam type="float" name="E-Value" value="0.034"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.712448020910727"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289672851563" RT="6767.79970000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289672851563" RT="6767.79970000002" >
+			<PeptideHit score="0.999375797281708" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289611816406" RT="6769.65259999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289611816406" RT="6769.65259999998" >
+			<PeptideHit score="0.973239129162826" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.3"/>
 				<UserParam type="float" name="E-Value" value="0.0015"/>
 				<UserParam type="float" name="nextscore" value="10.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.973239129162826"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302612304688" RT="6800.48170000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302612304688" RT="6800.48170000002" >
+			<PeptideHit score="0.998964248012865" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.7"/>
 				<UserParam type="float" name="E-Value" value="2.5e-05"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998964248012865"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302429199219" RT="6802.2528" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302429199219" RT="6802.2528" >
+			<PeptideHit score="0.999266889838404" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.4"/>
 				<UserParam type="float" name="E-Value" value="1.6e-05"/>
 				<UserParam type="float" name="nextscore" value="11.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999266889838404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.898315429688" RT="6821.85799999998" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.898315429688" RT="6821.85799999998" >
+			<PeptideHit score="0.999996530182202" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51"/>
 				<UserParam type="float" name="E-Value" value="1.6e-08"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996530182202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976623535156" RT="6832.87999999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976623535156" RT="6832.87999999998" >
+			<PeptideHit score="0.998932314583604" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.4"/>
 				<UserParam type="float" name="E-Value" value="2.6e-05"/>
 				<UserParam type="float" name="nextscore" value="10.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998932314583604"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.977294921875" RT="6834.0948" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.977294921875" RT="6834.0948" >
+			<PeptideHit score="0.999626472939553" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.8"/>
 				<UserParam type="float" name="E-Value" value="6.7e-06"/>
 				<UserParam type="float" name="nextscore" value="10.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999626472939553"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799713134766" RT="6844.94329999998" >
-			<PeptideHit score="0.00134408602150538" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799713134766" RT="6844.94329999998" >
+			<PeptideHit score="0.734542296491698" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.7"/>
 				<UserParam type="float" name="E-Value" value="0.03"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.734542296491698"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290283203125" RT="6861.13540000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290283203125" RT="6861.13540000002" >
+			<PeptideHit score="0.998626449672608" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="3.6e-05"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998626449672608"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.28955078125" RT="6863.2233" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.28955078125" RT="6863.2233" >
+			<PeptideHit score="0.98106717389803" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.8"/>
 				<UserParam type="float" name="E-Value" value="0.00098"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.98106717389803"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.4619140625" RT="6864.48580000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.4619140625" RT="6864.48580000002" >
+			<PeptideHit score="0.999988987733186" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.8"/>
 				<UserParam type="float" name="E-Value" value="7.1e-08"/>
 				<UserParam type="float" name="nextscore" value="9.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999988987733186"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46252441406" RT="6866.25040000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46252441406" RT="6866.25040000002" >
+			<PeptideHit score="0.999810014670625" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.9"/>
 				<UserParam type="float" name="E-Value" value="2.8e-06"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999810014670625"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="871.958435058594" RT="6885.6909" >
-			<PeptideHit score="0" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="871.958435058594" RT="6885.6909" >
+			<PeptideHit score="0.998093027078404" sequence="LYPIANGNNQSPVDIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.6"/>
 				<UserParam type="float" name="E-Value" value="5.5e-05"/>
 				<UserParam type="float" name="nextscore" value="10.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998093027078404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302917480469" RT="6897.92029999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302917480469" RT="6897.92029999998" >
+			<PeptideHit score="0.999498504307823" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="9.8e-06"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999498504307823"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="697.71533203125" RT="6907.90930000002" >
-			<PeptideHit score="0.02" sequence="HIGISFTPKEVGEHVVSVR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_80" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="697.71533203125" RT="6907.90930000002" >
+			<PeptideHit score="0.246856676048891" sequence="HIGISFTPKEVGEHVVSVR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_80" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.8"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.899841308594" RT="6915.7185" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.899841308594" RT="6915.7185" >
+			<PeptideHit score="0.999999417569271" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.4"/>
 				<UserParam type="float" name="E-Value" value="1.6e-09"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999417569271"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.601806640625" RT="6919.4655" >
-			<PeptideHit score="0.00134408602150538" sequence="ESISVSSEQLAQFR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.601806640625" RT="6919.4655" >
+			<PeptideHit score="0.592573680193453" sequence="ESISVSSEQLAQFR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.7"/>
 				<UserParam type="float" name="E-Value" value="0.062"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.592573680193453"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976379394531" RT="6951.54040000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976379394531" RT="6951.54040000002" >
+			<PeptideHit score="0.97469904242467" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.6"/>
 				<UserParam type="float" name="E-Value" value="0.0014"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97469904242467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46203613281" RT="6957.507" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46203613281" RT="6957.507" >
+			<PeptideHit score="0.989380474210414" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.6"/>
 				<UserParam type="float" name="E-Value" value="0.00048"/>
 				<UserParam type="float" name="nextscore" value="14.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989380474210414"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46215820312" RT="6959.28340000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46215820312" RT="6959.28340000002" >
+			<PeptideHit score="0.999534566298792" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.5"/>
 				<UserParam type="float" name="E-Value" value="8.9e-06"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999534566298792"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289398193359" RT="6959.6262" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289398193359" RT="6959.6262" >
+			<PeptideHit score="0.95053753529317" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.1"/>
 				<UserParam type="float" name="E-Value" value="0.0032"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.95053753529317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="581.325927734375" RT="6960.126" >
-			<PeptideHit score="0.0434782608695652" sequence="VLPCIDFAKR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_16" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="581.325927734375" RT="6960.126" >
+			<PeptideHit score="0.111148168009872" sequence="VLPCIDFAKR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_16" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.5"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="525.284484863281" RT="6967.89130000002" >
-			<PeptideHit score="0" sequence="DLFNAIATGK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="525.284484863281" RT="6967.89130000002" >
+			<PeptideHit score="0.994321746497951" sequence="DLFNAIATGK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="525.284790039063" RT="6969.56419999998" >
-			<PeptideHit score="0" sequence="DLFNAIATGK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="525.284790039063" RT="6969.56419999998" >
+			<PeptideHit score="0.994736999948131" sequence="DLFNAIATGK" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.3"/>
 				<UserParam type="float" name="E-Value" value="0.0002"/>
 				<UserParam type="float" name="nextscore" value="17.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994736999948131"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="482.266540527344" RT="6979.69060000002" >
-			<PeptideHit score="0.0489844683393071" sequence="ALRAEFEK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_143" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="482.266540527344" RT="6979.69060000002" >
+			<PeptideHit score="0.0969386199829794" sequence="ALRAEFEK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_143" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303497314453" RT="6988.5333" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303497314453" RT="6988.5333" >
+			<PeptideHit score="0.99984239932391" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.6"/>
 				<UserParam type="float" name="E-Value" value="2.2e-06"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99984239932391"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303527832031" RT="6992.40520000002" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303527832031" RT="6992.40520000002" >
+			<PeptideHit score="0.998119986595388" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.9"/>
 				<UserParam type="float" name="E-Value" value="5.4e-05"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998119986595388"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.899230957031" RT="7009.49710000002" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.899230957031" RT="7009.49710000002" >
+			<PeptideHit score="0.999999623909072" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.7"/>
 				<UserParam type="float" name="E-Value" value="9.1e-10"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999623909072"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.900268554688" RT="7011.8121" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.900268554688" RT="7011.8121" >
+			<PeptideHit score="0.999999504148436" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.4"/>
 				<UserParam type="float" name="E-Value" value="1.3e-09"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999504148436"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.318115234375" RT="7013.66449999998" >
-			<PeptideHit score="0" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.318115234375" RT="7013.66449999998" >
+			<PeptideHit score="0.976178644666495" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.4"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="645.864196777344" RT="7028.3826" >
-			<PeptideHit score="0.0363636363636364" sequence="LLVHQRMHTR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_81" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="645.864196777344" RT="7028.3826" >
+			<PeptideHit score="0.168511319241557" sequence="LLVHQRMHTR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_81" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.7"/>
 				<UserParam type="float" name="E-Value" value="0.57"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.168511319241557"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46228027344" RT="7051.44730000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46228027344" RT="7051.44730000002" >
+			<PeptideHit score="0.996958329726846" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.2"/>
 				<UserParam type="float" name="E-Value" value="0.0001"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996958329726846"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="707.976318359375" RT="7053.24370000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="707.976318359375" RT="7053.24370000002" >
+			<PeptideHit score="0.916150345988615" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="3" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.5"/>
 				<UserParam type="float" name="E-Value" value="0.0062"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.916150345988615"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302917480469" RT="7084.75159999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302917480469" RT="7084.75159999998" >
+			<PeptideHit score="0.997446493984178" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37"/>
 				<UserParam type="float" name="E-Value" value="8e-05"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997446493984178"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="790.898254394531" RT="7102.17919999998" >
-			<PeptideHit score="0" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="790.898254394531" RT="7102.17919999998" >
+			<PeptideHit score="0.999993918918339" sequence="ESISVSSEQLAQFR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.9"/>
 				<UserParam type="float" name="E-Value" value="3.3e-08"/>
 				<UserParam type="float" name="nextscore" value="17.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993918918339"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="527.943725585938" RT="7111.69510000002" >
-			<PeptideHit score="0" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="527.943725585938" RT="7111.69510000002" >
+			<PeptideHit score="0.860612864765694" sequence="YAAELHLVHWNTK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.7"/>
 				<UserParam type="float" name="E-Value" value="0.012"/>
 				<UserParam type="float" name="nextscore" value="12.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.860612864765694"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799682617188" RT="7114.52959999998" >
-			<PeptideHit score="0.029520295202952" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799682617188" RT="7114.52959999998" >
+			<PeptideHit score="0.193496525438801" sequence="VLDALQAIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.1"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="19.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289245605469" RT="7121.15479999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289245605469" RT="7121.15479999998" >
+			<PeptideHit score="0.827735811978521" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.5"/>
 				<UserParam type="float" name="E-Value" value="0.016"/>
 				<UserParam type="float" name="nextscore" value="12.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.827735811978521"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289947509766" RT="7126.7025" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289947509766" RT="7126.7025" >
+			<PeptideHit score="0.90267681364214" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.1"/>
 				<UserParam type="float" name="E-Value" value="0.0075"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.90267681364214"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="700.844909667969" RT="7133.80969999998" >
-			<PeptideHit score="0" sequence="STDYGIFQINSR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_58" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="700.844909667969" RT="7133.80969999998" >
+			<PeptideHit score="0.999994498417026" sequence="STDYGIFQINSR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_58" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.8"/>
 				<UserParam type="float" name="E-Value" value="2.9e-08"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999994498417026"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303405761719" RT="7180.18549999998" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303405761719" RT="7180.18549999998" >
+			<PeptideHit score="0.993511362275586" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.6"/>
 				<UserParam type="float" name="E-Value" value="0.00026"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993511362275586"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="553.826843261719" RT="7181.3238" >
-			<PeptideHit score="0.029520295202952" sequence="ALSAKQNFVK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_75" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="553.826843261719" RT="7181.3238" >
+			<PeptideHit score="0.190629580961098" sequence="ALSAKQNFVK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_75" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="15.7"/>
 				<UserParam type="float" name="E-Value" value="0.48"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.190629580961098"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46130371094" RT="7187.32690000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46130371094" RT="7187.32690000002" >
+			<PeptideHit score="0.998423979561058" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="4.3e-05"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998423979561058"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46166992188" RT="7198.5582" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46166992188" RT="7198.5582" >
+			<PeptideHit score="0.989024704232947" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.5"/>
 				<UserParam type="float" name="E-Value" value="0.0005"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989024704232947"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.290069580078" RT="7218.75220000002" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.290069580078" RT="7218.75220000002" >
+			<PeptideHit score="0.989919202493546" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.4"/>
 				<UserParam type="float" name="E-Value" value="0.00045"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989919202493546"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="611.969055175781" RT="7240.7208" >
-			<PeptideHit score="0" sequence="TYFPHFDLSHGSAQVK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="611.969055175781" RT="7240.7208" >
+			<PeptideHit score="0.999413322128202" sequence="TYFPHFDLSHGSAQVK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.8"/>
 				<UserParam type="float" name="E-Value" value="1.2e-05"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999413322128202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="611.969116210938" RT="7242.46849999998" >
-			<PeptideHit score="0.00134408602150538" sequence="TYFPHFDLSHGSAQVK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="611.969116210938" RT="7242.46849999998" >
+			<PeptideHit score="0.672686395927008" sequence="TYFPHFDLSHGSAQVK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.2"/>
 				<UserParam type="float" name="E-Value" value="0.042"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.672686395927008"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289855957031" RT="7244.24959999998" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289855957031" RT="7244.24959999998" >
+			<PeptideHit score="0.985591053717679" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.8"/>
 				<UserParam type="float" name="E-Value" value="0.0007"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.985591053717679"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034790039063" RT="7279.36900000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034790039063" RT="7279.36900000002" >
+			<PeptideHit score="0.997880742629807" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.3"/>
 				<UserParam type="float" name="E-Value" value="6.3e-05"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997880742629807"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035705566406" RT="7281.12019999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035705566406" RT="7281.12019999998" >
+			<PeptideHit score="0.999990459802719" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="5.9e-08"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999990459802719"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.30322265625" RT="7285.21909999998" >
-			<PeptideHit score="0.00134408602150538" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.30322265625" RT="7285.21909999998" >
+			<PeptideHit score="0.572587814312497" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.7"/>
 				<UserParam type="float" name="E-Value" value="0.068"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.572587814312497"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46069335938" RT="7294.86280000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46069335938" RT="7294.86280000002" >
+			<PeptideHit score="0.997102585203685" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.8"/>
 				<UserParam type="float" name="E-Value" value="9.4e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997102585203685"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="741.373291015625" RT="7302.83800000002" >
-			<PeptideHit score="0" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="741.373291015625" RT="7302.83800000002" >
+			<PeptideHit score="0.999982401673567" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.3"/>
 				<UserParam type="float" name="E-Value" value="1.3e-07"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999982401673567"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="741.373474121094" RT="7304.56930000002" >
-			<PeptideHit score="0" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="741.373474121094" RT="7304.56930000002" >
+			<PeptideHit score="0.999999504148436" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.4"/>
 				<UserParam type="float" name="E-Value" value="1.3e-09"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999504148436"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="894.4677734375" RT="7354.18249999998" >
-			<PeptideHit score="0" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="894.4677734375" RT="7354.18249999998" >
+			<PeptideHit score="0.99999976723339" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.9"/>
 				<UserParam type="float" name="E-Value" value="4.9e-10"/>
 				<UserParam type="float" name="nextscore" value="20.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999976723339"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="691.667602539063" RT="7365.17449999998" >
-			<PeptideHit score="0.0102432778489117" sequence="(Glu->pyro-Glu)EASTQSSSAAASQGWVLPEGK" charge="3" aa_before="R" aa_after="I" protein_refs="PH_77 PH_102 PH_133 PH_134" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="691.667602539063" RT="7365.17449999998" >
+			<PeptideHit score="0.311171156417568" sequence="(Glu->pyro-Glu)EASTQSSSAAASQGWVLPEGK" charge="3" aa_before="R" aa_after="I" protein_refs="PH_77 PH_102 PH_133 PH_134" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.23"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.311171156417568"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035888671875" RT="7372.31200000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035888671875" RT="7372.31200000002" >
+			<PeptideHit score="0.999996871332784" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.8"/>
 				<UserParam type="float" name="E-Value" value="1.4e-08"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996871332784"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302673339844" RT="7375.6725" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302673339844" RT="7375.6725" >
+			<PeptideHit score="0.812550391896406" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.6"/>
 				<UserParam type="float" name="E-Value" value="0.018"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.812550391896406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46057128906" RT="7390.69669999998" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46057128906" RT="7390.69669999998" >
+			<PeptideHit score="0.999764215082746" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="3.7e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999764215082746"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="639.79443359375" RT="7391.27020000002" >
-			<PeptideHit score="0" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="639.79443359375" RT="7391.27020000002" >
+			<PeptideHit score="0.880392902346972" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27"/>
 				<UserParam type="float" name="E-Value" value="0.0098"/>
 				<UserParam type="float" name="nextscore" value="9.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.880392902346972"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="741.372802734375" RT="7422.1527" >
-			<PeptideHit score="0" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="741.372802734375" RT="7422.1527" >
+			<PeptideHit score="0.999859324618151" sequence="AFYVNVLNEEQR" charge="2" aa_before="R" aa_after="K" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.5"/>
 				<UserParam type="float" name="E-Value" value="1.9e-06"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999859324618151"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="485.799743652344" RT="7432.2645" >
-			<PeptideHit score="0.0489844683393071" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="485.799743652344" RT="7432.2645" >
+			<PeptideHit score="0.0969386199829794" sequence="IVPTGDLKK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_88" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="17.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="894.468444824219" RT="7433.64190000002" >
-			<PeptideHit score="0" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="894.468444824219" RT="7433.64190000002" >
+			<PeptideHit score="0.999999981251654" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="70.1"/>
 				<UserParam type="float" name="E-Value" value="1.9e-11"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999981251654"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="626.861145019531" RT="7443.46930000002" >
-			<PeptideHit score="0" sequence="FLASVSTVLTSK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="626.861145019531" RT="7443.46930000002" >
+			<PeptideHit score="0.999907897771499" sequence="FLASVSTVLTSK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43"/>
 				<UserParam type="float" name="E-Value" value="1.1e-06"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999907897771499"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035461425781" RT="7464.34939999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035461425781" RT="7464.34939999998" >
+			<PeptideHit score="0.999999564367445" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-09"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999564367445"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036376953125" RT="7466.11420000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036376953125" RT="7466.11420000002" >
+			<PeptideHit score="0.999996699477478" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.7"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="22.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="639.7939453125" RT="7481.35249999998" >
-			<PeptideHit score="0" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="639.7939453125" RT="7481.35249999998" >
+			<PeptideHit score="0.954315536242781" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.9"/>
 				<UserParam type="float" name="E-Value" value="0.0029"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.954315536242781"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="639.794128417969" RT="7483.0311" >
-			<PeptideHit score="0" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="639.794128417969" RT="7483.0311" >
+			<PeptideHit score="0.967570696734317" sequence="EGMNIVEAMER" charge="2" aa_before="K" aa_after="F" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.9"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46252441406" RT="7485.51250000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46252441406" RT="7485.51250000002" >
+			<PeptideHit score="0.99999021009498" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.2"/>
 				<UserParam type="float" name="E-Value" value="6.1e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999021009498"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.302642822266" RT="7489.43410000002" >
-			<PeptideHit score="0.00526315789473684" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.302642822266" RT="7489.43410000002" >
+			<PeptideHit score="0.446677932430767" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.2"/>
 				<UserParam type="float" name="E-Value" value="0.12"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.446677932430767"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.289581298828" RT="7518.09" >
-			<PeptideHit score="0" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.289581298828" RT="7518.09" >
+			<PeptideHit score="0.894717809051713" sequence="VVDVLDSIK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.1"/>
 				<UserParam type="float" name="E-Value" value="0.0083"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.894717809051713"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="894.46826171875" RT="7528.3089" >
-			<PeptideHit score="0" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="894.46826171875" RT="7528.3089" >
+			<PeptideHit score="0.999993355049058" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.4"/>
 				<UserParam type="float" name="E-Value" value="3.7e-08"/>
 				<UserParam type="float" name="nextscore" value="19.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993355049058"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="626.861938476563" RT="7534.5417" >
-			<PeptideHit score="0" sequence="FLASVSTVLTSK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="626.861938476563" RT="7534.5417" >
+			<PeptideHit score="0.999266889838404" sequence="FLASVSTVLTSK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.9"/>
 				<UserParam type="float" name="E-Value" value="1.6e-05"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999266889838404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036193847656" RT="7570.4844" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036193847656" RT="7570.4844" >
+			<PeptideHit score="0.996259978029628" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="0.00013"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996259978029628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034973144531" RT="7578.81" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034973144531" RT="7578.81" >
+			<PeptideHit score="0.999943915092245" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.7"/>
 				<UserParam type="float" name="E-Value" value="5.8e-07"/>
 				<UserParam type="float" name="nextscore" value="16.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999943915092245"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46118164062" RT="7582.2843" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46118164062" RT="7582.2843" >
+			<PeptideHit score="0.999983460247774" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="8.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="507.303863525391" RT="7597.2018" >
-			<PeptideHit score="0" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="507.303863525391" RT="7597.2018" >
+			<PeptideHit score="0.966191334252643" sequence="LVAASQAALGL" charge="2" aa_before="K" aa_after="]" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.8"/>
 				<UserParam type="float" name="E-Value" value="0.002"/>
 				<UserParam type="float" name="nextscore" value="10.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.966191334252643"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46081542969" RT="7677.276" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46081542969" RT="7677.276" >
+			<PeptideHit score="0.999999958478686" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.6"/>
 				<UserParam type="float" name="E-Value" value="5.3e-11"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999958478686"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="493.786560058594" RT="7681.6461" >
-			<PeptideHit score="0.0139416983523447" sequence="IQILEGWK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_42" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="493.786560058594" RT="7681.6461" >
+			<PeptideHit score="0.281438322829347" sequence="IQILEGWK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_42" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.7"/>
 				<UserParam type="float" name="E-Value" value="0.27"/>
 				<UserParam type="float" name="nextscore" value="10.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.281438322829347"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.45971679688" RT="7687.98850000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.45971679688" RT="7687.98850000002" >
+			<PeptideHit score="0.999999956668419" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.5"/>
 				<UserParam type="float" name="E-Value" value="5.6e-11"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999956668419"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="894.468200683594" RT="7709.8992" >
-			<PeptideHit score="0" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="894.468200683594" RT="7709.8992" >
+			<PeptideHit score="0.943202686631416" sequence="TITLEVEPSDTIENVK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28"/>
 				<UserParam type="float" name="E-Value" value="0.0038"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.943202686631416"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.0361328125" RT="7730.41000000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.0361328125" RT="7730.41000000002" >
+			<PeptideHit score="0.999571462358373" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.7"/>
 				<UserParam type="float" name="E-Value" value="8e-06"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999571462358373"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46069335938" RT="7788.70540000002" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46069335938" RT="7788.70540000002" >
+			<PeptideHit score="0.987281990010137" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.0006"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.987281990010137"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="541.287536621094" RT="7805.7777" >
-			<PeptideHit score="0.00134408602150538" sequence="YDLTVPFAR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_39 PH_53" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="541.287536621094" RT="7805.7777" >
+			<PeptideHit score="0.771058061136823" sequence="YDLTVPFAR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_39 PH_53" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.7"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1063.00256347656" RT="7829.82109999998" >
-			<PeptideHit score="0.0102432778489117" sequence="(Gln->pyro-Glu)QSSMTVMEAQESPLFNNVK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_128" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1063.00256347656" RT="7829.82109999998" >
+			<PeptideHit score="0.319722467127969" sequence="(Gln->pyro-Glu)QSSMTVMEAQESPLFNNVK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_128" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.3"/>
 				<UserParam type="float" name="E-Value" value="0.22"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.319722467127969"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034606933594" RT="7870.8831" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034606933594" RT="7870.8831" >
+			<PeptideHit score="0.999997608236872" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.2"/>
 				<UserParam type="float" name="E-Value" value="9.9e-09"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997608236872"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="602.814208984375" RT="7897.31719999998" >
-			<PeptideHit score="0" sequence="ELFDPIISDR" charge="2" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="602.814208984375" RT="7897.31719999998" >
+			<PeptideHit score="0.980753850169904" sequence="ELFDPIISDR" charge="2" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.2"/>
 				<UserParam type="float" name="E-Value" value="0.001"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980753850169904"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="541.286804199219" RT="7910.27320000002" >
-			<PeptideHit score="0" sequence="YDLTVPFAR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_39 PH_53" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="541.286804199219" RT="7910.27320000002" >
+			<PeptideHit score="0.784273217611407" sequence="YDLTVPFAR" charge="2" aa_before="R" aa_after="Y" protein_refs="PH_39 PH_53" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.022"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.784273217611407"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="602.813781738281" RT="7917.50449999998" >
-			<PeptideHit score="0" sequence="ELFDPIISDR" charge="2" aa_before="K" aa_after="H" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="602.813781738281" RT="7917.50449999998" >
+			<PeptideHit score="0.97179748620208" sequence="ELFDPIISDR" charge="2" aa_before="K" aa_after="H" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32"/>
 				<UserParam type="float" name="E-Value" value="0.0016"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97179748620208"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1061.46203613281" RT="7934.478" >
-			<PeptideHit score="0" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1061.46203613281" RT="7934.478" >
+			<PeptideHit score="0.973239129162826" sequence="(Acetyl)ASPDWGYDDKNGPEQWSK" charge="2" aa_before="M" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.3"/>
 				<UserParam type="float" name="E-Value" value="0.0015"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.973239129162826"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.648315429688" RT="7946.60419999998" >
-			<PeptideHit score="0.0115089514066496" sequence="CTYQGQDEARVDAITLK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_111" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.648315429688" RT="7946.60419999998" >
+			<PeptideHit score="0.295486312650848" sequence="CTYQGQDEARVDAITLK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_111" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.7"/>
 				<UserParam type="float" name="E-Value" value="0.25"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.295486312650848"/>
+				<UserParam type="float" name="q-value" value="0.0115089514066496"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="837.382995605469" RT="7951.44439999998" >
-			<PeptideHit score="0" sequence="EIETYHNLLEGGQEDFESSGAGK" charge="3" aa_before="K" aa_after="I" protein_refs="PH_49" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="837.382995605469" RT="7951.44439999998" >
+			<PeptideHit score="0.999981361280163" sequence="EIETYHNLLEGGQEDFESSGAGK" charge="3" aa_before="K" aa_after="I" protein_refs="PH_49" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.9"/>
 				<UserParam type="float" name="E-Value" value="1.4e-07"/>
 				<UserParam type="float" name="nextscore" value="21.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999981361280163"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="825.745849609375" RT="7953.19870000002" >
-			<PeptideHit score="0.0489844683393071" sequence="MSCRESAPLTPSSAPVSQESLAVK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_145" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="825.745849609375" RT="7953.19870000002" >
+			<PeptideHit score="0.0969386199829794" sequence="MSCRESAPLTPSSAPVSQESLAVK" charge="3" aa_before="K" aa_after="E" protein_refs="PH_145" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.1"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="752.685791015625" RT="7955.3595" >
-			<PeptideHit score="0" sequence="EIINVGHSFHVNFEDNDNR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="752.685791015625" RT="7955.3595" >
+			<PeptideHit score="0.97179748620208" sequence="EIINVGHSFHVNFEDNDNR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.0016"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97179748620208"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036376953125" RT="7961.30470000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036376953125" RT="7961.30470000002" >
+			<PeptideHit score="0.999999990410417" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="69.4"/>
 				<UserParam type="float" name="E-Value" value="8e-12"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999990410417"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035217285156" RT="7963.06789999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035217285156" RT="7963.06789999998" >
+			<PeptideHit score="0.999998151509767" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.5"/>
 				<UserParam type="float" name="E-Value" value="7.1e-09"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998151509767"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="738.37841796875" RT="8031.38770000002" >
-			<PeptideHit score="0" sequence="WELLQQVDTSTR" charge="2" aa_before="K" aa_after="T" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="738.37841796875" RT="8031.38770000002" >
+			<PeptideHit score="0.999999564367445" sequence="WELLQQVDTSTR" charge="2" aa_before="K" aa_after="T" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-09"/>
 				<UserParam type="float" name="nextscore" value="18.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999564367445"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="738.378356933594" RT="8033.00500000002" >
-			<PeptideHit score="0" sequence="WELLQQVDTSTR" charge="2" aa_before="K" aa_after="T" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="738.378356933594" RT="8033.00500000002" >
+			<PeptideHit score="0.99989516753533" sequence="WELLQQVDTSTR" charge="2" aa_before="K" aa_after="T" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.6"/>
 				<UserParam type="float" name="E-Value" value="1.3e-06"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99989516753533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="752.686767578125" RT="8043.3462" >
-			<PeptideHit score="0" sequence="EIINVGHSFHVNFEDNDNR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="752.686767578125" RT="8043.3462" >
+			<PeptideHit score="0.995811820230489" sequence="EIINVGHSFHVNFEDNDNR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="0.00015"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995811820230489"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036071777344" RT="8046.85090000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036071777344" RT="8046.85090000002" >
+			<PeptideHit score="0.999302633161889" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.5"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1070.548828125" RT="8130.01390000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1070.548828125" RT="8130.01390000002" >
+			<PeptideHit score="0.99331247569031" sequence="YDPSLKPLSVSYDQATSLR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.7"/>
 				<UserParam type="float" name="E-Value" value="0.00027"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99331247569031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1070.54968261719" RT="8131.71490000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1070.54968261719" RT="8131.71490000002" >
+			<PeptideHit score="0.997297766960443" sequence="YDPSLKPLSVSYDQATSLR" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.3"/>
 				<UserParam type="float" name="E-Value" value="8.6e-05"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997297766960443"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.279144287109" RT="8181.26359999998" >
-			<PeptideHit score="0.0434782608695652" sequence="ELFEKPPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_131" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.279144287109" RT="8181.26359999998" >
+			<PeptideHit score="0.136426593016225" sequence="ELFEKPPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_131" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="26.4"/>
 				<UserParam type="float" name="E-Value" value="0.76"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.136426593016225"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="494.279144287109" RT="8183.02030000002" >
-			<PeptideHit score="0.0363636363636364" sequence="ELFEKPPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_131" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="494.279144287109" RT="8183.02030000002" >
+			<PeptideHit score="0.139151226014516" sequence="ELFEKPPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_131" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="26.4"/>
 				<UserParam type="float" name="E-Value" value="0.74"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.139151226014516"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.0361328125" RT="8195.21329999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.0361328125" RT="8195.21329999998" >
+			<PeptideHit score="0.999999943424381" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.6"/>
 				<UserParam type="float" name="E-Value" value="7.9e-11"/>
 				<UserParam type="float" name="nextscore" value="24.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999943424381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="604.978576660156" RT="8195.5044" >
-			<PeptideHit score="0.0151133501259446" sequence="ATFDEVLELMATGFLR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_139" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="604.978576660156" RT="8195.5044" >
+			<PeptideHit score="0.257305155260055" sequence="ATFDEVLELMATGFLR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_139" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.2"/>
 				<UserParam type="float" name="E-Value" value="0.31"/>
 				<UserParam type="float" name="nextscore" value="10.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.257305155260055"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="492.291656494141" RT="8227.67479999998" >
-			<PeptideHit score="0.0259259259259259" sequence="(Gln->pyro-Glu)QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="492.291656494141" RT="8227.67479999998" >
+			<PeptideHit score="0.209402044145386" sequence="(Gln->pyro-Glu)QTALVELVK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.4"/>
 				<UserParam type="float" name="E-Value" value="0.42"/>
 				<UserParam type="float" name="nextscore" value="11.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.209402044145386"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="584.321655273438" RT="8248.10560000002" >
-			<PeptideHit score="0" sequence="KQGGLGPMNIPLVSDPK" charge="3" aa_before="K" aa_after="R" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="584.321655273438" RT="8248.10560000002" >
+			<PeptideHit score="0.997322409292524" sequence="KQGGLGPMNIPLVSDPK" charge="3" aa_before="K" aa_after="R" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.1"/>
 				<UserParam type="float" name="E-Value" value="8.5e-05"/>
 				<UserParam type="float" name="nextscore" value="22.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997322409292524"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="584.321350097656" RT="8252.14519999998" >
-			<PeptideHit score="0" sequence="KQGGLGPMNIPLVSDPK" charge="3" aa_before="K" aa_after="R" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="584.321350097656" RT="8252.14519999998" >
+			<PeptideHit score="0.999338919682092" sequence="KQGGLGPMNIPLVSDPK" charge="3" aa_before="K" aa_after="R" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="1.4e-05"/>
 				<UserParam type="float" name="nextscore" value="20.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999338919682092"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036437988281" RT="8289.3645" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036437988281" RT="8289.3645" >
+			<PeptideHit score="0.999999883776959" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="69.2"/>
 				<UserParam type="float" name="E-Value" value="2e-10"/>
 				<UserParam type="float" name="nextscore" value="21.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999883776959"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035583496094" RT="8291.07079999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035583496094" RT="8291.07079999998" >
+			<PeptideHit score="0.999999228385608" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.3"/>
 				<UserParam type="float" name="E-Value" value="2.3e-09"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999228385608"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952026367188" RT="8296.7532" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952026367188" RT="8296.7532" >
+			<PeptideHit score="0.999998483417254" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.5"/>
 				<UserParam type="float" name="E-Value" value="5.5e-09"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998483417254"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425231933594" RT="8332.5582" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425231933594" RT="8332.5582" >
+			<PeptideHit score="0.99984239932391" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.4"/>
 				<UserParam type="float" name="E-Value" value="2.2e-06"/>
 				<UserParam type="float" name="nextscore" value="11.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99984239932391"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425842285156" RT="8334.80089999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425842285156" RT="8334.80089999998" >
+			<PeptideHit score="0.999981361280163" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50"/>
 				<UserParam type="float" name="E-Value" value="1.4e-07"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999981361280163"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952239990234" RT="8364.04750000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952239990234" RT="8364.04750000002" >
+			<PeptideHit score="0.999935834951473" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.9"/>
 				<UserParam type="float" name="E-Value" value="6.9e-07"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999935834951473"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034851074219" RT="8364.2982" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034851074219" RT="8364.2982" >
+			<PeptideHit score="0.999995558807143" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.9"/>
 				<UserParam type="float" name="E-Value" value="2.2e-08"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995558807143"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952178955078" RT="8366.1249" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952178955078" RT="8366.1249" >
+			<PeptideHit score="0.999999926876528" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.3"/>
 				<UserParam type="float" name="E-Value" value="1.1e-10"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999926876528"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.424743652344" RT="8369.88469999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.424743652344" RT="8369.88469999998" >
+			<PeptideHit score="0.999810014670625" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.9"/>
 				<UserParam type="float" name="E-Value" value="2.8e-06"/>
 				<UserParam type="float" name="nextscore" value="11.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999810014670625"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.657836914063" RT="8371.1454" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.657836914063" RT="8371.1454" >
+			<PeptideHit score="0.931534620353677" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.8"/>
 				<UserParam type="float" name="E-Value" value="0.0048"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.931534620353677"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425598144531" RT="8372.751" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425598144531" RT="8372.751" >
+			<PeptideHit score="0.999919808785286" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.3"/>
 				<UserParam type="float" name="E-Value" value="9.2e-07"/>
 				<UserParam type="float" name="nextscore" value="11.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999919808785286"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.034729003906" RT="8381.82259999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.034729003906" RT="8381.82259999998" >
+			<PeptideHit score="0.999995096243584" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.4"/>
 				<UserParam type="float" name="E-Value" value="2.5e-08"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995096243584"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035339355469" RT="8389.67500000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035339355469" RT="8389.67500000002" >
+			<PeptideHit score="0.999999474833695" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.6"/>
 				<UserParam type="float" name="E-Value" value="1.4e-09"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999474833695"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953033447266" RT="8391.4419" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953033447266" RT="8391.4419" >
+			<PeptideHit score="0.999999892890679" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.5"/>
 				<UserParam type="float" name="E-Value" value="1.8e-10"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999892890679"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952178955078" RT="8393.2023" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952178955078" RT="8393.2023" >
+			<PeptideHit score="0.999995403129308" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.1"/>
 				<UserParam type="float" name="E-Value" value="2.3e-08"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995403129308"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="601.843383789063" RT="8400.23869999998" >
-			<PeptideHit score="0.0139416983523447" sequence="YEILAANAIPK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_50" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="601.843383789063" RT="8400.23869999998" >
+			<PeptideHit score="0.28827458994223" sequence="YEILAANAIPK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_50" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.6"/>
 				<UserParam type="float" name="E-Value" value="0.26"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.28827458994223"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.6572265625" RT="8405.5359" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.6572265625" RT="8405.5359" >
+			<PeptideHit score="0.999948466346366" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.3"/>
 				<UserParam type="float" name="E-Value" value="5.2e-07"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999948466346366"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.42431640625" RT="8411.45620000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.42431640625" RT="8411.45620000002" >
+			<PeptideHit score="0.999413322128202" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.9"/>
 				<UserParam type="float" name="E-Value" value="1.2e-05"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999413322128202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425903320313" RT="8413.65730000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425903320313" RT="8413.65730000002" >
+			<PeptideHit score="0.999957135954253" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.7"/>
 				<UserParam type="float" name="E-Value" value="4.1e-07"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999957135954253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.280212402344" RT="8417.12140000002" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.280212402344" RT="8417.12140000002" >
+			<PeptideHit score="0.992145529169711" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.6"/>
 				<UserParam type="float" name="E-Value" value="0.00033"/>
 				<UserParam type="float" name="nextscore" value="8.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992145529169711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.281433105469" RT="8422.90099999998" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.281433105469" RT="8422.90099999998" >
+			<PeptideHit score="0.991954978966702" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.6"/>
 				<UserParam type="float" name="E-Value" value="0.00034"/>
 				<UserParam type="float" name="nextscore" value="8.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991954978966702"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952453613281" RT="8443.3758" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952453613281" RT="8443.3758" >
+			<PeptideHit score="0.999999990132854" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.8"/>
 				<UserParam type="float" name="E-Value" value="8.3e-12"/>
 				<UserParam type="float" name="nextscore" value="20"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999990132854"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.95263671875" RT="8445.1419" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.95263671875" RT="8445.1419" >
+			<PeptideHit score="0.999998908036975" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-09"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998908036975"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="710.722961425781" RT="8461.26070000002" >
-			<PeptideHit score="0.00526315789473684" sequence="TLSDYNIQKESTLHLVLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_36 PH_37 PH_62 PH_63" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="710.722961425781" RT="8461.26070000002" >
+			<PeptideHit score="0.503347576910457" sequence="TLSDYNIQKESTLHLVLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_36 PH_37 PH_62 PH_63" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.4"/>
 				<UserParam type="float" name="E-Value" value="0.093"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.503347576910457"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.657958984375" RT="8490.31489999998" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.657958984375" RT="8490.31489999998" >
+			<PeptideHit score="0.999451560929756" sequence="QGGLGPMNIPLVSDPKR" charge="3" aa_before="K" aa_after="T" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.7"/>
 				<UserParam type="float" name="E-Value" value="1.1e-05"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999451560929756"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="528.273681640625" RT="8498.51770000002" >
-			<PeptideHit score="0" sequence="VSFELFADK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="528.273681640625" RT="8498.51770000002" >
+			<PeptideHit score="0.989919202493546" sequence="VSFELFADK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.4"/>
 				<UserParam type="float" name="E-Value" value="0.00045"/>
 				<UserParam type="float" name="nextscore" value="19.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989919202493546"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.280151367188" RT="8513.45950000002" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.280151367188" RT="8513.45950000002" >
+			<PeptideHit score="0.99331247569031" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.1"/>
 				<UserParam type="float" name="E-Value" value="0.00027"/>
 				<UserParam type="float" name="nextscore" value="12.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99331247569031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="734.425231933594" RT="8535.5481" >
-			<PeptideHit score="0.02" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="734.425231933594" RT="8535.5481" >
+			<PeptideHit score="0.246856676048891" sequence="RHPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.4"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952087402344" RT="8537.3286" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952087402344" RT="8537.3286" >
+			<PeptideHit score="0.999999445986628" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-09"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999445986628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951995849609" RT="8539.10290000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951995849609" RT="8539.10290000002" >
+			<PeptideHit score="0.999999907005607" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-10"/>
 				<UserParam type="float" name="nextscore" value="18.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999907005607"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036315917969" RT="8562.1803" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036315917969" RT="8562.1803" >
+			<PeptideHit score="0.999999307602226" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60"/>
 				<UserParam type="float" name="E-Value" value="2e-09"/>
 				<UserParam type="float" name="nextscore" value="19.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999307602226"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035827636719" RT="8565.71749999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035827636719" RT="8565.71749999998" >
+			<PeptideHit score="0.999998569625157" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.8"/>
 				<UserParam type="float" name="E-Value" value="5.1e-09"/>
 				<UserParam type="float" name="nextscore" value="19.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998569625157"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.2802734375" RT="8606.00800000002" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.2802734375" RT="8606.00800000002" >
+			<PeptideHit score="0.991576891487535" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.4"/>
 				<UserParam type="float" name="E-Value" value="0.00036"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991576891487535"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="536.2802734375" RT="8607.68029999998" >
-			<PeptideHit score="0" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="536.2802734375" RT="8607.68029999998" >
+			<PeptideHit score="0.984269703140117" sequence="MFLSFPTTK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_72" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.7"/>
 				<UserParam type="float" name="E-Value" value="0.00078"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984269703140117"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="609.814575195313" RT="8608.82569999998" >
-			<PeptideHit score="0.00402684563758389" sequence="ELQDSKEELK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_9" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="609.814575195313" RT="8608.82569999998" >
+			<PeptideHit score="0.51314785373008" sequence="ELQDSKEELK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_9" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="27.8"/>
 				<UserParam type="float" name="E-Value" value="0.089"/>
 				<UserParam type="float" name="nextscore" value="22.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.51314785373008"/>
+				<UserParam type="float" name="q-value" value="0.00402684563758389"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951812744141" RT="8630.12179999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951812744141" RT="8630.12179999998" >
+			<PeptideHit score="0.999999921775042" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.4"/>
 				<UserParam type="float" name="E-Value" value="1.2e-10"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999921775042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.9521484375" RT="8631.7935" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.9521484375" RT="8631.7935" >
+			<PeptideHit score="0.999999965328785" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64"/>
 				<UserParam type="float" name="E-Value" value="4.2e-11"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999965328785"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.0361328125" RT="8652.91000000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.0361328125" RT="8652.91000000002" >
+			<PeptideHit score="0.999999659649047" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.4"/>
 				<UserParam type="float" name="E-Value" value="8e-10"/>
 				<UserParam type="float" name="nextscore" value="19.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999659649047"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="528.273498535156" RT="8676.77320000002" >
-			<PeptideHit score="0.0259259259259259" sequence="VSFELFADK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="528.273498535156" RT="8676.77320000002" >
+			<PeptideHit score="0.20599231767492" sequence="VSFELFADK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21"/>
 				<UserParam type="float" name="E-Value" value="0.43"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.20599231767492"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="601.848388671875" RT="8687.31460000002" >
-			<PeptideHit score="0.02" sequence="NITVDPRLFK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_18" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="601.848388671875" RT="8687.31460000002" >
+			<PeptideHit score="0.246856676048891" sequence="NITVDPRLFK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_18" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.4"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952392578125" RT="8723.28379999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952392578125" RT="8723.28379999998" >
+			<PeptideHit score="0.999999993338167" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.7"/>
 				<UserParam type="float" name="E-Value" value="5e-12"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999993338167"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952270507813" RT="8724.94510000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952270507813" RT="8724.94510000002" >
+			<PeptideHit score="0.999999981251654" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.4"/>
 				<UserParam type="float" name="E-Value" value="1.9e-11"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999981251654"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.650268554688" RT="8736.46600000002" >
-			<PeptideHit score="0.029520295202952" sequence="LELYDSKQTQHDTFGK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_11" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.650268554688" RT="8736.46600000002" >
+			<PeptideHit score="0.196460921093246" sequence="LELYDSKQTQHDTFGK" charge="3" aa_before="R" aa_after="G" protein_refs="PH_11" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.46"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.196460921093246"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="570.894470214844" RT="8745.05389999998" >
-			<PeptideHit score="0" sequence="EGEETGEGDKTPSSDGD" charge="3" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="570.894470214844" RT="8745.05389999998" >
+			<PeptideHit score="0.00951478018092533" sequence="EGEETGEGDKTPSSDGD" charge="3" >
 				<UserParam type="string" name="target_decoy" value=""/>
 				<UserParam type="float" name="XTandem_score" value="9.1"/>
 				<UserParam type="float" name="E-Value" value="530"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.00951478018092533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952270507813" RT="8793.76000000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952270507813" RT="8793.76000000002" >
+			<PeptideHit score="0.999999967916601" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.2"/>
 				<UserParam type="float" name="E-Value" value="3.8e-11"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999967916601"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="692.348876953125" RT="8811.97630000002" >
-			<PeptideHit score="0" sequence="SLNNQFASFIDK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="692.348876953125" RT="8811.97630000002" >
+			<PeptideHit score="0.999997933185207" sequence="SLNNQFASFIDK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.4"/>
 				<UserParam type="float" name="E-Value" value="8.2e-09"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997933185207"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="692.350524902344" RT="8813.775" >
-			<PeptideHit score="0.029520295202952" sequence="SILDQSISSFMR" charge="2" aa_before="K" aa_after="K" protein_refs="PH_3" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="692.350524902344" RT="8813.775" >
+			<PeptideHit score="0.193496525438801" sequence="SILDQSISSFMR" charge="2" aa_before="K" aa_after="K" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="728.694946289063" RT="8847.0489" >
-			<PeptideHit score="0" sequence="NFTEVHPDYGSHIQALLDK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="728.694946289063" RT="8847.0489" >
+			<PeptideHit score="0.960802305355011" sequence="NFTEVHPDYGSHIQALLDK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34"/>
 				<UserParam type="float" name="E-Value" value="0.0024"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.960802305355011"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035095214844" RT="8858.38039999998" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035095214844" RT="8858.38039999998" >
+			<PeptideHit score="0.999999051936364" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.8"/>
 				<UserParam type="float" name="E-Value" value="3e-09"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999051936364"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.03515625" RT="8863.54720000002" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.03515625" RT="8863.54720000002" >
+			<PeptideHit score="0.999975426201442" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.1"/>
 				<UserParam type="float" name="E-Value" value="2e-07"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999975426201442"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="788.767944335938" RT="8870.54599999998" >
-			<PeptideHit score="0" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="788.767944335938" RT="8870.54599999998" >
+			<PeptideHit score="0.99999999999095" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="87.5"/>
 				<UserParam type="float" name="E-Value" value="1e-15"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999999999095"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="788.768615722656" RT="8874.39529999998" >
-			<PeptideHit score="0" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="788.768615722656" RT="8874.39529999998" >
+			<PeptideHit score="0.99999999999095" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="86.8"/>
 				<UserParam type="float" name="E-Value" value="1e-15"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999999999095"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951934814453" RT="8885.76049999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951934814453" RT="8885.76049999998" >
+			<PeptideHit score="0.999999956668419" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.5"/>
 				<UserParam type="float" name="E-Value" value="5.6e-11"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999956668419"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953002929688" RT="8887.4292" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953002929688" RT="8887.4292" >
+			<PeptideHit score="0.999998591411326" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.7"/>
 				<UserParam type="float" name="E-Value" value="5e-09"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998591411326"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="788.768432617188" RT="8966.88199999998" >
-			<PeptideHit score="0" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="788.768432617188" RT="8966.88199999998" >
+			<PeptideHit score="0.999962082800366" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.8"/>
 				<UserParam type="float" name="E-Value" value="3.5e-07"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999962082800366"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.036010742188" RT="8968.5414" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.036010742188" RT="8968.5414" >
+			<PeptideHit score="0.99999995726936" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="68.9"/>
 				<UserParam type="float" name="E-Value" value="5.5e-11"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999995726936"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="788.768127441406" RT="8972.1195" >
-			<PeptideHit score="0" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="788.768127441406" RT="8972.1195" >
+			<PeptideHit score="0.999999999971969" sequence="ADVLTTGAGNPVGDKLNVITVGPR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="83"/>
 				<UserParam type="float" name="E-Value" value="4.3e-15"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999971969"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952453613281" RT="8978.41630000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952453613281" RT="8978.41630000002" >
+			<PeptideHit score="0.999999993545645" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.8"/>
 				<UserParam type="float" name="E-Value" value="4.8e-12"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999993545645"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951995849609" RT="8980.19959999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951995849609" RT="8980.19959999998" >
+			<PeptideHit score="0.999997778551365" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.7"/>
 				<UserParam type="float" name="E-Value" value="9e-09"/>
 				<UserParam type="float" name="nextscore" value="16.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997778551365"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="877.921264648438" RT="8986.41949999998" >
-			<PeptideHit score="0.02" sequence="GTFGPCCRWALDTVTK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_135" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="877.921264648438" RT="8986.41949999998" >
+			<PeptideHit score="0.251961841294195" sequence="GTFGPCCRWALDTVTK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_135" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="21.7"/>
 				<UserParam type="float" name="E-Value" value="0.32"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.251961841294195"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.61328125" RT="9043.52029999998" >
-			<PeptideHit score="0.00134408602150538" sequence="GAGAFGYFEVTHDITK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.61328125" RT="9043.52029999998" >
+			<PeptideHit score="0.752250699877261" sequence="GAGAFGYFEVTHDITK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.1"/>
 				<UserParam type="float" name="E-Value" value="0.027"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.752250699877261"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="856.916931152344" RT="9068.28559999998" >
-			<PeptideHit score="0" sequence="GAGAFGYFEVTHDITK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="856.916931152344" RT="9068.28559999998" >
+			<PeptideHit score="0.999999921775042" sequence="GAGAFGYFEVTHDITK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.3"/>
 				<UserParam type="float" name="E-Value" value="1.2e-10"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999921775042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="9071.85199999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="9071.85199999998" >
+			<PeptideHit score="0.999999954879847" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.4"/>
 				<UserParam type="float" name="E-Value" value="5.9e-11"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999954879847"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952575683594" RT="9073.63519999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952575683594" RT="9073.63519999998" >
+			<PeptideHit score="0.999999936870942" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.7"/>
 				<UserParam type="float" name="E-Value" value="9.1e-11"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999936870942"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="611.308166503906" RT="9088.60519999998" >
-			<PeptideHit score="0.0444711538461538" sequence="SIYGEKFEDENFILK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="611.308166503906" RT="9088.60519999998" >
+			<PeptideHit score="0.103478204192389" sequence="SIYGEKFEDENFILK" charge="3" aa_before="K" aa_after="H" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="16.2"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="916.459655761719" RT="9116.55370000002" >
-			<PeptideHit score="0" sequence="SIYGEKFEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="916.459655761719" RT="9116.55370000002" >
+			<PeptideHit score="0.999997702404425" sequence="SIYGEKFEDENFILK" charge="2" aa_before="K" aa_after="H" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61"/>
 				<UserParam type="float" name="E-Value" value="9.4e-09"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997702404425"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.613708496094" RT="9137.04859999998" >
-			<PeptideHit score="0" sequence="GAGAFGYFEVTHDITK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.613708496094" RT="9137.04859999998" >
+			<PeptideHit score="0.835623332778618" sequence="GAGAFGYFEVTHDITK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.1"/>
 				<UserParam type="float" name="E-Value" value="0.015"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.835623332778618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="661.677490234375" RT="9201.54049999998" >
-			<PeptideHit score="0" sequence="TIAQDYGVLKADEGISFR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="661.677490234375" RT="9201.54049999998" >
+			<PeptideHit score="0.812550391896406" sequence="TIAQDYGVLKADEGISFR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.018"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.812550391896406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="661.678466796875" RT="9203.3178" >
-			<PeptideHit score="0" sequence="TIAQDYGVLKADEGISFR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="661.678466796875" RT="9203.3178" >
+			<PeptideHit score="0.933818296789238" sequence="TIAQDYGVLKADEGISFR" charge="3" aa_before="R" aa_after="G" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.8"/>
 				<UserParam type="float" name="E-Value" value="0.0046"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.933818296789238"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951934814453" RT="9256.33729999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951934814453" RT="9256.33729999998" >
+			<PeptideHit score="0.9999998975322" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.6"/>
 				<UserParam type="float" name="E-Value" value="1.7e-10"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.9999998975322"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952606201172" RT="9257.7678" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952606201172" RT="9257.7678" >
+			<PeptideHit score="0.999996530182202" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64"/>
 				<UserParam type="float" name="E-Value" value="1.6e-08"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996530182202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="690.384704589844" RT="9258.41860000002" >
-			<PeptideHit score="0.0139416983523447" sequence="DQDNAIIRPLPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_10" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="690.384704589844" RT="9258.41860000002" >
+			<PeptideHit score="0.274948227693009" sequence="DQDNAIIRPLPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_10" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20"/>
 				<UserParam type="float" name="E-Value" value="0.28"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.274948227693009"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="690.382202148438" RT="9260.03419999998" >
-			<PeptideHit score="0" sequence="VSFELFADKVPK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_61" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="690.382202148438" RT="9260.03419999998" >
+			<PeptideHit score="0.999915119404183" sequence="VSFELFADKVPK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_61" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.4"/>
 				<UserParam type="float" name="E-Value" value="9.9e-07"/>
 				<UserParam type="float" name="nextscore" value="12.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999915119404183"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.7890625" RT="9312.14440000002" >
-			<PeptideHit score="0.00906735751295337" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.7890625" RT="9312.14440000002" >
+			<PeptideHit score="0.384387191798194" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.16"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.384387191798194"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.788024902344" RT="9313.90990000002" >
-			<PeptideHit score="0.0151133501259446" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.788024902344" RT="9313.90990000002" >
+			<PeptideHit score="0.262904122502352" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="21.1"/>
 				<UserParam type="float" name="E-Value" value="0.3"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.262904122502352"/>
+				<UserParam type="float" name="q-value" value="0.0151133501259446"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="714.035339355469" RT="9343.6032" >
-			<PeptideHit score="0" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="714.035339355469" RT="9343.6032" >
+			<PeptideHit score="0.999968991099384" sequence="YDPSLKPLSVSYDQATSLR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.3"/>
 				<UserParam type="float" name="E-Value" value="2.7e-07"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999968991099384"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952087402344" RT="9349.0917" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952087402344" RT="9349.0917" >
+			<PeptideHit score="0.999999916768411" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60"/>
 				<UserParam type="float" name="E-Value" value="1.3e-10"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999916768411"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952270507813" RT="9350.86240000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952270507813" RT="9350.86240000002" >
+			<PeptideHit score="0.999999921775042" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.3"/>
 				<UserParam type="float" name="E-Value" value="1.2e-10"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999921775042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="617.979614257813" RT="9382.46119999998" >
-			<PeptideHit score="0" sequence="TLNDMRQEYEQLIAK" charge="3" aa_before="K" aa_after="N" protein_refs="PH_49" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="617.979614257813" RT="9382.46119999998" >
+			<PeptideHit score="0.960802305355011" sequence="TLNDMRQEYEQLIAK" charge="3" aa_before="K" aa_after="N" protein_refs="PH_49" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.4"/>
 				<UserParam type="float" name="E-Value" value="0.0024"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.960802305355011"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="509.94189453125" RT="9386.17339999998" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="509.94189453125" RT="9386.17339999998" >
+			<PeptideHit score="0.999061854320524" sequence="NVIQISNDLENLR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.4"/>
 				<UserParam type="float" name="E-Value" value="2.2e-05"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999061854320524"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="562.310180664063" RT="9400.54210000002" >
-			<PeptideHit score="0.0102432778489117" sequence="DPILFPSFIHSQKR" charge="3" aa_before="R" aa_after="N" protein_refs="PH_24" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="562.310180664063" RT="9400.54210000002" >
+			<PeptideHit score="0.303106246021224" sequence="DPILFPSFIHSQKR" charge="3" aa_before="R" aa_after="N" protein_refs="PH_24" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.4"/>
 				<UserParam type="float" name="E-Value" value="0.24"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.303106246021224"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="811.932739257813" RT="9402.3291" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="811.932739257813" RT="9402.3291" >
+			<PeptideHit score="0.999993635170618" sequence="QGGLGPMNIPLVSDPK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.2"/>
 				<UserParam type="float" name="E-Value" value="3.5e-08"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993635170618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.788208007813" RT="9404.10949999998" >
-			<PeptideHit score="0.00906735751295337" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.788208007813" RT="9404.10949999998" >
+			<PeptideHit score="0.384387191798194" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.4"/>
 				<UserParam type="float" name="E-Value" value="0.16"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.384387191798194"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.788146972656" RT="9405.88060000002" >
-			<PeptideHit score="0.00134408602150538" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.788146972656" RT="9405.88060000002" >
+			<PeptideHit score="0.777594217720977" sequence="MSPPYKFPK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_118" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="24.8"/>
 				<UserParam type="float" name="E-Value" value="0.023"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.777594217720977"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="811.932189941406" RT="9406.3017" >
-			<PeptideHit score="0" sequence="QGGLGPMNIPLVSDPK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_73" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="811.932189941406" RT="9406.3017" >
+			<PeptideHit score="0.999996699477478" sequence="QGGLGPMNIPLVSDPK" charge="2" aa_before="K" aa_after="R" protein_refs="PH_73" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.9"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="411.580322265625" RT="9435.4674" >
-			<PeptideHit score="0.0102432778489117" sequence="ANRPFLVFIR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_15" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="411.580322265625" RT="9435.4674" >
+			<PeptideHit score="0.328807035189251" sequence="ANRPFLVFIR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_15" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.1"/>
 				<UserParam type="float" name="E-Value" value="0.21"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.328807035189251"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.410949707031" RT="9440.95399999998" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.410949707031" RT="9440.95399999998" >
+			<PeptideHit score="0.999999973980493" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.6"/>
 				<UserParam type="float" name="E-Value" value="2.9e-11"/>
 				<UserParam type="float" name="nextscore" value="22.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999973980493"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952209472656" RT="9441.21730000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952209472656" RT="9441.21730000002" >
+			<PeptideHit score="0.999998931620711" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.3"/>
 				<UserParam type="float" name="E-Value" value="3.5e-09"/>
 				<UserParam type="float" name="nextscore" value="18.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998931620711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.410583496094" RT="9442.8513" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.410583496094" RT="9442.8513" >
+			<PeptideHit score="0.999999982800186" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.6"/>
 				<UserParam type="float" name="E-Value" value="1.7e-11"/>
 				<UserParam type="float" name="nextscore" value="22.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999982800186"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.9189453125" RT="9460.11979999998" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.9189453125" RT="9460.11979999998" >
+			<PeptideHit score="0.968964271876771" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.5"/>
 				<UserParam type="float" name="E-Value" value="0.0018"/>
 				<UserParam type="float" name="nextscore" value="22.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.968964271876771"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="621.296691894531" RT="9514.19770000002" >
-			<PeptideHit score="0" sequence="YDGLVGMFDPK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_39 PH_53" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="621.296691894531" RT="9514.19770000002" >
+			<PeptideHit score="0.982173192499341" sequence="YDGLVGMFDPK" charge="2" aa_before="R" aa_after="G" protein_refs="PH_39 PH_53" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.2"/>
 				<UserParam type="float" name="E-Value" value="0.00091"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.982173192499341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953155517578" RT="9535.70110000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953155517578" RT="9535.70110000002" >
+			<PeptideHit score="0.999964626875691" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.3"/>
 				<UserParam type="float" name="E-Value" value="3.2e-07"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999964626875691"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="656.375183105469" RT="9537.0171" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="656.375183105469" RT="9537.0171" >
+			<PeptideHit score="0.878537248230859" sequence="HPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.4"/>
 				<UserParam type="float" name="E-Value" value="0.01"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.878537248230859"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952362060547" RT="9537.28660000002" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952362060547" RT="9537.28660000002" >
+			<PeptideHit score="0.999999774631398" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.8"/>
 				<UserParam type="float" name="E-Value" value="4.7e-10"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999774631398"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.410766601563" RT="9537.84979999998" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.410766601563" RT="9537.84979999998" >
+			<PeptideHit score="0.999993216272323" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.6"/>
 				<UserParam type="float" name="E-Value" value="3.8e-08"/>
 				<UserParam type="float" name="nextscore" value="22.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993216272323"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.918304443359" RT="9554.40589999998" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.918304443359" RT="9554.40589999998" >
+			<PeptideHit score="0.999996699477478" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-08"/>
 				<UserParam type="float" name="nextscore" value="21.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996699477478"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.918975830078" RT="9556.19440000002" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.918975830078" RT="9556.19440000002" >
+			<PeptideHit score="0.989559356772796" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.9"/>
 				<UserParam type="float" name="E-Value" value="0.00047"/>
 				<UserParam type="float" name="nextscore" value="18.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.989559356772796"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952087402344" RT="9629.43379999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952087402344" RT="9629.43379999998" >
+			<PeptideHit score="0.999999417569271" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.7"/>
 				<UserParam type="float" name="E-Value" value="1.6e-09"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999417569271"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="382.541900634766" RT="9629.95360000002" >
-			<PeptideHit score="0.00134408602150538" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="382.541900634766" RT="9629.95360000002" >
+			<PeptideHit score="0.637783228316437" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.3"/>
 				<UserParam type="float" name="E-Value" value="0.05"/>
 				<UserParam type="float" name="nextscore" value="17.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.637783228316437"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.409423828125" RT="9630.58729999998" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.409423828125" RT="9630.58729999998" >
+			<PeptideHit score="0.999999957872764" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.6"/>
 				<UserParam type="float" name="E-Value" value="5.4e-11"/>
 				<UserParam type="float" name="nextscore" value="22"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999957872764"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="656.374633789063" RT="9631.86649999998" >
-			<PeptideHit score="0.00526315789473684" sequence="HPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="656.374633789063" RT="9631.86649999998" >
+			<PeptideHit score="0.446677932430767" sequence="HPDYSVVLLLR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.4"/>
 				<UserParam type="float" name="E-Value" value="0.12"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.446677932430767"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.867065429688" RT="9633.0147" >
-			<PeptideHit score="0.00134408602150538" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.867065429688" RT="9633.0147" >
+			<PeptideHit score="0.728863619332872" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.9"/>
 				<UserParam type="float" name="E-Value" value="0.031"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.728863619332872"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="382.541809082031" RT="9636.5097" >
-			<PeptideHit score="0.00134408602150538" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="382.541809082031" RT="9636.5097" >
+			<PeptideHit score="0.603177103780716" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.4"/>
 				<UserParam type="float" name="E-Value" value="0.059"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.603177103780716"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.918334960938" RT="9655.66510000002" >
-			<PeptideHit score="0" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.918334960938" RT="9655.66510000002" >
+			<PeptideHit score="0.979203874797132" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.1"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="20.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="437.918640136719" RT="9672.41239999998" >
-			<PeptideHit score="0.00651890482398957" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="437.918640136719" RT="9672.41239999998" >
+			<PeptideHit score="0.412959460251658" sequence="HPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35"/>
 				<UserParam type="float" name="E-Value" value="0.14"/>
 				<UserParam type="float" name="nextscore" value="25"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.412959460251658"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="573.308044433594" RT="9715.11469999998" >
-			<PeptideHit score="0" sequence="DLKWWELR" charge="2" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="573.308044433594" RT="9715.11469999998" >
+			<PeptideHit score="0.892764267514638" sequence="DLKWWELR" charge="2" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36"/>
 				<UserParam type="float" name="E-Value" value="0.0085"/>
 				<UserParam type="float" name="nextscore" value="23.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.892764267514638"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="573.309265136719" RT="9716.9076" >
-			<PeptideHit score="0" sequence="DLKWWELR" charge="2" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="573.309265136719" RT="9716.9076" >
+			<PeptideHit score="0.937288968996664" sequence="DLKWWELR" charge="2" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.7"/>
 				<UserParam type="float" name="E-Value" value="0.0043"/>
 				<UserParam type="float" name="nextscore" value="20.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.937288968996664"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866333007813" RT="9725.45599999998" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866333007813" RT="9725.45599999998" >
+			<PeptideHit score="0.994528455081984" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.6"/>
 				<UserParam type="float" name="E-Value" value="0.00021"/>
 				<UserParam type="float" name="nextscore" value="18.9"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994528455081984"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="382.5419921875" RT="9727.8306" >
-			<PeptideHit score="0.00134408602150538" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="382.5419921875" RT="9727.8306" >
+			<PeptideHit score="0.542451678177793" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.5"/>
 				<UserParam type="float" name="E-Value" value="0.078"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.542451678177793"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.8662109375" RT="9728.15689999998" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.8662109375" RT="9728.15689999998" >
+			<PeptideHit score="0.999997664605406" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.6"/>
 				<UserParam type="float" name="E-Value" value="9.6e-09"/>
 				<UserParam type="float" name="nextscore" value="21.3"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997664605406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.409912109375" RT="9729.1245" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.409912109375" RT="9729.1245" >
+			<PeptideHit score="0.999998462088884" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.5"/>
 				<UserParam type="float" name="E-Value" value="5.6e-09"/>
 				<UserParam type="float" name="nextscore" value="21.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998462088884"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="382.5419921875" RT="9730.9296" >
-			<PeptideHit score="0.00526315789473684" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="382.5419921875" RT="9730.9296" >
+			<PeptideHit score="0.465947082204611" sequence="DLKWWELR" charge="3" aa_before="R" aa_after="H" protein_refs="PH_17" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.5"/>
 				<UserParam type="float" name="E-Value" value="0.11"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.465947082204611"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="557.301940917969" RT="9743.69830000002" >
-			<PeptideHit score="0.0363636363636364" sequence="VLGAFSDGLAHLDNLK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="557.301940917969" RT="9743.69830000002" >
+			<PeptideHit score="0.175225488597367" sequence="VLGAFSDGLAHLDNLK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="0.54"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.175225488597367"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="600.000061035156" RT="9775.02070000002" >
-			<PeptideHit score="0" sequence="KVLGAFSDGLAHLDNLK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="600.000061035156" RT="9775.02070000002" >
+			<PeptideHit score="0.999128598342253" sequence="KVLGAFSDGLAHLDNLK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.7"/>
 				<UserParam type="float" name="E-Value" value="2e-05"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999128598342253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="644.684631347656" RT="9814.5594" >
-			<PeptideHit score="0.0363636363636364" sequence="SQAQIWVSILQQLEMR" charge="3" aa_before="K" aa_after="A" protein_refs="PH_140" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="644.684631347656" RT="9814.5594" >
+			<PeptideHit score="0.175225488597367" sequence="SQAQIWVSILQQLEMR" charge="3" aa_before="K" aa_after="A" protein_refs="PH_140" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.7"/>
 				<UserParam type="float" name="E-Value" value="0.54"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.175225488597367"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866516113281" RT="9818.12290000002" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866516113281" RT="9818.12290000002" >
+			<PeptideHit score="0.999991092618655" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.6"/>
 				<UserParam type="float" name="E-Value" value="5.4e-08"/>
 				<UserParam type="float" name="nextscore" value="18.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999991092618655"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952545166016" RT="9818.3883" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952545166016" RT="9818.3883" >
+			<PeptideHit score="0.999925958251218" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52"/>
 				<UserParam type="float" name="E-Value" value="8.3e-07"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999925958251218"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866455078125" RT="9820.87759999998" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866455078125" RT="9820.87759999998" >
+			<PeptideHit score="0.999999003306759" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.5"/>
 				<UserParam type="float" name="E-Value" value="3.2e-09"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999003306759"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.867065429688" RT="9911.84050000002" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.867065429688" RT="9911.84050000002" >
+			<PeptideHit score="0.999998547934873" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.6"/>
 				<UserParam type="float" name="E-Value" value="5.2e-09"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998547934873"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952301025391" RT="9912.15829999998" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952301025391" RT="9912.15829999998" >
+			<PeptideHit score="0.999882872506843" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-06"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999882872506843"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866882324219" RT="9913.60669999998" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866882324219" RT="9913.60669999998" >
+			<PeptideHit score="0.998996472288824" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.5"/>
 				<UserParam type="float" name="E-Value" value="2.4e-05"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998996472288824"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951812744141" RT="9913.9353" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951812744141" RT="9913.9353" >
+			<PeptideHit score="0.999784218688703" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.1"/>
 				<UserParam type="float" name="E-Value" value="3.3e-06"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999784218688703"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866455078125" RT="10004.6873" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866455078125" RT="10004.6873" >
+			<PeptideHit score="0.977679598036381" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.9"/>
 				<UserParam type="float" name="E-Value" value="0.0012"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.977679598036381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951965332031" RT="10005.078" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951965332031" RT="10005.078" >
+			<PeptideHit score="0.999983460247774" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.4"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.8662109375" RT="10006.3346" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.8662109375" RT="10006.3346" >
+			<PeptideHit score="0.906747837131065" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="32.6"/>
 				<UserParam type="float" name="E-Value" value="0.0071"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.906747837131065"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952178955078" RT="10006.9708" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952178955078" RT="10006.9708" >
+			<PeptideHit score="0.999999151466588" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.8"/>
 				<UserParam type="float" name="E-Value" value="2.6e-09"/>
 				<UserParam type="float" name="nextscore" value="19.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999151466588"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.408813476563" RT="10026.1521" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.408813476563" RT="10026.1521" >
+			<PeptideHit score="0.999933683228512" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.4"/>
 				<UserParam type="float" name="E-Value" value="7.2e-07"/>
 				<UserParam type="float" name="nextscore" value="20.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999933683228512"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866027832031" RT="10097.8358" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866027832031" RT="10097.8358" >
+			<PeptideHit score="0.933818296789238" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.2"/>
 				<UserParam type="float" name="E-Value" value="0.0046"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.933818296789238"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952392578125" RT="10098.3343" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952392578125" RT="10098.3343" >
+			<PeptideHit score="0.999375797281708" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.1"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952514648438" RT="10099.6339" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952514648438" RT="10099.6339" >
+			<PeptideHit score="0.997371865907272" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="8.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997371865907272"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="493.639282226563" RT="10137.6489" >
-			<PeptideHit score="0.00134408602150538" sequence="HGATVLTALGGILKK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="493.639282226563" RT="10137.6489" >
+			<PeptideHit score="0.771058061136823" sequence="HGATVLTALGGILKK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.6"/>
 				<UserParam type="float" name="E-Value" value="0.024"/>
 				<UserParam type="float" name="nextscore" value="9.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.771058061136823"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.408874511719" RT="10146.1742" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.408874511719" RT="10146.1742" >
+			<PeptideHit score="0.996259978029628" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38.4"/>
 				<UserParam type="float" name="E-Value" value="0.00013"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996259978029628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951843261719" RT="10192.6241" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951843261719" RT="10192.6241" >
+			<PeptideHit score="0.999847979667845" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.3"/>
 				<UserParam type="float" name="E-Value" value="2.1e-06"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999847979667845"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952911376953" RT="10193.914" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952911376953" RT="10193.914" >
+			<PeptideHit score="0.999162532344856" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.6"/>
 				<UserParam type="float" name="E-Value" value="1.9e-05"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999162532344856"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.86669921875" RT="10197.89" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.86669921875" RT="10197.89" >
+			<PeptideHit score="0.812550391896406" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.3"/>
 				<UserParam type="float" name="E-Value" value="0.018"/>
 				<UserParam type="float" name="nextscore" value="8.8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.812550391896406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.865844726563" RT="10201.9416" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.865844726563" RT="10201.9416" >
+			<PeptideHit score="0.98265189056406" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.4"/>
 				<UserParam type="float" name="E-Value" value="0.00088"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.98265189056406"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="493.639923095703" RT="10252.761" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILKK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="493.639923095703" RT="10252.761" >
+			<PeptideHit score="0.967570696734317" sequence="HGATVLTALGGILKK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.2"/>
 				<UserParam type="float" name="E-Value" value="0.0019"/>
 				<UserParam type="float" name="nextscore" value="11.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.967570696734317"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="764.408935546875" RT="10260.1498" >
-			<PeptideHit score="0" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="764.408935546875" RT="10260.1498" >
+			<PeptideHit score="0.999946936748021" sequence="NVIQISNDLENLR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.9"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="846.744445800781" RT="10297.0524" >
-			<PeptideHit score="0" sequence="LIQFHFHWGSLDGQGSEHTVDK" charge="3" aa_before="R" aa_after="K" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="846.744445800781" RT="10297.0524" >
+			<PeptideHit score="0.999957135954253" sequence="LIQFHFHWGSLDGQGSEHTVDK" charge="3" aa_before="R" aa_after="K" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="4.1e-07"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999957135954253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="10297.9818" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="10297.9818" >
+			<PeptideHit score="0.998746131332642" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.8"/>
 				<UserParam type="float" name="E-Value" value="3.2e-05"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998746131332642"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952941894531" RT="10368.2199" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952941894531" RT="10368.2199" >
+			<PeptideHit score="0.999749532301869" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49"/>
 				<UserParam type="float" name="E-Value" value="4e-06"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999749532301869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="453.938171386719" RT="10389.8785" >
-			<PeptideHit score="0.00526315789473684" sequence="GLFIIDDKGILR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="453.938171386719" RT="10389.8785" >
+			<PeptideHit score="0.487163428094098" sequence="GLFIIDDKGILR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.2"/>
 				<UserParam type="float" name="E-Value" value="0.1"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.487163428094098"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952880859375" RT="10390.3099" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952880859375" RT="10390.3099" >
+			<PeptideHit score="0.998174212639616" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="5.2e-05"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998174212639616"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="453.937835693359" RT="10392.1662" >
-			<PeptideHit score="0" sequence="GLFIIDDKGILR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="453.937835693359" RT="10392.1662" >
+			<PeptideHit score="0.995160070637582" sequence="GLFIIDDKGILR" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.1"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="680.402526855469" RT="10396.0063" >
-			<PeptideHit score="0" sequence="GLFIIDDKGILR" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="680.402526855469" RT="10396.0063" >
+			<PeptideHit score="0.999999703356172" sequence="GLFIIDDKGILR" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_73 PH_78" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="56.2"/>
 				<UserParam type="float" name="E-Value" value="6.7e-10"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999703356172"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="835.448181152344" RT="10408.5453" >
-			<PeptideHit score="0" sequence="VLGAFSDGLAHLDNLK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="835.448181152344" RT="10408.5453" >
+			<PeptideHit score="0.999999883776959" sequence="VLGAFSDGLAHLDNLK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_19 PH_69" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="63.7"/>
 				<UserParam type="float" name="E-Value" value="2e-10"/>
 				<UserParam type="float" name="nextscore" value="17"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999883776959"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866943359375" RT="10466.1475" >
-			<PeptideHit score="0.00134408602150538" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866943359375" RT="10466.1475" >
+			<PeptideHit score="0.717819888667725" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.4"/>
 				<UserParam type="float" name="E-Value" value="0.033"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.717819888667725"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831481933594" RT="10478.977" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831481933594" RT="10478.977" >
+			<PeptideHit score="0.960802305355011" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.7"/>
 				<UserParam type="float" name="E-Value" value="0.0024"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.960802305355011"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="381.557189941406" RT="10484.3266" >
-			<PeptideHit score="0.0434782608695652" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="381.557189941406" RT="10484.3266" >
+			<PeptideHit score="0.111148168009872" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.5"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951934814453" RT="10488.2903" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951934814453" RT="10488.2903" >
+			<PeptideHit score="0.999622160834219" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="6.8e-06"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999622160834219"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821960449219" RT="10558.6428" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821960449219" RT="10558.6428" >
+			<PeptideHit score="0.999990085933915" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.7"/>
 				<UserParam type="float" name="E-Value" value="6.2e-08"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999990085933915"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831237792969" RT="10570.3483" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831237792969" RT="10570.3483" >
+			<PeptideHit score="0.999998440846017" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.5"/>
 				<UserParam type="float" name="E-Value" value="5.7e-09"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998440846017"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832458496094" RT="10572.1407" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832458496094" RT="10572.1407" >
+			<PeptideHit score="0.999946936748021" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.6"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="381.557678222656" RT="10576.8814" >
-			<PeptideHit score="0.0363636363636364" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="381.557678222656" RT="10576.8814" >
+			<PeptideHit score="0.166398718169042" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19"/>
 				<UserParam type="float" name="E-Value" value="0.58"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.166398718169042"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="10581.1537" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="10581.1537" >
+			<PeptideHit score="0.999095046374717" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.7"/>
 				<UserParam type="float" name="E-Value" value="2.1e-05"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999095046374717"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952392578125" RT="10594.3958" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952392578125" RT="10594.3958" >
+			<PeptideHit score="0.979203874797132" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.8"/>
 				<UserParam type="float" name="E-Value" value="0.0011"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.979203874797132"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821166992188" RT="10633.0791" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821166992188" RT="10633.0791" >
+			<PeptideHit score="0.99999997056655" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.4"/>
 				<UserParam type="float" name="E-Value" value="3.4e-11"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999997056655"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.82177734375" RT="10634.8285" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.82177734375" RT="10634.8285" >
+			<PeptideHit score="0.999999969233292" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="62.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-11"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999969233292"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832885742188" RT="10642.3779" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832885742188" RT="10642.3779" >
+			<PeptideHit score="0.999996871332784" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.9"/>
 				<UserParam type="float" name="E-Value" value="1.4e-08"/>
 				<UserParam type="float" name="nextscore" value="19.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996871332784"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.83251953125" RT="10644.0808" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.83251953125" RT="10644.0808" >
+			<PeptideHit score="0.999998031549755" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58"/>
 				<UserParam type="float" name="E-Value" value="7.7e-09"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998031549755"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="945.429443359375" RT="10694.4256" >
-			<PeptideHit score="0" sequence="SSPDPTSTLSNTVSYERSTDGSFQDR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_40" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="945.429443359375" RT="10694.4256" >
+			<PeptideHit score="0.937288968996664" sequence="SSPDPTSTLSNTVSYERSTDGSFQDR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_40" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.5"/>
 				<UserParam type="float" name="E-Value" value="0.0043"/>
 				<UserParam type="float" name="nextscore" value="14.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.937288968996664"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.8212890625" RT="10720.912" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.8212890625" RT="10720.912" >
+			<PeptideHit score="0.999999666262621" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.6"/>
 				<UserParam type="float" name="E-Value" value="7.8e-10"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999666262621"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821655273438" RT="10722.6374" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821655273438" RT="10722.6374" >
+			<PeptideHit score="0.999996871332784" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.8"/>
 				<UserParam type="float" name="E-Value" value="1.4e-08"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996871332784"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832092285156" RT="10735.0964" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832092285156" RT="10735.0964" >
+			<PeptideHit score="0.996958329726846" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.8"/>
 				<UserParam type="float" name="E-Value" value="0.0001"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996958329726846"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="381.557098388672" RT="10762.5068" >
-			<PeptideHit score="0.0363636363636364" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="381.557098388672" RT="10762.5068" >
+			<PeptideHit score="0.170684806755907" sequence="DLLHVLAFSK" charge="3" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.6"/>
 				<UserParam type="float" name="E-Value" value="0.56"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.170684806755907"/>
+				<UserParam type="float" name="q-value" value="0.0363636363636364"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="599.815551757813" RT="10764.8166" >
-			<PeptideHit score="0" sequence="YWGVASFLQK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_22" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="599.815551757813" RT="10764.8166" >
+			<PeptideHit score="0.999413322128202" sequence="YWGVASFLQK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_22" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.5"/>
 				<UserParam type="float" name="E-Value" value="1.2e-05"/>
 				<UserParam type="float" name="nextscore" value="11.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999413322128202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820922851563" RT="10813.58" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820922851563" RT="10813.58" >
+			<PeptideHit score="0.999994351943102" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.3"/>
 				<UserParam type="float" name="E-Value" value="3e-08"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999994351943102"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821594238281" RT="10815.3625" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821594238281" RT="10815.3625" >
+			<PeptideHit score="0.99999280475604" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.8"/>
 				<UserParam type="float" name="E-Value" value="4.1e-08"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999280475604"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952667236328" RT="10819.8723" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952667236328" RT="10819.8723" >
+			<PeptideHit score="0.999977353129764" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.6"/>
 				<UserParam type="float" name="E-Value" value="1.8e-07"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999977353129764"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831237792969" RT="10830.1527" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831237792969" RT="10830.1527" >
+			<PeptideHit score="0.994116771387973" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="0.00023"/>
 				<UserParam type="float" name="nextscore" value="22.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994116771387973"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="754.403869628906" RT="10830.7796" >
-			<PeptideHit score="0" sequence="LSVEALNSLTGEFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="754.403869628906" RT="10830.7796" >
+			<PeptideHit score="0.999999921775042" sequence="LSVEALNSLTGEFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58"/>
 				<UserParam type="float" name="E-Value" value="1.2e-10"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999921775042"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="546.9580078125" RT="10838.39" >
-			<PeptideHit score="0.0102432778489117" sequence="SLNNQFASFIDKVR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="546.9580078125" RT="10838.39" >
+			<PeptideHit score="0.328807035189251" sequence="SLNNQFASFIDKVR" charge="3" aa_before="K" aa_after="F" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.7"/>
 				<UserParam type="float" name="E-Value" value="0.21"/>
 				<UserParam type="float" name="nextscore" value="17.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.328807035189251"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="762.0625" RT="10845.8772" >
-			<PeptideHit score="0.00651890482398957" sequence="ASELHQRDVLLTELSNCTVR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_83" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="762.0625" RT="10845.8772" >
+			<PeptideHit score="0.412959460251658" sequence="ASELHQRDVLLTELSNCTVR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_83" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.1"/>
 				<UserParam type="float" name="E-Value" value="0.14"/>
 				<UserParam type="float" name="nextscore" value="18.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.412959460251658"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="548.610656738281" RT="10878.8077" >
-			<PeptideHit score="0.00134408602150538" sequence="SFLVWVNEEDHLR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_29" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="548.610656738281" RT="10878.8077" >
+			<PeptideHit score="0.637783228316437" sequence="SFLVWVNEEDHLR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_29" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.3"/>
 				<UserParam type="float" name="E-Value" value="0.05"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.637783228316437"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820068359375" RT="10906.5965" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820068359375" RT="10906.5965" >
+			<PeptideHit score="0.999990965036209" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.6"/>
 				<UserParam type="float" name="E-Value" value="5.5e-08"/>
 				<UserParam type="float" name="nextscore" value="11.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999990965036209"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821350097656" RT="10908.3694" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821350097656" RT="10908.3694" >
+			<PeptideHit score="0.999921163166508" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.8"/>
 				<UserParam type="float" name="E-Value" value="9e-07"/>
 				<UserParam type="float" name="nextscore" value="9.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999921163166508"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832092285156" RT="10928.734" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832092285156" RT="10928.734" >
+			<PeptideHit score="0.999688506246991" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.9"/>
 				<UserParam type="float" name="E-Value" value="5.3e-06"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999688506246991"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.83154296875" RT="10932.7183" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.83154296875" RT="10932.7183" >
+			<PeptideHit score="0.994321746497951" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.2"/>
 				<UserParam type="float" name="E-Value" value="0.00022"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994321746497951"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="625.821899414063" RT="10935.2857" >
-			<PeptideHit score="0.0342298288508557" sequence="MLQDTVLAAGCK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_137" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="625.821899414063" RT="10935.2857" >
+			<PeptideHit score="0.182566859658893" sequence="MLQDTVLAAGCK" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_137" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20"/>
 				<UserParam type="float" name="E-Value" value="0.51"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.182566859658893"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="639.02734375" RT="10936.4735" >
-			<PeptideHit score="0.00134408602150538" sequence="TFVNITPAEVGVLVGKDR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_31" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="639.02734375" RT="10936.4735" >
+			<PeptideHit score="0.723290649933401" sequence="TFVNITPAEVGVLVGKDR" charge="3" aa_before="K" aa_after="S" protein_refs="PH_31" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.2"/>
 				<UserParam type="float" name="E-Value" value="0.032"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.723290649933401"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="758.906494140625" RT="10956.2658" >
-			<PeptideHit score="0.0434782608695652" sequence="ELMQLEKELVER" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_109" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="758.906494140625" RT="10956.2658" >
+			<PeptideHit score="0.111148168009872" sequence="ELMQLEKELVER" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_109" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.4"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="23.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821899414063" RT="11000.4961" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821899414063" RT="11000.4961" >
+			<PeptideHit score="0.999997589533166" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.5"/>
 				<UserParam type="float" name="E-Value" value="1e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997589533166"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820922851563" RT="11002.8139" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820922851563" RT="11002.8139" >
+			<PeptideHit score="0.999995403129308" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.5"/>
 				<UserParam type="float" name="E-Value" value="2.3e-08"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995403129308"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831665039063" RT="11026.5059" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831665039063" RT="11026.5059" >
+			<PeptideHit score="0.983780616446989" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.7"/>
 				<UserParam type="float" name="E-Value" value="0.00081"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.983780616446989"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="11039.2794" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="11039.2794" >
+			<PeptideHit score="0.988671489432927" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.1"/>
 				<UserParam type="float" name="E-Value" value="0.00052"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.988671489432927"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="851.456176757813" RT="11063.2" >
-			<PeptideHit score="0" sequence="AVFVDLEPTVIDEVR" charge="2" aa_before="R" aa_after="T" protein_refs="PH_68 PH_97 PH_127" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="851.456176757813" RT="11063.2" >
+			<PeptideHit score="0.999991349393745" sequence="AVFVDLEPTVIDEVR" charge="2" aa_before="R" aa_after="T" protein_refs="PH_68 PH_97 PH_127" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.9"/>
 				<UserParam type="float" name="E-Value" value="5.2e-08"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999991349393745"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821838378906" RT="11094.4943" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821838378906" RT="11094.4943" >
+			<PeptideHit score="0.999996530182202" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.4"/>
 				<UserParam type="float" name="E-Value" value="1.6e-08"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996530182202"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821228027344" RT="11096.1463" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821228027344" RT="11096.1463" >
+			<PeptideHit score="0.999993355049058" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.4"/>
 				<UserParam type="float" name="E-Value" value="3.7e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993355049058"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370910644531" RT="11104.6555" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370910644531" RT="11104.6555" >
+			<PeptideHit score="0.980910367654004" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.3"/>
 				<UserParam type="float" name="E-Value" value="0.00099"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.980910367654004"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369934082031" RT="11106.4405" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369934082031" RT="11106.4405" >
+			<PeptideHit score="0.995374869594322" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.4"/>
 				<UserParam type="float" name="E-Value" value="0.00017"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995374869594322"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1023.05206298828" RT="11114.6575" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1023.05206298828" RT="11114.6575" >
+			<PeptideHit score="0.999996035830139" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.1"/>
 				<UserParam type="float" name="E-Value" value="1.9e-08"/>
 				<UserParam type="float" name="nextscore" value="11.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996035830139"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.83251953125" RT="11118.0506" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.83251953125" RT="11118.0506" >
+			<PeptideHit score="0.998423979561058" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47"/>
 				<UserParam type="float" name="E-Value" value="4.3e-05"/>
 				<UserParam type="float" name="nextscore" value="15.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998423979561058"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="695.019165039063" RT="11121.5798" >
-			<PeptideHit score="0.0259259259259259" sequence="DYGTGLSAGPGTSRPASYVVK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_4" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="695.019165039063" RT="11121.5798" >
+			<PeptideHit score="0.209402044145386" sequence="DYGTGLSAGPGTSRPASYVVK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_4" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.4"/>
 				<UserParam type="float" name="E-Value" value="0.42"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.209402044145386"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="517.636291503906" RT="11129.829" >
-			<PeptideHit score="0.0434782608695652" sequence="YVIGIGVGAGAYVLAK" charge="3" aa_before="K" aa_after="F" protein_refs="PH_141" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="517.636291503906" RT="11129.829" >
+			<PeptideHit score="0.111148168009872" sequence="YVIGIGVGAGAYVLAK" charge="3" aa_before="K" aa_after="F" protein_refs="PH_141" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="18.4"/>
 				<UserParam type="float" name="E-Value" value="1"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.111148168009872"/>
+				<UserParam type="float" name="q-value" value="0.0434782608695652"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.941711425781" RT="11147.4383" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.941711425781" RT="11147.4383" >
+			<PeptideHit score="0.999955524143958" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.7"/>
 				<UserParam type="float" name="E-Value" value="4.3e-07"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999955524143958"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.37060546875" RT="11155.3576" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.37060546875" RT="11155.3576" >
+			<PeptideHit score="0.999991608400688" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60"/>
 				<UserParam type="float" name="E-Value" value="5e-08"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999991608400688"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.909118652344" RT="11155.6377" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="675.909118652344" RT="11155.6377" >
+			<PeptideHit score="0.999999812773505" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.2"/>
 				<UserParam type="float" name="E-Value" value="3.7e-10"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999812773505"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="11157.1155" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="11157.1155" >
+			<PeptideHit score="0.999997223667326" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.6"/>
 				<UserParam type="float" name="E-Value" value="1.2e-08"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997223667326"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.909118652344" RT="11159.1848" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="675.909118652344" RT="11159.1848" >
+			<PeptideHit score="0.999999988776952" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.3"/>
 				<UserParam type="float" name="E-Value" value="9.8e-12"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999988776952"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1023.05230712891" RT="11165.0249" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1023.05230712891" RT="11165.0249" >
+			<PeptideHit score="0.999999417569271" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61"/>
 				<UserParam type="float" name="E-Value" value="1.6e-09"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999417569271"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="1023.05126953125" RT="11166.6494" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="1023.05126953125" RT="11166.6494" >
+			<PeptideHit score="0.999990085933915" sequence="VFDEFKPLVEEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.3"/>
 				<UserParam type="float" name="E-Value" value="6.2e-08"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999990085933915"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831298828125" RT="11167.3857" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831298828125" RT="11167.3857" >
+			<PeptideHit score="0.991576891487535" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.4"/>
 				<UserParam type="float" name="E-Value" value="0.00036"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.991576891487535"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.942047119141" RT="11172.1491" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.942047119141" RT="11172.1491" >
+			<PeptideHit score="0.999999991933441" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="62.3"/>
 				<UserParam type="float" name="E-Value" value="6.4e-12"/>
 				<UserParam type="float" name="nextscore" value="15.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999991933441"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="450.941925048828" RT="11175.0736" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="450.941925048828" RT="11175.0736" >
+			<PeptideHit score="0.999993635170618" sequence="HGATVLTALGGILK" charge="3" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.6"/>
 				<UserParam type="float" name="E-Value" value="3.5e-08"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993635170618"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="11181.0511" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="11181.0511" >
+			<PeptideHit score="0.99999994231739" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="68.8"/>
 				<UserParam type="float" name="E-Value" value="8.1e-11"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999994231739"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.909484863281" RT="11182.8302" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="675.909484863281" RT="11182.8302" >
+			<PeptideHit score="0.999999926876528" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="60.4"/>
 				<UserParam type="float" name="E-Value" value="1.1e-10"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999926876528"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.908996582031" RT="11184.5948" >
-			<PeptideHit score="0" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="675.908996582031" RT="11184.5948" >
+			<PeptideHit score="0.99999998931328" sequence="HGATVLTALGGILK" charge="2" aa_before="K" aa_after="K" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="64.2"/>
 				<UserParam type="float" name="E-Value" value="9.2e-12"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999998931328"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="995.47119140625" RT="11185.6931" >
-			<PeptideHit score="0" sequence="FFDSFGNLSSASAIMGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="995.47119140625" RT="11185.6931" >
+			<PeptideHit score="0.999999999893731" sequence="FFDSFGNLSSASAIMGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="78"/>
 				<UserParam type="float" name="E-Value" value="2.4e-14"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999999893731"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821228027344" RT="11251.4589" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821228027344" RT="11251.4589" >
+			<PeptideHit score="0.999986425241788" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55"/>
 				<UserParam type="float" name="E-Value" value="9.3e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999986425241788"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820434570313" RT="11253.2345" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820434570313" RT="11253.2345" >
+			<PeptideHit score="0.99998722407621" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54"/>
 				<UserParam type="float" name="E-Value" value="8.6e-08"/>
 				<UserParam type="float" name="nextscore" value="11.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998722407621"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370849609375" RT="11272.7042" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370849609375" RT="11272.7042" >
+			<PeptideHit score="0.999999836765708" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="68.3"/>
 				<UserParam type="float" name="E-Value" value="3.1e-10"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999836765708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.3701171875" RT="11274.4743" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.3701171875" RT="11274.4743" >
+			<PeptideHit score="0.999999990690331" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="74.4"/>
 				<UserParam type="float" name="E-Value" value="7.7e-12"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999990690331"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.829895019531" RT="11332.9605" >
-			<PeptideHit score="0.0259259259259259" sequence="DLKPTSIAAAR" charge="2" aa_before="K" aa_after="M" protein_refs="PH_74" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.829895019531" RT="11332.9605" >
+			<PeptideHit score="0.209402044145386" sequence="DLKPTSIAAAR" charge="2" aa_before="K" aa_after="M" protein_refs="PH_74" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22.2"/>
 				<UserParam type="float" name="E-Value" value="0.42"/>
 				<UserParam type="float" name="nextscore" value="21.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.209402044145386"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820495605469" RT="11346.574" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820495605469" RT="11346.574" >
+			<PeptideHit score="0.999951566095295" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54"/>
 				<UserParam type="float" name="E-Value" value="4.8e-07"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999951566095295"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952117919922" RT="11348.3681" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952117919922" RT="11348.3681" >
+			<PeptideHit score="0.996488921991653" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.2"/>
 				<UserParam type="float" name="E-Value" value="0.00012"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996488921991653"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370910644531" RT="11366.1036" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370910644531" RT="11366.1036" >
+			<PeptideHit score="0.999999902235584" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="67.1"/>
 				<UserParam type="float" name="E-Value" value="1.6e-10"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999902235584"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370300292969" RT="11367.8875" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370300292969" RT="11367.8875" >
+			<PeptideHit score="0.999999984390352" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="72.2"/>
 				<UserParam type="float" name="E-Value" value="1.5e-11"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999984390352"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847045898438" RT="11403.308" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847045898438" RT="11403.308" >
+			<PeptideHit score="0.99998453888027" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.6"/>
 				<UserParam type="float" name="E-Value" value="1.1e-07"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99998453888027"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.8466796875" RT="11405.1473" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.8466796875" RT="11405.1473" >
+			<PeptideHit score="0.999779168898944" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.5"/>
 				<UserParam type="float" name="E-Value" value="3.4e-06"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999779168898944"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820678710938" RT="11431.2577" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820678710938" RT="11431.2577" >
+			<PeptideHit score="0.999998483417254" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.8"/>
 				<UserParam type="float" name="E-Value" value="5.5e-09"/>
 				<UserParam type="float" name="nextscore" value="12.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998483417254"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832885742188" RT="11456.7483" >
-			<PeptideHit score="0" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832885742188" RT="11456.7483" >
+			<PeptideHit score="0.922621924276223" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28.6"/>
 				<UserParam type="float" name="E-Value" value="0.0056"/>
 				<UserParam type="float" name="nextscore" value="16.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.922621924276223"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.84716796875" RT="11495.2914" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.84716796875" RT="11495.2914" >
+			<PeptideHit score="0.999998955356525" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58"/>
 				<UserParam type="float" name="E-Value" value="3.4e-09"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998955356525"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847106933594" RT="11496.9184" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847106933594" RT="11496.9184" >
+			<PeptideHit score="0.999999964690663" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66"/>
 				<UserParam type="float" name="E-Value" value="4.3e-11"/>
 				<UserParam type="float" name="nextscore" value="17.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999964690663"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820068359375" RT="11523.7577" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820068359375" RT="11523.7577" >
+			<PeptideHit score="0.999764215082746" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.6"/>
 				<UserParam type="float" name="E-Value" value="3.7e-06"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999764215082746"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821411132813" RT="11525.5315" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821411132813" RT="11525.5315" >
+			<PeptideHit score="0.999993078314779" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52"/>
 				<UserParam type="float" name="E-Value" value="3.9e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993078314779"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="999.500915527344" RT="11526.1693" >
-			<PeptideHit score="0" sequence="FFDSFGNLSSPSAILGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_20" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="999.500915527344" RT="11526.1693" >
+			<PeptideHit score="0.999998356693945" sequence="FFDSFGNLSSPSAILGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_20" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.4"/>
 				<UserParam type="float" name="E-Value" value="6.1e-09"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998356693945"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="999.502075195313" RT="11527.4781" >
-			<PeptideHit score="0" sequence="FFDSFGNLSSPSAILGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_20" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="999.502075195313" RT="11527.4781" >
+			<PeptideHit score="0.999995875058368" sequence="FFDSFGNLSSPSAILGNPK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_20" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.9"/>
 				<UserParam type="float" name="E-Value" value="2e-08"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995875058368"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952941894531" RT="11547.6119" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952941894531" RT="11547.6119" >
+			<PeptideHit score="0.995160070637582" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.2"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="13.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.903503417969" RT="11563.7497" >
-			<PeptideHit score="0" sequence="VDLLNQEIEFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_51" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.903503417969" RT="11563.7497" >
+			<PeptideHit score="0.999999254517236" sequence="VDLLNQEIEFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_51" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.8"/>
 				<UserParam type="float" name="E-Value" value="2.2e-09"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999254517236"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="730.90380859375" RT="11572.1475" >
-			<PeptideHit score="0" sequence="VDLLNQEIEFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_51" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="730.90380859375" RT="11572.1475" >
+			<PeptideHit score="0.999998635280842" sequence="VDLLNQEIEFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_51" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.2"/>
 				<UserParam type="float" name="E-Value" value="4.8e-09"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998635280842"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="694.682922363281" RT="11576.1105" >
-			<PeptideHit score="0" sequence="MDQTLAVYQQILTSMPSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="694.682922363281" RT="11576.1105" >
+			<PeptideHit score="0.940816934477305" sequence="MDQTLAVYQQILTSMPSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.8"/>
 				<UserParam type="float" name="E-Value" value="0.004"/>
 				<UserParam type="float" name="nextscore" value="16.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.940816934477305"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846984863281" RT="11588.8606" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846984863281" RT="11588.8606" >
+			<PeptideHit score="0.999999051936364" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.6"/>
 				<UserParam type="float" name="E-Value" value="3e-09"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999051936364"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847412109375" RT="11590.6018" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847412109375" RT="11590.6018" >
+			<PeptideHit score="0.999994062235367" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.8"/>
 				<UserParam type="float" name="E-Value" value="3.2e-08"/>
 				<UserParam type="float" name="nextscore" value="17.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999994062235367"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820983886719" RT="11617.6404" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820983886719" RT="11617.6404" >
+			<PeptideHit score="0.999970786631432" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54"/>
 				<UserParam type="float" name="E-Value" value="2.5e-07"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999970786631432"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820861816406" RT="11619.4209" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820861816406" RT="11619.4209" >
+			<PeptideHit score="0.999907897771499" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50"/>
 				<UserParam type="float" name="E-Value" value="1.1e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999907897771499"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="940.09423828125" RT="11621.1977" >
-			<PeptideHit score="0.0331695331695332" sequence="TSSSAFEKRPYEPSSNGSSSGEYAHR" charge="3" aa_before="R" aa_after="T" protein_refs="PH_142" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="940.09423828125" RT="11621.1977" >
+			<PeptideHit score="0.187855272905827" sequence="TSSSAFEKRPYEPSSNGSSSGEYAHR" charge="3" aa_before="R" aa_after="T" protein_refs="PH_142" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="22"/>
 				<UserParam type="float" name="E-Value" value="0.49"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.187855272905827"/>
+				<UserParam type="float" name="q-value" value="0.0331695331695332"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.83154296875" RT="11625.3879" >
-			<PeptideHit score="0.0259259259259259" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.83154296875" RT="11625.3879" >
+			<PeptideHit score="0.199527926792731" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.9"/>
 				<UserParam type="float" name="E-Value" value="0.45"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.199527926792731"/>
+				<UserParam type="float" name="q-value" value="0.0259259259259259"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370666503906" RT="11637.9578" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370666503906" RT="11637.9578" >
+			<PeptideHit score="0.999993776575081" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.5"/>
 				<UserParam type="float" name="E-Value" value="3.4e-08"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999993776575081"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846801757813" RT="11682.5972" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846801757813" RT="11682.5972" >
+			<PeptideHit score="0.999999741852381" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="61.6"/>
 				<UserParam type="float" name="E-Value" value="5.6e-10"/>
 				<UserParam type="float" name="nextscore" value="17"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999741852381"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.831665039063" RT="11686.5743" >
-			<PeptideHit score="0.00134408602150538" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.831665039063" RT="11686.5743" >
+			<PeptideHit score="0.734542296491698" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.3"/>
 				<UserParam type="float" name="E-Value" value="0.03"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.734542296491698"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="651.86083984375" RT="11715.5111" >
-			<PeptideHit score="0" sequence="SLDLDSIIAEVK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_26" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="651.86083984375" RT="11715.5111" >
+			<PeptideHit score="0.999999969233292" sequence="SLDLDSIIAEVK" charge="2" aa_before="R" aa_after="A" protein_refs="PH_26" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="66.3"/>
 				<UserParam type="float" name="E-Value" value="3.6e-11"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999969233292"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820495605469" RT="11717.2955" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820495605469" RT="11717.2955" >
+			<PeptideHit score="0.999999861833214" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57.9"/>
 				<UserParam type="float" name="E-Value" value="2.5e-10"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999861833214"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820617675781" RT="11719.0615" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820617675781" RT="11719.0615" >
+			<PeptideHit score="0.999999745432481" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.3"/>
 				<UserParam type="float" name="E-Value" value="5.5e-10"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999745432481"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370056152344" RT="11729.9001" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370056152344" RT="11729.9001" >
+			<PeptideHit score="0.999996035830139" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="55.5"/>
 				<UserParam type="float" name="E-Value" value="1.9e-08"/>
 				<UserParam type="float" name="nextscore" value="17.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999996035830139"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370361328125" RT="11731.6593" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370361328125" RT="11731.6593" >
+			<PeptideHit score="0.999988867709711" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58"/>
 				<UserParam type="float" name="E-Value" value="7.2e-08"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999988867709711"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846618652344" RT="11774.5616" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846618652344" RT="11774.5616" >
+			<PeptideHit score="0.999998356693945" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="52.8"/>
 				<UserParam type="float" name="E-Value" value="6.1e-09"/>
 				<UserParam type="float" name="nextscore" value="9.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999998356693945"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846618652344" RT="11776.3465" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846618652344" RT="11776.3465" >
+			<PeptideHit score="0.999985862936074" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="57"/>
 				<UserParam type="float" name="E-Value" value="9.8e-08"/>
 				<UserParam type="float" name="nextscore" value="19.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999985862936074"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="758.906127929688" RT="11776.9792" >
-			<PeptideHit score="0.0444711538461538" sequence="ELMQLEKELVER" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_109" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="758.906127929688" RT="11776.9792" >
+			<PeptideHit score="0.103478204192389" sequence="ELMQLEKELVER" charge="2" aa_before="R" aa_after="Q" protein_refs="PH_109" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.2"/>
 				<UserParam type="float" name="E-Value" value="1.1"/>
 				<UserParam type="float" name="nextscore" value="22.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.103478204192389"/>
+				<UserParam type="float" name="q-value" value="0.0444711538461538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="506.2724609375" RT="11793.3171" >
-			<PeptideHit score="0" sequence="ELMQLEKELVER" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_109" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="506.2724609375" RT="11793.3171" >
+			<PeptideHit score="0.949295381752261" sequence="ELMQLEKELVER" charge="3" aa_before="R" aa_after="Q" protein_refs="PH_109" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33"/>
 				<UserParam type="float" name="E-Value" value="0.0033"/>
 				<UserParam type="float" name="nextscore" value="19.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.949295381752261"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820495605469" RT="11830.0419" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820495605469" RT="11830.0419" >
+			<PeptideHit score="0.999923892492664" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.1"/>
 				<UserParam type="float" name="E-Value" value="8.6e-07"/>
 				<UserParam type="float" name="nextscore" value="11.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999923892492664"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="808.423400878906" RT="11865.0132" >
-			<PeptideHit score="0" sequence="IGDYVQQHGGVSLVEQLLQDPK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="808.423400878906" RT="11865.0132" >
+			<PeptideHit score="0.999095046374717" sequence="IGDYVQQHGGVSLVEQLLQDPK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.8"/>
 				<UserParam type="float" name="E-Value" value="2.1e-05"/>
 				<UserParam type="float" name="nextscore" value="17.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999095046374717"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="808.424438476563" RT="11873.4521" >
-			<PeptideHit score="0" sequence="IGDYVQQHGGVSLVEQLLQDPK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_39" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="808.424438476563" RT="11873.4521" >
+			<PeptideHit score="0.999986312247327" sequence="IGDYVQQHGGVSLVEQLLQDPK" charge="3" aa_before="R" aa_after="L" protein_refs="PH_39" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.7"/>
 				<UserParam type="float" name="E-Value" value="9.4e-08"/>
 				<UserParam type="float" name="nextscore" value="21.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999986312247327"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846313476563" RT="11881.4266" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846313476563" RT="11881.4266" >
+			<PeptideHit score="0.999338919682092" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45"/>
 				<UserParam type="float" name="E-Value" value="1.4e-05"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999338919682092"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="550.970031738281" RT="11885.4044" >
-			<PeptideHit score="0.0139416983523447" sequence="AEFAEVSKLVTDLTK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="550.970031738281" RT="11885.4044" >
+			<PeptideHit score="0.268778038393828" sequence="AEFAEVSKLVTDLTK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="24.1"/>
 				<UserParam type="float" name="E-Value" value="0.29"/>
 				<UserParam type="float" name="nextscore" value="18"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.268778038393828"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370239257813" RT="11939.8503" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370239257813" RT="11939.8503" >
+			<PeptideHit score="0.999779168898944" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.1"/>
 				<UserParam type="float" name="E-Value" value="3.4e-06"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999779168898944"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846069335938" RT="11979.9218" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846069335938" RT="11979.9218" >
+			<PeptideHit score="0.999992133559993" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.5"/>
 				<UserParam type="float" name="E-Value" value="4.6e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999992133559993"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="726.427856445313" RT="11990.928" >
-			<PeptideHit score="0" sequence="QKVTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="726.427856445313" RT="11990.928" >
+			<PeptideHit score="0.996034376504582" sequence="QKVTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.9"/>
 				<UserParam type="float" name="E-Value" value="0.00014"/>
 				<UserParam type="float" name="nextscore" value="9.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996034376504582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.846496582031" RT="11993.8354" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.846496582031" RT="11993.8354" >
+			<PeptideHit score="0.999946936748021" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.6"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369140625" RT="12030.5414" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369140625" RT="12030.5414" >
+			<PeptideHit score="0.999963773117924" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.9"/>
 				<UserParam type="float" name="E-Value" value="3.3e-07"/>
 				<UserParam type="float" name="nextscore" value="13.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999963773117924"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="12032.5811" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="12032.5811" >
+			<PeptideHit score="0.998746131332642" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.2"/>
 				<UserParam type="float" name="E-Value" value="3.2e-05"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998746131332642"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369750976563" RT="12122.8152" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369750976563" RT="12122.8152" >
+			<PeptideHit score="0.999928040886378" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.5"/>
 				<UserParam type="float" name="E-Value" value="8e-07"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999928040886378"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="12124.4913" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="12124.4913" >
+			<PeptideHit score="0.999999907005607" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.8"/>
 				<UserParam type="float" name="E-Value" value="1.5e-10"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999907005607"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847351074219" RT="12145.8654" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847351074219" RT="12145.8654" >
+			<PeptideHit score="0.999954724592998" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.4"/>
 				<UserParam type="float" name="E-Value" value="4.4e-07"/>
 				<UserParam type="float" name="nextscore" value="11.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999954724592998"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.04296875" RT="12158.1052" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.04296875" RT="12158.1052" >
+			<PeptideHit score="0.903688650931131" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.1"/>
 				<UserParam type="float" name="E-Value" value="0.0074"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.903688650931131"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.043090820313" RT="12159.8759" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.043090820313" RT="12159.8759" >
+			<PeptideHit score="0.97469904242467" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.4"/>
 				<UserParam type="float" name="E-Value" value="0.0014"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97469904242467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="556.941650390625" RT="12209.9494" >
-			<PeptideHit score="0.0342298288508557" sequence="GKYSDDTPLPTPSYK" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_113" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="556.941650390625" RT="12209.9494" >
+			<PeptideHit score="0.180044603065486" sequence="GKYSDDTPLPTPSYK" charge="3" aa_before="R" aa_after="Y" protein_refs="PH_113" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.7"/>
 				<UserParam type="float" name="E-Value" value="0.52"/>
 				<UserParam type="float" name="nextscore" value="18.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.180044603065486"/>
+				<UserParam type="float" name="q-value" value="0.0342298288508557"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370971679688" RT="12219.9087" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370971679688" RT="12219.9087" >
+			<PeptideHit score="0.999997836161518" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="59.6"/>
 				<UserParam type="float" name="E-Value" value="8.7e-09"/>
 				<UserParam type="float" name="nextscore" value="14.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997836161518"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952667236328" RT="12233.479" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952667236328" RT="12233.479" >
+			<PeptideHit score="0.993913437040977" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.2"/>
 				<UserParam type="float" name="E-Value" value="0.00024"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.993913437040977"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.043273925781" RT="12250.79" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.043273925781" RT="12250.79" >
+			<PeptideHit score="0.946835341093983" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.9"/>
 				<UserParam type="float" name="E-Value" value="0.0035"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.946835341093983"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.04345703125" RT="12252.2493" >
-			<PeptideHit score="0.0102432778489117" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.04345703125" RT="12252.2493" >
+			<PeptideHit score="0.348796391782609" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="20.4"/>
 				<UserParam type="float" name="E-Value" value="0.19"/>
 				<UserParam type="float" name="nextscore" value="13"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.348796391782609"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847595214844" RT="12257.8923" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847595214844" RT="12257.8923" >
+			<PeptideHit score="0.999859324618151" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.5"/>
 				<UserParam type="float" name="E-Value" value="1.9e-06"/>
 				<UserParam type="float" name="nextscore" value="14.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999859324618151"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.3701171875" RT="12310.77" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.3701171875" RT="12310.77" >
+			<PeptideHit score="0.999961245837018" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.1"/>
 				<UserParam type="float" name="E-Value" value="3.6e-07"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999961245837018"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.37060546875" RT="12312.2907" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.37060546875" RT="12312.2907" >
+			<PeptideHit score="0.995160070637582" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.5"/>
 				<UserParam type="float" name="E-Value" value="0.00018"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995160070637582"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="966.086853027344" RT="12367.4332" >
-			<PeptideHit score="0" sequence="VTIAQGGVLPNIQAVLLPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_27 PH_32 PH_43 PH_85 PH_93 PH_98 PH_114 PH_120 PH_124 PH_129" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="966.086853027344" RT="12367.4332" >
+			<PeptideHit score="0.999999445986628" sequence="VTIAQGGVLPNIQAVLLPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_27 PH_32 PH_43 PH_85 PH_93 PH_98 PH_114 PH_120 PH_124 PH_129" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="58.4"/>
 				<UserParam type="float" name="E-Value" value="1.5e-09"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999445986628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="966.089477539063" RT="12371.0178" >
-			<PeptideHit score="0" sequence="VTIAQGGVLPNIQAVLLPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_27 PH_32 PH_43 PH_85 PH_93 PH_98 PH_114 PH_120 PH_124 PH_129" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="966.089477539063" RT="12371.0178" >
+			<PeptideHit score="0.999997223667326" sequence="VTIAQGGVLPNIQAVLLPK" charge="2" aa_before="R" aa_after="K" protein_refs="PH_27 PH_32 PH_43 PH_85 PH_93 PH_98 PH_114 PH_120 PH_124 PH_129" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="1.2e-08"/>
 				<UserParam type="float" name="nextscore" value="10"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997223667326"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370788574219" RT="12499.1708" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370788574219" RT="12499.1708" >
+			<PeptideHit score="0.999128598342253" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.6"/>
 				<UserParam type="float" name="E-Value" value="2e-05"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999128598342253"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369140625" RT="12504.8106" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369140625" RT="12504.8106" >
+			<PeptideHit score="0.99999280475604" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="53.4"/>
 				<UserParam type="float" name="E-Value" value="4.1e-08"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99999280475604"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.044311523438" RT="12599.12" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.044311523438" RT="12599.12" >
+			<PeptideHit score="0.954315536242781" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.6"/>
 				<UserParam type="float" name="E-Value" value="0.0029"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.954315536242781"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370483398438" RT="12599.8651" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370483398438" RT="12599.8651" >
+			<PeptideHit score="0.999958765560895" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="47.1"/>
 				<UserParam type="float" name="E-Value" value="3.9e-07"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999958765560895"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="641.043212890625" RT="12601.1792" >
-			<PeptideHit score="0" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="641.043212890625" RT="12601.1792" >
+			<PeptideHit score="0.997030240257234" sequence="VTGLDFIPGLHPILTLSK" charge="3" aa_before="K" aa_after="M" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="34.5"/>
 				<UserParam type="float" name="E-Value" value="9.7e-05"/>
 				<UserParam type="float" name="nextscore" value="12.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997030240257234"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369689941406" RT="12602.738" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369689941406" RT="12602.738" >
+			<PeptideHit score="0.999972614812384" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.8"/>
 				<UserParam type="float" name="E-Value" value="2.3e-07"/>
 				<UserParam type="float" name="nextscore" value="14.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999972614812384"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952697753906" RT="12627.5154" >
-			<PeptideHit score="0.00134408602150538" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952697753906" RT="12627.5154" >
+			<PeptideHit score="0.777594217720977" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.6"/>
 				<UserParam type="float" name="E-Value" value="0.023"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.777594217720977"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="628.02001953125" RT="12653.2417" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMKVGEANPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="628.02001953125" RT="12653.2417" >
+			<PeptideHit score="0.984106302508389" sequence="ADGLAVIGVLMKVGEANPK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.4"/>
 				<UserParam type="float" name="E-Value" value="0.00079"/>
 				<UserParam type="float" name="nextscore" value="17.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.984106302508389"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369873046875" RT="12695.2392" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369873046875" RT="12695.2392" >
+			<PeptideHit score="0.992918683767341" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="0.00029"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992918683767341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.3701171875" RT="12698.8891" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.3701171875" RT="12698.8891" >
+			<PeptideHit score="0.994528455081984" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.8"/>
 				<UserParam type="float" name="E-Value" value="0.00021"/>
 				<UserParam type="float" name="nextscore" value="16.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994528455081984"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="922.138427734375" RT="12766.2569" >
-			<PeptideHit score="0.00134408602150538" sequence="LTYYEPNPLSWGDCVEKIISALPR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_119" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="922.138427734375" RT="12766.2569" >
+			<PeptideHit score="0.520783328476773" sequence="LTYYEPNPLSWGDCVEKIISALPR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_119" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="24.7"/>
 				<UserParam type="float" name="E-Value" value="0.086"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.520783328476773"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="922.138061523438" RT="12774.18" >
-			<PeptideHit score="0.02" sequence="LTYYEPNPLSWGDCVEKIISALPR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_119" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="922.138061523438" RT="12774.18" >
+			<PeptideHit score="0.246856676048891" sequence="LTYYEPNPLSWGDCVEKIISALPR" charge="3" aa_before="R" aa_after="K" protein_refs="PH_119" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="20.7"/>
 				<UserParam type="float" name="E-Value" value="0.33"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.246856676048891"/>
+				<UserParam type="float" name="q-value" value="0.02"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951934814453" RT="13016.0227" >
-			<PeptideHit score="0.00526315789473684" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951934814453" RT="13016.0227" >
+			<PeptideHit score="0.505758287449657" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25"/>
 				<UserParam type="float" name="E-Value" value="0.092"/>
 				<UserParam type="float" name="nextscore" value="15.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.505758287449657"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951873779297" RT="13110.0707" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951873779297" RT="13110.0707" >
+			<PeptideHit score="0.976178644666495" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="33.7"/>
 				<UserParam type="float" name="E-Value" value="0.0013"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.976178644666495"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="589.989929199219" RT="13239.5817" >
-			<PeptideHit score="0.00906735751295337" sequence="(Gln->pyro-Glu)QLAGAMAYLGARGLVHR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_79" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="589.989929199219" RT="13239.5817" >
+			<PeptideHit score="0.384387191798194" sequence="(Gln->pyro-Glu)QLAGAMAYLGARGLVHR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_79" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.4"/>
 				<UserParam type="float" name="E-Value" value="0.16"/>
 				<UserParam type="float" name="nextscore" value="13.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.384387191798194"/>
+				<UserParam type="float" name="q-value" value="0.00906735751295337"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="589.990356445313" RT="13241.3679" >
-			<PeptideHit score="0.029520295202952" sequence="(Gln->pyro-Glu)QLAGAMAYLGARGLVHR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_79" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="589.990356445313" RT="13241.3679" >
+			<PeptideHit score="0.193496525438801" sequence="(Gln->pyro-Glu)QLAGAMAYLGARGLVHR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_79" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.4"/>
 				<UserParam type="float" name="E-Value" value="0.47"/>
 				<UserParam type="float" name="nextscore" value="11"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.193496525438801"/>
+				<UserParam type="float" name="q-value" value="0.029520295202952"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370544433594" RT="13318.4235" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370544433594" RT="13318.4235" >
+			<PeptideHit score="0.999302633161889" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.1"/>
 				<UserParam type="float" name="E-Value" value="1.5e-05"/>
 				<UserParam type="float" name="nextscore" value="14"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999302633161889"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952056884766" RT="13407.5118" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952056884766" RT="13407.5118" >
+			<PeptideHit score="0.951788100541034" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.6"/>
 				<UserParam type="float" name="E-Value" value="0.0031"/>
 				<UserParam type="float" name="nextscore" value="16.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.951788100541034"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="556.993957519531" RT="13451.6427" >
-			<PeptideHit score="0" sequence="AVQQPDGLAVLGIFLK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="556.993957519531" RT="13451.6427" >
+			<PeptideHit score="0.999964626875691" sequence="AVQQPDGLAVLGIFLK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.3"/>
 				<UserParam type="float" name="E-Value" value="3.2e-07"/>
 				<UserParam type="float" name="nextscore" value="16.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999964626875691"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="556.994201660156" RT="13452.9542" >
-			<PeptideHit score="0" sequence="AVQQPDGLAVLGIFLK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="556.994201660156" RT="13452.9542" >
+			<PeptideHit score="0.999375797281708" sequence="AVQQPDGLAVLGIFLK" charge="3" aa_before="K" aa_after="V" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="18.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369995117188" RT="13520.5009" >
-			<PeptideHit score="0.00134408602150538" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369995117188" RT="13520.5009" >
+			<PeptideHit score="0.734542296491698" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="27.9"/>
 				<UserParam type="float" name="E-Value" value="0.03"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.734542296491698"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="834.98876953125" RT="13556.1474" >
-			<PeptideHit score="0" sequence="AVQQPDGLAVLGIFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_14" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="834.98876953125" RT="13556.1474" >
+			<PeptideHit score="0.999999996982134" sequence="AVQQPDGLAVLGIFLK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_14" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="65.5"/>
 				<UserParam type="float" name="E-Value" value="1.8e-12"/>
 				<UserParam type="float" name="nextscore" value="14.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999999996982134"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369873046875" RT="13616.3295" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369873046875" RT="13616.3295" >
+			<PeptideHit score="0.998900658395066" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.9"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="13.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="504.742309570313" RT="13643.9999" >
-			<PeptideHit score="0.0489844683393071" sequence="AAGSMSSLER" charge="2" aa_before="R" aa_after="E" protein_refs="PH_121" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="504.742309570313" RT="13643.9999" >
+			<PeptideHit score="0.0969386199829794" sequence="AAGSMSSLER" charge="2" aa_before="R" aa_after="E" protein_refs="PH_121" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="16.2"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952484130859" RT="13691.2799" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952484130859" RT="13691.2799" >
+			<PeptideHit score="0.998838128770909" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.2"/>
 				<UserParam type="float" name="E-Value" value="2.9e-05"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998838128770909"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369567871094" RT="13939.6" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369567871094" RT="13939.6" >
+			<PeptideHit score="0.953047340351405" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.2"/>
 				<UserParam type="float" name="E-Value" value="0.003"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.953047340351405"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370483398438" RT="13972.8499" >
-			<PeptideHit score="0.00526315789473684" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370483398438" RT="13972.8499" >
+			<PeptideHit score="0.465947082204611" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="25.9"/>
 				<UserParam type="float" name="E-Value" value="0.11"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.465947082204611"/>
+				<UserParam type="float" name="q-value" value="0.00526315789473684"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.95263671875" RT="14083.9204" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.95263671875" RT="14083.9204" >
+			<PeptideHit score="0.995811820230489" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.8"/>
 				<UserParam type="float" name="E-Value" value="0.00015"/>
 				<UserParam type="float" name="nextscore" value="19"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.995811820230489"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953216552734" RT="14186.9672" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953216552734" RT="14186.9672" >
+			<PeptideHit score="0.949295381752261" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.6"/>
 				<UserParam type="float" name="E-Value" value="0.0033"/>
 				<UserParam type="float" name="nextscore" value="12.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.949295381752261"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370422363281" RT="14220.2283" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370422363281" RT="14220.2283" >
+			<PeptideHit score="0.996488921991653" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="38"/>
 				<UserParam type="float" name="E-Value" value="0.00012"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996488921991653"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952911376953" RT="14315.9501" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952911376953" RT="14315.9501" >
+			<PeptideHit score="0.996721562845727" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.1"/>
 				<UserParam type="float" name="E-Value" value="0.00011"/>
 				<UserParam type="float" name="nextscore" value="16.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996721562845727"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.372253417969" RT="14447.5702" >
-			<PeptideHit score="0.0489844683393071" sequence="LNQESTAPKVLFTGVVDAR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_82" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.372253417969" RT="14447.5702" >
+			<PeptideHit score="0.0969386199829794" sequence="LNQESTAPKVLFTGVVDAR" charge="3" aa_before="K" aa_after="G" protein_refs="PH_82" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.2"/>
 				<UserParam type="float" name="E-Value" value="1.2"/>
 				<UserParam type="float" name="nextscore" value="12.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.0969386199829794"/>
+				<UserParam type="float" name="q-value" value="0.0489844683393071"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370422363281" RT="14719.5142" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370422363281" RT="14719.5142" >
+			<PeptideHit score="0.990100202387883" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="35.4"/>
 				<UserParam type="float" name="E-Value" value="0.00044"/>
 				<UserParam type="float" name="nextscore" value="15.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.990100202387883"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952972412109" RT="14721.1148" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952972412109" RT="14721.1148" >
+			<PeptideHit score="0.970372889310467" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.9"/>
 				<UserParam type="float" name="E-Value" value="0.0017"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.970372889310467"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.372131347656" RT="14875.4339" >
-			<PeptideHit score="0.0211970074812968" sequence="VFSVNVGVLPTGDTTVVQGR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_136" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.372131347656" RT="14875.4339" >
+			<PeptideHit score="0.228519335906576" sequence="VFSVNVGVLPTGDTTVVQGR" charge="3" aa_before="K" aa_after="I" protein_refs="PH_136" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="float" name="XTandem_score" value="23.3"/>
 				<UserParam type="float" name="E-Value" value="0.37"/>
 				<UserParam type="float" name="nextscore" value="15"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.228519335906576"/>
+				<UserParam type="float" name="q-value" value="0.0211970074812968"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370178222656" RT="15290.849" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370178222656" RT="15290.849" >
+			<PeptideHit score="0.994947495670415" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.7"/>
 				<UserParam type="float" name="E-Value" value="0.00019"/>
 				<UserParam type="float" name="nextscore" value="13.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.994947495670415"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369689941406" RT="15300.3902" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369689941406" RT="15300.3902" >
+			<PeptideHit score="0.903688650931131" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.9"/>
 				<UserParam type="float" name="E-Value" value="0.0074"/>
 				<UserParam type="float" name="nextscore" value="17.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.903688650931131"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952819824219" RT="15342.89" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952819824219" RT="15342.89" >
+			<PeptideHit score="0.99951844176704" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.8"/>
 				<UserParam type="float" name="E-Value" value="9.3e-06"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99951844176704"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952758789063" RT="15360.3901" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952758789063" RT="15360.3901" >
+			<PeptideHit score="0.999967225273061" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.2"/>
 				<UserParam type="float" name="E-Value" value="2.9e-07"/>
 				<UserParam type="float" name="nextscore" value="16.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999967225273061"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820556640625" RT="15394.85" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820556640625" RT="15394.85" >
+			<PeptideHit score="0.99989516753533" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="42.6"/>
 				<UserParam type="float" name="E-Value" value="1.3e-06"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99989516753533"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821166992188" RT="15413.6197" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821166992188" RT="15413.6197" >
+			<PeptideHit score="0.999579785920331" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.3"/>
 				<UserParam type="float" name="E-Value" value="7.8e-06"/>
 				<UserParam type="float" name="nextscore" value="12.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999579785920331"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370910644531" RT="15429.8295" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370910644531" RT="15429.8295" >
+			<PeptideHit score="0.99331247569031" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.4"/>
 				<UserParam type="float" name="E-Value" value="0.00027"/>
 				<UserParam type="float" name="nextscore" value="14.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.99331247569031"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952911376953" RT="15462.4923" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952911376953" RT="15462.4923" >
+			<PeptideHit score="0.910883820050366" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.3"/>
 				<UserParam type="float" name="E-Value" value="0.0067"/>
 				<UserParam type="float" name="nextscore" value="9.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.910883820050366"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821899414063" RT="15510.8384" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821899414063" RT="15510.8384" >
+			<PeptideHit score="0.999995248967135" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="50.2"/>
 				<UserParam type="float" name="E-Value" value="2.4e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999995248967135"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.3701171875" RT="15556.6064" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.3701171875" RT="15556.6064" >
+			<PeptideHit score="0.886985857691212" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29.6"/>
 				<UserParam type="float" name="E-Value" value="0.0091"/>
 				<UserParam type="float" name="nextscore" value="13.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.886985857691212"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952362060547" RT="15558.281" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952362060547" RT="15558.281" >
+			<PeptideHit score="0.998685890644916" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43.1"/>
 				<UserParam type="float" name="E-Value" value="3.4e-05"/>
 				<UserParam type="float" name="nextscore" value="16"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998685890644916"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="637.866027832031" RT="15650.3902" >
-			<PeptideHit score="0" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="637.866027832031" RT="15650.3902" >
+			<PeptideHit score="0.820048379204749" sequence="LLVVYPWTQR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_19 PH_20 PH_69 PH_70 PH_71" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="28"/>
 				<UserParam type="float" name="E-Value" value="0.017"/>
 				<UserParam type="float" name="nextscore" value="10.4"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.820048379204749"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820251464844" RT="15651.9001" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820251464844" RT="15651.9001" >
+			<PeptideHit score="0.999986994393307" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="48.4"/>
 				<UserParam type="float" name="E-Value" value="8.8e-08"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999986994393307"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.953094482422" RT="15694.6148" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.953094482422" RT="15694.6148" >
+			<PeptideHit score="0.999266889838404" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.9"/>
 				<UserParam type="float" name="E-Value" value="1.6e-05"/>
 				<UserParam type="float" name="nextscore" value="13.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999266889838404"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821960449219" RT="15787.434" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821960449219" RT="15787.434" >
+			<PeptideHit score="0.999997045974291" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="54.2"/>
 				<UserParam type="float" name="E-Value" value="1.3e-08"/>
 				<UserParam type="float" name="nextscore" value="10.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999997045974291"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370178222656" RT="15803.28" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370178222656" RT="15803.28" >
+			<PeptideHit score="0.999661517151359" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="45.6"/>
 				<UserParam type="float" name="E-Value" value="5.9e-06"/>
 				<UserParam type="float" name="nextscore" value="14.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999661517151359"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370910644531" RT="15806.2892" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370910644531" RT="15806.2892" >
+			<PeptideHit score="0.996259978029628" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="36.9"/>
 				<UserParam type="float" name="E-Value" value="0.00013"/>
 				<UserParam type="float" name="nextscore" value="15.3"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.996259978029628"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370849609375" RT="15898.1901" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370849609375" RT="15898.1901" >
+			<PeptideHit score="0.918288520543892" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="31.2"/>
 				<UserParam type="float" name="E-Value" value="0.006"/>
 				<UserParam type="float" name="nextscore" value="11.5"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.918288520543892"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821533203125" RT="15899.621" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821533203125" RT="15899.621" >
+			<PeptideHit score="0.999946936748021" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="46.5"/>
 				<UserParam type="float" name="E-Value" value="5.4e-07"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999946936748021"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.820678710938" RT="15913.6905" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.820678710938" RT="15913.6905" >
+			<PeptideHit score="0.999983460247774" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51.6"/>
 				<UserParam type="float" name="E-Value" value="1.2e-07"/>
 				<UserParam type="float" name="nextscore" value="11.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999983460247774"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="593.847473144531" RT="16046.88" >
-			<PeptideHit score="0" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="593.847473144531" RT="16046.88" >
+			<PeptideHit score="0.97179748620208" sequence="ADGLAVIGVLMK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_13" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.5"/>
 				<UserParam type="float" name="E-Value" value="0.0016"/>
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.97179748620208"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="671.821472167969" RT="16549.1195" >
-			<PeptideHit score="0" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="671.821472167969" RT="16549.1195" >
+			<PeptideHit score="0.999375797281708" sequence="AVMDDFAAFVEK" charge="2" aa_before="K" aa_after="C" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="39.5"/>
 				<UserParam type="float" name="E-Value" value="1.3e-05"/>
 				<UserParam type="float" name="nextscore" value="13.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999375797281708"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369995117188" RT="16561.4053" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369995117188" RT="16561.4053" >
+			<PeptideHit score="0.938458406649018" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="30.9"/>
 				<UserParam type="float" name="E-Value" value="0.0042"/>
 				<UserParam type="float" name="nextscore" value="14.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.938458406649018"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952209472656" RT="16564.7626" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952209472656" RT="16564.7626" >
+			<PeptideHit score="0.999749532301869" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="49.7"/>
 				<UserParam type="float" name="E-Value" value="4e-06"/>
 				<UserParam type="float" name="nextscore" value="16.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999749532301869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317932128906" RT="16571.1423" >
-			<PeptideHit score="0.00134408602150538" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317932128906" RT="16571.1423" >
+			<PeptideHit score="0.682127937096026" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23"/>
 				<UserParam type="float" name="E-Value" value="0.04"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.682127937096026"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="571.832763671875" RT="16573.6894" >
-			<PeptideHit score="0.0139416983523447" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="571.832763671875" RT="16573.6894" >
+			<PeptideHit score="0.274948227693009" sequence="DLLHVLAFSK" charge="2" aa_before="R" aa_after="S" protein_refs="PH_52" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.9"/>
 				<UserParam type="float" name="E-Value" value="0.28"/>
 				<UserParam type="float" name="nextscore" value="17.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.274948227693009"/>
+				<UserParam type="float" name="q-value" value="0.0139416983523447"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.951843261719" RT="16656.5309" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.951843261719" RT="16656.5309" >
+			<PeptideHit score="0.998339553383431" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="44.5"/>
 				<UserParam type="float" name="E-Value" value="4.6e-05"/>
 				<UserParam type="float" name="nextscore" value="13.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998339553383431"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369384765625" RT="16657.182" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369384765625" RT="16657.182" >
+			<PeptideHit score="0.999029002284869" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="40.9"/>
 				<UserParam type="float" name="E-Value" value="2.3e-05"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999029002284869"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952026367188" RT="16659.8628" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952026367188" RT="16659.8628" >
+			<PeptideHit score="0.999779168898944" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="51"/>
 				<UserParam type="float" name="E-Value" value="3.4e-06"/>
 				<UserParam type="float" name="nextscore" value="16.2"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.999779168898944"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370056152344" RT="16661.7031" >
-			<PeptideHit score="0" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370056152344" RT="16661.7031" >
+			<PeptideHit score="0.992918683767341" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="37.5"/>
 				<UserParam type="float" name="E-Value" value="0.00029"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.992918683767341"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317016601563" RT="16672.2733" >
-			<PeptideHit score="0.0115089514066496" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317016601563" RT="16672.2733" >
+			<PeptideHit score="0.295486312650848" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="19.8"/>
 				<UserParam type="float" name="E-Value" value="0.25"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.295486312650848"/>
+				<UserParam type="float" name="q-value" value="0.0115089514066496"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.310363769531" RT="16784.36" >
-			<PeptideHit score="0" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.310363769531" RT="16784.36" >
+			<PeptideHit score="0.951788100541034" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="29"/>
 				<UserParam type="float" name="E-Value" value="0.0031"/>
 				<UserParam type="float" name="nextscore" value="22"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.951788100541034"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.95263671875" RT="16845.4006" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.95263671875" RT="16845.4006" >
+			<PeptideHit score="0.998900658395066" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="41.8"/>
 				<UserParam type="float" name="E-Value" value="2.7e-05"/>
 				<UserParam type="float" name="nextscore" value="14.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.998900658395066"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.369018554688" RT="16858.5801" >
-			<PeptideHit score="0.00651890482398957" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.369018554688" RT="16858.5801" >
+			<PeptideHit score="0.412959460251658" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="23.2"/>
 				<UserParam type="float" name="E-Value" value="0.14"/>
 				<UserParam type="float" name="nextscore" value="15.7"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.412959460251658"/>
+				<UserParam type="float" name="q-value" value="0.00651890482398957"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="682.370544433594" RT="16870.2984" >
-			<PeptideHit score="0.00134408602150538" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="682.370544433594" RT="16870.2984" >
+			<PeptideHit score="0.74033038219602" sequence="VFDEFKPLVEEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="26.5"/>
 				<UserParam type="float" name="E-Value" value="0.029"/>
 				<UserParam type="float" name="nextscore" value="15.8"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.74033038219602"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="575.311584472656" RT="16909.2503" >
-			<PeptideHit score="0.00134408602150538" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="575.311584472656" RT="16909.2503" >
+			<PeptideHit score="0.557059990676927" sequence="LVNEVTEFAK" charge="2" aa_before="K" aa_after="T" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22"/>
 				<UserParam type="float" name="E-Value" value="0.073"/>
 				<UserParam type="float" name="nextscore" value="15.1"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.557059990676927"/>
+				<UserParam type="float" name="q-value" value="0.00134408602150538"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317810058594" RT="16910.7179" >
-			<PeptideHit score="0.0102432778489117" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317810058594" RT="16910.7179" >
+			<PeptideHit score="0.348796391782609" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="22.3"/>
 				<UserParam type="float" name="E-Value" value="0.19"/>
 				<UserParam type="float" name="nextscore" value="14.4"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.348796391782609"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="489.952514648438" RT="16947.04" >
-			<PeptideHit score="0" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="489.952514648438" RT="16947.04" >
+			<PeptideHit score="0.997572119635703" sequence="RHPDYSVVLLLR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="43"/>
 				<UserParam type="float" name="E-Value" value="7.5e-05"/>
 				<UserParam type="float" name="nextscore" value="15.6"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.997572119635703"/>
+				<UserParam type="float" name="q-value" value="0"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="547.317016601563" RT="17008.87" >
-			<PeptideHit score="0.0102432778489117" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
+		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="547.317016601563" RT="17008.87" >
+			<PeptideHit score="0.303106246021224" sequence="KVPQVSTPTLVEVSR" charge="3" aa_before="K" aa_after="N" protein_refs="PH_23" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="XTandem_score" value="21.6"/>
 				<UserParam type="float" name="E-Value" value="0.24"/>
 				<UserParam type="float" name="nextscore" value="14.9"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 				<UserParam type="float" name="Posterior Probability_score" value="0.303106246021224"/>
+				<UserParam type="float" name="q-value" value="0.0102432778489117"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/topp/FidoAdapter.cpp
+++ b/src/topp/FidoAdapter.cpp
@@ -64,15 +64,18 @@ using namespace std;
    <table>
      <tr>
        <td ALIGN="center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
-       <td VALIGN="middle" ROWSPAN=3> \f$ \longrightarrow \f$ FidoAdapter \f$ \longrightarrow \f$</td>
+       <td VALIGN="middle" ROWSPAN=4> \f$ \longrightarrow \f$ FidoAdapter \f$ \longrightarrow \f$</td>
        <td ALIGN="center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
      </tr>
     <tr>
-      <td VALIGN="middle" ALIGN="center" ROWSPAN=1> @ref TOPP_PeptideIndexer\n(with @p annotate_proteins option) </td>
-      <td VALIGN="middle" ALIGN="center" ROWSPAN=2> @ref TOPP_ProteinQuantifier\n(via @p protein_groups parameter) </td>
+      <td VALIGN="middle" ALIGN="center" ROWSPAN=1> @ref TOPP_PeptideIndexer </td>
+      <td VALIGN="middle" ALIGN="center" ROWSPAN=3> @ref TOPP_ProteinQuantifier\n(via @p protein_groups parameter) </td>
     </tr>
     <tr>
       <td VALIGN="middle" ALIGN="center" ROWSPAN=1> @ref TOPP_IDPosteriorErrorProbability\n(with @p prob_correct option) </td>
+    </tr>
+    <tr>
+      <td VALIGN="middle" ALIGN="center" ROWSPAN=1> @ref UTILS_IDScoreSwitcher </td>
     </tr>
    </table>
  </CENTER>
@@ -87,8 +90,9 @@ using namespace std;
  
  <b>Input format:</b>
  
- Care has to be taken to provide suitable input data for this adapter. In the peptide/protein identification results (e.g. coming from a database search engine), the proteins have to be annotated with target/decoy meta data. To achieve this, run @ref TOPP_PeptideIndexer with the @p annotate_proteins option switched on.@n
- In addition, the scores for peptide hits in the input data have to be posterior probabilities - as produced e.g. by PeptideProphet in the TPP or by @ref TOPP_IDPosteriorErrorProbability (with the @p prob_correct option switched on) in OpenMS. Inputs from @ref TOPP_IDPosteriorErrorProbability (without @p prob_correct) or from @ref TOPP_ConsensusID are treated as special cases: Their posterior error probabilities (lower is better) are converted to posterior probabilities (higher is better) for processing.
+ Care has to be taken to provide suitable input data for this adapter. In the peptide/protein identification results (e.g. coming from a database search engine), the proteins have to be annotated with target/decoy meta data. To achieve this, run @ref TOPP_PeptideIndexer.@n
+ In addition, the scores for peptide hits in the input data have to be posterior probabilities - as produced e.g. by PeptideProphet in the TPP or by @ref TOPP_IDPosteriorErrorProbability (with the @p prob_correct option switched on) in OpenMS. If scores are found to be posterior error probabilities (PEPs, lower is better), they are converted to posterior probabilities (higher is better) using "1 - PEP".@n
+ If the posterior (error) probabilities are stored in user parameters ("UserParam") in the idXML instead of in the score fields, @ref UTILS_IDScoreSwitcher can be used to rewrite the scores. (This may be the case e.g. if @ref TOPP_FalseDiscoveryRate and @ref TOPP_IDFilter were applied for FDR filtering prior to protein inference.)
  
  <b>Output format:</b>
  
@@ -133,7 +137,6 @@ protected:
     setValidFormats_("out", ListUtils::create<String>("idXML"));
     registerInputFile_("fido_executable", "<path>", "Fido", "Path to the Fido executable to use; may be empty if the executable is globally available.", true, false, ListUtils::create<String>("skipexists"));
     registerInputFile_("fidocp_executable", "<path>", "FidoChooseParameters", "Path to the FidoChooseParameters executable to use; may be empty if the executable is globally available.", true, false, ListUtils::create<String>("skipexists"));
-    registerStringOption_("prob_param", "<string>", "Posterior Probability_score", "Read the peptide probability from this user parameter ('UserParam') in the input file, instead of from the 'score' field, if available. (Use e.g. for search results that were processed with the TOPP tools IDPosteriorErrorProbability followed by FalseDiscoveryRate.)", false);
     registerFlag_("separate_runs", "Process multiple protein identification runs in the input separately, don't merge them. Merging results in loss of descriptive information of the single protein identification runs.");
     registerFlag_("keep_zero_group", "Keep the group of proteins with estimated probability of zero, which is otherwise removed (it may be very large)", true);
     registerFlag_("greedy_group_resolution", "Post-process Fido output with greedy resolution of shared peptides based on the protein probabilities. Also adds the resolved ambiguity groups to output.");
@@ -158,8 +161,7 @@ protected:
   // write a PSM graph file for Fido based on the given peptide identifications;
   // optionally only use IDs with given identifier (filter by protein ID run):
   void writePSMGraph_(vector<PeptideIdentification>& peptides,
-                      const String& out_path, const String& prob_param = "",
-                      const String& identifier = "")
+                      const String& out_path, const String& identifier = "")
   {
     ofstream graph_out(out_path.c_str());
     bool warned_once = false;
@@ -178,40 +180,35 @@ protected:
         continue;
       }
       
-      double score = 0.0;
-      String error_reason;
-      if (prob_param.empty() || !hit.metaValueExists(prob_param))
+      double score = hit.getScore();
+      String score_type = pep_it->getScoreType();
+      bool higher_better = pep_it->isHigherScoreBetter();
+
+      // workaround for posterior error probabilities (PEPs):
+      if (score_type.hasSuffix("_score"))
       {
-        score = hit.getScore();
-        if (!pep_it->isHigherScoreBetter())
+        score_type.chop(6);
+      }
+      score_type.toLower().remove(' ').remove('_').remove('-');
+      if (score_type == "posteriorerrorprobability")
+      {
+        if (!warned_once)
         {
-          // workaround for important TOPP tools:
-          String score_type = pep_it->getScoreType();
-          score_type.toLower();
-          if ((score_type == "posterior error probability") ||
-              score_type.hasPrefix("consensus_"))
-          {
-            if (!warned_once)
-            {
-              LOG_WARN << "Warning: Scores of peptide hits seem to be posterior"
-                " error probabilities. Converting to (positive) posterior"
-                " probabilities." << endl;
-              warned_once = true;
-            }
-            score = 1.0 - score;
-          }
-          else
-          {
-            error_reason = "lower scores are better";
-          }
+          LOG_WARN << "Warning: Scores of peptide hits seem to be posterior "
+            "error probabilities. Converting to (positive) posterior "
+            "probabilities." << endl;
+          warned_once = true;
         }
+        score = 1.0 - score;
+        higher_better = true;
       }
-      else
+
+      String error_reason;
+      if (!higher_better)
       {
-        score = hit.getMetaValue(prob_param);
-      }
-      
-      if (score < 0.0)
+        error_reason = "lower scores are better";
+      }     
+      else if (score < 0.0)
       {
         error_reason = "score < 0";
       }
@@ -333,8 +330,7 @@ protected:
     current_fido_params.replaceInStrings("INPUT_GRAPH",
                                          input_graph.toQString());
 
-    writePSMGraph_(peptides, input_graph, getStringOption_("prob_param"),
-                   protein.getIdentifier());
+    writePSMGraph_(peptides, input_graph, protein.getIdentifier());
     if (choose_params)
     {
       String input_proteins = temp_dir + "fido_input_proteins" + num + ".txt";
@@ -502,7 +498,6 @@ protected:
     String out = getStringOption_("out");
     String fido_executable = getStringOption_("fido_executable");
     String fidocp_executable = getStringOption_("fidocp_executable");
-    String prob_param = getStringOption_("prob_param");
     bool separate_runs = getFlag_("separate_runs");
     bool keep_zero_group = getFlag_("keep_zero_group");
     bool greedy_flag = getFlag_("greedy_group_resolution");


### PR DESCRIPTION
Solves #1575. Instead of handling meta values/UserParams directly in FidoAdapter, this can now be done (better) using IDScoreSwitcher. The documentation and one test case were updated to reflect this.