### PR TITLE
fix silent conversion of incomplete strings

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -62,7 +62,7 @@ struct ProbablePhosphoSites
   */
 class OPENMS_DLLAPI AScore
 {
-  friend class PScore;
+  friend struct PScore;
   public:
     ///Default constructor
     AScore();

--- a/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
@@ -215,7 +215,7 @@ public:
     {
       try
       {
-        c.push_back(boost::lexical_cast<T>(boost::trim_copy(*it)));
+        c.push_back(boost::lexical_cast<T>(boost::trim_copy(*it))); // succeeds only if the whole output can be explained, i.e. "1.3 3" will fail (which is good)
       }
       catch (boost::bad_lexical_cast&)
       {

--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -681,10 +681,15 @@ public:
 
       // boost::spirit::qi was found to be vastly superior to boost::lexical_cast or stringstream extraction (especially for VisualStudio),
       // so don't change this unless you have benchmarks for all platforms!
-      if (!qi::phrase_parse(this_s.begin(), this_s.end(),
-          qi::int_, ascii::space, ret))
+      String::ConstIterator it = this_s.begin();
+      if (!qi::phrase_parse(it, this_s.end(), qi::int_, ascii::space, ret))
       {
         throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Could not convert string '") + this_s + "' to an integer value");
+      }
+      // was the string parsed (white spaces are skipped automatically!) completely? If not, we have a problem because a previous split might have used the wrong split char
+      if (it != this_s.end())
+      {
+        throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Prefix of string '") + this_s + "' successfully converted to an integer value. Additional characters found at position " + (int)(distance(this_s.begin(), it) + 1));
       }
       return ret;
     }
@@ -698,10 +703,15 @@ public:
 
       // boost::spirit::qi was found to be vastly superior to boost::lexical_cast or stringstream extraction (especially for VisualStudio),
       // so don't change this unless you have benchmarks for all platforms!
-      if (!qi::phrase_parse(this_s.begin(), this_s.end(),
-          qi::float_, ascii::space, ret))
+      String::ConstIterator it = this_s.begin();
+      if (!qi::phrase_parse(it, this_s.end(), qi::float_, ascii::space, ret))
       {
         throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Could not convert string '") + this_s + "' to a float value");
+      }
+      // was the string parsed (white spaces are skipped automatically!) completely? If not, we have a problem because a previous split might have used the wrong split char
+      if (it != this_s.end())
+      {
+        throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Prefix of string '") + this_s + "' successfully converted to a float value. Additional characters found at position " + (int)(distance(this_s.begin(), it) + 1));
       }
       return ret;
     }
@@ -714,9 +724,15 @@ public:
       double ret;
       // boost::spirit::qi was found to be vastly superior to boost::lexical_cast or stringstream extraction (especially for VisualStudio),
       // so don't change this unless you have benchmarks for all platforms!
-      if (!qi::phrase_parse(this_s.begin(), this_s.end(), qi::double_, ascii::space, ret))
+      String::ConstIterator it = this_s.begin();
+      if (!qi::phrase_parse(it, this_s.end(), qi::double_, ascii::space, ret))
       {
         throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Could not convert string '") + this_s + "' to a double value");
+      }
+      // was the string parsed (white spaces are skipped automatically!) completely? If not, we have a problem because a previous split might have used the wrong split char
+      if (it != this_s.end())
+      {
+        throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Prefix of string '") + this_s + "' successfully converted to a double value. Additional characters found at position " + (int)(distance(this_s.begin(), it) + 1));
       }
       return ret;
     }

