### PR TITLE
[FIX-#1740] MzTabExporter: modification "Phospho (ST)" throws error

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -173,6 +173,9 @@ public:
 
     /// get all modifications that can be used for identification searches
     void getAllSearchModifications(std::vector<String> & modifications);
+    
+    /// returns true if the modification exists
+    bool has(String modification) const;
 
 protected:
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h
@@ -36,6 +36,7 @@
 #define OPENMS_FORMAT_HANDLERS_MASCOTXMLHANDLER_H
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/DATASTRUCTURES/Map.h>
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
@@ -74,6 +75,9 @@ public:
 
       // Docu in base class
       virtual void characters(const XMLCh* const chars, const XMLSize_t /*length*/);
+      
+      /// Split modification search parameter if for more than one amino acid specified e.g. Phospho (ST)
+      static std::vector<String> splitModificationBySpecifiedAA(String mod);
 
 private:
 
@@ -96,6 +100,10 @@ private:
       String character_buffer_; ///< filled by MascotXMLHandler::characters
       String major_version_;
       String minor_version_;
+      
+      // list of modifications, which cannot be set as fixed and needs
+      // to be removed, because added from mascot as variable modification
+      std::vector<String> remove_fixed_mods_;
 
       /// Helper object for looking up RT information
       const SpectrumMetaDataLookup& lookup_;

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -199,6 +199,11 @@ namespace OpenMS
     }
     return **mods.begin();
   }
