### PR TITLE
Moves the SpectraMerger tool to the correct section

### DIFF
--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -57,7 +57,6 @@
   - @subpage TOPP_IDRipper - Splits protein/peptide identifications according their file-origin.
   - @subpage TOPP_IDFileConverter - Converts identification engine file formats.
   - @subpage TOPP_MapStatistics - Extract extended statistics on the features of a map for quality control.
-  - @subpage TOPP_SpectraMerger - Merges spectra from an LC-MS map, either by precursor or by RT blocks
   - @subpage TOPP_TextExporter - Exports various XML formats to a text file.
   - @subpage TOPP_MzTabExporter - Exports various XML formats to an mzTab file
 
@@ -82,6 +81,7 @@
   - @subpage TOPP_SpectraFilterSqrtMower - Applies a filter to peak spectra.
   - @subpage TOPP_SpectraFilterThresholdMower - Applies a filter to peak spectra.
   - @subpage TOPP_SpectraFilterWindowMower - Applies a filter to peak spectra.
+  - @subpage TOPP_SpectraMerger - Merges spectra from an LC-MS map, either by precursor or by RT blocks
   - @subpage TOPP_TOFCalibration - Applies time of flight calibration.
 
   <b>Quantitation</b>


### PR DESCRIPTION
SpectraMerger is now listed under the "Signal processing and pre-processing" section instead of "File Handling".