### PR TITLE
[FIX] add missing include

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/SMOOTHING/FastLowessSmoothing.h
+++ b/src/openms/include/OpenMS/FILTERING/SMOOTHING/FastLowessSmoothing.h
@@ -39,6 +39,7 @@
 #include <OpenMS/CONCEPT/Macros.h>
 #include <vector>
 #include <algorithm>    // std::min, std::max
+#include <functional>
 
 namespace OpenMS
 {


### PR DESCRIPTION
Compiling in debug mode (OSX 10.10.5, Apple LLVM version 7.0.0 (clang-700.0.72)) fails as std::greater is unknown.