### PR TITLE
mzIdentML handler stores scores now as float

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1297,7 +1297,7 @@ namespace OpenMS
         {
           for (vector<CVTerm>::const_iterator cv = cvs->second.begin(); cv != cvs->second.end(); ++cv)
           {
-            hit.setMetaValue(cvs->first, ((cv->getValue()).toString()).toDouble());
+            hit.setMetaValue(cvs->first, cv->getValue().toString().toDouble());
           }
         }
         for (map<String, DataValue>::const_iterator up = params.second.begin(); up != params.second.end(); ++up)

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1297,7 +1297,7 @@ namespace OpenMS
         {
           for (vector<CVTerm>::const_iterator cv = cvs->second.begin(); cv != cvs->second.end(); ++cv)
           {
-            hit.setMetaValue(cvs->first, cv->getValue());
+            hit.setMetaValue(cvs->first, ((cv->getValue()).toString()).toDouble());
           }
         }
         for (map<String, DataValue>::const_iterator up = params.second.begin(); up != params.second.end(); ++up)

--- a/src/tests/topp/IDFileConverter_15_output.idXML
+++ b/src/tests/topp/IDFileConverter_15_output.idXML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
 <IdXML version="1.3" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/nfs/t17_project/OpenMS/src/tests/topp/SEARCHENGINES/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/home/lars/Desktop/tests/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 				<UserParam type="string" name="MS:1001211" value=""/>
 				<UserParam type="string" name="MS:1001256" value=""/>
@@ -19,7 +19,7 @@
 				<UserParam type="string" name="Protocol" value="Standard"/>
 				<UserParam type="string" name="TargetDecoyApproach" value="false"/>
 	</SearchParameters>
-	<IdentificationRun date="2015-10-28T13:51:29" search_engine="MS-GF+" search_engine_version="Beta (v10089)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2016-02-09T17:57:36" search_engine="MS-GF+" search_engine_version="Beta (v10089)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="BSA3" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
@@ -30,14 +30,14 @@
 			<ProteinHit id="PH_2" accession="" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
 			</ProteinHit>
-			<UserParam type="string" name="spectra_data" value="/nfs/t17_project/OpenMS/src/tests/topp/SEARCHENGINES/spectra.mzML"/>
+			<UserParam type="string" name="spectra_data" value="/home/lars/Desktop/tests/THIRDPARTY/spectra.mzML"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="1063.20983886719" RT="4587.6689453125" spectrum_reference="spectrum=1" >
 			<PeptideHit score="163" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="-" aa_after="E" protein_refs="PH_1" >
-				<UserParam type="string" name="MS:1002049" value="163"/>
-				<UserParam type="string" name="MS:1002050" value="199"/>
-				<UserParam type="string" name="MS:1002052" value="3.864406E-26"/>
-				<UserParam type="string" name="MS:1002053" value="1.5921352E-23"/>
+				<UserParam type="float" name="MS:1002049" value="163"/>
+				<UserParam type="float" name="MS:1002050" value="199"/>
+				<UserParam type="float" name="MS:1002052" value="3.864406e-26"/>
+				<UserParam type="float" name="MS:1002053" value="1.5921352e-23"/>
 				<UserParam type="string" name="AssumedDissociationMethod" value="HCD"/>
 				<UserParam type="string" name="IsotopeError" value="0"/>
 				<UserParam type="float" name="calcMZ" value="1063.20935058594"/>
@@ -49,10 +49,10 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
 			<PeptideHit score="151" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="-" aa_after="A" protein_refs="PH_0" >
-				<UserParam type="string" name="MS:1002049" value="151"/>
-				<UserParam type="string" name="MS:1002050" value="188"/>
-				<UserParam type="string" name="MS:1002052" value="1.7573099E-19"/>
-				<UserParam type="string" name="MS:1002053" value="7.0468125E-17"/>
+				<UserParam type="float" name="MS:1002049" value="151"/>
+				<UserParam type="float" name="MS:1002050" value="188"/>
+				<UserParam type="float" name="MS:1002052" value="1.7573099e-19"/>
+				<UserParam type="float" name="MS:1002053" value="7.0468125e-17"/>
 				<UserParam type="string" name="AssumedDissociationMethod" value="HCD"/>
 				<UserParam type="string" name="IsotopeError" value="0"/>
 				<UserParam type="float" name="calcMZ" value="775.385437011719"/>
