### PR TITLE
PeptideIndexer performance optimizations

### DIFF
--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -722,6 +722,11 @@ protected:
         vector<Size> prot_DB_indexes; // store indexes that pass the filtering
         if (!SA_only)
         {
+          // Note for future developers: Creating a new StringSet is much faster
+          // than either filtering an existing one (via "removeValueById") or
+          // creating a Dependent StringSet (via "assignValueById"), at least
+          // with SeqAn 1.4!
+
           // search peptides which remained unidentified during Aho-Corasick:
           for (Size i = 0; i < length(pep_DB); ++i)
           {


### PR DESCRIPTION
Addresses issue #1824; see the discussion there. Changes implemented:
- The tolerant search does not need to run at all if no mismatches or matches to ambiguous amino acids (AAAs) are allowed, i.e. if the parameters "mismatches_max" and "aaa_max" are both zero.
- If only AAAs are allowed during the tolerant search, only proteins with AAAs need to be considered.

This PR clashes with #1833. I'll update it when #1833 is merged.