### PR TITLE
label sets for MultiplexDeltaMasses

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -88,7 +88,7 @@ namespace OpenMS
     /**
      * @brief constructor
      */
-    MultiplexDeltaMasses(std::vector<DeltaMass> dm);
+    MultiplexDeltaMasses(const std::vector<DeltaMass>& dm);
         
     /**
      * @brief returns delta masses

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -105,11 +105,6 @@ namespace OpenMS
     unsigned size() const;
    
     /**
-     * @brief returns delta mass at position i
-     */
-    DeltaMass getDeltaMassAt(int i) const;
-    
-    /**
      * @brief returns mass shift at position i
      */
     double getMassShiftAt(int i) const;

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -108,10 +108,25 @@ namespace OpenMS
     std::vector<double> getMassShifts() const;
     
     /**
+     * @brief returns delta masses
+     */
+    std::vector<DeltaMass> getDeltaMasses() const;
+    
+    /**
+     * @brief returns number of delta masses
+     */
+    unsigned getDeltaMassesCount() const;
+   
+    /**
      * @brief returns number of mass shifts
      */
     unsigned getMassShiftCount() const;
    
+    /**
+     * @brief returns delta mass at position i
+     */
+    DeltaMass getDeltaMassAt(int i) const;
+    
     /**
      * @brief returns mass shift at position i
      */

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -91,11 +91,6 @@ namespace OpenMS
     MultiplexDeltaMasses(std::vector<DeltaMass> dm);
         
     /**
-     * @brief add a delta mass
-     */
-    void addDeltaMass(DeltaMass dm);
-        
-    /**
      * @brief returns delta masses
      */
     std::vector<DeltaMass>& getDeltaMasses();

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -69,7 +69,11 @@ namespace OpenMS
     /**
      * @brief mass shift with corresponding label set
      */
-    typedef std::pair<double,LabelSet> DeltaMass;
+    //typedef std::pair<double,LabelSet> DeltaMass;
+    struct DeltaMass {
+      double mass_shift;
+      LabelSet label_set;
+    };
 
     /**
      * @brief constructor

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -122,6 +122,11 @@ namespace OpenMS
      */
     double getMassShiftAt(int i) const;
     
+    /**
+     * @brief returns label set at position i
+     */
+    LabelSet getLabelSetAt(int i) const;
+    
     private:
    
     /**

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -97,18 +97,18 @@ namespace OpenMS
     /**
      * @brief returns delta masses
      */
-    std::vector<DeltaMass> getDeltaMasses();
+    std::vector<DeltaMass>& getDeltaMasses();
+    
+    /**
+     * @brief returns delta masses
+     */
+    const std::vector<DeltaMass>& getDeltaMasses() const;
     
     /**
      * @brief returns number of delta masses
      */
     unsigned size() const;
    
-    /**
-     * @brief returns mass shift at position i
-     */
-    double getMassShiftAt(int i) const;
-    
     /**
      * @brief returns label set at position i
      */

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -73,6 +73,8 @@ namespace OpenMS
     {
       double delta_mass;
       LabelSet label_set;
+      
+      DeltaMass(double dm, LabelSet ls);
     };
 
     /**
@@ -93,13 +95,13 @@ namespace OpenMS
     /**
      * @brief add a delta mass
      */
-    void addDeltaMass(double m, LabelSet ls);
+    void addDeltaMass(double dm, LabelSet ls);
     
     /**
      * @brief add a delta mass (with a label set consisting of a
      * single label)
      */
-    void addDeltaMass(double m, String l);
+    void addDeltaMass(double dm, String l);
     
     /**
      * @brief returns mass shifts

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -109,11 +109,6 @@ namespace OpenMS
      */
     unsigned size() const;
    
-    /**
-     * @brief returns label set at position i
-     */
-    LabelSet getLabelSetAt(int i) const;
-    
     private:
    
     /**

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -69,7 +69,6 @@ namespace OpenMS
     /**
      * @brief mass shift with corresponding label set
      */
-    //typedef std::pair<double,LabelSet> DeltaMass;
     struct DeltaMass {
       double mass_shift;
       LabelSet label_set;

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -79,18 +79,8 @@ namespace OpenMS
     /**
      * @brief constructor
      */
-    MultiplexDeltaMasses(std::vector<double> ms);
-    
-    /**
-     * @brief constructor
-     */
     MultiplexDeltaMasses(std::vector<DeltaMass> dm);
         
-    /**
-     * @brief add a mass shift
-     */
-    void addMassShift(double ms);
-    
     /**
      * @brief add a delta mass
      */
@@ -123,11 +113,6 @@ namespace OpenMS
     unsigned getDeltaMassesCount() const;
    
     /**
-     * @brief returns number of mass shifts
-     */
-    unsigned getMassShiftCount() const;
-   
-    /**
      * @brief returns delta mass at position i
      */
     DeltaMass getDeltaMassAt(int i) const;
@@ -139,12 +124,6 @@ namespace OpenMS
     
     private:
    
-    /**
-     * @brief mass shifts between peptides
-     * (including zero mass shift for first peptide)
-     */
-    std::vector<double> mass_shifts_;
-      
     /**
      * @brief mass shifts between peptides
      * (including zero mass shift for first peptide)

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -71,7 +71,7 @@ namespace OpenMS
      */
     struct DeltaMass
     {
-      double mass_shift;
+      double delta_mass;
       LabelSet label_set;
     };
 

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -150,8 +150,10 @@ namespace OpenMS
      * (including zero mass shift for first peptide)
      */
     std::vector<DeltaMass> delta_masses_;
-      
+    
  };
+ 
+ bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2);
   
 }
 

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -69,7 +69,8 @@ namespace OpenMS
     /**
      * @brief mass shift with corresponding label set
      */
-    struct DeltaMass {
+    struct DeltaMass
+    {
       double mass_shift;
       LabelSet label_set;
     };

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -95,19 +95,14 @@ namespace OpenMS
     void addDeltaMass(DeltaMass dm);
         
     /**
-     * @brief returns mass shifts
-     */
-    std::vector<double> getMassShifts() const;
-    
-    /**
      * @brief returns delta masses
      */
-    std::vector<DeltaMass> getDeltaMasses() const;
+    std::vector<DeltaMass> getDeltaMasses();
     
     /**
      * @brief returns number of delta masses
      */
-    unsigned getDeltaMassesCount() const;
+    unsigned size() const;
    
     /**
      * @brief returns delta mass at position i

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -76,6 +76,7 @@ namespace OpenMS
       
       DeltaMass(double dm, LabelSet ls);
       
+      // delta mass with a label set containg a single label
       DeltaMass(double dm, String l);
     };
 

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -93,18 +93,7 @@ namespace OpenMS
      * @brief add a delta mass
      */
     void addDeltaMass(DeltaMass dm);
-    
-    /**
-     * @brief add a delta mass
-     */
-    void addDeltaMass(double dm, LabelSet ls);
-    
-    /**
-     * @brief add a delta mass (with a label set consisting of a
-     * single label)
-     */
-    void addDeltaMass(double dm, String l);
-    
+        
     /**
      * @brief returns mass shifts
      */

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -75,6 +75,8 @@ namespace OpenMS
       LabelSet label_set;
       
       DeltaMass(double dm, LabelSet ls);
+      
+      DeltaMass(double dm, String l);
     };
 
     /**

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -100,11 +100,6 @@ namespace OpenMS
      */
     const std::vector<DeltaMass>& getDeltaMasses() const;
     
-    /**
-     * @brief returns number of delta masses
-     */
-    unsigned size() const;
-   
     private:
    
     /**

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -103,7 +103,7 @@ namespace OpenMS
     /**
      * @brief returns number of delta masses
      */
-    unsigned size() const;
+    unsigned size();
    
     private:
    

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -74,13 +74,18 @@ namespace OpenMS
     /**
      * @brief constructor
      */
+    MultiplexDeltaMasses();
+    
+    /**
+     * @brief constructor
+     */
     MultiplexDeltaMasses(std::vector<double> ms);
     
     /**
      * @brief constructor
      */
     MultiplexDeltaMasses(std::vector<DeltaMass> dm);
-    
+        
     /**
      * @brief add a mass shift
      */
@@ -94,7 +99,7 @@ namespace OpenMS
     /**
      * @brief add a delta mass
      */
-    void addDeltaMass(double m, std::multiset<String> ls);
+    void addDeltaMass(double m, LabelSet ls);
     
     /**
      * @brief add a delta mass (with a label set consisting of a

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------
+//// --------------------------------------------------------------------------
 //                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
@@ -103,7 +103,7 @@ namespace OpenMS
     /**
      * @brief returns number of delta masses
      */
-    unsigned size();
+    unsigned size() const;
    
     private:
    

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -57,6 +57,19 @@ namespace OpenMS
   class OPENMS_DLLAPI MultiplexDeltaMasses
   {
     public:
+    
+    /**
+     * @brief set of labels associated with a mass shift
+     * 
+     * For example, a set of SILAC labels [Lys8, Lys8, Arg10] would
+     * result in a +26 Da mass shift.
+     */
+    typedef std::multiset<String> LabelSet;
+
+    /**
+     * @brief mass shift with corresponding label set
+     */
+    typedef std::pair<double,LabelSet> DeltaMass;
 
     /**
      * @brief constructor
@@ -64,9 +77,30 @@ namespace OpenMS
     MultiplexDeltaMasses(std::vector<double> ms);
     
     /**
+     * @brief constructor
+     */
+    MultiplexDeltaMasses(std::vector<DeltaMass> dm);
+    
+    /**
      * @brief add a mass shift
      */
     void addMassShift(double ms);
+    
+    /**
+     * @brief add a delta mass
+     */
+    void addDeltaMass(DeltaMass dm);
+    
+    /**
+     * @brief add a delta mass
+     */
+    void addDeltaMass(double m, std::multiset<String> ls);
+    
+    /**
+     * @brief add a delta mass (with a label set consisting of a
+     * single label)
+     */
+    void addDeltaMass(double m, String l);
     
     /**
      * @brief returns mass shifts
@@ -90,6 +124,12 @@ namespace OpenMS
      * (including zero mass shift for first peptide)
      */
     std::vector<double> mass_shifts_;
+      
+    /**
+     * @brief mass shifts between peptides
+     * (including zero mass shift for first peptide)
+     */
+    std::vector<DeltaMass> delta_masses_;
       
  };
   

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.h
@@ -71,7 +71,7 @@ namespace OpenMS
      * @brief generate all mass shifts that can occur due to the absence of one or multiple peptides
      * (e.g. for a triplet experiment generate the doublets and singlets that might be present)
      */
