### PR TITLE
[BUILD] add flag for incremental linking (Win 32 bit)

### DIFF
--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -103,6 +103,11 @@ elseif (MSVC)
 	## use multiple CPU cores (if available)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
+  option(DISABLE_INCREMENTAL_LINKING "Disable incremental linking on Windows (/INCREMENTAL:NO) " OFF)
+  if (DISABLE_INCREMENTAL_LINKING)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /INCREMENTAL:NO")
+  endif()
+
   if (NOT OPENMS_64BIT_ARCHITECTURE)
     ## enable SSE1 on 32bit, on 64bit the compiler flag does not exist
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:SSE")

--- a/src/openms_gui/CMakeLists.txt
+++ b/src/openms_gui/CMakeLists.txt
@@ -100,7 +100,7 @@ openms_add_library(TARGET_NAME OpenMS_GUI
 # --------------------------------------------------------------------------
 # additional linker flags required by openms_gui
 if (MSVC)
-  set (GUI_lnk_flags "/FORCE:MULTIPLE /INCREMENTAL:NO /ignore:4006 /ignore:4088")
+  set (GUI_lnk_flags "/FORCE:MULTIPLE /ignore:4006 /ignore:4088")
   set_target_properties(OpenMS_GUI PROPERTIES LINK_FLAGS ${GUI_lnk_flags}) ## allow multiple definitions of symbols (e.g. from template instanciations or STL-derived classes)
 endif()
 


### PR DESCRIPTION
not sure whether we want this but sometimes for 32 bit builds on Windows, it is important to disable incremental linking. Instead of messing around in the build system and figuring out which cmake file needs modification, it would be nice to have a simple and easy flag for this.

addresses #2038 
