### PR TITLE
[BUILD] fix platform for Python 3

### DIFF
--- a/src/pyOpenMS/pyopenms/__init__.py
+++ b/src/pyOpenMS/pyopenms/__init__.py
@@ -9,7 +9,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 os.environ["OPENMS_DATA_PATH"] = os.path.join(here, "share/OpenMS")
 
 import sys
-if sys.platform == "linux2":
+if sys.platform.startswith("linux"):
     # load local shared libries before we import pyopenms.so, else
     # those are not found. setting LD_LIBRARY_PATH does not work,
     # see: http://stackoverflow.com/questions/1178094

--- a/src/pyOpenMS/pyopenms/sysinfo.py
+++ b/src/pyOpenMS/pyopenms/sysinfo.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.platform == "linux2":
+if sys.platform.startswith("linux"):
     import ctypes as c
     import ctypes.util
 

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -108,7 +108,7 @@ extra_compile_args = []
 
 if iswin:
     extra_compile_args = ["/EHs", "/bigobj"]
-elif sys.platform == "linux2":
+elif sys.platform.startswith("linux"):
     extra_link_args = ["-Wl,-s"]
 elif sys.platform == "darwin":
     # we need to manually link to the Qt Frameworks


### PR DESCRIPTION
- complete work from 286785c5775d3edc0e037a41e09e5a816b72ab66
- Python 3 simply uses "linux" as platform and was therefore not recognized.