+  
+  bool ModificationsDB::has(String modification) const
+  {
+    return (modification_names_.has(modification)) ? true : false;
+  }
 
   const ResidueModification & ModificationsDB::getModification(const String & modification) const
   {

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -202,7 +202,7 @@ namespace OpenMS
   
   bool ModificationsDB::has(String modification) const
   {
-    return (modification_names_.has(modification)) ? true : false;
+    return modification_names_.has(modification);
   }
 
   const ResidueModification & ModificationsDB::getModification(const String & modification) const

--- a/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Nico Pfeifer $
-// $Authors: Nico Pfeifer, Chris Bielow, Hendrik Weisser $
+// $Authors: Nico Pfeifer, Chris Bielow, Hendrik Weisser, Petra Gutenbrunner $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h>
@@ -193,49 +193,60 @@ namespace OpenMS
       else if (tag_ == "pep_seq")
       {
         AASequence temp_aa_sequence = AASequence::fromString(character_buffer_.trim());
-
+        
         // if everything is just read from the MascotXML file
         if (modified_peptides_.empty())
         {
           // fixed modifications
           for (vector<String>::const_iterator it = search_parameters_.fixed_modifications.begin(); it != search_parameters_.fixed_modifications.end(); ++it)
           {
-            // e.g. Carboxymethyl (C)
             vector<String> mod_split;
             it->split(' ', mod_split);
-            if (mod_split.size() >= 2)
+            if (mod_split.size() < 2 || mod_split.size() > 3)
             {
-              // could be "(C-term)" or "(C-term X)" etc.
-              if (mod_split[1].hasPrefix("(C-term") || mod_split[1].hasPrefix("(Protein C-term"))
-              {
-                temp_aa_sequence.setCTerminalModification(mod_split[0]);
-              }
-              else
-              {
-                // could be "(N-term)" or "(N-term X)" etc.
-                if (mod_split[1].hasPrefix("(N-term") || mod_split[1].hasPrefix("(Protein N-term"))
-                {
-                  temp_aa_sequence.setNTerminalModification(mod_split[0]);
-                }
-                else
-                {
-                  String origin = mod_split[1];
-                  origin.remove(')');
-                  origin.remove('(');
-                  for (Size i = 0; i != temp_aa_sequence.size(); ++i)
-                  {
-                    // best way we can check; because origin can be e.g. (STY)
-                    if (origin.hasSubstring(temp_aa_sequence[i].getOneLetterCode()))
-                    {
-                      temp_aa_sequence.setModification(i, mod_split[0]);
-                    }
-                  }
-                }
-              }
+              error(LOAD, String("Cannot parse fixed modification '") + *it + "'");
             }
             else
             {
-              error(LOAD, String("Cannot parse fixed modification '") + *it + "'");
+              // C-term modification without specification or protein terminus
+              if (mod_split[1] == "(C-term)" || (mod_split[1] == "(Protein" && mod_split[2] == "C-term)"))
+              {
+                temp_aa_sequence.setCTerminalModification(mod_split[0]);
+              }
+              // N-term modification without specification or protein terminus
+              else if (mod_split[1] == "(N-term)" || (mod_split[1] == "(Protein" && mod_split[2] == "N-term)"))
+              {
+                temp_aa_sequence.setNTerminalModification(mod_split[0]);
+              }
+              // C-term modification for specific amino acid; e.g. <Modification> (N-term C)
+              else if ((mod_split[1] == "(C-term") && (mod_split.size() == 3))
+              {
+                if ((temp_aa_sequence.end() - 1)->getOneLetterCode() == mod_split[2].remove(')'))
+                {
+                  temp_aa_sequence.setCTerminalModification(mod_split[0]);
+                }
+              }
+              // N-term modification for specific amino acid; e.g. <Modification> (N-term C)
+              else if ((mod_split[1] == "(N-term") && (mod_split.size() == 3))
+              {
+                if (temp_aa_sequence.begin()->getOneLetterCode() == mod_split[2].remove(')'))
+                {
+                  temp_aa_sequence.setNTerminalModification(mod_split[0]);
+                }
+              }
+              else 
+              { // e.g. Carboxymethyl (C)
+                String AA = mod_split[1];
+                AA.remove(')');
+                AA.remove('(');
+                for (Size i = 0; i != temp_aa_sequence.size(); ++i)
+                {
+                  if (AA == temp_aa_sequence[i].getOneLetterCode())
+                  {
+                    temp_aa_sequence.setModification(i, mod_split[0]);
+                  }
+                }
+              }
             }
           }
         }
@@ -262,7 +273,10 @@ namespace OpenMS
         AASequence temp_aa_sequence = actual_peptide_hit_.getSequence();
         String temp_string = character_buffer_.trim();
         vector<String> parts;
-
+        
+        // E.g. seq: QKAAGSK, pos: 4.0000000.0 -> mod at position 4 in var_mods vector is n-terminal
+        // therefore it is not possible to split Phospho (ST) to Phospho (S), Phospho (T) before this,
+        // because the original order is required
         temp_string.split('.', parts);
         if (parts.size() == 3)
         {
@@ -431,7 +445,19 @@ namespace OpenMS
         if (search_parameters_.fixed_modifications.empty())
         {
           String temp_string = (character_buffer_.trim());
-          temp_string.split(',', search_parameters_.fixed_modifications);
+          vector<String> tmp_mods;
+          temp_string.split(',', tmp_mods);
+          
+          for (vector<String>::const_iterator it = tmp_mods.begin(); it != tmp_mods.end(); ++it)
+          {
+            // check if modification is not on the remove list
+            if (std::find(remove_fixed_mods_.begin(), remove_fixed_mods_.end(), *it) == remove_fixed_mods_.end())
+            {
+              // split because e.g. Phospho (ST)
+              vector<String> mods_split = splitModificationBySpecifiedAA(*it);
+              search_parameters_.fixed_modifications.insert(search_parameters_.fixed_modifications.end(), mods_split.begin(), mods_split.end());
+            }
+          }
         }
       }
       else if (tag_ == "IT_MODS")
@@ -443,7 +469,15 @@ namespace OpenMS
         if (search_parameters_.variable_modifications.empty())
         {
           String temp_string = (character_buffer_.trim());
-          temp_string.split(',', search_parameters_.variable_modifications);
+          vector<String> tmp_mods;
+          temp_string.split(',', tmp_mods);
+          
+          for (vector<String>::const_iterator it = tmp_mods.begin(); it != tmp_mods.end(); ++it)
+          {
+            // split because e.g. Phospho (ST)
+            vector<String> mods_split = splitModificationBySpecifiedAA(*it);
+            search_parameters_.variable_modifications.insert(search_parameters_.variable_modifications.end(), mods_split.begin(), mods_split.end());
+          }
         }
       }
       else if (tag_ == "CLE")
@@ -478,19 +512,48 @@ namespace OpenMS
            || (tags_open_.size() >= 2 &&
                tags_open_[tags_open_.size() - 2] == "variable_mods"))
         {
+          // e.g. Phospho (ST) cannot be split for variable modifications at this point, because the order of
+          // variable modifications needs to be preserved. Split before search parameters are set.
           search_parameters_.variable_modifications.push_back(character_buffer_.trim());
           // cerr << "var. mod. added: " << search_parameters_.variable_modifications.back() << "\n";
         }
         else if (tags_open_.size() >= 2 &&
                  tags_open_[tags_open_.size() - 2] == "fixed_mods")
         {
-          search_parameters_.fixed_modifications.push_back(character_buffer_.trim());
-          // cerr << "fixed mod. added: " << search_parameters_.fixed_modifications.back() << "\n";
+          // check if modification is not on the remove list
+          String fixed_mod = character_buffer_.trim();
+          if (std::find(remove_fixed_mods_.begin(), remove_fixed_mods_.end(), fixed_mod) == remove_fixed_mods_.end())
+          {
+            // split because e.g. Phospho (ST)
+            vector<String> mods_split = splitModificationBySpecifiedAA(character_buffer_.trim());
+            search_parameters_.fixed_modifications.insert(search_parameters_.fixed_modifications.end(), mods_split.begin(), mods_split.end());
+            // cerr << "fixed mod. added: " << search_parameters_.fixed_modifications.back() << "\n";
+          }
+          else
+          {
+            warning(LOAD, String("Modification removed as fixed modification: '") + character_buffer_.trim() + String("'"));
+          }
         }
       }
       else if (tag_ == "warning")
       {
         warning(LOAD, String("Warnings were present: '") + character_buffer_ + String("'"));
+        
+        // check if fixed modification can only be used as variable modification
+        if (character_buffer_.trim().hasSubstring("can only be used as a variable modification"))
+        {
+          vector<String> warn_split;
+          character_buffer_.trim().split(';', warn_split);
+          if (warn_split[0].hasPrefix("'"))
+          {
+            Size end_pos = warn_split[0].find("'", 1);
+            if (end_pos < warn_split[0].size())
+            {
+              warn_split[0] = warn_split[0].substr(1, end_pos - 1);
+              remove_fixed_mods_.push_back(warn_split[0]);
+            }
+          }
+        }
       }
       else if (tag_ == "protein")
       {
@@ -544,7 +607,17 @@ namespace OpenMS
       {
         protein_identification_.setSearchEngine("Mascot");
         protein_identification_.setIdentifier(identifier_);
-        protein_identification_.setSearchParameters(search_parameters_);
+        
+        // split variable modifications e.g. Phospho (ST)
+        //vector<String> var_mods;
+        vector<String> var_mods;
+        for (vector<String>::iterator it = search_parameters_.variable_modifications.begin(); it != search_parameters_.variable_modifications.end(); ++it)
+        {
+          vector<String> mods_split = splitModificationBySpecifiedAA(*it);
+          var_mods.insert(var_mods.end(), mods_split.begin(), mods_split.end());
+        }
+        search_parameters_.variable_modifications = var_mods;
+        protein_identification_.setSearchParameters(search_parameters_);        
       }
 
       tag_ = ""; // reset tag, for the following characters() call (due to line break) of the parent tag
@@ -561,6 +634,45 @@ namespace OpenMS
       if (tag_.empty()) return;
 
       character_buffer_ += String(sm_.convert(chars));
+    }
+    
+    vector<String> MascotXMLHandler::splitModificationBySpecifiedAA(String mod)
+    {
+      vector<String> mods;
+      vector<String> parts;
+      mod.split(' ', parts);
+      
+      // either format "Modification (Protein C-term)" or "Modification (C-term X)"
+      if (parts.size() != 2)
+      {
+        mods.push_back(mod);
+        return mods;
+      }
+      
+      if (parts[1].hasPrefix("(N-term") || parts[1].hasPrefix("(C-term"))
+      {
+        mods.push_back(mod);
+        return mods;
+      }
+      
+      // format e.g. Phospho (ST)
+      ModificationsDB* mod_db = ModificationsDB::getInstance();
+      String AAs = parts[1];
+      AAs.remove(')');
+      AAs.remove('(');
+      for (String::const_iterator it = AAs.begin(); it != AAs.end(); ++it)
+      {
+        String tmp_mod = parts[0] + " (" + *it + ")";
+        if (mod_db->has(tmp_mod))
+        {
+          mods.push_back(tmp_mod);
+        }
+        else
+        {
+          throw Exception::ElementNotFound(__FILE__, __LINE__, __PRETTY_FUNCTION__, tmp_mod);
+        }
+      }
+      return mods;
     }
 
   } // namespace Internal

