### PR TITLE
[FIX] Fixed an error in m/z value calculation

### DIFF
--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -233,7 +233,7 @@ namespace OpenMS
 
   void TheoreticalSpectrumGenerator::addIsotopeCluster_(RichPeakSpectrum & spectrum, const AASequence & ion, Residue::ResidueType res_type, Int charge, double intensity) const
   {
-    double pos = ion.getMonoWeight(res_type, charge) / (double)charge;
+    double pos = ion.getMonoWeight(res_type, charge);
     RichPeak1D p;
     IsotopeDistribution dist = ion.getFormula(res_type, charge).getIsotopeDistribution(max_isotope_);
 
@@ -306,7 +306,7 @@ namespace OpenMS
       {
         continue;
       }
-      double loss_pos = loss_ion.getMonoWeight() / (double)charge;
+      double loss_pos = loss_ion.getMonoWeight();
       const String& loss_name = *it;
 
       if (add_isotopes_)
@@ -328,7 +328,7 @@ namespace OpenMS
       }
       else
       {
-        p.setMZ(loss_pos);
+        p.setMZ(loss_pos / (double)charge);
         if (add_metainfo_)
         {
           // note: important to construct a string from char. If omitted it will perform pointer arithmetics on the "-" string literal
@@ -477,7 +477,7 @@ namespace OpenMS
     }
 
     // precursor peak
-    double mono_pos = peptide.getMonoWeight(Residue::Full, charge) / double(charge);
+    double mono_pos = peptide.getMonoWeight(Residue::Full, charge);
 
     if (add_isotopes_)
     {
@@ -492,7 +492,7 @@ namespace OpenMS
     }
     else
     {
-      p.setMZ(mono_pos);
+      p.setMZ(mono_pos / (double)charge);
       p.setIntensity(pre_int_);
       spec.push_back(p);
     }
@@ -500,7 +500,7 @@ namespace OpenMS
 
     //loss of water
     EmpiricalFormula ion = peptide.getFormula(Residue::Full, charge) - EmpiricalFormula("H2O");
-    mono_pos = ion.getMonoWeight() / double(charge);
+    mono_pos = ion.getMonoWeight();
     if (add_isotopes_)
     {
       IsotopeDistribution dist = ion.getIsotopeDistribution(max_isotope_);
@@ -519,7 +519,7 @@ namespace OpenMS
     }
     else
     {
-      p.setMZ(mono_pos);
+      p.setMZ(mono_pos / (double)charge);
       p.setIntensity(pre_int_H2O_);
       if (add_metainfo_)
       {
@@ -531,7 +531,7 @@ namespace OpenMS
 
     //loss of ammonia
     ion = peptide.getFormula(Residue::Full, charge) - EmpiricalFormula("NH3");
-    mono_pos = ion.getMonoWeight() / double(charge);
+    mono_pos = ion.getMonoWeight();
     if (add_isotopes_)
     {
       IsotopeDistribution dist = ion.getIsotopeDistribution(max_isotope_);
@@ -550,7 +550,7 @@ namespace OpenMS
     }
     else
     {
-      p.setMZ(mono_pos);
+      p.setMZ(mono_pos / (double)charge);
       p.setIntensity(pre_int_NH3_);
       if (add_metainfo_)
       {

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -342,6 +342,72 @@ START_SECTION(([EXTRA] test monomer extreme case))
 }
 END_SECTION
 
+START_SECTION(([EXTRA] test isotope clusters for all peak types))
+{
+  AASequence tmp_aa = AASequence::fromString("ARRGH");
+  RichPeakSpectrum spec;
+  TheoreticalSpectrumGenerator t_gen;
+  Param params;
+  params.setValue("add_isotopes", "true");
+  params.setValue("max_isotope", 2);
+  t_gen.setParameters(params);
+
+  // isotope cluster for y-ions
+  t_gen.addPeaks(spec, tmp_aa, Residue::YIon, 2);
+  TEST_EQUAL(spec.size(), 8)
+
+  TOLERANCE_ABSOLUTE(0.001)
+  double neutron_shift = Constants::NEUTRON_MASS_U;
+
+  // 4 monoisotopic masses, 4 second peaks with added neutron mass / 2
+  double result[] = {78.54206, 107.05279, 185.10335, 263.15390, 78.54206+(neutron_shift/2), 107.05279+(neutron_shift/2), 185.10335+(neutron_shift/2), 263.15390+(neutron_shift/2)};
+  std::sort(result, result+8);
+  for (Size i = 0; i != spec.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec[i].getPosition()[0], result[i])
+  }
+
+  // isotope cluster for losses
+  spec.clear(true);
+  params.setValue("add_losses", "true");
+  params.setValue("add_b_ions", "false");
+  t_gen.setParameters(params);
+  t_gen.getSpectrum(spec, tmp_aa, 2);
+  TEST_EQUAL(spec.size(), 40)
+
+  double proton_shift = Constants::PROTON_MASS_U;
+  // 10 monoisotopic peaks with charge=1, 10 second peaks, 20 with charge=2
+  double result_losses[] = {156.07675, 213.09821, 325.18569, 327.17753, 352.17278, 369.19932, 481.28680, 483.27864, 508.27389, 525.30044,
+                                           156.07675+neutron_shift, 213.09821+neutron_shift, 325.18569+neutron_shift, 327.17753+neutron_shift, 352.17278+neutron_shift, 369.19932+neutron_shift, 481.28680+neutron_shift, 483.27864+neutron_shift, 508.27389+neutron_shift, 525.30044+neutron_shift,
+                                           (156.07675+proton_shift)/2, (213.09821+proton_shift)/2, (325.18569+proton_shift)/2, (327.17753+proton_shift)/2, (352.17278+proton_shift)/2, (369.19932+proton_shift)/2, (481.28680+proton_shift)/2, (483.27864+proton_shift)/2, (508.27389+proton_shift)/2, (525.30044+proton_shift)/2,
+                                           (156.07675+proton_shift)/2+(neutron_shift/2), (213.09821+proton_shift)/2+(neutron_shift/2), (325.18569+proton_shift)/2+(neutron_shift/2), (327.17753+proton_shift)/2+(neutron_shift/2), (352.17278+proton_shift)/2+(neutron_shift/2),
+                                           (369.19932+proton_shift)/2+(neutron_shift/2), (481.28680+proton_shift)/2+(neutron_shift/2), (483.27864+proton_shift)/2+(neutron_shift/2), (508.27389+proton_shift)/2+(neutron_shift/2), (525.30044+proton_shift)/2+(neutron_shift/2)};
+  std::sort(result_losses, result_losses+40);
+  for (Size i = 0; i != spec.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec[i].getPosition()[0], result_losses[i])
+  }
+
+  // isotope cluster for precurser peaks with losses
+  spec.clear(true);
+  params.setValue("add_precursor_peaks", "true");
+  t_gen.setParameters(params);
+  t_gen.addPrecursorPeaks(spec, tmp_aa, 2);
+  TEST_EQUAL(spec.size(), 6)
+
+  // 3 monoisitopic peaks, 3 second peaks
+  double result_precursors[] = {(578.32698+proton_shift)/2, (579.31100+proton_shift)/2, (596.33755+proton_shift)/2,
+                                                  (578.32698+proton_shift)/2+(neutron_shift/2), (579.31100+proton_shift)/2+(neutron_shift/2), (596.33755+proton_shift)/2+(neutron_shift/2)};
+  std::sort(result_precursors, result_precursors+6);
+  for (Size i = 0; i != spec.size(); ++i)
+  {
+    TEST_REAL_SIMILAR(spec[i].getPosition()[0], result_precursors[i])
+  }
+
+
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Fixed an error in m/z value calculation in the TheoreticalSpectrumGenerator.
The mass was divided by the charge two times in some cases.
Once on initializing the monoisotopic mass and again for each isotopic peak.