### PR TITLE
[FIX-#1703] MzTabExporter: header columns doesn't match with data columns

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MzTab.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTab.h
@@ -735,16 +735,16 @@ public:
     void setSmallMoleculeSectionRows(const MzTabSmallMoleculeSectionRows& smsd);
 
     // Extract opt_ (custom, optional column names)
-    std::vector<String> getProteinOptionalColumnNames() const;
+    std::set<String> getProteinOptionalColumnNames() const;
 
     // Extract opt_ (custom, optional column names)
-    std::vector<String> getPeptideOptionalColumnNames() const;
+    std::set<String> getPeptideOptionalColumnNames() const;
 
     // Extract opt_ (custom, optional column names)
-    std::vector<String> getPSMOptionalColumnNames() const;
+    std::set<String> getPSMOptionalColumnNames() const;
 
     // Extract opt_ (custom, optional column names)
-    std::vector<String> getSmallMoleculeOptionalColumnNames() const;
+    std::set<String> getSmallMoleculeOptionalColumnNames() const;
 
 protected:
     MzTabMetaData meta_data_;

--- a/src/openms/include/OpenMS/FORMAT/MzTab.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTab.h
@@ -735,16 +735,16 @@ public:
     void setSmallMoleculeSectionRows(const MzTabSmallMoleculeSectionRows& smsd);
 
     // Extract opt_ (custom, optional column names)
-    std::set<String> getProteinOptionalColumnNames() const;
+    std::vector<String> getProteinOptionalColumnNames() const;
 
     // Extract opt_ (custom, optional column names)
-    std::set<String> getPeptideOptionalColumnNames() const;
+    std::vector<String> getPeptideOptionalColumnNames() const;
 
     // Extract opt_ (custom, optional column names)
-    std::set<String> getPSMOptionalColumnNames() const;
+    std::vector<String> getPSMOptionalColumnNames() const;
 
     // Extract opt_ (custom, optional column names)
-    std::set<String> getSmallMoleculeOptionalColumnNames() const;
+    std::vector<String> getSmallMoleculeOptionalColumnNames() const;
 
 protected:
     MzTabMetaData meta_data_;

--- a/src/openms/include/OpenMS/FORMAT/MzTabFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTabFile.h
@@ -91,27 +91,27 @@ protected:
 
     void generateMzTabMetaDataSection_(const MzTabMetaData& map, StringList& sl) const;
 
-    void generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
+    void generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const std::set<String>& optional_columns) const;
 
-    String generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::vector<String>& optional_columns) const;
+    String generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::set<String>& optional_columns) const;
 
-    String generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const std::vector<String>& optional_columns) const;
+    String generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const std::set<String>& optional_columns) const;
 
-    void generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
+    void generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const std::set<String>& optional_columns) const;
 
-    String generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::vector<String>& optional_columns) const;
+    String generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::set<String>& optional_columns) const;
 
-    String generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const std::vector<String>& optional_columns) const;
+    String generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const std::set<String>& optional_columns) const;
 
-    void generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
+    void generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const std::set<String>& optional_columns) const;
 
-    String generateMzTabPSMHeader_(Size n_search_engine_scores, const std::vector<String>& optional_columns) const;
+    String generateMzTabPSMHeader_(Size n_search_engine_scores, const std::set<String>& optional_columns) const;
 
-    String generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const std::vector<String>& optional_columns) const;
+    String generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const std::set<String>& optional_columns) const;
 
     void generateMzTabSmallMoleculeSection_(const MzTabSmallMoleculeSectionRows& map, StringList& sl) const;
 
-    String generateMzTabSmallMoleculeHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::vector<String>& optional_columns) const;
+    String generateMzTabSmallMoleculeHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::set<String>& optional_columns) const;
 
     String generateMzTabSmallMoleculeSectionRow_(const MzTabSmallMoleculeSectionRow& row) const;
 

--- a/src/openms/include/OpenMS/FORMAT/MzTabFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTabFile.h
@@ -91,23 +91,23 @@ protected:
 
     void generateMzTabMetaDataSection_(const MzTabMetaData& map, StringList& sl) const;
 
-    void generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl) const;
+    void generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
 
     String generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row) const;
+    String generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const std::vector<String>& optional_columns) const;
 
-    void generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl) const;
+    void generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
 
     String generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row) const;
+    String generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const std::vector<String>& optional_columns) const;
 
-    void generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl) const;
+    void generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
 
     String generateMzTabPSMHeader_(Size n_search_engine_scores, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row) const;
+    String generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const std::vector<String>& optional_columns) const;
 
     void generateMzTabSmallMoleculeSection_(const MzTabSmallMoleculeSectionRows& map, StringList& sl) const;
 

--- a/src/openms/include/OpenMS/FORMAT/MzTabFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTabFile.h
@@ -91,29 +91,29 @@ protected:
 
     void generateMzTabMetaDataSection_(const MzTabMetaData& map, StringList& sl) const;
 
-    void generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const std::set<String>& optional_columns) const;
+    void generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::set<String>& optional_columns) const;
+    String generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const std::set<String>& optional_columns) const;
+    String generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const std::vector<String>& optional_columns) const;
 
-    void generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const std::set<String>& optional_columns) const;
+    void generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::set<String>& optional_columns) const;
+    String generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const std::set<String>& optional_columns) const;
+    String generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const std::vector<String>& optional_columns) const;
 
-    void generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const std::set<String>& optional_columns) const;
+    void generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabPSMHeader_(Size n_search_engine_scores, const std::set<String>& optional_columns) const;
+    String generateMzTabPSMHeader_(Size n_search_engine_scores, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const std::set<String>& optional_columns) const;
+    String generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const std::vector<String>& optional_columns) const;
 
-    void generateMzTabSmallMoleculeSection_(const MzTabSmallMoleculeSectionRows& map, StringList& sl) const;
+    void generateMzTabSmallMoleculeSection_(const MzTabSmallMoleculeSectionRows& map, StringList& sl, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabSmallMoleculeHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::set<String>& optional_columns) const;
+    String generateMzTabSmallMoleculeHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_score, Size assays, Size study_variables, const std::vector<String>& optional_columns) const;
 