@@ -64,10 +64,10 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="520.262817382812" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="123" sequence="DFASSGGYVLHLHR" charge="3" aa_before="-" aa_after="E" >
-				<UserParam type="string" name="MS:1002049" value="123"/>
-				<UserParam type="string" name="MS:1002050" value="125"/>
-				<UserParam type="string" name="MS:1002052" value="4.6521305E-19"/>
-				<UserParam type="string" name="MS:1002053" value="1.63755E-16"/>
+				<UserParam type="float" name="MS:1002049" value="123"/>
+				<UserParam type="float" name="MS:1002050" value="125"/>
+				<UserParam type="float" name="MS:1002052" value="4.6521305e-19"/>
+				<UserParam type="float" name="MS:1002053" value="1.63755e-16"/>
 				<UserParam type="string" name="AssumedDissociationMethod" value="HCD"/>
 				<UserParam type="string" name="IsotopeError" value="0"/>
 				<UserParam type="float" name="calcMZ" value="520.263549804688"/>

--- a/src/tests/topp/IDFileConverter_8_output.idXML
+++ b/src/tests/topp/IDFileConverter_8_output.idXML
@@ -17,13 +17,13 @@
 		</ProteinIdentification>
 		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.9" RT="1234.5" spectrum_reference="17" >
 			<PeptideHit score="0.9" sequence="PEPTIDER" charge="1" aa_before="A A" aa_after="B B" protein_refs="PH_0 PH_1" >
-				<UserParam type="string" name="MS:1002354" value="0.9"/>
+				<UserParam type="float" name="MS:1002354" value="0.9"/>
 				<UserParam type="float" name="calcMZ" value="956.468357540271"/>
 				<UserParam type="int" name="pass_threshold" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</PeptideHit>
 			<PeptideHit score="1.4" sequence="PEPTIDERR" charge="1" aa_before="A A" aa_after="B B" protein_refs="PH_0 PH_1" >
-				<UserParam type="string" name="MS:1002354" value="1.4"/>
+				<UserParam type="float" name="MS:1002354" value="1.4"/>
 				<UserParam type="float" name="calcMZ" value="1112.56946892307"/>
 				<UserParam type="int" name="pass_threshold" value="0"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
@@ -34,13 +34,13 @@
 				<UserParam type="float" name="calcMZ" value="634.838928386321"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="string" name="MS:1001331" value="44.4"/>
+				<UserParam type="float" name="MS:1001331" value="44.4"/>
 			</PeptideHit>
 			<PeptideHit score="33.3" sequence="PEPTIDERRRR" charge="2" aa_before="A" aa_after="B" protein_refs="PH_0" >
 				<UserParam type="float" name="calcMZ" value="712.889484077721"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
-				<UserParam type="string" name="MS:1001331" value="33.3"/>
+				<UserParam type="float" name="MS:1001331" value="33.3"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot:score" higher_score_better="true" significance_threshold="0" MZ="987.6" RT="5432.1" spectrum_reference="99" >
@@ -48,13 +48,13 @@
 				<UserParam type="float" name="calcMZ" value="634.838928386321"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="string" name="MS:1001171" value="99.4"/>
+				<UserParam type="float" name="MS:1001171" value="99.4"/>
 			</PeptideHit>
 			<PeptideHit score="33.3" sequence="PEPTIDERRRR" charge="1" aa_before="A" aa_after="B" protein_refs="PH_0" >
 				<UserParam type="float" name="calcMZ" value="1424.77169168867"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
