### PR TITLE
[FIX] schema simplifications and adaptation of enzyme entry

### DIFF
--- a/share/OpenMS/SCHEMAS/ConsensusXML_1_6.xsd
+++ b/share/OpenMS/SCHEMAS/ConsensusXML_1_6.xsd
@@ -74,156 +74,8 @@
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="SearchParameters">
-								<xs:annotation>
-									<xs:documentation>Search parameters that can be used for several identification runs</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="FixedModification" minOccurs="0" maxOccurs="unbounded">
-											<xs:annotation>
-												<xs:documentation>fixed modifications for the search</xs:documentation>
-											</xs:annotation>
-											<xs:complexType>
-												<xs:sequence minOccurs="0">
-													<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-												</xs:sequence>
-												<xs:attribute name="name" use="required">
-													<xs:annotation>
-														<xs:documentation>modification name</xs:documentation>
-													</xs:annotation>
-													<xs:simpleType>
-														<xs:restriction base="xs:string">
-															<xs:minLength value="1"/>
-														</xs:restriction>
-													</xs:simpleType>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="VariableModification" minOccurs="0" maxOccurs="unbounded">
-											<xs:annotation>
-												<xs:documentation>variable modifications for the search</xs:documentation>
-											</xs:annotation>
-											<xs:complexType>
-												<xs:sequence minOccurs="0">
-													<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-												</xs:sequence>
-												<xs:attribute name="name" use="required">
-													<xs:annotation>
-														<xs:documentation>modification name</xs:documentation>
-													</xs:annotation>
-													<xs:simpleType>
-														<xs:restriction base="xs:string">
-															<xs:minLength value="1"/>
-														</xs:restriction>
-													</xs:simpleType>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-									</xs:sequence>
-									<xs:attribute name="db" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>protein sequence database name</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="db_version" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>database version</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="taxonomy" type="xs:string">
-										<xs:annotation>
-											<xs:documentation>taxonomy restriction</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="mass_type" type="MassType" use="required">
-										<xs:annotation>
-											<xs:documentation>mass type ('monoisotopic' or 'average')</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="charges" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>searched for charges. If you want these charges to be automatically processed use the following format: '+1,+2,+3'</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="enzyme" type="DigestionEnzyme">
-										<xs:annotation>
-											<xs:documentation>digestion enzyme ('trypsin','pepsin_a','chymotrypsin','proteinase_k','no_enzyme' or 'unknown_enzyme')</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="missed_cleavages" type="xs:unsignedInt">
-										<xs:annotation>
-											<xs:documentation>number of allowed missed cleavages</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="precursor_peak_tolerance" type="xs:float" use="required">
-										<xs:annotation>
-											<xs:documentation>peak mass tolerance of precursor peak in Da</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="peak_mass_tolerance" type="xs:float" use="required">
-										<xs:annotation>
-											<xs:documentation>peak mass tolerance of fragment ions in Da</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="ProteinIdentification" minOccurs="0">
-								<xs:annotation>
-									<xs:documentation>Collection of identified proteins</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="ProteinHit" minOccurs="0" maxOccurs="unbounded">
-											<xs:annotation>
-												<xs:documentation>Single reported protein hit</xs:documentation>
-											</xs:annotation>
-											<xs:complexType>
-												<xs:sequence minOccurs="0">
-													<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-												</xs:sequence>
-												<xs:attribute name="id" type="xs:ID" use="required">
-													<xs:annotation>
-														<xs:documentation>'id' of the protein hit. Is referenced by peptide hits.</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="accession" type="xs:string" use="required">
-													<xs:annotation>
-														<xs:documentation>accession of the protein in the used database.</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="score" type="xs:float" use="required">
-													<xs:annotation>
-														<xs:documentation>score of the hit</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="sequence" type="xs:string">
-													<xs:annotation>
-														<xs:documentation>protein sequences, if known</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-									</xs:sequence>
-									<xs:attribute name="score_type" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
-										<xs:annotation>
-											<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="significance_threshold" type="xs:float">
-										<xs:annotation>
-											<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
+							<xs:element name="SearchParameters" type="SearchParametersType" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="ProteinIdentification" type="ProteinIdentificationType" minOccurs="0" maxOccurs="unbounded"/>
 						</xs:sequence>
 						<xs:attribute name="id" type="xs:ID" use="required">
 							<xs:annotation>
@@ -247,52 +99,7 @@
 						</xs:attribute>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="UnassignedPeptideIdentification" minOccurs="0" maxOccurs="unbounded">