-    String generateMzTabSmallMoleculeSectionRow_(const MzTabSmallMoleculeSectionRow& row) const;
+    String generateMzTabSmallMoleculeSectionRow_(const MzTabSmallMoleculeSectionRow& row, const std::vector<String>& optional_columns) const;
 
     // auxiliary functions
     // extract two integers from string (e.g. search_engine_score[1]_ms_run[2] -> 1,2)

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -656,6 +656,7 @@ namespace OpenMS
 
   std::vector<String> MzTab::getProteinOptionalColumnNames() const
   {
+    // vector is used to preserve the column order
     std::vector<String> names;
     if (!protein_data_.empty())
     {
@@ -675,6 +676,7 @@ namespace OpenMS
 
   std::vector<String> MzTab::getPeptideOptionalColumnNames() const
   {
+    // vector is used to preserve the column order
     std::vector<String> names;
     if (!peptide_data_.empty())
     {
@@ -694,6 +696,7 @@ namespace OpenMS
 
   std::vector<String> MzTab::getPSMOptionalColumnNames() const
   {
+    // vector is used to preserve the column order
     std::vector<String> names;
     if (!psm_data_.empty())
     {
@@ -713,6 +716,7 @@ namespace OpenMS
 
   std::vector<String> MzTab::getSmallMoleculeOptionalColumnNames() const
   {
+    // vector is used to preserve the column order
     std::vector<String> names;
     if (!small_molecule_data_.empty())
     {

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -654,9 +654,9 @@ namespace OpenMS
     small_molecule_data_ = smsd;
   }
 
-  std::set<String> MzTab::getProteinOptionalColumnNames() const
+  std::vector<String> MzTab::getProteinOptionalColumnNames() const
   {
-    std::set<String> names;
+    std::vector<String> names;
     if (!protein_data_.empty())
     {
       for (MzTabProteinSectionRows::const_iterator it = protein_data_.begin(); it != protein_data_.end(); ++it)
@@ -665,7 +665,7 @@ namespace OpenMS
         {
           if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
-            names.insert(it_opt->first);
+            names.push_back(it_opt->first);
           }
         }
       }
@@ -673,9 +673,9 @@ namespace OpenMS
     return names;
   }
 
-  std::set<String> MzTab::getPeptideOptionalColumnNames() const
+  std::vector<String> MzTab::getPeptideOptionalColumnNames() const
   {
-    std::set<String> names;
+    std::vector<String> names;
     if (!peptide_data_.empty())
     {
       for (MzTabPeptideSectionRows::const_iterator it = peptide_data_.begin(); it != peptide_data_.end(); ++it)
@@ -684,7 +684,7 @@ namespace OpenMS
         {
           if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
-            names.insert(it_opt->first);
+            names.push_back(it_opt->first);
           }
         }
       }
@@ -692,9 +692,9 @@ namespace OpenMS
     return names;
   }
 
-  std::set<String> MzTab::getPSMOptionalColumnNames() const
+  std::vector<String> MzTab::getPSMOptionalColumnNames() const
   {
-    std::set<String> names;
+    std::vector<String> names;
     if (!psm_data_.empty())
     {
       for (MzTabPSMSectionRows::const_iterator it = psm_data_.begin(); it != psm_data_.end(); ++it)
@@ -703,7 +703,7 @@ namespace OpenMS
         {
           if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
-            names.insert(it_opt->first);
+            names.push_back(it_opt->first);
           }
         }
       }
@@ -711,15 +711,20 @@ namespace OpenMS
     return names;
   }
 
-  std::set<String> MzTab::getSmallMoleculeOptionalColumnNames() const
+  std::vector<String> MzTab::getSmallMoleculeOptionalColumnNames() const
   {
-    std::set<String> names;
+    std::vector<String> names;
     if (!small_molecule_data_.empty())
     {
-      const std::vector<MzTabOptionalColumnEntry>& opt_ = small_molecule_data_[0].opt_;
-      for (std::vector<MzTabOptionalColumnEntry>::const_iterator it = opt_.begin(); it != opt_.end(); ++it)
+      for (MzTabSmallMoleculeSectionRows::const_iterator it = small_molecule_data_.begin(); it != small_molecule_data_.end(); ++it)
       {
-        names.insert(it->first);
+        for (std::vector<MzTabOptionalColumnEntry>::const_iterator it_opt = it->opt_.begin(); it_opt != it->opt_.end(); ++it_opt)
+        {
+          if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
+          {
+            names.push_back(it_opt->first);
+          }
+        }
       }
     }
     return names;

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -654,9 +654,9 @@ namespace OpenMS
     small_molecule_data_ = smsd;
   }
 
-  std::vector<String> MzTab::getProteinOptionalColumnNames() const
+  std::set<String> MzTab::getProteinOptionalColumnNames() const
   {
-    std::vector<String> names;
+    std::set<String> names;
     if (!protein_data_.empty())
     {
       for (MzTabProteinSectionRows::const_iterator it = protein_data_.begin(); it != protein_data_.end(); ++it)
@@ -665,7 +665,7 @@ namespace OpenMS
         {
           if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
-            names.push_back(it_opt->first);
+            names.insert(it_opt->first);
           }
         }
       }
@@ -673,9 +673,9 @@ namespace OpenMS
     return names;
   }
 
-  std::vector<String> MzTab::getPeptideOptionalColumnNames() const
+  std::set<String> MzTab::getPeptideOptionalColumnNames() const
   {
-    std::vector<String> names;
+    std::set<String> names;
     if (!peptide_data_.empty())
     {
       for (MzTabPeptideSectionRows::const_iterator it = peptide_data_.begin(); it != peptide_data_.end(); ++it)
@@ -684,7 +684,7 @@ namespace OpenMS
         {
           if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
-            names.push_back(it_opt->first);
+            names.insert(it_opt->first);
           }
         }
       }
@@ -692,9 +692,9 @@ namespace OpenMS
     return names;
   }
 
-  std::vector<String> MzTab::getPSMOptionalColumnNames() const
+  std::set<String> MzTab::getPSMOptionalColumnNames() const
   {
-    std::vector<String> names;
+    std::set<String> names;
     if (!psm_data_.empty())
     {
       for (MzTabPSMSectionRows::const_iterator it = psm_data_.begin(); it != psm_data_.end(); ++it)
@@ -703,7 +703,7 @@ namespace OpenMS
         {
           if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
-            names.push_back(it_opt->first);
+            names.insert(it_opt->first);
           }
         }
       }
@@ -711,15 +711,15 @@ namespace OpenMS
     return names;
   }
 
-  std::vector<String> MzTab::getSmallMoleculeOptionalColumnNames() const
+  std::set<String> MzTab::getSmallMoleculeOptionalColumnNames() const
   {
-    std::vector<String> names;
+    std::set<String> names;
     if (!small_molecule_data_.empty())
     {
       const std::vector<MzTabOptionalColumnEntry>& opt_ = small_molecule_data_[0].opt_;
       for (std::vector<MzTabOptionalColumnEntry>::const_iterator it = opt_.begin(); it != opt_.end(); ++it)
       {
-        names.push_back(it->first);
+        names.insert(it->first);
       }
     }
     return names;

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -664,7 +664,7 @@ namespace OpenMS
       {
         for (std::vector<MzTabOptionalColumnEntry>::const_iterator it_opt = it->opt_.begin(); it_opt != it->opt_.end(); ++it_opt)
         {
-          if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
+          if (std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
             names.push_back(it_opt->first);
           }
@@ -684,7 +684,7 @@ namespace OpenMS
       {
         for (std::vector<MzTabOptionalColumnEntry>::const_iterator it_opt = it->opt_.begin(); it_opt != it->opt_.end(); ++it_opt)
         {
-          if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
+          if (std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
             names.push_back(it_opt->first);
           }
@@ -704,7 +704,7 @@ namespace OpenMS
       {
         for (std::vector<MzTabOptionalColumnEntry>::const_iterator it_opt = it->opt_.begin(); it_opt != it->opt_.end(); ++it_opt)
         {
-          if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
+          if (std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
             names.push_back(it_opt->first);
           }
@@ -724,7 +724,7 @@ namespace OpenMS
       {
         for (std::vector<MzTabOptionalColumnEntry>::const_iterator it_opt = it->opt_.begin(); it_opt != it->opt_.end(); ++it_opt)
         {
-          if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
+          if (std::find(names.begin(), names.end(), it_opt->first) == names.end())
           {
             names.push_back(it_opt->first);
           }

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -659,10 +659,15 @@ namespace OpenMS
     std::vector<String> names;
     if (!protein_data_.empty())
     {
-      const std::vector<MzTabOptionalColumnEntry>& opt_ = protein_data_[0].opt_;
-      for (std::vector<MzTabOptionalColumnEntry>::const_iterator it = opt_.begin(); it != opt_.end(); ++it)
+      for (MzTabProteinSectionRows::const_iterator it = protein_data_.begin(); it != protein_data_.end(); ++it)
       {
-        names.push_back(it->first);
+        for (std::vector<MzTabOptionalColumnEntry>::const_iterator it_opt = it->opt_.begin(); it_opt != it->opt_.end(); ++it_opt)
+        {
+          if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
+          {
+            names.push_back(it_opt->first);
+          }
+        }
       }
     }
     return names;
@@ -673,10 +678,15 @@ namespace OpenMS
     std::vector<String> names;
     if (!peptide_data_.empty())
     {
-      const std::vector<MzTabOptionalColumnEntry>& opt_ = peptide_data_[0].opt_;
-      for (std::vector<MzTabOptionalColumnEntry>::const_iterator it = opt_.begin(); it != opt_.end(); ++it)
+      for (MzTabPeptideSectionRows::const_iterator it = peptide_data_.begin(); it != peptide_data_.end(); ++it)
       {
-        names.push_back(it->first);
+        for (std::vector<MzTabOptionalColumnEntry>::const_iterator it_opt = it->opt_.begin(); it_opt != it->opt_.end(); ++it_opt)
+        {
+          if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
+          {
+            names.push_back(it_opt->first);
+          }
+        }
       }
     }
     return names;
@@ -687,10 +697,15 @@ namespace OpenMS
     std::vector<String> names;
     if (!psm_data_.empty())
     {
-      const std::vector<MzTabOptionalColumnEntry>& opt_ = psm_data_[0].opt_;
-      for (std::vector<MzTabOptionalColumnEntry>::const_iterator it = opt_.begin(); it != opt_.end(); ++it)
+      for (MzTabPSMSectionRows::const_iterator it = psm_data_.begin(); it != psm_data_.end(); ++it)
       {
-        names.push_back(it->first);
+        for (std::vector<MzTabOptionalColumnEntry>::const_iterator it_opt = it->opt_.begin(); it_opt != it->opt_.end(); ++it_opt)
+        {
+          if(std::find(names.begin(), names.end(), it_opt->first) == names.end())
+          {
+            names.push_back(it_opt->first);
+          }
+        }
       }
     }
     return names;

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -1961,7 +1961,7 @@ String MzTabFile::generateMzTabProteinHeader_(const MzTabProteinSectionRow& refe
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row) const
+String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const std::vector<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PRT");
@@ -2043,28 +2043,41 @@ String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& 
   }
 
   // print optional columns
-  for (Size i = 0; i != row.opt_.size(); ++i)
+  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
-    s.push_back(row.opt_[i].second.toCellString());
+    bool found = false;
+    for (Size i = 0; i != row.opt_.size(); ++i)
+    {
+      if (row.opt_[i].first.compare(*it) == 0)
+      {
+        s.push_back(row.opt_[i].second.toCellString());
+        found = true;
+        break;
+      }
+    }
+    if(!found)
+    {
+      s.push_back(MzTabString("null").toCellString());
+    }
   }
 
   return ListUtils::concatenate(s, "\t");
 }
 
-void MzTabFile::generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl) const
+void MzTabFile::generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const
 {
   for (MzTabProteinSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
-    sl.push_back(generateMzTabProteinSectionRow_(*it));
+    sl.push_back(generateMzTabProteinSectionRow_(*it, optional_columns));
   }
   sl.push_back(String("\n"));
 }
 
-void MzTabFile::generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl) const
+void MzTabFile::generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const vector<String>& optional_columns) const
 {
   for (MzTabPeptideSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
-    sl.push_back(generateMzTabPeptideSectionRow_(*it));
+    sl.push_back(generateMzTabPeptideSectionRow_(*it, optional_columns));
   }
   sl.push_back(String("\n"));
 }
@@ -2180,7 +2193,7 @@ String MzTabFile::generateMzTabPSMHeader_(Size n_search_engine_scores, const vec
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row) const
+String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const vector<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PEP");
@@ -2244,24 +2257,37 @@ String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& 
   }
 
   // print optional columns
-  for (Size i = 0; i != row.opt_.size(); ++i)
+  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
-    s.push_back(row.opt_[i].second.toCellString());
+    bool found = false;
+    for (Size i = 0; i != row.opt_.size(); ++i)
+    {
+      if (row.opt_[i].first.compare(*it) == 0)
+      {
+        s.push_back(row.opt_[i].second.toCellString());
+        found = true;
+        break;
+      }
+    }
+    if(!found)
+    {
+      s.push_back(MzTabString("null").toCellString());
+    }
   }
 
   return ListUtils::concatenate(s, "\t");
 }
 
-void MzTabFile::generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl) const
+void MzTabFile::generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const vector<String>& optional_columns) const
 {
   for (MzTabPSMSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
-    sl.push_back(generateMzTabPSMSectionRow_(*it));
+    sl.push_back(generateMzTabPSMSectionRow_(*it, optional_columns));
   }
   sl.push_back(String("\n"));
 }
 
