### PR TITLE
Fix/fix ms1 segfaults

### DIFF
--- a/src/tests/topp/OpenSwathWorkflow_1_input.TraML
+++ b/src/tests/topp/OpenSwathWorkflow_1_input.TraML
@@ -11,6 +11,17 @@
     </Protein>
   </ProteinList>
   <CompoundList>
+    <Peptide id="PEPTIDEA_Extra" sequence="PEPTIDEAAAA">
+      <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
+      <cvParam cvRef="MS" accession="MS:1000893" name="peptide group label" value="light"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="PEPTIDEAAAA"/>
+      <ProteinRef ref="ProteinA"/>
+      <RetentionTimeList>
+        <RetentionTime>
+          <cvParam cvRef="MS" accession="MS:1000896" name="normalized retention time" value="0.9"/>
+        </RetentionTime>
+      </RetentionTimeList>
+    </Peptide>
     <Peptide id="PEPTIDEA" sequence="PEPTIDEA">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
       <cvParam cvRef="MS" accession="MS:1000893" name="peptide group label" value="light"/>

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -489,6 +489,7 @@ namespace OpenMS
 
           for (Size j = 0; j < coordinates.size(); j++)
           {
+            if ( chromatograms[j].empty() ) {continue;} // skip empty chromatograms
             ms1_chromatograms [ coordinates[j].id ] = chrom_list[j];
             // write MS1 chromatograms to disk
             chromConsumer->consumeChromatogram( chromatograms[j] );
@@ -1141,7 +1142,7 @@ namespace OpenMS
           {
             LOG_INFO << "Warning: no transitions found for peptide " << pep.id << std::endl;
             coord.rt_start = -1;
-            coord.rt_end = -1;
+            coord.rt_end = -2; // create negative range
             coord.id = pep.id;
             coordinates.push_back(coord);
             continue;

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -1135,6 +1135,21 @@ namespace OpenMS
         if (ms1)
         {
           pep = transition_exp_used.getPeptides()[i];
+
+          // Catch cases where a peptide has no transitions
+          if (peptide_trans_map.count(pep.id) == 0 )
+          {
+            LOG_INFO << "Warning: no transitions found for peptide " << pep.id << std::endl;
+            coord.rt_start = -1;
+            coord.rt_end = -1;
+            coord.id = pep.id;
+            coordinates.push_back(coord);
+            continue;
+          }
+
+          // This is slightly awkward but the m/z of the precursor is *not*
+          // stored in the precursor object but only in the transition object
+          // itself.
           transition = (*peptide_trans_map[pep.id][0]);
           coord.mz = transition.getPrecursorMZ();
           coord.id = pep.id;


### PR DESCRIPTION
Fixes a set of segfaults that can occur in OpenSwathWorkflow if there are peptides that do not have transitions attached

fixes #1769