### PR TITLE
Fix phospho scoring

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -113,21 +113,27 @@ class OPENMS_DLLAPI AScore
         {
           //check mz2 until no match
           ++first2;
-          int ret = compareMZ_(mz1, first2->getMZ(), fragment_mass_tolerance, fragment_mass_unit_ppm);
-          while (ret == 0)
+          if (first2 != last2)
           {
-            ++first2;
-            ret = compareMZ_(mz1, first2->getMZ(), fragment_mass_tolerance, fragment_mass_unit_ppm);
+            int ret = compareMZ_(mz1, first2->getMZ(), fragment_mass_tolerance, fragment_mass_unit_ppm);
+            while (ret == 0 && first2 != last2)
+            {
+              ++first2;
+              ret = compareMZ_(mz1, first2->getMZ(), fragment_mass_tolerance, fragment_mass_unit_ppm);
+            }
           }
           
           //check mz1 until no match
           ++first1;
-          ret = compareMZ_(first1->getMZ(), mz2, fragment_mass_tolerance, fragment_mass_unit_ppm);
-          while (ret == 0)
+          if (first1 != last1)
           {
-            ++first1;
-            ret = compareMZ_(first1->getMZ(), mz2, fragment_mass_tolerance, fragment_mass_unit_ppm);
-          }          
+            int ret = compareMZ_(first1->getMZ(), mz2, fragment_mass_tolerance, fragment_mass_unit_ppm);
+            while (ret == 0 && first1 != last1)
+            {
+              ++first1;
+              ret = compareMZ_(first1->getMZ(), mz2, fragment_mass_tolerance, fragment_mass_unit_ppm);
+            }
+          }
         }
       }
       return std::copy(first1, last1, result);

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -38,6 +38,7 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/ANALYSIS/RNPXL/PScore.h>
+#include <limits>
 #include <vector>
 
 namespace OpenMS
@@ -152,9 +153,6 @@ class OPENMS_DLLAPI AScore
     
     /// Create theoretical spectra with all combinations with the number of phosphorylation events
     std::vector<RichPeakSpectrum> createTheoreticalSpectra_(const std::vector<std::vector<Size> > & permutations, const AASequence & seq_without_phospho) const;
-    
-    /// Create theoretical spectrum for sequence without phospho event
-    std::vector<RichPeakSpectrum> createTheoreticalSpectra_(const AASequence & seq_without_phospho) const;
     
     /// Pick top 10 intensity peaks for each 100 Da windows
     std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrum_(PeakSpectrum & real_spectrum) const;

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -81,7 +81,7 @@ class OPENMS_DLLAPI AScore
 
         @note the original sequence is saved in the PeptideHits as MetaValue Search_engine_sequence.
     */
-    PeptideHit compute(const PeptideHit & hit, PeakSpectrum &real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
+    PeptideHit compute(const PeptideHit & hit, PeakSpectrum &real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm, Size max_peptide_len = 60, Size max_num_perm = 16384);
 
   protected:
   

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -169,9 +169,7 @@ namespace OpenMS
         LOG_DEBUG << "\tfirst - N: " << N << ",p: " << p << ",n: " << n_first << ", score: " << score_first << std::endl;
         LOG_DEBUG << "\tsecond - N: " << N2 << ",p: " << p << ",n: " << n_second << ", score: " << score_second << std::endl;
         
-        //double AScore_first = score_first - score_second;      
         Ascore = score_first - score_second;
-        //phospho.setMetaValue("AScore_" + String(rank), AScore_first);
         LOG_DEBUG << "\tAscore_" << rank << ": " << Ascore << std::endl;
         
         if (Ascore < best_Ascore)
@@ -360,7 +358,6 @@ namespace OpenMS
         }
       }
     }
-    //return n;
     return th_peaks_matches.size();
   }
 

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -122,12 +122,10 @@ namespace OpenMS
     
     double peptide1_score = rev->first;
     phospho.setMetaValue("AScore_pep_score", peptide1_score); // initialize score with highest peptide score (aka highest weighted score)
-    //std::cout << "SEQ1: " << th_spectra[rev->second].getName() << ", score: " << peptide1_score << std::endl;
     
     rev++;
     String seq2 = th_spectra[rev->second].getName();
     double peptide2_score = rev->first;
