### PR TITLE
ModificationParams and Enzymes section in mzid moved

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h
@@ -147,7 +147,7 @@ protected:
       //void writeSourceFile_(std::ostream& os, const String& id, const SourceFile& software);
 
       /// Helper method that writes the Enzymes
-      void writeEnyzme_(String& s, Enzyme enzy, UInt miss, UInt indent) const;
+      void writeEnzyme_(String& s, Enzyme enzy, UInt miss, UInt indent) const;
 
       /// Helper method that writes the modification search params
       void writeModParam_(String& s, const std::vector<String>& fixed, const std::vector<String>& variable, UInt indent) const;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -492,6 +492,8 @@ namespace OpenMS
         sip += String(3, '\t') + "<userParam name=\"" + "charges" + "\" unitName=\"" + "xsd:string" + "\" value=\"" + it->getSearchParameters().charges + "\"/>" + "\n";
 //        sip += String(3, '\t') + "<userParam name=\"" + "missed_cleavages" + "\" unitName=\"" + "xsd:integer" + "\" value=\"" + String(it->getSearchParameters().missed_cleavages) + "\"/>" + "\n";
         sip += String("\t\t</AdditionalSearchParams>\n");
+        writeModParam_(sip, it->getSearchParameters().fixed_modifications, it->getSearchParameters().variable_modifications, 2);
+        writeEnzyme_(sip, it->getSearchParameters().digestion_enzyme, it->getSearchParameters().missed_cleavages, 2);
         sip += String("\t\t<FragmentTolerance>\n");
         String unit_str = "unitCvRef=\"UO\" unitName=\"dalton\" unitAccession=\"UO:0000221\"";
         if (it->getSearchParameters().fragment_mass_tolerance_ppm)
@@ -512,8 +514,6 @@ namespace OpenMS
         sip += String("\t\t</ParentTolerance>\n");
         sip += String("\t\t<Threshold>\n\t\t\t") + thcv + "\n";
         sip += String("\t\t</Threshold>\n");
-        writeModParam_(sip, it->getSearchParameters().fixed_modifications, it->getSearchParameters().variable_modifications, 2);
-        writeEnzyme_(sip, it->getSearchParameters().digestion_enzyme, it->getSearchParameters().missed_cleavages, 2);
         sip += String("\t</SpectrumIdentificationProtocol>\n");
         sip_set.insert(sip);
         sil_2_date.insert(make_pair(sil_id, String(it->getDateTime().getDate() + "T" + it->getDateTime().getTime())));

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -494,6 +494,7 @@ namespace OpenMS
         sip += String("\t\t</AdditionalSearchParams>\n");
         writeModParam_(sip, it->getSearchParameters().fixed_modifications, it->getSearchParameters().variable_modifications, 2);
         writeEnzyme_(sip, it->getSearchParameters().digestion_enzyme, it->getSearchParameters().missed_cleavages, 2);
+        // TODO MassTable section
         sip += String("\t\t<FragmentTolerance>\n");
         String unit_str = "unitCvRef=\"UO\" unitName=\"dalton\" unitAccession=\"UO:0000221\"";
         if (it->getSearchParameters().fragment_mass_tolerance_ppm)

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -513,7 +513,7 @@ namespace OpenMS
         sip += String("\t\t<Threshold>\n\t\t\t") + thcv + "\n";
         sip += String("\t\t</Threshold>\n");
         writeModParam_(sip, it->getSearchParameters().fixed_modifications, it->getSearchParameters().variable_modifications, 2);
-        writeEnyzme_(sip, it->getSearchParameters().digestion_enzyme, it->getSearchParameters().missed_cleavages, 2);
+        writeEnzyme_(sip, it->getSearchParameters().digestion_enzyme, it->getSearchParameters().missed_cleavages, 2);
         sip += String("\t</SpectrumIdentificationProtocol>\n");
         sip_set.insert(sip);
         sil_2_date.insert(make_pair(sil_id, String(it->getDateTime().getDate() + "T" + it->getDateTime().getTime())));
@@ -1078,7 +1078,7 @@ namespace OpenMS
       }
     }
 
