### PR TITLE
[FIX] theoretical spectrum generator tries to create X_1 and C_1 ions…

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -394,7 +394,10 @@ protected:
     /// returns the average weight of the peptide
     double getAverageWeight(Residue::ResidueType type = Residue::Full, Int charge = 0) const;
 
-    /// returns the mono isotopic weight of the peptide
+    /// returns the mono isotopic weight of the peptide in the given ionic form
+    /// @note will not (and cannot) controll whether the required ion can exist
+    /// (e.g. x/c ions for monomers) as it does not do framentation but rather
+    /// supplementing/deduction of the sequence to its ionic form.
     double getMonoWeight(Residue::ResidueType type = Residue::Full, Int charge = 0) const;
 
     /// returns a pointer to the residue at given position

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -395,7 +395,7 @@ protected:
     double getAverageWeight(Residue::ResidueType type = Residue::Full, Int charge = 0) const;
 
     /// returns the mono isotopic weight of the peptide in the given ionic form
-    /// @note will not (and cannot) controll whether the required ion can exist
+    /// @note will not (and cannot) control whether the required ion can exist
     /// (e.g. x/c ions for monomers) as it does not do framentation but rather
     /// supplementing/deduction of the sequence to its ionic form.
     double getMonoWeight(Residue::ResidueType type = Residue::Full, Int charge = 0) const;

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -182,13 +182,6 @@ namespace OpenMS
 
     if (peptide_.size() >= 1)
     {
-    // // x/c-ion for a single residue is not defined
-    // if ((peptide_.size() == 1) && (type == Residue::XIon ||
-    //  type == Residue::CIon))
-    // {
-    //   LOG_WARN << "AASequence::getFormula: Mass for ResidueType " << type << " not defined for sequences of length 1." << std::endl;
-    // }
-
       // Initialize with the missing/additional protons
       EmpiricalFormula ef; // = EmpiricalFormula("H") * charge; ??
       ef.setCharge(charge);
@@ -282,13 +275,6 @@ namespace OpenMS
     
     if (peptide_.size() >= 1)
     {
-    // // x/c-ion for a monomer is not defined, so we might warn
-    // if ((peptide_.size() == 1) && (type == Residue::XIon ||
-    //                                type == Residue::CIon))
-    // {
-    //   LOG_WARN << "AASequence::getMonoWeight: Mass for ResidueType " << type << " not defined for sequences of length 1." << std::endl;
-    // }
-
       double mono_weight(Constants::PROTON_MASS_U * charge);
 
       // terminal modifications

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -182,12 +182,12 @@ namespace OpenMS
 
     if (peptide_.size() >= 1)
     {
-      // x/c-ion for a single residue is not defined
-      if ((peptide_.size() == 1) && (type == Residue::XIon ||
-       type == Residue::CIon))
-      {
-        LOG_ERROR << "AASequence::getFormula: Mass for ResidueType " << type << " not defined for sequences of length 1." << std::endl;
-      }
+    // // x/c-ion for a single residue is not defined
+    // if ((peptide_.size() == 1) && (type == Residue::XIon ||
+    //  type == Residue::CIon))
+    // {
+    //   LOG_WARN << "AASequence::getFormula: Mass for ResidueType " << type << " not defined for sequences of length 1." << std::endl;
+    // }
 
       // Initialize with the missing/additional protons
       EmpiricalFormula ef; // = EmpiricalFormula("H") * charge; ??
@@ -282,12 +282,12 @@ namespace OpenMS
     
     if (peptide_.size() >= 1)
     {
-      // x/c-ion for a single residue is not defined
-      if ((peptide_.size() == 1) && (type == Residue::XIon ||
-                                     type == Residue::CIon))
-      {
-        LOG_ERROR << "AASequence::getMonoWeight: Mass for ResidueType " << type << " not defined for sequences of length 1." << std::endl;
-      }
+    // // x/c-ion for a monomer is not defined, so we might warn
+    // if ((peptide_.size() == 1) && (type == Residue::XIon ||
+    //                                type == Residue::CIon))
+    // {
+    //   LOG_WARN << "AASequence::getMonoWeight: Mass for ResidueType " << type << " not defined for sequences of length 1." << std::endl;
+    // }
 
       double mono_weight(Constants::PROTON_MASS_U * charge);
 

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -412,11 +412,7 @@ namespace OpenMS
 
     case Residue::CIon:
     {
-      Size i = 1;
-      if (!add_first_prefix_ion_)
-      {
-        i = 2;
-      }
+      Size i = 2;
       for (; i < peptide.size(); ++i)
       {
         AASequence ion = peptide.getPrefix(i);
@@ -440,7 +436,7 @@ namespace OpenMS
 
     case Residue::XIon:
     {
-      for (Size i = 1; i < peptide.size(); ++i)
+      for (Size i = 2; i < peptide.size(); ++i)
       {
         AASequence ion = peptide.getSuffix(i);
         if (add_isotopes_)

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -412,7 +412,16 @@ namespace OpenMS
 
     case Residue::CIon:
     {
-      Size i = 2;
+      Size i = 1;
+      if (!add_first_prefix_ion_)
+      {
+        i = 2;
+      }
+      if (peptide.size() < 2)
+      {
+        //"Cannot create c ions of a monomer."
+        throw Exception::InvalidSize(__FILE__, __LINE__, __PRETTY_FUNCTION__, 1);
+      }
       for (; i < peptide.size(); ++i)
       {
         AASequence ion = peptide.getPrefix(i);
@@ -436,7 +445,17 @@ namespace OpenMS
 
     case Residue::XIon:
     {
-      for (Size i = 2; i < peptide.size(); ++i)
+      Size i = 1;
+      if (!add_first_prefix_ion_)
+      {
+        i = 2;
+      }
+      if (peptide.size() < 2)
+      {
+        // "Cannot create c ions of a monomer."
+        throw Exception::InvalidSize(__FILE__, __LINE__, __PRETTY_FUNCTION__, 1);
+      }
+      for (; i < peptide.size(); ++i)
       {
         AASequence ion = peptide.getSuffix(i);
         if (add_isotopes_)


### PR DESCRIPTION
…. These are not defined and subsequently AASequence.getMonoWeight (which theoretical spectrum generator uses) does not produce them.