-    //std::cout << "SEQ2: " << th_spectra[rev->second].getName() << ", score: " << peptide2_score << std::endl;
     
     vector<ProbablePhosphoSites> phospho_sites;
     determineHighestScoringPermutations_(peptide_site_scores, phospho_sites, permutations, ranking);
@@ -152,7 +150,6 @@ namespace OpenMS
         Size n_first = 0; // number of matching peaks for first peptide
         for (Size window_idx = 0; window_idx != windows_top10.size(); ++window_idx) // for each 100 m/z window
         {
-          //std::cout << "window idx = " << window_idx << std::endl;
           n_first += numberOfMatchedIons_(site_determining_ions[0], windows_top10[window_idx], s_it->peak_depth, fragment_mass_tolerance, fragment_mass_unit_ppm);        
         }
         double P_first = computeCumulativeScore_(N, n_first, p);
@@ -160,7 +157,6 @@ namespace OpenMS
         Size n_second = 0; // number of matching peaks for second peptide
         for (Size window_idx = 0; window_idx <  windows_top10.size(); ++window_idx) //each 100 m/z window
         {
-          //std::cout << "window idx = " << window_idx << std::endl;
           n_second += numberOfMatchedIons_(site_determining_ions[1], windows_top10[window_idx], s_it->peak_depth, fragment_mass_tolerance, fragment_mass_unit_ppm);        
         }
         Size N2 = site_determining_ions[1].size(); // all possibilities have the same number so take the first one

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -73,7 +73,7 @@ namespace OpenMS
     Size number_of_phosphorylation_events = numberOfPhosphoEvents_(sequence_str);
     AASequence seq_without_phospho = removePhosphositesFromSequence_(sequence_str);
     
-    if (seq_without_phospho.toString().size() > max_peptide_len)
+    if (seq_without_phospho.toUnmodifiedString().size() > max_peptide_len)
     {
       LOG_DEBUG << "\tcalculation aborted: peptide too long: " << seq_without_phospho.toString() << std::endl;
       return phospho;

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -90,11 +90,6 @@ class AScoreTest : public AScore
       return createTheoreticalSpectra_(permutations, seq_without_phospho);
     }
     
-    std::vector<RichPeakSpectrum> createTheoreticalSpectraTest_(const AASequence & seq_without_phospho) const
-    {
-      return createTheoreticalSpectra_(seq_without_phospho);
-    }
-    
     std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrumTest_(PeakSpectrum & real_spectrum) const
     {
       return peakPickingPerWindowsInSpectrum_(real_spectrum);
@@ -723,18 +718,6 @@ START_SECTION(std::vector<RichPeakSpectrum> createTheoreticalSpectraTest_(const 
   TEST_REAL_SIMILAR(th_spectra[4][21].getMZ(), 1352.57723);
   
   th_spectra.clear();
-  
-  // create theoretical spectra with phospho event
-  th_spectra = ptr_test->createTheoreticalSpectraTest_(seq_without_phospho);
-  TEST_EQUAL(th_spectra.size(),1);
-  TEST_EQUAL(th_spectra[0].getName(),seq_without_phospho.toString());
-  
-  // without phospho event
-  vector<RichPeakSpectrum> th_spectra2(ptr_test->createTheoreticalSpectraTest_(AASequence::fromString("QSSVTQSK")));
-  TEST_EQUAL(th_spectra2[0].getName(),"QSSVTQSK");
-  TEST_REAL_SIMILAR(th_spectra2[0][2].getMZ(), 234.14543);
-  TEST_REAL_SIMILAR(th_spectra2[0][11].getMZ(), 718.33720);
-  TEST_REAL_SIMILAR(th_spectra2[0][12].getMZ(), 736.38415);
 }
 END_SECTION 
 

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -711,7 +711,6 @@ END_SECTION
 // of best peptide
 START_SECTION(calculateCumulativeBinominalProbabilityScore)
 {
-  std::cout << std::endl;
   double fragment_mass_tolerance = 0.5;
   bool fragment_mass_unit_ppm = false;
   

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -28,7 +28,7 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer:	David Wojnar $
+// $Maintainer:	Petra Gutenbrunner $
 // $Authors: David Wojnar, Petra Gutenbrunner $
 // --------------------------------------------------------------------------
 
@@ -553,6 +553,51 @@ START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<RichPeakSpectrum
   TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),917.403)
   TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),290.135)
   TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),997.37)
