### PR TITLE
Xtandem-Adapter usability

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XTandemInfileXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XTandemInfileXMLHandler.h
@@ -64,7 +64,7 @@ namespace OpenMS
 public:
 
       /// Default constructor
-      XTandemInfileXMLHandler(const String & filename, std::vector<XTandemInfileNote> & notes, XTandemInfile * infile);
+      XTandemInfileXMLHandler(const String & filename, std::vector<XTandemInfileNote> & notes);
 
       /// Destructor
       virtual ~XTandemInfileXMLHandler();
@@ -82,11 +82,9 @@ protected:
 
       std::vector<XTandemInfileNote> & notes_;
 
-      XTandemInfile * infile_;
-
       XTandemInfileNote actual_note_;
 
-      String tag_;
+      StringList tag_;
     };
 
   }   // namespace Internal

--- a/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
+++ b/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
@@ -217,7 +217,7 @@ public:
     /// set state of noise suppression
     void setNoiseSuppression(const bool noise_suppression);
 
-    /// set the cleavage site with a xtandem conform regex
+    /// set the cleavage site with a X! Tandem conform regex
     void setCleavageSite(const String& cleavage_site);
     
     /// returns the cleavage site regex
@@ -226,10 +226,17 @@ public:
     /** 
       @brief Writes the XTandemInfile to the given file
 
+      By default, member variables take precedence over values previously
+      read via load().
+      If ignore_member_parameters is true, only a very limited number of
+      tags fed by member variables (i.e. in, out, database/taxonomy) is written.
+      For everything else, only external tags (from a previous load()) are used.
+      
       @param filename the name of the file which is written
+      @param ignore_member_parameters Do not write tags for class members
       @throw UnableToCreateFile is thrown if the given file could not be created
     */
-    void write(const String& filename);
+    void write(const String& filename, bool ignore_member_parameters = false);
 
     /** 
       @brief Reads the information from the given filename
@@ -254,13 +261,13 @@ protected:
 
     XTandemInfile& operator=(const XTandemInfile& rhs);
 
-    void writeTo_(std::ostream& os);
+    void writeTo_(std::ostream& os, bool ignore_member_parameters);
 
-    void writeNote_(std::ostream& os, const String& type, const String& label, const String& value);
+    const String& writeNote_(std::ostream& os, const String& type, const String& label, const String& value);
 
-    void writeNote_(std::ostream& os, const String& type, const String& label, const char* value);
+    const String& writeNote_(std::ostream& os, const String& type, const String& label, const char* value);
 
-    void writeNote_(std::ostream& os, const String& type, const String& label, bool value);
+    const String& writeNote_(std::ostream& os, const String& type, const String& label, bool value);
 
     /**
       @brief Converts the given set of Modifications into a format compatible to X!Tandem.

--- a/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
+++ b/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Stephan Aiche $
-// $Authors: Andreas Bertsch $
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_FORMAT_XTANDEMINFILE_H
@@ -45,7 +45,18 @@ namespace OpenMS
   /**
     @brief XTandem input file.
 
-    This class is able to create a X!Tandem configuration files to be used with Xtandem.
+    This class is able to load/write a X!Tandem configuration file.
+
+    These files store parameters within 'note' tags, e.g.,
+    @verbatim
+      <note type="input" label="spectrum, fragment monoisotopic mass error">0.4</note>
+    	<note type="input" label="output, proteins">yes</note>
+    @endverbatim
+
+    Internally, there is a double book-keeping of parameters obtained from a config-xml file via load()
+    and the member parameters exposed via get/set functions.
+    During write(), member params take precedence over additional note-parameters loaded from a config file.
+    If load() was not called before write(), only member parameters are written.
 
     @ingroup FileIO
   */
@@ -228,6 +239,14 @@ public:
       @throw ParseError is thrown if the given file could not be parsed
     */
     void load(const String& filename);
+
+    /**
+       @brief Returns the number of notes read from external XML file.
+
+       @return Number of &lt;note&gt; tags.
+
+    */
+    Size getNoteCount() const;
 
 protected:
 

--- a/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
+++ b/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
@@ -265,10 +265,16 @@ protected:
     /**
       @brief Converts the given set of Modifications into a format compatible to X!Tandem.
 
-      @param mods The modifications to convert.
+      The set affected_origins can be used to avoid duplicate modifications, which are not supported in X!Tandem.
+      Currently, a warning message is printed.
+      Also, if a fixed mod is already given, a corresponding variable mods needs to have its delta mass reduced by the fixed modifications mass.
+      This is also done automatically here.
+
+      @param mods The modifications to convert
+      @param affected_origins Set of origins, which were used previously. Will be augmented with the current mods.
       @return A X!Tandem compatible string representation.
     */
-    String convertModificationSet_(const std::set<ModificationDefinition>& mods) const;
+    String convertModificationSet_(const std::set<ModificationDefinition>& mods, std::map<String, double>& affected_origins) const;
 
     double fragment_mass_tolerance_;
 

--- a/src/openms/source/FORMAT/HANDLERS/XTandemInfileXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XTandemInfileXMLHandler.cpp
@@ -43,25 +43,24 @@ namespace OpenMS
   namespace Internal
   {
 
-    XTandemInfileXMLHandler::XTandemInfileXMLHandler(const String & filename, vector<XTandemInfileNote> & notes, XTandemInfile * infile) :
+    XTandemInfileXMLHandler::XTandemInfileXMLHandler(const String & filename, vector<XTandemInfileNote> & notes) :
       XMLHandler(filename, ""),
-      notes_(notes),
-      infile_(infile)
+      notes_(notes), // this is a reference!
+      actual_note_(),
+      tag_()
     {
-
     }
 
     XTandemInfileXMLHandler::~XTandemInfileXMLHandler()
     {
-
     }
 
     void XTandemInfileXMLHandler::startElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname, const Attributes & attributes)
     {
 
-      tag_ = String(sm_.convert(qname));
+      tag_.push_back(String(sm_.convert(qname)));
 
-      if (tag_ == "note")
+      if (tag_.back() == "note")
       {
         int type_idx = attributes.getIndex(sm_.convert("type"));
         int label_idx = attributes.getIndex(sm_.convert("label"));
@@ -74,29 +73,32 @@ namespace OpenMS
         {
           actual_note_.note_label = String(sm_.convert(attributes.getValue(label_idx)));
         }
-        return;
       }
 
     }
 
     void XTandemInfileXMLHandler::endElement(const XMLCh * const /*uri*/, const XMLCh * const /*local_name*/, const XMLCh * const qname)
     {
-      tag_ = String(sm_.convert(qname)).trim();
-      if (tag_ == "note")
+      String tag_close = String(sm_.convert(qname)).trim();
+      if (tag_.back() != tag_close)
       {
-        return;
+        fatalError(LOAD, "Invalid closing/opening tag sequence. Unexpected tag '</ " + tag_close + ">'!");
       }
+      if (tag_.back() == "note")
+      {
+        notes_.push_back(actual_note_);
+        // prepare for new note
+        actual_note_ = XTandemInfileNote();
+      }
+      
+      tag_.pop_back();
     }
 
     void XTandemInfileXMLHandler::characters(const XMLCh * const chars, const XMLSize_t /*length*/)
     {
-      String value = ((String)sm_.convert(chars)).trim();
-      if (tag_ == "note")
+      if (tag_.back() == "note")
       {
-        actual_note_.note_value = value;
-        notes_.push_back(actual_note_);
-        actual_note_ = XTandemInfileNote();
-        return;
+        actual_note_.note_value = ((String)sm_.convert(chars)).trim();
       }
     }
 

--- a/src/openms/source/FORMAT/XTandemInfile.cpp
+++ b/src/openms/source/FORMAT/XTandemInfile.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Stephan Aiche $
-// $Authors: Andreas Bertsch $
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/XTandemInfile.h>
@@ -71,7 +71,8 @@ namespace OpenMS
     number_of_missed_cleavages_(1),
     default_parameters_file_(""),
     output_results_("all"),
-    max_valid_evalue_(1000)
+    max_valid_evalue_(1000),
+    notes_()
   {
 
   }
