### PR TITLE
correction of generic R script wrappers for mzTab to tsv conversion

### DIFF
--- a/share/OpenMS/TOOLS/EXTERNAL/Rscript_mzTab2tsv_PEP.ttd
+++ b/share/OpenMS/TOOLS/EXTERNAL/Rscript_mzTab2tsv_PEP.ttd
@@ -16,17 +16,13 @@
 			<path>Rscript</path>
 			<mappings>
 				<mapping id="1" cl="%%scriptpath" />
-				<mapping id="2" cl="%%inTSVacc" />
-				<mapping id="3" cl="%TMP/%BASENAME[%%inTSVacc]_acc.tsv" />
-				<file_post location="%TMP/%BASENAME[%%inTSVacc]_acc.tsv" target="out" />
+				<mapping id="2" cl="%%in" />
+				<mapping id="3" cl="%%out" />
 			</mappings>
 			<ini_param>
-				<ITEM name="scriptpath" value="." type="string" description="input script path, this should point
-to share/OpenMS/SCRIPTS of your OpenMS installation"/>
-				<ITEM name="inTSVacc" value="" type="string" description="tabular input data (valid formats:
-&apos;tsv&apos;)" tags="input file" />
-				<ITEM name="out" value="" type="string" description="output tsv file (valid formats:
-&apos;tsv&apos;)" tags="output file" />
+				<ITEM name="scriptpath" value="." type="string" description="input script path, this should point to share/OpenMS/SCRIPTS of your OpenMS installation"/>
+				<ITEM name="in" value="" type="input-file" description="tabular input data" required="true" advanced="false" supported_formats="*.tsv" />
+				<ITEM name="out" value="" type="output-file" description="output tsv file" required="true" advanced="false" supported_formats="*.pdf" />
 			</ini_param>
 		</external>
 	</tool>

--- a/share/OpenMS/TOOLS/EXTERNAL/Rscript_mzTab2tsv_PRT.ttd
+++ b/share/OpenMS/TOOLS/EXTERNAL/Rscript_mzTab2tsv_PRT.ttd
@@ -16,17 +16,13 @@
 			<path>Rscript</path>
 			<mappings>
 				<mapping id="1" cl="%%scriptpath" />
-				<mapping id="2" cl="%%inTSVacc" />
-				<mapping id="3" cl="%TMP/%BASENAME[%%inTSVacc]_acc.tsv" />
-				<file_post location="%TMP/%BASENAME[%%inTSVacc]_acc.tsv" target="out" />
+				<mapping id="2" cl="%%in" />
+				<mapping id="3" cl="%%out" />
 			</mappings>
 			<ini_param>
-				<ITEM name="scriptpath" value="." type="string" description="input script path, this should point
-to share/OpenMS/SCRIPTS of your OpenMS installation"/>
-				<ITEM name="inTSVacc" value="" type="string" description="tabular input data (valid formats:
-&apos;tsv&apos;)" tags="input file" />
-				<ITEM name="out" value="" type="string" description="output tsv file (valid formats:
-&apos;tsv&apos;)" tags="output file" />
+				<ITEM name="scriptpath" value="." type="string" description="input script path, this should point to share/OpenMS/SCRIPTS of your OpenMS installation"/>
+				<ITEM name="in" value="" type="input-file" description="tabular input data" required="true" advanced="false" supported_formats="*.tsv" />
+				<ITEM name="out" value="" type="output-file" description="output tsv file" required="true" advanced="false" supported_formats="*.pdf" />
 			</ini_param>
 		</external>
 	</tool>

--- a/share/OpenMS/TOOLS/EXTERNAL/Rscript_mzTab2tsv_PSM.ttd
+++ b/share/OpenMS/TOOLS/EXTERNAL/Rscript_mzTab2tsv_PSM.ttd
@@ -16,17 +16,13 @@
 			<path>Rscript</path>
 			<mappings>
 				<mapping id="1" cl="%%scriptpath" />
-				<mapping id="2" cl="%%inTSVacc" />
-				<mapping id="3" cl="%TMP/%BASENAME[%%inTSVacc]_acc.tsv" />
-				<file_post location="%TMP/%BASENAME[%%inTSVacc]_acc.tsv" target="out" />
+				<mapping id="2" cl="%%in" />
+				<mapping id="3" cl="%%out" />
 			</mappings>
 			<ini_param>
-				<ITEM name="scriptpath" value="." type="string" description="input script path, this should point
-to share/OpenMS/SCRIPTS of your OpenMS installation"/>
-				<ITEM name="inTSVacc" value="" type="string" description="tabular input data (valid formats:
-&apos;tsv&apos;)" tags="input file" />
-				<ITEM name="out" value="" type="string" description="output tsv file (valid formats:
-&apos;tsv&apos;)" tags="output file" />
+				<ITEM name="scriptpath" value="." type="string" description="input script path, this should point to share/OpenMS/SCRIPTS of your OpenMS installation"/>
+				<ITEM name="in" value="" type="input-file" description="tabular input data" required="true" advanced="false" supported_formats="*.tsv" />
+				<ITEM name="out" value="" type="output-file" description="output tsv file" required="true" advanced="false" supported_formats="*.pdf" />
 			</ini_param>
 		</external>
 	</tool>


### PR DESCRIPTION
There are three R scripts for the conversion of `*.mzTab` to better readable `*.tsv`. Previously, output files had the suffix `*.unknown`. After corrections of the `ttd`, it is now `*.tsv`. 