### PR TITLE
CTD Schema v1.7 compatibility changes (ctdVersion attribute, tool name)

### DIFF
--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2310,7 +2310,7 @@ namespace OpenMS
       // morph to ctd format
       QStringList lines = ini_file_str.toQString().split("\n", QString::SkipEmptyParts);
       lines.replace(0, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-      lines.insert(1, QString("<tool version=\"%1\" name=\"%2\" docurl=\"%3\" category=\"%4\" >").arg(version_.toQString(), tool_name_.toQString(), docurl, category));
+      lines.insert(1, QString("<tool ctdVersion=\"1.7\" version=\"%1\" name=\"%2\" docurl=\"%3\" category=\"%4\" >").arg(version_.toQString(), tool_name_.toQString(), docurl, category));
       lines.insert(2, QString("<description><![CDATA[") + tool_description_.toQString() + "]]></description>");
       QString html_doc = tool_description_.toQString();
       lines.insert(3, QString("<manual><![CDATA[") + html_doc + "]]></manual>");

--- a/src/utils/LowMemPeakPickerHiRes_RandomAccess.cpp
+++ b/src/utils/LowMemPeakPickerHiRes_RandomAccess.cpp
@@ -1,4 +1,4 @@
-// --------------------------------------------------------------------------
+LowMemPeakPickerHiRes_RandomAccess// --------------------------------------------------------------------------
 //                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
@@ -116,7 +116,7 @@ class TOPPLowMemPeakPickerHiRes_RandomAccess :
 {
 public:
   TOPPLowMemPeakPickerHiRes_RandomAccess() :
-    TOPPBase("LowMemPeakPickerHiRes_RandomAccess", "Finds mass spectrometric peaks in profile mass spectra.", false)
+    TOPPBase("LowMemPeakPickerHiResRandomAccess", "Finds mass spectrometric peaks in profile mass spectra.", false)
   {
   }
 

--- a/src/utils/LowMemPeakPickerHiRes_RandomAccess.cpp
+++ b/src/utils/LowMemPeakPickerHiRes_RandomAccess.cpp
@@ -1,4 +1,4 @@
-LowMemPeakPickerHiRes_RandomAccess// --------------------------------------------------------------------------
+// --------------------------------------------------------------------------
 //                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
@@ -116,7 +116,7 @@ class TOPPLowMemPeakPickerHiRes_RandomAccess :
 {
 public:
   TOPPLowMemPeakPickerHiRes_RandomAccess() :
-    TOPPBase("LowMemPeakPickerHiResRandomAccess", "Finds mass spectrometric peaks in profile mass spectra.", false)
+    TOPPBase("LowMemPeakPickerHiRes_RandomAccess", "Finds mass spectrometric peaks in profile mass spectra.", false)
   {
   }
 


### PR DESCRIPTION
The new CTD Schema version (https://github.com/WorkflowConversion/CTDSchema) contains a new mandatory attribute, `ctdVersion`.

Also, tool names are only allowed alphanumerical characters, so `LowMemPeakPickerHiRes_RandomAccess` is not a valid tool name.