-    void generateKnockoutMassShifts();
+    void generateKnockoutDeltaMasses();
 
     /**
      * @brief write the list of labels for each sample

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -124,10 +124,7 @@ namespace OpenMS
   
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
   {
-    std::vector<double> ms1 = dm1.getMassShifts();
-    std::vector<double> ms2 = dm2.getMassShifts();
-    
-    return ms1<ms2;
+    return (dm1.getMassShifts() < dm1.getMassShifts());
   }
   
 }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -65,11 +65,6 @@ namespace OpenMS
   {
   }
 
-  void MultiplexDeltaMasses::addDeltaMass(MultiplexDeltaMasses::DeltaMass dm)
-  {
-    delta_masses_.push_back(dm);
-  }
-
   std::vector<MultiplexDeltaMasses::DeltaMass>& MultiplexDeltaMasses::getDeltaMasses()
   {
     return delta_masses_;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -105,7 +105,8 @@ namespace OpenMS
   
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
   {
-    return (dm1.getMassShifts() < dm2.getMassShifts());
+    //return (dm1.getMassShifts() < dm2.getMassShifts());
+    return (dm1.getMassShiftAt(0) < dm2.getMassShiftAt(0));
   }
   
 }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -103,6 +103,11 @@ namespace OpenMS
     return delta_masses_[i].first;
   }
   
+  MultiplexDeltaMasses::LabelSet MultiplexDeltaMasses::getLabelSetAt(int i) const
+  {
+    return delta_masses_[i].second;
+  }
+  
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
   {
     //return (dm1.getMassShifts() < dm2.getMassShifts());

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -59,16 +59,18 @@ namespace OpenMS
     delta_masses_.push_back(dm);
   }
 
-  void MultiplexDeltaMasses::addDeltaMass(double m, MultiplexDeltaMasses::LabelSet ls)
+  void MultiplexDeltaMasses::addDeltaMass(double ms, MultiplexDeltaMasses::LabelSet ls)
   {
-    delta_masses_.push_back(MultiplexDeltaMasses::DeltaMass(m,ls));
+    MultiplexDeltaMasses::DeltaMass dm = {ms, ls};
+    delta_masses_.push_back(dm);
   }
 
-  void MultiplexDeltaMasses::addDeltaMass(double m, String l)
+  void MultiplexDeltaMasses::addDeltaMass(double ms, String l)
   {
     MultiplexDeltaMasses::LabelSet ls;
     ls.insert(l);
-    delta_masses_.push_back(std::make_pair(m,ls));
+    MultiplexDeltaMasses::DeltaMass dm = {ms, ls};
+    delta_masses_.push_back(dm);
   }
 
   std::vector<double> MultiplexDeltaMasses::getMassShifts() const
@@ -77,7 +79,7 @@ namespace OpenMS
     
     for (unsigned i = 0; delta_masses_.size(); ++i)
     {
-      ms.push_back(delta_masses_[i].first);
+      ms.push_back(delta_masses_[i].mass_shift);
     }
     
     return ms;
@@ -100,12 +102,12 @@ namespace OpenMS
 
   double MultiplexDeltaMasses::getMassShiftAt(int i) const
   {
-    return delta_masses_[i].first;
+    return delta_masses_[i].mass_shift;
   }
   
   MultiplexDeltaMasses::LabelSet MultiplexDeltaMasses::getLabelSetAt(int i) const
   {
-    return delta_masses_[i].second;
+    return delta_masses_[i].label_set;
   }
   
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -79,7 +79,21 @@ namespace OpenMS
 
   std::vector<double> MultiplexDeltaMasses::getMassShifts() const
   {
+    /*std::vector<double> ms;
+    
+    for (unsigned i = 0; delta_masses_.size(); ++i)
+    {
+      ms.push_back(delta_masses_[i].first);
+    }
+    
+    return ms;*/
+    
     return mass_shifts_;
+  }
+  
+  std::vector<MultiplexDeltaMasses::DeltaMass> MultiplexDeltaMasses::getDeltaMasses() const
+  {
+    return delta_masses_;
   }
 
   unsigned MultiplexDeltaMasses::getMassShiftCount() const
@@ -87,8 +101,20 @@ namespace OpenMS
     return mass_shifts_.size();
   }
 
