### PR TITLE
[FIX] handles invalid mzML without data type

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
@@ -69,6 +69,24 @@ namespace OpenMS
         std::vector<String> decoded_char;
         MetaInfoDescription meta;
         MSNumpressCoder::NumpressCompression np_compression;
+
+        /// Constructor
+        BinaryData() :
+          base64(),
+          precision(PRE_NONE),
+          size(0),
+          compression(false),
+          data_type(DT_NONE),
+          floats_32(),
+          floats_64(),
+          ints_32(),
+          ints_64(),
+          decoded_char(),
+          meta(),
+          np_compression()
+        {
+        }
+
       };
 
       /**


### PR DESCRIPTION
- proteowizard seems to not set the data type when using ms-numpress
  even though this is required by the standard.
- as ms-numpress does not care about 32/64 bit, this seems to be the
  safest course of action at the moment and makes converted files work
  in OpenMS
- partial fix for #1618
- unsolved: how to deal with the general case when no attribute is provided about the identity of the array (now it at least outputs a warning)

Fixes #1618