@@ -82,7 +83,8 @@ namespace OpenMS
 
   void XTandemInfile::load(const String& filename)
   {
-    Internal::XTandemInfileXMLHandler handler(filename, notes_, this);
+    // just fills 'notes_' 
+    Internal::XTandemInfileXMLHandler handler(filename, notes_);
     parse_(filename, &handler);
   }
 
@@ -725,6 +727,11 @@ namespace OpenMS
   const String& XTandemInfile::getCleavageSite() const
   {
     return cleavage_site_;
+  }
+
+  Size XTandemInfile::getNoteCount() const
+  {
+    return notes_.size();
   }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/XTandemInfile.cpp
+++ b/src/openms/source/FORMAT/XTandemInfile.cpp
@@ -90,14 +90,14 @@ namespace OpenMS
     parse_(filename, &handler);
   }
 
-  void XTandemInfile::write(const String& filename)
+  void XTandemInfile::write(const String& filename, bool ignore_member_parameters)
   {
     if (!File::writable(filename))
     {
       throw (Exception::UnableToCreateFile(__FILE__, __LINE__, __PRETTY_FUNCTION__, filename));
     }
     ofstream os(filename.c_str());
-    writeTo_(os);
+    writeTo_(os, ignore_member_parameters);
     return;
   }
 
@@ -159,7 +159,7 @@ namespace OpenMS
     return ListUtils::concatenate(xtandem_mods, ",");
   }
 
