### PR TITLE
[Feature] MS/MS precursor filtering by mass list

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/RangeUtils.h
+++ b/src/openms/include/OpenMS/KERNEL/RangeUtils.h
@@ -41,6 +41,7 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 
 namespace OpenMS
 {
@@ -649,6 +650,61 @@ public:
 
 private:
     double min_size_, max_size_;
+    bool reverse_;
+  };
+
+    /**
+    @brief Predicate that determines if the isolation window covers ANY of the given m/z values.
+    @note This predicate will return always true for spectra with getMSLevel() = 1.
+
+    @ingroup RangeUtils
+  */
+  template <class SpectrumType>
+  class IsInIsolationWindow :
+    std::unary_function<SpectrumType, bool>
+  {
+
+public:
+    /**
+      @brief Constructor
+
+      @param vec_mz Vector of m/z values, of which at least one needs to be covered
+      @param reverse if @p reverse is true, operator() returns true if the isolation window is outside for ALL m/z values.
+    */
+    IsInIsolationWindow(std::vector<double> vec_mz, bool reverse = false) :
+      vec_mz_(vec_mz),
+      reverse_(reverse)
+    {
+      std::sort(vec_mz_.begin(), vec_mz_.end());
+    }
+
+    inline bool operator()(const SpectrumType& s) const
+    {
+      // leave non-fragmentation spectra untouched
+      if (s.getMSLevel() == 1) return false;
+
+      bool isIn = false;
+      for (std::vector<Precursor>::const_iterator it = s.getPrecursors().begin(); it != s.getPrecursors().end(); ++it)
+      {
+        if (it->getIsolationWindowLowerOffset() == 0 || it->getIsolationWindowLowerOffset() == 0)
+        {
+          LOG_WARN << "IsInIsolationWindow(): Lower/Upper Offset for Precursor Isolation Window is Zero! Filtering will probably be too strict (unless you hit the exact precursor m/z)!" << std::endl;
+        }
+        const double lower_mz = it->getMZ() - it->getIsolationWindowLowerOffset();
+        std::vector<double>::const_iterator it_mz = std::lower_bound(vec_mz_.begin(), vec_mz_.end(), lower_mz);
+        if (it_mz != vec_mz_.end()) // left side ok
+        { // right side?
+          const double upper_mz = it->getMZ() + it->getIsolationWindowUpperOffset();
+          isIn |= (*it_mz <= upper_mz);
+        }
+      }
+
+      if (reverse_) return !isIn;
+      else return isIn;
+    }
+
+private:
+    std::vector<double> vec_mz_;
     bool reverse_;
   };
 

--- a/src/openms/source/METADATA/Precursor.cpp
+++ b/src/openms/source/METADATA/Precursor.cpp
@@ -135,6 +135,7 @@ namespace OpenMS
 
   void Precursor::setIsolationWindowLowerOffset(double bound)
   {
+    if (bound < 0) throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Precursor::setIsolationWindowLowerOffset() received a negative lower offset", String(bound));
     window_low_ = bound;
   }
 
@@ -145,6 +146,7 @@ namespace OpenMS
 
   void Precursor::setIsolationWindowUpperOffset(double bound)
   {
+    if (bound < 0) throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Precursor::setIsolationWindowUpperOffset() received a negative lower offset", String(bound));
     window_up_ = bound;
   }
 

--- a/src/tests/class_tests/openms/source/RangeUtils_test.cpp
+++ b/src/tests/class_tests/openms/source/RangeUtils_test.cpp
@@ -378,6 +378,58 @@ START_SECTION((bool operator()(const SpectrumType& s) const))
 
 END_SECTION
 
