### PR TITLE
Fix mgf space/tab while loading

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/DTAFile.h
+++ b/src/openms/include/OpenMS/FORMAT/DTAFile.h
@@ -238,7 +238,7 @@ public:
 protected:
 
     /// Default MS level used when reading the file
-    Size default_ms_level_;
+    UInt default_ms_level_;
 
   };
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h
@@ -67,13 +67,13 @@ public:
       virtual ~MascotXMLHandler();
 
       // Docu in base class
-      virtual void endElement(const XMLCh* /*uri*/, const XMLCh* /*local_name*/, const XMLCh* qname);
+      virtual void endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname);
 
       // Docu in base class
-      virtual void startElement(const XMLCh* /*uri*/, const XMLCh* /*local_name*/, const XMLCh* qname, const xercesc::Attributes& attributes);
+      virtual void startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes);
 
       // Docu in base class
-      virtual void characters(const XMLCh* chars, const XMLSize_t /*length*/);
+      virtual void characters(const XMLCh* const chars, const XMLSize_t /*length*/);
 
 private:
 

--- a/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Andreas Bertsch $
-// $Authors: Andreas Bertsch $
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_FORMAT_MASCOTGENERICFILE_H
@@ -198,17 +198,24 @@ protected:
                   continue;
                 }
 
-                //line.substitute('\t', ' ');
-                line.split(' ', split);
-                if (split.size() >= 2)
+                line.simplify(); // merge double spaces (explicitly allowed by MGF), to prevent empty split() chunks and subsequent parse error
+                line.substitute('\t', ' '); // also accept Tab (strictly, only space(s) are allowed)
+                if (line.split(' ', split, false))
                 {
-                  p.setPosition(split[0].toDouble());
-                  p.setIntensity(split[1].toDouble());
+                  try 
+                  {
+                    p.setPosition(split[0].toDouble());
+                    p.setIntensity(split[1].toDouble());
+                  }
+                  catch (Exception::ConversionError& /*e*/)
+                  {
+                    throw Exception::ParseError(__FILE__, __LINE__, __PRETTY_FUNCTION__, "The content '" + line + "' at line #" + String(line_number) + " could not be converted to a number! Expected two (m/z int) or three (m/z int charge) numbers separated by whitespace (space or tab).", "");
+                  }
                   spectrum.push_back(p);
                 }
                 else
                 {
-                  throw Exception::ParseError(__FILE__, __LINE__, __PRETTY_FUNCTION__, "the line (" + line + ") should contain m/z and intensity value separated by whitespace!", "");
+                  throw Exception::ParseError(__FILE__, __LINE__, __PRETTY_FUNCTION__, "The content '" + line + "' at line #" + String(line_number) + " does not contain m/z and intensity values separated by whitespace (space or tab)!", "");
                 }
               }
               while (getline(is, line, '\n') && ++line_number && line.trim() != "END IONS"); // line.trim() is important here!
