### PR TITLE
Feature/mtd fix

### DIFF
--- a/src/openms/source/FILTERING/DATAREDUCTION/MassTraceDetection.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/MassTraceDetection.cpp
@@ -238,7 +238,7 @@ namespace OpenMS
             tmp_spec.push_back(input_exp[scan_idx][peak_idx]);
             if (tmp_peak_int > chrom_peak_snr_ * noise_threshold_int_)
             {
-              chrom_apeces.insert(std::make_pair(tmp_peak_int, std::make_pair(scan_idx, spec_peak_idx)));
+              chrom_apeces.insert(std::make_pair(tmp_peak_int, std::make_pair(spectra_count, spec_peak_idx)));
             }
             ++peak_count;
             ++spec_peak_idx;

--- a/src/tests/class_tests/openms/source/MassTraceDetection_test.cpp
+++ b/src/tests/class_tests/openms/source/MassTraceDetection_test.cpp
@@ -135,6 +135,43 @@ START_SECTION((void run(const MSExperiment< Peak1D > &, std::vector< MassTrace >
         TEST_REAL_SIMILAR(output_mt[i].getCentroidMZ(), exp_mt_mzs[i]);
         TEST_REAL_SIMILAR(output_mt[i].computePeakArea(), exp_mt_ints[i]);
     }
+
+    // Regression test for bug #1633
+    // Test by adding MS2 spectra to the input
+    {
+      MSExperiment<> input_new;
+      MSSpectrum<> s;
+      s.setMSLevel(2);
+      {
+        Peak1D p;
+        p.setMZ( 500 );
+        p.setIntensity( 6000 );
+        s.push_back(p);
+      }
+
+      // add a few additional MS2 spectra in front
+      for (Size i = 0; i < input.size(); ++i)
+      {
+        input_new.addSpectrum(s);
+      }
+      // now add the "real" spectra at the end
+      for (Size i = 0; i < input.size(); ++i)
+      {
+        input_new.addSpectrum(input[i]);
+      }
+      output_mt.clear();
+      test_mtd.run(input_new, output_mt);
+      TEST_EQUAL(output_mt.size(), 3);
+
+      for (Size i = 0; i < output_mt.size(); ++i)
+      {
+          TEST_EQUAL(output_mt[i].getSize(), exp_mt_lengths[i]);
+          TEST_REAL_SIMILAR(output_mt[i].getCentroidRT(), exp_mt_rts[i]);
+          TEST_REAL_SIMILAR(output_mt[i].getCentroidMZ(), exp_mt_mzs[i]);
+          TEST_REAL_SIMILAR(output_mt[i].computePeakArea(), exp_mt_ints[i]);
+      }
+
+    }
 }
 END_SECTION
 


### PR DESCRIPTION
Fixes a major bug leading to a segfault and wrong output in
MassTraceDetection.

This error occured in MassTraceDetection::run when MS2 spectra are
present in the input_exp (which they are usually not since
FeatureFinderMetabo and MassTraceExtractor do not load them).

Rationale:
- MassTraceDetection works with a temporary MSExperiment work_exp which
  only contains part of the input data (not all spectra, not all peaks)
- The initial seed peaks are stored in chrom_apeces and need to be in
  the reference frame of the work_exp and *not* in the reference frame
  of the old input_exp
- Therefore, the pairs appended to chrom_apeces need to use
  (spectra_count, spec_peak_idx) and not (scan_idx, peak_idx)

Solution:
- use (spectra_count, spec_peak_idx) for chrom_apeces which maps
  correctly to work_exp

Fixes #1633