### PR TITLE
[FEATURE] add function that returns simple list

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/ConsensusFeature.h
+++ b/src/openms/include/OpenMS/KERNEL/ConsensusFeature.h
@@ -222,6 +222,9 @@ public:
 
     /// Non-mutable access to the contained feature handles
     const HandleSetType& getFeatures() const;
+
+    /// Mutable access to a copy of the contained feature handles
+    std::vector<FeatureHandle> getFeatureList() const;
     //@}
 
     ///@name Accessors

--- a/src/openms/source/KERNEL/ConsensusFeature.cpp
+++ b/src/openms/source/KERNEL/ConsensusFeature.cpp
@@ -128,6 +128,16 @@ namespace OpenMS
     return handles_;
   }
 
+  std::vector<FeatureHandle> ConsensusFeature::getFeatureList() const
+  {
+    std::vector<FeatureHandle> tmp;
+    for (ConsensusFeature::HandleSetType::const_iterator it = handles_.begin(); it != handles_.end(); ++it)
+    {
+      tmp.push_back(*it);
+    }
+    return tmp;
+  }
+
   DRange<2> ConsensusFeature::getPositionRange() const
   {
     DPosition<2> min = DPosition<2>::maxPositive();

--- a/src/pyOpenMS/pxds/ConsensusFeature.pxd
+++ b/src/pyOpenMS/pxds/ConsensusFeature.pxd
@@ -6,6 +6,7 @@ from RichPeak2D cimport *
 from UniqueIdInterface cimport *
 from FeatureMap cimport *
 from BaseFeature cimport *
+from FeatureHandle cimport *
 from PeptideIdentification cimport *
 
 cdef extern from "<OpenMS/KERNEL/ConsensusFeature.h>" namespace "OpenMS":
@@ -40,6 +41,8 @@ cdef extern from "<OpenMS/KERNEL/ConsensusFeature.h>" namespace "OpenMS":
 
         Int getCharge() nogil except +
         void setCharge(Int q) nogil except +
+
+        libcpp_vector[FeatureHandle] getFeatureList() nogil except +
 
         Size size() nogil except +
 

--- a/src/pyOpenMS/pxds/FileHandler.pxd
+++ b/src/pyOpenMS/pxds/FileHandler.pxd
@@ -27,5 +27,5 @@ cdef extern from "<OpenMS/FORMAT/FileHandler.h>" namespace "OpenMS::FileHandler"
     int  getType(String filename) nogil except + # wrap-attach:FileHandler
     Type getTypeByFileName(String & filename) nogil except + # wrap-attach:FileHandler 
     Type getTypeByContent(String & filename) nogil except + # wrap-attach:FileHandler 
-    bool computeFileHash(String & filename) nogil except + # wrap-attach:FileHandler 
+    String computeFileHash(String & filename) nogil except + # wrap-attach:FileHandler 
     bool isSupported(Type type_) nogil except + # wrap-attach:FileHandler 

--- a/src/pyOpenMS/pxds/MSExperiment.pxd
+++ b/src/pyOpenMS/pxds/MSExperiment.pxd
@@ -31,7 +31,6 @@ cdef extern from "<OpenMS/KERNEL/MSExperiment.h>" namespace "OpenMS":
         bool clearMetaDataArrays() nogil except +
         ExperimentalSettings getExperimentalSettings() nogil except +
         
-        void setPrimaryMSRunPath(StringList& s) nogil except +
         StringList getPrimaryMSRunPath() nogil except +
 
         void swap(MSExperiment[PeakT, ChromoPeakT]) nogil except +


### PR DESCRIPTION
Currently it is not possible to access the individual FeatureHandle inside an ConsensusFeature using pyOpenMS which makes the wrapper rather pointless. This will allow to access a list of FeatureHandle for each ConsensusFeature (non-mutable). 

A possible extension is to also add a "set" function but right now this could be accomplished by `clear` and then `insert`