+  unsigned MultiplexDeltaMasses::getDeltaMassesCount() const
+  {
+    return delta_masses_.size();
+  }
+
+  MultiplexDeltaMasses::DeltaMass MultiplexDeltaMasses::getDeltaMassAt(int i) const
+  {
+    return delta_masses_[i];
+  }
+
   double MultiplexDeltaMasses::getMassShiftAt(int i) const
   {
+    //return delta_masses_[i].first;
+    
     return mass_shifts_[i];
   }
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -45,6 +45,10 @@ using namespace std;
 namespace OpenMS
 {
 
+  MultiplexDeltaMasses::MultiplexDeltaMasses()
+  {
+  }
+
   MultiplexDeltaMasses::MultiplexDeltaMasses(vector<double> ms) :
     mass_shifts_(ms)
   {
@@ -65,7 +69,7 @@ namespace OpenMS
     delta_masses_.push_back(dm);
   }
 
-  void MultiplexDeltaMasses::addDeltaMass(double m, std::multiset<String> ls)
+  void MultiplexDeltaMasses::addDeltaMass(double m, MultiplexDeltaMasses::LabelSet ls)
   {
     delta_masses_.push_back(std::make_pair(m,ls));
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -75,21 +75,16 @@ namespace OpenMS
     return delta_masses_;
   }
 
-  unsigned MultiplexDeltaMasses::size() const
-  {
-    return delta_masses_.size();
-  }
-
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
   {
-    if (dm1.size() != dm2.size())
+    if (dm1.getDeltaMasses().size() != dm2.getDeltaMasses().size())
     {
       // Search first for complete multiplets, then knock-out cases.
-      return (dm1.size() > dm2.size());
+      return (dm1.getDeltaMasses().size() > dm2.getDeltaMasses().size());
     }
     else
     {
-      for (unsigned i = 0; i < dm1.size(); ++i)
+      for (unsigned i = 0; i < dm1.getDeltaMasses().size(); ++i)
       {
         double ms1 = dm1.getDeltaMasses()[i].delta_mass - dm1.getDeltaMasses()[0].delta_mass;
         double ms2 = dm2.getDeltaMasses()[i].delta_mass - dm2.getDeltaMasses()[0].delta_mass;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -45,6 +45,11 @@ using namespace std;
 namespace OpenMS
 {
 
+  MultiplexDeltaMasses::DeltaMass::DeltaMass(double dm, LabelSet ls) :
+    delta_mass(dm), label_set(ls)
+  {
+  }
+
   MultiplexDeltaMasses::MultiplexDeltaMasses()
   {
   }
@@ -59,18 +64,16 @@ namespace OpenMS
     delta_masses_.push_back(dm);
   }
 
-  void MultiplexDeltaMasses::addDeltaMass(double ms, MultiplexDeltaMasses::LabelSet ls)
+  void MultiplexDeltaMasses::addDeltaMass(double dm, MultiplexDeltaMasses::LabelSet ls)
   {
-    MultiplexDeltaMasses::DeltaMass dm = {ms, ls};
-    delta_masses_.push_back(dm);
+    delta_masses_.push_back(MultiplexDeltaMasses::DeltaMass(dm,ls));
   }
 
-  void MultiplexDeltaMasses::addDeltaMass(double ms, String l)
+  void MultiplexDeltaMasses::addDeltaMass(double dm, String l)
   {
     MultiplexDeltaMasses::LabelSet ls;
     ls.insert(l);
-    MultiplexDeltaMasses::DeltaMass dm = {ms, ls};
-    delta_masses_.push_back(dm);
+    delta_masses_.push_back(MultiplexDeltaMasses::DeltaMass(dm,ls));
   }
 
   std::vector<double> MultiplexDeltaMasses::getMassShifts() const

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -60,7 +60,7 @@ namespace OpenMS
   {
   }
 
-  MultiplexDeltaMasses::MultiplexDeltaMasses(vector<MultiplexDeltaMasses::DeltaMass> dm) :
+  MultiplexDeltaMasses::MultiplexDeltaMasses(const vector<MultiplexDeltaMasses::DeltaMass>& dm) :
     delta_masses_(dm)
   {
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -50,9 +50,31 @@ namespace OpenMS
   {
   }
 
+  MultiplexDeltaMasses::MultiplexDeltaMasses(vector<MultiplexDeltaMasses::DeltaMass> dm) :
+    delta_masses_(dm)
+  {
+  }
+
   void MultiplexDeltaMasses::addMassShift(double ms)
   {
     mass_shifts_.push_back(ms);
+  }
+
+  void MultiplexDeltaMasses::addDeltaMass(MultiplexDeltaMasses::DeltaMass dm)
+  {
+    delta_masses_.push_back(dm);
+  }
+
+  void MultiplexDeltaMasses::addDeltaMass(double m, std::multiset<String> ls)
+  {
+    delta_masses_.push_back(std::make_pair(m,ls));
+  }
+
+  void MultiplexDeltaMasses::addDeltaMass(double m, String l)
+  {
+    MultiplexDeltaMasses::LabelSet ls;
+    ls.insert(l);
+    delta_masses_.push_back(std::make_pair(m,ls));
   }
 
   std::vector<double> MultiplexDeltaMasses::getMassShifts() const

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -85,11 +85,6 @@ namespace OpenMS
     return delta_masses_.size();
   }
 
-  MultiplexDeltaMasses::LabelSet MultiplexDeltaMasses::getLabelSetAt(int i) const
-  {
-    return delta_masses_[i].label_set;
-  }
-  
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
   {
     if (dm1.size() != dm2.size())

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -75,7 +75,7 @@ namespace OpenMS
     return delta_masses_;
   }
 
-  unsigned MultiplexDeltaMasses::size() const
+  unsigned MultiplexDeltaMasses::size()
   {
     return delta_masses_.size();
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -61,7 +61,7 @@ namespace OpenMS
 
   void MultiplexDeltaMasses::addDeltaMass(double m, MultiplexDeltaMasses::LabelSet ls)
   {
-    delta_masses_.push_back(std::make_pair(m,ls));
+    delta_masses_.push_back(MultiplexDeltaMasses::DeltaMass(m,ls));
   }
 
   void MultiplexDeltaMasses::addDeltaMass(double m, String l)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -77,9 +77,14 @@ namespace OpenMS
   {
     std::vector<double> ms;
     
-    for (unsigned i = 0; delta_masses_.size(); ++i)
+    /*for (unsigned i = 0; delta_masses_.size(); ++i)
     {
       ms.push_back(delta_masses_[i].mass_shift);
+    }*/
+    
+    for (std::vector<MultiplexDeltaMasses::DeltaMass>::const_iterator it = delta_masses_.begin(); it != delta_masses_.end(); ++it)
+    {
+      ms.push_back((*it).mass_shift);
     }
     
     return ms;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -77,14 +77,9 @@ namespace OpenMS
   {
     std::vector<double> ms;
     
-    /*for (unsigned i = 0; delta_masses_.size(); ++i)
-    {
-      ms.push_back(delta_masses_[i].mass_shift);
-    }*/
-    
     for (std::vector<MultiplexDeltaMasses::DeltaMass>::const_iterator it = delta_masses_.begin(); it != delta_masses_.end(); ++it)
     {
-      ms.push_back((*it).mass_shift);
+      ms.push_back((*it).delta_mass);
     }
     
     return ms;
@@ -107,7 +102,7 @@ namespace OpenMS
 
   double MultiplexDeltaMasses::getMassShiftAt(int i) const
   {
-    return delta_masses_[i].mass_shift;
+    return delta_masses_[i].delta_mass;
   }
   
   MultiplexDeltaMasses::LabelSet MultiplexDeltaMasses::getLabelSetAt(int i) const

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -70,18 +70,6 @@ namespace OpenMS
     delta_masses_.push_back(dm);
   }
 
-  void MultiplexDeltaMasses::addDeltaMass(double dm, MultiplexDeltaMasses::LabelSet ls)
-  {
-    delta_masses_.push_back(MultiplexDeltaMasses::DeltaMass(dm,ls));
-  }
-
-  void MultiplexDeltaMasses::addDeltaMass(double dm, String l)
-  {
-    MultiplexDeltaMasses::LabelSet ls;
-    ls.insert(l);
-    delta_masses_.push_back(MultiplexDeltaMasses::DeltaMass(dm,ls));
-  }
-
   std::vector<double> MultiplexDeltaMasses::getMassShifts() const
   {
     std::vector<double> ms;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -121,5 +121,13 @@ namespace OpenMS
     
     return mass_shifts_[i];
   }
-
+  
+  bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
+  {
+    std::vector<double> ms1 = dm1.getMassShifts();
+    std::vector<double> ms2 = dm2.getMassShifts();
+    
+    return ms1<ms2;
+  }
+  
 }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -75,7 +75,7 @@ namespace OpenMS
     return delta_masses_;
   }
 
-  unsigned MultiplexDeltaMasses::size()
+  unsigned MultiplexDeltaMasses::size() const
   {
     return delta_masses_.size();
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -49,19 +49,9 @@ namespace OpenMS
   {
   }
 
-  MultiplexDeltaMasses::MultiplexDeltaMasses(vector<double> ms) :
-    mass_shifts_(ms)
-  {
-  }
-
   MultiplexDeltaMasses::MultiplexDeltaMasses(vector<MultiplexDeltaMasses::DeltaMass> dm) :
     delta_masses_(dm)
   {
-  }
-
-  void MultiplexDeltaMasses::addMassShift(double ms)
-  {
-    mass_shifts_.push_back(ms);
   }
 
   void MultiplexDeltaMasses::addDeltaMass(MultiplexDeltaMasses::DeltaMass dm)
@@ -83,26 +73,19 @@ namespace OpenMS
 
   std::vector<double> MultiplexDeltaMasses::getMassShifts() const
   {
-    /*std::vector<double> ms;
+    std::vector<double> ms;
     
     for (unsigned i = 0; delta_masses_.size(); ++i)
     {
       ms.push_back(delta_masses_[i].first);
     }
     
-    return ms;*/
-    
-    return mass_shifts_;
+    return ms;
   }
   
   std::vector<MultiplexDeltaMasses::DeltaMass> MultiplexDeltaMasses::getDeltaMasses() const
   {
     return delta_masses_;
-  }
-
-  unsigned MultiplexDeltaMasses::getMassShiftCount() const
-  {
-    return mass_shifts_.size();
   }
 
   unsigned MultiplexDeltaMasses::getDeltaMassesCount() const
@@ -117,14 +100,12 @@ namespace OpenMS
 
   double MultiplexDeltaMasses::getMassShiftAt(int i) const
   {
-    //return delta_masses_[i].first;
-    
-    return mass_shifts_[i];
+    return delta_masses_[i].first;
   }
   
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
   {
-    return (dm1.getMassShifts() < dm1.getMassShifts());
+    return (dm1.getMassShifts() < dm2.getMassShifts());
   }
   
 }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -70,24 +70,12 @@ namespace OpenMS
     delta_masses_.push_back(dm);
   }
 
-  std::vector<double> MultiplexDeltaMasses::getMassShifts() const
-  {
-    std::vector<double> ms;
-    
-    for (std::vector<MultiplexDeltaMasses::DeltaMass>::const_iterator it = delta_masses_.begin(); it != delta_masses_.end(); ++it)
-    {
-      ms.push_back((*it).delta_mass);
-    }
-    
-    return ms;
-  }
-  
-  std::vector<MultiplexDeltaMasses::DeltaMass> MultiplexDeltaMasses::getDeltaMasses() const
+  std::vector<MultiplexDeltaMasses::DeltaMass> MultiplexDeltaMasses::getDeltaMasses()
   {
     return delta_masses_;
   }
 
-  unsigned MultiplexDeltaMasses::getDeltaMassesCount() const
+  unsigned MultiplexDeltaMasses::size() const
   {
     return delta_masses_.size();
   }
@@ -109,14 +97,14 @@ namespace OpenMS
   
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
   {
-    if (dm1.getDeltaMassesCount() != dm2.getDeltaMassesCount())
+    if (dm1.size() != dm2.size())
     {
       // Search first for complete multiplets, then knock-out cases.
-      return (dm1.getDeltaMassesCount() > dm2.getDeltaMassesCount());
+      return (dm1.size() > dm2.size());
     }
     else
     {
-      for (unsigned i = 0; i < dm1.getDeltaMassesCount(); ++i)
+      for (unsigned i = 0; i < dm1.size(); ++i)
       {
         double ms1 = dm1.getMassShiftAt(i) - dm1.getMassShiftAt(0);
         double ms2 = dm2.getMassShiftAt(i) - dm2.getMassShiftAt(0);

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -80,11 +80,6 @@ namespace OpenMS
     return delta_masses_.size();
   }
 
-  MultiplexDeltaMasses::DeltaMass MultiplexDeltaMasses::getDeltaMassAt(int i) const
-  {
-    return delta_masses_[i];
-  }
-
   double MultiplexDeltaMasses::getMassShiftAt(int i) const
   {
     return delta_masses_[i].delta_mass;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -70,7 +70,12 @@ namespace OpenMS
     delta_masses_.push_back(dm);
   }
 
-  std::vector<MultiplexDeltaMasses::DeltaMass> MultiplexDeltaMasses::getDeltaMasses()
+  std::vector<MultiplexDeltaMasses::DeltaMass>& MultiplexDeltaMasses::getDeltaMasses()
+  {
+    return delta_masses_;
+  }
+
+  const std::vector<MultiplexDeltaMasses::DeltaMass>& MultiplexDeltaMasses::getDeltaMasses() const
   {
     return delta_masses_;
   }
@@ -80,11 +85,6 @@ namespace OpenMS
     return delta_masses_.size();
   }
 
-  double MultiplexDeltaMasses::getMassShiftAt(int i) const
-  {
-    return delta_masses_[i].delta_mass;
-  }
-  
   MultiplexDeltaMasses::LabelSet MultiplexDeltaMasses::getLabelSetAt(int i) const
   {
     return delta_masses_[i].label_set;
@@ -101,8 +101,8 @@ namespace OpenMS
     {
       for (unsigned i = 0; i < dm1.size(); ++i)
       {
-        double ms1 = dm1.getMassShiftAt(i) - dm1.getMassShiftAt(0);
-        double ms2 = dm2.getMassShiftAt(i) - dm2.getMassShiftAt(0);
+        double ms1 = dm1.getDeltaMasses()[i].delta_mass - dm1.getDeltaMasses()[0].delta_mass;
+        double ms2 = dm2.getDeltaMasses()[i].delta_mass - dm2.getDeltaMasses()[0].delta_mass;
         
         if (ms1 != ms2)
         {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -117,8 +117,27 @@ namespace OpenMS
   
   bool operator<(const MultiplexDeltaMasses &dm1, const MultiplexDeltaMasses &dm2)
   {
-    //return (dm1.getMassShifts() < dm2.getMassShifts());
-    return (dm1.getMassShiftAt(0) < dm2.getMassShiftAt(0));
+    if (dm1.getDeltaMassesCount() != dm2.getDeltaMassesCount())
+    {
+      // Search first for complete multiplets, then knock-out cases.
+      return (dm1.getDeltaMassesCount() > dm2.getDeltaMassesCount());
+    }
+    else
+    {
+      for (unsigned i = 0; i < dm1.getDeltaMassesCount(); ++i)
+      {
+        double ms1 = dm1.getMassShiftAt(i) - dm1.getMassShiftAt(0);
+        double ms2 = dm2.getMassShiftAt(i) - dm2.getMassShiftAt(0);
+        
+        if (ms1 != ms2)
+        {
+          // Search first for cases without miscleavages.
+          return (ms1 < ms2);
+        }
+      }
+    }
+
+    return (false);
   }
   
 }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.cpp
@@ -49,6 +49,12 @@ namespace OpenMS
     delta_mass(dm), label_set(ls)
   {
   }
+  
+  MultiplexDeltaMasses::DeltaMass::DeltaMass(double dm, String l) :
+    delta_mass(dm), label_set()
+  {
+    label_set.insert(l);
+  }
 
   MultiplexDeltaMasses::MultiplexDeltaMasses()
   {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -259,18 +259,18 @@ namespace OpenMS
       {
         // add doublets
         MultiplexDeltaMasses doublet1;
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
+        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
         mass_pattern_list_.push_back(doublet1);
 
         MultiplexDeltaMasses doublet2;
-        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
-        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
+        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
+        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(doublet2);
 
         MultiplexDeltaMasses doublet3;
-        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
+        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(doublet3);
       }
       
@@ -285,59 +285,59 @@ namespace OpenMS
       {
         // add triplets
         MultiplexDeltaMasses triplet1;
-        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
-        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
-        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(3));
+        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
+        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
+        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(triplet1);
         
         MultiplexDeltaMasses triplet2;
-        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
-        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(3));
+        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
+        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
+        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(triplet2);
 
         /*MultiplexDeltaMasses triplet3;
-        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
-        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(3));
+        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
+        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
+        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(triplet3);*/
         
         MultiplexDeltaMasses triplet4;
-        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
-        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
+        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
+        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
+        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(triplet4);
 
 
         // add doublets
         MultiplexDeltaMasses doublet1;
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
+        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
         mass_pattern_list_.push_back(doublet1);
 
         MultiplexDeltaMasses doublet2;
-        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
+        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(doublet2);
 
         MultiplexDeltaMasses doublet3;
-        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(3));
+        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(doublet3);
 
         MultiplexDeltaMasses doublet4;
-        doublet4.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
-        doublet4.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
+        doublet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
+        doublet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(doublet4);
 
         MultiplexDeltaMasses doublet5;
-        doublet5.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
-        doublet5.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(3));
+        doublet5.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
+        doublet5.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(doublet5);
 
         MultiplexDeltaMasses doublet6;
-        doublet6.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
-        doublet6.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(3));
+        doublet6.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
+        doublet6.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(doublet6);
       }
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -374,7 +374,19 @@ namespace OpenMS
       std::cout << "mass shift " << (i + 1) << ":    ";
       for (unsigned j = 0; j < mass_pattern_list_[i].getDeltaMassesCount(); ++j)
       {
-        std::cout << mass_pattern_list_[i].getMassShiftAt(j) << "    ";
+        double mass_shift = mass_pattern_list_[i].getMassShiftAt(j);
+        MultiplexDeltaMasses::LabelSet label_set = mass_pattern_list_[i].getLabelSetAt(j);
+        
+        std::cout << mass_shift << " (";
+        for (std::multiset<String>::iterator it = label_set.begin(); it != label_set.end(); ++it)
+        {
+          if (it != label_set.begin())
+          {
+            std::cout << ",";
+          }
+          std::cout << *it;
+        }
+        std::cout << ")    ";
       }
       std::cout << "\n";
     }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -350,6 +350,11 @@ namespace OpenMS
     {
       throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Knock-outs for multiplex experiments with more than 4 samples not supported.");
     }
+    
+    // sort mass patterns
+    // (from small mass shifts to larger ones, i.e. few miscleavages = simple explanation first)
+    std::sort(mass_pattern_list_.begin(), mass_pattern_list_.end());
+
   }
   
   void MultiplexDeltaMassesGenerator::printLabelsList() const

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -185,7 +185,7 @@ namespace OpenMS
               }
             }
 
-            if (delta_masses_temp.size() > 1)
+            if (delta_masses_temp.getDeltaMasses().size() > 1)
             {
               mass_pattern_list_.push_back(delta_masses_temp);
             }
@@ -240,7 +240,7 @@ namespace OpenMS
       throw OpenMS::Exception::InvalidSize(__FILE__, __LINE__, __PRETTY_FUNCTION__, 0);
     }
     
