### PR TITLE
Java fix

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
@@ -201,7 +201,7 @@ public:
         std::find(container.begin(), container.end(), elem);
       if (pos == container.end()) return -1;
 
-      return std::distance(container.begin(), pos);
+      return static_cast<Int>(std::distance(container.begin(), pos));
     }
 
   };

--- a/src/openms/include/OpenMS/SYSTEM/JavaInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/JavaInfo.h
@@ -48,8 +48,16 @@ namespace OpenMS
   class OPENMS_DLLAPI JavaInfo
   {
 public:
-    /// Returns false if java executable can not be called. true if java executable can be executed.
-    static bool canRun(String java_executable);
+    /**
+      @brief Determine if Java is installed and reachable
+
+      The call fails if either Java is not installed or if a relative location is given and Java is not on the search PATH.
+
+      @param java_executable Path to Java executable. Can be absolute, relative or just a filename
+      @param verbose On error, should an error message be printed to LOG_ERROR?
+      @return Returns false if Java executable can not be called; true if Java executable can be executed
+    **/
+    static bool canRun(const String& java_executable, bool verbose_on_error = true);
   };
 
 }

--- a/src/openms/include/OpenMS/SYSTEM/JavaInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/JavaInfo.h
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors: Timo Sachsenberg $
+// $Authors: Timo Sachsenberg, Chris Bielow $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_SYSTEM_JAVAINFO_H

--- a/src/openms/source/SYSTEM/JavaInfo.cpp
+++ b/src/openms/source/SYSTEM/JavaInfo.cpp
@@ -88,7 +88,7 @@ namespace OpenMS
         else
         {
           LOG_ERROR << "  Error executing '" << java_executable << "'!\n"
-                    << "  Error description: '" << qp.errorString() << "'.\n";
+                    << "  Error description: '" << qp.errorString().toStdString() << "'.\n";
         }
     }
     return success;

--- a/src/openms/source/SYSTEM/JavaInfo.cpp
+++ b/src/openms/source/SYSTEM/JavaInfo.cpp
@@ -72,7 +72,7 @@ namespace OpenMS
                     << "  or use an absolute path+filename pointing to Java.\n" 
                     << "  The current SYSTEM PATH is: '" << path << "'.\n\n"
 #ifdef __APPLE__
-                    << "  On MacOSX, application bundles change the system PATH; Use an abolute path to Java or open your exectuable (e.g. KNIME/TOPPAS/TOPPView) from within the bundle!\n"
+                    << "  On MacOSX, application bundles change the system PATH; Use an absolute path to Java or open your executable (e.g. KNIME/TOPPAS/TOPPView) from within the bundle (e.g. ./TOPPAS.app/Contents/MacOS/TOPPAS)!\n"
 #endif
                     << std::endl;
         }

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -180,6 +180,9 @@ protected:
 
     registerStringOption_("run_mode", "<choice>", "0", "Determines how Luciphor will run: 0 = calculate FLR then rerun scoring without decoys (two iterations), 1 = Report Decoys: calculate FLR but don't rescore PSMs, all decoy hits will be reported", false);
     setValidStrings_("run_mode", ListUtils::create<String>("0,1")); 
+    
+    registerInputFile_("java_executable", "<file>", "java", "The Java executable. Usually Java is on the system PATH. If Java is not found, use this parameter to specify the full path to Java", true, false, ListUtils::create<String>("skipexists"));
+
   }
   
   String makeModString_(const String& mod_name)
@@ -479,14 +482,12 @@ protected:
   
   ExitCodes main_(int, const char**)
   {
-    vector<PeptideIdentification> pep_ids;
-    vector<ProteinIdentification> prot_ids;
-    
+    String java_executable = getStringOption_("java_executable");
     if (!getFlag_("force"))
     {
-      if (!JavaInfo::canRun("java"))
+      if (!JavaInfo::canRun(java_executable))
       {
-        writeLog_("Fatal error: Java not found, or the Java process timed out. Java is needed to run LuciPHOr2. Make sure that it can be executed by calling 'java', e.g. add the directory containing the Java binary to your PATH variable. If you are certain java is installed, please set the 'force' flag in order to avoid this error message.");
+        writeLog_("Fatal error: Java is needed to run LuciPHOr2!");
         return EXTERNAL_PROGRAM_ERROR;
       }
     }
@@ -496,14 +497,13 @@ protected:
     }
 
     // create temporary directory
-    String temp_dir, conf_file;
-    temp_dir = QDir::toNativeSeparators((File::getTempDirectory() + "/" + File::getUniqueName() + "/").toQString());
+    String temp_dir = QDir::toNativeSeparators((File::getTempDirectory() + "/" + File::getUniqueName() + "/").toQString());
     writeDebug_("Creating temporary directory '" + temp_dir + "'", 1);
     QDir d;
     d.mkpath(temp_dir.toQString());
 
     // create a temporary config file for LuciPHOr2 parameters
-    conf_file = temp_dir + "luciphor2_input_template.txt";
+    String conf_file = temp_dir + "luciphor2_input_template.txt";
     
     String id = getStringOption_("id");
     String in = getStringOption_("in");
@@ -512,13 +512,15 @@ protected:
     FileHandler fh;
     FileTypes::Type in_type = fh.getType(id);
     