-String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row) const
+String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PSM");
@@ -2301,11 +2327,24 @@ String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row) con
   s.push_back(row.end.toCellString());
 
   // print optional columns
-  for (Size i = 0; i != row.opt_.size(); ++i)
+  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
-    s.push_back(row.opt_[i].second.toCellString());
+    bool found = false;
+    for (Size i = 0; i != row.opt_.size(); ++i)
+    {
+      if (row.opt_[i].first.compare(*it) == 0)
+      {
+        s.push_back(row.opt_[i].second.toCellString());
+        found = true;
+        break;
+      }
+    }
+    if(!found)
+    {
+      s.push_back(MzTabString("null").toCellString());
+    }
   }
-
+  
   return ListUtils::concatenate(s, "\t");
 }
 
@@ -2465,7 +2504,7 @@ void MzTabFile::store(const String& filename, const MzTab& mz_tab) const
     out.push_back(generateMzTabProteinHeader_(protein_section[0], n_best_search_engine_score, mz_tab.getProteinOptionalColumnNames()));
 
     // add section
-    generateMzTabProteinSection_(protein_section, out);
+    generateMzTabProteinSection_(protein_section, out, mz_tab.getProteinOptionalColumnNames());
   }
 
   if (!peptide_section.empty())
@@ -2497,7 +2536,7 @@ void MzTabFile::store(const String& filename, const MzTab& mz_tab) const
     Size n_search_engine_score = peptide_section[0].search_engine_score_ms_run.size();
     Size n_best_search_engine_score = mz_tab.getMetaData().peptide_search_engine_score.size();
     out.push_back(generateMzTabPeptideHeader_(search_ms_runs, n_best_search_engine_score, n_search_engine_score, assays, study_variables, mz_tab.getPeptideOptionalColumnNames()));
