### PR TITLE
[FIX] Fixed unreported error in FORMAT/PepXMLFile.cpp

### DIFF
--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -392,7 +392,7 @@ namespace OpenMS
           if (seq.hasCTerminalModification())
           {
             const ResidueModification& mod = ModificationsDB::getInstance()->getTerminalModification(seq.getCTerminalModification(), ResidueModification::C_TERM);
-            f << "mod_cterm_mass=\"" <<
+            f << " mod_cterm_mass=\"" <<
               precisionWrapper(mod.getMonoMass() + seq[seq.size() - 1].getMonoWeight(Residue::Internal)) << "\"";
           }
 


### PR DESCRIPTION
Blank was missing to write attribute mod_nterm_mass in tag modification_info.

	modified:   ../src/openms/source/FORMAT/PepXMLFile.cpp