-  void XTandemInfile::writeTo_(ostream& os)
+  void XTandemInfile::writeTo_(ostream& os, bool ignore_member_parameters)
   {
     set<String> used_labels; // labels which are set by OpenMS not by the default parameters file
 
@@ -167,340 +167,320 @@ namespace OpenMS
        << "<?xml-stylesheet type=\"text/xsl\" href=\"tandem-input-style.xsl\"?>" << "\n"
        << "<bioml>" << "\n";
 
-    //////////////// list path parameters
-    writeNote_(os, "input", "list path, default parameters", default_parameters_file_);
-    used_labels.insert("list path, default parameters");
-    writeNote_(os, "input", "list path, taxonomy information", taxonomy_file_);
-    used_labels.insert("list path, taxonomy information");
-    //<note type="input" label="spectrum, path">test_spectra.mgf</note>
-    writeNote_(os, "input", "spectrum, path", input_filename_);
-    used_labels.insert("spectrum, path");
-    ////////////////////////////////////////////////////////////////////////////////
+    used_labels.insert(writeNote_(os, "input", "spectrum, path", input_filename_));
+    used_labels.insert(writeNote_(os, "input", "output, path", output_filename_));
+    used_labels.insert(writeNote_(os, "input", "list path, taxonomy information", taxonomy_file_)); // contains the FASTA database
 
-
-    //////////////// spectrum parameters
-    //<note type="input" label="spectrum, fragment monoisotopic mass error">0.4</note>
-    writeNote_(os, "input", "spectrum, fragment monoisotopic mass error", String(fragment_mass_tolerance_));
-    used_labels.insert("spectrum, fragment monoisotopic mass error");
-    //<note type="input" label="spectrum, parent monoisotopic mass error plus">100</note>
-    writeNote_(os, "input", "spectrum, parent monoisotopic mass error plus", String(precursor_mass_tolerance_plus_));
-    used_labels.insert("spectrum, parent monoisotopic mass error plus");
-    //<note type="input" label="spectrum, parent monoisotopic mass error minus">100</note>
-    writeNote_(os, "input", "spectrum, parent monoisotopic mass error minus", String(precursor_mass_tolerance_minus_));
-    used_labels.insert("spectrum, parent monoisotopic mass error minus");
-    //<note type="input" label="spectrum, parent monoisotopic mass isotope error">yes</note>
-    String allow = allow_isotope_error_ ? "yes" : "no";
-    writeNote_(os, "input", "spectrum, parent monoisotopic mass isotope error", allow);
-    used_labels.insert("spectrum, parent monoisotopic mass isotope error");
-    //<note type="input" label="spectrum, fragment monoisotopic mass error units">Daltons</note>
-    //<note>The value for this parameter may be 'Daltons' or 'ppm': all other values are ignored</note>
-    if (fragment_mass_error_unit_ == XTandemInfile::DALTONS)
+    if (!ignore_member_parameters)
     {
-      writeNote_(os, "input", "spectrum, fragment monoisotopic mass error units", "Daltons");
-    }
-    else
-    {
-      writeNote_(os, "input", "spectrum, fragment monoisotopic mass error units", "ppm");
-    }
-    used_labels.insert("spectrum, fragment monoisotopic mass error units");
-
-    //<note type="input" label="spectrum, parent monoisotopic mass error units">ppm</note>
-    //<note>The value for this parameter may be 'Daltons' or 'ppm': all other values are ignored</note>
-    if (precursor_mass_error_unit_ == XTandemInfile::PPM)
-    {
-      writeNote_(os, "input", "spectrum, parent monoisotopic mass error units", "ppm");
-    }
-    else
-    {
-      writeNote_(os, "input", "spectrum, parent monoisotopic mass error units", "Daltons");
-    }
-    used_labels.insert("spectrum, parent monoisotopic mass error units");
-
-    //<note type="input" label="spectrum, fragment mass type">monoisotopic</note>
-    //<note>values are monoisotopic|average </note>
-    if (fragment_mass_type_ == XTandemInfile::MONOISOTOPIC)
-    {
-      writeNote_(os, "input", "spectrum, fragment mass type", "monoisotopic");
-    }
-    else
-    {
-      writeNote_(os, "input", "spectrum, fragment mass type", "average");
-    }
-    used_labels.insert("spectrum, fragment mass type");
-    ////////////////////////////////////////////////////////////////////////////////
+      //////////////// list path parameters
+      used_labels.insert(writeNote_(os, "input", "list path, default parameters", default_parameters_file_));
+      //<note type="input" label="spectrum, path">test_spectra.mgf</note>
+      ////////////////////////////////////////////////////////////////////////////////
 
 
-    //////////////// spectrum conditioning parameters
-    //<note type="input" label="spectrum, dynamic range">100.0</note>
-    //<note>The peaks read in are normalized so that the most intense peak
-    //is set to the dynamic range value. All peaks with values of less that
-    //1, using this normalization, are not used. This normalization has the
-    //overall effect of setting a threshold value for peak intensities.</note>
-    //writeNote_(os, "input", "spectrum, dynamic range", String(dynamic_range_));
+      //////////////// spectrum parameters
+      //<note type="input" label="spectrum, fragment monoisotopic mass error">0.4</note>
+      used_labels.insert(writeNote_(os, "input", "spectrum, fragment monoisotopic mass error", String(fragment_mass_tolerance_)));
+      //<note type="input" label="spectrum, parent monoisotopic mass error plus">100</note>
+      used_labels.insert(writeNote_(os, "input", "spectrum, parent monoisotopic mass error plus", String(precursor_mass_tolerance_plus_)));
+      //<note type="input" label="spectrum, parent monoisotopic mass error minus">100</note>
+      used_labels.insert(writeNote_(os, "input", "spectrum, parent monoisotopic mass error minus", String(precursor_mass_tolerance_minus_)));
+      //<note type="input" label="spectrum, parent monoisotopic mass isotope error">yes</note>
+      String allow = allow_isotope_error_ ? "yes" : "no";
+      used_labels.insert(writeNote_(os, "input", "spectrum, parent monoisotopic mass isotope error", allow));
+      //<note type="input" label="spectrum, fragment monoisotopic mass error units">Daltons</note>
+      //<note>The value for this parameter may be 'Daltons' or 'ppm': all other values are ignored</note>
+      if (fragment_mass_error_unit_ == XTandemInfile::DALTONS)
+      {
+        used_labels.insert(writeNote_(os, "input", "spectrum, fragment monoisotopic mass error units", "Daltons"));
+      }
+      else
+      {
+        used_labels.insert(writeNote_(os, "input", "spectrum, fragment monoisotopic mass error units", "ppm"));
+      }
 
-    //<note type="input" label="spectrum, total peaks">50</note>
-    //<note>If this value is 0, it is ignored. If it is greater than zero (lets say 50),
-    //then the number of peaks in the spectrum with be limited to the 50 most intense
-    //peaks in the spectrum. X! tandem does not do any peak finding: it only
-    //limits the peaks used by this parameter, and the dynamic range parameter.</note>
-    //writeNote_(os, "input", "spectrum, total peaks", String(total_number_peaks_));
+      //<note type="input" label="spectrum, parent monoisotopic mass error units">ppm</note>
+      //<note>The value for this parameter may be 'Daltons' or 'ppm': all other values are ignored</note>
+      if (precursor_mass_error_unit_ == XTandemInfile::PPM)
+      {
+        used_labels.insert(writeNote_(os, "input", "spectrum, parent monoisotopic mass error units", "ppm"));
+      }
+      else
+      {
+        used_labels.insert(writeNote_(os, "input", "spectrum, parent monoisotopic mass error units", "Daltons"));
+      }
 
-    //<note type="input" label="spectrum, maximum parent charge">4</note>
-    writeNote_(os, "input", "spectrum, maximum parent charge", String(max_precursor_charge_));
-    used_labels.insert("spectrum, maximum parent charge");
-
-    // <note type="input" label="spectrum, use noise suppression">yes</note>
-    //writeNote_(os, "input", "spectrum, use noise suppression", noise_supression_);
-
-    //<note type="input" label="spectrum, minimum parent m+h">500.0</note>
-    //writeNote_(os, "input", "spectrum, minimum parent m+h", String(precursor_lower_mz_));
-
-    //<note type="input" label="spectrum, minimum fragment mz">150.0</note>
-    //writeNote_(os, "input", "spectrum, minimum fragment mz", String(fragment_lower_mz_));
-    //used_labels.insert("spectrum, minimum fragment mz");
-
-    //<note type="input" label="spectrum, minimum peaks">15</note>
-    //writeNote_(os, "input", "spectrum, minimum peaks", String(min_number_peaks_));
-
-    //<note type="input" label="spectrum, threads">1</note>
-    writeNote_(os, "input", "spectrum, threads", String(number_of_threads_));
-    used_labels.insert("spectrum, threads");
-
-    //<note type="input" label="spectrum, sequence batch size">1000</note>
-    //writeNote_(os, "input", "spectrum, sequence batch size", String(batch_size_));
-    ////////////////////////////////////////////////////////////////////////////////
-
-
-    //////////////// residue modification parameters
-    //<note type="input" label="residue, modification mass">57.022@C</note>
-    //<note>The format of this parameter is m@X, where m is the modification
-    //mass in Daltons and X is the appropriate residue to modify. Lists of
-    //modifications are separated by commas. For example, to modify M and C
-    //with the addition of 16.0 Daltons, the parameter line would be
-    //+16.0@M,+16.0@C
-    //Positive and negative values are allowed.
-    //</note>
-
-    std::map<String, double> affected_origins;
-    writeNote_(os, "input", "residue, modification mass", convertModificationSet_(modifications_.getFixedModifications(), affected_origins));
-    used_labels.insert("residue, modification mass");
-
-    //<note type="input" label="residue, potential modification mass"></note>
-    //<note>The format of this parameter is the same as the format
-    //for residue, modification mass (see above).</note>
-
-    writeNote_(os, "input", "residue, potential modification mass", convertModificationSet_(modifications_.getVariableModifications(), affected_origins));
-    used_labels.insert("residue, potential modification mass");
-
-    writeNote_(os, "input", "protein, taxon", taxon_);
-    used_labels.insert("protein, taxon");
-
-    writeNote_(os, "input", "output, path", output_filename_);
-    used_labels.insert("output, path");
-/*
-    //<note type="input" label="residue, potential modification motif"></note>
-    //<note>The format of this parameter is similar to residue, modification mass,
-    //with the addition of a modified PROSITE notation sequence motif specification.
-    //For example, a value of 80@[ST!]PX[KR] indicates a modification
-    //of either S or T when followed by P, and residue and the a K or an R.
-    //A value of 204@N!{P}[ST]{P} indicates a modification of N by 204, if it
-    //is NOT followed by a P, then either an S or a T, NOT followed by a P.
-    //Positive and negative values are allowed.
-    //</note>
-        writeNote_(os, "input", "residue, potential modification motif", variable_modification_motif_);
-        ////////////////////////////////////////////////////////////////////////////////
+      //<note type="input" label="spectrum, fragment mass type">monoisotopic</note>
+      //<note>values are monoisotopic|average </note>
+      if (fragment_mass_type_ == XTandemInfile::MONOISOTOPIC)
+      {
+        used_labels.insert(writeNote_(os, "input", "spectrum, fragment mass type", "monoisotopic"));
+      }
+      else
+      {
+        used_labels.insert(writeNote_(os, "input", "spectrum, fragment mass type", "average"));
+      }
+      ////////////////////////////////////////////////////////////////////////////////
 
 
-        //////////////// protein parameters
-        //<note type="input" label="protein, taxon">other mammals</note>
-    //<note>This value is interpreted using the information in taxonomy.xml.</note>
-        writeNote_(os, "input", "protein, taxon", taxon_);
-        used_labels.insert("protein, taxon");
-*/
-    //<note type="input" label="protein, cleavage site">[RK]|{P}</note>
-    //<note>this setting corresponds to the enzyme trypsin. The first characters
-    //in brackets represent residues N-terminal to the bond - the '|' pipe -
-    //and the second set of characters represent residues C-terminal to the
-    //bond. The characters must be in square brackets (denoting that only
-    //these residues are allowed for a cleavage) or french brackets (denoting
-    //that these residues cannot be in that position). Use UPPERCASE characters.
-    //To denote cleavage at any residue, use [X]|[X] and reset the
-    //scoring, maximum missed cleavage site parameter (see below) to something like 50.
-    //</note>
-    writeNote_(os, "input", "protein, cleavage site", cleavage_site_);
-    used_labels.insert("protein, cleavage site");
+      //////////////// spectrum conditioning parameters
+      //<note type="input" label="spectrum, dynamic range">100.0</note>
+      //<note>The peaks read in are normalized so that the most intense peak
+      //is set to the dynamic range value. All peaks with values of less that
+      //1, using this normalization, are not used. This normalization has the
+      //overall effect of setting a threshold value for peak intensities.</note>
+      //used_labels.insert(writeNote_(os, "input", "spectrum, dynamic range", String(dynamic_range_));
+
+      //<note type="input" label="spectrum, total peaks">50</note>
+      //<note>If this value is 0, it is ignored. If it is greater than zero (lets say 50),
+      //then the number of peaks in the spectrum with be limited to the 50 most intense
+      //peaks in the spectrum. X! tandem does not do any peak finding: it only
+      //limits the peaks used by this parameter, and the dynamic range parameter.</note>
+      //used_labels.insert(writeNote_(os, "input", "spectrum, total peaks", String(total_number_peaks_));
+
+      //<note type="input" label="spectrum, maximum parent charge">4</note>
+      used_labels.insert(writeNote_(os, "input", "spectrum, maximum parent charge", String(max_precursor_charge_)));
+
+      // <note type="input" label="spectrum, use noise suppression">yes</note>
+      //used_labels.insert(writeNote_(os, "input", "spectrum, use noise suppression", noise_supression_);
+
+      //<note type="input" label="spectrum, minimum parent m+h">500.0</note>
+      //used_labels.insert(writeNote_(os, "input", "spectrum, minimum parent m+h", String(precursor_lower_mz_));
+
+      //<note type="input" label="spectrum, minimum fragment mz">150.0</note>
+      //used_labels.insert(writeNote_(os, "input", "spectrum, minimum fragment mz", String(fragment_lower_mz_));
+
+      //<note type="input" label="spectrum, minimum peaks">15</note>
+      //used_labels.insert(writeNote_(os, "input", "spectrum, minimum peaks", String(min_number_peaks_));
+
+      //<note type="input" label="spectrum, threads">1</note>
+      used_labels.insert(writeNote_(os, "input", "spectrum, threads", String(number_of_threads_)));
+
+      //<note type="input" label="spectrum, sequence batch size">1000</note>
+      //used_labels.insert(writeNote_(os, "input", "spectrum, sequence batch size", String(batch_size_));
+      ////////////////////////////////////////////////////////////////////////////////
+
+
+      //////////////// residue modification parameters
+      //<note type="input" label="residue, modification mass">57.022@C</note>
+      //<note>The format of this parameter is m@X, where m is the modification
+      //mass in Daltons and X is the appropriate residue to modify. Lists of
+      //modifications are separated by commas. For example, to modify M and C
+      //with the addition of 16.0 Daltons, the parameter line would be
+      //+16.0@M,+16.0@C
+      //Positive and negative values are allowed.
+      //</note>
+
+      std::map<String, double> affected_origins;
+      used_labels.insert(writeNote_(os, "input", "residue, modification mass", convertModificationSet_(modifications_.getFixedModifications(), affected_origins)));
+
+      //<note type="input" label="residue, potential modification mass"></note>
+      //<note>The format of this parameter is the same as the format
+      //for residue, modification mass (see above).</note>
+
+      used_labels.insert(writeNote_(os, "input", "residue, potential modification mass", convertModificationSet_(modifications_.getVariableModifications(), affected_origins)));
+
+      used_labels.insert(writeNote_(os, "input", "protein, taxon", taxon_));
+
+  /*
+      //<note type="input" label="residue, potential modification motif"></note>
+      //<note>The format of this parameter is similar to residue, modification mass,
+      //with the addition of a modified PROSITE notation sequence motif specification.
+      //For example, a value of 80@[ST!]PX[KR] indicates a modification
+      //of either S or T when followed by P, and residue and the a K or an R.
+      //A value of 204@N!{P}[ST]{P} indicates a modification of N by 204, if it
+      //is NOT followed by a P, then either an S or a T, NOT followed by a P.
+      //Positive and negative values are allowed.
+      //</note>
+          used_labels.insert(writeNote_(os, "input", "residue, potential modification motif", variable_modification_motif_);
+          ////////////////////////////////////////////////////////////////////////////////
+
+
+          //////////////// protein parameters
+          //<note type="input" label="protein, taxon">other mammals</note>
+      //<note>This value is interpreted using the information in taxonomy.xml.</note>
+          used_labels.insert(writeNote_(os, "input", "protein, taxon", taxon_);
+  */
+      //<note type="input" label="protein, cleavage site">[RK]|{P}</note>
+      //<note>this setting corresponds to the enzyme trypsin. The first characters
+      //in brackets represent residues N-terminal to the bond - the '|' pipe -
+      //and the second set of characters represent residues C-terminal to the
+      //bond. The characters must be in square brackets (denoting that only
+      //these residues are allowed for a cleavage) or french brackets (denoting
+      //that these residues cannot be in that position). Use UPPERCASE characters.
+      //To denote cleavage at any residue, use [X]|[X] and reset the
+      //scoring, maximum missed cleavage site parameter (see below) to something like 50.
+      //</note>
+      used_labels.insert(writeNote_(os, "input", "protein, cleavage site", cleavage_site_));
       
-    //////////////// semi cleavage parameter
-    //<note type="input" label="protein, cleavage semi">yes</note>
-    writeNote_(os, "input", "protein, cleavage semi", semi_cleavage_);
-    used_labels.insert("protein, cleavage semi");
+      //////////////// semi cleavage parameter
+      //<note type="input" label="protein, cleavage semi">yes</note>
+      used_labels.insert(writeNote_(os, "input", "protein, cleavage semi", semi_cleavage_));
 
+      //<note type="input" label="protein, modified residue mass file"></note>
+      //used_labels.insert(writeNote_(os, "input", "protein, modified residue mass file", modified_residue_mass_file_);
 
-    //<note type="input" label="protein, modified residue mass file"></note>
-    //writeNote_(os, "input", "protein, modified residue mass file", modified_residue_mass_file_);
+      //<note type="input" label="protein, cleavage C-terminal mass change">+17.002735</note>
+      //used_labels.insert(writeNote_(os, "input", "protein, cleavage C-terminal mass change", String(cleavage_c_term_mass_change_));
 
-    //<note type="input" label="protein, cleavage C-terminal mass change">+17.002735</note>
-    //writeNote_(os, "input", "protein, cleavage C-terminal mass change", String(cleavage_c_term_mass_change_));
+      //<note type="input" label="protein, cleavage N-terminal mass change">+1.007825</note>
+      //used_labels.insert(writeNote_(os, "input", "protein, cleavage N-terminal mass change", String(cleavage_n_term_mass_change_));
 
-    //<note type="input" label="protein, cleavage N-terminal mass change">+1.007825</note>
-    //writeNote_(os, "input", "protein, cleavage N-terminal mass change", String(cleavage_n_term_mass_change_));
+      //<note type="input" label="protein, N-terminal residue modification mass">0.0</note>
+      //used_labels.insert(writeNote_(os, "input", "protein, N-terminal residue modification mass", String(protein_n_term_mod_mass_));
 
-    //<note type="input" label="protein, N-terminal residue modification mass">0.0</note>
-    //writeNote_(os, "input", "protein, N-terminal residue modification mass", String(protein_n_term_mod_mass_));
+      //<note type="input" label="protein, C-terminal residue modification mass">0.0</note>
+      //used_labels.insert(writeNote_(os, "input", "protein, C-terminal residue modification mass", String(protein_c_term_mod_mass_));
 
-    //<note type="input" label="protein, C-terminal residue modification mass">0.0</note>
-    //writeNote_(os, "input", "protein, C-terminal residue modification mass", String(protein_c_term_mod_mass_));
-
-    //<note type="input" label="protein, homolog management">no</note>
-    //<note>if yes, an upper limit is set on the number of homologues kept for a particular spectrum</note>
-    //writeNote_(os, "input", "protein, homolog management", protein_homolog_management_);
-    ////////////////////////////////////////////////////////////////////////////////
+      //<note type="input" label="protein, homolog management">no</note>
+      //<note>if yes, an upper limit is set on the number of homologues kept for a particular spectrum</note>
+      //used_labels.insert(writeNote_(os, "input", "protein, homolog management", protein_homolog_management_);
+      ////////////////////////////////////////////////////////////////////////////////
 
 
 
-    //////////////// model refinement parameters
-    //<note type="input" label="refine">yes</note>
-    writeNote_(os, "input", "refine", refine_);
-    used_labels.insert("refine");
+      //////////////// model refinement parameters
+      //<note type="input" label="refine">yes</note>
+      used_labels.insert(writeNote_(os, "input", "refine", refine_));
 
 
-    //////////////// noise suppression parameter
-    //<note type="input" label="spectrum, use noise suppression">no</note>
-    writeNote_(os, "input", "spectrum, use noise suppression", noise_suppression_);
-    used_labels.insert("spectrum, use noise suppression");
+      //////////////// noise suppression parameter
+      //<note type="input" label="spectrum, use noise suppression">no</note>
+      used_labels.insert(writeNote_(os, "input", "spectrum, use noise suppression", noise_suppression_));
+
+  /*
+      //<note type="input" label="refine, modification mass"></note>
+          used_labels.insert(writeNote_(os, "input", "refine, modification mass", String(refine_mod_mass_));
+      //<note type="input" label="refine, sequence path"></note>
+          used_labels.insert(writeNote_(os, "input", "refine, sequence path", refine_sequence_path_);
+      //<note type="input" label="refine, tic percent">20</note>
+          used_labels.insert(writeNote_(os, "input", "refine, tic percent", String(refine_tic_percent_));
+      //<note type="input" label="refine, spectrum synthesis">yes</note>
+          used_labels.insert(writeNote_(os, "input", "refine, spectrum synthesis", refine_spectrum_sythesis_);
+      //<note type="input" label="refine, maximum valid expectation value">0.1</note>
+          used_labels.insert(writeNote_(os, "input", "refine, maximum valid expectation value", String(refine_max_valid_evalue_));
+      //<note type="input" label="refine, potential N-terminus modifications">+42.010565@[</note>
+          used_labels.insert(writeNote_(os, "input", "refine, potential N-terminus modifications", refine_variable_n_term_mods_);
+      //<note type="input" label="refine, potential C-terminus modifications"></note>
+          used_labels.insert(writeNote_(os, "input", "refine, potential C-terminus modifications", refine_variable_c_term_mods_);
+      //<note type="input" label="refine, unanticipated cleavage">yes</note>
+          used_labels.insert(writeNote_(os, "input", "refine, unanticipated cleavage", refine_unanticipated_cleavage_);
+      //<note type="input" label="refine, potential modification mass"></note>
+          used_labels.insert(writeNote_(os, "input", "refine, potential modification mass", String(variable_mod_mass_));
+      //<note type="input" label="refine, point mutations">no</note>
+          used_labels.insert(writeNote_(os, "input", "refine, point mutations", refine_point_mutations_);
+      //<note type="input" label="refine, use potential modifications for full refinement">no</note>
+          used_labels.insert(writeNote_(os, "input", "refine, use potential modifications for full refinement", use_var_mod_for_full_refinement_);*/
+      //<note type="input" label="refine, potential modification motif"></note>
+      //<note>The format of this parameter is similar to residue, modification mass,
+      //with the addition of a modified PROSITE notation sequence motif specification.
+      //For example, a value of 80@[ST!]PX[KR] indicates a modification
+      //of either S or T when followed by P, and residue and the a K or an R.
+      //A value of 204@N!{P}[ST]{P} indicates a modification of N by 204, if it
+      //is NOT followed by a P, then either an S or a T, NOT followed by a P.
+      //Positive and negative values are allowed.
+      //</note>
+
+      //used_labels.insert(writeNote_(os, "input", "refine, potential modification motif", refine_var_mod_motif_);
+      ////////////////////////////////////////////////////////////////////////////////
 
 
-/*
-    //<note type="input" label="refine, modification mass"></note>
-        writeNote_(os, "input", "refine, modification mass", String(refine_mod_mass_));
-    //<note type="input" label="refine, sequence path"></note>
-        writeNote_(os, "input", "refine, sequence path", refine_sequence_path_);
-    //<note type="input" label="refine, tic percent">20</note>
-        writeNote_(os, "input", "refine, tic percent", String(refine_tic_percent_));
-    //<note type="input" label="refine, spectrum synthesis">yes</note>
-        writeNote_(os, "input", "refine, spectrum synthesis", refine_spectrum_sythesis_);
-    //<note type="input" label="refine, maximum valid expectation value">0.1</note>
-        writeNote_(os, "input", "refine, maximum valid expectation value", String(refine_max_valid_evalue_));
-    //<note type="input" label="refine, potential N-terminus modifications">+42.010565@[</note>
-        writeNote_(os, "input", "refine, potential N-terminus modifications", refine_variable_n_term_mods_);
-    //<note type="input" label="refine, potential C-terminus modifications"></note>
-        writeNote_(os, "input", "refine, potential C-terminus modifications", refine_variable_c_term_mods_);
-    //<note type="input" label="refine, unanticipated cleavage">yes</note>
-        writeNote_(os, "input", "refine, unanticipated cleavage", refine_unanticipated_cleavage_);
-    //<note type="input" label="refine, potential modification mass"></note>
-        writeNote_(os, "input", "refine, potential modification mass", String(variable_mod_mass_));
-    //<note type="input" label="refine, point mutations">no</note>
-        writeNote_(os, "input", "refine, point mutations", refine_point_mutations_);
-    //<note type="input" label="refine, use potential modifications for full refinement">no</note>
-        writeNote_(os, "input", "refine, use potential modifications for full refinement", use_var_mod_for_full_refinement_);*/
-    //<note type="input" label="refine, potential modification motif"></note>
-    //<note>The format of this parameter is similar to residue, modification mass,
-    //with the addition of a modified PROSITE notation sequence motif specification.
-    //For example, a value of 80@[ST!]PX[KR] indicates a modification
-    //of either S or T when followed by P, and residue and the a K or an R.
-    //A value of 204@N!{P}[ST]{P} indicates a modification of N by 204, if it
-    //is NOT followed by a P, then either an S or a T, NOT followed by a P.
-    //Positive and negative values are allowed.
-    //</note>
-
-    //writeNote_(os, "input", "refine, potential modification motif", refine_var_mod_motif_);
-    ////////////////////////////////////////////////////////////////////////////////
+      //////////////// scoring parameters
+      //<note type="input" label="scoring, minimum ion count">4</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, minimum ion count", String(scoring_min_ion_count_));
+      //<note type="input" label="scoring, maximum missed cleavage sites">1</note>
+      used_labels.insert(writeNote_(os, "input", "scoring, maximum missed cleavage sites", String(number_of_missed_cleavages_)));
+      //<note type="input" label="scoring, x ions">no</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, x ions", score_x_ions_);
+      //<note type="input" label="scoring, y ions">yes</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, y ions", score_y_ions_);
+      //<note type="input" label="scoring, z ions">no</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, z ions", score_z_ions_);
+      //<note type="input" label="scoring, a ions">no</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, a ions", score_a_ions_);
+      //<note type="input" label="scoring, b ions">yes</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, b ions", score_b_ions_);
+      //<note type="input" label="scoring, c ions">no</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, c ions", score_c_ions_);
+      //<note type="input" label="scoring, cyclic permutation">no</note>
+      //<note>if yes, cyclic peptide sequence permutation is used to pad the scoring histograms</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, cyclic permutation", scoring_cyclic_permutation_);
+      //<note type="input" label="scoring, include reverse">no</note>
+      //<note>if yes, then reversed sequences are searched at the same time as forward sequences</note>
+      //used_labels.insert(writeNote_(os, "input", "scoring, include reverse", scoring_include_reverse_);
+      ////////////////////////////////////////////////////////////////////////////////
 
 
-    //////////////// scoring parameters
-    //<note type="input" label="scoring, minimum ion count">4</note>
-    //writeNote_(os, "input", "scoring, minimum ion count", String(scoring_min_ion_count_));
-    //<note type="input" label="scoring, maximum missed cleavage sites">1</note>
-    writeNote_(os, "input", "scoring, maximum missed cleavage sites", String(number_of_missed_cleavages_));
-    used_labels.insert("scoring, maximum missed cleavage sites");
-    //<note type="input" label="scoring, x ions">no</note>
-    //writeNote_(os, "input", "scoring, x ions", score_x_ions_);
-    //<note type="input" label="scoring, y ions">yes</note>
-    //writeNote_(os, "input", "scoring, y ions", score_y_ions_);
-    //<note type="input" label="scoring, z ions">no</note>
-    //writeNote_(os, "input", "scoring, z ions", score_z_ions_);
-    //<note type="input" label="scoring, a ions">no</note>
-    //writeNote_(os, "input", "scoring, a ions", score_a_ions_);
-    //<note type="input" label="scoring, b ions">yes</note>
-    //writeNote_(os, "input", "scoring, b ions", score_b_ions_);
-    //<note type="input" label="scoring, c ions">no</note>
-    //writeNote_(os, "input", "scoring, c ions", score_c_ions_);
-    //<note type="input" label="scoring, cyclic permutation">no</note>
-    //<note>if yes, cyclic peptide sequence permutation is used to pad the scoring histograms</note>
-    //writeNote_(os, "input", "scoring, cyclic permutation", scoring_cyclic_permutation_);
-    //<note type="input" label="scoring, include reverse">no</note>
-    //<note>if yes, then reversed sequences are searched at the same time as forward sequences</note>
-    //writeNote_(os, "input", "scoring, include reverse", scoring_include_reverse_);
-    ////////////////////////////////////////////////////////////////////////////////
+      //////////////// output parameters
+      //<note type="input" label="output, log path"></note>
+      //<note type="input" label="output, message">...</note>
+      //used_labels.insert(writeNote_(os, "input", "output, message", String("..."));
+      //<note type="input" label="output, one sequence copy">no</note>
+      //<note type="input" label="output, sequence path"></note>
+      //<note type="input" label="output, path">output.xml</note>
+      //used_labels.insert(writeNote_(os, "input", "output, path", output_filename_);
+      //<note type="input" label="output, sort results by">protein</note>
+      used_labels.insert(writeNote_(os, "input", "output, sort results by", "spectrum"));
 
+      //<note>values = protein|spectrum (spectrum is the default)</note>
+      //<note type="input" label="output, path hashing">yes</note>
+      //<note>values = yes|no</note>
+      //<note type="input" label="output, xsl path">tandem-style.xsl</note>
+      //<note type="input" label="output, parameters">yes</note>
+      //<note>values = yes|no</note>
+      //<note type="input" label="output, performance">yes</note>
+      //<note>values = yes|no</note>
+      //<note type="input" label="output, spectra">yes</note>
+      //<note>values = yes|no</note>
+      //<note type="input" label="output, histograms">yes</note>
+      //<note>values = yes|no</note>
+      //<note type="input" label="output, proteins">yes</note>
+      //<note>values = yes|no</note>
+      //<note type="input" label="output, sequences">yes</note>
+      //<note>values = yes|no</note>
+      //<note type="input" label="output, one sequence copy">no</note>
+      //<note>values = yes|no, set to yes to produce only one copy of each protein sequence in the output xml</note>
+      //<note type="input" label="output, results">valid</note>
+      //<note>values = all|valid|stochastic</note>
+      used_labels.insert(writeNote_(os, "input", "output, results", output_results_));
+ 
+      //<note type="input" label="output, maximum valid expectation value">0.1</note>
+      used_labels.insert(writeNote_(os, "input", "output, maximum valid expectation value", String(max_valid_evalue_)));
 
-    //////////////// output parameters
-    //<note type="input" label="output, log path"></note>
-    //<note type="input" label="output, message">...</note>
-    //writeNote_(os, "input", "output, message", String("..."));
-    //<note type="input" label="output, one sequence copy">no</note>
-    //<note type="input" label="output, sequence path"></note>
-    //<note type="input" label="output, path">output.xml</note>
-    //writeNote_(os, "input", "output, path", output_filename_);
-    //<note type="input" label="output, sort results by">protein</note>
-    writeNote_(os, "input", "output, sort results by", "spectrum");
-    used_labels.insert("output, sort results by");
-    //<note>values = protein|spectrum (spectrum is the default)</note>
-    //<note type="input" label="output, path hashing">yes</note>
-    //<note>values = yes|no</note>
-    //<note type="input" label="output, xsl path">tandem-style.xsl</note>
-    //<note type="input" label="output, parameters">yes</note>
-    //<note>values = yes|no</note>
-    //<note type="input" label="output, performance">yes</note>
-    //<note>values = yes|no</note>
-    //<note type="input" label="output, spectra">yes</note>
-    //<note>values = yes|no</note>
-    //<note type="input" label="output, histograms">yes</note>
-    //<note>values = yes|no</note>
-    //<note type="input" label="output, proteins">yes</note>
-    //<note>values = yes|no</note>
-    //<note type="input" label="output, sequences">yes</note>
-    //<note>values = yes|no</note>
-    //<note type="input" label="output, one sequence copy">no</note>
-    //<note>values = yes|no, set to yes to produce only one copy of each protein sequence in the output xml</note>
-    //<note type="input" label="output, results">valid</note>
-    //<note>values = all|valid|stochastic</note>
-    writeNote_(os, "input", "output, results", output_results_);
-    used_labels.insert("output, results");    
-    //<note type="input" label="output, maximum valid expectation value">0.1</note>
-    writeNote_(os, "input", "output, maximum valid expectation value", String(max_valid_evalue_));
-    used_labels.insert("output, maximum valid expectation value");
-    //<note>value is used in the valid|stochastic setting of output, results</note>
-    //<note type="input" label="output, histogram column width">30</note>
-    //<note>values any integer greater than 0. Setting this to '1' makes cutting and pasting histograms
-    //into spread sheet programs easier.</note>
-    //<note type="description">ADDITIONAL EXPLANATIONS</note>
-    //<note type="description">Each one of the parameters for X! tandem is entered as a labeled note
-    //  node. In the current version of X!, keep those note nodes
-    //  on a single line.
-    //</note>
-    //<note type="description">The presence of the type 'input' is necessary if a note is to be considered
-    //  an input parameter.
-    //</note>
-    //<note type="description">Any of the parameters that are paths to files may require alteration for a
-    //  particular installation. Full path names usually cause the least trouble,
-    //  but there is no reason not to use relative path names, if that is the
-    //  most convenient.
-    //</note>
-    //<note type="description">Any parameter values set in the 'list path, default parameters' file are
-    //  reset by entries in the normal input file, if they are present. Otherwise,
-    //  the default set is used.
-    //</note>
-    //<note type="description">The 'list path, taxonomy information' file must exist.
-    //</note>
-    //<note type="description">The directory containing the 'output, path' file must exist: it will not be created.
-    //</note>
-    //<note type="description">The 'output, xsl path' is optional: it is only of use if a good XSLT style sheet exists.
-    //</note>
-    ////////////////////////////////////////////////////////////////////////////////
+      //<note>value is used in the valid|stochastic setting of output, results</note>
+      //<note type="input" label="output, histogram column width">30</note>
+      //<note>values any integer greater than 0. Setting this to '1' makes cutting and pasting histograms
+      //into spread sheet programs easier.</note>
+      //<note type="description">ADDITIONAL EXPLANATIONS</note>
+      //<note type="description">Each one of the parameters for X! tandem is entered as a labeled note
+      //  node. In the current version of X!, keep those note nodes
+      //  on a single line.
+      //</note>
+      //<note type="description">The presence of the type 'input' is necessary if a note is to be considered
+      //  an input parameter.
+      //</note>
+      //<note type="description">Any of the parameters that are paths to files may require alteration for a
+      //  particular installation. Full path names usually cause the least trouble,
+      //  but there is no reason not to use relative path names, if that is the
+      //  most convenient.
+      //</note>
+      //<note type="description">Any parameter values set in the 'list path, default parameters' file are
+      //  reset by entries in the normal input file, if they are present. Otherwise,
+      //  the default set is used.
+      //</note>
+      //<note type="description">The 'list path, taxonomy information' file must exist.
+      //</note>
+      //<note type="description">The directory containing the 'output, path' file must exist: it will not be created.
+      //</note>
+      //<note type="description">The 'output, xsl path' is optional: it is only of use if a good XSLT style sheet exists.
+      //</note>
+      ////////////////////////////////////////////////////////////////////////////////
 
-    // those of the parameters that are not set by this file adapter
-    // are just written from the default XTandem infile
+    }
+
+    // parameters that are not set by this file adapter
+    // are just taken from the default XTandem infile (if load() was called before)
     for (vector<Internal::XTandemInfileNote>::const_iterator it = notes_.begin(); it != notes_.end(); ++it)
     {
       if (it->note_type != "" && it->note_label != "" && used_labels.find(it->note_label) == used_labels.end())
@@ -513,18 +493,20 @@ namespace OpenMS
 
   }
 
