### PR TITLE
[FIX] adopt activation modes to new obo

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -2097,7 +2097,7 @@ protected:
           }
           else if (accession == "MS:1002472") //trap-type collision-induced dissociation
           {
-            spec_.getPrecursor().getActivationMethods().insert(Precursor::TRAP);
+            spec_.getPrecursors().getActivationMethods().insert(Precursor::TRAP);
           }
           else if (accession == "MS:1002481") //high-energy collision-induced dissociation
           {

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -2091,7 +2091,15 @@ protected:
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::SORI);
           }
-          else if (accession == "MS:1000422") //high-energy collision-induced dissociation
+          else if (accession == "MS:1000422") //beam-type collision-induced dissociation
+          {
+            spec_.getPrecursors().back().getActivationMethods().insert(Precursor::BEAM);
+          }
+          else if (accession == "MS:1002472") //trap-type collision-induced dissociation
+          {
+            spec_.getPrecursor().getActivationMethods().insert(Precursor::TRAP);
+          }
+          else if (accession == "MS:1002481") //high-energy collision-induced dissociation
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::HCID);
           }
@@ -2110,6 +2118,14 @@ protected:
           else if (accession == "MS:1000599") //pulsed q dissociation
           {
             spec_.getPrecursors().back().getActivationMethods().insert(Precursor::PQD);
+          }
+          else if (accession == "MS:1001880") //in-source collision-induced dissociation
+          {
+            spec_.getPrecursors().back().getActivationMethods().insert(Precursor::INSOURCE);
+          }
+          else if (accession == "MS:1002000") //LIFT
+          {
+            spec_.getPrecursors().back().getActivationMethods().insert(Precursor::LIFT);
           }
           else
             warning(LOAD, String("Unhandled cvParam '") + accession + "' in tag '" + parent_tag + "'.");
@@ -2187,7 +2203,15 @@ protected:
           {
             chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::SORI);
           }
-          else if (accession == "MS:1000422") //high-energy collision-induced dissociation
+          else if (accession == "MS:1000422") //beam-type collision-induced dissociation
+          {
+            chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::BEAM);
+          }
+          else if (accession == "MS:1002472") //trap-type collision-induced dissociation
+          {
+            chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::TRAP);
+          }
+          else if (accession == "MS:1002481") //high-energy collision-induced dissociation
           {
             chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::HCID);
           }
@@ -2207,8 +2231,18 @@ protected:
           {
             chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::PQD);
           }
+          else if (accession == "MS:1001880") //in-source collision-induced dissociation
+          {
+            chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::INSOURCE);
+          }
+          else if (accession == "MS:1002000") //LIFT
+          {
+            chromatogram_.getPrecursor().getActivationMethods().insert(Precursor::LIFT);
+          }
           else
+          {
             warning(LOAD, String("Unhandled cvParam '") + accession + "' in tag '" + parent_tag + "'.");
+          }
         }
       }
       //------------------------- isolationWindow ----------------------------
