### PR TITLE
[FIX] fix XML parsing in MzMLSpectrumDecoder

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/Base64.h
+++ b/src/openms/include/OpenMS/FORMAT/Base64.h
@@ -416,6 +416,10 @@ private:
     {
       return;
     }
+    if (in.size() % 4 != 0)
+    {
+      throw Exception::ConversionError(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Malformed base64 input, length is not a multiple of 4.");
+    }
 
     Size src_size = in.size();
     // last one or two '=' are skipped if contained

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSpectrumDecoder.cpp
@@ -213,6 +213,7 @@ namespace OpenMS
     //  - binary (1)
     xercesc::DOMNodeList* index_elems = indexListNode->getChildNodes();
     const  XMLSize_t nodeCount_ = index_elems->getLength();
+    bool has_binary_tag = false;
     for (XMLSize_t j = 0; j < nodeCount_; ++j)
     {
       xercesc::DOMNode* currentNode = index_elems->item(j);
@@ -222,7 +223,25 @@ namespace OpenMS
         xercesc::DOMElement* currentElement = dynamic_cast<xercesc::DOMElement*>(currentNode);
         if (xercesc::XMLString::equals(currentElement->getTagName(), TAG_binary))
         {
+          // Found the <binary> tag
+          has_binary_tag = true;
+
+          // Skip any empty <binary></binar> tags
+          if (!currentNode->hasChildNodes())
+          {
+            continue;
+          }
+
+          // Valid mzML does not have any other child nodes except text
+          if (currentNode->getChildNodes()->getLength() != 1)
+          {
+            throw Exception::ParseError(__FILE__, __LINE__, __PRETTY_FUNCTION__, 
+                "", "Invalid XML: 'binary' element can only have a single, text node child element.");
+          }
+
+          // Now we know that the <binary> node has exactly one single child node, the text that we want!
           xercesc::DOMNode* textNode_ = currentNode->getFirstChild();
+
           if (textNode_->getNodeType() == xercesc::DOMNode::TEXT_NODE)
           {
             xercesc::DOMText* textNode (static_cast<xercesc::DOMText*> (textNode_));
@@ -232,7 +251,7 @@ namespace OpenMS
           else
           {
             throw Exception::ParseError(__FILE__, __LINE__, __PRETTY_FUNCTION__, 
-                "", "Binary element can only have a single, text node child element.");
+                "", "Invalid XML: 'binary' element can only have a single, text node child element.");
           }
         }
         else if (xercesc::XMLString::equals(currentElement->getTagName(), TAG_CV))
@@ -257,6 +276,13 @@ namespace OpenMS
           //std::cout << "unhandled" << (string)xercesc::XMLString::transcode(currentNode->getNodeName() << std::endl;
         }
       }
+    }
+
+    // Throw exception upon invalid mzML: the <binary> tag is required inside <binaryDataArray>
+    if (!has_binary_tag)
+    {
+      throw Exception::ParseError(__FILE__, __LINE__, __PRETTY_FUNCTION__, 
+          "", "Invalid XML: 'binary' element needs to be present at least once inside 'binaryDataArray' element.");
     }
   }
 