-    generateMzTabPeptideSection_(mz_tab.getPeptideSectionRows(), out);
+    generateMzTabPeptideSection_(mz_tab.getPeptideSectionRows(), out, mz_tab.getPeptideOptionalColumnNames());
   }
 
   if (!psm_section.empty())
@@ -2509,7 +2548,7 @@ void MzTabFile::store(const String& filename, const MzTab& mz_tab) const
       // TODO warn
     }
     out.push_back(generateMzTabPSMHeader_(n_search_engine_scores, mz_tab.getPSMOptionalColumnNames()));
-    generateMzTabPSMSection_(mz_tab.getPSMSectionRows(), out);
+    generateMzTabPSMSection_(mz_tab.getPSMSectionRows(), out, mz_tab.getPSMOptionalColumnNames());
   }
 
   if (!smallmolecule_section.empty())
@@ -2564,4 +2603,3 @@ void MzTabFile::store(const String& filename, const MzTab& mz_tab) const
 }
 
 #pragma clang diagnostic pop
-

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -2055,7 +2055,7 @@ String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& 
         break;
       }
     }
-    if(!found)
+    if (!found)
     {
       s.push_back(MzTabString("null").toCellString());
     }
@@ -2269,7 +2269,7 @@ String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& 
         break;
       }
     }
-    if(!found)
+    if (!found)
     {
       s.push_back(MzTabString("null").toCellString());
     }
@@ -2339,7 +2339,7 @@ String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, con
         break;
       }
     }
-    if(!found)
+    if (!found)
     {
       s.push_back(MzTabString("null").toCellString());
     }
@@ -2488,7 +2488,7 @@ String MzTabFile::generateMzTabSmallMoleculeSectionRow_(const MzTabSmallMolecule
         break;
       }
     }
-    if(!found)
+    if (!found)
     {
       s.push_back(MzTabString("null").toCellString());
     }

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -1878,7 +1878,7 @@ void MzTabFile::generateMzTabMetaDataSection_(const MzTabMetaData& md, StringLis
   sl.push_back(String("\n"));
 }
 
-String MzTabFile::generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::set<String>& optional_columns) const
+String MzTabFile::generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::vector<String>& optional_columns) const
 {
   Size n_search_engine_scores = reference_row.search_engine_score_ms_run.size();
 
@@ -1961,7 +1961,7 @@ String MzTabFile::generateMzTabProteinHeader_(const MzTabProteinSectionRow& refe
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const set<String>& optional_columns) const
+String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const vector<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PRT");
@@ -2043,7 +2043,7 @@ String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& 
   }
 
   // print optional columns