-    unsigned n = mass_pattern_list_[0].size();    // n=1 for singlets, n=2 for doublets, n=3 for triplets, n=4 for quadruplets
+    unsigned n = mass_pattern_list_[0].getDeltaMasses().size();    // n=1 for singlets, n=2 for doublets, n=3 for triplets, n=4 for quadruplets
     unsigned m = mass_pattern_list_.size();    // number of mass shift patterns before extension of the list
     if (n == 1)
     {
@@ -377,7 +377,7 @@ namespace OpenMS
     for (unsigned i = 0; i < mass_pattern_list_.size(); ++i)
     {
       std::cout << "mass shift " << (i + 1) << ":    ";
-      for (unsigned j = 0; j < mass_pattern_list_[i].size(); ++j)
+      for (unsigned j = 0; j < mass_pattern_list_[i].getDeltaMasses().size(); ++j)
       {
         double mass_shift = mass_pattern_list_[i].getDeltaMasses()[j].delta_mass;
         MultiplexDeltaMasses::LabelSet label_set = mass_pattern_list_[i].getDeltaMasses()[j].label_set;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -134,7 +134,7 @@ namespace OpenMS
           if (ArgPerPeptide + LysPerPeptide <= (unsigned) missed_cleavages_ + 1)
           {
             MultiplexDeltaMasses delta_masses_temp;    // single mass shift pattern
-            delta_masses_temp.addDeltaMass(0,"no_label");
+            delta_masses_temp.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
             for (unsigned i = 0; i < samples_labels_.size(); i++)
             {
               double mass_shift = 0;
@@ -181,7 +181,7 @@ namespace OpenMS
 
               if (goAhead_Arg && goAhead_Lys && (mass_shift != 0))
               {
-                delta_masses_temp.addDeltaMass(mass_shift,label_set);
+                delta_masses_temp.addDeltaMass(MultiplexDeltaMasses::DeltaMass(mass_shift, label_set));
               }
             }
 
@@ -211,8 +211,8 @@ namespace OpenMS
           {
             label_set.insert(samples_labels_[i][0]);
           }
-         
-          delta_masses_temp.addDeltaMass(mass_shift,label_set);
+
+         delta_masses_temp.addDeltaMass(MultiplexDeltaMasses::DeltaMass(mass_shift, label_set));
         }
         mass_pattern_list_.push_back(delta_masses_temp);
       }
@@ -222,7 +222,7 @@ namespace OpenMS
     {
       // none (singlet detection)
       MultiplexDeltaMasses delta_masses_temp;
-      delta_masses_temp.addDeltaMass(0,"no_label");
+      delta_masses_temp.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
       mass_pattern_list_.push_back(delta_masses_temp);
     }
     
@@ -250,7 +250,7 @@ namespace OpenMS
     {
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.addDeltaMass(0,"any_label");    // There are two singlets with different label sets. But only a single singlet with "any_label" is added.
+      dm.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"any_label"));    // There are two singlets with different label sets. But only a single singlet with "any_label" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 3)
@@ -276,7 +276,7 @@ namespace OpenMS
       
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.addDeltaMass(0,"any_label");    // There are three singlets with different label sets. But only a single singlet with "any_label" is added.
+      dm.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"any_label"));    // There are three singlets with different label sets. But only a single singlet with "any_label" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 4)
@@ -343,7 +343,7 @@ namespace OpenMS
 
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.addDeltaMass(0,"any_label");
+      dm.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"any_label_set"));
       mass_pattern_list_.push_back(dm);
     }
     else if (n > 4)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -379,7 +379,7 @@ namespace OpenMS
       std::cout << "mass shift " << (i + 1) << ":    ";
       for (unsigned j = 0; j < mass_pattern_list_[i].size(); ++j)
       {
-        double mass_shift = mass_pattern_list_[i].getMassShiftAt(j);
+        double mass_shift = mass_pattern_list_[i].getDeltaMasses()[j].delta_mass;
         MultiplexDeltaMasses::LabelSet label_set = mass_pattern_list_[i].getLabelSetAt(j);
         
         std::cout << mass_shift << " (";

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -134,7 +134,7 @@ namespace OpenMS
           if (ArgPerPeptide + LysPerPeptide <= (unsigned) missed_cleavages_ + 1)
           {
             MultiplexDeltaMasses delta_masses_temp;    // single mass shift pattern
-            delta_masses_temp.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+            delta_masses_temp.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
             for (unsigned i = 0; i < samples_labels_.size(); i++)
             {
               double mass_shift = 0;
@@ -181,7 +181,7 @@ namespace OpenMS
 
               if (goAhead_Arg && goAhead_Lys && (mass_shift != 0))
               {
-                delta_masses_temp.addDeltaMass(MultiplexDeltaMasses::DeltaMass(mass_shift, label_set));
+                delta_masses_temp.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(mass_shift, label_set));
               }
             }
 
@@ -212,7 +212,7 @@ namespace OpenMS
             label_set.insert(samples_labels_[i][0]);
           }
 
-         delta_masses_temp.addDeltaMass(MultiplexDeltaMasses::DeltaMass(mass_shift, label_set));
+         delta_masses_temp.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(mass_shift, label_set));
         }
         mass_pattern_list_.push_back(delta_masses_temp);
       }
@@ -222,7 +222,7 @@ namespace OpenMS
     {
       // none (singlet detection)
       MultiplexDeltaMasses delta_masses_temp;
-      delta_masses_temp.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+      delta_masses_temp.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
       mass_pattern_list_.push_back(delta_masses_temp);
     }
     
@@ -250,7 +250,7 @@ namespace OpenMS
     {
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"any_label"));    // There are two singlets with different label sets. But only a single singlet with "any_label" is added.
+      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"any_label"));    // There are two singlets with different label sets. But only a single singlet with "any_label" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 3)
@@ -259,24 +259,24 @@ namespace OpenMS
       {
         // add doublets
         MultiplexDeltaMasses doublet1;
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
+        doublet1.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet1.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);
         mass_pattern_list_.push_back(doublet1);
 
         MultiplexDeltaMasses doublet2;
-        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
-        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
+        doublet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);
+        doublet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(doublet2);
 
         MultiplexDeltaMasses doublet3;
-        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
-        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
+        doublet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(doublet3);
       }
       
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"any_label"));    // There are three singlets with different label sets. But only a single singlet with "any_label" is added.
+      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"any_label"));    // There are three singlets with different label sets. But only a single singlet with "any_label" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 4)
@@ -285,65 +285,65 @@ namespace OpenMS
       {
         // add triplets
         MultiplexDeltaMasses triplet1;
-        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
-        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
-        triplet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
+        triplet1.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);
+        triplet1.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
+        triplet1.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(triplet1);
         
         MultiplexDeltaMasses triplet2;
-        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
-        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
-        triplet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
+        triplet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
+        triplet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
+        triplet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(triplet2);
 
         /*MultiplexDeltaMasses triplet3;
-        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
-        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
-        triplet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
+        triplet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
+        triplet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);
+        triplet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(triplet3);*/
         
         MultiplexDeltaMasses triplet4;
-        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
-        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
-        triplet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
+        triplet4.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
+        triplet4.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);
+        triplet4.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(triplet4);
 
 
         // add doublets
         MultiplexDeltaMasses doublet1;
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
+        doublet1.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet1.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);
         mass_pattern_list_.push_back(doublet1);
 
         MultiplexDeltaMasses doublet2;
-        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
-        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
+        doublet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(doublet2);
 
         MultiplexDeltaMasses doublet3;
-        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[0]);
-        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
+        doublet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
+        doublet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(doublet3);
 
         MultiplexDeltaMasses doublet4;
-        doublet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
-        doublet4.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
+        doublet4.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);
+        doublet4.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
         mass_pattern_list_.push_back(doublet4);
 
         MultiplexDeltaMasses doublet5;
-        doublet5.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[1]);
-        doublet5.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
+        doublet5.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);
+        doublet5.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(doublet5);
 
         MultiplexDeltaMasses doublet6;
-        doublet6.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[2]);
-        doublet6.addDeltaMass(mass_pattern_list_[i].getDeltaMasses()[3]);
+        doublet6.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
+        doublet6.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(doublet6);
       }
 
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"any_label_set"));
+      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"any_label_set"));
       mass_pattern_list_.push_back(dm);
     }
     else if (n > 4)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -225,7 +225,7 @@ namespace OpenMS
       delta_masses_temp.addDeltaMass(0,"no_label");
       mass_pattern_list_.push_back(delta_masses_temp);
     }
-
+    
     // sort mass patterns
     // (from small mass shifts to larger ones, i.e. few miscleavages = simple explanation first)
     std::sort(mass_pattern_list_.begin(), mass_pattern_list_.end());

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -250,7 +250,7 @@ namespace OpenMS
     {
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"any_label"));    // There are two singlets with different label sets. But only a single singlet with "any_label" is added.
+      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"any_label_set"));    // There are two singlets with different label sets. But only a single singlet with "any_label_set" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 3)
@@ -276,7 +276,7 @@ namespace OpenMS
       
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"any_label"));    // There are three singlets with different label sets. But only a single singlet with "any_label" is added.
+      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"any_label_set"));    // There are three singlets with different label sets. But only a single singlet with "any_label_set" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 4)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -380,7 +380,7 @@ namespace OpenMS
       for (unsigned j = 0; j < mass_pattern_list_[i].size(); ++j)
       {
         double mass_shift = mass_pattern_list_[i].getDeltaMasses()[j].delta_mass;
-        MultiplexDeltaMasses::LabelSet label_set = mass_pattern_list_[i].getLabelSetAt(j);
+        MultiplexDeltaMasses::LabelSet label_set = mass_pattern_list_[i].getDeltaMasses()[j].label_set;
         
         std::cout << mass_shift << " (";
         for (std::multiset<String>::iterator it = label_set.begin(); it != label_set.end(); ++it)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -134,7 +134,7 @@ namespace OpenMS
           if (ArgPerPeptide + LysPerPeptide <= (unsigned) missed_cleavages_ + 1)
           {
             MultiplexDeltaMasses delta_masses_temp;    // single mass shift pattern
-            delta_masses_temp.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+            delta_masses_temp.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
             for (unsigned i = 0; i < samples_labels_.size(); i++)
             {
               double mass_shift = 0;
@@ -222,7 +222,7 @@ namespace OpenMS
     {
       // none (singlet detection)
       MultiplexDeltaMasses delta_masses_temp;
-      delta_masses_temp.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+      delta_masses_temp.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
       mass_pattern_list_.push_back(delta_masses_temp);
     }
     
@@ -276,7 +276,7 @@ namespace OpenMS
       
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"any_label_set"));    // There are three singlets with different label sets. But only a single singlet with "any_label_set" is added.
+      dm.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "any_label_set"));    // There are three singlets with different label sets. But only a single singlet with "any_label_set" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 4)
@@ -295,7 +295,8 @@ namespace OpenMS
         triplet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[2]);
         triplet2.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[3]);
         mass_pattern_list_.push_back(triplet2);