+  
+  //=============================================================================
+  
+  //ATPGNLGSSVLMY(Phospho)K; ATPGNLGSS(Phospho)VLMYK
+  th_s.clear();
+  seq = AASequence::fromString("ATPGNLGSSVLMYK");
+  candidates.seq_1 = 0;
+  candidates.seq_2 = 1;
+  candidates.first = 12;
+  candidates.second = 8;
+  
+  p.clear();
+  perm.clear();
+  perm.push_back(candidates.first);
+  p.push_back(perm);
+
+  perm.clear();
+  perm.push_back(candidates.second);
+  p.push_back(perm);
+  
+  th_s = ptr_test->createTheoreticalSpectraTest_(p, seq);
+  
+  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
+  TEST_EQUAL(site_determining_ions.size(),2)
+  TEST_EQUAL(site_determining_ions[0].size(),8)
+  TEST_EQUAL(site_determining_ions[1].size(),4)
+  
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),390.142)
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),1128.57 )
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),310.176)
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),1208.54)
+    
+  candidates.seq_1 = 1;
+  candidates.seq_2 = 0;
+  candidates.first = 8;
+  candidates.second = 12;
+  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
+  TEST_EQUAL(site_determining_ions.size(),2)
+  TEST_EQUAL(site_determining_ions[0].size(),4)
+  TEST_EQUAL(site_determining_ions[1].size(),8)
+
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),390.142)
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),1128.57 )
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),310.176)
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),1208.54)
 }
 END_SECTION
 