-  for (set<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
+  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
     bool found = false;
     for (Size i = 0; i != row.opt_.size(); ++i)
@@ -2064,7 +2064,7 @@ String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& 
   return ListUtils::concatenate(s, "\t");
 }
 
-void MzTabFile::generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const set<String>& optional_columns) const
+void MzTabFile::generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const vector<String>& optional_columns) const
 {
   for (MzTabProteinSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
@@ -2073,7 +2073,7 @@ void MzTabFile::generateMzTabProteinSection_(const MzTabProteinSectionRows& rows
   sl.push_back(String("\n"));
 }
 
-void MzTabFile::generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const set<String>& optional_columns) const
+void MzTabFile::generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const vector<String>& optional_columns) const
 {
   for (MzTabPeptideSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
@@ -2082,15 +2082,15 @@ void MzTabFile::generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows
   sl.push_back(String("\n"));
 }
 
-void MzTabFile::generateMzTabSmallMoleculeSection_(const MzTabSmallMoleculeSectionRows& rows, StringList& sl) const
+void MzTabFile::generateMzTabSmallMoleculeSection_(const MzTabSmallMoleculeSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const
 {
   for (MzTabSmallMoleculeSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
-    sl.push_back(generateMzTabSmallMoleculeSectionRow_(*it));
+    sl.push_back(generateMzTabSmallMoleculeSectionRow_(*it, optional_columns));
   }
 }
 
-String MzTabFile::generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_scores, Size assays, Size study_variables, const set<String>& optional_columns) const
+String MzTabFile::generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_scores, Size assays, Size study_variables, const vector<String>& optional_columns) const
 {
   StringList header;
   header.push_back("PEH");
@@ -2149,7 +2149,7 @@ String MzTabFile::generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_s
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabPSMHeader_(Size n_search_engine_scores, const set<String>& optional_columns) const
+String MzTabFile::generateMzTabPSMHeader_(Size n_search_engine_scores, const vector<String>& optional_columns) const
 {
   StringList header;
   header.push_back("PSH");
@@ -2193,7 +2193,7 @@ String MzTabFile::generateMzTabPSMHeader_(Size n_search_engine_scores, const set
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const set<String>& optional_columns) const
+String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const vector<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PEP");
@@ -2257,7 +2257,7 @@ String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& 
   }
 
   // print optional columns
-  for (set<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
+  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
     bool found = false;
     for (Size i = 0; i != row.opt_.size(); ++i)
@@ -2278,7 +2278,7 @@ String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& 
   return ListUtils::concatenate(s, "\t");
 }
 
-void MzTabFile::generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const set<String>& optional_columns) const
+void MzTabFile::generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const vector<String>& optional_columns) const
 {
   for (MzTabPSMSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
@@ -2287,7 +2287,7 @@ void MzTabFile::generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, String
   sl.push_back(String("\n"));
 }
 
-String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const set<String>& optional_columns) const
+String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PSM");
@@ -2327,7 +2327,7 @@ String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, con
   s.push_back(row.end.toCellString());
 
   // print optional columns
-  for (set<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
+  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
     bool found = false;
     for (Size i = 0; i != row.opt_.size(); ++i)
@@ -2348,7 +2348,7 @@ String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, con
   return ListUtils::concatenate(s, "\t");
 }
 
-String MzTabFile::generateMzTabSmallMoleculeHeader_(Size ms_runs, Size n_best_search_engine_scores, Size n_search_engine_scores, Size assays, Size study_variables, const set<String>& optional_smallmolecule_columns) const
+String MzTabFile::generateMzTabSmallMoleculeHeader_(Size ms_runs, Size n_best_search_engine_scores, Size n_search_engine_scores, Size assays, Size study_variables, const vector<String>& optional_smallmolecule_columns) const
 {
   StringList header;
   header.push_back("SMH");
@@ -2412,7 +2412,7 @@ String MzTabFile::generateMzTabSmallMoleculeHeader_(Size ms_runs, Size n_best_se
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabSmallMoleculeSectionRow_(const MzTabSmallMoleculeSectionRow& row) const
+String MzTabFile::generateMzTabSmallMoleculeSectionRow_(const MzTabSmallMoleculeSectionRow& row, const std::vector<String>& optional_columns) const
 {
   StringList s;
   s.push_back("SML");
@@ -2475,9 +2475,23 @@ String MzTabFile::generateMzTabSmallMoleculeSectionRow_(const MzTabSmallMolecule
   }
 
   // print optional columns
-  for (Size i = 0; i != row.opt_.size(); ++i)
+  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
-    s.push_back(row.opt_[i].second.toCellString());
+    bool found = false;
+    for (Size i = 0; i != row.opt_.size(); ++i)
+    {
+      
+      if (row.opt_[i].first == *it)
+      {
+        s.push_back(row.opt_[i].second.toCellString());
+        found = true;
+        break;
+      }
+    }
+    if(!found)
+    {
+      s.push_back(MzTabString("null").toCellString());
+    }
   }
 
   return ListUtils::concatenate(s, "\t");
@@ -2558,7 +2572,7 @@ void MzTabFile::store(const String& filename, const MzTab& mz_tab) const
     Size n_search_engine_score = smallmolecule_section[0].search_engine_score_ms_run.size();
     Size n_best_search_engine_score = mz_tab.getMetaData().smallmolecule_search_engine_score.size();
     out.push_back(generateMzTabSmallMoleculeHeader_(ms_runs, n_best_search_engine_score, n_search_engine_score, assays, study_variables, mz_tab.getSmallMoleculeOptionalColumnNames()));
-    generateMzTabSmallMoleculeSection_(smallmolecule_section, out);
+    generateMzTabSmallMoleculeSection_(smallmolecule_section, out, mz_tab.getSmallMoleculeOptionalColumnNames());
   }
 
   // insert comment (might provide critical cues for human reader) and empty lines

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -1878,7 +1878,7 @@ void MzTabFile::generateMzTabMetaDataSection_(const MzTabMetaData& md, StringLis
   sl.push_back(String("\n"));
 }
 
-String MzTabFile::generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::vector<String>& optional_columns) const
+String MzTabFile::generateMzTabProteinHeader_(const MzTabProteinSectionRow& reference_row, const Size n_best_search_engine_scores, const std::set<String>& optional_columns) const
 {
   Size n_search_engine_scores = reference_row.search_engine_score_ms_run.size();
 
@@ -1961,7 +1961,7 @@ String MzTabFile::generateMzTabProteinHeader_(const MzTabProteinSectionRow& refe
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const std::vector<String>& optional_columns) const
+String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& row, const set<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PRT");
@@ -2043,12 +2043,12 @@ String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& 
   }
 
   // print optional columns
