### PR TITLE
missing macro added to struct DeltaMass

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -69,7 +69,7 @@ namespace OpenMS
     /**
      * @brief mass shift with corresponding label set
      */
-    struct DeltaMass
+    struct OPENMS_DLLAPI DeltaMass
     {
       double delta_mass;
       LabelSet label_set;


### PR DESCRIPTION
Fixes bug in #1682.