### PR TITLE
Feature/qt algorithm

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/QTClusterFinder.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/QTClusterFinder.h
@@ -144,17 +144,6 @@ private:
     double getDistance_(const OpenMS::GridFeature* left, const
         OpenMS::GridFeature* right);
 
-    /**
-       @brief Checks whether the peptide IDs of a cluster and a neighboring
-       feature are compatible.
-
-       A neighboring feature without identification is always compatible.
-       Otherwise, the cluster and feature are compatible if the best peptide
-       hits of each of their identifications have the same sequences.
-    */
-    bool compatibleIDs_(QTCluster& cluster, 
-        const OpenMS::GridFeature* neighbor);
-
     /// Sets algorithm parameters
     void setParameters_(double max_intensity, double max_mz);
 
@@ -177,7 +166,7 @@ private:
 
     /// Adds elements to the cluster based on the elements hashed in the grid
     void addClusterElements_(int x, int y, const Grid& grid, QTCluster& cluster,
-      const OpenMS::GridFeature* center_feature, bool firstPass);
+      const OpenMS::GridFeature* center_feature);
 
 protected:
 

--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/QTClusterFinder.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/QTClusterFinder.h
@@ -177,7 +177,7 @@ private:
 
     /// Adds elements to the cluster based on the elements hashed in the grid
     void addClusterElements_(int x, int y, const Grid& grid, QTCluster& cluster,
-      const OpenMS::GridFeature* center_feature);
+      const OpenMS::GridFeature* center_feature, bool firstPass);
 
 protected:
 

--- a/src/openms/include/OpenMS/DATASTRUCTURES/QTCluster.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/QTCluster.h
@@ -150,7 +150,11 @@ private:
     /// Has the cluster changed (if yes, quality needs to be recomputed)?
     bool changed_;
 
+    /// Has the cluster been finalized once in its lifetime?
     bool finalized_once_;
+
+    /// Has the cluster been finalized once in its lifetime?
+    bool emulate_old_behavior_;
 
     /// Keep track of peptide IDs and use them for matching?
     bool use_IDs_;
@@ -224,7 +228,7 @@ public:
      */
     QTCluster(GridFeature* center_point, Size num_maps,
               double max_distance, bool use_IDs, 
-              Int x_coord, Int y_coord);
+              Int x_coord, Int y_coord, bool emulate_old = true);
 
     /// Destructor
     virtual ~QTCluster();

--- a/src/openms/include/OpenMS/DATASTRUCTURES/QTCluster.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/QTCluster.h
@@ -150,6 +150,8 @@ private:
     /// Has the cluster changed (if yes, quality needs to be recomputed)?
     bool changed_;
 
+    bool finalized_once_;
+
     /// Keep track of peptide IDs and use them for matching?
     bool use_IDs_;
 

--- a/src/openms/include/OpenMS/DATASTRUCTURES/QTCluster.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/QTCluster.h
@@ -150,12 +150,6 @@ private:
     /// Has the cluster changed (if yes, quality needs to be recomputed)?
     bool changed_;
 
-    /// Has the cluster been finalized once in its lifetime?
-    bool finalized_once_;
-
-    /// Has the cluster been finalized once in its lifetime?
-    bool emulate_old_behavior_;
-
     /// Keep track of peptide IDs and use them for matching?
     bool use_IDs_;
 
@@ -228,7 +222,7 @@ public:
      */
     QTCluster(GridFeature* center_point, Size num_maps,
               double max_distance, bool use_IDs, 
-              Int x_coord, Int y_coord, bool emulate_old = true);
+              Int x_coord, Int y_coord);
 
     /// Destructor
     virtual ~QTCluster();

--- a/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
@@ -434,8 +434,8 @@ namespace OpenMS
 #ifdef DEBUG_QTCLUSTERFINDER
     std::cout << " Compute Clustering: "<< x << " " << y << " with id " << center_feature->getFeature().getUniqueId() << std::endl;
     std::set<AASequence> a = cluster.getAnnotations();
-    std::cout << " with annotations: " ;
-    for( std::set<AASequence>::iterator it = a.begin(); it != a.end(); it++) std::cout << " " << *it;
+    std::cout << " with annotations: ";
+    for (std::set<AASequence>::iterator it = a.begin(); it != a.end(); it++) std::cout << " " << *it;
     std::cout << std::endl;
 #endif
 
