### PR TITLE
[FIX] Improvements for running Mascot searches (MascotAdapterOnline)

### DIFF
--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -68,7 +68,7 @@ namespace OpenMS
     defaults_.setMinFloat("fragment_mass_tolerance", 0.0);
     defaults_.setValue("fragment_error_units", "Da", "Units of the fragment peaks tolerance");
     defaults_.setValidStrings("fragment_error_units", ListUtils::create<String>("mmu,Da"));
-    defaults_.setValue("charges", "1,2,3", "Allowed charge states, given as a comma separated list of integers");
+    defaults_.setValue("charges", "1,2,3", "Charge states to consider, given as a comma separated list of integers (only used for spectra without precursor charge information)");
     defaults_.setValue("taxonomy", "All entries", "Taxonomy specification of the sequences");
     vector<String> all_mods;
     ModificationsDB::getInstance()->getAllSearchModifications(all_mods);

--- a/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+++ b/src/openms/source/FORMAT/MascotRemoteQuery.cpp
@@ -81,7 +81,7 @@ namespace OpenMS
     defaults_.setValidStrings("use_ssl", ListUtils::create<String>("true,false"));
 
     // Mascot export options
-    defaults_.setValue("export_params", "_sigthreshold=0.99&_showsubsets=1&show_same_sets=1&report=0&percolate=0&query_master=0", "Adjustable export parameters (passed to Mascot's 'export_dat_2.pl' script). Generally only parameters that control which hits to export are safe to adjust/add. Many settings that govern what types of information to include are required by OpenMS and cannot be changed. Note that setting 'query_master' to 1 may lead to incorrect protein references for peptides.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("export_params", "_ignoreionsscorebelow=0&_sigthreshold=0.99&_showsubsets=1&show_same_sets=1&report=0&percolate=0&query_master=0", "Adjustable export parameters (passed to Mascot's 'export_dat_2.pl' script). Generally only parameters that control which hits to export are safe to adjust/add. Many settings that govern what types of information to include are required by OpenMS and cannot be changed. Note that setting 'query_master' to 1 may lead to incorrect protein references for peptides.", ListUtils::create<String>("advanced"));
     defaults_.setValue("skip_export", "false", "For use with an external Mascot Percolator (via GenericWrapper): Run the Mascot search, but do not export the results. The output file produced by MascotAdapterOnline will contain only the Mascot search number.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("skip_export", ListUtils::create<String>("true,false"));
     defaultsToParam_();
@@ -598,8 +598,8 @@ namespace OpenMS
         if (mascot_error_regex.cap() == "[M00380]")
         {
           // we know this error, so we give a much shorter and readable error message for the user
-          LOG_ERROR << "You must enter an email address and user name when using the Matrix Science public web site [M00380]." << std::endl;
           error_message_ = "You must enter an email address and user name when using the Matrix Science public web site [M00380].";
+          LOG_ERROR << error_message_ << std::endl;
         }
         else
         {
@@ -726,7 +726,7 @@ namespace OpenMS
     String tmp = path.substr(pos + 1);
     pos = tmp.find_last_of(".");
     tmp = tmp.substr(1, pos - 1);
-   
+
     return tmp.toInt();
   }
 }

--- a/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
@@ -142,7 +142,7 @@ START_SECTION((void store(std::ostream &os, const String &filename, const PeakMa
                     "TITLE=901.23457_234.568_ident_test\n"
                     "PEPMASS=901.23457\n"
                     "RTINSECONDS=234.568\n"
-                    "890.12346 2345.68\n"
+                    "890.12346 2345.679\n"
                     "END IONS");
   TEST_EQUAL(mgf_file.hasSubstring(content), true);
 }

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -174,9 +174,9 @@ protected:
     registerStringOption_("tryptic", "<choice>", tryptic_[2], "Level of cleavage specificity required (MS-GF+ parameter '-ntt')", false);
     setValidStrings_("tryptic", tryptic_);
 
-    registerIntOption_("min_precursor_charge", "<num>", 2, "Minimum precursor ion charge (MS-GF+ parameter '-minCharge')", false);
+    registerIntOption_("min_precursor_charge", "<num>", 2, "Minimum precursor ion charge (only used for spectra without charge information; MS-GF+ parameter '-minCharge')", false);
     setMinInt_("min_precursor_charge", 1);
-    registerIntOption_("max_precursor_charge", "<num>", 3, "Maximum precursor ion charge (MS-GF+ parameter '-maxCharge')", false);
+    registerIntOption_("max_precursor_charge", "<num>", 3, "Maximum precursor ion charge (only used for spectra without charge information; MS-GF+ parameter '-maxCharge')", false);
     setMinInt_("max_precursor_charge", 1);
 
     registerIntOption_("min_peptide_length", "<num>", 6, "Minimum peptide length to consider (MS-GF+ parameter '-minLength')", false);


### PR DESCRIPTION
1. When writing MGF (e.g. submitting data to Mascot), use fixed numbers of digits after the decimal point (3 for RT and intensity values, 5 for m/z), rather than a fixed (minimal) number of total digits. This keeps the RT precision adequate even for very long gradients (> 10,000 s) and fixes #1961.
2. Add a Mascot export parameter ("_ignoreionsscorebelow=0") to the defaults in OpenMS. Without this, some PSMs may be filtered out from the Mascot results in the export step.