### PR TITLE
MSGFPlusAdapter sets MS-GF+ e-value as peptide score

### DIFF
--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
@@ -19,7 +19,7 @@
 				<UserParam type="string" name="Protocol" value="Standard"/>
 				<UserParam type="string" name="TargetDecoyApproach" value="false"/>
 	</SearchParameters>
-	<IdentificationRun date="2016-02-09T17:53:01" search_engine="MS-GF+" search_engine_version="Beta (v10089)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2016-02-10T15:20:54" search_engine="MS-GF+" search_engine_version="Beta (v10089)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="BSA3" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
@@ -32,8 +32,8 @@
 			</ProteinHit>
 			<UserParam type="string" name="spectra_data" value="/home/lars/Desktop/tests/THIRDPARTY/spectra.mzML"/>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="1063.20983886719" RT="4587.6689453125" spectrum_reference="spectrum=1" >
-			<PeptideHit score="163" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="-" aa_after="E" protein_refs="PH_1" >
+		<PeptideIdentification score_type="MSGFPlus" higher_score_better="false" significance_threshold="0" MZ="1063.20983886719" RT="4587.6689453125" spectrum_reference="spectrum=1" >
+			<PeptideHit score="3.864406e-26" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="-" aa_after="E" protein_refs="PH_1" >
 				<UserParam type="float" name="MS:1002049" value="163"/>
 				<UserParam type="float" name="MS:1002050" value="199"/>
 				<UserParam type="float" name="MS:1002052" value="3.864406e-26"/>
@@ -47,8 +47,8 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
-			<PeptideHit score="151" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="-" aa_after="A" protein_refs="PH_0" >
+		<PeptideIdentification score_type="MSGFPlus" higher_score_better="false" significance_threshold="0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
+			<PeptideHit score="1.7573099e-19" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="-" aa_after="A" protein_refs="PH_0" >
 				<UserParam type="float" name="MS:1002049" value="151"/>
 				<UserParam type="float" name="MS:1002050" value="188"/>
 				<UserParam type="float" name="MS:1002052" value="1.7573099e-19"/>
@@ -62,8 +62,8 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="520.262817382812" RT="2655.095703125" spectrum_reference="spectrum=0" >
-			<PeptideHit score="123" sequence="DFASSGGYVLHLHR" charge="3" aa_before="-" aa_after="E" >
+		<PeptideIdentification score_type="MSGFPlus" higher_score_better="false" significance_threshold="0" MZ="520.262817382812" RT="2655.095703125" spectrum_reference="spectrum=0" >
+			<PeptideHit score="4.6521305e-19" sequence="DFASSGGYVLHLHR" charge="3" aa_before="-" aa_after="E" >
 				<UserParam type="float" name="MS:1002049" value="123"/>
 				<UserParam type="float" name="MS:1002050" value="125"/>
 				<UserParam type="float" name="MS:1002052" value="4.6521305e-19"/>

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.idXML
@@ -19,7 +19,7 @@
 				<UserParam type="string" name="Protocol" value="Standard"/>
 				<UserParam type="string" name="TargetDecoyApproach" value="false"/>
 	</SearchParameters>
-	<IdentificationRun date="2016-02-10T15:20:54" search_engine="MS-GF+" search_engine_version="Beta (v10089)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2016-02-10T16:21:06" search_engine="MS-GF+" search_engine_version="Beta (v10089)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="BSA3" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
@@ -32,7 +32,7 @@
 			</ProteinHit>
 			<UserParam type="string" name="spectra_data" value="/home/lars/Desktop/tests/THIRDPARTY/spectra.mzML"/>
 		</ProteinIdentification>
-		<PeptideIdentification score_type="MSGFPlus" higher_score_better="false" significance_threshold="0" MZ="1063.20983886719" RT="4587.6689453125" spectrum_reference="spectrum=1" >
+		<PeptideIdentification score_type="SpecEValue" higher_score_better="false" significance_threshold="0" MZ="1063.20983886719" RT="4587.6689453125" spectrum_reference="spectrum=1" >
 			<PeptideHit score="3.864406e-26" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="-" aa_after="E" protein_refs="PH_1" >
 				<UserParam type="float" name="MS:1002049" value="163"/>
 				<UserParam type="float" name="MS:1002050" value="199"/>
@@ -47,7 +47,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="MSGFPlus" higher_score_better="false" significance_threshold="0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
+		<PeptideIdentification score_type="SpecEValue" higher_score_better="false" significance_threshold="0" MZ="775.38720703125" RT="4923.77734375" spectrum_reference="spectrum=2" >
 			<PeptideHit score="1.7573099e-19" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="-" aa_after="A" protein_refs="PH_0" >
 				<UserParam type="float" name="MS:1002049" value="151"/>
 				<UserParam type="float" name="MS:1002050" value="188"/>
@@ -62,7 +62,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</PeptideHit>
 		</PeptideIdentification>
