### PR TITLE
[GUI] customizable TOPP[as/view] look and feel

### DIFF
--- a/share/OpenMS/GUISTYLE/qtStyleSheet.qss
+++ b/share/OpenMS/GUISTYLE/qtStyleSheet.qss
@@ -1,0 +1,9 @@
+
+/* for ALL widgets where items can be selected: make background more prominent when they loose focus (i.e. are not active) */
+
+*::item:selected:!active{
+  background-color: lightblue;
+}
+
+/* more customizations here */
+  

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
@@ -59,7 +59,6 @@
 
 //QT
 #include <QtGui/QApplication>
-#include <QtGui/QStyleFactory>
 #include <QtGui/QSplashScreen>
 #include <QtCore/QDir>
 
@@ -163,19 +162,6 @@ int main(int argc, const char** argv)
 
     QApplicationTOPP a(argc, const_cast<char**>(argv));
     a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
-    // set plastique style unless windows / mac style is available
-    if (QStyleFactory::keys().contains("windowsxp", Qt::CaseInsensitive))
-    {
-      a.setStyle("windowsxp");
-    }
-    else if (QStyleFactory::keys().contains("macintosh", Qt::CaseInsensitive))
-    {
-      a.setStyle("macintosh");
-    }
-    else if (QStyleFactory::keys().contains("plastique", Qt::CaseInsensitive))
-    {
-      a.setStyle("plastique");
-    }
 
     TOPPASBase* mw = new TOPPASBase();
     mw->show();

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPView.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPView.cpp
@@ -48,7 +48,6 @@
 */
 
 //QT
-#include <QtGui/QStyleFactory>
 #include <QtGui/QSplashScreen>
 #include <QMessageBox>
 
@@ -141,20 +140,6 @@ int main(int argc, const char** argv)
   {
     QApplicationTOPP a(argc, const_cast<char**>(argv));
     a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
-
-    //set plastique style unless windows / mac style is available
-    if (QStyleFactory::keys().contains("windowsxp", Qt::CaseInsensitive))
-    {
-      a.setStyle("windowsxp");
-    }
-    else if (QStyleFactory::keys().contains("macintosh", Qt::CaseInsensitive))
-    {
-      a.setStyle("macintosh");
-    }
-    else if (QStyleFactory::keys().contains("plastique", Qt::CaseInsensitive))
-    {
-      a.setStyle("plastique");
-    }
 
     TOPPViewBase* mw = new TOPPViewBase();
     a.connect(&a, SIGNAL(fileOpen(QString)), mw, SLOT(loadFile(QString)));

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.cpp
@@ -36,17 +36,18 @@
 #include <stdlib.h>
 
 #include <OpenMS/CONCEPT/Exception.h>
-#include <OpenMS/CONCEPT/LogStream.h>
-#include <OpenMS/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.h>
-
-#include <OpenMS/CONCEPT/ProgressLogger.h>
-#include <OpenMS/VISUAL/GUIProgressLoggerImpl.h>
 #include <OpenMS/CONCEPT/Factory.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.h>
+#include <OpenMS/VISUAL/GUIProgressLoggerImpl.h>
 
 //Qt
 #include <QtGui/QApplication>
+#include <QtGui/QStyleFactory>
 #include <QMessageBox>
 #include <QFileOpenEvent>
+
 
 namespace OpenMS
 {
@@ -56,6 +57,28 @@ namespace OpenMS
   {
     // register GUI ProgressLogger that can be used in GUI tools
     Factory<ProgressLogger::ProgressLoggerImpl>::registerProduct(GUIProgressLoggerImpl::getProductName(), &GUIProgressLoggerImpl::create);
+
+    // set plastique style unless windows / mac style is available
+    if (QStyleFactory::keys().contains("windowsxp", Qt::CaseInsensitive))
+    {
+      this->setStyle("windowsxp");
+    }
+    else if (QStyleFactory::keys().contains("macintosh", Qt::CaseInsensitive))
+    {
+      this->setStyle("macintosh");
+    }
+    else if (QStyleFactory::keys().contains("plastique", Qt::CaseInsensitive))
+    {
+      this->setStyle("plastique");
+    }
+
+    // customize look and feel via Qt style sheets
+    String filename = File::find("GUISTYLE/qtStyleSheet.qss");
+    QFile fh(filename.toQString());
+    fh.open(QFile::ReadOnly);
+    QString style_string = QLatin1String(fh.readAll());
+    std::cerr << "Content: " << style_string.toStdString() << "\n\n\n";
+    this->setStyleSheet(style_string);
   }
 
   QApplicationTOPP::~QApplicationTOPP()


### PR DESCRIPTION
 - introduce CSS-like stylesheets 
 - make background items more prominent (the initial reason to make this PR)

example (rows which are out of focus are not better visible -- so the user can select the next row more conveniently):
![css_background](https://cloud.githubusercontent.com/assets/6008722/13534287/aa13a5bc-e234-11e5-9f74-45a6d01a0c28.png)
