### PR TITLE
[BUILD] use only OpenMS boost headers

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -122,7 +122,7 @@ if(AUTOWRAP_MISSING)
 else()
     execute_process(
         COMMAND
-        ${PYTHON_EXECUTABLE} -c "import autowrap; exit(autowrap.version >= (0, 7, 0))"
+        ${PYTHON_EXECUTABLE} -c "import autowrap; exit(autowrap.version >= (0, 7, 1))"
         RESULT_VARIABLE _AUTOWRAP_VERSION_OK
         ERROR_QUIET
         OUTPUT_QUIET
@@ -137,7 +137,7 @@ else()
         message(STATUS "Looking for autowrap - found autowrap ${AUTOWRAP_VERSION}, version ok")
         set(AUTOWRAP_VERSION_OK TRUE)
     else()
-        message(STATUS "Found autowrap version ${AUTOWRAP_VERSION}. The version is to old (>= 0.7.0 is required)")
+        message(STATUS "Found autowrap version ${AUTOWRAP_VERSION}. The version is to old (>= 0.7.1 is required)")
         message(FATAL_ERROR "Please upgrade autowrap or disable pyOpenMS.")
     endif()
 endif()

--- a/src/pyOpenMS/create_cpp_extension.py
+++ b/src/pyOpenMS/create_cpp_extension.py
@@ -61,9 +61,9 @@ for d in decls:
             break
 
 autowrap_include_dirs = autowrap.Main.create_wrapper_code(decls, instance_map, addons,
-                                                          converters, "pyopenms/pyopenms.pyx",
-                                                          extra_cimports,
-                                                          None)
+                                                          converters, out="pyopenms/pyopenms.pyx",
+                                                          extra_inc_dirs=extra_cimports,
+                                                          extra_opts=None, include_boost=False)
 
 pickle.dump(autowrap_include_dirs, open(persisted_data_path, "wb"))
 


### PR DESCRIPTION
- prevent autowrap from using its own boost headers
- requires a newer version of autowrap
- related to #1207 (provides a complete fix)

using its own boost headers led to conflicts when OpenMS used boost >= 1.55 and
pyOpenMS did not compile any more

NOTE: please wait with merge until autowrap version 0.7.1 is available on PyPI