### PR TITLE
[PARAM, FIX] MapAlignerIdentification peptide filtering (PEP scores) issue

### DIFF
--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.cpp
@@ -44,22 +44,19 @@ namespace OpenMS
 
   MapAlignmentAlgorithmIdentification::MapAlignmentAlgorithmIdentification() :
     DefaultParamHandler("MapAlignmentAlgorithmIdentification"),
-    ProgressLogger(), reference_index_(-1), reference_(), score_threshold_(0.0),
-    min_run_occur_(0)
+    ProgressLogger(), reference_index_(-1), reference_(), min_run_occur_(0)
   {
-    defaults_.setValue("peptide_score_threshold", 0.0, "Score threshold for peptide hits to be used in the alignment.\nSelect a value that allows only 'high confidence' matches.");
-
-    defaults_.setValue("min_run_occur", 2, "Minimum number of runs (incl. reference, if any) a peptide must occur in to be used for the alignment.\nUnless you have very few runs or identifications, increase this value to focus on more informative peptides.");
+    defaults_.setValue("min_run_occur", 2, "Minimum number of runs (incl. reference, if any) in which a peptide must occur to be used for the alignment.\nUnless you have very few runs or identifications, increase this value to focus on more informative peptides.");
     defaults_.setMinInt("min_run_occur", 2);
 
     defaults_.setValue("max_rt_shift", 0.5, "Maximum realistic RT difference for a peptide (median per run vs. reference). Peptides with higher shifts (outliers) are not used to compute the alignment.\nIf 0, no limit (disable filter); if > 1, the final value in seconds; if <= 1, taken as a fraction of the range of the reference RT scale.");
     defaults_.setMinFloat("max_rt_shift", 0.0);
 
-    defaults_.setValue("use_unassigned_peptides", "true", "Should unassigned peptide identifications be used when computing an alignment of feature maps? If 'false', only peptide IDs assigned to features will be used.");
+    defaults_.setValue("use_unassigned_peptides", "true", "Should unassigned peptide identifications be used when computing an alignment of feature or consensus maps? If 'false', only peptide IDs assigned to features will be used.");
     defaults_.setValidStrings("use_unassigned_peptides",
                               ListUtils::create<String>("true,false"));
 
-    defaults_.setValue("use_feature_rt", "false", "When aligning feature maps, don't use the retention time of a peptide identification directly; instead, use the retention time of the centroid of the feature (apex of the elution profile) that the peptide was matched to. If different identifications are matched to one feature, only the peptide closest to the centroid in RT is used.\nPrecludes 'use_unassigned_peptides'.");
+    defaults_.setValue("use_feature_rt", "false", "When aligning feature or consensus maps, don't use the retention time of a peptide identification directly; instead, use the retention time of the centroid of the feature (apex of the elution profile) that the peptide was matched to. If different identifications are matched to one feature, only the peptide closest to the centroid in RT is used.\nPrecludes 'use_unassigned_peptides'.");
     defaults_.setValidStrings("use_feature_rt", ListUtils::create<String>("true,false"));
 
     defaultsToParam_();
@@ -78,15 +75,13 @@ namespace OpenMS
 
     if (min_run_occur_ > runs)
     {
-      String msg = "Warning: Value of parameter 'min_run_occur' (here: " + 
+      String msg = "Warning: Value of parameter 'min_run_occur' (here: " +
         String(min_run_occur_) + ") is higher than the number of runs incl. "
         "reference (here: " + String(runs) + "). Using " + String(runs) +
         " instead.";
-      LOG_WARN << msg << endl;      
+      LOG_WARN << msg << endl;
       min_run_occur_ = runs;
     }
-
-    score_threshold_ = param_.getValue("peptide_score_threshold");
   }
 
   // RT lists in "rt_data" will be sorted (unless "sorted" is true)
@@ -106,17 +101,6 @@ namespace OpenMS
     }
   }
 
-  // list of peptide hits in "peptide" will be sorted
-  bool MapAlignmentAlgorithmIdentification::hasGoodHit_(PeptideIdentification&
-                                                        peptide)
-  {
-    if (peptide.empty() || peptide.getHits().empty()) return false;
-    peptide.sort();
-    double score = peptide.getHits().begin()->getScore();
-    if (peptide.isHigherScoreBetter()) return score >= score_threshold_;
-    return score <= score_threshold_;
-  }
-
   // lists of peptide hits in "peptides" will be sorted
   bool MapAlignmentAlgorithmIdentification::getRetentionTimes_(
     vector<PeptideIdentification>& peptides, SeqToList& rt_data)
@@ -124,8 +108,9 @@ namespace OpenMS
     for (vector<PeptideIdentification>::iterator pep_it = peptides.begin();
          pep_it != peptides.end(); ++pep_it)
     {
-      if (hasGoodHit_(*pep_it))
+      if (!pep_it->getHits().empty())
       {
+        pep_it->sort();
         const String& seq = pep_it->getHits()[0].getSequence().toString();
         rt_data[seq].push_back(pep_it->getRT());
       }
@@ -216,25 +201,30 @@ namespace OpenMS
       temp.swap(medians_per_seq);
       computeMedians_(medians_per_seq, reference_);
     }