-
+        
+        // Knockout combination previously forgotten. Will be un-commented in final FFM/MultiplexResolver version.
         /*MultiplexDeltaMasses triplet3;
         triplet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[0]);
         triplet3.getDeltaMasses().push_back(mass_pattern_list_[i].getDeltaMasses()[1]);

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -357,10 +357,10 @@ namespace OpenMS
     cout << "\n";
     for (unsigned i = 0; i < samples_labels_.size(); ++i)
     {
-      cout << "sample " << (i + 1) << ":   ";
+      cout << "sample " << (i + 1) << ":    ";
       for (unsigned j = 0; j < samples_labels_[i].size(); ++j)
       {
-        cout << samples_labels_[i][j] << " ";
+        cout << samples_labels_[i][j] << "    ";
       }
       cout << "\n";
     }
@@ -374,7 +374,7 @@ namespace OpenMS
       std::cout << "mass shift " << (i + 1) << ":    ";
       for (unsigned j = 0; j < mass_pattern_list_[i].getDeltaMassesCount(); ++j)
       {
-        std::cout << mass_pattern_list_[i].getMassShiftAt(j) << "  ";
+        std::cout << mass_pattern_list_[i].getMassShiftAt(j) << "    ";
       }
       std::cout << "\n";
     }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -264,13 +264,13 @@ namespace OpenMS
         mass_pattern_list_.push_back(doublet1);
 
         MultiplexDeltaMasses doublet2;
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
+        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(1));
+        doublet2.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
         mass_pattern_list_.push_back(doublet2);
 
         MultiplexDeltaMasses doublet3;
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
-        doublet1.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
+        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(0));
+        doublet3.addDeltaMass(mass_pattern_list_[i].getDeltaMassAt(2));
         mass_pattern_list_.push_back(doublet3);
       }
       

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -185,7 +185,7 @@ namespace OpenMS
               }
             }
 
-            if (delta_masses_temp.getDeltaMassesCount() > 1)
+            if (delta_masses_temp.size() > 1)
             {
               mass_pattern_list_.push_back(delta_masses_temp);
             }
@@ -240,7 +240,7 @@ namespace OpenMS
       throw OpenMS::Exception::InvalidSize(__FILE__, __LINE__, __PRETTY_FUNCTION__, 0);
     }
     
-    unsigned n = mass_pattern_list_[0].getDeltaMassesCount();    // n=1 for singlets, n=2 for doublets, n=3 for triplets, n=4 for quadruplets
+    unsigned n = mass_pattern_list_[0].size();    // n=1 for singlets, n=2 for doublets, n=3 for triplets, n=4 for quadruplets
     unsigned m = mass_pattern_list_.size();    // number of mass shift patterns before extension of the list
     if (n == 1)
     {
@@ -377,7 +377,7 @@ namespace OpenMS
     for (unsigned i = 0; i < mass_pattern_list_.size(); ++i)
     {
       std::cout << "mass shift " << (i + 1) << ":    ";
-      for (unsigned j = 0; j < mass_pattern_list_[i].getDeltaMassesCount(); ++j)
+      for (unsigned j = 0; j < mass_pattern_list_[i].size(); ++j)
       {
         double mass_shift = mass_pattern_list_[i].getMassShiftAt(j);
         MultiplexDeltaMasses::LabelSet label_set = mass_pattern_list_[i].getLabelSetAt(j);

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -105,7 +105,7 @@ namespace OpenMS
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Unknown labelling. Neither SILAC, Dimethyl nor ICPL.");
     }
-
+    
     // check if the labels are included in advanced section "labels"
     String all_labels = "Arg6 Arg10 Lys4 Lys6 Lys8 Dimethyl0 Dimethyl4 Dimethyl6 Dimethyl8 ICPL0 ICPL4 ICPL6 ICPL10 no_label";
     for (unsigned i = 0; i < samples_labels_.size(); i++)
@@ -240,7 +240,7 @@ namespace OpenMS
       throw OpenMS::Exception::InvalidSize(__FILE__, __LINE__, __PRETTY_FUNCTION__, 0);
     }
     
-    unsigned n = mass_pattern_list_[0].getMassShiftCount();    // n=1 for singlets, n=2 for doublets, n=3 for triplets, n=4 for quadruplets
+    unsigned n = mass_pattern_list_[0].getDeltaMassesCount();    // n=1 for singlets, n=2 for doublets, n=3 for triplets, n=4 for quadruplets
     unsigned m = mass_pattern_list_.size();    // number of mass shift patterns before extension of the list
     if (n == 1)
     {
@@ -250,7 +250,7 @@ namespace OpenMS
     {
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.addDeltaMass(0,"any_label");    // There are multiple singlets with different label sets. But only a single singlet with "any_label" is added.
+      dm.addDeltaMass(0,"any_label");    // There are two singlets with different label sets. But only a single singlet with "any_label" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 3)
@@ -276,7 +276,7 @@ namespace OpenMS
       
       // add singlets
       MultiplexDeltaMasses dm;
-      dm.addDeltaMass(0,"any_label");
+      dm.addDeltaMass(0,"any_label");    // There are three singlets with different label sets. But only a single singlet with "any_label" is added.
       mass_pattern_list_.push_back(dm);
     }
     else if (n == 4)
@@ -372,7 +372,7 @@ namespace OpenMS
     for (unsigned i = 0; i < mass_pattern_list_.size(); ++i)
     {
       std::cout << "mass shift " << (i + 1) << ":    ";
-      for (unsigned j = 0; j < mass_pattern_list_[i].getMassShiftCount(); ++j)
+      for (unsigned j = 0; j < mass_pattern_list_[i].getDeltaMassesCount(); ++j)
       {
         std::cout << mass_pattern_list_[i].getMassShiftAt(j) << "  ";
       }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -232,7 +232,7 @@ namespace OpenMS
 
   }
 
-  void MultiplexDeltaMassesGenerator::generateKnockoutMassShifts()
+  void MultiplexDeltaMassesGenerator::generateKnockoutDeltaMasses()
   {
     if (mass_pattern_list_.empty())
     {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMassesGenerator.cpp
@@ -211,11 +211,22 @@ namespace OpenMS
       for (unsigned mc = 0; mc <= (unsigned) missed_cleavages_; ++mc)
       {
         std::vector<double> temp;
+        MultiplexDeltaMasses delta_masses_temp;    // single mass shift pattern
         for (unsigned i = 0; i < samples_labels_.size(); i++)
         {
+          double mass_shift = (mc + 1) * (label_mass_shift_[samples_labels_[i][0]] - label_mass_shift_[samples_labels_[0][0]]);
+          MultiplexDeltaMasses::LabelSet label_set;
+          // construct label set
+          for (unsigned k = 1; k < (mc + 2); ++k)
+          {
+            label_set.insert(samples_labels_[i][0]);
+          }
+         
           temp.push_back((mc + 1) * (label_mass_shift_[samples_labels_[i][0]] - label_mass_shift_[samples_labels_[0][0]]));
+          delta_masses_temp.addDeltaMass(mass_shift,label_set);
         }
         list.push_back(temp);
+        delta_masses.push_back(delta_masses_temp);
       }
 
     }
@@ -225,6 +236,10 @@ namespace OpenMS
       std::vector<double> temp;
       temp.push_back(0);
       list.push_back(temp);
+      
+      MultiplexDeltaMasses delta_masses_temp;
+      delta_masses_temp.addDeltaMass(0,"no_label");
+      delta_masses.push_back(delta_masses_temp);
     }
 
     // sort mass patterns

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.h>
 
 #include <vector>
@@ -54,7 +55,8 @@ namespace OpenMS
       for (int j = -1; j < peaks_per_peptide_; ++j)
       {
         // j=-1 shift corresponds to the zeroth peak
-        mz_shifts_.push_back((mass_shifts_.getDeltaMasses()[i].delta_mass + j * Constants::C13C12_MASSDIFF_U) / charge_);
+        const std::vector<MultiplexDeltaMasses::DeltaMass> delta_masses = mass_shifts_.getDeltaMasses();
+        mz_shifts_.push_back((delta_masses[i].delta_mass + j * Constants::C13C12_MASSDIFF_U) / charge_);
       }
     }
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
@@ -49,7 +49,7 @@ namespace OpenMS
     charge_(c), peaks_per_peptide_(ppp), mass_shifts_(ms), mass_shift_index_(msi)
   {
     // generate m/z shifts
-    for (unsigned i = 0; i < mass_shifts_.size(); ++i)
+    for (unsigned i = 0; i < mass_shifts_.getDeltaMasses().size(); ++i)
     {
       for (int j = -1; j < peaks_per_peptide_; ++j)
       {
@@ -81,7 +81,7 @@ namespace OpenMS
 
   unsigned MultiplexIsotopicPeakPattern::getMassShiftCount() const
   {
-    return mass_shifts_.size();
+    return mass_shifts_.getDeltaMasses().size();
   }
 
   double MultiplexIsotopicPeakPattern::getMassShiftAt(int i) const

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
@@ -49,7 +49,7 @@ namespace OpenMS
     charge_(c), peaks_per_peptide_(ppp), mass_shifts_(ms), mass_shift_index_(msi)
   {
     // generate m/z shifts
-    for (unsigned i = 0; i < mass_shifts_.getMassShiftCount(); ++i)
+    for (unsigned i = 0; i < mass_shifts_.getDeltaMassesCount(); ++i)
     {
       for (int j = -1; j < peaks_per_peptide_; ++j)
       {
@@ -81,7 +81,7 @@ namespace OpenMS
 
   unsigned MultiplexIsotopicPeakPattern::getMassShiftCount() const
   {
-    return mass_shifts_.getMassShiftCount();
+    return mass_shifts_.getDeltaMassesCount();
   }
 
   double MultiplexIsotopicPeakPattern::getMassShiftAt(int i) const

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
@@ -55,7 +55,7 @@ namespace OpenMS
       for (int j = -1; j < peaks_per_peptide_; ++j)
       {
         // j=-1 shift corresponds to the zeroth peak
-        const std::vector<MultiplexDeltaMasses::DeltaMass> delta_masses = mass_shifts_.getDeltaMasses();
+        const std::vector<MultiplexDeltaMasses::DeltaMass>& delta_masses = mass_shifts_.getDeltaMasses();
         mz_shifts_.push_back((delta_masses[i].delta_mass + j * Constants::C13C12_MASSDIFF_U) / charge_);
       }
     }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
@@ -54,7 +54,7 @@ namespace OpenMS
       for (int j = -1; j < peaks_per_peptide_; ++j)
       {
         // j=-1 shift corresponds to the zeroth peak
-        mz_shifts_.push_back((mass_shifts_.getMassShiftAt(i) + j * Constants::C13C12_MASSDIFF_U) / charge_);
+        mz_shifts_.push_back((mass_shifts_.getDeltaMasses()[i].delta_mass + j * Constants::C13C12_MASSDIFF_U) / charge_);
       }
     }
   }
@@ -86,7 +86,7 @@ namespace OpenMS
 
   double MultiplexIsotopicPeakPattern::getMassShiftAt(int i) const
   {
-    return mass_shifts_.getMassShiftAt(i);
+    return mass_shifts_.getDeltaMasses()[i].delta_mass;
   }
 
   double MultiplexIsotopicPeakPattern::getMZShiftAt(int i) const

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.cpp
@@ -49,7 +49,7 @@ namespace OpenMS
     charge_(c), peaks_per_peptide_(ppp), mass_shifts_(ms), mass_shift_index_(msi)
   {
     // generate m/z shifts
-    for (unsigned i = 0; i < mass_shifts_.getDeltaMassesCount(); ++i)
+    for (unsigned i = 0; i < mass_shifts_.size(); ++i)
     {
       for (int j = -1; j < peaks_per_peptide_; ++j)
       {
@@ -81,7 +81,7 @@ namespace OpenMS
 
   unsigned MultiplexIsotopicPeakPattern::getMassShiftCount() const
   {
-    return mass_shifts_.getDeltaMassesCount();
+    return mass_shifts_.size();
   }
 
   double MultiplexIsotopicPeakPattern::getMassShiftAt(int i) const

--- a/src/tests/class_tests/openms/source/MultiplexClustering_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexClustering_test.cpp
@@ -80,14 +80,14 @@ double rt_minimum = 5;
 
 // construct list of peak patterns
 MultiplexDeltaMasses shifts1;
-shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
-shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
+shifts1.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
+shifts1.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(8.0443702794, "Arg8"));
 MultiplexDeltaMasses shifts2;
-shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts2.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
 MultiplexDeltaMasses::LabelSet label_set;
 label_set.insert("Arg8");
 label_set.insert("Arg8");
-shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
+shifts2.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(2*8.0443702794, label_set));
 std::vector<MultiplexIsotopicPeakPattern> patterns;
 for (int c = charge_max; c >= charge_min; --c)
 {

--- a/src/tests/class_tests/openms/source/MultiplexClustering_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexClustering_test.cpp
@@ -80,14 +80,14 @@ double rt_minimum = 5;
 
 // construct list of peak patterns
 MultiplexDeltaMasses shifts1;
-shifts1.addDeltaMass(0,"no_label");
-shifts1.addDeltaMass(8.0443702794,"Arg8");
+shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
 MultiplexDeltaMasses shifts2;
-shifts2.addDeltaMass(0,"no_label");
+shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
 MultiplexDeltaMasses::LabelSet label_set;
 label_set.insert("Arg8");
 label_set.insert("Arg8");
-shifts2.addDeltaMass(2*8.0443702794,label_set);
+shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
 std::vector<MultiplexIsotopicPeakPattern> patterns;
 for (int c = charge_max; c >= charge_min; --c)
 {

--- a/src/tests/class_tests/openms/source/MultiplexClustering_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexClustering_test.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
 
+#include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilterResult.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilterResultRaw.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilterResultPeak.h>
@@ -78,13 +79,16 @@ double rt_typical = 90;
 double rt_minimum = 5;
 
 // construct list of peak patterns
+MultiplexDeltaMasses shifts1;
+shifts1.addDeltaMass(0,"no_label");
+shifts1.addDeltaMass(8.0443702794,"Arg8");
+MultiplexDeltaMasses shifts2;
+shifts2.addDeltaMass(0,"no_label");
+MultiplexDeltaMasses::LabelSet label_set;
+label_set.insert("Arg8");
+label_set.insert("Arg8");
+shifts2.addDeltaMass(2*8.0443702794,label_set);
 std::vector<MultiplexIsotopicPeakPattern> patterns;
-std::vector<double> shifts1;
-shifts1.push_back(0);
-shifts1.push_back(8.0443702794);
-std::vector<double> shifts2;
-shifts2.push_back(0);
-shifts2.push_back(2*8.0443702794);
 for (int c = charge_max; c >= charge_min; --c)
 {
     MultiplexIsotopicPeakPattern pattern1(c, peaks_per_peptide_max, shifts1, 0);

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
@@ -67,7 +67,7 @@ MultiplexDeltaMassesGenerator list(labels, missed_cleavages, label_mass_shift);
 START_SECTION(std::vector<MultiplexDeltaMasses> getMassPatternList() const)
   std::vector<MultiplexDeltaMasses> masses = list.getMassPatternList();
   TEST_EQUAL(masses.size(), 5);
-  TEST_REAL_SIMILAR(masses[2].getMassShiftAt(1), 6.0201290268);
+  TEST_REAL_SIMILAR(masses[2].getMassShiftAt(1), 8.0502139672);
   TEST_REAL_SIMILAR(masses[4].getMassShiftAt(2), 20.0165372);
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
@@ -67,7 +67,7 @@ MultiplexDeltaMassesGenerator list(labels, missed_cleavages, label_mass_shift);
 START_SECTION(std::vector<MultiplexDeltaMasses> getMassPatternList() const)
   std::vector<MultiplexDeltaMasses> masses = list.getMassPatternList();
   TEST_EQUAL(masses.size(), 5);
-  TEST_REAL_SIMILAR(masses[2].getMassShiftAt(1), 8.0502139672);
+  TEST_REAL_SIMILAR(masses[2].getMassShiftAt(1), 6.0201290268);
   TEST_REAL_SIMILAR(masses[4].getMassShiftAt(2), 20.0165372);
 END_SECTION
 
@@ -75,7 +75,7 @@ START_SECTION(void generateKnockoutMassShifts())
   list.generateKnockoutMassShifts();
   std::vector<MultiplexDeltaMasses> masses_knockout = list.getMassPatternList();
   TEST_EQUAL(masses_knockout.size(), 21);
-  TEST_REAL_SIMILAR(masses_knockout[6].getMassShiftAt(1), 3.98909);
+  TEST_REAL_SIMILAR(masses_knockout[6].getMassShiftAt(1), 8.0141988132);
   TEST_REAL_SIMILAR(masses_knockout[19].getMassShiftAt(1), 20.0165372);
   TEST_EQUAL(masses_knockout[20].getDeltaMassesCount(), 1);
 END_SECTION

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
@@ -77,7 +77,7 @@ START_SECTION(void generateKnockoutDeltaMasses())
   TEST_EQUAL(masses_knockout.size(), 21);
   TEST_REAL_SIMILAR(masses_knockout[6].getDeltaMasses()[1].delta_mass, 8.0141988132);
   TEST_REAL_SIMILAR(masses_knockout[19].getDeltaMasses()[1].delta_mass, 20.0165372);
-  TEST_EQUAL(masses_knockout[20].size(), 1);
+  TEST_EQUAL(masses_knockout[20].getDeltaMasses().size(), 1);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
@@ -77,7 +77,7 @@ START_SECTION(void generateKnockoutMassShifts())
   TEST_EQUAL(masses_knockout.size(), 21);
   TEST_REAL_SIMILAR(masses_knockout[6].getMassShiftAt(1), 3.98909);
   TEST_REAL_SIMILAR(masses_knockout[19].getMassShiftAt(1), 20.0165372);
-  TEST_EQUAL(masses_knockout[20].getMassShiftCount(), 1);
+  TEST_EQUAL(masses_knockout[20].getDeltaMassesCount(), 1);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
@@ -67,16 +67,16 @@ MultiplexDeltaMassesGenerator list(labels, missed_cleavages, label_mass_shift);
 START_SECTION(std::vector<MultiplexDeltaMasses> getMassPatternList() const)
   std::vector<MultiplexDeltaMasses> masses = list.getMassPatternList();
   TEST_EQUAL(masses.size(), 5);
-  TEST_REAL_SIMILAR(masses[2].getMassShiftAt(1), 8.0502139672);
-  TEST_REAL_SIMILAR(masses[4].getMassShiftAt(2), 20.0165372);
+  TEST_REAL_SIMILAR(masses[2].getDeltaMasses()[1].delta_mass, 8.0502139672);
+  TEST_REAL_SIMILAR(masses[4].getDeltaMasses()[2].delta_mass, 20.0165372);
 END_SECTION
 
 START_SECTION(void generateKnockoutDeltaMasses())
   list.generateKnockoutDeltaMasses();
   std::vector<MultiplexDeltaMasses> masses_knockout = list.getMassPatternList();
   TEST_EQUAL(masses_knockout.size(), 21);
-  TEST_REAL_SIMILAR(masses_knockout[6].getMassShiftAt(1), 8.0141988132);
-  TEST_REAL_SIMILAR(masses_knockout[19].getMassShiftAt(1), 20.0165372);
+  TEST_REAL_SIMILAR(masses_knockout[6].getDeltaMasses()[1].delta_mass, 8.0141988132);
+  TEST_REAL_SIMILAR(masses_knockout[19].getDeltaMasses()[1].delta_mass, 20.0165372);
   TEST_EQUAL(masses_knockout[20].size(), 1);
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMassesGenerator_test.cpp
@@ -71,13 +71,13 @@ START_SECTION(std::vector<MultiplexDeltaMasses> getMassPatternList() const)
   TEST_REAL_SIMILAR(masses[4].getMassShiftAt(2), 20.0165372);
 END_SECTION
 
-START_SECTION(void generateKnockoutMassShifts())
-  list.generateKnockoutMassShifts();
+START_SECTION(void generateKnockoutDeltaMasses())
+  list.generateKnockoutDeltaMasses();
   std::vector<MultiplexDeltaMasses> masses_knockout = list.getMassPatternList();
   TEST_EQUAL(masses_knockout.size(), 21);
   TEST_REAL_SIMILAR(masses_knockout[6].getMassShiftAt(1), 8.0141988132);
   TEST_REAL_SIMILAR(masses_knockout[19].getMassShiftAt(1), 20.0165372);
-  TEST_EQUAL(masses_knockout[20].getDeltaMassesCount(), 1);
+  TEST_EQUAL(masses_knockout[20].size(), 1);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -41,26 +41,24 @@ using namespace OpenMS;
 
 START_TEST(MultiplexDeltaMasses, "$Id$")
 
-std::vector<double> mass_shifts;
-mass_shifts.push_back(0);
-mass_shifts.push_back(6.031817);
-
 MultiplexDeltaMasses* nullPointer = 0;
 MultiplexDeltaMasses* ptr;
 
-START_SECTION(MultiplexDeltaMasses(std::vector<double> ms))
-    MultiplexDeltaMasses pattern(mass_shifts);
-    TEST_EQUAL(pattern.getMassShiftCount(), 2);
-    ptr = new MultiplexDeltaMasses(mass_shifts);
+START_SECTION(MultiplexDeltaMasses())
+    MultiplexDeltaMasses pattern;
+    TEST_EQUAL(pattern.getDeltaMassesCount(), 0);
+    ptr = new MultiplexDeltaMasses();
     TEST_NOT_EQUAL(ptr, nullPointer);
     delete ptr;
 END_SECTION
 
-MultiplexDeltaMasses pattern(mass_shifts);
+MultiplexDeltaMasses pattern;
+pattern.addDeltaMass(0,"no_label");
+pattern.addDeltaMass(6.031817,"Arg6");
 
-START_SECTION(void addMassShifts(double ms) const)
-  pattern.addMassShift(12.063634);
-  TEST_EQUAL(pattern.getMassShifts()[2], 12.063634);
+START_SECTION(void addDeltaMass(double m, String l))
+  pattern.addDeltaMass(10.008268600,"Arg10");
+  TEST_EQUAL(pattern.getMassShifts()[2], 10.008268600);
 END_SECTION
 
 START_SECTION(std::vector<double> getMassShifts() const)
@@ -68,14 +66,14 @@ START_SECTION(std::vector<double> getMassShifts() const)
   TEST_EQUAL(pattern.getMassShifts()[1], 6.031817);
 END_SECTION
 
-START_SECTION(unsigned getMassShiftCount() const)
-  TEST_EQUAL(pattern.getMassShiftCount(), 3);
+START_SECTION(unsigned getDeltaMassesCount() const)
+  TEST_EQUAL(pattern.getDeltaMassesCount(), 3);
 END_SECTION
 
 START_SECTION(double getMassShiftAt(int i) const)
   TEST_EQUAL(pattern.getMassShiftAt(0), 0);
   TEST_EQUAL(pattern.getMassShiftAt(1), 6.031817);
-  TEST_EQUAL(pattern.getMassShiftAt(2), 12.063634);
+  TEST_EQUAL(pattern.getMassShiftAt(2), 10.008268600);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -53,17 +53,22 @@ START_SECTION(MultiplexDeltaMasses())
 END_SECTION
 
 MultiplexDeltaMasses pattern;
-pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
-pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817,"Arg6"));
+pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
+pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817, "Arg6"));
 
-/*START_SECTION(std::vector<double> getMassShifts() const)
-  std::vector<double> ms = pattern.getMassShifts();
-  TEST_REAL_SIMILAR(ms[0], 0);
-  TEST_REAL_SIMILAR(ms[1], 6.031817);
-END_SECTION*/
+START_SECTION(void addDeltaMass(DeltaMass dm))
+  pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(10.008268600, "Arg10"));
+  TEST_REAL_SIMILAR(pattern.getDeltaMasses()[2].delta_mass, 10.008268600);
+END_SECTION
+
+START_SECTION(std::vector<DeltaMass>& getDeltaMasses())
+  TEST_REAL_SIMILAR(pattern.getDeltaMasses()[0].delta_mass, 0);
+  TEST_REAL_SIMILAR(pattern.getDeltaMasses()[1].delta_mass, 6.031817);
+  TEST_REAL_SIMILAR(pattern.getDeltaMasses()[2].delta_mass, 10.008268600);
+END_SECTION
 
 START_SECTION(unsigned size() const)
