### PR TITLE
[INTERNAL] add another string as identifier for MS-GF+ search engine

### DIFF
--- a/src/topp/IDPosteriorErrorProbability.cpp
+++ b/src/topp/IDPosteriorErrorProbability.cpp
@@ -192,7 +192,7 @@ protected:
         return (-1) * log10(max((double)hit.getMetaValue("E-Value"), smallest_e_value_));
       }
     }
-    else if (engine == "MSGFPlus")
+    else if ((engine == "MSGFPlus") || (engine == "MS-GF+"))
     {
       return (-1) * log10(max(hit.getScore(), smallest_e_value_));
     }
@@ -238,7 +238,7 @@ protected:
     set<Int> charges;
     PosteriorErrorProbabilityModel PEP_model;
     PEP_model.setParameters(fit_algorithm);
-    StringList search_engines = ListUtils::create<String>("XTandem,OMSSA,MASCOT,SpectraST,MyriMatch,SimTandem,MSGFPlus");
+    StringList search_engines = ListUtils::create<String>("XTandem,OMSSA,MASCOT,SpectraST,MyriMatch,SimTandem,MSGFPlus,MS-GF+");
     //-------------------------------------------------------------
     // calculations
     //-------------------------------------------------------------


### PR DESCRIPTION
The search engine MS-GF+ is writing
```
search engine="MS-GF+"
```
in the `mzid`output. In the `MSGFPlusAdapter`, this tag is forwarded to `idXML`. The `IDPEP` tool expects
```
search engine="MSGFPlus"
```
instead. The pull request now allows for both cases.