+    if (reference_.empty())
+    {
+      throw Exception::MissingInformation(__FILE__, __LINE__, __PRETTY_FUNCTION__, "No reference RT information left after filtering");
+    }
 
     double max_rt_shift = param_.getValue("max_rt_shift");
-    if (max_rt_shift == 0)
-    {
-      max_rt_shift = numeric_limits<double>::max();
-    }
-    else if (max_rt_shift <= 1)
+    if (max_rt_shift <= 1)
     {
       // compute max. allowed shift from overall retention time range:
-      double rt_range, rt_min = reference_.begin()->second,
-             rt_max = rt_min;
-      for (SeqToValue::iterator it = ++reference_.begin();
-           it != reference_.end(); ++it)
+      double rt_min = numeric_limits<double>::infinity(), rt_max = -rt_min;
+      for (SeqToValue::iterator it = reference_.begin(); it != reference_.end();
+           ++it)
       {
         rt_min = min(rt_min, it->second);
         rt_max = max(rt_max, it->second);
       }
-      rt_range = rt_max - rt_min;
+      double rt_range = rt_max - rt_min;
       max_rt_shift *= rt_range;
+      // in the degenerate case of only one reference point, "max_rt_shift"
+      // should be zero (because "rt_range" is zero) - this is covered below
+    }
+    if (max_rt_shift == 0)
+    {
+      max_rt_shift = numeric_limits<double>::max();
     }
     LOG_DEBUG << "Max. allowed RT shift (in seconds): " << max_rt_shift << endl;
 

--- a/src/tests/topp/MapAlignerIdentification_parameters.ini
+++ b/src/tests/topp/MapAlignerIdentification_parameters.ini
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NODE name="MapAlignerIdentification" description="Corrects retention time distortions between maps based on common peptide identifications.">
-    <ITEM name="version" value="1.12.0" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
+    <ITEM name="version" value="2.0.0" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;MapAlignerIdentification&apos;">
-      <ITEMLIST name="in" type="input-file" description="Input files separated by blanks (all must have the same file type)" required="true" advanced="false" supported_formats="*.featureXML,*.consensusXML,*.idXML">
+      <ITEMLIST name="in" type="input-file" description="Input files to align (all must have the same file type)" required="true" advanced="false" supported_formats="*.featureXML,*.consensusXML,*.idXML">
       </ITEMLIST>
-      <ITEMLIST name="out" type="output-file" description="Output files separated by blanks. Either &apos;out&apos; or &apos;trafo_out&apos; has to be provided. They can be used together." required="false" advanced="false" supported_formats="*.featureXML,*.consensusXML,*.idXML">
+      <ITEMLIST name="out" type="output-file" description="Output files (same file type as &apos;in&apos;). Either this option or &apos;trafo_out&apos; has to be provided; they can be used together." required="false" advanced="false" supported_formats="*.featureXML,*.consensusXML,*.idXML">
       </ITEMLIST>
-      <ITEMLIST name="trafo_out" type="output-file" description="Transformation output files separated by blanks. Either &apos;out&apos; or &apos;trafo_out&apos; has to be provided. They can be used together." required="false" advanced="false" supported_formats="*.trafoXML">
+      <ITEMLIST name="trafo_out" type="output-file" description="Transformation output files. Either this option or &apos;out&apos; has to be provided; they can be used together." required="false" advanced="false" supported_formats="*.trafoXML">
       </ITEMLIST>
       <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
       <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
       <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
       <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
-      <NODE name="reference" description="Options to define a reference file (use either &apos;file&apos; or &apos;index&apos;, not both; if neither is given &apos;index&apos; is used).">
-        <ITEM name="file" value="" type="input-file" description="File to use as reference (same file format as input files required)" required="false" advanced="false" supported_formats="*.featureXML,*.consensusXML,*.idXML" />
+      <NODE name="reference" description="Options to define a reference file (use either &apos;file&apos; or &apos;index&apos;, not both)">
+        <ITEM name="file" value="" type="input-file" description="File to use as reference" required="false" advanced="false" supported_formats="*.featureXML,*.consensusXML,*.idXML" />
         <ITEM name="index" value="0" type="int" description="Use one of the input files as reference (&apos;1&apos; for the first file, etc.).#br#If &apos;0&apos;, no explicit reference is set - the algorithm will select a reference." required="false" advanced="false" restrictions="0:" />
       </NODE>
       <NODE name="algorithm" description="Algorithm parameters section">