-					<xs:annotation>
-						<xs:documentation>Peptide identifications not mapped to any consensus feature.</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="PeptideHit" type="PeptideHitType" minOccurs="0" maxOccurs="unbounded"/>
-							<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-						</xs:sequence>
-						<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
-							<xs:annotation>
-								<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="score_type" type="xs:string" use="required">
-							<xs:annotation>
-								<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
-							<xs:annotation>
-								<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="significance_threshold" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
-							<xs:annotation>
-								<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="RT" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="MZ" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
+				<xs:element name="UnassignedPeptideIdentification" type="PeptideIdentificationType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element ref="mapList"/>
 				<xs:element ref="consensusElementList"/>
 			</xs:sequence>
@@ -344,39 +151,6 @@
 			</xs:attribute>
 		</xs:complexType>
 	</xs:element>
-	<xs:simpleType name="UserParamType">
-		<xs:annotation>
-			<xs:documentation>Enumeration of types</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="int"/>
-			<xs:enumeration value="float"/>
-			<xs:enumeration value="string"/>
-			<xs:enumeration value="intList"/>
-			<xs:enumeration value="floatList"/>
-			<xs:enumeration value="stringList"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:complexType name="UserParam">
-		<xs:annotation>
-			<xs:documentation>Type-Name-Value type for annotations</xs:documentation>
-		</xs:annotation>
-		<xs:attribute name="type" type="UserParamType" use="required">
-			<xs:annotation>
-				<xs:documentation>value type ('int', 'float' or 'string')</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="name" type="xs:string" use="required">
-			<xs:annotation>
-				<xs:documentation>name of the annotation</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="value" type="xs:anySimpleType" use="required">
-			<xs:annotation>
-				<xs:documentation>actual value of the annotation</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-	</xs:complexType>
 	<xs:element name="map">
 		<xs:complexType>
 			<xs:sequence>
@@ -432,52 +206,7 @@
 			<xs:sequence>
 				<xs:element ref="centroid"/>
 				<xs:element ref="groupedElementList"/>
-				<xs:element name="PeptideIdentification" minOccurs="0" maxOccurs="unbounded">
-					<xs:annotation>
-						<xs:documentation>Peptide identifications mapped to this consensus feature.</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="PeptideHit" type="PeptideHitType" minOccurs="0" maxOccurs="unbounded"/>
-							<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-						</xs:sequence>
-						<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
-							<xs:annotation>
-								<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="score_type" type="xs:string" use="required">
-							<xs:annotation>
-								<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
-							<xs:annotation>
-								<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="significance_threshold" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
-							<xs:annotation>
-								<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="RT" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="MZ" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
+				<xs:element name="PeptideIdentification" type="PeptideIdentificationType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>user parameters</xs:documentation>
@@ -572,6 +301,203 @@
 		</xs:complexType>
 	</xs:element>
 
+	<xs:complexType name="SearchParametersType">
+		<xs:annotation>
+			<xs:documentation>Search parameters that can be used for several identification runs</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="FixedModification" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>fixed modifications for the search</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="name" use="required">
+						<xs:annotation>
+							<xs:documentation>modification name</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:minLength value="1"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="VariableModification" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>variable modifications for the search</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="name" use="required">
+						<xs:annotation>
+							<xs:documentation>modification name</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:minLength value="1"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+<!--
+		<xs:attribute name="id" type="xs:ID" use="required">
+			<xs:annotation>
+				<xs:documentation>'id' of search parameters.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+-->
+		<xs:attribute name="db" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>protein sequence database name</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="db_version" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>database version</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="taxonomy" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>taxonomy restriction</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="mass_type" type="MassType" use="required">
+			<xs:annotation>
+				<xs:documentation>mass type ('monoisotopic' or 'average')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="charges" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>searched for charges. If you want these charges to be automatically processed use the following format: '+1,+2,+3'</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="enzyme" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>digestion enzyme name</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="missed_cleavages" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation>number of allowed missed cleavages</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="precursor_peak_tolerance" type="xs:float" use="required">
+			<xs:annotation>
+				<xs:documentation>peak mass tolerance of precursor peak in Da</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="peak_mass_tolerance" type="xs:float" use="required">
+			<xs:annotation>
+				<xs:documentation>peak mass tolerance of fragment ions in Da</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="ProteinIdentificationType">
+		<xs:annotation>
+			<xs:documentation>Collection of identified proteins</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ProteinHit" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Single reported protein hit</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="id" type="xs:ID" use="required">
+						<xs:annotation>
+							<xs:documentation>'id' of the protein hit. Is referenced by peptide hits.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="accession" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation>accession of the protein in the used database.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="score" type="xs:float" use="required">
+						<xs:annotation>
+							<xs:documentation>score of the hit</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="sequence" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>protein sequences, if known</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="score_type" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+			<xs:annotation>
+				<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="significance_threshold" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="PeptideIdentificationType">
+		<xs:annotation>
+			<xs:documentation>Peptide identifications not mapped to any consensus feature.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="PeptideHit" type="PeptideHitType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
+			<xs:annotation>
+				<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="score_type" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+			<xs:annotation>
+				<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="significance_threshold" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="RT" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="MZ" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 	<xs:complexType name="PeptideHitType">
 		<xs:annotation>
 			<xs:documentation>single reported peptide hit</xs:documentation>
