### PR TITLE
[BUILD] fix build system for WM5

### DIFF
--- a/cmake/modules/FindWM5.cmake
+++ b/cmake/modules/FindWM5.cmake
@@ -82,8 +82,16 @@ if(WM5_FOUND)
   #------------------------------------------------------------------------------
   # check if we have a static Wm5 lib
   if(MSVC AND NOT DEFINED WM5_IS_STATIC)
-    # we try the optimized version of WM5_CORE to win32 path
-    list(GET WM5_Wm5Core_LIBRARY 1 _wm5_opt_core)
+  
+    # if we found more than one lib, we try the optimized version of WM5_CORE
+    # to win32 path 
+    list(LENGTH WM5_Wm5Core_LIBRARY nrlibs)
+    if(nrlibs GREATER 1)
+      list(GET WM5_Wm5Core_LIBRARY 1 _wm5_opt_core)
+    else()
+      list(GET WM5_Wm5Core_LIBRARY 0 _wm5_opt_core)
+    endif()
+
     file(TO_NATIVE_PATH "${_wm5_opt_core}" _native_wm5_opt_core)
 
     # find dumpbin and translate to win32 path

--- a/cmake/modules/FindWM5.cmake
+++ b/cmake/modules/FindWM5.cmake
@@ -90,6 +90,8 @@ if(WM5_FOUND)
       list(GET WM5_Wm5Core_LIBRARY 1 _wm5_opt_core)
     else()
       list(GET WM5_Wm5Core_LIBRARY 0 _wm5_opt_core)
+      message(FATAL_ERROR "Only one WM library found, expected debug and release library. This indicates a potential problem when building the contrib.")
+
     endif()
 
     file(TO_NATIVE_PATH "${_wm5_opt_core}" _native_wm5_opt_core)

--- a/cmake/modules/FindWM5.cmake
+++ b/cmake/modules/FindWM5.cmake
@@ -89,9 +89,7 @@ if(WM5_FOUND)
     if(nrlibs GREATER 1)
       list(GET WM5_Wm5Core_LIBRARY 1 _wm5_opt_core)
     else()
-      list(GET WM5_Wm5Core_LIBRARY 0 _wm5_opt_core)
       message(FATAL_ERROR "Only one WM library found, expected debug and release library. This indicates a potential problem when building the contrib.")
-
     endif()
 
     file(TO_NATIVE_PATH "${_wm5_opt_core}" _native_wm5_opt_core)


### PR DESCRIPTION
- if only one library was built, then use the first one in the list
- fixes bug where configuration would fail on a 32bit Win system with
  MSVS 2008

I dont fully understand the code here, apparently it tries to select the second element in the list but in my builds there is only one element, so configuration fails.

As this is a blocker and makes the build of the 2.0.1 release fail, I opened it against master. 