--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Stephan Aiche$
-// $Authors: Marc Sturm $
+// $Maintainer: Stephan Aiche, Chris Bielow $
+// $Authors: Marc Sturm, Stephan Aiche, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_DATASTRUCTURES_STRINGUTILS_H
@@ -674,15 +674,12 @@ public:
 
     static Int toInt(const String & this_s)
     {
-      namespace qi = boost::spirit::qi;
-      namespace ascii = boost::spirit::ascii;
-
       Int ret;
 
       // boost::spirit::qi was found to be vastly superior to boost::lexical_cast or stringstream extraction (especially for VisualStudio),
       // so don't change this unless you have benchmarks for all platforms!
       String::ConstIterator it = this_s.begin();
-      if (!qi::phrase_parse(it, this_s.end(), qi::int_, ascii::space, ret))
+      if (!boost::spirit::qi::phrase_parse(it, this_s.end(), boost::spirit::qi::int_, boost::spirit::ascii::space, ret))
       {
         throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Could not convert string '") + this_s + "' to an integer value");
       }
@@ -694,17 +691,14 @@ public:
       return ret;
     }
 
-    static float toFloat(const String & this_s)
+    static float toFloat(const String& this_s)
     {
-      namespace qi = boost::spirit::qi;
-      namespace ascii = boost::spirit::ascii;
-
       float ret;
 
       // boost::spirit::qi was found to be vastly superior to boost::lexical_cast or stringstream extraction (especially for VisualStudio),
       // so don't change this unless you have benchmarks for all platforms!
       String::ConstIterator it = this_s.begin();
-      if (!qi::phrase_parse(it, this_s.end(), qi::float_, ascii::space, ret))
+      if (!boost::spirit::qi::phrase_parse(it, this_s.end(), parse_float_, boost::spirit::ascii::space, ret))
       {
         throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Could not convert string '") + this_s + "' to a float value");
       }
@@ -716,16 +710,13 @@ public:
       return ret;
     }
 
-    static double toDouble(const String & this_s)
+    static double toDouble(const String& this_s)
     {
-      namespace qi = boost::spirit::qi;
-      namespace ascii = boost::spirit::ascii;
-
       double ret;
       // boost::spirit::qi was found to be vastly superior to boost::lexical_cast or stringstream extraction (especially for VisualStudio),
       // so don't change this unless you have benchmarks for all platforms!
       String::ConstIterator it = this_s.begin();
-      if (!qi::phrase_parse(it, this_s.end(), qi::double_, ascii::space, ret))
+      if (!boost::spirit::qi::phrase_parse(it, this_s.end(), parse_double_, boost::spirit::ascii::space, ret))
       {
         throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Could not convert string '") + this_s + "' to a double value");
       }
@@ -736,6 +727,7 @@ public:
       }
       return ret;
     }
+
 
     static String& toUpper(String & this_s)
     {
@@ -816,6 +808,55 @@ public:
 
     return this_s;
   }
+
+  private:
+
+  /*
+    @brief A fixed Boost:pi real parser policy, capable of dealing with 'nan' without crashing
+
+    The original Boost implementation has a bug, see https://svn.boost.org/trac/boost/ticket/6955.
+    Can be removed if Boost 1.60 or above is required
+    
+  */
+  template <typename T>
+  struct real_policies_NANfixed_ : boost::spirit::qi::real_policies<T>
+  {
+    template <typename Iterator, typename Attribute>
+    static bool
+      parse_nan(Iterator& first, Iterator const& last, Attribute& attr_)
+    {
+      if (first == last)
+        return false;   // end of input reached
+
+      if (*first != 'n' && *first != 'N')
+        return false;   // not "nan"
+
+      // nan[(...)] ?
+      if (boost::spirit::qi::detail::string_parse("nan", "NAN", first, last, boost::spirit::qi::unused))
+      {
+        if (first != last && *first == '(')  /* this check is broken in boost 1.49 - (at least) 1.54; fixed in 1.60 */
+        {
+          // skip trailing (...) part
+          Iterator i = first;
+
+          while (++i != last && *i != ')')
+            ;
+          if (i == last)
+            return false;     // no trailing ')' found, give up
+
+          first = ++i;
+        }
+        attr_ = std::numeric_limits<T>::quiet_NaN();
+        return true;
+      }
+      return false;
+    }
+  };
+  
+  // Qi parsers using the 'real_policies_NANfixed_' template which allows for 'nan'
+  // (the original Boost implementation has a bug, see https://svn.boost.org/trac/boost/ticket/6955)
+  static boost::spirit::qi::real_parser<double, real_policies_NANfixed_<double> > parse_double_;
+  static boost::spirit::qi::real_parser<float, real_policies_NANfixed_<float> > parse_float_;
 
   };
 