@@ -620,7 +546,6 @@
 			</xs:annotation>
 		</xs:attribute>
 	</xs:complexType>
-
 	<xs:simpleType name="MassType">
 		<xs:annotation>
 			<xs:documentation>Enumeration of mass types</xs:documentation>
@@ -628,19 +553,6 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="average"/>
 			<xs:enumeration value="monoisotopic"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="DigestionEnzyme">
-		<xs:annotation>
-			<xs:documentation>Enumeration of digestion enzymes</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="pepsin_a"/>
-			<xs:enumeration value="chymotrypsin"/>
-			<xs:enumeration value="proteinase_k"/>
-			<xs:enumeration value="trypsin"/>
-			<xs:enumeration value="no_enzyme"/>
-			<xs:enumeration value="unknown_enzyme"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="IntListType">
@@ -655,4 +567,37 @@
 		</xs:annotation>
 		<xs:list itemType="xs:string"/>
 	</xs:simpleType>
+	<xs:simpleType name="UserParamType">
+		<xs:annotation>
+			<xs:documentation>Enumeration of types</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="int"/>
+			<xs:enumeration value="float"/>
+			<xs:enumeration value="string"/>
+			<xs:enumeration value="intList"/>
+			<xs:enumeration value="floatList"/>
+			<xs:enumeration value="stringList"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="UserParam">
+		<xs:annotation>
+			<xs:documentation>Type-Name-Value type for annotations</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="type" type="UserParamType" use="required">
+			<xs:annotation>
+				<xs:documentation>value type ('int', 'float' or 'string')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>name of the annotation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="value" type="xs:anySimpleType" use="required">
+			<xs:annotation>
+				<xs:documentation>actual value of the annotation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 </xs:schema>

--- a/share/OpenMS/SCHEMAS/FeatureXML_1_8.xsd
+++ b/share/OpenMS/SCHEMAS/FeatureXML_1_8.xsd
@@ -50,16 +50,7 @@
 									</xs:attribute>
 								</xs:complexType>
 							</xs:element>
-							<xs:element name="UserParam" minOccurs="0" maxOccurs="unbounded">
-								<xs:annotation>
-									<xs:documentation>user parameters</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:complexContent>
-										<xs:extension base="UserParam"/>
-									</xs:complexContent>
-								</xs:complexType>
-							</xs:element>
+			                                <xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
 						</xs:sequence>
 						<xs:attribute name="completion_time" type="xs:dateTime" use="required">
 							<xs:annotation>