+    vector<PeptideIdentification> pep_ids;
+    vector<ProteinIdentification> prot_ids;
     // convert input to pepXML if necessary
     if (in_type == FileTypes::IDXML)
     {
       IdXMLFile().load(id, prot_ids, pep_ids);
-      IDFilter::keepNBestHits(pep_ids, 1); // Luciphor only calculates the best hit
+      IDFilter::keepNBestHits(pep_ids, 1); // LuciPHOR2 only calculates the best hit
       
-      // create a tempory pepXML file for LuciPHOR2 input
+      // create a temporary pepXML file for LuciPHOR2 input
       String in_file_name = File::removeExtension(File::basename(id));
       id = temp_dir + in_file_name + ".pepXML";
       
@@ -565,7 +567,7 @@ protected:
     process_params << "-jar" << executable << conf_file.toQString();                   
 
     // execute LuciPHOr2    
-    int status = QProcess::execute("java", process_params);
+    int status = QProcess::execute(java_executable.toQString(), process_params);
     if (status != 0)
     {
       writeLog_("Fatal error: Running LuciPHOr2 returned an error code. Does the LuciPHOr2 executable (.jar file) exist?");

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -201,6 +201,7 @@ protected:
     
     registerFlag_("legacy_conversion", "Use the indirect conversion of MS-GF+ results to idXML via export to TSV. Try this only if the default conversion takes too long or uses too much memory.", true);
 
+    registerInputFile_("java_executable", "<file>", "java", "The Java executable. Usually Java is on the system PATH. If Java is not found, use this parameter to specify the full path to Java", true, false, ListUtils::create<String>("skipexists"));
     registerIntOption_("java_memory", "<num>", 3500, "Maximum Java heap size (in MB)", false);
     registerIntOption_("java_permgen", "<num>", 0, "Maximum Java permanent generation space (in MB); only for Java 7 and below", false, true);
   }
@@ -428,6 +429,7 @@ protected:
       return ILLEGAL_PARAMETERS;
     }
 
+    String java_executable = getStringOption_("java_executable");
     String db_name = getStringOption_("database");
     if (!File::readable(db_name))
     {
@@ -454,9 +456,9 @@ protected:
 
     if (!getFlag_("force"))
     {
-      if (!JavaInfo::canRun("java"))
+      if (!JavaInfo::canRun(java_executable))
       {
-        writeLog_("Fatal error: Java not found, or the Java process timed out. Java is needed to run MS-GF+. Make sure that it can be executed by calling 'java', e.g. add the directory containing the Java binary to your PATH variable. If you are certain java is installed, please set the 'force' flag in order to avoid this error message.");
+        writeLog_("Fatal error: Java is needed to run MS-GF+!");
         return EXTERNAL_PROGRAM_ERROR;
       }
     }
@@ -542,7 +544,7 @@ protected:
 
     // run MS-GF+ process and create the .mzid file
 
-    int status = QProcess::execute("java", process_params);
+    int status = QProcess::execute(java_executable.toQString(), process_params);
     if (status != 0)
     {
       writeLog_("Fatal error: Running MS-GF+ returned an error code. Does the MS-GF+ executable (.jar file) exist?");
@@ -572,7 +574,7 @@ protected:
                        << "-showQValue" << "1"
                        << "-showDecoy" << "1"
                        << "-unroll" << "1";
-        status = QProcess::execute("java", process_params);
+        status = QProcess::execute(java_executable.toQString(), process_params);
         if (status != 0)
         {
           writeLog_("Fatal error: Running MzIDToTSVConverter returned an error code.");

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -136,9 +136,6 @@ protected:
   // primary MS run referenced in the mzML file
   StringList primary_ms_run_path_;
   
-  // legacy conversion via tsv instead of mzid
-  bool legacy_conversion_;
-
   void registerOptionsAndFlags_()
   {
     registerInputFile_("in", "<file>", "", "Input file (MS-GF+ parameter '-s')");
@@ -535,8 +532,6 @@ protected:
     {
       process_params << "-mod" << mod_file.toQString();
     }
-    
-    legacy_conversion_ = getFlag_("legacy_conversion");
 
     //-------------------------------------------------------------
     // execute MS-GF+
@@ -547,7 +542,7 @@ protected:
     int status = QProcess::execute(java_executable.toQString(), process_params);
     if (status != 0)
     {
-      writeLog_("Fatal error: Running MS-GF+ returned an error code. Does the MS-GF+ executable (.jar file) exist?");
+      writeLog_("Fatal error: Running MS-GF+ returned an error code '" + String(status) + "'. Does the MS-GF+ executable (.jar file) exist?");
       return EXTERNAL_PROGRAM_ERROR;
     }
 
@@ -557,7 +552,7 @@ protected:
     
     if (!out.empty())
     {
-      if (legacy_conversion_)
+      if (getFlag_("legacy_conversion"))
       {
         // run TSV converter
         String tsv_out = temp_dir + "msgfplus_converted.tsv";
@@ -577,7 +572,7 @@ protected:
         status = QProcess::execute(java_executable.toQString(), process_params);
         if (status != 0)
         {
-          writeLog_("Fatal error: Running MzIDToTSVConverter returned an error code.");
+          writeLog_("Fatal error: Running MzIDToTSVConverter returned an error code '" + String(status) + "'.");
           return EXTERNAL_PROGRAM_ERROR;
         }
     


### PR DESCRIPTION
We are constantly running into issues that TOPP tools cannot find Java, usually because App-bundles on MacOSX mess up the PATH, such that a simple call to 'java' fails.
This affects all TOPP tools internally calling Java, i.e. MSGF+ and Luciphor

This PR fixes this by:
 - allow path to Java to be specified explicitly
 - better Java checking and error messages

replaces #1941