@@ -3929,7 +3963,15 @@ protected:
       }
       if (precursor.getActivationMethods().count(Precursor::HCID) != 0)
       {
-        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000422\" name=\"high-energy collision-induced dissociation\" />\n";
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002481\" name=\"high-energy collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::BEAM) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000422\" name=\"beam-type collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::TRAP) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002472\" name=\"trap-type collision-induced dissociation\" />\n";
       }
       if (precursor.getActivationMethods().count(Precursor::LCID) != 0)
       {
@@ -3946,6 +3988,14 @@ protected:
       if (precursor.getActivationMethods().count(Precursor::PQD) != 0)
       {
         os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1000599\" name=\"pulsed q dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::INSOURCE) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1001880\" name=\"in-source collision-induced dissociation\" />\n";
+      }
+      if (precursor.getActivationMethods().count(Precursor::LIFT) != 0)
+      {
+        os << "\t\t\t\t\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1002000\" name=\"LIFT\" />\n";
       }
       if (precursor.getActivationMethods().empty())
       {

--- a/src/openms/include/OpenMS/METADATA/Precursor.h
+++ b/src/openms/include/OpenMS/METADATA/Precursor.h
@@ -47,9 +47,9 @@ namespace OpenMS
       @brief Precursor meta information.
 
       This class contains precursor information:
-  - isolation window
-  - activation
-  - selected ion (m/z, intensity, charge, possible charge states)
+        - isolation window
+        - activation
+        - selected ion (m/z, intensity, charge, possible charge states)
 
       @ingroup Metadata
   */
@@ -67,15 +67,19 @@ public:
       PSD,                      ///< Post-source decay
       PD,                       ///< Plasma desorption
       SID,                      ///< Surface-induced dissociation
-      BIRD,                             ///< Blackbody infrared radiative dissociation
-      ECD,                              ///< Electron capture dissociation
-      IMD,                              ///< Infrared multiphoton dissociation
-      SORI,                             ///< Sustained off-resonance irradiation
-      HCID,                             ///< High-energy collision-induced dissociation
-      LCID,                             ///< Low-energy collision-induced dissociation
-      PHD,                              ///< Photodissociation
-      ETD,                              ///< Electron transfer dissociation
-      PQD,                              ///< Pulsed q dissociation
+      BIRD,                     ///< Blackbody infrared radiative dissociation
+      ECD,                      ///< Electron capture dissociation
+      IMD,                      ///< Infrared multiphoton dissociation
+      SORI,                     ///< Sustained off-resonance irradiation
+      HCID,                     ///< High-energy collision-induced dissociation
+      LCID,                     ///< Low-energy collision-induced dissociation
+      PHD,                      ///< Photodissociation
+      ETD,                      ///< Electron transfer dissociation
+      PQD,                      ///< Pulsed q dissociation
+      TRAP,                     ///< trap-type collision-induced dissociation (MS:1002472)
+      BEAM,                     ///< beam-type collision-induced dissociation (MS:1000422) "HCD"
+      INSOURCE,                 ///< in-source collision-induced dissociation (MS:1001880)
+      LIFT,                     ///< Bruker proprietary method (MS:1002000)
       SIZE_OF_ACTIVATIONMETHOD
     };
     /// Names of activation methods

--- a/src/pyOpenMS/pxds/Precursor.pxd
+++ b/src/pyOpenMS/pxds/Precursor.pxd
@@ -89,18 +89,22 @@ cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS":
 
 cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS::Precursor":
     cdef enum ActivationMethod:
-      CID,                      #< Collision-induced dissociation
-      PSD,                      #< Post-source decay
-      PD,                       #< Plasma desorption
-      SID,                      #< Surface-induced dissociation
-      BIRD,                             #< Blackbody infrared radiative dissociation
-      ECD,                              #< Electron capture dissociation
-      IMD,                              #< Infrared multiphoton dissociation
-      SORI,                             #< Sustained off-resonance irradiation
-      HCID,                             #< High-energy collision-induced dissociation
-      LCID,                             #< Low-energy collision-induced dissociation
-      PHD,                              #< Photodissociation
-      ETD,                              #< Electron transfer dissociation
-      PQD,                              #< Pulsed q dissociation
+      CID,                      # Collision-induced dissociation
+      PSD,                      # Post-source decay
+      PD,                       # Plasma desorption
+      SID,                      # Surface-induced dissociation
+      BIRD,                     # Blackbody infrared radiative dissociation
+      ECD,                      # Electron capture dissociation
+      IMD,                      # Infrared multiphoton dissociation
+      SORI,                     # Sustained off-resonance irradiation
+      HCID,                     # High-energy collision-induced dissociation
+      LCID,                     # Low-energy collision-induced dissociation
+      PHD,                      # Photodissociation
+      ETD,                      # Electron transfer dissociation
+      PQD,                      # Pulsed q dissociation
+      TRAP,                     # trap-type collision-induced dissociation (MS:1002472)
+      BEAM,                     # beam-type collision-induced dissociation (MS:1000422) "HCD"
+      INSOURCE,                 # in-source collision-induced dissociation (MS:1001880)
+      LIFT,                     # Bruker proprietary method (MS:1002000)
       SIZE_OF_ACTIVATIONMETHOD
 


### PR DESCRIPTION
It seems that some time ago, in 4fea083fd6a3fc820216ef3298860aad5cb5784d the HCD term in the obo file was replaced

```
-[Term]
-id: MS:1000422
-name: high-energy collision-induced dissociation
-def: "A collision-induced dissociation process wherein the projectile ion has the translational energy higher than approximately 1000 eV." [PSI:MS]
-synonym: "HCD" EXACT []
-is_a: MS:1000044 ! dissociation method
```

is now

```
+
+[Term]
+id: MS:1000422
+name: beam-type collision-induced dissociation
+def: "A collision-induced dissociation process that occurs in a beam-type collision cell." [PSI:MS]
+synonym: "HCD" EXACT []
+is_a: MS:1000133 ! collision-induced dissociation
+[Term]
+id: MS:1002481
+name: higher energy beam-type collision-induced dissociation
+def: "A collision-induced dissociation process wherein the projectile ion has the translational energy higher than approximately 1000 eV." [PSI:MS]
+is_a: MS:1000422 ! beam-type collision-induced dissociation

```

while OpenMS still has the old name hardcoded. This leads to warnings when writing and reading the same file again

```
While loading Name of CV term not correct: 'MS:1000422 - high-energy collision-induced dissociation' should be 'beam-type collision-induced dissociation'
```

it seems that in a rather unorthodox change, the `MS:1000422` term got changed from HCD to a very general "beam-type" collision mode

@mwalzer can you comment on whether this is a good idea?

@cbielow can you comment on the impact this will have on `ItraqChannelExtractor.cpp` which seems to use the HCD activation mode CV term
