### PR TITLE
refactor R scripts for mzTab postprocessing

### DIFF
--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PEP.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PEP.R
@@ -6,33 +6,42 @@ options(digits=10)
 input.file <- commandArgs(TRUE)[1]
 output.file <- commandArgs(TRUE)[2]
 
-# read entire mzTab
-no.col <- max(count.fields(input.file, sep = "\t", quote=""))
-data <- read.table(input.file,sep="\t",fill=TRUE, quote="", col.names=1:no.col)
-
-# extract peptide data
-peptide.data <- data[which(data[,1]=="PEP"),]
-colnames(peptide.data) <- unlist(data[which(data[,1]=="PEH")[1],])
-peptide.data$PEH <- NULL
-
-countOccurrences <- function(char,s) {
+# count the occurences of character c in string s
+count.occurrences <- function(char,s) {
 	s2 <- gsub(char,"",s)
 	return (nchar(s) - nchar(s2))
 }
 
-checkAccessionFormat <- function(accessions) {
+# check that all protein accessions are of the format *|*|*
+check.accession.format <- function(accessions) {
 	n <- length(accessions)
-	count <- countOccurrences("[|]",accessions)
+	count <- count.occurrences("[|]",accessions)
 	m <- length(which(count==2))
 	return (n==m)
 }
 
-# simplify accession (in case it is of the format *|*|* )
-peptide.data$accession <- as.character(peptide.data$accession)
-if (checkAccessionFormat(peptide.data$accession)) {
-	list <- strsplit(peptide.data$accession,"[|]")
-	peptide.data$accession <- unlist(lapply(list, '[[', 2))
-	peptide.data$gene <- unlist(lapply(list, '[[', 3))
+# read the PEP section of an mzTab file
+readMzTabPEP <- function(file) {
+  
+  # read entire mzTab
+  no.col <- max(count.fields(file, sep = "\t", quote=""))
+  data <- read.table(file,sep="\t",fill=TRUE, quote="", col.names=1:no.col)
+  
+  # extract PEP data
+  peptide.data <- data[which(data[,1]=="PEP"),]
+  colnames(peptide.data) <- unlist(data[which(data[,1]=="PEH")[1],])
+  peptide.data$PEH <- NULL
+  
+  # simplify accession (in case it is of the format *|*|* )
+  peptide.data$accession <- as.character(peptide.data$accession)
+  if (check.accession.format(peptide.data$accession)) {
+    list <- strsplit(peptide.data$accession,"[|]")
+    peptide.data$accession <- unlist(lapply(list, '[[', 2))
+    peptide.data$gene <- unlist(lapply(list, '[[', 3))
+  }
+  
+  return (peptide.data)
 }
 
+peptide.data <- readMzTabPEP(input.file)
 write.table(peptide.data, output.file, sep="\t", row.names=FALSE, col.names=TRUE, quote=FALSE)

--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PEP.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PEP.R
@@ -7,15 +7,15 @@ input.file <- commandArgs(TRUE)[1]
 output.file <- commandArgs(TRUE)[2]
 
 # count the occurences of character c in string s
-count.occurrences <- function(char,s) {
+countOccurrences <- function(char,s) {
 	s2 <- gsub(char,"",s)
 	return (nchar(s) - nchar(s2))
 }
 
 # check that all protein accessions are of the format *|*|*
-check.accession.format <- function(accessions) {
+checkAccessionFormat <- function(accessions) {
 	n <- length(accessions)
-	count <- count.occurrences("[|]",accessions)
+	count <- countOccurrences("[|]",accessions)
 	m <- length(which(count==2))
 	return (n==m)
 }
@@ -34,7 +34,7 @@ readMzTabPEP <- function(file) {
   
   # simplify accession (in case it is of the format *|*|* )
   peptide.data$accession <- as.character(peptide.data$accession)
-  if (check.accession.format(peptide.data$accession)) {
+  if (checkAccessionFormat(peptide.data$accession)) {
     list <- strsplit(peptide.data$accession,"[|]")
     peptide.data$accession <- unlist(lapply(list, '[[', 2))
     peptide.data$gene <- unlist(lapply(list, '[[', 3))

--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PRT.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PRT.R
@@ -6,29 +6,11 @@ options(digits=10)
 input.file <- commandArgs(TRUE)[1]
 output.file <- commandArgs(TRUE)[2]
 
-# read entire mzTab
-no.col <- max(count.fields(input.file, sep = "\t", quote=""))
-data <- read.table(input.file, sep="\t", fill=TRUE, quote="", col.names=1:no.col)
-
-# extract protein data
-protein.data <- data[which(data[,1]=="PRT"),]
-colnames(protein.data) <- unlist(data[which(data[,1]=="PRH")[1],])
-protein.data$PRH <- NULL
-columns.to.keep <- which(colnames(protein.data)!="")
-protein.data <- protein.data[,columns.to.keep]
-
-proteins <- protein.data[which(protein.data$opt_global_protein_group_type=="single_protein"),]
-protein.groups <- protein.data[which(protein.data$opt_global_protein_group_type=="protein_group"),]
-indistinguishable.groups <- protein.data[which(protein.data$opt_global_protein_group_type=="indistinguishable_group"),]
-
-protein.groups.members <- as.character(protein.groups$ambiguity_members)
-indistinguishable.groups.members <- as.character(indistinguishable.groups$ambiguity_members)
-
 # get index in protein groups list containing protein x
 getIndex <- function(x) {
 	g <- gsub(x, "", protein.groups.members, fixed=TRUE)
 	d <- nchar(protein.groups.members)-nchar(g)
-	return(which(d>0)[1])
+	return (which(d>0)[1])
 }
 
 # returns first entry of a comma-separated list
@@ -37,30 +19,13 @@ firstEntry <- function(x) {
 	return (unlist(lapply(list, '[[', 1)))
 }
 
-if ((dim(protein.groups)[1] > 0) && (dim(indistinguishable.groups)[1] > 0)) {
-	# match indistinguishable groups to protein groups
-	group.index <- as.vector(sapply(firstEntry(indistinguishable.groups.members), getIndex))
-	table <- data.frame(cbind(group.index, indistinguishable.groups.members))
-
-	# merge information from the protein list
-	colnames(table) <- c("protein group","accessions")
-	table$accession <- firstEntry(table$accessions)
-	table <- merge(table, proteins, by="accession")
-	table$accession <- NULL
-
-	# order table by protein.group
-	table$"protein group" <- as.integer(table$"protein group")
-	table <- table[order(table$"protein group"),]
-} else {
-	table <- proteins
-	colnames(table) <- gsub("accession","accessions", colnames(table))
-}
-
+# count the occurences of character c in string s
 countOccurrences <- function(char,s) {
 	s2 <- gsub(char,"",s)
 	return (nchar(s) - nchar(s2))
 }
 
+# check that all protein accessions are of the format *|*|*
 checkAccessionFormat <- function(accessions) {
 	n <- length(accessions)
 	count <- countOccurrences("[|]",accessions)
@@ -72,23 +37,67 @@ getAccessions <- function(string) {
 	accessions <- strsplit(string,",")
 	accessions <- lapply(accessions,strsplit,"[|]")
 	accessions <- data.frame(matrix(unlist(accessions),ncol=3,byrow=TRUE))
-	return(paste(as.character(accessions[,2]), collapse=","))
+	return (paste(as.character(accessions[,2]), collapse=","))
 }
 
 getGenes <- function(string) {
 	accessions <- strsplit(string,",")
 	accessions <- lapply(accessions,strsplit,"[|]")
 	accessions <- data.frame(matrix(unlist(accessions),ncol=3,byrow=TRUE))
-	return(paste(as.character(accessions[,3]), collapse=","))
+	return (paste(as.character(accessions[,3]), collapse=","))
 }
 
-# simplify accessions (in case they are of the format *|*|* )
-table$accessions <- as.character(table$accessions)
-if (checkAccessionFormat(table$accessions)) {
-	x <- unlist(lapply(table$accessions,getAccessions))
-	y <- unlist(lapply(table$accessions,getGenes))
-	table$accessions <- x
-	table$gene <- y
+# read the PRT section of an mzTab file
+readMzTabPRT <- function(file) {
+  
+  # read entire mzTab
+  no.col <- max(count.fields(file, sep = "\t", quote=""))
+  data <- read.table(file, sep="\t", fill=TRUE, quote="", col.names=1:no.col)
+  
+  # extract protein data
+  protein.data <- data[which(data[,1]=="PRT"),]
+  colnames(protein.data) <- unlist(data[which(data[,1]=="PRH")[1],])
+  protein.data$PRH <- NULL
+  columns.to.keep <- which(colnames(protein.data)!="")
+  protein.data <- protein.data[,columns.to.keep]
+  
+  proteins <- protein.data[which(protein.data$opt_global_protein_group_type=="single_protein"),]
+  protein.groups <- protein.data[which(protein.data$opt_global_protein_group_type=="protein_group"),]
+  indistinguishable.groups <- protein.data[which(protein.data$opt_global_protein_group_type=="indistinguishable_group"),]
+  
+  protein.groups.members <- as.character(protein.groups$ambiguity_members)
+  indistinguishable.groups.members <- as.character(indistinguishable.groups$ambiguity_members)
+  
+  if ((dim(protein.groups)[1] > 0) && (dim(indistinguishable.groups)[1] > 0)) {
+    # match indistinguishable groups to protein groups
+    group.index <- as.vector(sapply(firstEntry(indistinguishable.groups.members), getIndex))
+    table <- data.frame(cbind(group.index, indistinguishable.groups.members))
+    
+    # merge information from the protein list
+    colnames(table) <- c("protein group","accessions")
+    table$accession <- firstEntry(table$accessions)
+    table <- merge(table, proteins, by="accession")
+    table$accession <- NULL
+    
+    # order table by protein.group
+    table$"protein group" <- as.integer(table$"protein group")
+    table <- table[order(table$"protein group"),]
+  } else {
+    table <- proteins
+    colnames(table) <- gsub("accession","accessions", colnames(table))
+  }
+  
+  # simplify accessions (in case they are of the format *|*|* )
+  table$accessions <- as.character(table$accessions)
+  if (checkAccessionFormat(table$accessions)) {
+    x <- unlist(lapply(table$accessions,getAccessions))
+    y <- unlist(lapply(table$accessions,getGenes))
+    table$accessions <- x
+    table$gene <- y
+  }
+  
+  return (table)
 }
 
+table <- readMzTabPRT(input.file)
 write.table(table, output.file, sep="\t", row.names=FALSE, col.names=TRUE, quote=FALSE)

--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PSM.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PSM.R
@@ -6,33 +6,75 @@ options(digits=10)
 input.file <- commandArgs(TRUE)[1]
 output.file <- commandArgs(TRUE)[2]
 
-# read entire mzTab
-no.col <- max(count.fields(input.file, sep = "\t", quote=""))
-data <- read.table(input.file,sep="\t",fill=TRUE, quote="", col.names=1:no.col)
-
-# extract peptide data
-psm.data <- data[which(data[,1]=="PSM"),]
-colnames(psm.data) <- unlist(data[which(data[,1]=="PSH")[1],])
-psm.data$PSH <- NULL
-
-countOccurrences <- function(char,s) {
-	s2 <- gsub(char,"",s)
-	return (nchar(s) - nchar(s2))
+# count the occurences of character c in string s
+countOccurrences <- function(c,s) {
+  s2 <- gsub(c,"",s)
+  return (nchar(s) - nchar(s2))
 }
 
+# check that all protein accessions are of the format *|*|* 
 checkAccessionFormat <- function(accessions) {
-	n <- length(accessions)
-	count <- countOccurrences("[|]",accessions)
-	m <- length(which(count==2))
-	return (n==m)
+  n <- length(accessions)
+  count <- countOccurrences("[|]",accessions)
+  m <- length(which(count==2))
+  return (n==m)
 }
 
-# simplify accession (in case it is of the format *|*|* )
-psm.data$accession <- as.character(psm.data$accession)
-if (checkAccessionFormat(psm.data$accession)) {
-	list <- strsplit(psm.data$accession,"[|]")
-	psm.data$accession <- unlist(lapply(list, '[[', 2))
-	psm.data$gene <- unlist(lapply(list, '[[', 3))
+# collapse rows
+# (In mzTab, PSMs with multiple protein accessions are reported in multiple rows. This function collapses them to a single row.)
+collapseRows <- function(psm.data) {
+  
+  # generate index vector idx
+  tmp.psm.id <- 0
+  idx <- c()
+  accessions.tmp <- c()
+  accessions.strings <- c()
+  for (i in 1:length(psm.data$PSM_ID)) {
+    
+    if (psm.data$PSM_ID[i] == tmp.psm.id) {
+      if (length(accessions.tmp) > 0) {
+        accessions.strings <- c(accessions.strings, toString(accessions.tmp, sep=','))
+        accessions.tmp <- c()
+      }
+      
+      idx <- c(idx,i)
+      tmp.psm.id <- tmp.psm.id + 1
+    }
+    
+    accessions.tmp <- c(accessions.tmp, psm.data$accession[i])
+  }
+  accessions.strings <- c(accessions.strings, toString(accessions.tmp, sep=','))
+  
+  psm.data <- psm.data[idx,]
+  psm.data$accession <- accessions.strings
+  
+  return (psm.data)
 }
 
+# read the PSM section of an mzTab file
+readMzTabPSM <- function(file) {
+  
+  # read entire mzTab
+  no.col <- max(count.fields(file, sep = "\t", quote=""))
+  data <- read.table(file, sep="\t", fill=TRUE, quote="", col.names=1:no.col)
+  
+  # extract PSM data
+  psm.data <- data[which(data[,1]=="PSM"),]
+  colnames(psm.data) <- unlist(data[which(data[,1]=="PSH")[1],])
+  psm.data$PSH <- NULL
+  
+  # simplify accession (in case it is of the format *|*|* )
+  psm.data$accession <- as.character(psm.data$accession)
+  if (checkAccessionFormat(psm.data$accession)) {
+    list <- strsplit(psm.data$accession, "[|]")
+    psm.data$accession <- unlist(lapply(list, '[[', 2))
+    psm.data$gene <- unlist(lapply(list, '[[', 3))
+  }
+  
+  psm.data <- collapseRows(psm.data)
+  
+  return (psm.data)
+}
+
+psm.data <- readMzTabPSM(input.file)
 write.table(psm.data, output.file, sep="\t", row.names=FALSE, col.names=TRUE, quote=FALSE)


### PR DESCRIPTION
This pull request combines two minor changes to the R scripts that convert `mzTab` output to better readable text files.

(1) The functionality is wrapped in functions `readMzTabPSM`, `readMzTabPEP` and `readMzTabPRT`. 

(2) The `PSM` script collapses each PSM to a single row. (In `mzTab` PSMs are reported in multiple lines, one for each protein accession.)