--- a/src/tests/class_tests/openms/data/MascotXMLFile_test_out_3.idXML
+++ b/src/tests/class_tests/openms/data/MascotXMLFile_test_out_3.idXML
@@ -5,7 +5,7 @@
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
 		<VariableModification name="Deamidated (N)" />
-    <VariableModification name="Deamidated (Q)" />
+		<VariableModification name="Deamidated (Q)" />		
 		<VariableModification name="Label:13C(6)15N(2) (K)" />
 		<VariableModification name="Label:13C(6)15N(4) (R)" />
 	</SearchParameters>

--- a/src/tests/class_tests/openms/data/MascotXMLFile_test_out_3.idXML
+++ b/src/tests/class_tests/openms/data/MascotXMLFile_test_out_3.idXML
@@ -5,7 +5,7 @@
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
 		<VariableModification name="Deamidated (N)" />
-		<VariableModification name="Deamidated (Q)" />		
+		<VariableModification name="Deamidated (Q)" />
 		<VariableModification name="Label:13C(6)15N(2) (K)" />
 		<VariableModification name="Label:13C(6)15N(4) (R)" />
 	</SearchParameters>

--- a/src/tests/class_tests/openms/data/MascotXMLFile_test_out_3.idXML
+++ b/src/tests/class_tests/openms/data/MascotXMLFile_test_out_3.idXML
@@ -4,7 +4,8 @@
 	<SearchParameters id="SP_0" db="p996_silac" db_version="fgcz_ipi_human_v3.68_decoy_contaminants_20120103.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="20" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.02" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Oxidation (M)" />