@@ -743,7 +788,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit & hit, PeakSpectrum & 
   hit1 = ptr_test->compute(hit1, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
   
   // http://ascore.med.harvard.edu/ascore.html result=3.51, sequence=QSSVT*QSK
-  TEST_REAL_SIMILAR(static_cast<double>(hit1.getMetaValue("AScore_1")), 11.099601202339);
+  TEST_REAL_SIMILAR(static_cast<double>(hit1.getMetaValue("AScore_1")), 9.40409359086883);
   TEST_EQUAL(hit1.getSequence().toString(),"QSS(Phospho)VTQSK");
   
   // ===========================================================================
@@ -753,7 +798,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit & hit, PeakSpectrum & 
   hit2 = ptr_test->compute(hit2, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
   
   // http://ascore.med.harvard.edu/ascore.html result=21.3
-  TEST_REAL_SIMILAR(static_cast<double>(hit2.getMetaValue("AScore_1")), 22.8513147929718);
+  TEST_REAL_SIMILAR(static_cast<double>(hit2.getMetaValue("AScore_1")), 20.4116482719882);
   TEST_EQUAL(hit2.getSequence().toString(),"RIRLT(Phospho)ATTR");
   
   // ===========================================================================
@@ -777,7 +822,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit & hit, PeakSpectrum & 
   hit4 = ptr_test->compute(hit4, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
-  TEST_REAL_SIMILAR(static_cast<double>(hit4.getMetaValue("AScore_1")), 22.3745512581164);
+  TEST_REAL_SIMILAR(static_cast<double>(hit4.getMetaValue("AScore_1")), 20.1669211754322);
   TEST_EQUAL(hit4.getSequence().toString(),"ATPGNLGSSVLHS(Phospho)K");
   
   // ===========================================================================
@@ -792,7 +837,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit & hit, PeakSpectrum & 
   hit5 = ptr_test->compute(hit5, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
   
   // http://ascore.med.harvard.edu/ascore.html result=3.51, sequence=QSSVT*QSK
-  TEST_REAL_SIMILAR(static_cast<double>(hit5.getMetaValue("AScore_1")), 11.099601202339);
+  TEST_REAL_SIMILAR(static_cast<double>(hit5.getMetaValue("AScore_1")), 9.40409359086883);
   TEST_EQUAL(hit5.getSequence().toString(),"QSS(Phospho)VTQSK");
   
   fragment_mass_tolerance = 70; // 0.05 Da were converted to ppm based on a small peptide
@@ -804,7 +849,7 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit & hit, PeakSpectrum & 
   hit6 = ptr_test->compute(hit6, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
-  TEST_REAL_SIMILAR(static_cast<double>(hit6.getMetaValue("AScore_1")), 22.3745512581164);
+  TEST_REAL_SIMILAR(static_cast<double>(hit6.getMetaValue("AScore_1")), 20.1669211754322);
   TEST_EQUAL(hit6.getSequence().toString(),"ATPGNLGSSVLHS(Phospho)K");  
 }
 END_SECTION 

--- a/src/topp/PhosphoScoring.cpp
+++ b/src/topp/PhosphoScoring.cpp
@@ -245,7 +245,13 @@ protected:
     fragment_mass_tolerance_unit_valid_strings.push_back("Da");
     fragment_mass_tolerance_unit_valid_strings.push_back("ppm");
     registerStringOption_("fragment_mass_unit", "<unit>", "Da", "Unit of fragment mass error", false, false);
-    setValidStrings_("fragment_mass_unit", fragment_mass_tolerance_unit_valid_strings);    
+    setValidStrings_("fragment_mass_unit", fragment_mass_tolerance_unit_valid_strings);  
+
+    registerIntOption_("max_peptide_length", "<num>", 40, "Restrict scoring to peptides with a length shorter than this value", false);
+    setMinInt_("max_peptide_length", 1);
+    
+    registerIntOption_("max_num_perm", "<num>", 16384, "Maximum number of permutations a sequence can have", false);
+    setMinInt_("max_num_perm", 1);
   }
   
   // If the score_type has a different name in the meta_values, it is not possible to find it.
@@ -278,6 +284,8 @@ protected:
     String out(getStringOption_("out"));
     double fragment_mass_tolerance(getDoubleOption_("fragment_mass_tolerance"));
     bool fragment_mass_unit_ppm = getStringOption_("fragment_mass_unit") == "Da" ? false : true;
+    Size max_peptide_len = getIntOption_("max_peptide_length");
+    Size max_num_perm = getIntOption_("max_num_perm");
     
     AScore ascore;
 
@@ -318,7 +326,7 @@ protected:
         LOG_DEBUG << "starting to compute AScore RT=" << pep_id->getRT() << " SEQUENCE: " << scored_hit.getSequence().toString() << std::endl;
         
         PeptideHit phospho_sites = scored_hit;
-        phospho_sites = ascore.compute(scored_hit, temp, fragment_mass_tolerance, fragment_mass_unit_ppm);
+        phospho_sites = ascore.compute(scored_hit, temp, fragment_mass_tolerance, fragment_mass_unit_ppm, max_peptide_len, max_num_perm);
         scored_peptides.push_back(phospho_sites);
       }
 


### PR DESCRIPTION
Following changes were necessary: 
* Limitations: if too many phosphorylation events and sites are in a peptide, the number of permutations gets extremely big. Because of this the calculation times takes extremely long and also the used memory is increasing rapidly. These limitations are now the same as in LuciPHOr.
* Adapt PhosphoScoring output format to LuciphorAdapter output format: the main score of the peptide hit is now the lowest AScore
* Per theoretical spectrum peak only one match to the experimental spectrum per window is allowed. Otherwise it can happen that the number of site determining ion matches are more than the number of site determining ion matches.
* Corrected calculation of number of matched peaks (iteration limit was set wrong)
if the peptide score of the two best scoring peptides is the same, Ascore is set to 0 because no further calculation is necessary, because the number of matched ions of the two peptides are the same. Therefore the algorithm can not tell which peptide is the better one. 
- Changes calculation of site determining ions:
  if two ion masses of the two best scoring theoretical spectra are matching, but another ion mass would also be within the tolerance, this ion within the tolerance should not become a site determining ion. Therefore I included a check if the next ions are also within the tolerance.

  Because of this the number of site determining ions of the two best scoring peptides can differ. Therefore for each peptide their specific number of site determining ions is used to calculate the cumulative binomial probability.

  E.g.: 441.209, 441.217 are all counted as one peak and 441.217 can not be seen as site determining ion
  441.209        441.209
  521.183        441.217

 If this is not considered minus Ascores can occur which is not correct. The scores should be >= 0.

- Test: Ascores changed because of different number of matching peaks
        Added test case for different number of site determining ions