--- a/src/tests/class_tests/openms/source/Base64_test.cpp
+++ b/src/tests/class_tests/openms/source/Base64_test.cpp
@@ -180,9 +180,17 @@ START_SECTION((template < typename ToType > void decode(const String &in, ByteOr
   b64.decode(src, Base64::BYTEORDER_BIGENDIAN, res);
   TEST_EQUAL(res.size(), 0)
 
+  // corrupted data
+  src = "whoPutMeHere:somecrazyperson,obviously!WhatifIcontaininvalidcharacterslikethese";
+  TEST_EXCEPTION(Exception::ConversionError, b64.decode(src, Base64::BYTEORDER_BIGENDIAN, res) );
+
+  // TODO : some error checking and handling
+  // currently there is no "safe" Base64 decoding that checks that all
+  // characters are actually valid and the string is actually encoding to
+  // floats.
+  // 
   // src = "Q A..A=="; // spaces and dots are not allowed
   // b64.decode(src, Base64::BYTEORDER_BIGENDIAN, res);
-  // TODO : some error checking and handling
   // TEST_EQUAL(res.size(), 0)
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/MzMLSpectrumDecoder_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLSpectrumDecoder_test.cpp
@@ -66,6 +66,7 @@ START_SECTION((~MzMLSpectrumDecoder()))
 }
 END_SECTION
 
+// Working example of parsing a spectrum
 START_SECTION(( void domParseSpectrum(const std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
 {
   ptr = new MzMLSpectrumDecoder();
@@ -99,9 +100,48 @@ START_SECTION(( void domParseSpectrum(const std::string& in, OpenMS::Interfaces:
 }
 END_SECTION
 
+// Working example of parsing a spectrum with some extra CV terms in there (should still work)
+START_SECTION(([EXTRA] void domParseSpectrum(const std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
+{
+  ptr = new MzMLSpectrumDecoder();
+  std::string testString = MULTI_LINE_STRING(
+      <spectrum index="2" id="index=2" defaultArrayLength="15">
+        <binaryDataArrayList count="2">
+          <binaryDataArray encodedLength="160" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+            <binary>AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxA</binary>
+          </binaryDataArray>
+          <binaryDataArray encodedLength="160" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <binary>AAAAAAAALkAAAAAAAAAsQAAAAAAAACpAAAAAAAAAKEAAAAAAAAAmQAAAAAAAACRAAAAAAAAAIkAAAAAAAAAgQAAAAAAAABxAAAAAAAAAGEAAAAAAAAAUQAAAAAAAABBAAAAAAAAACEAAAAAAAAAAQAAAAAAAAPA/</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+  );
+
+  OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
+  ptr->domParseSpectrum(testString, cptr);
+
+  TEST_EQUAL(cptr->getMZArray()->data.size(), 15)
+  TEST_EQUAL(cptr->getIntensityArray()->data.size(), 15)
+
+  TEST_REAL_SIMILAR(cptr->getMZArray()->data[7], 7)
+  TEST_REAL_SIMILAR(cptr->getIntensityArray()->data[7], 8)
+}
+END_SECTION
+
+// missing defaultArrayLength -> should give an exception of ParseError
 START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
 {
-  // missing defaultArrayLength -> should give an exception of ParseError
   ptr = new MzMLSpectrumDecoder();
   std::string testString = MULTI_LINE_STRING(
       <spectrum index="2" id="index=2">
@@ -127,6 +167,7 @@ START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces
 }
 END_SECTION
 
+// root tag is neither spectrum or chromatogram -> precondition violation
 START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
 {
   // root tag is neither spectrum or chromatogram
@@ -162,9 +203,9 @@ START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces
 }
 END_SECTION
 
+// no XML at all here ...  -> Exception
 START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
 {
-  // no XML at all here ... 
   ptr = new MzMLSpectrumDecoder();
   std::string testString = MULTI_LINE_STRING(
       Lorem ipsum
@@ -175,9 +216,34 @@ START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces
 }
 END_SECTION
 
+// Working example without intensity -> simply an empty spectrum
+START_SECTION(( void domParseSpectrum(const std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
+{
+  ptr = new MzMLSpectrumDecoder();
+  std::string testString = MULTI_LINE_STRING(
+      <spectrum index="2" id="index=2" defaultArrayLength="15">
+        <binaryDataArrayList count="2">
+          <binaryDataArray encodedLength="160" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+            <binary>AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxA</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+  );
+
+  OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
+  ptr->domParseSpectrum(testString, cptr);
+
+  TEST_EQUAL(cptr->getMZArray()->data.size(), 0)
+  TEST_EQUAL(cptr->getIntensityArray()->data.size(), 0)
+}
+END_SECTION
+
+// missing 64 bit float tag -> should throw Exception
 START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
 {
-  // missing 64 bit float tag
   ptr = new MzMLSpectrumDecoder();
   std::string testString = MULTI_LINE_STRING(
       <spectrum index="2" id="index=2" defaultArrayLength="15">
@@ -201,9 +267,160 @@ START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces
 }
 END_SECTION
 
+// This is a valid XML structure, but simply empty <binary></binary> -> empty spectra output
 START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
 {
-  // encode as int instead of float 
+  ptr = new MzMLSpectrumDecoder();
+  std::string testString = MULTI_LINE_STRING(
+      <spectrum index="2" id="index=2" defaultArrayLength="15">
+        <binaryDataArrayList count="3">
+          <binaryDataArray encodedLength="0" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+            <binary></binary>
+          </binaryDataArray>
+          <binaryDataArray encodedLength="160" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+            <binary></binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+  );
+
+  OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
+  ptr->domParseSpectrum(testString, cptr);
+
+  TEST_EQUAL(cptr->getMZArray()->data.size(), 0)
+  TEST_EQUAL(cptr->getIntensityArray()->data.size(), 0)
+}
+END_SECTION
+
+// Invalid XML (unclosed brackets) -> should throw Exception
+START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
+{
+  ptr = new MzMLSpectrumDecoder();
+  std::string testString = MULTI_LINE_STRING(
+      <spectrum index="2" id="index=2" defaultArrayLength="15">
+        <binaryDataArrayList count="3">
+          <binaryDataArray encodedLength="0" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+            <bina
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+  );
+
+  OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
+  TEST_EXCEPTION(Exception::ParseError,ptr->domParseSpectrum(testString, cptr))
+}
+END_SECTION
+
+// Invalid XML (unclosed brackets) -> should throw Exception
+START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
+{
+  ptr = new MzMLSpectrumDecoder();
+  std::string testString = MULTI_LINE_STRING(
+      <spectrum index="2" id="index=2" defaultArrayLength="15">
+        <binaryDataArrayList count="3">
+          <binaryDataArray encodedLength="0" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+            <cvParam cvRef="MS" accession="MS:100057
+            <binary>AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxA</binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>"
+  );
+
+  OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
+  TEST_EXCEPTION(Exception::ParseError,ptr->domParseSpectrum(testString, cptr))
+}
+END_SECTION
+
+// Invalid mzML (too much content inside <binary>) -> should throw Exception
+START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
+{
+  ptr = new MzMLSpectrumDecoder();
+  std::string testString = MULTI_LINE_STRING(
+      <spectrum index="2" id="index=2" defaultArrayLength="15">
+        <binaryDataArrayList count="3">
+          <binaryDataArray encodedLength="0" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+            <binary>
+              <whoPutMeHere>
+                some crazy person, obviously
+              </whoPutMeHere>
+            </binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+  );
+
+  OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
+  TEST_EXCEPTION(Exception::ParseError,ptr->domParseSpectrum(testString, cptr))
+}
+END_SECTION
+
+// Invalid mzML (missing <binary> tag)-> should throw Exception
+START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
+{
+  ptr = new MzMLSpectrumDecoder();
+  std::string testString = MULTI_LINE_STRING(
+      <spectrum index="2" id="index=2" defaultArrayLength="15">
+        <binaryDataArrayList count="3">
+          <binaryDataArray encodedLength="0" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+  );
+
+  OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
+  TEST_EXCEPTION(Exception::ParseError,ptr->domParseSpectrum(testString, cptr))
+}
+END_SECTION
+
+// Invalid content of <binary> -> empty spectrum
+START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
+{
+  ptr = new MzMLSpectrumDecoder();
+  std::string testString = MULTI_LINE_STRING(
+      <spectrum index="2" id="index=2" defaultArrayLength="15">
+        <binaryDataArrayList count="3">
+          <binaryDataArray encodedLength="0" >
+            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+            <binary>
+              whoPutMeHere: some crazy person, obviously! What if I contain invalid characters like these &- 
+            </binary>
+          </binaryDataArray>
+        </binaryDataArrayList>
+      </spectrum>
+  );
+
+  OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
+  ptr->domParseSpectrum(testString, cptr);
+
+  TEST_EQUAL(cptr->getMZArray()->data.size(), 0)
+  TEST_EQUAL(cptr->getIntensityArray()->data.size(), 0)
+}
+END_SECTION
+
+// encode as int instead of float -> throw Exception
+START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
+{
   ptr = new MzMLSpectrumDecoder();
   std::string testString = MULTI_LINE_STRING(
       <spectrum index="2" id="index=2" defaultArrayLength="15">
@@ -228,9 +445,9 @@ START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces
 }
 END_SECTION
 
+// missing m/z array -> no Exception but simply empty data
 START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces::SpectrumPtr & sptr) ))
 {
-  // missing m/z array 
   ptr = new MzMLSpectrumDecoder();
   std::string testString = MULTI_LINE_STRING(
       <spectrum index="2" id="index=2" defaultArrayLength="15">
@@ -299,7 +516,7 @@ START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces
 }
 END_SECTION
 
-/// Chromatogram
+// Working example of parsing a chromatogram
 START_SECTION(( void domParseChromatogram(const std::string& in, OpenMS::Interfaces::ChromatogramPtr & cptr) ))
 {
   ptr = new MzMLSpectrumDecoder();

--- a/src/tests/class_tests/openms/source/MzMLSpectrumDecoder_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLSpectrumDecoder_test.cpp
@@ -332,11 +332,11 @@ START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces
             <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
             <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
             <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
-            <cvParam cvRef="MS" accession="MS:100057
+            <cvParam cvRef="MS" accession="MS:100057"
             <binary>AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBAAAAAAAAAIkAAAAAAAAAkQAAAAAAAACZAAAAAAAAAKEAAAAAAAAAqQAAAAAAAACxA</binary>
           </binaryDataArray>
         </binaryDataArrayList>
-      </spectrum>"
+      </spectrum>
   );
 
   OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);

--- a/src/tests/class_tests/openms/source/MzMLSpectrumDecoder_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLSpectrumDecoder_test.cpp
@@ -411,10 +411,7 @@ START_SECTION(([EXTRA] void domParseSpectrum(std::string& in, OpenMS::Interfaces
   );
 
   OpenMS::Interfaces::SpectrumPtr cptr(new OpenMS::Interfaces::Spectrum);
-  ptr->domParseSpectrum(testString, cptr);
-
-  TEST_EQUAL(cptr->getMZArray()->data.size(), 0)
-  TEST_EQUAL(cptr->getIntensityArray()->data.size(), 0)
+  TEST_EXCEPTION(Exception::ConversionError, ptr->domParseSpectrum(testString, cptr) );
 }
 END_SECTION
 


### PR DESCRIPTION
- catch case of empty <binary> element
- ensure we have valid mzML with exactly one element inside <binary>
- ensure that <binary> is present
- add tests