### PR TITLE
[FIX] PepXMLFile - scan number

### DIFF
--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -267,6 +267,8 @@ namespace OpenMS
       f << "\t<analysis_timestamp analysis=\"peptideprophet\" time=\"2007-12-05T17:49:52\" id=\"1\"/>" << "\n";
     }
 
+    // Scan index and scan number will be reconstructed if no spectrum lookup is possible to retrieve the values.
+    // The scan index is generally zero-based and the scan number generally one-based.
     Int count(0);
     for (vector<PeptideIdentification>::const_iterator it = peptide_ids.begin();
          it != peptide_ids.end(); ++it, ++count)

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -267,7 +267,7 @@ namespace OpenMS
       f << "\t<analysis_timestamp analysis=\"peptideprophet\" time=\"2007-12-05T17:49:52\" id=\"1\"/>" << "\n";
     }
 
-    Int count(1);
+    Int count(0);
     for (vector<PeptideIdentification>::const_iterator it = peptide_ids.begin();
          it != peptide_ids.end(); ++it, ++count)
     {

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -111,7 +111,6 @@ namespace OpenMS
     f.precision(writtenDigits<double>(0.0));
     String raw_data;
     String base_name;
-    //delete SpectrumLookup lookup;
     SpectrumMetaDataLookup lookup;
     
     // The mz-File (if given)

--- a/src/tests/class_tests/openms/data/PepXMLFile_test_out.pepxml
+++ b/src/tests/class_tests/openms/data/PepXMLFile_test_out.pepxml
@@ -11,7 +11,7 @@
 		<terminal_modification terminus="n" massdiff="-18.010565" mass="0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
 	</search_summary>
 	<analysis_timestamp analysis="peptideprophet" time="2007-12-05T17:49:52" id="1"/>
-	<spectrum_query spectrum="test.2.2.3" start_scan="2" end_scan="2" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="1" retention_time_sec="1.3653" >
+	<spectrum_query spectrum="test.1.1.3" start_scan="1" end_scan="1" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="0" retention_time_sec="1.3653" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.8242994942" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394137" num_tol_term="2"/>
@@ -25,7 +25,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="2" retention_time_sec="1.719" >
+	<spectrum_query spectrum="test.2.2.2" start_scan="2" end_scan="2" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="1" retention_time_sec="1.719" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.7758133814" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<modification_info modified_peptide="(Gln->pyro-Glu)QLPGVNIKPVVK" mod_nterm_mass="128.0585782552">
@@ -37,7 +37,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.4.4.2" start_scan="4" end_scan="4" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="3" retention_time_sec="2.0436" >
+	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="2" retention_time_sec="2.0436" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.7285291262" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<analysis_result analysis="peptideprophet">
@@ -47,7 +47,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.5.5.3" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="4" retention_time_sec="2.7843" >
+	<spectrum_query spectrum="test.4.4.3" start_scan="4" end_scan="4" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="3" retention_time_sec="2.7843" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
@@ -60,7 +60,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.6.6.2" start_scan="6" end_scan="6" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="5" retention_time_sec="3.085" >
+	<spectrum_query spectrum="test.5.5.2" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="4" retention_time_sec="3.085" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
@@ -73,7 +73,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="6" retention_time_sec="3.4018" >
+	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="5" retention_time_sec="3.4018" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.1212295002" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000001143" num_tol_term="2"/>
@@ -89,7 +89,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.8.8.3" start_scan="8" end_scan="8" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="7" retention_time_sec="4.4573" >
+	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="6" retention_time_sec="4.4573" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000622428" num_tol_term="2"/>
@@ -101,7 +101,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="8" retention_time_sec="4.8288" >
+	<spectrum_query spectrum="test.8.8.2" start_scan="8" end_scan="8" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="7" retention_time_sec="4.8288" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.7593913176" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394916" num_tol_term="2"/>
@@ -113,7 +113,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.10.10.2" start_scan="10" end_scan="10" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="9" retention_time_sec="5.1785" >
+	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="8" retention_time_sec="5.1785" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.5349143287" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000459115" num_tol_term="2"/>

--- a/src/tests/class_tests/openms/data/PepXMLFile_test_out.pepxml
+++ b/src/tests/class_tests/openms/data/PepXMLFile_test_out.pepxml
@@ -11,7 +11,7 @@
 		<terminal_modification terminus="n" massdiff="-18.010565" mass="0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
 	</search_summary>
 	<analysis_timestamp analysis="peptideprophet" time="2007-12-05T17:49:52" id="1"/>
-	<spectrum_query spectrum="test.1.1.3" start_scan="1" end_scan="1" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="1" retention_time_sec="1.3653" >
+	<spectrum_query spectrum="test.2.2.3" start_scan="2" end_scan="2" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="1" retention_time_sec="1.3653" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.8242994942" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394137" num_tol_term="2"/>
@@ -25,7 +25,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.2.2.2" start_scan="2" end_scan="2" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="2" retention_time_sec="1.719" >
+	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="2" retention_time_sec="1.719" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.7758133814" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<modification_info modified_peptide="(Gln->pyro-Glu)QLPGVNIKPVVK" mod_nterm_mass="128.0585782552">
@@ -37,7 +37,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="3" retention_time_sec="2.0436" >
+	<spectrum_query spectrum="test.4.4.2" start_scan="4" end_scan="4" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="3" retention_time_sec="2.0436" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.7285291262" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<analysis_result analysis="peptideprophet">
@@ -47,7 +47,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.4.4.3" start_scan="4" end_scan="4" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="4" retention_time_sec="2.7843" >
+	<spectrum_query spectrum="test.5.5.3" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="4" retention_time_sec="2.7843" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
@@ -60,7 +60,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.5.5.2" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="5" retention_time_sec="3.085" >
+	<spectrum_query spectrum="test.6.6.2" start_scan="6" end_scan="6" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="5" retention_time_sec="3.085" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
@@ -73,7 +73,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="6" retention_time_sec="3.4018" >
+	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="6" retention_time_sec="3.4018" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.1212295002" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000001143" num_tol_term="2"/>
@@ -89,7 +89,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="7" retention_time_sec="4.4573" >
+	<spectrum_query spectrum="test.8.8.3" start_scan="8" end_scan="8" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="7" retention_time_sec="4.4573" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000622428" num_tol_term="2"/>
@@ -101,7 +101,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.8.8.2" start_scan="8" end_scan="8" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="8" retention_time_sec="4.8288" >
+	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="8" retention_time_sec="4.8288" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.7593913176" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394916" num_tol_term="2"/>
@@ -113,7 +113,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="9" retention_time_sec="5.1785" >
+	<spectrum_query spectrum="test.10.10.2" start_scan="10" end_scan="10" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="9" retention_time_sec="5.1785" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.5349143287" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000459115" num_tol_term="2"/>

--- a/src/tests/class_tests/openms/data/PepXMLFile_test_out_1.pepxml
+++ b/src/tests/class_tests/openms/data/PepXMLFile_test_out_1.pepxml
@@ -10,7 +10,7 @@
 		<terminal_modification terminus="n" massdiff="-17.026549" mass="0" variable="Y" description="Gln->pyro-Glu (N-term Q)" protein_terminus=""/>
 		<terminal_modification terminus="n" massdiff="-18.010565" mass="0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
 	</search_summary>
-	<spectrum_query spectrum="test.2.2.3" start_scan="2" end_scan="2" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="1" retention_time_sec="1.3653" >
+	<spectrum_query spectrum="test.1.1.3" start_scan="1" end_scan="1" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="0" retention_time_sec="1.3653" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.8242994942" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394137" num_tol_term="2"/>
@@ -21,7 +21,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="2" retention_time_sec="1.719" >
+	<spectrum_query spectrum="test.2.2.2" start_scan="2" end_scan="2" precursor_neutral_mass="1273.7758133814" assumed_charge="2" index="1" retention_time_sec="1.719" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.7758133814" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<modification_info modified_peptide="(Gln->pyro-Glu)QLPGVNIKPVVK" mod_nterm_mass="128.0585782552">
@@ -30,14 +30,14 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.4.4.2" start_scan="4" end_scan="4" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="3" retention_time_sec="2.0436" >
+	<spectrum_query spectrum="test.3.3.2" start_scan="3" end_scan="3" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="2" retention_time_sec="2.0436" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.7285291262" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<search_score name="expect" value="4.9"/>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.5.5.3" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="4" retention_time_sec="2.7843" >
+	<spectrum_query spectrum="test.4.4.3" start_scan="4" end_scan="4" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="3" retention_time_sec="2.7843" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
@@ -47,7 +47,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.6.6.2" start_scan="6" end_scan="6" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="5" retention_time_sec="3.085" >
+	<spectrum_query spectrum="test.5.5.2" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="4" retention_time_sec="3.085" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
@@ -57,7 +57,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="6" retention_time_sec="3.4018" >
+	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="5" retention_time_sec="3.4018" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.1212295002" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000001143" num_tol_term="2"/>
@@ -70,7 +70,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.8.8.3" start_scan="8" end_scan="8" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="7" retention_time_sec="4.4573" >
+	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="6" retention_time_sec="4.4573" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000622428" num_tol_term="2"/>
@@ -79,7 +79,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="8" retention_time_sec="4.8288" >
+	<spectrum_query spectrum="test.8.8.2" start_scan="8" end_scan="8" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="7" retention_time_sec="4.8288" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.7593913176" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394916" num_tol_term="2"/>
@@ -88,7 +88,7 @@
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.10.10.2" start_scan="10" end_scan="10" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="9" retention_time_sec="5.1785" >
+	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="8" retention_time_sec="5.1785" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.5349143287" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000459115" num_tol_term="2"/>

--- a/src/tests/class_tests/openms/data/PepXMLFile_test_out_mzML.pepxml
+++ b/src/tests/class_tests/openms/data/PepXMLFile_test_out_mzML.pepxml
@@ -10,6 +10,7 @@
 		<terminal_modification terminus="n" massdiff="-17.026549" mass="0" variable="Y" description="Gln->pyro-Glu (N-term Q)" protein_terminus=""/>
 		<terminal_modification terminus="n" massdiff="-18.010565" mass="0" variable="Y" description="Glu->pyro-Glu (N-term E)" protein_terminus=""/>
 	</search_summary>
+	<analysis_timestamp analysis="peptideprophet" time="2007-12-05T17:49:52" id="1"/>
 	<spectrum_query spectrum="test.2.2.3" start_scan="2" end_scan="2" precursor_neutral_mass="1612.8242994942" assumed_charge="3" index="1" retention_time_sec="1.3653" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="ELNKEMAAEKAKAAAG" peptide_prev_aa="R" peptide_next_aa="E" protein="ddb000449223" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.8242994942" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
@@ -17,7 +18,10 @@
 		<alternative_protein protein="ddb000015734" num_tol_term="2"/>
 			<modification_info modified_peptide="(Glu->pyro-Glu)ELNKEMAAEKAKAAAG" mod_nterm_mass="129.0425942233">
 			</modification_info>
-			<search_score name="expect" value="8"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="8" all_ntt_prob="(8,8,8)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
@@ -26,38 +30,50 @@
 		<search_hit hit_rank="1" peptide="QLPGVNIKPVVK" peptide_prev_aa="R" peptide_next_aa="V" protein="ddb000014286" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1273.7758133814" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 			<modification_info modified_peptide="(Gln->pyro-Glu)QLPGVNIKPVVK" mod_nterm_mass="128.0585782552">
 			</modification_info>
-			<search_score name="expect" value="7.7"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="7.7" all_ntt_prob="(7.7,7.7,7.7)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
 	<spectrum_query spectrum="test.4.4.2" start_scan="4" end_scan="4" precursor_neutral_mass="1354.7285291262" assumed_charge="2" index="3" retention_time_sec="2.0436" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="IFQAALYAAPYK" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000517740" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1354.7285291262" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
-			<search_score name="expect" value="4.9"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="4.9" all_ntt_prob="(4.9,4.9,4.9)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.5.5.3" start_scan="5" end_scan="5" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="4" retention_time_sec="2.7843" >
+	<spectrum_query spectrum="test.6.6.3" start_scan="6" end_scan="6" precursor_neutral_mass="2285.138699104" assumed_charge="3" index="5" retention_time_sec="2.7843" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
 		<alternative_protein protein="ddb000626346" num_tol_term="2"/>
 		<alternative_protein protein="ddb005168372" num_tol_term="2"/>
-			<search_score name="expect" value="0.00091"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="0.00091" all_ntt_prob="(0.00091,0.00091,0.00091)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.6.6.2" start_scan="6" end_scan="6" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="5" retention_time_sec="3.085" >
+	<spectrum_query spectrum="test.7.7.2" start_scan="7" end_scan="7" precursor_neutral_mass="2285.138699104" assumed_charge="2" index="6" retention_time_sec="3.085" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="EISPDTTLLDLQNNDISELR" peptide_prev_aa="K" peptide_next_aa="K" protein="ddb000026697" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2285.138699104" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000626345" num_tol_term="2"/>
 		<alternative_protein protein="ddb000626346" num_tol_term="2"/>
 		<alternative_protein protein="ddb005168372" num_tol_term="2"/>
-			<search_score name="expect" value="7.9e-05"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="7.9e-05" all_ntt_prob="(7.9e-05,7.9e-05,7.9e-05)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.7.7.3" start_scan="7" end_scan="7" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="6" retention_time_sec="3.4018" >
+	<spectrum_query spectrum="test.8.8.3" start_scan="8" end_scan="8" precursor_neutral_mass="2307.1212295002" assumed_charge="3" index="7" retention_time_sec="3.4018" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="RSHTILNSSQSFAKGCVQCK" peptide_prev_aa="K" peptide_next_aa="H" protein="rev000025591" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2307.1212295002" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000001143" num_tol_term="2"/>
@@ -66,33 +82,45 @@
 				<mod_aminoacid_mass position="16" mass="160.0306489852"/>
 				<mod_aminoacid_mass position="19" mass="160.0306489852"/>
 			</modification_info>
-			<search_score name="expect" value="14"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="14" all_ntt_prob="(14,14,14)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.8.8.3" start_scan="8" end_scan="8" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="7" retention_time_sec="4.4573" >
+	<spectrum_query spectrum="test.10.10.3" start_scan="10" end_scan="10" precursor_neutral_mass="2269.1954242316" assumed_charge="3" index="9" retention_time_sec="4.4573" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="VSLPNYPAIPSDATLEVQSLR" peptide_prev_aa="K" peptide_next_aa="S" protein="ddb000622429" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="2269.1954242316" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000622428" num_tol_term="2"/>
 		<alternative_protein protein="ddb000450900" num_tol_term="2"/>
-			<search_score name="expect" value="0.65"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="0.65" all_ntt_prob="(0.65,0.65,0.65)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.9.9.2" start_scan="9" end_scan="9" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="8" retention_time_sec="4.8288" >
+	<spectrum_query spectrum="test.11.11.2" start_scan="11" end_scan="11" precursor_neutral_mass="1612.7593913176" assumed_charge="2" index="10" retention_time_sec="4.8288" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="NALWHTGDTESQVR" peptide_prev_aa="R" peptide_next_aa="L" protein="ddb000409092" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1612.7593913176" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="ddb000394916" num_tol_term="2"/>
 		<alternative_protein protein="ddb000012684" num_tol_term="2"/>
-			<search_score name="expect" value="0.0046"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="0.0046" all_ntt_prob="(0.0046,0.0046,0.0046)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>
-	<spectrum_query spectrum="test.10.10.2" start_scan="10" end_scan="10" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="9" retention_time_sec="5.1785" >
+	<spectrum_query spectrum="test.12.12.2" start_scan="12" end_scan="12" precursor_neutral_mass="1023.5349143287" assumed_charge="2" index="11" retention_time_sec="5.1785" >
 	<search_result>
 		<search_hit hit_rank="1" peptide="SSLKNYANK" peptide_prev_aa="R" peptide_next_aa="I" protein="rev000409159" num_tot_proteins="1" num_matched_ions="0" tot_num_ions="0" calc_neutral_pep_mass="1023.5349143287" massdiff="0.0" num_tol_term="2" num_missed_cleavages="0" is_rejected="0" protein_descr="Protein No. 1">
 		<alternative_protein protein="rev000459115" num_tol_term="2"/>
-			<search_score name="expect" value="1.1"/>
+			<analysis_result analysis="peptideprophet">
+			<peptideprophet_result probability="1.1" all_ntt_prob="(1.1,1.1,1.1)">
+			</peptideprophet_result>
+			</analysis_result>
 		</search_hit>
 	</search_result>
 	</spectrum_query>

--- a/src/tests/class_tests/openms/source/PepXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/PepXMLFile_test.cpp
@@ -429,6 +429,29 @@ START_SECTION([EXTRA] void store(const String& filename, std::vector<ProteinIden
 }
 END_SECTION
 
+// store PepXML with mzML file information
+START_SECTION(void store(const String& filename, std::vector<ProteinIdentification>& protein_ids, std::vector<PeptideIdentification>& peptide_ids, const String& mz_file = "PepXMLFile_test.mzML", const String& mz_name = "", bool peptideprophet_analyzed = false))
+{
+  vector<ProteinIdentification> proteins;
+  vector<PeptideIdentification> peptides;
+  String mzML_filename = OPENMS_GET_TEST_DATA_PATH("PepXMLFile_test.mzML");
+  String filename = OPENMS_GET_TEST_DATA_PATH("PepXMLFile_test_store.pepxml");
+  PepXMLFile().load(filename, proteins, peptides);
+
+  // Test PeptideProphet-analyzed pepxml.
+  String cm_file_out;
+  NEW_TMP_FILE(cm_file_out);
+  PepXMLFile().store(cm_file_out, proteins, peptides, mzML_filename, "test", true);
+
+  FuzzyStringComparator fsc;
+  fsc.setAcceptableAbsolute(1e-7);
+  fsc.setAcceptableRelative(1.0 + 1e-7);
+  // fsc.setWhitelist (ListUtils::create<String>("base_name, local_path, <spectrum_query "));
+  String filename_out = OPENMS_GET_TEST_DATA_PATH("PepXMLFile_test_out_mzML.pepxml");
+  TEST_EQUAL(fsc.compareFiles(cm_file_out.c_str(), filename_out.c_str()), true)
+}
+END_SECTION
+
 START_SECTION(void keepNativeSpectrumName(bool keep) )
 {
   // tested above in the [EXTRA] store as we store / load once with


### PR DESCRIPTION
* Read spectrum scan_number from the spectrum metavalues instead of setting scan_number = scan_index + 1