@@ -74,156 +65,8 @@
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="SearchParameters">
-								<xs:annotation>
-									<xs:documentation>Search parameters that can be used for several identification runs</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="FixedModification" minOccurs="0" maxOccurs="unbounded">
-											<xs:annotation>
-												<xs:documentation>fixed modifications for the search</xs:documentation>
-											</xs:annotation>
-											<xs:complexType>
-												<xs:sequence minOccurs="0">
-													<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-												</xs:sequence>
-												<xs:attribute name="name" use="required">
-													<xs:annotation>
-														<xs:documentation>modification name</xs:documentation>
-													</xs:annotation>
-													<xs:simpleType>
-														<xs:restriction base="xs:string">
-															<xs:minLength value="1"/>
-														</xs:restriction>
-													</xs:simpleType>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="VariableModification" minOccurs="0" maxOccurs="unbounded">
-											<xs:annotation>
-												<xs:documentation>variable modifications for the search</xs:documentation>
-											</xs:annotation>
-											<xs:complexType>
-												<xs:sequence minOccurs="0">
-													<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-												</xs:sequence>
-												<xs:attribute name="name" use="required">
-													<xs:annotation>
-														<xs:documentation>modification name</xs:documentation>
-													</xs:annotation>
-													<xs:simpleType>
-														<xs:restriction base="xs:string">
-															<xs:minLength value="1"/>
-														</xs:restriction>
-													</xs:simpleType>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-									</xs:sequence>
-									<xs:attribute name="db" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>protein sequence database name</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="db_version" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>database version</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="taxonomy" type="xs:string">
-										<xs:annotation>
-											<xs:documentation>taxonomy restriction</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="mass_type" type="MassType" use="required">
-										<xs:annotation>
-											<xs:documentation>mass type ('monoisotopic' or 'average')</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="charges" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>searched for charges. If you want these charges to be automatically processed use the following format: '+1,+2,+3'</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="enzyme" type="DigestionEnzyme">
-										<xs:annotation>
-											<xs:documentation>digestion enzyme ('trypsin','pepsin_a','chymotrypsin','proteinase_k','no_enzyme' or 'unknown_enzyme')</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="missed_cleavages" type="xs:unsignedInt">
-										<xs:annotation>
-											<xs:documentation>number of allowed missed cleavages</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="precursor_peak_tolerance" type="xs:float" use="required">
-										<xs:annotation>
-											<xs:documentation>peak mass tolerance of precursor peak in Da</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="peak_mass_tolerance" type="xs:float" use="required">
-										<xs:annotation>
-											<xs:documentation>peak mass tolerance of fragment ions in Da</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="ProteinIdentification" minOccurs="0">
-								<xs:annotation>
-									<xs:documentation>Collection of identified proteins</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="ProteinHit" minOccurs="0" maxOccurs="unbounded">
-											<xs:annotation>
-												<xs:documentation>Single reported protein hit</xs:documentation>
-											</xs:annotation>
-											<xs:complexType>
-												<xs:sequence minOccurs="0">
-													<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-												</xs:sequence>
-												<xs:attribute name="id" type="xs:ID" use="required">
-													<xs:annotation>
-														<xs:documentation>'id' of the protein hit. Is referenced by peptide hits.</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="accession" type="xs:string" use="required">
-													<xs:annotation>
-														<xs:documentation>accession of the protein in the used database.</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="score" type="xs:float" use="required">
-													<xs:annotation>
-														<xs:documentation>score of the hit</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="sequence" type="xs:string">
-													<xs:annotation>
-														<xs:documentation>protein sequences, if known</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-									</xs:sequence>
-									<xs:attribute name="score_type" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
-										<xs:annotation>
-											<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="significance_threshold" type="xs:float">
-										<xs:annotation>
-											<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
+							<xs:element name="SearchParameters" type="SearchParametersType" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="ProteinIdentification" type="ProteinIdentificationType" minOccurs="0" maxOccurs="unbounded"/>
 						</xs:sequence>
 						<xs:attribute name="id" type="xs:ID" use="required">
 							<xs:annotation>
@@ -247,52 +90,7 @@
 						</xs:attribute>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="UnassignedPeptideIdentification" minOccurs="0" maxOccurs="unbounded">
-					<xs:annotation>
-						<xs:documentation>Peptide identifications not mapped to any feature.</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="PeptideHit" type="PeptideHitType" minOccurs="0" maxOccurs="unbounded"/>
-							<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-						</xs:sequence>
-						<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
-							<xs:annotation>
-								<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="score_type" type="xs:string" use="required">
-							<xs:annotation>
-								<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
-							<xs:annotation>
-								<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="significance_threshold" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
-							<xs:annotation>
-								<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="RT" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="MZ" type="xs:float">
-							<xs:annotation>
-								<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
+				<xs:element name="UnassignedPeptideIdentification" type="PeptideIdentificationType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="featureList">
 					<xs:annotation>
 						<xs:documentation>A list of several features</xs:documentation>
@@ -330,26 +128,6 @@
 			</xs:attribute>
 		</xs:complexType>
 	</xs:element>
-	<xs:complexType name="UserParam">
-		<xs:annotation>
-			<xs:documentation>Type-Name-Value type for annotations</xs:documentation>
-		</xs:annotation>
-		<xs:attribute name="type" type="UserParamType" use="required">
-			<xs:annotation>
-				<xs:documentation>value type ('int', 'float' or 'string')</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="name" type="xs:string" use="required">
-			<xs:annotation>
-				<xs:documentation>name of the annotation</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="value" type="xs:anySimpleType" use="required">
-			<xs:annotation>
-				<xs:documentation>actual value of the annotation</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-	</xs:complexType>
 	<xs:complexType name="featureType">
 		<xs:sequence>
 			<xs:element name="position" minOccurs="2" maxOccurs="2">
