### PR TITLE
[FEAT] TOPPView: search ScanView

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
@@ -76,10 +76,11 @@ private:
     /// cache to store mapping of chromatogram precursors to chromatogram indices
     std::map<size_t, std::map<Precursor, std::vector<Size>, Precursor::MZLess> > map_precursor_to_chrom_idx_cache_;
 private slots:
-    void spectrumSearchText_(const QString & text); //< searches for rows containing a search text; called when text search box is used
+    void spectrumSearchText_(); //< searches for rows containing a search text (from spectra_search_box_); called when text search box is used
     void spectrumBrowserHeaderContextMenu_(const QPoint &);
     void spectrumSelectionChange_(QTreeWidgetItem *, QTreeWidgetItem *);
-    void spectrumDoubleClicked_(QTreeWidgetItem *, int);
+    void searchAndShow_(); //< searches using text box and plots the spectrum
+    void spectrumDoubleClicked_(QTreeWidgetItem *); //< called upon double click; emits spectrumDoubleClicked() after some checking (opens a new Tab)
     void spectrumContextMenu_(const QPoint &);
   };
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
@@ -73,10 +73,10 @@ private:
     QLineEdit * spectra_search_box_;
     QComboBox * spectra_combo_box_;
     QTreeWidget * spectra_treewidget_;
-    // cache to store mapping of chromatogram precursors to chromatogram indices
+    /// cache to store mapping of chromatogram precursors to chromatogram indices
     std::map<size_t, std::map<Precursor, std::vector<Size>, Precursor::MZLess> > map_precursor_to_chrom_idx_cache_;
 private slots:
-    void spectrumSelected_(const QString & text);
+    void spectrumSearchText_(const QString & text); //< searches for rows containing a search text; called when text search box is used
     void spectrumBrowserHeaderContextMenu_(const QPoint &);
     void spectrumSelectionChange_(QTreeWidgetItem *, QTreeWidgetItem *);
     void spectrumDoubleClicked_(QTreeWidgetItem *, int);

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
@@ -129,7 +129,7 @@ public:
     /// ----- Annotations
 
     /// Add an annotation item for the given peak
-    Annotation1DItem * addPeakAnnotation(PeakIndex peak_index, QString text, QColor color);
+    Annotation1DItem * addPeakAnnotation(const PeakIndex& peak_index, const QString& text, const QColor& color);
 
     /// Draws all annotation items of @p layer_index on @p painter
     void drawAnnotations(Size layer_index, QPainter & painter);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.cpp
@@ -78,7 +78,7 @@ namespace OpenMS
     QFile fh(filename.toQString());
     fh.open(QFile::ReadOnly);
     QString style_string = QLatin1String(fh.readAll());
-    std::cerr << "Content: " << style_string.toStdString() << "\n\n\n";
+    //std::cerr << "Stylesheet content: " << style_string.toStdString() << "\n\n\n";
     this->setStyleSheet(style_string);
   }
 

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -65,14 +65,12 @@ namespace OpenMS
 
     ///@improvement write the visibility-status of the columns in toppview.ini and read at start
 
+    QStringList qsl; // names of searchable columns
+    qsl << "index" << "RT" << "PC m/z" << "dissociation" << "scan" << "zoom";
+
     QStringList header_labels; /// @improvement make this global to change only once (otherwise changes must be applied in several slots too!)
     header_labels.append(QString("MS level"));
-    header_labels.append(QString("index"));
-    header_labels.append(QString("RT"));
-    header_labels.append(QString("precursor m/z"));
-    header_labels.append(QString("dissociation"));
-    header_labels.append(QString("scan type"));
-    header_labels.append(QString("zoom"));
+    header_labels.append(qsl); // all searchable columns
     spectra_treewidget_->setHeaderLabels(header_labels);
 
     spectra_treewidget_->setDragEnabled(true);
@@ -88,19 +86,12 @@ namespace OpenMS
 
     QHBoxLayout * tmp_hbox_layout = new QHBoxLayout();
 
-    spectra_search_box_ = new QLineEdit("", this);
+    spectra_search_box_ = new QLineEdit("<search text>", this);
 
-    QStringList qsl;
-    qsl.push_back("index");
-    qsl.push_back("RT");
-    qsl.push_back("MZ");
-    qsl.push_back("dissociation");
-    qsl.push_back("scan");
-    qsl.push_back("zoom");
     spectra_combo_box_ = new QComboBox(this);
     spectra_combo_box_->addItems(qsl);
 