-  TEST_EQUAL(pattern.size(), 2);
+  TEST_EQUAL(pattern.size(), 3);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -59,11 +59,10 @@ pattern.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(6.031817, "Ar
 START_SECTION(std::vector<DeltaMass>& getDeltaMasses())
   TEST_REAL_SIMILAR(pattern.getDeltaMasses()[0].delta_mass, 0);
   TEST_REAL_SIMILAR(pattern.getDeltaMasses()[1].delta_mass, 6.031817);
-  TEST_REAL_SIMILAR(pattern.getDeltaMasses()[2].delta_mass, 10.008268600);
 END_SECTION
 
 START_SECTION(unsigned size() const)
-  TEST_EQUAL(pattern.size(), 3);
+  TEST_EQUAL(pattern.size(), 2);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -58,12 +58,13 @@ pattern.addDeltaMass(6.031817,"Arg6");
 
 START_SECTION(void addDeltaMass(double m, String l))
   pattern.addDeltaMass(10.008268600,"Arg10");
-  TEST_EQUAL(pattern.getMassShifts()[2], 10.008268600);
+  TEST_REAL_SIMILAR(pattern.getMassShiftAt(2), 10.008268600);
 END_SECTION
 
 START_SECTION(std::vector<double> getMassShifts() const)
-  TEST_EQUAL(pattern.getMassShifts()[0], 0);
-  TEST_EQUAL(pattern.getMassShifts()[1], 6.031817);
+  std::vector<double> ms = pattern.getMassShifts();
+  TEST_REAL_SIMILAR(ms[0], 0);
+  TEST_REAL_SIMILAR(ms[1], 6.031817);
 END_SECTION
 
 START_SECTION(unsigned getDeltaMassesCount() const)
@@ -71,9 +72,9 @@ START_SECTION(unsigned getDeltaMassesCount() const)
 END_SECTION
 
 START_SECTION(double getMassShiftAt(int i) const)
-  TEST_EQUAL(pattern.getMassShiftAt(0), 0);
-  TEST_EQUAL(pattern.getMassShiftAt(1), 6.031817);
-  TEST_EQUAL(pattern.getMassShiftAt(2), 10.008268600);
+  TEST_REAL_SIMILAR(pattern.getMassShiftAt(0), 0);
+  TEST_REAL_SIMILAR(pattern.getMassShiftAt(1), 6.031817);
+  TEST_REAL_SIMILAR(pattern.getMassShiftAt(2), 10.008268600);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -56,11 +56,6 @@ MultiplexDeltaMasses pattern;
 pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
 pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817, "Arg6"));
 