@@ -485,52 +263,7 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="PeptideIdentification" minOccurs="0" maxOccurs="unbounded">
-				<xs:annotation>
-					<xs:documentation>Peptide identifications mapped to this feature.</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element name="PeptideHit" type="PeptideHitType" minOccurs="0" maxOccurs="unbounded"/>
-						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-					</xs:sequence>
-					<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
-						<xs:annotation>
-							<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="score_type" type="xs:string" use="required">
-						<xs:annotation>
-							<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
-						<xs:annotation>
-							<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="significance_threshold" type="xs:float">
-						<xs:annotation>
-							<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
-						<xs:annotation>
-							<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="RT" type="xs:float">
-						<xs:annotation>
-							<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="MZ" type="xs:float">
-						<xs:annotation>
-							<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
+			<xs:element name="PeptideIdentification" type="PeptideIdentificationType" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attribute name="id" type="xs:ID" use="required" form="unqualified">
@@ -540,6 +273,203 @@
 		</xs:attribute>
 	</xs:complexType>
 
+	<xs:complexType name="SearchParametersType">
+		<xs:annotation>
+			<xs:documentation>Search parameters that can be used for several identification runs</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="FixedModification" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>fixed modifications for the search</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="name" use="required">
+						<xs:annotation>
+							<xs:documentation>modification name</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:minLength value="1"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="VariableModification" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>variable modifications for the search</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="name" use="required">
+						<xs:annotation>
+							<xs:documentation>modification name</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:minLength value="1"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+<!--
+		<xs:attribute name="id" type="xs:ID" use="required">
+			<xs:annotation>
+				<xs:documentation>'id' of search parameters.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+-->
+		<xs:attribute name="db" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>protein sequence database name</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="db_version" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>database version</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="taxonomy" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>taxonomy restriction</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="mass_type" type="MassType" use="required">
+			<xs:annotation>
+				<xs:documentation>mass type ('monoisotopic' or 'average')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="charges" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>searched for charges. If you want these charges to be automatically processed use the following format: '+1,+2,+3'</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="enzyme" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>digestion enzyme name</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="missed_cleavages" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation>number of allowed missed cleavages</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="precursor_peak_tolerance" type="xs:float" use="required">
+			<xs:annotation>
+				<xs:documentation>peak mass tolerance of precursor peak in Da</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="peak_mass_tolerance" type="xs:float" use="required">
+			<xs:annotation>
+				<xs:documentation>peak mass tolerance of fragment ions in Da</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="ProteinIdentificationType">
+		<xs:annotation>
+			<xs:documentation>Collection of identified proteins</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ProteinHit" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Single reported protein hit</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="id" type="xs:ID" use="required">
+						<xs:annotation>
+							<xs:documentation>'id' of the protein hit. Is referenced by peptide hits.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="accession" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation>accession of the protein in the used database.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="score" type="xs:float" use="required">
+						<xs:annotation>
+							<xs:documentation>score of the hit</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="sequence" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>protein sequences, if known</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="score_type" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+			<xs:annotation>
+				<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="significance_threshold" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="PeptideIdentificationType">
+		<xs:annotation>
+			<xs:documentation>Peptide identifications not mapped to any consensus feature.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="PeptideHit" type="PeptideHitType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
+			<xs:annotation>
+				<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="score_type" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+			<xs:annotation>
+				<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="significance_threshold" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="RT" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="MZ" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 	<xs:complexType name="PeptideHitType">
 		<xs:annotation>
 			<xs:documentation>single reported peptide hit</xs:documentation>
@@ -589,19 +519,6 @@
 		</xs:attribute>
 	</xs:complexType>
 
-	<xs:simpleType name="UserParamType">
-		<xs:annotation>
-			<xs:documentation>Enumeration of types</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="int"/>
-			<xs:enumeration value="float"/>
-			<xs:enumeration value="string"/>
-			<xs:enumeration value="intList"/>
-			<xs:enumeration value="floatList"/>
-			<xs:enumeration value="stringList"/>
-		</xs:restriction>
-	</xs:simpleType>
 	<xs:simpleType name="MassType">
 		<xs:annotation>
 			<xs:documentation>Enumeration of mass types</xs:documentation>
@@ -609,19 +526,6 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="average"/>
 			<xs:enumeration value="monoisotopic"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="DigestionEnzyme">
