### PR TITLE
[LOG] PeptideIndexer: suppress uninformative param update message

### DIFF
--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -119,14 +119,10 @@ protected:
     String in = getStringOption_("in");
     String out = getStringOption_("out");
 
-
     PeptideIndexing indexer;
-
     Param param = getParam_().copy("", true);
-
     Param param_pi = indexer.getParameters();
-    param_pi.update(param);
-
+    param_pi.update(param, false, Log_debug); // suppress param. update message
     indexer.setParameters(param_pi);
 
     bool keep_unreferenced_proteins = param.getValue("keep_unreferenced_proteins").toBool();


### PR DESCRIPTION
A message like this would get printed whenever PeptideIndexer was run (introduced with #1833):
```
Unknown (or deprecated) Parameter 'in' given in old parameter file! Ignoring ...
Unknown (or deprecated) Parameter 'fasta' given in old parameter file! Ignoring ...
Unknown (or deprecated) Parameter 'out' given in old parameter file! Ignoring ...
Overriding Default-Parameter 'decoy_string' with new value 'XXX_'!
Overriding Default-Parameter 'prefix' with new value 'true'!
Overriding Default-Parameter 'missing_decoy_action' with new value 'warn'!
Overriding Default-Parameter 'allow_unmatched' with new value 'true'!
Overriding Default-Parameter 'IL_equivalent' with new value 'true'!
Unknown (or deprecated) Parameter 'threads' given in old parameter file! Ignoring ...
Unknown (or deprecated) Parameter 'no_progress' given in old parameter file! Ignoring ...
Unknown (or deprecated) Parameter 'force' given in old parameter file! Ignoring ...
Unknown (or deprecated) Parameter 'test' given in old parameter file! Ignoring ...
Unknown (or deprecated) Parameter 'ini' given in old parameter file! Ignoring ...
Overriding Default-Parameter 'enzyme:specificity' with new value 'semi'!
```

This change stops that from happening (unless in debug mode).