-  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
+  for (set<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
     bool found = false;
     for (Size i = 0; i != row.opt_.size(); ++i)
     {
-      if (row.opt_[i].first.compare(*it) == 0)
+      if (row.opt_[i].first == *it)
       {
         s.push_back(row.opt_[i].second.toCellString());
         found = true;
@@ -2064,7 +2064,7 @@ String MzTabFile::generateMzTabProteinSectionRow_(const MzTabProteinSectionRow& 
   return ListUtils::concatenate(s, "\t");
 }
 
-void MzTabFile::generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const std::vector<String>& optional_columns) const
+void MzTabFile::generateMzTabProteinSection_(const MzTabProteinSectionRows& rows, StringList& sl, const set<String>& optional_columns) const
 {
   for (MzTabProteinSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
@@ -2073,7 +2073,7 @@ void MzTabFile::generateMzTabProteinSection_(const MzTabProteinSectionRows& rows
   sl.push_back(String("\n"));
 }
 
-void MzTabFile::generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const vector<String>& optional_columns) const
+void MzTabFile::generateMzTabPeptideSection_(const MzTabPeptideSectionRows& rows, StringList& sl, const set<String>& optional_columns) const
 {
   for (MzTabPeptideSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
@@ -2090,7 +2090,7 @@ void MzTabFile::generateMzTabSmallMoleculeSection_(const MzTabSmallMoleculeSecti
   }
 }
 
-String MzTabFile::generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_scores, Size assays, Size study_variables, const vector<String>& optional_columns) const
+String MzTabFile::generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_search_engine_scores, Size n_search_engine_scores, Size assays, Size study_variables, const set<String>& optional_columns) const
 {
   StringList header;
   header.push_back("PEH");
@@ -2149,7 +2149,7 @@ String MzTabFile::generateMzTabPeptideHeader_(Size search_ms_runs, Size n_best_s
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabPSMHeader_(Size n_search_engine_scores, const vector<String>& optional_columns) const
+String MzTabFile::generateMzTabPSMHeader_(Size n_search_engine_scores, const set<String>& optional_columns) const
 {
   StringList header;
   header.push_back("PSH");
@@ -2193,7 +2193,7 @@ String MzTabFile::generateMzTabPSMHeader_(Size n_search_engine_scores, const vec
   return ListUtils::concatenate(header, "\t");
 }
 
-String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const vector<String>& optional_columns) const
+String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& row, const set<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PEP");
@@ -2257,12 +2257,12 @@ String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& 
   }
 
   // print optional columns
-  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
+  for (set<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
     bool found = false;
     for (Size i = 0; i != row.opt_.size(); ++i)
     {
-      if (row.opt_[i].first.compare(*it) == 0)
+      if (row.opt_[i].first == *it)
       {
         s.push_back(row.opt_[i].second.toCellString());
         found = true;
@@ -2278,7 +2278,7 @@ String MzTabFile::generateMzTabPeptideSectionRow_(const MzTabPeptideSectionRow& 
   return ListUtils::concatenate(s, "\t");
 }
 
-void MzTabFile::generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const vector<String>& optional_columns) const
+void MzTabFile::generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, StringList& sl, const set<String>& optional_columns) const
 {
   for (MzTabPSMSectionRows::const_iterator it = rows.begin(); it != rows.end(); ++it)
   {
@@ -2287,7 +2287,7 @@ void MzTabFile::generateMzTabPSMSection_(const MzTabPSMSectionRows& rows, String
   sl.push_back(String("\n"));
 }
 
-String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const
+String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const set<String>& optional_columns) const
 {
   StringList s;
   s.push_back("PSM");
@@ -2327,12 +2327,12 @@ String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, con
   s.push_back(row.end.toCellString());
 
   // print optional columns
-  for (vector<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
+  for (set<String>::const_iterator it = optional_columns.begin(); it != optional_columns.end(); ++it)
   {
     bool found = false;
     for (Size i = 0; i != row.opt_.size(); ++i)
     {
-      if (row.opt_[i].first.compare(*it) == 0)
+      if (row.opt_[i].first == *it)
       {
         s.push_back(row.opt_[i].second.toCellString());
         found = true;
@@ -2348,7 +2348,7 @@ String MzTabFile::generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, con
   return ListUtils::concatenate(s, "\t");
 }
 
-String MzTabFile::generateMzTabSmallMoleculeHeader_(Size ms_runs, Size n_best_search_engine_scores, Size n_search_engine_scores, Size assays, Size study_variables, const vector<String>& optional_smallmolecule_columns) const
+String MzTabFile::generateMzTabSmallMoleculeHeader_(Size ms_runs, Size n_best_search_engine_scores, Size n_search_engine_scores, Size assays, Size study_variables, const set<String>& optional_smallmolecule_columns) const
 {
   StringList header;
   header.push_back("SMH");

--- a/src/tests/class_tests/openms/source/MzTabFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzTabFile_test.cpp
@@ -44,12 +44,22 @@
 using namespace OpenMS;
 using namespace std;
 
+class MzTabFile2 : public MzTabFile
+{
+  public:
+    String generateMzTabPSMSectionRow2_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const
+    {
+      return generateMzTabPSMSectionRow_(row, optional_columns);
+    }
+};
+
 START_TEST(MzTabFile, "$Id$")
 
 /////////////////////////////////////////////////////////////
 
 MzTabFile* ptr = 0;
 MzTabFile* null_ptr = 0;
+
 START_SECTION(MzTabFile())
 {
   ptr = new MzTabFile();
@@ -117,9 +127,62 @@ START_SECTION(~MzTabFile())
 }
 END_SECTION
 
+START_SECTION(generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const)
+{
+  MzTabFile2 mzTab;
+  MzTabPSMSectionRow row;
+  MzTabOptionalColumnEntry e;
+  MzTabString s;
+  
+  row.sequence.fromCellString("NDYKAPPQPAPGK");
+  row.PSM_ID.fromCellString("38");
+  row.accession.fromCellString("IPI:B1");
+  row.unique.fromCellString("1");
+  row.database.fromCellString("null");
+  row.database_version.fromCellString("null");
+  row.search_engine.fromCellString("[, , Percolator, ]");
+  row.search_engine_score[0].fromCellString("51.9678841193106");
+  
+  e.first = "Percolator_score";
+  s.fromCellString("0.359083");
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "Percolator_qvalue";
+  s.fromCellString("0.00649874");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "Percolator_PEP";
+  s.fromCellString("0.0420992");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "search_engine_sequence";
+  s.fromCellString("NDYKAPPQPAPGK");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  // Tests ///////////////////////////////  
+  vector<String> optional_columns;
+  optional_columns.push_back("Percolator_score");
+  optional_columns.push_back("Percolator_qvalue");
+  optional_columns.push_back("EMPTY");
+  optional_columns.push_back("Percolator_PEP");
+  optional_columns.push_back("search_engine_sequence");
+  optional_columns.push_back("AScore_1");
+    
+  String strRow(mzTab.generateMzTabPSMSectionRow2_(row, optional_columns));
+  
+  std::vector<String> substrings;
+  strRow.split('\t', substrings);
+  TEST_EQUAL(substrings[substrings.size() - 1],"null")
+  TEST_EQUAL(substrings[substrings.size() - 2],"NDYKAPPQPAPGK")
+  TEST_EQUAL(substrings[substrings.size() - 3],"0.0420992")
+  TEST_EQUAL(substrings[substrings.size() - 4],"null")
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-
-
-

--- a/src/tests/class_tests/openms/source/MzTabFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzTabFile_test.cpp
@@ -47,7 +47,7 @@ using namespace std;
 class MzTabFile2 : public MzTabFile
 {
   public:
-    String generateMzTabPSMSectionRow2_(const MzTabPSMSectionRow& row, const set<String>& optional_columns) const
+    String generateMzTabPSMSectionRow2_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const
     {
       return generateMzTabPSMSectionRow_(row, optional_columns);
     }
@@ -127,7 +127,7 @@ START_SECTION(~MzTabFile())
 }
 END_SECTION
 
-START_SECTION(generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const set<String>& optional_columns) const)
+START_SECTION(generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const)
 {
   MzTabFile2 mzTab;
   MzTabPSMSectionRow row;
@@ -164,25 +164,22 @@ START_SECTION(generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const s
   row.opt_.push_back(e);
   
   // Tests ///////////////////////////////  
-  set<String> optional_columns;
-  optional_columns.insert("AScore_1");
-  optional_columns.insert("EMPTY");
-  optional_columns.insert("Percolator_PEP");
-  optional_columns.insert("Percolator_qvalue");
-  optional_columns.insert("Percolator_score");
-  optional_columns.insert("search_engine_sequence");
-  
+  vector<String> optional_columns;
+  optional_columns.push_back("Percolator_score");
+  optional_columns.push_back("Percolator_qvalue");
+  optional_columns.push_back("EMPTY");
+  optional_columns.push_back("Percolator_PEP");
+  optional_columns.push_back("search_engine_sequence");
+  optional_columns.push_back("AScore_1");
+ 
     
-  String strRow(mzTab.generateMzTabPSMSectionRow2_(row, optional_columns));
-  
+  String strRow(mzTab.generateMzTabPSMSectionRow2_(row, optional_columns));  
   std::vector<String> substrings;
   strRow.split('\t', substrings);
-  TEST_EQUAL(substrings[substrings.size() - 5],"null")
-  TEST_EQUAL(substrings[substrings.size() - 6],"null")
-  TEST_EQUAL(substrings[substrings.size() - 4],"0.0420992")
-  TEST_EQUAL(substrings[substrings.size() - 3],"0.00649874")
-  TEST_EQUAL(substrings[substrings.size() - 2],"0.359083")
-  TEST_EQUAL(substrings[substrings.size() - 1],"NDYKAPPQPAPGK")
+  TEST_EQUAL(substrings[substrings.size() - 1],"null")
+  TEST_EQUAL(substrings[substrings.size() - 2],"NDYKAPPQPAPGK")
+  TEST_EQUAL(substrings[substrings.size() - 3],"0.0420992")
+  TEST_EQUAL(substrings[substrings.size() - 4],"null")
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MzTabFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzTabFile_test.cpp
@@ -47,7 +47,7 @@ using namespace std;
 class MzTabFile2 : public MzTabFile
 {
   public:
-    String generateMzTabPSMSectionRow2_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const
+    String generateMzTabPSMSectionRow2_(const MzTabPSMSectionRow& row, const set<String>& optional_columns) const
     {
       return generateMzTabPSMSectionRow_(row, optional_columns);
     }
@@ -127,7 +127,7 @@ START_SECTION(~MzTabFile())
 }
 END_SECTION
 
-START_SECTION(generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const vector<String>& optional_columns) const)
+START_SECTION(generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const set<String>& optional_columns) const)
 {
   MzTabFile2 mzTab;
   MzTabPSMSectionRow row;
@@ -164,22 +164,25 @@ START_SECTION(generateMzTabPSMSectionRow_(const MzTabPSMSectionRow& row, const v
   row.opt_.push_back(e);
   
   // Tests ///////////////////////////////  
-  vector<String> optional_columns;
-  optional_columns.push_back("Percolator_score");
-  optional_columns.push_back("Percolator_qvalue");
-  optional_columns.push_back("EMPTY");
-  optional_columns.push_back("Percolator_PEP");
-  optional_columns.push_back("search_engine_sequence");
-  optional_columns.push_back("AScore_1");
+  set<String> optional_columns;
+  optional_columns.insert("AScore_1");
+  optional_columns.insert("EMPTY");
+  optional_columns.insert("Percolator_PEP");
+  optional_columns.insert("Percolator_qvalue");
+  optional_columns.insert("Percolator_score");
+  optional_columns.insert("search_engine_sequence");
+  
     
   String strRow(mzTab.generateMzTabPSMSectionRow2_(row, optional_columns));
   
   std::vector<String> substrings;
   strRow.split('\t', substrings);
-  TEST_EQUAL(substrings[substrings.size() - 1],"null")
-  TEST_EQUAL(substrings[substrings.size() - 2],"NDYKAPPQPAPGK")
-  TEST_EQUAL(substrings[substrings.size() - 3],"0.0420992")
-  TEST_EQUAL(substrings[substrings.size() - 4],"null")
+  TEST_EQUAL(substrings[substrings.size() - 5],"null")
+  TEST_EQUAL(substrings[substrings.size() - 6],"null")
+  TEST_EQUAL(substrings[substrings.size() - 4],"0.0420992")
+  TEST_EQUAL(substrings[substrings.size() - 3],"0.00649874")
+  TEST_EQUAL(substrings[substrings.size() - 2],"0.359083")
+  TEST_EQUAL(substrings[substrings.size() - 1],"NDYKAPPQPAPGK")
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MzTab_test.cpp
+++ b/src/tests/class_tests/openms/source/MzTab_test.cpp
@@ -62,7 +62,7 @@ START_SECTION(~MzTab())
 }
 END_SECTION
 
-START_SECTION(std::vector<String> getPSMOptionalColumnNames() const)
+START_SECTION(std::set<String> getPSMOptionalColumnNames() const)
 {
   MzTab mztab;
   MzTabPSMSectionRow row;
@@ -141,7 +141,7 @@ START_SECTION(std::vector<String> getPSMOptionalColumnNames() const)
   mztab.setPSMSectionRows(rows);
   
   // Tests ///////////////////////////////  
-  vector<String> optional_columns = mztab.getPSMOptionalColumnNames();
+  set<String> optional_columns = mztab.getPSMOptionalColumnNames();
   
   TEST_EQUAL(mztab.getPSMSectionRows().size(),2)
   TEST_EQUAL(optional_columns.size(),5)

--- a/src/tests/class_tests/openms/source/MzTab_test.cpp
+++ b/src/tests/class_tests/openms/source/MzTab_test.cpp
@@ -62,7 +62,7 @@ START_SECTION(~MzTab())
 }
 END_SECTION
 
-START_SECTION(std::set<String> getPSMOptionalColumnNames() const)
+START_SECTION(std::vector<String> getPSMOptionalColumnNames() const)
 {
   MzTab mztab;
   MzTabPSMSectionRow row;
@@ -141,7 +141,7 @@ START_SECTION(std::set<String> getPSMOptionalColumnNames() const)
   mztab.setPSMSectionRows(rows);
   
   // Tests ///////////////////////////////  
-  set<String> optional_columns = mztab.getPSMOptionalColumnNames();
+  vector<String> optional_columns = mztab.getPSMOptionalColumnNames();
   
   TEST_EQUAL(mztab.getPSMSectionRows().size(),2)
   TEST_EQUAL(optional_columns.size(),5)

--- a/src/tests/class_tests/openms/source/MzTab_test.cpp
+++ b/src/tests/class_tests/openms/source/MzTab_test.cpp
@@ -62,6 +62,91 @@ START_SECTION(~MzTab())
 }
 END_SECTION
 
+START_SECTION(std::vector<String> getPSMOptionalColumnNames() const)
+{
+  MzTab mztab;
+  MzTabPSMSectionRow row;
+  MzTabPSMSectionRows rows;
+  MzTabString s;
+  MzTabOptionalColumnEntry e;
+  
+  // row 1 //////////////////////
+  row.sequence.fromCellString("NDYKAPPQPAPGK");
+  row.PSM_ID.fromCellString("38");
+  row.accession.fromCellString("IPI:B1");
+  row.unique.fromCellString("1");
+  row.database.fromCellString("null");
+  row.database_version.fromCellString("null");
+  row.search_engine.fromCellString("[, , Percolator, ]");
+  row.search_engine_score[0].fromCellString("51.9678841193106");
+  
+  e.first = "Percolator_score";
+  s.fromCellString("0.359083");
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "Percolator_qvalue";
+  s.fromCellString("0.00649874");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "Percolator_PEP";
+  s.fromCellString("0.0420992");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "search_engine_sequence";
+  s.fromCellString("NDYKAPPQPAPGK");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  rows.push_back(row);
+  
+  // row 2 //////////////////////
+  row.sequence.fromCellString("IRRS(Phospho)SFSSK");
+  row.PSM_ID.fromCellString("39");
+  row.accession.fromCellString("IPI:IPI00009899.4");
+  row.unique.fromCellString("0");
+  row.database.fromCellString("null");
+  row.database_version.fromCellString("null");
+  row.search_engine.fromCellString("[, , Percolator, ]");
+  row.search_engine_score[0].fromCellString("9.55915773892318");
+  
+  e.first = "Percolator_score";
+  s.fromCellString("0.157068");
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "Percolator_qvalue";
+  s.fromCellString("0.00774619");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "Percolator_PEP";
+  s.fromCellString("0.0779777");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "search_engine_sequence";
+  s.fromCellString("IRRSSFS(Phospho)SK");  
+  e.second = s;
+  row.opt_.push_back(e);
+  
+  e.first = "AScore_1";
+  s.fromCellString("3.64384830671351");  
+  e.second = s;
+  row.opt_.push_back(e);
+  rows.push_back(row);
+  
+  mztab.setPSMSectionRows(rows);
+  
+  // Tests ///////////////////////////////  
+  vector<String> optional_columns = mztab.getPSMOptionalColumnNames();
+  
+  TEST_EQUAL(mztab.getPSMSectionRows().size(),2)
+  TEST_EQUAL(optional_columns.size(),5)
+}
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION

* create protein-, peptide-, and psm header based on all data instead of the first object in the list.
* check that the optional meta value is written in the correct column
* added class test to check if all header columns are existing
* added class test to check if the data fits to the header column