-		<PeptideIdentification score_type="MSGFPlus" higher_score_better="false" significance_threshold="0" MZ="520.262817382812" RT="2655.095703125" spectrum_reference="spectrum=0" >
+		<PeptideIdentification score_type="SpecEValue" higher_score_better="false" significance_threshold="0" MZ="520.262817382812" RT="2655.095703125" spectrum_reference="spectrum=0" >
 			<PeptideHit score="4.6521305e-19" sequence="DFASSGGYVLHLHR" charge="3" aa_before="-" aa_after="E" >
 				<UserParam type="float" name="MS:1002049" value="123"/>
 				<UserParam type="float" name="MS:1002050" value="125"/>

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.mzid
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.mzid
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MzIdentML id="MS-GF+" version="1.1.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" creationDate="2016-02-09T17:53:00" >
+<MzIdentML id="MS-GF+" version="1.1.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" creationDate="2016-02-10T15:20:54" >
 <cvList xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
     <cv id="PSI-MS" uri="http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="3.30.0" fullName="PSI-MS"/>
     <cv id="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" fullName="UNIMOD"/>

--- a/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.mzid
+++ b/src/tests/topp/THIRDPARTY/MSGFPlusAdapter_1_out.mzid
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MzIdentML id="MS-GF+" version="1.1.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" creationDate="2016-02-10T15:20:54" >
+<MzIdentML id="MS-GF+" version="1.1.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" creationDate="2016-02-10T16:21:06" >
 <cvList xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
     <cv id="PSI-MS" uri="http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="3.30.0" fullName="PSI-MS"/>
     <cv id="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" fullName="UNIMOD"/>

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -398,7 +398,7 @@ protected:
   // Set the MS-GF+ e-value (MS:1002052) as new peptide identification score.
   void switchScores_(PeptideIdentification& id)
   {
-    for (vector<PeptideIdentification::HitType>::iterator hit_it = id.getHits().begin(); hit_it != id.getHits().end(); ++hit_it)
+    for (vector<PeptideHit>::iterator hit_it = id.getHits().begin(); hit_it != id.getHits().end(); ++hit_it)
     {
       // MS:1002052 == MS-GF spectral E-value
       if (!hit_it->metaValueExists("MS:1002052"))
@@ -409,7 +409,7 @@ protected:
       
       hit_it->setScore(hit_it->getMetaValue("MS:1002052"));
     }
-    id.setScoreType("MSGFPlus");
+    id.setScoreType("SpecEValue");
     id.setHigherScoreBetter(false);
   }
   
@@ -747,7 +747,7 @@ protected:
         vector<ProteinIdentification> protein_ids;
         vector<PeptideIdentification> peptide_ids;
         MzIdentMLFile().load(mzid_temp, protein_ids, peptide_ids);
-        // set the MS-GF+ e-value as new peptide identification score
+        // set the MS-GF+ spectral e-value as new peptide identification score
         for (vector<PeptideIdentification>::iterator pep_it = peptide_ids.begin(); pep_it != peptide_ids.end(); ++pep_it)
         {
           switchScores_(*pep_it);

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -388,6 +388,31 @@ protected:
     }
   }
   
+  String describeHit_(const PeptideHit& hit)
+  {
+    return "peptide hit with sequence '" + hit.getSequence().toString() +
+      "', charge " + String(hit.getCharge()) + ", score " + 
+      String(hit.getScore());
+  }
+
+  // Set the MS-GF+ e-value (MS:1002052) as new peptide identification score.
+  void switchScores_(PeptideIdentification& id)
+  {
+    for (vector<PeptideIdentification::HitType>::iterator hit_it = id.getHits().begin(); hit_it != id.getHits().end(); ++hit_it)
+    {
+      // MS:1002052 == MS-GF spectral E-value
+      if (!hit_it->metaValueExists("MS:1002052"))
+      {
+        String msg = "Meta value 'MS:1002052' not found for " + describeHit_(*hit_it);
+        throw Exception::MissingInformation(__FILE__, __LINE__, __PRETTY_FUNCTION__, msg);
+      }
+      
+      hit_it->setScore(hit_it->getMetaValue("MS:1002052"));
+    }
+    id.setScoreType("MSGFPlus");
+    id.setHigherScoreBetter(false);
+  }
+  
   ExitCodes main_(int, const char**)
   {
     //-------------------------------------------------------------
@@ -722,6 +747,11 @@ protected:
         vector<ProteinIdentification> protein_ids;
         vector<PeptideIdentification> peptide_ids;
         MzIdentMLFile().load(mzid_temp, protein_ids, peptide_ids);
+        // set the MS-GF+ e-value as new peptide identification score
+        for (vector<PeptideIdentification>::iterator pep_it = peptide_ids.begin(); pep_it != peptide_ids.end(); ++pep_it)
+        {
+          switchScores_(*pep_it);
+        }
         SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptide_ids, in, false);
         IdXMLFile().store(out, protein_ids, peptide_ids);
       }


### PR DESCRIPTION
Since #1679, the MS-GF+ adapter converts `mzid` directly to `idXML`. The `mzid` handler sets `MS:1002049` (MS-GF raw score) as peptide identification score.

The `MSGFPlusAdapter` now re-sets the peptide identification score to `MS:1002052` (MS-GF spectral E-value) after the `mzid` to `idXML` conversion. Fixes #1691.