-				<UserParam type="string" name="MS:1001171" value="33.3"/>
+				<UserParam type="float" name="MS:1001171" value="33.3"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
 <IdXML version="1.3" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/home/lars/Desktop/MSGFPlusTest/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" peak_mass_tolerance="0" >
+	<SearchParameters id="SP_0" db="/home/lars/Desktop/tests/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 				<UserParam type="string" name="MS:1001211" value=""/>
 				<UserParam type="string" name="MS:1001256" value=""/>
@@ -19,7 +19,7 @@
 				<UserParam type="string" name="Protocol" value="Standard"/>
 				<UserParam type="string" name="TargetDecoyApproach" value="false"/>
 	</SearchParameters>
-	<IdentificationRun date="2015-10-29T10:17:01" search_engine="MS-GF+" search_engine_version="Beta (v10089)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2016-02-09T17:53:01" search_engine="MS-GF+" search_engine_version="Beta (v10089)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="BSA3" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
@@ -30,14 +30,14 @@
 			<ProteinHit id="PH_2" accession="" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
 			</ProteinHit>
-			<UserParam type="string" name="spectra_data" value="/home/lars/Desktop/MSGFPlusTest/spectra.mzML"/>
+			<UserParam type="string" name="spectra_data" value="/home/lars/Desktop/tests/THIRDPARTY/spectra.mzML"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="1063.20983886719" RT="4587.6689453125" spectrum_reference="spectrum=1" >
 			<PeptideHit score="163" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="-" aa_after="E" protein_refs="PH_1" >
-				<UserParam type="string" name="MS:1002049" value="163"/>
-				<UserParam type="string" name="MS:1002050" value="199"/>
-				<UserParam type="string" name="MS:1002052" value="3.864406E-26"/>
-				<UserParam type="string" name="MS:1002053" value="1.5921352E-23"/>
+				<UserParam type="float" name="MS:1002049" value="163"/>
+				<UserParam type="float" name="MS:1002050" value="199"/>
+				<UserParam type="float" name="MS:1002052" value="3.864406e-26"/>
+				<UserParam type="float" name="MS:1002053" value="1.5921352e-23"/>
 				<UserParam type="string" name="AssumedDissociationMethod" value="HCD"/>
 				<UserParam type="string" name="IsotopeError" value="0"/>
 				<UserParam type="float" name="calcMZ" value="1063.20935058594"/>
@@ -49,10 +49,10 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
 			<PeptideHit score="151" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="-" aa_after="A" protein_refs="PH_0" >
-				<UserParam type="string" name="MS:1002049" value="151"/>
-				<UserParam type="string" name="MS:1002050" value="188"/>
-				<UserParam type="string" name="MS:1002052" value="1.7573099E-19"/>
-				<UserParam type="string" name="MS:1002053" value="7.0468125E-17"/>
+				<UserParam type="float" name="MS:1002049" value="151"/>
+				<UserParam type="float" name="MS:1002050" value="188"/>
+				<UserParam type="float" name="MS:1002052" value="1.7573099e-19"/>
+				<UserParam type="float" name="MS:1002053" value="7.0468125e-17"/>
 				<UserParam type="string" name="AssumedDissociationMethod" value="HCD"/>
 				<UserParam type="string" name="IsotopeError" value="0"/>
 				<UserParam type="float" name="calcMZ" value="775.385437011719"/>
