### PR TITLE
Fixes for problems with empty idXML files

### DIFF
--- a/src/tests/topp/degenerate_cases/empty.idXML
+++ b/src/tests/topp/degenerate_cases/empty.idXML
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
 <IdXML version="1.4" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-<SearchParameters charges="+0, +0" id="ID_1" db_version="0" mass_type="monoisotopic" peak_mass_tolerance="0.0" precursor_peak_tolerance="0.0" db="Unknown"/>
-<IdentificationRun date="1900-01-01T01:01:01.0Z" search_engine="Unknown" search_parameters_ref="ID_1" search_engine_version="0"/>
+	<SearchParameters id="SP_0" db="Unknown" db_version="0" taxonomy="" mass_type="monoisotopic" charges="+0, +0" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+	</SearchParameters>
+	<IdentificationRun date="0000-00-00T00:00:00" search_engine="Unknown" search_engine_version="0" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+		</ProteinIdentification>
+	</IdentificationRun>
 </IdXML>

--- a/src/topp/IDMerger.cpp
+++ b/src/topp/IDMerger.cpp
@@ -183,7 +183,14 @@ protected:
   {
     do
     {
-      date_time = date_time.addSecs(1);
+      if (date_time.isValid())
+      {
+        date_time = date_time.addSecs(1);
+      }
+      else
+      {
+        date_time = DateTime::now();
+      }
       new_id = search_engine + "_" + date_time.toString(Qt::ISODate);
     }
     while (used_ids.find(new_id) != used_ids.end());

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -125,8 +125,6 @@ protected:
     param_pi.update(param, false, Log_debug); // suppress param. update message
     indexer.setParameters(param_pi);
 
-    bool keep_unreferenced_proteins = param.getValue("keep_unreferenced_proteins").toBool();
-
     String db_name = getStringOption_("fasta");
     if (!File::readable(db_name))
     {

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -161,30 +161,20 @@ protected:
     // calculations
     //-------------------------------------------------------------
 
-    if (proteins.empty()) // we do not allow an empty database
+    PeptideIndexing::ExitCodes indexer_exit = indexer.run(proteins, prot_ids,
+                                                          pep_ids);
+    if ((indexer_exit != PeptideIndexing::EXECUTION_OK) &&
+        (indexer_exit != PeptideIndexing::PEPTIDE_IDS_EMPTY))
     {
-      LOG_ERROR << "Error: An empty FASTA file was provided. Mapping makes no sense. Aborting..." << std::endl;
-      return INPUT_FILE_EMPTY;
-    }
-
-    if (pep_ids.empty()) // Aho-Corasick requires non-empty input
-    {
-      LOG_WARN << "Warning: An empty idXML file was provided. Output will be empty as well." << std::endl;
-      if (!keep_unreferenced_proteins)
+      if (indexer_exit == PeptideIndexing::DATABASE_EMPTY)
       {
-        prot_ids.clear();
+        return INPUT_FILE_EMPTY;       
       }
-      IdXMLFile().store(out, prot_ids, pep_ids);
-      return EXECUTION_OK;
-    }
-
-    PeptideIndexing::ExitCodes indexer_exit = indexer.run(proteins, prot_ids, pep_ids);
-    if ( (indexer_exit != PeptideIndexing::EXECUTION_OK) )
-    {
-      if (indexer_exit == PeptideIndexing::UNEXPECTED_RESULT)
+      else if (indexer_exit == PeptideIndexing::UNEXPECTED_RESULT)
       {
         return UNEXPECTED_RESULT;
-      } else
+      }
+      else
       {
         return UNKNOWN_ERROR;
       }


### PR DESCRIPTION
This PR addresses two problems that can occur in pipelines that generate empty idXMLs (using IDFilter):
1. PeptideIndexer drops meta data of the ID run (e.g. search engine, date/time) when used on an idXML without peptide IDs.
2. IDMerger gets stuck on idXMLs with invalid search times ("0000-00-00T00:00:00"), like the empty ones produced by PeptideIndexer.