### PR TITLE
[FIX-#2020] ConsensusID: fix problems causing "nan"/"inf" support values

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -764,10 +764,10 @@ public:
     /**
        @brief Removes duplicate peptide hits from each peptide identification, keeping only unique hits (per ID).
 
-       Hits are considered duplicated if they compare as equal using PeptideHit::operator== (i.e. not only the sequences have to match!).
+       By default, hits are considered duplicated if they compare as equal using PeptideHit::operator==. However, if @p seq_only is set, only the sequences (incl. modifications) are compared. In both cases, the first occurrence of each hit in a peptide ID is kept, later ones are removed.
     */
     static void removeDuplicatePeptideHits(std::vector<PeptideIdentification>&
-                                           peptides);
+                                           peptides, bool seq_only = false);
 
     ///@}
 

--- a/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithm.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithm.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Macros.h> // for "OPENMS_PRECONDITION"
+#include <OpenMS/FILTERING/ID/IDFilter.h>
 
 using namespace std;
 
@@ -88,12 +89,14 @@ namespace OpenMS
          pep_it != ids.end(); ++pep_it)
     {
       pep_it->sort();
-      if ((considered_hits_ > 0) && 
+      if ((considered_hits_ > 0) &&
           (pep_it->getHits().size() > considered_hits_))
       {
         pep_it->getHits().resize(considered_hits_);
       }
     }
+    // make sure there are no duplicated hits (by sequence):
+    IDFilter::removeDuplicatePeptideHits(ids, true);
 
     SequenceGrouping results;
     apply_(ids, results); // actual (subclass-specific) processing

--- a/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithmIdentity.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithmIdentity.cpp
@@ -99,7 +99,7 @@ namespace OpenMS
                                    vector<double>(1, hit_it->getScore()));
         }
         else // previously seen sequence
-        { 
+        {
           compareChargeStates_(pos->second.first, hit_it->getCharge(),
                                pos->first);
           pos->second.second.push_back(hit_it->getScore());
@@ -114,7 +114,13 @@ namespace OpenMS
          res_it != results.end(); ++res_it)
     {
       double score = getAggregateScore_(res_it->second.second, higher_better);
-      double support = (res_it->second.second.size() - 1.0) / n_other_ids;
+      // if 'count_empty' is false, 'n_other_ids' may be zero, in which case
+      // we define the support to be one to avoid a NaN:
+      double support = 1.0;
+      if (n_other_ids > 0) // the normal case
+      {
+        support = (res_it->second.second.size() - 1.0) / n_other_ids;
+      }
       res_it->second.second.resize(2);
       res_it->second.second[0] = score;
       res_it->second.second[1] = support;

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -588,7 +588,7 @@ namespace OpenMS
       n_initial += pep_it->getHits().size();
       keepMatchingItems(pep_it->getHits(), present_filter);
       n_metavalue += pep_it->getHits().size();
-    
+
       keepMatchingItems(pep_it->getHits(), unique_filter);
     }
 
@@ -604,21 +604,36 @@ namespace OpenMS
 
   // @TODO: generalize this to protein hits?
   void IDFilter::removeDuplicatePeptideHits(vector<PeptideIdentification>&
-                                            peptides)
+                                            peptides, bool seq_only)
   {
     for (vector<PeptideIdentification>::iterator pep_it = peptides.begin();
          pep_it != peptides.end(); ++pep_it)
     {
-      // there's no "PeptideHit::operator<" defined, so we can't use a set nor
-      // "sort" + "unique" from the standard library:
       vector<PeptideHit> filtered_hits;
-      for (vector<PeptideHit>::iterator hit_it = pep_it->getHits().begin();
-           hit_it != pep_it->getHits().end(); ++hit_it)
+      if (seq_only)
       {
-        if (find(filtered_hits.begin(), filtered_hits.end(), *hit_it) == 
-            filtered_hits.end())
+        set<AASequence> seqs;
+        for (vector<PeptideHit>::iterator hit_it = pep_it->getHits().begin();
+             hit_it != pep_it->getHits().end(); ++hit_it)
         {
-          filtered_hits.push_back(*hit_it);
+          if (seqs.insert(hit_it->getSequence()).second) // new sequence
+          {
+            filtered_hits.push_back(*hit_it);
+          }
+        }
+      }
+      else
+      {
+        // there's no "PeptideHit::operator<" defined, so we can't use a set nor
+        // "sort" + "unique" from the standard library:
+        for (vector<PeptideHit>::iterator hit_it = pep_it->getHits().begin();
+             hit_it != pep_it->getHits().end(); ++hit_it)
+        {
+          if (find(filtered_hits.begin(), filtered_hits.end(), *hit_it) ==
+              filtered_hits.end())
+          {
+            filtered_hits.push_back(*hit_it);
+          }
         }
       }
       pep_it->getHits().swap(filtered_hits);

--- a/src/tests/class_tests/openms/source/IDFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/IDFilter_test.cpp
@@ -820,7 +820,7 @@ START_SECTION((static void keepUniquePeptidesPerProtein(vector<PeptideIdentifica
 }
 END_SECTION
 
-START_SECTION((static void removeDuplicatePeptideHits(vector<PeptideIdentification>& peptides)))
+START_SECTION((static void removeDuplicatePeptideHits(vector<PeptideIdentification>& peptides, bool seq_only)))
 {
   vector<PeptideIdentification> peptides(1, global_peptides[0]);
   vector<PeptideHit>& hits = peptides[0].getHits();
@@ -848,6 +848,12 @@ START_SECTION((static void removeDuplicatePeptideHits(vector<PeptideIdentificati
   TEST_EQUAL(hits[3].getCharge(), 2);
   TEST_EQUAL(hits[4].getSequence().toString(), "DFPIANGEK");
   TEST_EQUAL(hits[4].getCharge(), 5);
+
+  IDFilter::removeDuplicatePeptideHits(peptides, true);
+  TEST_EQUAL(hits.size(), 2);
+  TEST_EQUAL(hits[0].getSequence().toString(), "DFPIANGER");
+  TEST_EQUAL(hits[0].getScore(), 0.3);
+  TEST_EQUAL(hits[1].getSequence().toString(), "DFPIANGEK");
 }
 END_SECTION
 

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -208,13 +208,13 @@ protected:
       std::copy(search_params.variable_modifications.begin(), search_params.variable_modifications.end(), std::inserter(var_mods_set, var_mods_set.end()));
       StringList spectra_data = it_prot_ids->getPrimaryMSRunPath();
       std::copy(spectra_data.begin(), spectra_data.end(), std::inserter(merged_spectra_data, merged_spectra_data.end()));
-    }    
+    }
     ProteinIdentification::SearchParameters search_params;
     std::vector<String> fixed_mods(fixed_mods_set.begin(), fixed_mods_set.end());
     std::vector<String> var_mods(var_mods_set.begin(), var_mods_set.end());
     search_params.fixed_modifications    = fixed_mods;
     search_params.variable_modifications = var_mods;
-    
+
     prot_ids.clear();
     prot_ids.resize(1);
     prot_ids[0].setDateTime(DateTime::now());
@@ -229,7 +229,7 @@ protected:
     prot_ids[0].setPrimaryMSRunPath(merged_spectra_data);
   }
 
-  
+
   template <typename MapType>
   void processFeatureOrConsensusMap_(MapType& input_map,
                                      ConsensusIDAlgorithm* consensus)


### PR DESCRIPTION
Two fixes:
- remove duplicate peptide hits, if there are any (extended IDFilter for this purpose)
- added a special case for calculating agreement between searches ("support") with only one successful search