### PR TITLE
change of N- and C-terminal characters in mzid output

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -751,16 +751,16 @@ namespace OpenMS
               }
 
               String e;
-              String nc_termini = "-";
+              String nc_termini = "-";    // character for N- and C-termini as specified in mzIdentML
               e += "\t<PeptideEvidence id=\"" + pevid + "\" peptide_ref=\"" + pepid + "\" dBSequence_ref=\"" + dBSequence_ref + "\"";
 
               if (pe->getAAAfter() != PeptideEvidence::UNKNOWN_AA)
               {
-                e += " post=\"" + (pe->getAAAfter() == ']' ? nc_termini : String(pe->getAAAfter())) + "\"";
+                e += " post=\"" + (pe->getAAAfter() == PeptideEvidence::C_TERMINAL_AA ? nc_termini : String(pe->getAAAfter())) + "\"";
               }
               if (pe->getAABefore() != PeptideEvidence::UNKNOWN_AA)
               {
-                e += " pre=\"" + (pe->getAABefore() == '[' ? nc_termini : String(pe->getAABefore())) + "\"";
+                e += " pre=\"" + (pe->getAABefore() == PeptideEvidence::N_TERMINAL_AA ? nc_termini : String(pe->getAABefore())) + "\"";
               }
               if (pe->getStart() != PeptideEvidence::UNKNOWN_POSITION)
               {

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -755,11 +755,11 @@ namespace OpenMS
 
               if (pe->getAAAfter() != PeptideEvidence::UNKNOWN_AA)
               {
-                e += " post=\"" + String(pe->getAAAfter()) + "\"";
+                e += " post=\"" + (pe->getAAAfter() == ']' ? "-" : String(pe->getAAAfter())) + "\"";
               }
               if (pe->getAABefore() != PeptideEvidence::UNKNOWN_AA)
               {
-                e += " pre=\"" + String(pe->getAABefore()) + "\"";
+                e += " pre=\"" + (pe->getAABefore() == '[' ? "-" : String(pe->getAABefore())) + "\"";
               }
               if (pe->getStart() != PeptideEvidence::UNKNOWN_POSITION)
               {

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -751,15 +751,16 @@ namespace OpenMS
               }
 
               String e;
+              String nc_termini = "-";
               e += "\t<PeptideEvidence id=\"" + pevid + "\" peptide_ref=\"" + pepid + "\" dBSequence_ref=\"" + dBSequence_ref + "\"";
 
               if (pe->getAAAfter() != PeptideEvidence::UNKNOWN_AA)
               {
-                e += " post=\"" + (pe->getAAAfter() == ']' ? "-" : String(pe->getAAAfter())) + "\"";
+                e += " post=\"" + (pe->getAAAfter() == ']' ? nc_termini : String(pe->getAAAfter())) + "\"";
               }
               if (pe->getAABefore() != PeptideEvidence::UNKNOWN_AA)
               {
-                e += " pre=\"" + (pe->getAABefore() == '[' ? "-" : String(pe->getAABefore())) + "\"";
+                e += " pre=\"" + (pe->getAABefore() == '[' ? nc_termini : String(pe->getAABefore())) + "\"";
               }
               if (pe->getStart() != PeptideEvidence::UNKNOWN_POSITION)
               {


### PR DESCRIPTION
The N-terminal character `[` and C-terminal character `]` are changed to `-` in accordance with [1].

[1] see `pre=` and `post=` in 6.46 https://github.com/HUPO-PSI/mzIdentML/blob/master/specification_document/specdoc1_1/mzIdentML1.1.1.doc