-		<xs:annotation>
-			<xs:documentation>Enumeration of digestion enzymes</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="pepsin_a"/>
-			<xs:enumeration value="chymotrypsin"/>
-			<xs:enumeration value="proteinase_k"/>
-			<xs:enumeration value="trypsin"/>
-			<xs:enumeration value="no_enzyme"/>
-			<xs:enumeration value="unknown_enzyme"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="IntListType">
@@ -636,4 +540,38 @@
 		</xs:annotation>
 		<xs:list itemType="xs:string"/>
 	</xs:simpleType>
+	<xs:simpleType name="UserParamType">
+		<xs:annotation>
+			<xs:documentation>Enumeration of types</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="int"/>
+			<xs:enumeration value="float"/>
+			<xs:enumeration value="string"/>
+			<xs:enumeration value="intList"/>
+			<xs:enumeration value="floatList"/>
+			<xs:enumeration value="stringList"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="UserParam">
+		<xs:annotation>
+			<xs:documentation>Type-Name-Value type for annotations</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="type" type="UserParamType" use="required">
+			<xs:annotation>
+				<xs:documentation>value type ('int', 'float' or 'string')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>name of the annotation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="value" type="xs:anySimpleType" use="required">
+			<xs:annotation>
+				<xs:documentation>actual value of the annotation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 </xs:schema>
+

--- a/share/OpenMS/SCHEMAS/IdXML_1_3.xsd
+++ b/share/OpenMS/SCHEMAS/IdXML_1_3.xsd
@@ -7,208 +7,15 @@
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="SearchParameters" maxOccurs="unbounded">
-					<xs:annotation>
-						<xs:documentation>Search parameters that can be used for several identification runs</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="FixedModification" minOccurs="0" maxOccurs="unbounded">
-								<xs:annotation>
-									<xs:documentation>fixed modifications for the search</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence minOccurs="0">
-										<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-									</xs:sequence>
-									<xs:attribute name="name" use="required">
-										<xs:annotation>
-											<xs:documentation>modification name</xs:documentation>
-										</xs:annotation>
-										<xs:simpleType>
-											<xs:restriction base="xs:string">
-												<xs:minLength value="1"/>
-											</xs:restriction>
-										</xs:simpleType>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="VariableModification" minOccurs="0" maxOccurs="unbounded">
-								<xs:annotation>
-									<xs:documentation>variable modifications for the search</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence minOccurs="0">
-										<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-									</xs:sequence>
-									<xs:attribute name="name" use="required">
-										<xs:annotation>
-											<xs:documentation>modification name</xs:documentation>
-										</xs:annotation>
-										<xs:simpleType>
-											<xs:restriction base="xs:string">
-												<xs:minLength value="1"/>
-											</xs:restriction>
-										</xs:simpleType>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-						</xs:sequence>
-						<xs:attribute name="id" type="xs:ID" use="required">
-							<xs:annotation>
-								<xs:documentation>'id' referenced by IdentificationRun</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="db" type="xs:string" use="required">
-							<xs:annotation>
-								<xs:documentation>protein sequence database name</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="db_version" type="xs:string" use="required">
-							<xs:annotation>
-								<xs:documentation>database version</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="taxonomy" type="xs:string">
-							<xs:annotation>
-								<xs:documentation>taxonomy restriction</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="mass_type" type="MassType" use="required">
-							<xs:annotation>
-								<xs:documentation>mass type ('monoisotopic' or 'average')</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="charges" type="xs:string" use="required">
-							<xs:annotation>
-								<xs:documentation>searched for charges. If you want these charges to be automatically processed use the following format: '+1,+2,+3'</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="enzyme" type="DigestionEnzyme">
-							<xs:annotation>
-								<xs:documentation>digestion enzyme ('trypsin','pepsin_a','chymotrypsin','proteinase_k','no_enzyme' or 'unknown_enzyme')</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="missed_cleavages" type="xs:unsignedInt">
-							<xs:annotation>
-								<xs:documentation>number of allowed missed cleavages</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="precursor_peak_tolerance" type="xs:float" use="required">
-							<xs:annotation>
-								<xs:documentation>peak mass tolerance of precursor peak in Da</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="peak_mass_tolerance" type="xs:float" use="required">
-							<xs:annotation>
-								<xs:documentation>peak mass tolerance of fragment ions in Da</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
+				<xs:element name="SearchParameters" type="SearchParametersType" minOccurs="0" maxOccurs="unbounded"/>
 				<xs:element name="IdentificationRun" maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>One identification run. It can contain peptide and protein identifications</xs:documentation>
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="ProteinIdentification" minOccurs="0">
-								<xs:annotation>
-									<xs:documentation>Collection of identified proteins</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="ProteinHit" minOccurs="0" maxOccurs="unbounded">
-											<xs:annotation>
-												<xs:documentation>Single reported protein hit</xs:documentation>
-											</xs:annotation>
-											<xs:complexType>
-												<xs:sequence minOccurs="0">
-													<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-												</xs:sequence>
-												<xs:attribute name="id" type="xs:ID" use="required">
-													<xs:annotation>
-														<xs:documentation>'id' of the protein hit. Is referenced by peptide hits.</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="accession" type="xs:string" use="required">
-													<xs:annotation>
-														<xs:documentation>accession of the protein in the used database.</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="score" type="xs:float" use="required">
-													<xs:annotation>
-														<xs:documentation>score of the hit</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="sequence" type="xs:string">
-													<xs:annotation>
-														<xs:documentation>protein sequences, if known</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-										<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-									</xs:sequence>
-									<xs:attribute name="score_type" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
-										<xs:annotation>
-											<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="significance_threshold" type="xs:float">
-										<xs:annotation>
-											<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="PeptideIdentification" minOccurs="0" maxOccurs="unbounded">
-								<xs:annotation>
-									<xs:documentation>Collections of identified peptides. Typically one for each spectrum or feature.</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence>
-										<xs:element name="PeptideHit" type="PeptideHitType" minOccurs="0" maxOccurs="unbounded"/>
-										<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
-									</xs:sequence>
-									<xs:attribute name="score_type" type="xs:string" use="required">
-										<xs:annotation>
-											<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
-										<xs:annotation>
-											<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="significance_threshold" type="xs:float">
-										<xs:annotation>
-											<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
-										<xs:annotation>
-											<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="RT" type="xs:float">
-										<xs:annotation>
-											<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="MZ" type="xs:float">
-										<xs:annotation>
-											<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
+							<xs:element name="ProteinIdentification" type="ProteinIdentificationType" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="PeptideIdentification" type="PeptideIdentificationType" minOccurs="0" maxOccurs="unbounded"/>
 						</xs:sequence>
 						<xs:attribute name="search_engine" type="xs:string" use="required">
 							<xs:annotation>