-  void XTandemInfile::writeNote_(ostream& os, const String& type, const String& label, const String& value)
+  const String& XTandemInfile::writeNote_(ostream& os, const String& type, const String& label, const String& value)
   {
     os << "\t<note type=\"" << type << "\" label=\"" << label  << "\">" << value << "</note>" << "\n";
+    return label;
   }
 
-  void XTandemInfile::writeNote_(ostream& os, const String& type, const String& label, const char* value)
+  const String& XTandemInfile::writeNote_(ostream& os, const String& type, const String& label, const char* value)
   {
     String val(value);
     os << "\t<note type=\"" << type << "\" label=\"" << label  << "\">" << val << "</note>" << "\n";
+    return label;
   }
 
-  void XTandemInfile::writeNote_(ostream& os, const String& type, const String& label, bool value)
+  const String& XTandemInfile::writeNote_(ostream& os, const String& type, const String& label, bool value)
   {
     if (value)
     {
@@ -534,6 +516,7 @@ namespace OpenMS
     {
       os << "\t<note type=\"" << type << "\" label=\"" << label  << "\">no</note>" << "\n";
     }
+    return label;
   }
 
   void XTandemInfile::setOutputFilename(const String& filename)

--- a/src/tests/class_tests/openms/data/XTandemInfile_test_write.xml
+++ b/src/tests/class_tests/openms/data/XTandemInfile_test_write.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="tandem-input-style.xsl"?>
 <bioml>
-	<note type="input" label="list path, default parameters">blubb_new_default_parameters_file</note>
-	<note type="input" label="list path, taxonomy information">blubb_new_taxonomy_file</note>
 	<note type="input" label="spectrum, path">blubb_new_inputfilename</note>
+	<note type="input" label="output, path">blubb_new_outputfilename</note>
+	<note type="input" label="list path, taxonomy information">blubb_new_taxonomy_file</note>
+	<note type="input" label="list path, default parameters">blubb_new_default_parameters_file</note>
 	<note type="input" label="spectrum, fragment monoisotopic mass error">13</note>
 	<note type="input" label="spectrum, parent monoisotopic mass error plus">14</note>
 	<note type="input" label="spectrum, parent monoisotopic mass error minus">15</note>
@@ -16,7 +17,6 @@
 	<note type="input" label="residue, modification mass">+58.005479@C,+28.0313@[,+15.994915@M</note>
 	<note type="input" label="residue, potential modification mass">+17.026549@],+80.062601@C</note>
 	<note type="input" label="protein, taxon">blubb_taxon</note>
-	<note type="input" label="output, path">blubb_new_outputfilename</note>
 	<note type="input" label="protein, cleavage site">[RK]|{P}</note>
 	<note type="input" label="protein, cleavage semi">yes</note>
 	<note type="input" label="refine">yes</note>

--- a/src/tests/class_tests/openms/data/XTandemInfile_test_write.xml
+++ b/src/tests/class_tests/openms/data/XTandemInfile_test_write.xml
@@ -13,8 +13,8 @@
 	<note type="input" label="spectrum, fragment mass type">monoisotopic</note>
 	<note type="input" label="spectrum, maximum parent charge">17</note>
 	<note type="input" label="spectrum, threads">16</note>
-	<note type="input" label="residue, modification mass">+28.0313@[,+15.994915@M</note>
-	<note type="input" label="residue, potential modification mass">+17.026549@],+58.005479@C</note>
+	<note type="input" label="residue, modification mass">+58.005479@C,+28.0313@[,+15.994915@M</note>
+	<note type="input" label="residue, potential modification mass">+17.026549@],+80.062601@C</note>
 	<note type="input" label="protein, taxon">blubb_taxon</note>
 	<note type="input" label="output, path">blubb_new_outputfilename</note>
 	<note type="input" label="protein, cleavage site">[RK]|{P}</note>

--- a/src/tests/class_tests/openms/source/XTandemInfile_test.cpp
+++ b/src/tests/class_tests/openms/source/XTandemInfile_test.cpp
@@ -250,7 +250,7 @@ END_SECTION
 START_SECTION(void write(const String &filename))
 	String filename("XTandemInfile_test.tmp");
 	NEW_TMP_FILE(filename);
-  ModificationDefinitionsSet sets(ListUtils::create<String>("Oxidation (M),Dimethyl (N-term)"), ListUtils::create<String>("Ammonium (C-term),Carboxymethyl (C)"));
+  ModificationDefinitionsSet sets(ListUtils::create<String>("Oxidation (M),Dimethyl (N-term),Carboxymethyl (C)"), ListUtils::create<String>("Ammonium (C-term),ICDID (C)"));
   ptr->setModifications(sets);
 	ptr->write(filename);
 	XTandemInfile file;

--- a/src/tests/class_tests/openms/source/XTandemInfile_test.cpp
+++ b/src/tests/class_tests/openms/source/XTandemInfile_test.cpp
@@ -247,7 +247,7 @@ START_SECTION(const ModificationDefinitionsSet& getModifications() const)
   TEST_EQUAL(ptr->getModifications() == sets, true)
 END_SECTION
 
-START_SECTION(void write(const String &filename))
+START_SECTION(void write(const String &filename, bool ignore_member_parameters = false))
 	String filename("XTandemInfile_test.tmp");
 	NEW_TMP_FILE(filename);
   ModificationDefinitionsSet sets(ListUtils::create<String>("Oxidation (M),Dimethyl (N-term),Carboxymethyl (C)"), ListUtils::create<String>("Ammonium (C-term),ICDID (C)"));
@@ -256,6 +256,16 @@ START_SECTION(void write(const String &filename))
 	XTandemInfile file;
 	file.load(filename);
   TEST_FILE_SIMILAR(filename.c_str(), OPENMS_GET_TEST_DATA_PATH("XTandemInfile_test_write.xml"))
+  // test writing of a minimal set
+  String filename_minimal("XTandemInfile_test_minimal.tmp");
+  NEW_TMP_FILE(filename_minimal);
+  XTandemInfile file2;
+  file2.write(filename_minimal, true);
+  XTandemInfile file3;
+  file3.load(filename_minimal);
+  TEST_EQUAL(file3.getNoteCount(), 3) // only three notes are written: input, output, taxonomy/database file
+
+
 END_SECTION
 
 START_SECTION(void load(const String &filename))

--- a/src/tests/class_tests/openms/source/XTandemInfile_test.cpp
+++ b/src/tests/class_tests/openms/source/XTandemInfile_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Stephan Aiche $
-// $Authors: Andreas Bertsch $
+// $Maintainer: Chris Bielow $
+// $Authors: Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>
@@ -259,28 +259,17 @@ START_SECTION(void write(const String &filename))
 END_SECTION
 
 START_SECTION(void load(const String &filename))
-{
   XTandemInfile file;
 	file.load(OPENMS_GET_TEST_DATA_PATH("XTandemInfile_test.xml"));
-  NOT_TESTABLE
-  /*
-  TEST_STRING_EQUAL(file.getOutputFilename(), "/tmp/2008-07-29_214248_prejudice_30269_1_tandem_output_file.xml")
-	TEST_EQUAL(file.getNumberOfThreads(), 1)
-  TEST_EQUAL(file.getPrecursorMassToleranceMinus(), 3)
-  TEST_EQUAL(file.getPrecursorMassTolerancePlus(), 3)
-  TEST_EQUAL(file.getFragmentMassTolerance(), 0.3)
-  TEST_STRING_EQUAL(file.getInputFilename(), "/tmp/2008-07-29_214248_prejudice_30269_1_tandem_input_file.mgf")
-  TEST_STRING_EQUAL(file.getTaxonomyFilename(), "/tmp/2008-07-29_214248_prejudice_30269_1_tandem_taxonomy_file.xml")
-  TEST_STRING_EQUAL(file.getDefaultParametersFilename(), "Software/tandem/current/bin/default_input.xml")
-  TEST_STRING_EQUAL(file.getTaxon(), "OpenMS_dummy_taxonomy")
-  TEST_EQUAL(file.getMaxPrecursorCharge(), 4)
-  TEST_EQUAL(file.getNumberOfMissedCleavages(), 2)
-  TEST_EQUAL(file.getMaxValidEValue(), 0.1)
-  TEST_EQUAL(file.getPrecursorErrorType(), XTandemInfile::MONOISOTOPIC)
-  TEST_EQUAL(file.getFragmentMassErrorUnit(), XTandemInfile::DALTONS)
-  */
-}
+  TEST_EQUAL(file.getNoteCount(), 74)
+  // real testing of values is hard, since they are never
+  // exposed (just overwritten by class members during write())
 END_SECTION
+
+START_SECTION(Size getNoteCount() const)
+  NOT_TESTABLE // tested in load()
+END_SECTION
+
 
 START_SECTION(bool isRefining() const )
   XTandemInfile file;
@@ -303,6 +292,7 @@ START_SECTION(void setNoiseSuppression(const bool noise_suppression))
   file.setNoiseSuppression(false);
   TEST_EQUAL(file.getNoiseSuppression()==false, true)
 END_SECTION
+
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/topp/THIRDPARTY/XTandemAdapter_1.ini
+++ b/src/tests/topp/THIRDPARTY/XTandemAdapter_1.ini
@@ -19,7 +19,6 @@
       </ITEMLIST>
       <ITEM name="missed_cleavages" value="1" type="int" description="Number of possible cleavage sites missed by the enzyme" />
       <ITEM name="xtandem_executable" value="tandem.exe" type="string" description="X!Tandem executable of the installation e.g. &apos;tandem.exe&apos;" tags="input file,required" />
-      <ITEM name="default_input_file" value="" type="string" description="Default parameters input file, if not given default parameters are used" tags="input file" />
       <ITEM name="minimum_fragment_mz" value="150" type="float" description="Minimum fragment mz" />
       <ITEM name="cleavage_site" value="Trypsin" type="string" description="The enzyme used for peptide digestion." required="false" advanced="false" restrictions="2-iodobenzoate,Arg-C,Asp-N,Asp-N_ambic,CNBr,Chymotrypsin,Formic_acid,Lys-C,Lys-C/P,PepsinA,TrypChymo,Trypsin,Trypsin/P,V8-DE,V8-E,glutamyl endopeptidase,leukocyte elastase,unspecific cleavage" />
       <ITEM name="max_valid_expect" value="0.1" type="float" description="Maximal E-Value of a hit to be reported" />

--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -17,20 +17,21 @@ endmacro (OPENMS_FINDBINARY)
 macro (openms_check_tandem_version binary valid)
   if(NOT (${XTANDEM_BINARY} STREQUAL "XTANDEM_BINARY-NOTFOUND"))
     set(${valid} FALSE)
-    execute_process(COMMAND ${XTANDEM_BINARY}
+    execute_process(COMMAND "${XTANDEM_BINARY}"
       RESULT_VARIABLE _tandem_result
       OUTPUT_VARIABLE _tandem_output
-      ERROR_VARIABLE _tandem_error
-      INPUT_FILE ${DATA_DIR_TOPP}/THIRDPARTY/tandem_break.txt
+      ERROR_VARIABLE _tandem_output  ## write to the same variable, in case Tandem decides to use std::cerr one day
+      INPUT_FILE ${DATA_DIR_TOPP}/THIRDPARTY/tandem_break.txt  ## provide some input, otherwise tandem.exe will block and not finish
     )
 
     # we are looking for something like (2013.09.01.1)
     string(REGEX MATCH "\([0-9]+[.][0-9]+[.][0-9]+([.][0-9]+)\)"
-          _tandem_version ${_tandem_output})
+          _tandem_version "${_tandem_output}")
 
     if("${_tandem_version}" VERSION_LESS "2013.09.01")
-      message(STATUS "  - X! Tandem too old. Please provide an X! Tandem version >= 2013.09.01 to enable the tests.")
+      message(STATUS "  - X! Tandem too old (${_tandem_version}). Please provide an X! Tandem version >= 2013.09.01 to enable the tests.")
     else()
+      message(STATUS "  + X! Tandem version: ${_tandem_version}.")
       set(${valid} TRUE)
     endif()
   endif()

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -162,7 +162,10 @@ protected:
 #endif
                        "X!Tandem executable of the installation e.g. 'tandem.exe'", true, false, ListUtils::create<String>("skipexists"));
     
