### PR TITLE
change N- and C-terminal characters

### DIFF
--- a/src/openms/source/METADATA/PeptideEvidence.cpp
+++ b/src/openms/source/METADATA/PeptideEvidence.cpp
@@ -41,8 +41,8 @@ namespace OpenMS
   const int PeptideEvidence::UNKNOWN_POSITION = -1;
   const int PeptideEvidence::N_TERMINAL_POSITION = 0;
   const char PeptideEvidence::UNKNOWN_AA = 'X';
-  const char PeptideEvidence::N_TERMINAL_AA = '[';
-  const char PeptideEvidence::C_TERMINAL_AA = ']';
+  const char PeptideEvidence::N_TERMINAL_AA = '-';
+  const char PeptideEvidence::C_TERMINAL_AA = '-';
 
   PeptideEvidence::PeptideEvidence()
    : accession_(),

--- a/src/tests/topp/PeptideIndexer_10_output.idXML
+++ b/src/tests/topp/PeptideIndexer_10_output.idXML
@@ -13,13 +13,13 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="PEPTIDETTT" charge="2" aa_before="[ [" aa_after="] ]" start="0 0"  end="9 9" protein_refs="PH_0 PH_1" >
+			<PeptideHit score="40" sequence="PEPTIDETTT" charge="2" aa_before="- -" aa_after="- -" start="0 0"  end="9 9" protein_refs="PH_0 PH_1" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0" MZ="0" RT="0" >
-			<PeptideHit score="30" sequence="PEPTLDETTT" charge="2" aa_before="[ [" aa_after="] ]" start="0 0"  end="9 9" protein_refs="PH_0 PH_1" >
+			<PeptideHit score="30" sequence="PEPTLDETTT" charge="2" aa_before="- -" aa_after="- -" start="0 0"  end="9 9" protein_refs="PH_0 PH_1" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_12_out.idXML
+++ b/src/tests/topp/PeptideIndexer_12_out.idXML
@@ -30,17 +30,17 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="[" aa_after="]" start="0"  end="20" protein_refs="PH_2" >
+			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="-" aa_after="-" start="0"  end="20" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
+			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
+			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_14_out.idXML
+++ b/src/tests/topp/PeptideIndexer_14_out.idXML
@@ -19,13 +19,13 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="[ [" aa_after="] ]" start="0 0"  end="20 20" protein_refs="PH_1 PH_2" >
+			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="- -" aa_after="- -" start="0 0"  end="20 20" protein_refs="PH_1 PH_2" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -49,7 +49,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="SVGSMTVDMQR" charge="2" aa_before="[" aa_after="S" start="0"  end="10" protein_refs="PH_3" >
+			<PeptideHit score="0.0001" sequence="SVGSMTVDMQR" charge="2" aa_before="-" aa_after="S" start="0"  end="10" protein_refs="PH_3" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -57,7 +57,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="GWFD" charge="2" aa_before="R R K" aa_after="] ] ]" start="17 17 33"  end="20 20 36" protein_refs="PH_1 PH_2 PH_3" >
+			<PeptideHit score="0.0001" sequence="GWFD" charge="2" aa_before="R R K" aa_after="- - -" start="17 17 33"  end="20 20 36" protein_refs="PH_1 PH_2 PH_3" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_15_out.idXML
+++ b/src/tests/topp/PeptideIndexer_15_out.idXML
@@ -22,17 +22,17 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="[ [" aa_after="] ]" start="0 0"  end="20 20" protein_refs="PH_1 PH_2" >
+			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="- -" aa_after="- -" start="0 0"  end="20 20" protein_refs="PH_1 PH_2" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="TSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="TSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -52,7 +52,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="SVGSMTVDMQR" charge="2" aa_before="[ [" aa_after="S S" start="0 0"  end="10 10" protein_refs="PH_3 PH_4" >
+			<PeptideHit score="0.0001" sequence="SVGSMTVDMQR" charge="2" aa_before="- -" aa_after="S S" start="0 0"  end="10 10" protein_refs="PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
@@ -60,7 +60,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="GWFD" charge="2" aa_before="R R K K" aa_after="] ] ] ]" start="17 17 33 33"  end="20 20 36 36" protein_refs="PH_1 PH_2 PH_3 PH_4" >
+			<PeptideHit score="0.0001" sequence="GWFD" charge="2" aa_before="R R K K" aa_after="- - - -" start="17 17 33 33"  end="20 20 36 36" protein_refs="PH_1 PH_2 PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_16_out.idXML
+++ b/src/tests/topp/PeptideIndexer_16_out.idXML
@@ -25,21 +25,21 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="[ [" aa_after="] ]" start="0 0"  end="20 20" protein_refs="PH_1 PH_2" >
+			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="- -" aa_after="- -" start="0 0"  end="20 20" protein_refs="PH_1 PH_2" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="TSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="TSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="TTMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="TTMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -55,7 +55,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="SVGSMTVDMQR" charge="2" aa_before="[ [ [" aa_after="S S S" start="0 0 0"  end="10 10 10" protein_refs="PH_3 PH_4 PH_5" >
+			<PeptideHit score="0.0001" sequence="SVGSMTVDMQR" charge="2" aa_before="- - -" aa_after="S S S" start="0 0 0"  end="10 10 10" protein_refs="PH_3 PH_4 PH_5" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
@@ -63,7 +63,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="GWFD" charge="2" aa_before="R R K K K" aa_after="] ] ] ] ]" start="17 17 33 33 33"  end="20 20 36 36 36" protein_refs="PH_1 PH_2 PH_3 PH_4 PH_5" >
+			<PeptideHit score="0.0001" sequence="GWFD" charge="2" aa_before="R R K K K" aa_after="- - - - -" start="17 17 33 33 33"  end="20 20 36 36 36" protein_refs="PH_1 PH_2 PH_3 PH_4 PH_5" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_17_out.idXML
+++ b/src/tests/topp/PeptideIndexer_17_out.idXML
@@ -31,37 +31,37 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="[ [" aa_after="] ]" start="0 0"  end="20 20" protein_refs="PH_2 PH_3" >
+			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="- -" aa_after="- -" start="0 0"  end="20 20" protein_refs="PH_2 PH_3" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="GSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="TSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="TSMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="TTMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="TTMTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="TTTTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
-				<UserParam type="string" name="target_decoy" value="target"/>
-				<UserParam type="string" name="protein_references" value="unique"/>
-			</PeptideHit>
-		</PeptideIdentification>
-		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="TTTTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="[" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+			<PeptideHit score="0.0001" sequence="TTTTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="SVGSMTVDMQR" charge="2" aa_before="[ [ [ [" aa_after="S S S S" start="0 0 0 0"  end="10 10 10 10" protein_refs="PH_4 PH_5 PH_6 PH_7" >
+			<PeptideHit score="0.0001" sequence="TTTTVDMQEIGSTEMPYEVPTQPNATSASAGRGWFDGPSFK" charge="2" aa_before="-" aa_after="V" start="0"  end="40" protein_refs="PH_0" >
+				<UserParam type="string" name="target_decoy" value="target"/>
+				<UserParam type="string" name="protein_references" value="unique"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
+			<PeptideHit score="0.0001" sequence="SVGSMTVDMQR" charge="2" aa_before="- - - -" aa_after="S S S S" start="0 0 0 0"  end="10 10 10 10" protein_refs="PH_4 PH_5 PH_6 PH_7" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
@@ -69,7 +69,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="0.0001" sequence="GWFD" charge="2" aa_before="R R R K K K K" aa_after="] ] ] ] ] ] ]" start="22 17 17 33 33 33 33"  end="25 20 20 36 36 36 36" protein_refs="PH_1 PH_2 PH_3 PH_4 PH_5 PH_6 PH_7" >
+			<PeptideHit score="0.0001" sequence="GWFD" charge="2" aa_before="R R R K K K K" aa_after="- - - - - - -" start="22 17 17 33 33 33 33"  end="25 20 20 36 36 36 36" protein_refs="PH_1 PH_2 PH_3 PH_4 PH_5 PH_6 PH_7" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_1_out.idXML
+++ b/src/tests/topp/PeptideIndexer_1_out.idXML
@@ -35,21 +35,21 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="STFDFYQRRLVTLAESPRAPSP" charge="2" aa_after="G ]" start="227 4"  end="248 25" protein_refs="PH_0 PH_2" >
+			<PeptideHit score="40" sequence="STFDFYQRRLVTLAESPRAPSP" charge="2" aa_after="G -" start="227 4"  end="248 25" protein_refs="PH_0 PH_2" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="[ [ [" aa_after="] ] ]" start="0 0 0"  end="20 20 20" protein_refs="PH_3 PH_4 PH_6" >
+			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="- - -" aa_after="- - -" start="0 0 0"  end="20 20 20" protein_refs="PH_3 PH_4 PH_6" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_5 PH_7" >
+			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_5 PH_7" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_5 PH_7" >
+			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_5 PH_7" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_2_out.idXML
+++ b/src/tests/topp/PeptideIndexer_2_out.idXML
@@ -35,21 +35,21 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="STFDFYQRRLVTLAESPRAPSP" charge="2" aa_after="G ]" start="227 4"  end="248 25" protein_refs="PH_0 PH_2" >
+			<PeptideHit score="40" sequence="STFDFYQRRLVTLAESPRAPSP" charge="2" aa_after="G -" start="227 4"  end="248 25" protein_refs="PH_0 PH_2" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="[ [ [" aa_after="] ] ]" start="0 0 0"  end="20 20 20" protein_refs="PH_3 PH_4 PH_6" >
+			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="- - -" aa_after="- - -" start="0 0 0"  end="20 20 20" protein_refs="PH_3 PH_4 PH_6" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_5 PH_7" >
+			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_5 PH_7" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_5 PH_7" >
+			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_5 PH_7" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_3_out.idXML
+++ b/src/tests/topp/PeptideIndexer_3_out.idXML
@@ -41,21 +41,21 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="STFDFYQRRLVTLAESPRAPSP" charge="2" aa_after="G ]" start="227 4"  end="248 25" protein_refs="PH_0 PH_3" >
+			<PeptideHit score="40" sequence="STFDFYQRRLVTLAESPRAPSP" charge="2" aa_after="G -" start="227 4"  end="248 25" protein_refs="PH_0 PH_3" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="[ [ [" aa_after="] ] ]" start="0 0 0"  end="20 20 20" protein_refs="PH_5 PH_6 PH_8" >
+			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="- - -" aa_after="- - -" start="0 0 0"  end="20 20 20" protein_refs="PH_5 PH_6 PH_8" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_2 PH_7 PH_9" >
+			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_2 PH_7 PH_9" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_2 PH_7 PH_9" >
+			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_2 PH_7 PH_9" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_4_out.idXML
+++ b/src/tests/topp/PeptideIndexer_4_out.idXML
@@ -30,17 +30,17 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="[" aa_after="]" start="0"  end="20" protein_refs="PH_2" >
+			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="-" aa_after="-" start="0"  end="20" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
+			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
+			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_5_out.idXML
+++ b/src/tests/topp/PeptideIndexer_5_out.idXML
@@ -30,17 +30,17 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="[" aa_after="]" start="0"  end="20" protein_refs="PH_2" >
+			<PeptideHit score="40" sequence="EDQSC(Carboxymethyl)PSERRRAFSRLRFGPS" charge="2" aa_before="-" aa_after="-" start="0"  end="20" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
+			<PeptideHit score="40" sequence="EWATYTC(Carboxymethyl)VLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
+			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_3 PH_4" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_6_out.idXML
+++ b/src/tests/topp/PeptideIndexer_6_out.idXML
@@ -32,13 +32,13 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="[ [" aa_after="] ]" start="0 0"  end="20 20" protein_refs="PH_3 PH_5" >
+			<PeptideHit score="0.0001" sequence="EDQSCPSERRRAFSRLRXAAX" charge="2" aa_before="- -" aa_after="- -" start="0 0"  end="20 20" protein_refs="PH_3 PH_5" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="0.0001" sequence="SERRRAFSRLRXAAX" charge="2" aa_before="P P" aa_after="] ]" start="6 6"  end="20 20" protein_refs="PH_3 PH_5" >
+			<PeptideHit score="0.0001" sequence="SERRRAFSRLRXAAX" charge="2" aa_before="P P" aa_after="- -" start="6 6"  end="20 20" protein_refs="PH_3 PH_5" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
@@ -48,17 +48,17 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EDQSCPSERRRAFSRLRFGPS" charge="2" aa_before="[" aa_after="]" start="0"  end="20" protein_refs="PH_2" >
+			<PeptideHit score="40" sequence="EDQSCPSERRRAFSRLRFGPS" charge="2" aa_before="-" aa_after="-" start="0"  end="20" protein_refs="PH_2" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_4 PH_6" >
+			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_4 PH_6" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="[ A A" aa_after="] ] ]" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_4 PH_6" >
+			<PeptideHit score="40" sequence="EWATYTCVLGFHVYVPVR" charge="2" aa_before="- A A" aa_after="- - -" start="0 5 5"  end="17 22 22" protein_refs="PH_1 PH_4 PH_6" >
 				<UserParam type="string" name="target_decoy" value="target+decoy"/>
 				<UserParam type="string" name="protein_references" value="non-unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_7_out.idXML