-        <ITEM name="peptide_score_threshold" value="0" type="double" description="Score threshold for peptide hits to be used in the alignment.#br#Select a value that allows only &apos;high confidence&apos; matches." required="false" advanced="false" />
-        <ITEM name="min_run_occur" value="2" type="int" description="Minimum number of runs (incl. reference, if any) a peptide must occur in to be used for the alignment.#br#Unless you have very few runs or identifications, increase this value to focus on more informative peptides." required="false" advanced="false" restrictions="2:" />
+        <ITEM name="min_run_occur" value="2" type="int" description="Minimum number of runs (incl. reference, if any) in which a peptide must occur to be used for the alignment.#br#Unless you have very few runs or identifications, increase this value to focus on more informative peptides." required="false" advanced="false" restrictions="2:" />
         <ITEM name="max_rt_shift" value="0" type="double" description="Maximum realistic RT difference for a peptide (median per run vs. reference). Peptides with higher shifts (outliers) are not used to compute the alignment.#br#If 0, no limit (disable filter); if &gt; 1, the final value in seconds; if &lt;= 1, taken as a fraction of the range of the reference RT scale." required="false" advanced="false" restrictions="0:" />
-        <ITEM name="use_unassigned_peptides" value="true" type="string" description="Should unassigned peptide identifications be used when computing an alignment of feature maps? If &apos;false&apos;, only peptide IDs assigned to features will be used." required="false" advanced="false" restrictions="true,false" />
-        <ITEM name="use_feature_rt" value="false" type="string" description="When aligning feature maps, don&apos;t use the retention time of a peptide identification directly; instead, use the retention time of the centroid of the feature (apex of the elution profile) that the peptide was matched to. If different identifications are matched to one feature, only the peptide closest to the centroid in RT is used.#br#Precludes &apos;use_unassigned_peptides&apos;." required="false" advanced="false" restrictions="true,false" />
+        <ITEM name="use_unassigned_peptides" value="true" type="string" description="Should unassigned peptide identifications be used when computing an alignment of feature or consensus maps? If &apos;false&apos;, only peptide IDs assigned to features will be used." required="false" advanced="false" restrictions="true,false" />
+        <ITEM name="use_feature_rt" value="false" type="string" description="When aligning feature or consensus maps, don&apos;t use the retention time of a peptide identification directly; instead, use the retention time of the centroid of the feature (apex of the elution profile) that the peptide was matched to. If different identifications are matched to one feature, only the peptide closest to the centroid in RT is used.#br#Precludes &apos;use_unassigned_peptides&apos;." required="false" advanced="false" restrictions="true,false" />
       </NODE>
       <NODE name="model" description="Options to control the modeling of retention time transformations from data">
         <ITEM name="type" value="b_spline" type="string" description="Type of model" required="false" advanced="false" restrictions="linear,b_spline,interpolated" />
@@ -33,10 +33,12 @@
         <NODE name="b_spline" description="Parameters for &apos;b_spline&apos; model">
           <ITEM name="wavelength" value="0" type="double" description="Determines the amount of smoothing by setting the number of nodes for the B-spline. The number is chosen so that the spline approximates a low-pass filter with this cutoff wavelength. The wavelength is given in the same units as the data; a higher value means more smoothing. &apos;0&apos; sets the number of nodes to twice the number of input points." required="false" advanced="false" restrictions="0:" />
           <ITEM name="num_nodes" value="5" type="int" description="Number of nodes for B-spline fitting. Overrides &apos;wavelength&apos; if set (to two or greater). A lower value means more smoothing." required="false" advanced="false" restrictions="0:" />
-          <ITEM name="boundary_condition" value="2" type="int" description="Boundary condition at endpoints: 0 (value zero), 1 (first derivative zero) or 2 (second derivative zero)" required="false" advanced="false" restrictions="0:2" />
+          <ITEM name="extrapolate" value="linear" type="string" description="Method to use for extrapolation beyond the original data range. &apos;linear&apos;: Linear extrapolation using the slope of the B-spline at the corresponding endpoint. &apos;b_spline&apos;: Use the B-spline (as for interpolation). &apos;constant&apos;: Use the constant value of the B-spline at the corresponding endpoint. &apos;global_linear&apos;: Use a linear fit through the data (which will most probably introduce discontinuities at the ends of the data range)." required="false" advanced="false" restrictions="linear,b_spline,constant,global_linear" />
+          <ITEM name="boundary_condition" value="2" type="int" description="Boundary condition at B-spline endpoints: 0 (value zero), 1 (first derivative zero) or 2 (second derivative zero)" required="false" advanced="false" restrictions="0:2" />
         </NODE>
         <NODE name="interpolated" description="Parameters for &apos;interpolated&apos; model">
           <ITEM name="interpolation_type" value="cspline" type="string" description="Type of interpolation to apply." required="false" advanced="false" restrictions="linear,cspline,akima" />
+          <ITEM name="extrapolation_type" value="two-point-linear" type="string" description="Type of extrapolation to apply: two-point-linear: use the first and last data point to build a single linear model, four-point-linear: build two linear models on both ends using the first two / last two points, global-linear: use all points to build a single linear model. Note that global-linear may not be continuous at the border." required="false" advanced="false" restrictions="two-point-linear,four-point-linear,global-linear" />
         </NODE>
       </NODE>
     </NODE>


### PR DESCRIPTION
Fixes #1939 by removing the "peptide_score_threshold" algorithm parameter.