-    registerInputFile_("default_input_file", "<file>", "CHEMISTRY/XTandem_default_input.xml", "Default parameters input file, defaulting to the ones in the OpenMS/share folder. All parameters of this adapter take precedence over this file! Use it for parameters not available here!", false);
+    registerInputFile_("default_input_file", "<file>", "CHEMISTRY/XTandem_default_input.xml", 
+                       "Default parameters input file, defaulting to the ones in the OpenMS/share folder. "
+                       "All parameters of this adapter take precedence over this file! Use it for parameters not available here!",
+                       false, false, ListUtils::create<String>("skipexists"));
     registerDoubleOption_("minimum_fragment_mz", "<num>", 150.0, "Minimum fragment mz", false);
     vector<String> all_enzymes;
     EnzymesDB::getInstance()->getAllXTandemNames(all_enzymes);

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -92,12 +92,12 @@ using namespace std;
 
     X! Tandem settings not exposed by this adapter can be directly adjusted using an XML configuration file.
     By default, all (!) parameters available explicitly via this wrapper take precedence over the XML configuration file.
-    The parameter "default_input_file" can be used to specify such a custom configuration.
+    The parameter "default_config_file" can be used to specify such a custom configuration.
     An example of a configuration file (named "default_input.xml") is contained in the "bin" folder of the
     @em X! Tandem installation and the OpenMS installation under OpenMS/share/CHEMISTRY/XTandem_default_input.xml.
     The latter is loaded by default.
     If you want to use the XML configuration file and @em ignore most of the parameters set via this adapter, use the '-ignore_adapter_param'