@@ -224,7 +231,7 @@ protected:
             }
             else if (line.hasPrefix("PEPMASS")) // parse precursor position
             {
-              String tmp = line.substr(8);
+              String tmp = line.substr(8); // copy since we might need the original line for error reporting later
               tmp.substitute('\t', ' ');
               std::vector<String> split;
               tmp.split(' ', split);
@@ -239,7 +246,7 @@ protected:
               }
               else
               {
-                throw Exception::ParseError(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Cannot parse PEPMASS: '" + line + "' in line " + String(line_number) + " (expected 1 or 2 entries, but " + String(split.size()) + " were present!", "");
+                throw Exception::ParseError(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Cannot parse PEPMASS in '" + line + "' at line #" + String(line_number) + " (expected 1 or 2 entries, but " + String(split.size()) + " were present)!", "");
               }
             }
             else if (line.hasPrefix("CHARGE"))
@@ -282,8 +289,7 @@ protected:
                 {
                   // just do nothing and write the whole title to spec
                   std::vector<String> split;
-                  line.split('=', split);
-                  if (split.size() >= 2)
+                  if (line.split('=', split))
                   {
                     if (split[1] != "") spectrum.setMetaValue("TITLE", split[1]);
                   }

--- a/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MascotGenericFile.h
@@ -51,12 +51,10 @@
 namespace OpenMS
 {
   /**
-    @brief Mascot input file adapter.
+    @brief Read/write Mascot generic files (MGF).
 
-    Creates a file that can be used for Mascot search from a peak list or a whole experiment.
-
-    Loading a file supports multi-threading, since conversion from string to double is expensive and takes long using a single thread.
-
+    For details of the format, see http://www.matrixscience.com/help/data_file_help.html#GEN.
+    
     @htmlinclude OpenMS_MascotGenericFile.parameters
 
     @ingroup FileIO

--- a/src/openms/include/OpenMS/FORMAT/MascotInfile.h
+++ b/src/openms/include/OpenMS/FORMAT/MascotInfile.h
@@ -47,14 +47,14 @@
 namespace OpenMS
 {
   /**
-      @brief Mascot input file adapter.
+    @brief Mascot input file adapter.
 
-  @deprecated Use MascotGenericFile.h instead, which uses DefaultParamHandler, is more up to date and avoids weird behaviors of this class (especially in terms of
-              MIME boundaries when writing MGF....
+    @deprecated Use MascotGenericFile.h instead, which uses DefaultParamHandler, is more up to date and avoids weird behaviors of this class (especially in terms of
+              MIME boundaries when writing MGF. This class is currently only used by MascotAdapter.cpp.
 
-      Creates a file that can be used for Mascot search from a peak list or a whole experiment.
+    Creates a file that can be used for Mascot search from a peak list or a whole experiment.
 
-  @ingroup FileIO
+    @ingroup FileIO
   */
   class OPENMS_DLLAPI MascotInfile :
     public ProgressLogger

--- a/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
@@ -55,7 +55,7 @@ namespace OpenMS
     {
     }
 
-    void MascotXMLHandler::startElement(const XMLCh* /*uri*/, const XMLCh* /*local_name*/, const XMLCh* qname, const Attributes& attributes)
+    void MascotXMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const Attributes& attributes)
     {
       static const XMLCh* s_protein_accession = xercesc::XMLString::transcode("accession");
       static const XMLCh* s_queries_query_number = xercesc::XMLString::transcode("number");
@@ -93,7 +93,7 @@ namespace OpenMS
       }
     }
 
-    void MascotXMLHandler::endElement(const XMLCh* /*uri*/, const XMLCh* /*local_name*/, const XMLCh* qname)
+    void MascotXMLHandler::endElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname)
     {
       tag_ = String(sm_.convert(qname)).trim();
       // cerr << "close: " << tag_ << endl;
@@ -559,7 +559,7 @@ namespace OpenMS
       character_buffer_.clear();
     }
 
-    void MascotXMLHandler::characters(const XMLCh* chars, const XMLSize_t /*length*/)
+    void MascotXMLHandler::characters(const XMLCh* const chars, const XMLSize_t /*length*/)
     {
       // do not care about chars after internal tags, e.g.
       // <header>

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Andreas Bertsch $
-// $Authors: Andreas Bertsch $
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/MascotGenericFile.h>

--- a/src/openms/source/FORMAT/MascotInfile.cpp
+++ b/src/openms/source/FORMAT/MascotInfile.cpp
@@ -676,6 +676,7 @@ namespace OpenMS
           {
             do
             {
+              line.simplify(); // remove duplicate spaces (allowed by the format)
               line.substitute('\t', ' ');
               vector<String> split;
               line.split(' ', split);

--- a/src/tests/class_tests/openms/data/MascotInfile_test.mascot_in
+++ b/src/tests/class_tests/openms/data/MascotInfile_test.mascot_in
@@ -7,9 +7,9 @@ RTINSECONDS=25.379
 2 4
 3 9
 4 16
-5  25  # two spaces (allowed by the standard)
+5  25  #.two.spaces.(allowed.by.the.standard)
 6 36
-7	49  # tab character (extension of the standard)
+7	49  #.tab.character.(extension.of.the.standard)
 8 64
 9 81
 END IONS

--- a/src/tests/class_tests/openms/data/MascotInfile_test.mascot_in
+++ b/src/tests/class_tests/openms/data/MascotInfile_test.mascot_in
@@ -7,9 +7,9 @@ RTINSECONDS=25.379
 2 4
 3 9
 4 16
-5 25
+5  25  # two spaces (allowed by the standard)
 6 36
-7 49
+7	49  # tab character (extension of the standard)
 8 64
 9 81
 END IONS

--- a/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // 
 // --------------------------------------------------------------------------
-// $Maintainer: Andreas Bertsch $
-// $Authors: Andreas Bertsch $
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>


### PR DESCRIPTION
MGF parser would choke on
```
BEGIN IONS
123.1  456.7  # two spaces (allowed)
END IONS
```
and also if Tabs are used instead of spaces (strictly speaking not part of the standard, but a sensible extension).

Also, the error messages are now more explicit (mention line number etc).

Fix PR fixes this.