+++ b/src/tests/topp/PeptideIndexer_7_out.idXML
@@ -13,17 +13,17 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="DFIANGER" charge="2" aa_before="[" aa_after="]" start="0"  end="7" protein_refs="PH_0" >
+			<PeptideHit score="40" sequence="DFIANGER" charge="2" aa_before="-" aa_after="-" start="0"  end="7" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="MBCDEFGK" charge="2" aa_before="[" aa_after="A" start="0"  end="7" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGK" charge="2" aa_before="-" aa_after="A" start="0"  end="7" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCR" charge="2" aa_before="[" aa_after="A" start="0"  end="11" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCR" charge="2" aa_before="-" aa_after="A" start="0"  end="11" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -35,7 +35,7 @@
 				<UserParam type="string" name="target_decoy" value=""/>
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="[" aa_after="]" start="0"  end="23" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="-" aa_after="-" start="0"  end="23" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -57,7 +57,7 @@
 				<UserParam type="string" name="target_decoy" value=""/>
 				<UserParam type="string" name="protein_references" value="unmatched"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="BCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="M" aa_after="]" start="1"  end="23" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="BCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="M" aa_after="-" start="1"  end="23" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_8_out.idXML
+++ b/src/tests/topp/PeptideIndexer_8_out.idXML
@@ -13,29 +13,29 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="DFIANGER" charge="2" aa_before="[" aa_after="]" start="0"  end="7" protein_refs="PH_0" >
+			<PeptideHit score="40" sequence="DFIANGER" charge="2" aa_before="-" aa_after="-" start="0"  end="7" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="MBCDEFGK" charge="2" aa_before="[" aa_after="A" start="0"  end="7" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGK" charge="2" aa_before="-" aa_after="A" start="0"  end="7" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCR" charge="2" aa_before="[" aa_after="A" start="0"  end="11" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCR" charge="2" aa_before="-" aa_after="A" start="0"  end="11" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCRA" charge="2" aa_before="[" aa_after="A" start="0"  end="12" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCRA" charge="2" aa_before="-" aa_after="A" start="0"  end="12" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAAR" charge="2" aa_before="[" aa_after="P" start="0"  end="18" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAAR" charge="2" aa_before="-" aa_after="P" start="0"  end="18" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="[" aa_after="]" start="0"  end="23" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="-" aa_after="-" start="0"  end="23" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -57,7 +57,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="BCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="M" aa_after="]" start="1"  end="23" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="BCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="M" aa_after="-" start="1"  end="23" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>