-    flag. Then, the config given in '-default_input_file' is used exclusively and only '-in', '-out', '-database' and '-xtandem_executable' are
+    flag. Then, the config given in '-default_config_file' is used exclusively and only '-in', '-out', '-database' and '-xtandem_executable' are
     taken from this adapter.
 
     @note Currently mzIdentML (mzid) is not directly supported as an input/output format of this tool. Convert mzid files to/from idXML using @ref TOPP_IDFileConverter if necessary.
@@ -117,7 +117,7 @@ class TOPPXTandemAdapter :
 {
 public:
   TOPPXTandemAdapter() :
-    TOPPBase("XTandemAdapter", "Annotates MS/MS spectra using XTandem.")
+    TOPPBase("XTandemAdapter", "Annotates MS/MS spectra using X! Tandem.")
   {
   }
 
@@ -140,12 +140,12 @@ protected:
       "tandem.exe",
 #endif
       "X! Tandem executable of the installation e.g. 'tandem.exe'", true, false, ListUtils::create<String>("skipexists"));
-    registerInputFile_("default_input_file", "<file>",
+    registerInputFile_("default_config_file", "<file>",
                        "CHEMISTRY/XTandem_default_input.xml", 
-                       "Default parameters input file, defaulting to the ones in the OpenMS/share folder. "
-                       "All parameters of this adapter take precedence over this file! Use it for parameters not available here!",
+                       "Default parameters input file, defaulting to the ones in the OpenMS/share folder."
+                         "All parameters of this adapter take precedence over this file! Use it for parameters not available here!",
                        false, false, ListUtils::create<String>("skipexists"));
-    registerFlag_("ignore_adapter_param", "The config given in default_input_file is used exclusively! No matter what other parameters "
+    registerFlag_("ignore_adapter_param", "The config given in 'default_config_file' is used exclusively! No matter what other parameters "
                                           "(apart from -in,-out,-database,-xtandem_executable) are saying.");
 
 
@@ -349,13 +349,13 @@ protected:
     infile.setAllowIsotopeError(allow_isotope_error);
 
     // load default config (this will NOT overwrite the parameters already set, but rather augment them)
-    String default_XML_config = getStringOption_("default_input_file");
+    String default_XML_config = getStringOption_("default_config_file");
     if (!default_XML_config.empty())
     {
-      // augment with absolute path. If absolute filename is given, this is a no-op
+      // augment with absolute path. If absolute filename is already given, this is a no-op.
       default_XML_config = File::find(default_XML_config);
       infile.load(default_XML_config);
-      infile.setDefaultParametersFilename(default_XML_config);
+      //infile.setDefaultParametersFilename(default_XML_config);
     }
 
     infile.write(input_filename, getFlag_("ignore_adapter_param"));


### PR DESCRIPTION
 - improve impl. of XTandemInfile 
    - checks XML tag ordering now via recursion
    - also empty-values parameters are loaded (to be able to preserve them when writing)

 - better docs for Xtandem-Adapter (especially on the use of the default config)

 - The param '-default_input_file' is renamed to '-default_config_file' and has a non-empty default now (the XML config in OpenMS/share). The behaviour is IDENTICAL to before, but the file is now explicitly mentioned. If the parameter is set empty, no config file will be loaded in the background (was not possible before).

 - The user can set a flag 'ignore_adapter_param', which gives precendence to the XML config file for all but four parameters: -in -out -database and -xtandem_executable.