-START_SECTION(void addDeltaMass(DeltaMass dm))
-  pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(10.008268600, "Arg10"));
-  TEST_REAL_SIMILAR(pattern.getDeltaMasses()[2].delta_mass, 10.008268600);
-END_SECTION
-
 START_SECTION(std::vector<DeltaMass>& getDeltaMasses())
   TEST_REAL_SIMILAR(pattern.getDeltaMasses()[0].delta_mass, 0);
   TEST_REAL_SIMILAR(pattern.getDeltaMasses()[1].delta_mass, 6.031817);

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -53,8 +53,8 @@ START_SECTION(MultiplexDeltaMasses())
 END_SECTION
 
 MultiplexDeltaMasses pattern;
-pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
-pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817, "Arg6"));
+pattern.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
+pattern.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(6.031817, "Arg6"));
 
 START_SECTION(std::vector<DeltaMass>& getDeltaMasses())
   TEST_REAL_SIMILAR(pattern.getDeltaMasses()[0].delta_mass, 0);

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -56,20 +56,14 @@ MultiplexDeltaMasses pattern;
 pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
 pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817,"Arg6"));
 
-START_SECTION(std::vector<double> getMassShifts() const)
+/*START_SECTION(std::vector<double> getMassShifts() const)
   std::vector<double> ms = pattern.getMassShifts();
   TEST_REAL_SIMILAR(ms[0], 0);
   TEST_REAL_SIMILAR(ms[1], 6.031817);
-END_SECTION
+END_SECTION*/
 
-START_SECTION(unsigned getDeltaMassesCount() const)
-  TEST_EQUAL(pattern.getDeltaMassesCount(), 3);
-END_SECTION
-
-START_SECTION(double getMassShiftAt(int i) const)
-  TEST_REAL_SIMILAR(pattern.getMassShiftAt(0), 0);
-  TEST_REAL_SIMILAR(pattern.getMassShiftAt(1), 6.031817);
-  TEST_REAL_SIMILAR(pattern.getMassShiftAt(2), 10.008268600);
+START_SECTION(unsigned size() const)
+  TEST_EQUAL(pattern.size(), 3);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -63,7 +63,7 @@ pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817,"Arg6"));
 END_SECTION*/
 
 START_SECTION(unsigned size() const)
-  TEST_EQUAL(pattern.size(), 3);
+  TEST_EQUAL(pattern.size(), 2);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -46,7 +46,7 @@ MultiplexDeltaMasses* ptr;
 
 START_SECTION(MultiplexDeltaMasses())
     MultiplexDeltaMasses pattern;
-    TEST_EQUAL(pattern.getDeltaMassesCount(), 0);
+    TEST_EQUAL(pattern.size(), 0);
     ptr = new MultiplexDeltaMasses();
     TEST_NOT_EQUAL(ptr, nullPointer);
     delete ptr;

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -53,13 +53,8 @@ START_SECTION(MultiplexDeltaMasses())
 END_SECTION
 
 MultiplexDeltaMasses pattern;
-pattern.addDeltaMass(0,"no_label");
-pattern.addDeltaMass(6.031817,"Arg6");
-
-START_SECTION(void addDeltaMass(double m, String l))
-  pattern.addDeltaMass(10.008268600,"Arg10");
-  TEST_REAL_SIMILAR(pattern.getMassShiftAt(2), 10.008268600);
-END_SECTION
+pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+pattern.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817,"Arg6"));
 
 START_SECTION(std::vector<double> getMassShifts() const)
   std::vector<double> ms = pattern.getMassShifts();

--- a/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexDeltaMasses_test.cpp
@@ -46,7 +46,7 @@ MultiplexDeltaMasses* ptr;
 
 START_SECTION(MultiplexDeltaMasses())
     MultiplexDeltaMasses pattern;
-    TEST_EQUAL(pattern.size(), 0);
+    TEST_EQUAL(pattern.getDeltaMasses().size(), 0);
     ptr = new MultiplexDeltaMasses();
     TEST_NOT_EQUAL(ptr, nullPointer);
     delete ptr;
