### PR TITLE
[FIX] PhosphoScoring

### DIFF
--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -171,16 +171,15 @@ namespace OpenMS
         
         Ascore = score_first - score_second;
         LOG_DEBUG << "\tAscore_" << rank << ": " << Ascore << std::endl;
-        
-        if (Ascore < best_Ascore)
-        {
-          best_Ascore = Ascore;
-          phospho.setScore(Ascore);        
-        }
+      }
+      if (Ascore < best_Ascore)
+      {
+        best_Ascore = Ascore;
       }
       phospho.setMetaValue("AScore_" + String(rank), Ascore);
       ++rank;      
     }
+    phospho.setScore(best_Ascore);
     return phospho;
   }
 


### PR DESCRIPTION
Bug correction: if first and second peptide score are equal, set main score to 0 instead of leaving it at -1.

modified:   ../src/openms/source/ANALYSIS/ID/AScore.cpp