### PR TITLE
[FIX] allow user to turn off mass trace length check

### DIFF
--- a/src/openms/source/FILTERING/DATAREDUCTION/MassTraceDetection.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/MassTraceDetection.cpp
@@ -65,7 +65,7 @@ namespace OpenMS
 
     defaults_.setValue("min_sample_rate", 0.5, "Minimum fraction of scans along the mass trace that must contain a peak.", ListUtils::create<String>("advanced"));
     defaults_.setValue("min_trace_length", 5.0, "Minimum expected length of a mass trace (in seconds).", ListUtils::create<String>("advanced"));
-    defaults_.setValue("max_trace_length", 300.0, "Maximum expected length of a mass trace (in seconds).", ListUtils::create<String>("advanced"));
+    defaults_.setValue("max_trace_length", 300.0, "Maximum expected length of a mass trace (in seconds). Set to a negative value to disable maximal length check during mass trace detection.", ListUtils::create<String>("advanced"));
 
     defaultsToParam_();
 
@@ -515,7 +515,8 @@ namespace OpenMS
       // *********************************************************** //
       // Step 2.3 check if minimum length and quality of mass trace criteria are met
       // *********************************************************** //
-      if (rt_range >= min_trace_length_ && rt_range < max_trace_length_ && mt_quality >= min_sample_rate_)
+      bool max_trace_criteria = (max_trace_length_ < 0.0 || rt_range < max_trace_length_);
+      if (rt_range >= min_trace_length_ && max_trace_criteria && mt_quality >= min_sample_rate_)
       {
         // std::cout << "T" << trace_number << "\t" << mt_quality << std::endl;
 


### PR DESCRIPTION
The check for the length of the masstrace does not make sense if the
mass trace detection is followed by elution peak detection as in the
MassTraceExtractor where long mass traces are split up. Instead what
happens is that MTD is extremely slow since it finds the same masstraces
again and again but is prevented from adding them to the result and move
on.

This commit allows to set max_trace_length to -1 and skip the length
check.