@@ -59,10 +59,6 @@ pattern.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(6.031817, "Ar
 START_SECTION(std::vector<DeltaMass>& getDeltaMasses())
   TEST_REAL_SIMILAR(pattern.getDeltaMasses()[0].delta_mass, 0);
   TEST_REAL_SIMILAR(pattern.getDeltaMasses()[1].delta_mass, 6.031817);
-END_SECTION
-
-START_SECTION(unsigned size() const)
-  TEST_EQUAL(pattern.size(), 2);
 END_SECTION
 
 END_TEST

--- a/src/tests/class_tests/openms/source/MultiplexFilteringCentroided_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFilteringCentroided_test.cpp
@@ -76,14 +76,14 @@ bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
 MultiplexDeltaMasses shifts1;
-shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
-shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
+shifts1.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts1.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
 MultiplexDeltaMasses shifts2;
-shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts2.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
 MultiplexDeltaMasses::LabelSet label_set;
 label_set.insert("Arg8");
 label_set.insert("Arg8");
-shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
+shifts2.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
 std::vector<MultiplexIsotopicPeakPattern> patterns;
 for (int c = charge_max; c >= charge_min; --c)
 {

--- a/src/tests/class_tests/openms/source/MultiplexFilteringCentroided_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFilteringCentroided_test.cpp
@@ -76,14 +76,14 @@ bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
 MultiplexDeltaMasses shifts1;
-shifts1.addDeltaMass(0,"no_label");
-shifts1.addDeltaMass(8.0443702794,"Arg8");
+shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
 MultiplexDeltaMasses shifts2;
-shifts2.addDeltaMass(0,"no_label");
+shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
 MultiplexDeltaMasses::LabelSet label_set;
 label_set.insert("Arg8");
 label_set.insert("Arg8");
-shifts2.addDeltaMass(2*8.0443702794,label_set);
+shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
 std::vector<MultiplexIsotopicPeakPattern> patterns;
 for (int c = charge_max; c >= charge_min; --c)
 {

--- a/src/tests/class_tests/openms/source/MultiplexFilteringCentroided_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFilteringCentroided_test.cpp
@@ -75,13 +75,16 @@ double mz_tolerance = 40;
 bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
+MultiplexDeltaMasses shifts1;
+shifts1.addDeltaMass(0,"no_label");
+shifts1.addDeltaMass(8.0443702794,"Arg8");
+MultiplexDeltaMasses shifts2;
+shifts2.addDeltaMass(0,"no_label");
+MultiplexDeltaMasses::LabelSet label_set;
+label_set.insert("Arg8");
+label_set.insert("Arg8");
+shifts2.addDeltaMass(2*8.0443702794,label_set);
 std::vector<MultiplexIsotopicPeakPattern> patterns;
-std::vector<double> shifts1;
-shifts1.push_back(0);
-shifts1.push_back(8.0443702794);
-std::vector<double> shifts2;
-shifts2.push_back(0);
-shifts2.push_back(2*8.0443702794);
 for (int c = charge_max; c >= charge_min; --c)
 {
     MultiplexIsotopicPeakPattern pattern1(c, peaks_per_peptide_max, shifts1, 0);

--- a/src/tests/class_tests/openms/source/MultiplexFilteringProfile_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFilteringProfile_test.cpp
@@ -76,14 +76,14 @@ bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
 MultiplexDeltaMasses shifts1;
-shifts1.addDeltaMass(0,"no_label");
-shifts1.addDeltaMass(8.0443702794,"Arg8");
+shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
 MultiplexDeltaMasses shifts2;
-shifts2.addDeltaMass(0,"no_label");
+shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
 MultiplexDeltaMasses::LabelSet label_set;
 label_set.insert("Arg8");
 label_set.insert("Arg8");
-shifts2.addDeltaMass(2*8.0443702794,label_set);
+shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
 std::vector<MultiplexIsotopicPeakPattern> patterns;
 for (int c = charge_max; c >= charge_min; --c)
 {

--- a/src/tests/class_tests/openms/source/MultiplexFilteringProfile_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFilteringProfile_test.cpp
@@ -76,14 +76,14 @@ bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
 MultiplexDeltaMasses shifts1;
-shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
-shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
+shifts1.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
+shifts1.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(8.0443702794, "Arg8"));
 MultiplexDeltaMasses shifts2;
-shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts2.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
 MultiplexDeltaMasses::LabelSet label_set;
 label_set.insert("Arg8");
 label_set.insert("Arg8");
-shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
+shifts2.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(2*8.0443702794, label_set));
 std::vector<MultiplexIsotopicPeakPattern> patterns;
 for (int c = charge_max; c >= charge_min; --c)
 {

--- a/src/tests/class_tests/openms/source/MultiplexFilteringProfile_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFilteringProfile_test.cpp
@@ -75,13 +75,16 @@ double mz_tolerance = 40;
 bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
+MultiplexDeltaMasses shifts1;
+shifts1.addDeltaMass(0,"no_label");
+shifts1.addDeltaMass(8.0443702794,"Arg8");
+MultiplexDeltaMasses shifts2;
+shifts2.addDeltaMass(0,"no_label");
+MultiplexDeltaMasses::LabelSet label_set;
+label_set.insert("Arg8");
+label_set.insert("Arg8");
+shifts2.addDeltaMass(2*8.0443702794,label_set);
 std::vector<MultiplexIsotopicPeakPattern> patterns;
-std::vector<double> shifts1;
-shifts1.push_back(0);
-shifts1.push_back(8.0443702794);
-std::vector<double> shifts2;
-shifts2.push_back(0);
-shifts2.push_back(2*8.0443702794);
 for (int c = charge_max; c >= charge_min; --c)
 {
     MultiplexIsotopicPeakPattern pattern1(c, peaks_per_peptide_max, shifts1, 0);

--- a/src/tests/class_tests/openms/source/MultiplexFiltering_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFiltering_test.cpp
@@ -76,14 +76,14 @@ bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
 MultiplexDeltaMasses shifts1;
-shifts1.addDeltaMass(0,"no_label");
-shifts1.addDeltaMass(8.0443702794,"Arg8");
+shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
 MultiplexDeltaMasses shifts2;
-shifts2.addDeltaMass(0,"no_label");
+shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
 MultiplexDeltaMasses::LabelSet label_set;
 label_set.insert("Arg8");
 label_set.insert("Arg8");
-shifts2.addDeltaMass(2*8.0443702794,label_set);
+shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
 std::vector<MultiplexIsotopicPeakPattern> patterns;
 for (int c = charge_max; c >= charge_min; --c)
 {

--- a/src/tests/class_tests/openms/source/MultiplexFiltering_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFiltering_test.cpp
@@ -76,14 +76,14 @@ bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
 MultiplexDeltaMasses shifts1;
-shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
-shifts1.addDeltaMass(MultiplexDeltaMasses::DeltaMass(8.0443702794,"Arg8"));
+shifts1.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
+shifts1.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(8.0443702794, "Arg8"));
 MultiplexDeltaMasses shifts2;
-shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+shifts2.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0, "no_label"));
 MultiplexDeltaMasses::LabelSet label_set;
 label_set.insert("Arg8");
 label_set.insert("Arg8");
-shifts2.addDeltaMass(MultiplexDeltaMasses::DeltaMass(2*8.0443702794,label_set));
+shifts2.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(2*8.0443702794, label_set));
 std::vector<MultiplexIsotopicPeakPattern> patterns;
 for (int c = charge_max; c >= charge_min; --c)
 {

--- a/src/tests/class_tests/openms/source/MultiplexFiltering_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexFiltering_test.cpp
@@ -75,13 +75,16 @@ double mz_tolerance = 40;
 bool mz_tolerance_unit = true;    // ppm (true), Da (false)
 
 // construct list of peak patterns
+MultiplexDeltaMasses shifts1;
+shifts1.addDeltaMass(0,"no_label");
+shifts1.addDeltaMass(8.0443702794,"Arg8");
+MultiplexDeltaMasses shifts2;
+shifts2.addDeltaMass(0,"no_label");
+MultiplexDeltaMasses::LabelSet label_set;
+label_set.insert("Arg8");
+label_set.insert("Arg8");
+shifts2.addDeltaMass(2*8.0443702794,label_set);
 std::vector<MultiplexIsotopicPeakPattern> patterns;
-std::vector<double> shifts1;
-shifts1.push_back(0);
-shifts1.push_back(8.0443702794);
-std::vector<double> shifts2;
-shifts2.push_back(0);
-shifts2.push_back(2*8.0443702794);
 for (int c = charge_max; c >= charge_min; --c)
 {
     MultiplexIsotopicPeakPattern pattern1(c, peaks_per_peptide_max, shifts1, 0);

--- a/src/tests/class_tests/openms/source/MultiplexIsotopicPeakPattern_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexIsotopicPeakPattern_test.cpp
@@ -43,8 +43,8 @@ using namespace OpenMS;
 START_TEST(MultiplexIsotopicPeakPattern, "$Id$")
 
 MultiplexDeltaMasses mass_shifts;
-mass_shifts.addDeltaMass(0,"no_label");
-mass_shifts.addDeltaMass(6.031817,"Arg6");
+mass_shifts.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+mass_shifts.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817,"Arg6"));
 
 MultiplexIsotopicPeakPattern* nullPointer = 0;
 MultiplexIsotopicPeakPattern* ptr;

--- a/src/tests/class_tests/openms/source/MultiplexIsotopicPeakPattern_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexIsotopicPeakPattern_test.cpp
@@ -43,8 +43,8 @@ using namespace OpenMS;
 START_TEST(MultiplexIsotopicPeakPattern, "$Id$")
 
 MultiplexDeltaMasses mass_shifts;
-mass_shifts.addDeltaMass(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
-mass_shifts.addDeltaMass(MultiplexDeltaMasses::DeltaMass(6.031817,"Arg6"));
+mass_shifts.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(0,"no_label"));
+mass_shifts.getDeltaMasses().push_back(MultiplexDeltaMasses::DeltaMass(6.031817,"Arg6"));
 
 MultiplexIsotopicPeakPattern* nullPointer = 0;
 MultiplexIsotopicPeakPattern* ptr;

--- a/src/tests/class_tests/openms/source/MultiplexIsotopicPeakPattern_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexIsotopicPeakPattern_test.cpp
@@ -42,10 +42,9 @@ using namespace OpenMS;
 
 START_TEST(MultiplexIsotopicPeakPattern, "$Id$")
 
-std::vector<double> m;
-m.push_back(0);
-m.push_back(6.031817);
-MultiplexDeltaMasses mass_shifts(m);
+MultiplexDeltaMasses mass_shifts;
+mass_shifts.addDeltaMass(0,"no_label");
+mass_shifts.addDeltaMass(6.031817,"Arg6");
 
 MultiplexIsotopicPeakPattern* nullPointer = 0;
 MultiplexIsotopicPeakPattern* ptr;

--- a/src/tests/class_tests/openms/source/MultiplexIsotopicPeakPattern_test.cpp
+++ b/src/tests/class_tests/openms/source/MultiplexIsotopicPeakPattern_test.cpp
@@ -68,8 +68,8 @@ START_SECTION(int getPeaksPerPeptide() const)
 END_SECTION
 
 START_SECTION(std::vector<double> getMassShifts() const)
-  TEST_EQUAL(pattern.getMassShifts().getMassShiftAt(0), 0);
-  TEST_EQUAL(pattern.getMassShifts().getMassShiftAt(1), 6.031817);
+  TEST_EQUAL(pattern.getMassShifts().getDeltaMasses()[0].delta_mass, 0);
+  TEST_EQUAL(pattern.getMassShifts().getDeltaMasses()[1].delta_mass, 6.031817);
 END_SECTION
 
 START_SECTION(int getMassShiftIndex() const)

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -1009,7 +1009,7 @@ private:
     std::vector<MultiplexDeltaMasses> masses_test = generator.getMassPatternList();
     if (knock_out_)
     {
-      //generator.generateKnockoutMassShifts();
+      generator.generateKnockoutMassShifts();
     }
     generator.printLabelsList();
     generator.printMassPatternList();

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -1006,7 +1006,6 @@ private:
      * filter for peak patterns
      */
     MultiplexDeltaMassesGenerator generator = MultiplexDeltaMassesGenerator(labels_, missed_cleavages_, label_massshift_);
-    std::vector<MultiplexDeltaMasses> masses_test = generator.getMassPatternList();
     if (knock_out_)
     {
       generator.generateKnockoutMassShifts();

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -1008,7 +1008,7 @@ private:
     MultiplexDeltaMassesGenerator generator = MultiplexDeltaMassesGenerator(labels_, missed_cleavages_, label_massshift_);
     if (knock_out_)
     {
-      generator.generateKnockoutMassShifts();
+      generator.generateKnockoutDeltaMasses();
     }
     generator.printLabelsList();
     generator.printMassPatternList();

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -1009,7 +1009,7 @@ private:
     std::vector<MultiplexDeltaMasses> masses_test = generator.getMassPatternList();
     if (knock_out_)
     {
-      generator.generateKnockoutMassShifts();
+      //generator.generateKnockoutMassShifts();
     }
     generator.printLabelsList();
     generator.printMassPatternList();


### PR DESCRIPTION
For the search of peptide multiplets, a complete set of all possible delta masses a.k.a. mass shifts are necessary. Previously, only the delta mass vectors were constructed. Now also the label sets giving rise to the shifts are stored.

See label sets in brackets in the triple-SILAC example below.
```
mass shift 1:    0 (no_label)    4.02511 (Lys4)    8.0142 (Lys8)    
mass shift 2:    0 (no_label)    6.02013 (Arg6)    10.0083 (Arg10)    
mass shift 3:    0 (no_label)    8.05021 (Lys4,Lys4)    16.0284 (Lys8,Lys8)    
mass shift 4:    0 (no_label)    10.0452 (Arg6,Lys4)    18.0225 (Arg10,Lys8)    
mass shift 5:    0 (no_label)    12.0403 (Arg6,Arg6)    20.0165 (Arg10,Arg10)    
mass shift 6:    6.02013 (Arg6)    10.0083 (Arg10)    
mass shift 7:    4.02511 (Lys4)    8.0142 (Lys8)    
mass shift 8:    0 (no_label)    4.02511 (Lys4)    
mass shift 9:    0 (no_label)    6.02013 (Arg6)    
mass shift 10:    12.0403 (Arg6,Arg6)    20.0165 (Arg10,Arg10)    
mass shift 11:    10.0452 (Arg6,Lys4)    18.0225 (Arg10,Lys8)    
mass shift 12:    8.05021 (Lys4,Lys4)    16.0284 (Lys8,Lys8)    
mass shift 13:    0 (no_label)    8.0142 (Lys8)    
mass shift 14:    0 (no_label)    8.05021 (Lys4,Lys4)    
mass shift 15:    0 (no_label)    10.0083 (Arg10)    
mass shift 16:    0 (no_label)    10.0452 (Arg6,Lys4)    
mass shift 17:    0 (no_label)    12.0403 (Arg6,Arg6)    
mass shift 18:    0 (no_label)    16.0284 (Lys8,Lys8)    
mass shift 19:    0 (no_label)    18.0225 (Arg10,Lys8)    
mass shift 20:    0 (no_label)    20.0165 (Arg10,Arg10)    
mass shift 21:    0 (any_label)    
```