-		<VariableModification name="Deamidated (NQ)" />
+		<VariableModification name="Deamidated (N)" />
+    <VariableModification name="Deamidated (Q)" />
 		<VariableModification name="Label:13C(6)15N(2) (K)" />
 		<VariableModification name="Label:13C(6)15N(4) (R)" />
 	</SearchParameters>

--- a/src/tests/class_tests/openms/source/MascotXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MascotXMLFile_test.cpp
@@ -103,10 +103,11 @@ START_SECTION((void load(const String& filename, ProteinIdentification& protein_
     TEST_EQUAL(search_parameters.fragment_mass_tolerance_ppm, false);
     TEST_EQUAL(search_parameters.precursor_mass_tolerance_ppm, false);
     TEST_EQUAL(search_parameters.charges, "1+, 2+ and 3+");
-    TEST_EQUAL(search_parameters.fixed_modifications.size(), 3);
+    TEST_EQUAL(search_parameters.fixed_modifications.size(), 4);
     TEST_EQUAL(search_parameters.fixed_modifications[0], "Carboxymethyl (C)");
-    TEST_EQUAL(search_parameters.fixed_modifications[1], "Deamidated (NQ)");
-    TEST_EQUAL(search_parameters.fixed_modifications[2], "Guanidinyl (K)");
+    TEST_EQUAL(search_parameters.fixed_modifications[1], "Deamidated (N)");
+    TEST_EQUAL(search_parameters.fixed_modifications[2], "Deamidated (Q)");
+    TEST_EQUAL(search_parameters.fixed_modifications[3], "Guanidinyl (K)");
     TEST_EQUAL(search_parameters.variable_modifications.size(), 3);
     TEST_EQUAL(search_parameters.variable_modifications[0], "Acetyl (Protein N-term)");
     TEST_EQUAL(search_parameters.variable_modifications[1], "Biotin (K)");

--- a/src/tests/topp/IDFileConverter_1_output.idXML
+++ b/src/tests/topp/IDFileConverter_1_output.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="UPEcoli_SpikeIn" db_version="UPEcoli_SpikeIn_Jun13.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Deamidated (N)" />
-    <VariableModification name="Deamidated (Q)" />
+		<VariableModification name="Deamidated (Q)" />		
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<IdentificationRun date="2013-06-06T13:59:50" search_engine="Mascot" search_engine_version="2.4.0" search_parameters_ref="SP_0" >

--- a/src/tests/topp/IDFileConverter_1_output.idXML
+++ b/src/tests/topp/IDFileConverter_1_output.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="UPEcoli_SpikeIn" db_version="UPEcoli_SpikeIn_Jun13.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Deamidated (N)" />
-		<VariableModification name="Deamidated (Q)" />		
+		<VariableModification name="Deamidated (Q)" />
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<IdentificationRun date="2013-06-06T13:59:50" search_engine="Mascot" search_engine_version="2.4.0" search_parameters_ref="SP_0" >

--- a/src/tests/topp/IDFileConverter_1_output.idXML
+++ b/src/tests/topp/IDFileConverter_1_output.idXML
@@ -3,7 +3,8 @@
 <IdXML version="1.3" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="UPEcoli_SpikeIn" db_version="UPEcoli_SpikeIn_Jun13.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
-		<VariableModification name="Deamidated (NQ)" />
+		<VariableModification name="Deamidated (N)" />
+    <VariableModification name="Deamidated (Q)" />
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<IdentificationRun date="2013-06-06T13:59:50" search_engine="Mascot" search_engine_version="2.4.0" search_parameters_ref="SP_0" >

--- a/src/tests/topp/IDFileConverter_5_output.idXML
+++ b/src/tests/topp/IDFileConverter_5_output.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="UPEcoli_SpikeIn" db_version="UPEcoli_SpikeIn_Jun13.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Deamidated (N)" />
-    <VariableModification name="Deamidated (Q)" />
+		<VariableModification name="Deamidated (Q)" />		
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<IdentificationRun date="2013-06-06T13:59:50" search_engine="Mascot" search_engine_version="2.4.0" search_parameters_ref="SP_0" >

--- a/src/tests/topp/IDFileConverter_5_output.idXML
+++ b/src/tests/topp/IDFileConverter_5_output.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="UPEcoli_SpikeIn" db_version="UPEcoli_SpikeIn_Jun13.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
 		<VariableModification name="Deamidated (N)" />
-		<VariableModification name="Deamidated (Q)" />		
+		<VariableModification name="Deamidated (Q)" />
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<IdentificationRun date="2013-06-06T13:59:50" search_engine="Mascot" search_engine_version="2.4.0" search_parameters_ref="SP_0" >

--- a/src/tests/topp/IDFileConverter_5_output.idXML
+++ b/src/tests/topp/IDFileConverter_5_output.idXML
@@ -3,7 +3,8 @@
 <IdXML version="1.3" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="UPEcoli_SpikeIn" db_version="UPEcoli_SpikeIn_Jun13.fasta" taxonomy="All entries" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.5" peak_mass_tolerance_ppm="false" >
 		<FixedModification name="Carbamidomethyl (C)" />
-		<VariableModification name="Deamidated (NQ)" />
+		<VariableModification name="Deamidated (N)" />
+    <VariableModification name="Deamidated (Q)" />
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
 	<IdentificationRun date="2013-06-06T13:59:50" search_engine="Mascot" search_engine_version="2.4.0" search_parameters_ref="SP_0" >


### PR DESCRIPTION
[FIX-#1740] Split Phospho (ST) to Phospho (S), Phospho (T)
When Mascot output XML parsed, split the fixed modifications immediately after parsing, because identifier information don't needs to be preserved.

The order of variable modifications needs to be preserved, because the position of the modification in the list indicates the index of these pattern:
pep_seq: QKAAGSK
pep_var_mod_pos: 4.0000000.0
=> modification on the 4th position is the n-terminal modification.

![mascot_xml_mod_definition](https://cloud.githubusercontent.com/assets/6952271/13637201/f852bcd2-e5fd-11e5-9374-b4b936e6d44d.PNG)

Fixed in addition Mascot XML Parser - Terminal Modifications:

[FIX 1] Mascot adds fixed modifications, which cannot be set, additionally as variable modification.
Error example: Fixed mod: "Gln->pyro-Glu (N-term Q)"
<warning number="1">&apos;Gln-&gt;pyro-Glu (N-term Q)&apos; can only be used as a variable modification; setting it to variable</warning>

![mascot_fixed_added_as_var_mod](https://cloud.githubusercontent.com/assets/6952271/13636924/5b8bf414-e5fc-11e5-86aa-d93ecbf73ac8.PNG)

Solution: Parsing the warnings of Mascot:
<warning number="0">&apos;Ammonia-loss (N-term C)&apos; can only be used as a variable modification; setting it to variable</warning>
<warning number="1">&apos;Gln-&gt;pyro-Glu (N-term Q)&apos; can only be used as a variable modification; setting it to variable</warning>

If mentioned modifications occurs as fixed modification --> remove it. 

[FIX 2] Fixed modifications: N-term/C-term modifications on a specific amino acid are ignored.
If a terminal modification is set in the search parameters as fixed and it is defined for a specific amino acid, the specifity is ignored and
the terminal modification is set on every sequence in the Mascot idXML output.
Reason: in the mascot XML parsing step, amino acid specifications are not considered, when the fixed modifications are added to the sequence.

Set in all peptides as N-term modification:
![fixed_term_with_specifity_set_in_all_psms](https://cloud.githubusercontent.com/assets/6952271/13636951/7db9c35e-e5fc-11e5-9087-fe945fb8e2e5.PNG)

Solution: When set the fixed modifications, specific amino acid definitions are considered now

modified:   ../src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
modified:   ../src/openms/include/OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h
modified:   ../src/openms/source/CHEMISTRY/ModificationsDB.cpp
modified:   ../src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
modified:   ../src/tests/class_tests/openms/data/MascotXMLFile_test_out_3.idXML
modified:   ../src/tests/class_tests/openms/source/MascotXMLFile_test.cpp
modified:   ../src/tests/topp/IDFileConverter_1_output.idXML
modified:   ../src/tests/topp/IDFileConverter_5_output.idXML