### PR TITLE
[FEATURE] TOPPView: allow double clicking of AnnotationItems 

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h
@@ -88,6 +88,10 @@ public:
     /// Returns the text of the item
     const QString & getText() const;
 
+    /// open a GUI input field and let the user edit the text
+    /// If the text was changed, true is returned; otherwise false.
+    bool editText();
+
     /// Ensures that the item has coordinates within the visible area of the canvas
     virtual void ensureWithinDataRange(Spectrum1DCanvas * const canvas) = 0;
 
@@ -106,7 +110,7 @@ protected:
 
     /// Draws the bounding_box_
     void drawBoundingBox_(QPainter & painter);
-
+   
     /// The current bounding box of this item on the canvas where it has last been drawn
     QRectF bounding_box_;
 

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DItem.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DItem.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DItem.h>
 
+#include <QtGui/QInputDialog>
 #include <QtGui/QPainter>
 
 namespace OpenMS
@@ -89,6 +90,19 @@ namespace OpenMS
   const QString & Annotation1DItem::getText() const
   {
     return text_;
+  }
+
+  bool Annotation1DItem::editText()
+  {
+    bool ok;
+    QString text = QInputDialog::getText(NULL, "Edit text", "Enter text:", QLineEdit::Normal, this->getText(), &ok);
+    if (ok && !text.isEmpty())
+    {
+      if (text == getText()) return false;
+      this->setText(text);
+      return true;
+    }
+    return false;
   }
 
 } //Namespace

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -243,12 +243,17 @@ namespace OpenMS
     if (e->button() == Qt::LeftButton)
     {
       // selection/deselection of annotation items
-      Annotation1DItem * item = getCurrentLayer_().getCurrentAnnotations().getItemAt(last_mouse_pos_);
+      Annotation1DItem* item = getCurrentLayer_().getCurrentAnnotations().getItemAt(last_mouse_pos_);
       if (item)
       {
         if (!(e->modifiers() & Qt::ControlModifier))
         {
-          if (!item->isSelected())
+          // edit via double-click
+          if (e->type() == QEvent::MouseButtonDblClick)
+          {
+            item->editText();
+          }
+          else if (!item->isSelected())
           {
             // the item becomes the only selected item
             getCurrentLayer_().getCurrentAnnotations().deselectAll();
@@ -1286,14 +1291,7 @@ namespace OpenMS
         }
         else if (result->text() == "Edit")
         {
-          const String & old_text = annot_item->getText();
-
-          bool ok;
-          QString text = QInputDialog::getText(this, "Edit text", "Enter text:", QLineEdit::Normal, old_text.toQString(), &ok);
-          if (ok && !text.isEmpty())
-          {
-            annot_item->setText(text);
-          }
+          annot_item->editText();
         }
         update_(__PRETTY_FUNCTION__);
       }


### PR DESCRIPTION
in 1D View to *edit* them  (instead of right-click context menu + "edit")