### PR TITLE
[PYOPENMS][FIX] fixes parsing error for pyopenms

### DIFF
--- a/src/pyOpenMS/pxds/ConsensusMapNormalizerAlgorithmMedian.pxd
+++ b/src/pyOpenMS/pxds/ConsensusMapNormalizerAlgorithmMedian.pxd
@@ -1,15 +1,6 @@
 from libcpp.vector cimport vector as libcpp_vector
 from ConsensusMap cimport *
-
-cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmMedian.h>" namespace "OpenMS":
-
-    cdef cppclass ConsensusMapNormalizerAlgorithmMedian:
-
-        ConsensusMapNormalizerAlgorithmMedian() nogil except +
-        ConsensusMapNormalizerAlgorithmMedian(ConsensusMapNormalizerAlgorithmMedian) nogil except + #wrap-ignore
-
-        Size computeMedians(ConsensusMap & input_map, libcpp_vector[double] & medians, const String & acc_filter, const String & desc_filter) nogil except +
-        void normalizeMaps(ConsensusMap & input_map, NormalizationMethod method, const String & acc_filter, const String & desc_filter) nogil except +
+from ConsensusMapNormalizerAlgorithmThreshold cimport *
 
 cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmMedian.h>" namespace "OpenMS::ConsensusMapNormalizerAlgorithmMedian":
 
@@ -17,3 +8,11 @@ cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmMe
         NM_SCALE,
         NM_SHIFT
 
+cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmMedian.h>" namespace "OpenMS":
+    cdef cppclass ConsensusMapNormalizerAlgorithmMedian:
+
+        ConsensusMapNormalizerAlgorithmMedian() nogil except +
+        ConsensusMapNormalizerAlgorithmMedian(ConsensusMapNormalizerAlgorithmMedian) nogil except + #wrap-ignore
+
+        Size computeMedians(ConsensusMap & input_map, libcpp_vector[double] & medians, String & acc_filter, String & desc_filter) nogil except +
+        void normalizeMaps(ConsensusMap & input_map, NormalizationMethod method, String & acc_filter, String & desc_filter) nogil except +

--- a/src/pyOpenMS/pxds/ConsensusMapNormalizerAlgorithmThreshold.pxd
+++ b/src/pyOpenMS/pxds/ConsensusMapNormalizerAlgorithmThreshold.pxd
@@ -8,6 +8,6 @@ cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmTh
         ConsensusMapNormalizerAlgorithmThreshold() nogil except +
         ConsensusMapNormalizerAlgorithmThreshold(ConsensusMapNormalizerAlgorithmThreshold) nogil except + #wrap-ignore
 
-        libcpp_vector[double] computeCorrelation(ConsensusMap & input_map, double ratio_threshold, const String & acc_filter, const String & desc_filter) nogil except +
+        libcpp_vector[double] computeCorrelation(ConsensusMap & input_map, double ratio_threshold, String & acc_filter, String & desc_filter) nogil except +
         void normalizeMaps(ConsensusMap & input_map, libcpp_vector[double] & ratios) nogil except +
 


### PR DESCRIPTION
Should fix #1854.
PyopenMS did not build completely because of parsing errors. This lead to all the failing tests.