--- a/src/openms/source/CONCEPT/VersionInfo.cpp
+++ b/src/openms/source/CONCEPT/VersionInfo.cpp
@@ -89,7 +89,7 @@ namespace OpenMS
     size_t second_dot = version.find('.', first_dot + 1);
     try
     {
-      result.version_minor = String(version.substr(first_dot + 1, second_dot)).toInt();
+      result.version_minor = String(version.substr(first_dot + 1, second_dot - (first_dot + 1))).toInt();
     }
     catch (Exception::ConversionError & /*e*/)
     {
@@ -104,7 +104,7 @@ namespace OpenMS
     size_t third_dot = version.find('.', second_dot + 1);
     try
     {
-      result.version_patch = String(version.substr(second_dot + 1, third_dot)).toInt();
+      result.version_patch = String(version.substr(second_dot + 1, third_dot - (second_dot + 1))).toInt();
     }
     catch (Exception::ConversionError & /*e*/)
     {

--- a/src/openms/source/DATASTRUCTURES/StringUtils.cpp
+++ b/src/openms/source/DATASTRUCTURES/StringUtils.cpp
@@ -1,0 +1,43 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2015.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Stephan Aiche, Chris Bielow $
+// $Authors: Marc Sturm, Stephan Aiche, Chris Bielow $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/DATASTRUCTURES/StringUtils.h>
+
+namespace OpenMS
+{
+
+    boost::spirit::qi::real_parser<double, StringUtils::real_policies_NANfixed_<double> > StringUtils::parse_double_ = boost::spirit::qi::real_parser<double, real_policies_NANfixed_<double> >();
+    boost::spirit::qi::real_parser<float, StringUtils::real_policies_NANfixed_<float> > StringUtils::parse_float_ = boost::spirit::qi::real_parser<float, real_policies_NANfixed_<float> >();
+ 
+}

--- a/src/openms/source/DATASTRUCTURES/sources.cmake
+++ b/src/openms/source/DATASTRUCTURES/sources.cmake
@@ -34,6 +34,7 @@ QTCluster.cpp
 SparseVector.cpp
 String.cpp
 StringListUtils.cpp
+StringUtils.cpp
 SuffixArray.cpp
 SuffixArrayPeptideFinder.cpp
 SuffixArraySeqan.cpp

--- a/src/openms/source/FORMAT/SequestOutfile.cpp
+++ b/src/openms/source/FORMAT/SequestOutfile.cpp
@@ -849,7 +849,7 @@ namespace OpenMS
       else if (line.hasPrefix("display top") && substrings[0].hasPrefix("display top")) // get the number of peptides displayed
       {
         displayed_peptides = strlen("display top ");
-        displayed_peptides = substrings[0].substr(displayed_peptides, substrings[0].find('/', displayed_peptides)).toInt();
+        displayed_peptides = substrings[0].substr(displayed_peptides, substrings[0].find('/', displayed_peptides) - displayed_peptides).toInt();
       }
       else if (line.hasPrefix("#"))
       {

--- a/src/tests/class_tests/openms/source/MRMIonSeries_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMIonSeries_test.cpp
@@ -289,7 +289,7 @@ START_SECTION((void MRMIonSeries::annotateTransition(ReactionMonitoringTransitio
   TEST_EQUAL(tr2.getProduct().getInterpretationList()[0].hasCVTerm("MS:1001220"), true)
   TEST_EQUAL(tr2.getProduct().getInterpretationList()[0].getCVTerms()["MS:1000903"][0].getValue().toString().toInt(), 5)
   TEST_EQUAL(tr2.getProduct().getInterpretationList()[0].hasCVTerm("MS:1001524"), true)
-  TEST_EQUAL(tr2.getProduct().getInterpretationList()[0].getCVTerms()["MS:1001524"][0].getValue().toString().toInt(), -18)
+  TEST_EQUAL((int)tr2.getProduct().getInterpretationList()[0].getCVTerms()["MS:1001524"][0].getValue().toString().toDouble(), -18)
 
   tr3.setProductMZ(202.44);
   mrmis.annotateTransition(tr3, peptide, 0.05, 0.05, false, fragment_types, fragment_charges, false, false);

--- a/src/tests/class_tests/openms/source/PILISNeutralLossModel_test.cpp
+++ b/src/tests/class_tests/openms/source/PILISNeutralLossModel_test.cpp
@@ -116,7 +116,7 @@ START_SECTION((double train(const RichPeakSpectrum & spec, const AASequence &pep
 		{
 			ion_name.remove('+');
 			ion_name.remove('y');
-			AASequence suffix = AASequence::fromString("DFPIANGER").getSuffix(ion_name.toInt());
+			AASequence suffix = AASequence::fromString("DFPIANGER").getSuffix(ion_name.substr(0, ion_name.find("-")).toInt());
       model.train(spec1, suffix, suffix.getMonoWeight(Residue::YIon), charge, AASequence::fromString("DFPIANGER").getMonoWeight());
 		}
 	}
@@ -129,7 +129,7 @@ START_SECTION((double train(const RichPeakSpectrum & spec, const AASequence &pep
     {
 			ion_name.remove('+');
 			ion_name.remove('y');
-			AASequence suffix = AASequence::fromString("DFPIANGEK").getSuffix(ion_name.toInt());
+			AASequence suffix = AASequence::fromString("DFPIANGEK").getSuffix(ion_name.substr(0, ion_name.find("-")).toInt());
       model.train(spec1, suffix, suffix.getMonoWeight(Residue::YIon), charge, AASequence::fromString("DFPIANGEK").getMonoWeight());
     }
   }
@@ -142,7 +142,7 @@ START_SECTION((double train(const RichPeakSpectrum & spec, const AASequence &pep
     {
 			ion_name.remove('+');
 			ion_name.remove('y');
-			AASequence suffix = AASequence::fromString("DFPIANGEREK").getSuffix(ion_name.toInt());
+			AASequence suffix = AASequence::fromString("DFPIANGEREK").getSuffix(ion_name.substr(0, ion_name.find("-")).toInt());
       model.train(spec1, suffix, suffix.getMonoWeight(Residue::YIon), charge, AASequence::fromString("DFPIANGEREK").getMonoWeight());
     }
   }

--- a/src/tests/class_tests/openms/source/StringUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/StringUtils_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // 
 // --------------------------------------------------------------------------
-// $Maintainer: $
-// $Authors: $
+// $Maintainer: Stephan Aiche$
+// $Authors: Marc Sturm $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>
@@ -219,19 +219,50 @@ END_SECTION
 
 START_SECTION((static Int toInt(const String &this_s)))
 {
-  // TODO
+  // easy case
+  TEST_EQUAL(StringUtils::toInt("1234"), 1234)
+  // with spaces (allowed)
+  TEST_EQUAL(StringUtils::toInt("  1234"), 1234)
+  TEST_EQUAL(StringUtils::toInt("1234 "), 1234)
+  TEST_EQUAL(StringUtils::toInt("   1234  "), 1234)
+  // with trailing chars (unexplained) --> error (because it means the input was not split correctly beforehand)!!!
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt("1234  moreText"))  // 'moreText' is not explained...
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt(" 1234 911.0"))     // '911.0' is not explained...
+  // incorrect type
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt(" abc "))
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toInt(" 123.45 "))
 }
 END_SECTION
 
 START_SECTION((static float toFloat(const String &this_s)))
 {
-  // TODO
+  // easy case
+  TEST_REAL_SIMILAR(StringUtils::toFloat("1234.45"), 1234.45)
+  // with spaces (allowed)
+  TEST_REAL_SIMILAR(StringUtils::toFloat("  1234.45"), 1234.45)
+  TEST_REAL_SIMILAR(StringUtils::toFloat("1234.45 "), 1234.45)
+  TEST_REAL_SIMILAR(StringUtils::toFloat("   1234.45  "), 1234.45)
+  // with trailing chars (unexplained) --> error (because it means the input was not split correctly beforehand)!!!
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toFloat("1234.45  moreText"))  // 'moreText' is not explained...
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toFloat(" 1234.45 911.0"))     // '911.0' is not explained...
+  // incorrect type
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toFloat(" abc "))
 }
 END_SECTION
 
 START_SECTION((static double toDouble(const String &this_s)))
 {
-  // TODO
+  // easy case
+  TEST_REAL_SIMILAR(StringUtils::toDouble("1234.45"), 1234.45)
+  // with spaces (allowed)
+  TEST_REAL_SIMILAR(StringUtils::toDouble("  1234.45"), 1234.45)
+  TEST_REAL_SIMILAR(StringUtils::toDouble("1234.45 "), 1234.45)
+  TEST_REAL_SIMILAR(StringUtils::toDouble("   1234.45  "), 1234.45)
+  // with trailing chars (unexplained) --> error (because it means the input was not split correctly beforehand)!!!
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toDouble("1234.45  moreText"))  // 'moreText' is not explained...
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toDouble(" 1234.45 911.0"))     // '911.0' is not explained...
+  // incorrect type
+  TEST_EXCEPTION(Exception::ConversionError, StringUtils::toDouble(" abc "))
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/StringUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/StringUtils_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // 
 // --------------------------------------------------------------------------
-// $Maintainer: Stephan Aiche$
-// $Authors: Marc Sturm $
+// $Maintainer: Stephan Aiche, Chris Bielow $
+// $Authors: Marc Sturm, Stephan Aiche, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/ClassTest.h>

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -433,20 +433,19 @@ END_SECTION
 
 START_SECTION((Int toInt() const))
 	String s;
-	s = "123.456";
+	s = "123";
 	TEST_EQUAL(s.toInt(),123);
-	s = "-123.456";
+	s = "-123";
 	TEST_EQUAL(s.toInt(),-123);
-	s = "123.9";
-	TEST_EQUAL(s.toInt(),123);
-	s = "73629.00";
-	TEST_EQUAL(s.toInt(),73629);
-	s = "73629.50";
-	TEST_EQUAL(s.toInt(),73629);
-	s = "73629.99";
-	TEST_EQUAL(s.toInt(),73629);
+  s = "  -123";
+  TEST_EQUAL(s.toInt(),-123);
+  s = "-123  ";
+  TEST_EQUAL(s.toInt(),-123);
+  s = "  -123  ";
+  TEST_EQUAL(s.toInt(),-123);
+  // expect errors:
   s = "524 starts with an int";
-  TEST_EQUAL(s.toInt(), 524)
+  TEST_EXCEPTION(Exception::ConversionError, s.toInt())
   s = "not an int";
   TEST_EXCEPTION_WITH_MESSAGE(Exception::ConversionError, s.toInt(), String("Could not convert string '") + s + "' to an integer value")
   s = "contains an 13135 int";
@@ -467,7 +466,7 @@ START_SECTION((float toFloat() const))
 	TEST_EQUAL(String(s.toFloat()),"73629.9");
 	s = "47218.8";
 	TEST_EQUAL(String(s.toFloat()),"47218.8");
-  s = "nan";
+  s = String("nan");
   TEST_EQUAL(boost::math::isnan(s.toFloat()),true);
   s = "NaN";
   TEST_EQUAL(boost::math::isnan(s.toFloat()),true);

--- a/src/topp/MascotAdapter.cpp
+++ b/src/topp/MascotAdapter.cpp
@@ -360,55 +360,54 @@ protected:
       writeLog_("Both Mascot flags set. Aborting! Only one of the two flags [-mascot_in|-mascot_out] can be set!");
       return ILLEGAL_PARAMETERS;
     }
-    else
+    
+    db = getStringOption_("db");
+    hits = getStringOption_("hits");
+    cleavage = getStringOption_("cleavage");
+    missed_cleavages = getIntOption_("missed_cleavages");
+    mass_type = getStringOption_("mass_type");
+
+    sigthreshold = getDoubleOption_("sig_threshold");
+    pep_homol = getDoubleOption_("pep_homol");
+    pep_ident = getDoubleOption_("pep_ident");
+    pep_rank = getIntOption_("pep_rank");
+    pep_exp_z = getIntOption_("pep_exp_z");
+    show_unassigned = getIntOption_("show_unassigned");
+    prot_score = getDoubleOption_("prot_score");
+    pep_score = getDoubleOption_("pep_score");
+
+    instrument = getStringOption_("instrument");
+    precursor_mass_tolerance = getDoubleOption_("precursor_mass_tolerance");
+    peak_mass_tolerance = getDoubleOption_("peak_mass_tolerance");
+    taxonomy = getStringOption_("taxonomy");
+
+    /// fixed modifications
+    mods = getStringList_("modifications");
+
+    /// variable modifications
+    variable_mods = getStringList_("variable_modifications");
+
+    /// charges
+    parts = getStringList_("charges");
+
+    for (Size i = 0; i < parts.size(); i++)
     {
-      db = getStringOption_("db");
-      hits = getStringOption_("hits");
-      cleavage = getStringOption_("cleavage");
-      missed_cleavages = getIntOption_("missed_cleavages");
-      mass_type = getStringOption_("mass_type");
-
-      sigthreshold = getDoubleOption_("sig_threshold");
-      pep_homol = getDoubleOption_("pep_homol");
-      pep_ident = getDoubleOption_("pep_ident");
-      pep_rank = getIntOption_("pep_rank");
-      pep_exp_z = getIntOption_("pep_exp_z");
-      show_unassigned = getIntOption_("show_unassigned");
-      prot_score = getDoubleOption_("prot_score");
-      pep_score = getDoubleOption_("pep_score");
-
-      instrument = getStringOption_("instrument");
-      precursor_mass_tolerance = getDoubleOption_("precursor_mass_tolerance");
-      peak_mass_tolerance = getDoubleOption_("peak_mass_tolerance");
-      taxonomy = getStringOption_("taxonomy");
-
-      /// fixed modifications
-      mods = getStringList_("modifications");
-
-      /// variable modifications
-      variable_mods = getStringList_("variable_modifications");
-
-      ///charges
-      parts = getStringList_("charges");
-
-      for (Size i = 0; i < parts.size(); i++)
+      temp_charge = parts[i];
+      if (temp_charge[temp_charge.size() - 1] == '-' || temp_charge[0] == '-')
       {
-        temp_charge = parts[i];
-        if (temp_charge[temp_charge.size() - 1] == '-' || temp_charge[0] == '-')
-        {
-          charges.push_back(-1 * (temp_charge.toInt()));
-        }
-        else
-        {
-          charges.push_back(temp_charge.toInt());
-        }
+        charges.push_back(-1 * (parts[i].remove('-').toInt()));
       }
-      if (charges.empty())
+      else
       {
-        writeLog_("No charge states specified for Mascot search. Aborting!");
-        return ILLEGAL_PARAMETERS;
+        charges.push_back(parts[i].remove('+').toInt());
       }
     }
+    if (charges.empty())
+    {
+      writeLog_("No charge states specified for Mascot search. Aborting!");
+      return ILLEGAL_PARAMETERS;
+    }
+
 
     if (mascot_in)
     {


### PR DESCRIPTION
we currently use Boost's qi::phrase_parse
to convert a string to any other type (usually double, float or int).

However, passing a string with trailing characters, e.g., "1.2   3.4" would lead to successful conversion,
to 1.2, but does not throw an error.
**This is bad!**

Imagine the following command:
`Filefilter -in infile.mzML  -peak_options:level "1 2" -out outfile.mzML`

MS-level 2 would be removed, without the user even noticing (you can make up more complicated cases ofc).

With this PR, the above command will fail with:
`Invalid parameter values: Prefix of string '1 2' successfully converted to an integer value. Additional characters found at position 3. Aborting!`

This allows to correct the above command to (removing quotes):
` ....   -peak_options:level 1 2  ... `