--- a/src/tests/topp/PeptideIndexer_9_out.idXML
+++ b/src/tests/topp/PeptideIndexer_9_out.idXML
@@ -13,29 +13,29 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="DFIANGER" charge="2" aa_before="[" aa_after="]" start="0"  end="7" protein_refs="PH_0" >
+			<PeptideHit score="40" sequence="DFIANGER" charge="2" aa_before="-" aa_after="-" start="0"  end="7" protein_refs="PH_0" >
 				<UserParam type="string" name="target_decoy" value="decoy"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="31.8621" MZ="0" RT="0" >
-			<PeptideHit score="40" sequence="MBCDEFGK" charge="2" aa_before="[" aa_after="A" start="0"  end="7" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGK" charge="2" aa_before="-" aa_after="A" start="0"  end="7" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCR" charge="2" aa_before="[" aa_after="A" start="0"  end="11" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCR" charge="2" aa_before="-" aa_after="A" start="0"  end="11" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCRA" charge="2" aa_before="[" aa_after="A" start="0"  end="12" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCRA" charge="2" aa_before="-" aa_after="A" start="0"  end="12" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAAR" charge="2" aa_before="[" aa_after="P" start="0"  end="18" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAAR" charge="2" aa_before="-" aa_after="P" start="0"  end="18" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="[" aa_after="]" start="0"  end="23" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="MBCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="-" aa_after="-" start="0"  end="23" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
@@ -57,7 +57,7 @@
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>
-			<PeptideHit score="40" sequence="BCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="M" aa_after="]" start="1"  end="23" protein_refs="PH_1" >
+			<PeptideHit score="40" sequence="BCDEFGKABCRAAAKAARPBBBB" charge="2" aa_before="M" aa_after="-" start="1"  end="23" protein_refs="PH_1" >
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="string" name="protein_references" value="unique"/>
 			</PeptideHit>


### PR DESCRIPTION
The N-terminal character `[` and C-terminal character `]` are changed to `-`. That allows for valid `mzid` export [1]. The distinction between `[` and `]` is superfluous. In https://github.com/OpenMS/OpenMS/issues/1792 we will also use a single character `.` for both termini.

[1] see `pre=` and `post=` in 6.46 https://github.com/HUPO-PSI/mzIdentML/blob/master/specification_document/specdoc1_1/mzIdentML1.1.1.doc