### PR TITLE
[FIX] added code for peak alignment with relative tolerances

### DIFF
--- a/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h
+++ b/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h
@@ -51,9 +51,10 @@ namespace OpenMS
   /**
       @brief Aligns the peaks of two spectra
 
-        Using a banded (width via 'tolerance' parameter) alignment.
+        Using a banded (width via 'tolerance' parameter) alignment if absolute tolerances are given.
         Scoring function is the m/z distance between peaks. Intensity does not play a role!
 
+        If relative tolerance (ppm) is given simple matching of peaks is performed.
         @htmlinclude OpenMS_SpectrumAlignment.parameters
 
         @ingroup SpectraComparison
@@ -79,111 +80,108 @@ public:
     SpectrumAlignment & operator=(const SpectrumAlignment & source);
     // @}
 
-    template <typename SpectrumType>
-    void getSpectrumAlignment(std::vector<std::pair<Size, Size> > & alignment, const SpectrumType & s1, const SpectrumType & s2) const
+    template <typename SpectrumType1, typename SpectrumType2>
+    void getSpectrumAlignment(std::vector<std::pair<Size, Size> > & alignment, const SpectrumType1 & s1, const SpectrumType2 & s2) const
     {
       if (!s1.isSorted() || !s2.isSorted())
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Input to SpectrumAlignment is not sorted!");
       }
-      // TODO remove parameter 
-      if (param_.getValue("is_relative_tolerance").toBool() )
-      {
-        throw Exception::NotImplemented(__FILE__, __LINE__, __PRETTY_FUNCTION__);
-      }
 
       // clear result
       alignment.clear();
-
       double tolerance = (double)param_.getValue("tolerance");
-      std::map<Size, std::map<Size, std::pair<Size, Size> > > traceback;
-      std::map<Size, std::map<Size, double> > matrix;
 
-      // init the matrix with "gap costs" tolerance
-      matrix[0][0] = 0;
-      for (Size i = 1; i <= s1.size(); ++i)
+      if (!param_.getValue("is_relative_tolerance").toBool() )
       {
-        matrix[i][0] = i * tolerance;
-        traceback[i][0]  = std::make_pair(i - 1, 0);
-      }
-      for (Size j = 1; j <= s2.size(); ++j)
-      {
-        matrix[0][j] = j * tolerance;
-        traceback[0][j] = std::make_pair(0, j - 1);
-      }
+        std::map<Size, std::map<Size, std::pair<Size, Size> > > traceback;
+        std::map<Size, std::map<Size, double> > matrix;
 
-      // fill in the matrix
-      Size left_ptr(1);
-      Size last_i(0), last_j(0);
-
-      //Size off_band_counter(0);
-      for (Size i = 1; i <= s1.size(); ++i)
-      {
-        double pos1(s1[i - 1].getMZ());
-
-        for (Size j = left_ptr; j <= s2.size(); ++j)
+        // init the matrix with "gap costs" tolerance
+        matrix[0][0] = 0;
+        for (Size i = 1; i <= s1.size(); ++i)
         {
-          bool off_band(false);
-          // find min of the three possible directions
-          double pos2(s2[j - 1].getMZ());
-          double diff_align = fabs(pos1 - pos2);
+          matrix[i][0] = i * tolerance;
+          traceback[i][0]  = std::make_pair(i - 1, 0);
+        }
+        for (Size j = 1; j <= s2.size(); ++j)
+        {
+          matrix[0][j] = j * tolerance;
+          traceback[0][j] = std::make_pair(0, j - 1);
+        }
 
-          // running off the right border of the band?
-          if (pos2 > pos1 && diff_align > tolerance)
+        // fill in the matrix
+        Size left_ptr(1);
+        Size last_i(0), last_j(0);
+
+        //Size off_band_counter(0);
+        for (Size i = 1; i <= s1.size(); ++i)
+        {
+          double pos1(s1[i - 1].getMZ());
+
+          for (Size j = left_ptr; j <= s2.size(); ++j)
           {
-            if (i < s1.size() && j < s2.size() && s1[i].getMZ() < pos2)
+            bool off_band(false);
+            // find min of the three possible directions
+            double pos2(s2[j - 1].getMZ());
+            double diff_align = fabs(pos1 - pos2);
+
+            // running off the right border of the band?
+            if (pos2 > pos1 && diff_align > tolerance)
             {
-              off_band = true;
+              if (i < s1.size() && j < s2.size() && s1[i].getMZ() < pos2)
+              {
+                off_band = true;
+              }
             }
-          }
 
-          // can we tighten the left border of the band?
-          if (pos1 > pos2 && diff_align > tolerance && j > left_ptr + 1)
-          {
-            ++left_ptr;
-          }
+            // can we tighten the left border of the band?
+            if (pos1 > pos2 && diff_align > tolerance && j > left_ptr + 1)
+            {
+              ++left_ptr;
+            }
 
-          double score_align = diff_align;
+            double score_align = diff_align;
 
-          if (matrix.find(i - 1) != matrix.end() && matrix[i - 1].find(j - 1) != matrix[i - 1].end())
-          {
-            score_align += matrix[i - 1][j - 1];
-          }
-          else
-          {
-            score_align += (i - 1 + j - 1) * tolerance;
-          }
+            if (matrix.find(i - 1) != matrix.end() && matrix[i - 1].find(j - 1) != matrix[i - 1].end())
+            {
+              score_align += matrix[i - 1][j - 1];
+            }
+            else
+            {
+              score_align += (i - 1 + j - 1) * tolerance;
+            }
 
-          double score_up = tolerance;
-          if (matrix.find(i) != matrix.end() && matrix[i].find(j - 1) != matrix[i].end())
-          {
-            score_up += matrix[i][j - 1];
-          }
-          else
-          {
-            score_up += (i + j - 1) * tolerance;
-          }
+            double score_up = tolerance;
+            if (matrix.find(i) != matrix.end() && matrix[i].find(j - 1) != matrix[i].end())
+            {
+              score_up += matrix[i][j - 1];
+            }
+            else
+            {
+              score_up += (i + j - 1) * tolerance;
+            }
 
-          double score_left = tolerance;
-          if (matrix.find(i - 1) != matrix.end() && matrix[i - 1].find(j) != matrix[i - 1].end())
-          {
-            score_left += matrix[i - 1][j];
-          }
-          else
-          {
-            score_left += (i - 1 + j) * tolerance;
-          }
+            double score_left = tolerance;
+            if (matrix.find(i - 1) != matrix.end() && matrix[i - 1].find(j) != matrix[i - 1].end())
+            {
+              score_left += matrix[i - 1][j];
+            }
+            else
+            {
+              score_left += (i - 1 + j) * tolerance;
+            }
 
-#ifdef ALIGNMENT_DEBUG
+    #ifdef ALIGNMENT_DEBUG
           cerr << i << " " << j << " " << left_ptr << " " << pos1 << " " << pos2 << " " << score_align << " " << score_left << " " << score_up << endl;
-#endif
+    #endif
 
           if (score_align <= score_up && score_align <= score_left && diff_align <= tolerance)
           {
-            matrix[i][j] = score_align;
-            traceback[i][j] = std::make_pair(i - 1, j - 1);
-            last_i = i;
-            last_j = j;
+             matrix[i][j] = score_align;
+             traceback[i][j] = std::make_pair(i - 1, j - 1);
+             last_i = i;
+             last_j = j;
           }
           else
           {
@@ -206,21 +204,21 @@ public:
         }
       }
 
-      //last_i = s1.size() + 1;
-      //last_j = s2.size() + 1;
+          //last_i = s1.size() + 1;
+          //last_j = s2.size() + 1;
 
-      //cerr << last_i << " " << last_j << endl;
+          //cerr << last_i << " " << last_j << endl;
 
-#ifdef ALIGNMENT_DEBUG
-#if 0
-      cerr << "TheMatrix: " << endl << " \t  \t";
-      for (Size j = 0; j != s2.size(); ++j)
-      {
+    #ifdef ALIGNMENT_DEBUG
+    #if 0
+          cerr << "TheMatrix: " << endl << " \t  \t";
+          for (Size j = 0; j != s2.size(); ++j)
+          {
         cerr << s2[j].getPosition()[0] << " \t";
-      }
-      cerr << endl;
-      for (Size i = 0; i <= s1.size(); ++i)
-      {
+          }
+          cerr << endl;
+          for (Size i = 0; i <= s1.size(); ++i)
+          {
         if (i != 0)
         {
           cerr << s1[i - 1].getPosition()[0] << " \t";
@@ -241,11 +239,11 @@ public:
             {
               if (traceback[i][j].first == i - 1 && traceback[i][j].second == j)
               {
-                cerr << "|";
+            cerr << "|";
               }
               else
               {
-                cerr << "-";
+            cerr << "-";
               }
             }
 
@@ -257,9 +255,9 @@ public:
           }
         }
         cerr << endl;
-      }
-#endif
-#endif
+          }
+    #endif
+    #endif
 
       // do traceback
       Size i = last_i;
@@ -280,14 +278,14 @@ public:
 
       std::reverse(alignment.begin(), alignment.end());
 
-#ifdef ALIGNMENT_DEBUG
-#if 0
-      // print alignment
-      cerr << "Alignment (size=" << alignment.size() << "): " << endl;
+    #ifdef ALIGNMENT_DEBUG
+    #if 0
+          // print alignment
+          cerr << "Alignment (size=" << alignment.size() << "): " << endl;
 
-      Size i_s1(0), i_s2(0);
-      for (vector<pair<Size, Size> >::const_reverse_iterator it = alignment.rbegin(); it != alignment.rend(); ++it, ++i_s1, ++i_s2)
-      {
+          Size i_s1(0), i_s2(0);
+          for (vector<pair<Size, Size> >::const_reverse_iterator it = alignment.rbegin(); it != alignment.rend(); ++it, ++i_s1, ++i_s2)
+          {
         while (i_s1 < it->first - 1)
         {
           cerr << i_s1 << " " << s1[i_s1].getPosition()[0] << " " << s1[i_s1].getIntensity() << endl;
@@ -300,13 +298,29 @@ public:
         }
         cerr << "(" << s1[it->first - 1].getPosition()[0] << " <-> " << s2[it->second - 1].getPosition()[0] << ") ("
              << it->first << "|" << it->second << ") (" << s1[it->first - 1].getIntensity() << "|" << s2[it->second - 1].getIntensity() << ")" << endl;
-      }
-#endif
-#endif
-
+          }
+    #endif
+    #endif
     }
+    else  // relative alignment (ppm tolerance)
+    {        
+      for (Size i = 0; i != s1.size(); ++i)
+      {
+        const double& theo_mz = s1[i].getMZ();
+        double max_dist_dalton = theo_mz * tolerance * 1e-6;
+ 
+        // iterate over peaks in experimental spectrum in given fragment tolerance around theoretical peak
+        Size j = s2.findNearest(theo_mz);
+        double exp_mz = s2[j].getMZ();
 
-  };
-
+        // found peak match
+        if (std::abs(theo_mz - exp_mz) < max_dist_dalton)
+        {
+          alignment.push_back(std::make_pair(i, j));
+        }
+      }
+    }
+  }
+ };
 }
 #endif //OPENMS_COMPARISON_SPECTRA_SPECTRUMALIGNMENT_H

--- a/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h
+++ b/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h
@@ -49,15 +49,18 @@ namespace OpenMS
 {
 
   /**
-      @brief Aligns the peaks of two spectra
+      @brief Aligns the peaks of two sorted spectra
+      Method 1: Using a banded (width via 'tolerance' parameter) alignment if absolute tolerances are given.
+                Scoring function is the m/z distance between peaks. Intensity does not play a role!
 
-        Using a banded (width via 'tolerance' parameter) alignment if absolute tolerances are given.
-        Scoring function is the m/z distance between peaks. Intensity does not play a role!
+      Method 2: If relative tolerance (ppm) is specified a simple matching of peaks is performed:
+      Peaks from s1 (usually the theoretical spectrum) are assigned to the closest peak in s2 if it lies in the tolerance window
+      @note: a peak in s2 can be matched to none, one or multiple peaks in s1. Peaks in s1 may be matched to none or one peak in s2.
+      @note: intensity is ignored
 
-        If relative tolerance (ppm) is given simple matching of peaks is performed.
-        @htmlinclude OpenMS_SpectrumAlignment.parameters
+      @htmlinclude OpenMS_SpectrumAlignment.parameters
 
-        @ingroup SpectraComparison
+      @ingroup SpectraComparison
   */
 
   class OPENMS_DLLAPI SpectrumAlignment :

