### PR TITLE
add /usr/bin to the PATH in TOPPAS.plist

### DIFF
--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS-resources/TOPPAS.plist.in
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS-resources/TOPPAS.plist.in
@@ -48,7 +48,7 @@
 	<key>LSEnvironment</key>
 	<dict>
 		<key>PATH</key>
-		<string>TOPP/SEARCHENGINES/OMSSA:TOPP/SEARCHENGINES/XTandem</string>
+		<string>/usr/bin:TOPP/SEARCHENGINES/OMSSA:TOPP/SEARCHENGINES/XTandem</string>
 	</dict>  
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>


### PR DESCRIPTION
Adds `/usr/bin` to `PATH` in `TOPPAS.plist` in order for `java` to be found by `MSGFPlusAdapter`.
See #1764.