### PR TITLE
[FIX] fix for compile error

### DIFF
--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -782,7 +782,7 @@ DefaultParamHandler("PeptideIndexing")
         else
         { // func is empty anyways, since no AC was run
           OPENMS_PRECONDITION(func.pep_to_prot.empty(), "Internal error - unexpected AhoCorasick results found");
-          swap(func, func_SA);
+          std::swap(func, func_SA);
         }
       } // SA run
     } // end local scope

--- a/src/openms/source/FORMAT/IndexedMzMLFile.cpp
+++ b/src/openms/source/FORMAT/IndexedMzMLFile.cpp
@@ -47,7 +47,7 @@ namespace OpenMS
     //-------------------------------------------------------------
 
     index_offset_ = IndexedMzMLDecoder().findIndexListOffset(filename);
-    if (index_offset_ == -1)
+    if (index_offset_ == (std::streampos)-1)
     {
       parsing_success_ = false;
       return;


### PR DESCRIPTION
may fix the MSVS compile error

see the current compilation errors:

http://cdash.openms.de/viewBuildError.php?buildid=183885

```Error 	

3>/.../OpenMS/src/openms/source/FORMAT/IndexedMzMLFile.cpp(50): error C2666: 'std::fpos<_Statetype>::operator ==' : 3 overloads have similar conversions

3>          with
3>          [
3>              _Statetype=_Mbstatet
3>          ]
3>          c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\iosfwd(102): could be 'bool std::fpos<_Statetype>::operator ==(std::streamoff) const'
3>          with
3>          [
3>              _Statetype=_Mbstatet
3>          ]
3>          c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\iosfwd(97): or       'bool std::fpos<_Statetype>::operator ==(const std::fpos<_Statetype> &) const'


Repository 	https://github.com/OpenMS/OpenMS/blob/master/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
Build Log Line 	111
Error 	

3>/.../OpenMS/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp(785): error C2784: 'void seqan::swap(seqan::StringSet<TString,TSpec> &,seqan::StringSet<TString,TSpec> &)' : could not deduce template argument for 'seqan::StringSet<TString,TSpec> &' from 'seqan::FoundProteinFunctor'

3>          C:\dev\contrib_vs10_64bit\include\seqan/sequence/string_set_base.h(291) : see declaration of 'seqan::swap'


Repository 	https://github.com/OpenMS/OpenMS/blob/master/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
Build Log Line 	113
Error 	

3>/.../OpenMS/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp(785): error C2784: 'void seqan::swap(seqan::String<TValue,seqan::Alloc<TSpec>> &,seqan::String<TValue,seqan::Alloc<TSpec>> &)' : could not deduce template argument for 'seqan::String<TValue,seqan::Alloc<TSpec>> &' from 'seqan::FoundProteinFunctor'

3>          C:\dev\contrib_vs10_64bit\include\seqan/sequence/string_alloc.h(239) : see declaration of 'seqan::swap'


Repository 	https://github.com/OpenMS/OpenMS/blob/master/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
Build Log Line 	115
Error 	

3>/.../OpenMS/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp(785): error C2784: 'void seqan::swap(seqan::String<TValue,TSpec> &,seqan::String<TValue,TSpec> &)' : could not deduce template argument for 'seqan::String<TValue,TSpec> &' from 'seqan::FoundProteinFunctor'

3>          C:\dev\contrib_vs10_64bit\include\seqan/sequence/string_base.h(185) : see declaration of 'seqan::swap'


Repository 	https://github.com/OpenMS/OpenMS/blob/master/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
Build Log Line 	117
Error 	

3>/.../OpenMS/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp(785): error C3767: 'swap': candidate function(s) not accessible

3>          could be the friend function at 'C:\dev\NIGHTLY\OpenMS\src\openms\include\OpenMS/DATASTRUCTURES/ConstRefVector.h(583)' : 'swap'  [may be found via argument-dependent lookup]
3>          or the friend function at       'C:\dev\NIGHTLY\OpenMS\src\openms\include\OpenMS/DATASTRUCTURES/ConstRefVector.h(349)' : 'swap'  [may be found via argument-dependent lookup]
3>          or the friend function at       'C:\dev\NIGHTLY\OpenMS\src\openms\include\OpenMS/DATASTRUCTURES/ConstRefVector.h(583)' : 'swap'  [may be found via argument-dependent lookup]
3>          or the friend function at       'C:\dev\NIGHTLY\OpenMS\src\openms\include\OpenMS/DATASTRUCTURES/ConstRefVector.h(349)' : 'swap'  [may be found via argument-dependent lookup]


```

this may fix the first one, but the others still need fixing

@jpfeuffer  @cbielow can you comment on these errors ?