@@ -246,6 +53,203 @@
 		</xs:complexType>
 	</xs:element>
 
+	<xs:complexType name="SearchParametersType">
+		<xs:annotation>
+			<xs:documentation>Search parameters that can be used for several identification runs</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="FixedModification" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>fixed modifications for the search</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="name" use="required">
+						<xs:annotation>
+							<xs:documentation>modification name</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:minLength value="1"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="VariableModification" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>variable modifications for the search</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="name" use="required">
+						<xs:annotation>
+							<xs:documentation>modification name</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:minLength value="1"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="id" type="xs:ID" use="required">
+			<xs:annotation>
+				<xs:documentation>'id' of search parameters.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="db" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>protein sequence database name</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="db_version" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>database version</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="taxonomy" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>taxonomy restriction</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="mass_type" type="MassType" use="required">
+			<xs:annotation>
+				<xs:documentation>mass type ('monoisotopic' or 'average')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="charges" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>searched for charges. If you want these charges to be automatically processed use the following format: '+1,+2,+3'</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="enzyme" type="xs:string">
+			<xs:annotation>
+				<xs:documentation>digestion enzyme name</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="missed_cleavages" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation>number of allowed missed cleavages</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="precursor_peak_tolerance" type="xs:float" use="required">
+			<xs:annotation>
+				<xs:documentation>peak mass tolerance of precursor peak in Da</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="peak_mass_tolerance" type="xs:float" use="required">
+			<xs:annotation>
+				<xs:documentation>peak mass tolerance of fragment ions in Da</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="ProteinIdentificationType">
+		<xs:annotation>
+			<xs:documentation>Collection of identified proteins</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ProteinHit" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Single reported protein hit</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence minOccurs="0">
+						<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+					<xs:attribute name="id" type="xs:ID" use="required">
+						<xs:annotation>
+							<xs:documentation>'id' of the protein hit. Is referenced by peptide hits.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="accession" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation>accession of the protein in the used database.</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="score" type="xs:float" use="required">
+						<xs:annotation>
+							<xs:documentation>score of the hit</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="sequence" type="xs:string">
+						<xs:annotation>
+							<xs:documentation>protein sequences, if known</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+		<xs:attribute name="score_type" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+			<xs:annotation>
+				<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="significance_threshold" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="PeptideIdentificationType">
+		<xs:annotation>
+			<xs:documentation>Peptide identifications not mapped to any consensus feature.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="PeptideHit" type="PeptideHitType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="UserParam" type="UserParam" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+<!--
+		<xs:attribute name="identification_run_ref" type="xs:IDREF" use="required">
+			<xs:annotation>
+				<xs:documentation>Reference to the corresponding identification run.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+-->
+		<xs:attribute name="score_type" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>score type of the protein hits, e.g. MOWSE, p-value,...</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="higher_score_better" type="xs:boolean" use="required">
+			<xs:annotation>
+				<xs:documentation>if a higher score is better ('true' or false')</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="significance_threshold" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>significance threshold as calculated by the search engine</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="spectrum_reference" type="xs:unsignedInt">
+			<xs:annotation>
+				<xs:documentation>Integer reference number of the identified spectrum (or feature)</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="RT" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>Precursor peak retention time of the identified spectrum</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="MZ" type="xs:float">
+			<xs:annotation>
+				<xs:documentation>Precursor peak mass-to-charge ratio of the identified spectrum</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 	<xs:complexType name="PeptideHitType">
 		<xs:annotation>
 			<xs:documentation>single reported peptide hit</xs:documentation>
@@ -295,6 +299,40 @@
 		</xs:attribute>
 	</xs:complexType>
 
+	<xs:simpleType name="MassType">
+		<xs:annotation>
+			<xs:documentation>Enumeration of mass types</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="average"/>
+			<xs:enumeration value="monoisotopic"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="IntListType">
+		<xs:annotation>
+			<xs:documentation>list of integers</xs:documentation>
+		</xs:annotation>
+		<xs:list itemType="xs:int"/>
+	</xs:simpleType>
+	<xs:simpleType name="CharListType">
+		<xs:annotation>
+			<xs:documentation>list of strings</xs:documentation>
+		</xs:annotation>
+		<xs:list itemType="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="UserParamType">
+		<xs:annotation>
+			<xs:documentation>Enumeration of types</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="int"/>
+			<xs:enumeration value="float"/>
+			<xs:enumeration value="string"/>
+			<xs:enumeration value="intList"/>
+			<xs:enumeration value="floatList"/>
+			<xs:enumeration value="stringList"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:complexType name="UserParam">
 		<xs:annotation>
 			<xs:documentation>Type-Name-Value type for annotations</xs:documentation>
@@ -315,51 +353,5 @@
 			</xs:annotation>
 		</xs:attribute>
 	</xs:complexType>
-	<xs:simpleType name="DigestionEnzyme">
-		<xs:annotation>
-			<xs:documentation>Enumeration of digestion enzymes</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="pepsin_a"/>
-			<xs:enumeration value="chymotrypsin"/>
-			<xs:enumeration value="proteinase_k"/>
-			<xs:enumeration value="trypsin"/>
-			<xs:enumeration value="no_enzyme"/>
-			<xs:enumeration value="unknown_enzyme"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MassType">
-		<xs:annotation>
-			<xs:documentation>Enumeration of mass types</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="average"/>
-			<xs:enumeration value="monoisotopic"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="UserParamType">
-		<xs:annotation>
-			<xs:documentation>Enumeration of types</xs:documentation>
-		</xs:annotation>
-		<xs:restriction base="xs:string">
-			<xs:enumeration value="int"/>
-			<xs:enumeration value="float"/>
-			<xs:enumeration value="string"/>
-			<xs:enumeration value="intList"/>
-			<xs:enumeration value="floatList"/>
-			<xs:enumeration value="stringList"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="IntListType">
-		<xs:annotation>
-			<xs:documentation>list of integers</xs:documentation>
-		</xs:annotation>
-		<xs:list itemType="xs:int"/>
-	</xs:simpleType>
-	<xs:simpleType name="CharListType">
-		<xs:annotation>
-			<xs:documentation>list of strings</xs:documentation>
-		</xs:annotation>
-		<xs:list itemType="xs:string"/>
-	</xs:simpleType>
 </xs:schema>
+


### PR DESCRIPTION
This PR is mainly a rearrangement of the schema and introduction of common XML types (e.g. PeptideHitType, SearchParametersType, etc.) to make the schema easier readable.
One addition is the adaption of the enzyme entry (changed from enum to a xs:string) as we now support arbitrary enzymes via EnzymeDB.