@@ -64,10 +64,10 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="520.262817382812" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="123" sequence="DFASSGGYVLHLHR" charge="3" aa_before="-" aa_after="E" >
-				<UserParam type="string" name="MS:1002049" value="123"/>
-				<UserParam type="string" name="MS:1002050" value="125"/>
-				<UserParam type="string" name="MS:1002052" value="4.6521305E-19"/>
-				<UserParam type="string" name="MS:1002053" value="1.63755E-16"/>
+				<UserParam type="float" name="MS:1002049" value="123"/>
+				<UserParam type="float" name="MS:1002050" value="125"/>
+				<UserParam type="float" name="MS:1002052" value="4.6521305e-19"/>
+				<UserParam type="float" name="MS:1002053" value="1.63755e-16"/>
 				<UserParam type="string" name="AssumedDissociationMethod" value="HCD"/>
 				<UserParam type="string" name="IsotopeError" value="0"/>
 				<UserParam type="float" name="calcMZ" value="520.263549804688"/>

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.mzid
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.mzid
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MzIdentML id="MS-GF+" version="1.1.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" creationDate="2014-11-13T15:47:49" >
+<MzIdentML id="MS-GF+" version="1.1.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" creationDate="2016-02-09T17:53:00" >
 <cvList xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
     <cv id="PSI-MS" uri="http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="3.30.0" fullName="PSI-MS"/>
     <cv id="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" fullName="UNIMOD"/>
@@ -24,7 +24,7 @@
     </DBSequence>
     <Peptide id="Pep1">
         <PeptideSequence>IALSRPNVEVVALNDPFITNDYAAYMFK</PeptideSequence>
-        <Modification monoisotopicMassDelta="15.99491463" location="26">
+        <Modification monoisotopicMassDelta="15.994915" location="26">
             <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
         </Modification>
     </Peptide>
@@ -89,7 +89,7 @@
 </AnalysisProtocolCollection>
 <DataCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
     <Inputs>
-        <SearchDatabase numDatabaseSequences="10" location="/nfs/t17_project/OpenMS/src/tests/topp/SEARCHENGINES/proteins.fasta" id="SearchDB_1">
+        <SearchDatabase numDatabaseSequences="10" location="/home/lars/Desktop/tests/THIRDPARTY/proteins.fasta" id="SearchDB_1">
             <FileFormat>
                 <cvParam accession="MS:1001348" cvRef="PSI-MS" name="FASTA format"/>
             </FileFormat>
@@ -97,7 +97,7 @@
                 <userParam name="proteins.fasta"/>
             </DatabaseName>
         </SearchDatabase>
-        <SpectraData location="/nfs/t17_project/OpenMS/src/tests/topp/SEARCHENGINES/spectra.mzML" name="spectra.mzML" id="SID_1">
+        <SpectraData location="/home/lars/Desktop/tests/THIRDPARTY/spectra.mzML" name="spectra.mzML" id="SID_1">
             <FileFormat>
                 <cvParam accession="MS:1000584" cvRef="PSI-MS" name="mzML file"/>
             </FileFormat>

--- a/src/utils/IDScoreSwitcher.cpp
+++ b/src/utils/IDScoreSwitcher.cpp
@@ -116,10 +116,10 @@ protected:
   }
 
 
-  template <typename IDType, typename HitType>
+  template <typename IDType>
   void switchScores_(IDType& id, Size& counter)
   {
-    for (typename vector<HitType>::iterator hit_it = id.getHits().begin();
+    for (typename vector<typename IDType::HitType>::iterator hit_it = id.getHits().begin();
          hit_it != id.getHits().end(); ++hit_it, ++counter)
     {
       if (!hit_it->metaValueExists(new_score_))
@@ -178,7 +178,7 @@ protected:
       for (vector<ProteinIdentification>::iterator prot_it = proteins.begin();
            prot_it != proteins.end(); ++prot_it)
       {
-        switchScores_<ProteinIdentification, ProteinHit>(*prot_it, counter);
+        switchScores_<ProteinIdentification>(*prot_it, counter);
       }
     }
     else
@@ -186,7 +186,7 @@ protected:
       for (vector<PeptideIdentification>::iterator pep_it = peptides.begin();
            pep_it != peptides.end(); ++pep_it)
       {
-        switchScores_<PeptideIdentification, PeptideHit>(*pep_it, counter);
+        switchScores_<PeptideIdentification>(*pep_it, counter);
       }
     }
 


### PR DESCRIPTION
Previously, the `mzIdentML` handler stored scores as string cv params. The scores are now stored as float. This change fixes the `IDScoreSwitcher`.