-    void MzIdentMLHandler::writeEnyzme_(String& s, Enzyme enzy, UInt miss, UInt indent) const
+    void MzIdentMLHandler::writeEnzyme_(String& s, Enzyme enzy, UInt miss, UInt indent) const
     {
       String cv_ns = cv_.name();
       s += String(indent, '\t') + "<Enzymes independent=\"false\">" + "\n";

--- a/src/tests/topp/IDFileConverter_9_output.mzid
+++ b/src/tests/topp/IDFileConverter_9_output.mzid
@@ -4,7 +4,7 @@
 	xmlns="http://psidev.info/psi/pi/mzIdentML/1.1"
 	version="1.1.0"
 	id="OpenMS_7276556891837796968"
-	creationDate="2015-10-22T18:14:55">
+	creationDate="2016-02-26T14:58:04">
 <cvList> 
  	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies"  uri="http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="3.15.0"></cv> 
  	<cv id="UNIMOD" fullName="UNIMOD"        uri="http://www.unimod.org/obo/unimod.obo"></cv> 
@@ -49,9 +49,9 @@
  	<Peptide id="PEP_8119044117483804262"> 
 		<PeptideSequence>PEPTIDERRR</PeptideSequence> 
 	</Peptide> 
- 	<PeptideEvidence id="PEV_10306100746905639127" peptide_ref="PEP_2927519776102075938" dBSequence_ref="PROT_15916652588957785155" isDecoy="0"/> 
-	<PeptideEvidence id="PEV_16250062551099875712" peptide_ref="PEP_17716858074023296841" dBSequence_ref="PROT_12999979801269632061" isDecoy="0"/> 
-	<PeptideEvidence id="PEV_16907355690727166316" peptide_ref="PEP_2927519776102075938" dBSequence_ref="PROT_13440783915218733453" post="B" pre="A" isDecoy="0"/> 
+ 	<PeptideEvidence id="PEV_10306100746905639127" peptide_ref="PEP_2927519776102075938" dBSequence_ref="PROT_15916652588957785155"/> 
+	<PeptideEvidence id="PEV_16250062551099875712" peptide_ref="PEP_17716858074023296841" dBSequence_ref="PROT_12999979801269632061"/> 
+	<PeptideEvidence id="PEV_16907355690727166316" peptide_ref="PEP_2927519776102075938" dBSequence_ref="PROT_13440783915218733453" post="B" pre="A"/> 
 </SequenceCollection>
 <AnalysisCollection>
 	<SpectrumIdentification id="SI_Mascot_2006-01-12T12:13:14" spectrumIdentificationProtocol_ref="SIP_17749660155506638460" spectrumIdentificationList_ref="SIL_4835329514588776807" activityDate="2006-01-12T12:13:14">
@@ -71,17 +71,6 @@
 		<AdditionalSearchParams>
 			<userParam name="charges" unitName="xsd:string" value="+1, +2"/>
 		</AdditionalSearchParams>
-		<FragmentTolerance>
-			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
-			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
-		</FragmentTolerance>
-		<ParentTolerance>
-			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="1"/>
-			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="1"/>
-		</ParentTolerance>
-		<Threshold>
-			<cvParam accession="MS:1001494" cvRef="PSI-MS" name="no threshold"/>
-		</Threshold>
 		<ModificationParams>
 		</ModificationParams>
 		<Enzymes independent="false">
@@ -91,14 +80,6 @@
 				</EnzymeName>
 			</Enzyme>
 		</Enzymes>
-	</SpectrumIdentificationProtocol>
-	<SpectrumIdentificationProtocol id="SIP_6408859317243173796" analysisSoftware_ref="SOF_5233264595117471314"> 
-		<SearchType>
-			<cvParam accession="MS:1001083" cvRef="PSI-MS" name="ms-ms search"/> 
-		</SearchType>
-		<AdditionalSearchParams>
-			<userParam name="charges" unitName="xsd:string" value="+1, +2, +3"/>
-		</AdditionalSearchParams>
 		<FragmentTolerance>
 			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
 			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
@@ -110,6 +91,14 @@
 		<Threshold>
 			<cvParam accession="MS:1001494" cvRef="PSI-MS" name="no threshold"/>
 		</Threshold>
+	</SpectrumIdentificationProtocol>
+	<SpectrumIdentificationProtocol id="SIP_6408859317243173796" analysisSoftware_ref="SOF_5233264595117471314"> 
+		<SearchType>
+			<cvParam accession="MS:1001083" cvRef="PSI-MS" name="ms-ms search"/> 
+		</SearchType>
+		<AdditionalSearchParams>
+			<userParam name="charges" unitName="xsd:string" value="+1, +2, +3"/>
+		</AdditionalSearchParams>
 		<ModificationParams>
 			<SearchModification fixedMod="true" massDelta="0" residues="C">
 				<cvParam accession="UNIMOD:4" cvRef="PSI-MS" name="Carbamidomethyl"/>
@@ -131,6 +120,17 @@
 				</EnzymeName>
 			</Enzyme>
 		</Enzymes>
+		<FragmentTolerance>
+			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
+			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="0.3"/>
+		</FragmentTolerance>
+		<ParentTolerance>
+			<cvParam accession="MS:1001412" name="search tolerance plus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="1"/>
+			<cvParam accession="MS:1001413" name="search tolerance minus value" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" cvRef="PSI-MS" value="1"/>
+		</ParentTolerance>
+		<Threshold>
+			<cvParam accession="MS:1001494" cvRef="PSI-MS" name="no threshold"/>
+		</Threshold>
 	</SpectrumIdentificationProtocol>
 </AnalysisProtocolCollection>
 <DataCollection>


### PR DESCRIPTION
The `<ModificationParams>` and `<Enzymes>` sections were moved to the correct positions.
Required for valid `mzid`.