@@ -501,8 +501,8 @@ namespace OpenMS
 
     {
       std::set<AASequence> a = cluster.getAnnotations();
-      std::cout << " FINAL with annotations: " ;
-      for( std::set<AASequence>::iterator it = a.begin(); it != a.end(); it++) std::cout << " " << *it;
+      std::cout << " FINAL with annotations: ";
+      for (std::set<AASequence>::iterator it = a.begin(); it != a.end(); it++) std::cout << " " << *it;
       std::cout << std::endl;
     }
 #endif

--- a/src/openms/source/DATASTRUCTURES/QTCluster.cpp
+++ b/src/openms/source/DATASTRUCTURES/QTCluster.cpp
@@ -61,7 +61,7 @@ namespace OpenMS
 
   QTCluster::QTCluster(OpenMS::GridFeature* center_point, Size num_maps,
                        double max_distance, bool use_IDs, Int x_coord, 
-                       Int y_coord) :
+                       Int y_coord, bool emulate_old) :
     center_point_(center_point),
     neighbors_(),
     tmp_neighbors_(NULL),
@@ -70,6 +70,7 @@ namespace OpenMS
     quality_(0.0),
     changed_(false),
     finalized_once_(false),
+    emulate_old_behavior_(emulate_old),
     use_IDs_(use_IDs),
     valid_(true),
     collect_annotations_(false),
@@ -379,12 +380,12 @@ namespace OpenMS
       }
     }
 
-    // TODO: in the original implementation, the annotation cannot be easily
-    // changed any more once the first neighbor gets added. In the original
-    // implementation, the first GridFeature that got added (note that the order or
-    // addition is important for some reason) determines the annotation for the
-    // rest of the life of the current cluster. This means that from that
-    // timepoint onwards, the annotation_ cannot ever change.
+    // In the original implementation, the annotation cannot be easily changed
+    // any more once the first neighbor gets added. In the original
+    // implementation, the first GridFeature that got added (note that the
+    // order or addition is important for some reason) determines the
+    // annotation for the rest of the life of the current cluster. This means
+    // that from that timepoint onwards, the annotation_ cannot ever change.
     //
     // We can emulate that behavior here if we want to by using a
     // finalized_once_ variable that prevents changing the annotation vector
@@ -393,7 +394,10 @@ namespace OpenMS
     // Also, if we somehow picked in our first round a set of annotations that
     // were empty only then we are now allowed to redo it and settle on a final
     // set of annotations 
-    if (best_pos != seq_table.end() && (!finalized_once_ || annotations_.empty() ))
+    //
+    bool allow_annotation_change = !emulate_old_behavior_ || (!finalized_once_ || annotations_.empty() );
+    // bool allow_annotation_change = !emulate_old_behavior_ || (!finalized_once_  );
+    if (best_pos != seq_table.end() && allow_annotation_change)
     {
       annotations_ = best_pos->first;
     }

--- a/src/openms/source/DATASTRUCTURES/QTCluster.cpp
+++ b/src/openms/source/DATASTRUCTURES/QTCluster.cpp
@@ -148,24 +148,21 @@ namespace OpenMS
 
     Size map_index = element->getMapIndex();
 
-    // ensure we only add compatible peptide annotations
-    if (use_IDs_ )
+    // Ensure we only add compatible peptide annotations. If the cluster center
+    // has an annotation, then each added neighbor should have the same
+    // annotation. If the center element has no annotation we add all elements
+    // and select the optimal annotation later, using optimizeAnnotations_ 
+    if (use_IDs_)
     {
-      bool compatible_id = true;
-      if (this->getAnnotations().empty())
+      bool one_empty = (center_point_->getAnnotations().empty() || element->getAnnotations().empty());
+      if (!one_empty) // both are annotated
       {
-        compatible_id = true;
+        if (center_point_->getAnnotations() != element->getAnnotations()) 
+        {
+          // Both annotations are non-empty and are unequal, we dont add
+          return;
+        }
       }
-      else if (element->getAnnotations().empty() )
-      {
-        compatible_id = true;
-      }
-      else 
-      {
-        compatible_id = (getAnnotations() == element->getAnnotations());
-      }
-
-      if (!compatible_id) {return;}
     }
 
     // We have to store annotations in a temporary map first if we collect all


### PR DESCRIPTION
Makes the QT algorithm addition order-independent

- The algorithm is now independent of the order in which QTCluster::add
  is called as the annotations are not computed on the fly after each
  addition any more but rather at the end. The criteria whether an
  elements get added to the cluster is whether it conflicts with the
  center point of the cluster and *not* whether it conflicts with the
  *current* best annotation set.
- This should make the algorithm independent of addition order when
  using ids and yield better performance

it contains some initial, failed attempts to emulate the old, Release 2.0 behavior but this effort proved ultimately too complex and as the behavior seemed faulty in the first place, I have given up.