+
+
+//InPrecursorMZRange
+
+IsInIsolationWindow<MSSpectrum<> >* ptr500 = 0;
+IsInIsolationWindow<MSSpectrum<> >* nullPointer500 = 0;
+START_SECTION((IsInIsolationWindow(const double& mz_left, const double& mz_right, bool reverse = false)))
+  ptr500 = new IsInIsolationWindow<MSSpectrum<> >(ListUtils::create<double>("100.0, 200.0"));
+  TEST_NOT_EQUAL(ptr500, nullPointer500)
+END_SECTION
+
+START_SECTION(([EXTRA]~IsInIsolationWindow()))
+  delete ptr500;
+END_SECTION
+
+START_SECTION((bool operator()(const SpectrumType& s) const))
+  IsInIsolationWindow<MSSpectrum<> > s(ListUtils::create<double>("300.0, 100.0, 200.0, 400.0"));    // unsorted on purpose
+  IsInIsolationWindow<MSSpectrum<> > s2(ListUtils::create<double>("300.0, 100.0, 200.0, 400.0"), true);
+  
+  MSSpectrum<> spec;
+  spec.setMSLevel(2);
+  std::vector<Precursor> pc;
+  Precursor p;
+  p.setMZ(200.3);
+  p.setIsolationWindowLowerOffset(0.5);
+  p.setIsolationWindowUpperOffset(0.5);
+  pc.push_back(p);
+  spec.setPrecursors(pc);
+
+  TEST_EQUAL(s(spec), true);
+  TEST_EQUAL(s2(spec), false);
+
+  // outside of allowed window
+  p.setMZ(201.1);
+  pc[0] = p;
+  spec.setPrecursors(pc);
+
+  TEST_EQUAL(s(spec), false);
+  TEST_EQUAL(s2(spec), true);
+
+  // multiple precursors:
+  // adding second which is within limits... so it's a hit (any PC must match)
+  p.setMZ(299.9);
+  pc.push_back(p);
+  spec.setPrecursors(pc);
+
+  TEST_EQUAL(s(spec), true);
+  TEST_EQUAL(s2(spec), false);
+
+END_SECTION
+
+
 //HasScanPolarity
 
 HasScanPolarity<MSSpectrum<> >* ptr51 = 0;

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -456,15 +456,15 @@ set_tests_properties("TOPP_FileFilter_26_out1" PROPERTIES DEPENDS "TOPP_FileFilt
 add_test("TOPP_FileFilter_27" ${TOPP_BIN_PATH}/FileFilter -test -in ${DATA_DIR_TOPP}/FileFilter_25_input.mzML.gz -id:blacklist ${DATA_DIR_TOPP}/FileFilter_25_input.idXML -out FileFilter_27.tmp  -id:mz 0.05 -id:rt 1 )
 set_tests_properties("TOPP_FileFilter_27" PROPERTIES WILL_FAIL 1) ## has 2 imperfect matches
 
-add_test("TOPP_FileFilter_28" ${TOPP_BIN_PATH}/FileFilter -test -in ${DATA_DIR_TOPP}/FileFilter_28_input.mzML.gz -pc_mz 832:836 -out FileFilter_28.tmp -peak_options:level 2) ## only one MS2 remaining
+add_test("TOPP_FileFilter_28" ${TOPP_BIN_PATH}/FileFilter -test -in ${DATA_DIR_TOPP}/FileFilter_28_input.mzML.gz -peak_options:pc_mz_range 832:836 -out FileFilter_28.tmp -peak_options:level 2) ## only one MS2 remaining
 add_test("TOPP_FileFilter_28_out1" ${DIFF} -whitelist "id=" "href=" -in1 FileFilter_28.tmp -in2 ${DATA_DIR_TOPP}/FileFilter_28_output.mzML )
 set_tests_properties("TOPP_FileFilter_28_out1" PROPERTIES DEPENDS "TOPP_FileFilter_28")
 
-add_test("TOPP_FileFilter_29" ${TOPP_BIN_PATH}/FileFilter -test -in ${DATA_DIR_TOPP}/FileFilter_28_input.mzML.gz -pc_mz 832:836 -out FileFilter_29.tmp -peak_options:level 1 2) ## only one MS2 remaining, and lots of MS1
+add_test("TOPP_FileFilter_29" ${TOPP_BIN_PATH}/FileFilter -test -in ${DATA_DIR_TOPP}/FileFilter_28_input.mzML.gz -peak_options:pc_mz_range 832:836 -out FileFilter_29.tmp -peak_options:level 1 2) ## only one MS2 remaining, and lots of MS1
 add_test("TOPP_FileFilter_29_out1" ${DIFF} -whitelist "id=" "href=" -in1 FileFilter_29.tmp -in2 ${DATA_DIR_TOPP}/FileFilter_29_output.mzML )
 set_tests_properties("TOPP_FileFilter_29_out1" PROPERTIES DEPENDS "TOPP_FileFilter_29")
 
-add_test("TOPP_FileFilter_30" ${TOPP_BIN_PATH}/FileFilter -test -in ${DATA_DIR_TOPP}/FileFilter_28_input.mzML.gz -pc_mz 832:836 -out FileFilter_30.tmp -peak_options:level 1 2) ## no MS2 remaining since -mz filter empties it and it will be deleted, and lots of MS1
+add_test("TOPP_FileFilter_30" ${TOPP_BIN_PATH}/FileFilter -test -in ${DATA_DIR_TOPP}/FileFilter_28_input.mzML.gz -peak_options:pc_mz_range 832:836 -out FileFilter_30.tmp -peak_options:level 1 2) ## no MS2 remaining since -mz filter empties it and it will be deleted, and lots of MS1
 add_test("TOPP_FileFilter_30_out1" ${DIFF} -whitelist "id=" "href=" -in1 FileFilter_30.tmp -in2 ${DATA_DIR_TOPP}/FileFilter_30_output.mzML )
 set_tests_properties("TOPP_FileFilter_30_out1" PROPERTIES DEPENDS "TOPP_FileFilter_30")
 


### PR DESCRIPTION
additional option '-peak_options:pc_mz_list' for TOPP:FileFilter allows to provide a mass list.
All MS2 spectra whose precursor covers any of the given values is retained.
Other MS2 spectra are discarded.

Also:
 - renamed precursor mass range filter from '-pc_mz' to '-peak_options:pc_mz_range'