-    connect(spectra_search_box_, SIGNAL(textEdited(const QString &)), this, SLOT(spectrumSelected_(const QString &)));
+    connect(spectra_search_box_, SIGNAL(textEdited(const QString &)), this, SLOT(spectrumSearchText_(const QString &)));
 
     tmp_hbox_layout->addWidget(spectra_search_box_);
     tmp_hbox_layout->addWidget(spectra_combo_box_);
@@ -117,7 +108,7 @@ namespace OpenMS
     return spectra_combo_box_;
   }
 
-  void SpectraViewWidget::spectrumSelected_(const QString & text)
+  void SpectraViewWidget::spectrumSearchText_(const QString & text)
   {
     QTreeWidget * spectra_view_treewidget = spectra_treewidget_;
     QComboBox * spectra_view_combobox = spectra_combo_box_;
@@ -130,17 +121,17 @@ namespace OpenMS
       }
 
       Qt::MatchFlags matchflags = Qt::MatchFixedString;
-      //matchflags = matchflags | Qt::MatchRecursive; // whether we also want to match subitems
+      matchflags |=  Qt::MatchRecursive; // match subitems (below top-level)
       if (col != 1)
       {
         // only the index has to be matched exactly
         matchflags = matchflags | Qt::MatchStartsWith;
       }
       QList<QTreeWidgetItem *> searched = spectra_view_treewidget->findItems(text, matchflags, col);
-      QList<QTreeWidgetItem *> selected = spectra_view_treewidget->selectedItems();
 
       if (searched.size() > 0)
       {
+        QList<QTreeWidgetItem *> selected = spectra_view_treewidget->selectedItems();
         QTreeWidgetItem * olditem = spectra_view_treewidget->currentItem();
         for (int i = 0; i < selected.size(); ++i)
         {

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -115,7 +115,7 @@ namespace OpenMS
 
   void SpectraViewWidget::spectrumSearchText_()
   {
-    QString& text = spectra_search_box_->text(); // get text from QLineEdit
+    const QString text = spectra_search_box_->text(); // get text from QLineEdit
     if (text.size() > 0)
     {
       QTreeWidget * spectra_view_treewidget = spectra_treewidget_;

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -137,17 +137,12 @@ namespace OpenMS
 
       if (searched.size() > 0)
       {
-        QList<QTreeWidgetItem *> selected = spectra_view_treewidget->selectedItems();
-        QTreeWidgetItem * olditem = spectra_view_treewidget->currentItem();
-        for (int i = 0; i < selected.size(); ++i)
-        {
-          selected[i]->setSelected(false);
-        }
-        spectra_view_treewidget->update();
+        //QTreeWidgetItem * olditem = spectra_view_treewidget->currentItem();
+        spectra_view_treewidget->clearSelection();
         searched.first()->setSelected(true);
         spectra_view_treewidget->update();
         spectra_view_treewidget->scrollToItem(searched.first());
-        // spectrumSelectionChange_(searched.first(), olditem); // updates the plot
+        //spectrumSelectionChange_(searched.first(), olditem); // updates the plot
       }
     }
   }

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1420,7 +1420,7 @@ namespace OpenMS
         else if (result->text() == "Add peak annotation mz")
         {
           QString label = String::number(near_peak.getPeak(*getCurrentLayer().getPeakData()).getMZ(), 4).toQString();
-          addPeakAnnotation(near_peak, label, Qt::black);
+          addPeakAnnotation(near_peak, label, getCurrentLayer_().param.getValue("peak_color").toQString());
         }
         else if (result->text() == "Reset alignment")
         {
@@ -1466,11 +1466,11 @@ namespace OpenMS
     QString text = QInputDialog::getText(this, "Add peak annotation", "Enter text:", QLineEdit::Normal, "", &ok);
     if (ok && !text.isEmpty())
     {
-      addPeakAnnotation(near_peak, text, Qt::blue);
+      addPeakAnnotation(near_peak, text, QColor(getCurrentLayer_().param.getValue("peak_color").toQString()));
     }
   }
 
-  Annotation1DItem * Spectrum1DCanvas::addPeakAnnotation(PeakIndex peak_index, QString text, QColor color)
+  Annotation1DItem * Spectrum1DCanvas::addPeakAnnotation(const PeakIndex& peak_index, const QString& text, const QColor& color)
   {
     PeakType peak = peak_index.getPeak(*getCurrentLayer().getPeakData());
     PointType position(peak.getMZ(), peak.getIntensity());


### PR DESCRIPTION
 - enable searching of subitems in ScanView (useful for e.g. searching for a precursor mass)
 - make names of columns match the filter names
 - spectrum is shown upon pressing `Enter` (see "What's This" help text)

 (minor) - peak annotations are now colored in the layer color. Labels are still black, giving the user a free choice of color.