--- a/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h
+++ b/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h
@@ -56,7 +56,7 @@ namespace OpenMS
       Method 2: If relative tolerance (ppm) is specified a simple matching of peaks is performed:
       Peaks from s1 (usually the theoretical spectrum) are assigned to the closest peak in s2 if it lies in the tolerance window
       @note: a peak in s2 can be matched to none, one or multiple peaks in s1. Peaks in s1 may be matched to none or one peak in s2.
-      @note: intensity is ignored
+      @note: intensity is ignored TODO: improve time complexity, currently O(|s1|*log(|s2|))
 
       @htmlinclude OpenMS_SpectrumAlignment.parameters
 

--- a/src/tests/class_tests/openms/source/SpectrumAlignment_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumAlignment_test.cpp
@@ -130,12 +130,7 @@ START_SECTION(template <typename SpectrumType> void getSpectrumAlignment(std::ve
   DTAFile().load(OPENMS_GET_TEST_DATA_PATH("SpectrumAlignment_in1.dta"), s3);
   DTAFile().load(OPENMS_GET_TEST_DATA_PATH("SpectrumAlignment_in2.dta"), s4);
 
-	sas1.getSpectrumAlignment(alignment, s3, s4);
-	
-	for (vector<pair<Size, Size > >::const_iterator it = alignment.begin(); it != alignment.end(); ++it)
-	{
-		//cerr << it->first << " " << it->second << endl;
-	}
+  sas1.getSpectrumAlignment(alignment, s3, s4);	
 
   TEST_EQUAL(alignment.size(), 5)
 
@@ -154,6 +149,46 @@ START_SECTION(template <typename SpectrumType> void getSpectrumAlignment(std::ve
     TEST_EQUAL(alignment[i].second, alignment_result[i].second)
   }
 
+  // test relative tolerance alignment
+  alignment.clear();
+  p.setValue("is_relative_tolerance", "true");
+  p.setValue("tolerance", 10.0); // 10 ppm tolerance
+  sas1.setParameters(p);
+  sas1.getSpectrumAlignment(alignment, s3, s4);
+  TEST_EQUAL(alignment.size(), 1)
+  ABORT_IF(alignment.size()!=1)
+  alignment_result.clear();
+  alignment_result.push_back(std::make_pair(6,6));
+  for (Size i=0;i<alignment.size();++i)
+  {
+    TEST_EQUAL(alignment[i].first, alignment_result[i].first)
+    TEST_EQUAL(alignment[i].second, alignment_result[i].second)
+  }
+
+  alignment.clear();
+  p.setValue("is_relative_tolerance", "true");
+  p.setValue("tolerance", 1e4); // one percent tolerance
+  sas1.setParameters(p);
+  sas1.getSpectrumAlignment(alignment, s3, s4);
+  for (vector<pair<Size, Size > >::const_iterator it = alignment.begin(); it != alignment.end(); ++it)
+  {
+    cerr << it->first << " " << it->second << endl;
+  }
+  TEST_EQUAL(alignment.size(), 7)
+  ABORT_IF(alignment.size()!=7)
+  alignment_result.clear();
+  alignment_result.push_back(std::make_pair(0,0));
+  alignment_result.push_back(std::make_pair(1,1));
+  alignment_result.push_back(std::make_pair(2,2));
+  alignment_result.push_back(std::make_pair(3,3));
+  alignment_result.push_back(std::make_pair(4,5));
+  alignment_result.push_back(std::make_pair(5,5));
+  alignment_result.push_back(std::make_pair(6,6));
+  for (Size i=0;i<7;++i)
+  {
+    TEST_EQUAL(alignment[i].first, alignment_result[i].first)
+    TEST_EQUAL(alignment[i].second, alignment_result[i].second)
+  }
 
 
 END_SECTION

--- a/src/tests/class_tests/openms/source/SpectrumAlignment_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumAlignment_test.cpp
@@ -172,7 +172,7 @@ START_SECTION(template <typename SpectrumType> void getSpectrumAlignment(std::ve
   sas1.getSpectrumAlignment(alignment, s3, s4);
   for (vector<pair<Size, Size > >::const_iterator it = alignment.begin(); it != alignment.end(); ++it)
   {
-    cerr << it->first << " " << it->second << endl;
+    // cerr << it->first << " " << it->second << endl;
   }
   TEST_EQUAL(alignment.size(), 7)
   ABORT_IF(alignment.size()!=7)


### PR DESCRIPTION
alignment code contained parameter to set relative tolerances but this was not part of the implementation. This PR adds a simple peak matching algorithm using relative tolerances and tests.