### PR TITLE
mutliple DB for AMS

### DIFF
--- a/share/OpenMS/SCRIPTS/InternalCalibration_Residuals.R
+++ b/share/OpenMS/SCRIPTS/InternalCalibration_Residuals.R
@@ -31,17 +31,12 @@ png(filename = file.plot.out, width=1920)
 
 pl = ggplot(dpm2[grep("ppm", dpm2$variable),]) + 
        geom_hline(yintercept = 0, colour="grey") +
-       geom_hline(yintercept = c(-1,1), colour="grey", linetype = "dotdash")
-if (length(unique(d$mz.ref)) < 16) {
-  extra = facet_wrap(~ masstrace) #, scales = "free_y")
-}  else {
-  extra = NULL
-} 
-pl = pl + geom_point(aes(x = RT, y=value, color=variable)) +
-  guides(color=guide_legend(title=NULL)) +
-  ggtitle("Calibrant's ppm error over time") +
-  xlab("RT [sec]") +
-  extra
+       geom_hline(yintercept = c(-1,1), colour="grey", linetype = "dotdash") +
+       facet_wrap(~ masstrace) + 
+       geom_point(aes(x = RT, y=value, color=variable)) +
+       guides(color=guide_legend(title=NULL)) +
+       ggtitle("Calibrant's ppm error over time") +
+       xlab("RT [sec]")
 print(pl)
 
 dev.off()

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
@@ -324,8 +324,8 @@ private:
       return ion_mode_internal;
     }
     
-    void parseMappingFile_(const String&);
-    void parseStructMappingFile_(const String&);
+    void parseMappingFile_(const StringList&);
+    void parseStructMappingFile_(const StringList&);
     void parseAdductsFile_(const String& filename, std::vector<AdductInfo>& result);
     void searchMass_(double neutral_query_mass, double diff_mass, std::pair<Size, Size>& hit_indices) const;
 
@@ -387,8 +387,8 @@ private:
     String pos_adducts_fname_;
     String neg_adducts_fname_;
 
-    String db_mapping_file_;
-    String db_struct_file_;
+    StringList db_mapping_file_;
+    StringList db_struct_file_;
 
     std::vector<AdductInfo> pos_adducts_;
     std::vector<AdductInfo> neg_adducts_;

--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -609,8 +609,10 @@ protected:
        @param description Description of the parameter. Indentation of newline is done automatically.
        @param required If the user has to provide a value i.e. if the value has to differ from the default (checked in get-method)
        @param advanced If @em true, this parameter is advanced and by default hidden in the GUI.
+       @param tags A list of tags, e.g. 'skipexists', specifying the handling of the input file (e.g. when its an executable)
+              Valid tags: 'skipexists' - will prevent checking if the given file really exists (useful for an executable in global PATH)
      */
-    void registerInputFileList_(const String& name, const String& argument, StringList default_value, const String& description, bool required = true, bool advanced = false);
+    void registerInputFileList_(const String& name, const String& argument, StringList default_value, const String& description, bool required = true, bool advanced = false, const StringList& tags = StringList());
 
     /**
        @brief Registers a list of output files option.

--- a/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
+++ b/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
@@ -529,10 +529,10 @@ namespace OpenMS
     defaults_.setValue("isotopic_similarity", "false", "Computes a similarity score for each hit (only if the feature exhibits at least two isotopic mass traces).");
     defaults_.setValidStrings("isotopic_similarity", ListUtils::create<String>(("false,true")));
 
-    defaults_.setValue("db:mapping", "CHEMISTRY/HMDBMappingFile.tsv", "Database input file, containing three tab-separated columns of mass, formula, identifier. "
+    defaults_.setValue("db:mapping", ListUtils::create<String>("CHEMISTRY/HMDBMappingFile.tsv"), "Database input file(s), containing three tab-separated columns of mass, formula, identifier. "
                                                                       "If 'mass' is 0, it is re-computed from the molecular sum formula. "
                                                                       "By default CHEMISTRY/HMDBMappingFile.tsv in OpenMS/share is used! If empty, the default will be used.");
-    defaults_.setValue("db:struct", "CHEMISTRY/HMDB2StructMapping.tsv", "Database input file, containing four tab-separated columns of identifier, name, SMILES, INCHI."
+    defaults_.setValue("db:struct", ListUtils::create<String>("CHEMISTRY/HMDB2StructMapping.tsv"), "Database input file(s), containing four tab-separated columns of identifier, name, SMILES, INCHI."
                                                                         "The identifier should match with mapping file. SMILES and INCHI are reported in the output, but not used otherwise. "
                                                                         "By default CHEMISTRY/HMDB2StructMapping.tsv in OpenMS/share is used! If empty, the default will be used.");
     defaults_.setValue("positive_adducts_file", "CHEMISTRY/PositiveAdducts.tsv", "This file contains the list of potential positive adducts that will be looked for in the database. "
@@ -1264,10 +1264,10 @@ namespace OpenMS
     iso_similarity_ = param_.getValue("isotopic_similarity").toBool();
 
     // use defaults if empty for all .tsv files
-    db_mapping_file_ = (String)param_.getValue("db:mapping");
-    if (db_mapping_file_.trim().empty()) db_mapping_file_ = (String)defaults_.getValue("db:mapping");
-    db_struct_file_ = (String)param_.getValue("db:struct");
-    if (db_struct_file_.trim().empty()) db_struct_file_ = (String)defaults_.getValue("db:struct");
+    db_mapping_file_ = (StringList)param_.getValue("db:mapping");
+    if (db_mapping_file_.empty()) db_mapping_file_ = (StringList)defaults_.getValue("db:mapping");
+    db_struct_file_ = (StringList)param_.getValue("db:struct");
+    if (db_struct_file_.empty()) db_struct_file_ = (StringList)defaults_.getValue("db:struct");
 
     pos_adducts_fname_ = (String)param_.getValue("positive_adducts_file");
     if (pos_adducts_fname_.trim().empty()) pos_adducts_fname_ = (String)defaults_.getValue("positive_adducts_file");
@@ -1281,102 +1281,106 @@ namespace OpenMS
 
 /// private methods
 
-  void AccurateMassSearchEngine::parseMappingFile_(const String& db_mapping_file)
+  void AccurateMassSearchEngine::parseMappingFile_(const StringList& db_mapping_file)
   {
     mass_mappings_.clear();
 
     // load map_fname mapping file
-    String filename = db_mapping_file;
-
-    // load map_fname mapping file
-    if (!File::readable(filename))
+    for (StringList::const_iterator it_f = db_mapping_file.begin(); it_f != db_mapping_file.end(); ++it_f)
     {
-      // throws Exception::FileNotFound if not found
-      filename = File::find(filename);
-    }
-
-    String line;
-    Size line_count(0);
-    std::stringstream str_buf;
-    std::istream_iterator<String> eol;
-
-    // LOG_DEBUG << "parsing " << fname << " file..." << std::endl;
-
-    std::ifstream ifs(filename.c_str());
-    while (getline(ifs, line))
-    {
-      ++line_count;
-      line.trim();
-      // std::cout << line << std::endl;
-      if (line_count == 1)
+      String filename = *it_f;
+      // load map_fname mapping file
+      if (!File::readable(filename))
       {
-        std::vector<String> fields;
-        line.trim().split('\t', fields);
-        if (fields[0] == "database_name")
-        {
-          database_name_ = fields[1];
-          continue;
-        }
-        else
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Mapping file (") + filename + "') must contain \"database_name\t{NAME}\" as first line.!", line);
-        }
-      }
-      else if (line_count == 2)
-      {
-        std::vector<String> fields;
-        line.trim().split('\t', fields);
-        if (fields[0] == "database_version")
-        {
-          database_version_ = fields[1];
-          continue;
-        }
-        else
-        {
-          throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Mapping file (") + filename + "') must contain \"database_version\t{VERSION}\" as second line.!", line);
-        }
+        // throws Exception::FileNotFound if not found
+        filename = File::find(filename);
       }
 
-      str_buf.clear();
-      str_buf << line;
-      std::istream_iterator<String> istr_it(str_buf);
+      String line;
+      Size line_count(0);
+      std::stringstream str_buf;
+      std::istream_iterator<String> eol;
 
-      Size word_count(0);
-      MappingEntry_ entry;
+      // LOG_DEBUG << "parsing " << fname << " file..." << std::endl;
 
-      while (istr_it != eol)
+      std::ifstream ifs(filename.c_str());
+      while (getline(ifs, line))
       {
-        // LOG_DEBUG << *istr_it << " ";
-        if (word_count == 0)
+        line.trim();
+        // skip empty lines
+        if (line.empty()) continue;
+        ++line_count;
+
+        // std::cout << line << std::endl;
+        if (line_count == 1)
         {
-          entry.mass = istr_it->toDouble();
-        }
-        else if (word_count == 1)
-        {
-          entry.formula = *istr_it;
-          if (entry.mass == 0)
-          { // recompute mass from formula
-            entry.mass = EmpiricalFormula(entry.formula).getMonoWeight();
-            //std::cerr << "mass of " << entry.formula << " is " << entry.mass << "\n";
+          std::vector<String> fields;
+          line.trim().split('\t', fields);
+          if (fields[0] == "database_name")
+          {
+            database_name_ = fields[1];
+            continue;
+          }
+          else
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Mapping file (") + filename + "') must contain \"database_name\t{NAME}\" as first line.!", line);
           }
         }
-        else // one or more IDs can follow
+        else if (line_count == 2)
         {
-          entry.massIDs.push_back(*istr_it);
+          std::vector<String> fields;
+          line.trim().split('\t', fields);
+          if (fields[0] == "database_version")
+          {
+            database_version_ = fields[1];
+            continue;
+          }
+          else
+          {
+            throw Exception::InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("Mapping file (") + filename + "') must contain \"database_version\t{VERSION}\" as second line.!", line);
+          }
         }
 
-        ++word_count;
-        ++istr_it;
-      }
-      // LOG_DEBUG << std::endl;
+        str_buf.clear();
+        str_buf << line;
+        std::istream_iterator<String> istr_it(str_buf);
 
-      if (entry.massIDs.empty())
-      {
-        throw Exception::InvalidParameter(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("File '") + db_mapping_file + "' in line " + line_count + " as '" + line + "' cannot be parsed. Found " + word_count + " entries, expected at least three!");
+        Size word_count(0);
+        MappingEntry_ entry;
+
+        while (istr_it != eol)
+        {
+          // LOG_DEBUG << *istr_it << " ";
+          if (word_count == 0)
+          {
+            entry.mass = istr_it->toDouble();
+          }
+          else if (word_count == 1)
+          {
+            entry.formula = *istr_it;
+            if (entry.mass == 0)
+            { // recompute mass from formula
+              entry.mass = EmpiricalFormula(entry.formula).getMonoWeight();
+              //std::cerr << "mass of " << entry.formula << " is " << entry.mass << "\n";
+            }
+          }
+          else // one or more IDs can follow
+          {
+            entry.massIDs.push_back(*istr_it);
+          }
+
+          ++word_count;
+          ++istr_it;
+        }
+        // LOG_DEBUG << std::endl;
+
+        if (entry.massIDs.empty())
+        {
+          throw Exception::InvalidParameter(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("File '") + filename + "' in line " + line_count + " as '" + line + "' cannot be parsed. Found " + word_count + " entries, expected at least three!");
+        }
+        mass_mappings_.push_back(entry);
       }
-      mass_mappings_.push_back(entry);
     }
-
     std::sort(mass_mappings_.begin(), mass_mappings_.end(), CompareEntryAndMass_());
 
     LOG_INFO << "Read " << mass_mappings_.size() << " entries from mapping file!" << std::endl;
@@ -1384,44 +1388,47 @@ namespace OpenMS
     return;
   }
 
-  void AccurateMassSearchEngine::parseStructMappingFile_(const String& db_struct_file)
+  void AccurateMassSearchEngine::parseStructMappingFile_(const StringList& db_struct_file)
   {
     hmdb_properties_mapping_.clear();
 
-    String filename = db_struct_file;
-
-    // load map_fname mapping file
-    if (!File::readable(filename))
+    for (StringList::const_iterator it_f = db_struct_file.begin(); it_f != db_struct_file.end(); ++it_f)
     {
-      // throws Exception::FileNotFound if not found
-      filename = File::find(filename);
-    }
+      String filename = *it_f;
 
-    std::ifstream ifs(filename.c_str());
-    String line;
-    // LOG_DEBUG << "parsing " << fname << " file..." << std::endl;
-
-    std::vector<String> parts;
-    while (getline(ifs, line))
-    {
-      line.trim();
-      line.split("\t", parts);
-
-      if (parts.size() == 4)
+      // load map_fname mapping file
+      if (!File::readable(filename))
       {
-        String hmdb_id_key(parts[0]);
+        // throws Exception::FileNotFound if not found
+        filename = File::find(filename);
+      }
 
-        if (hmdb_properties_mapping_.count(hmdb_id_key))
+      std::ifstream ifs(filename.c_str());
+      String line;
+      // LOG_DEBUG << "parsing " << fname << " file..." << std::endl;
+
+      std::vector<String> parts;
+      while (getline(ifs, line))
+      {
+        line.trim();
+        line.split("\t", parts);
+
+        if (parts.size() == 4)
         {
-          throw Exception::InvalidParameter(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("File '") + db_struct_file + "' in line '" + line + "' cannot be parsed. The HMDB ID entry was already used (see above)!");
-        }
-        std::copy(parts.begin() + 1, parts.end(), std::back_inserter(hmdb_properties_mapping_[hmdb_id_key]));
-      }
-      else
-      {
-        throw Exception::InvalidParameter(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("File '") + db_struct_file + "' in line '" + line + "' cannot be parsed. Expected four entries separated by tab. Found " + parts.size() + " entries!");
-      }
+          String hmdb_id_key(parts[0]);
 
+          if (hmdb_properties_mapping_.count(hmdb_id_key))
+          {
+            throw Exception::InvalidParameter(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("File '") + filename + "' in line '" + line + "' cannot be parsed. The ID entry was already used (see above)!");
+          }
+          std::copy(parts.begin() + 1, parts.end(), std::back_inserter(hmdb_properties_mapping_[hmdb_id_key]));
+        }
+        else
+        {
+          throw Exception::InvalidParameter(__FILE__, __LINE__, __PRETTY_FUNCTION__, String("File '") + filename + "' in line '" + line + "' cannot be parsed. Expected four entries separated by tab. Found " + parts.size() + " entries!");
+        }
+
+      }
     }
 
     // add a null entry, so mzTab annotation does not discard 'not-found' features

--- a/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
+++ b/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
@@ -1264,10 +1264,10 @@ namespace OpenMS
     iso_similarity_ = param_.getValue("isotopic_similarity").toBool();
 
     // use defaults if empty for all .tsv files
-    db_mapping_file_ = (StringList)param_.getValue("db:mapping");
-    if (db_mapping_file_.empty()) db_mapping_file_ = (StringList)defaults_.getValue("db:mapping");
-    db_struct_file_ = (StringList)param_.getValue("db:struct");
-    if (db_struct_file_.empty()) db_struct_file_ = (StringList)defaults_.getValue("db:struct");
+    db_mapping_file_ = param_.getValue("db:mapping").toStringList();
+    if (db_mapping_file_.empty()) db_mapping_file_ = defaults_.getValue("db:mapping").toStringList();
+    db_struct_file_ = param_.getValue("db:struct").toStringList();
+    if (db_struct_file_.empty()) db_struct_file_ = defaults_.getValue("db:struct").toStringList();
 
     pos_adducts_fname_ = (String)param_.getValue("positive_adducts_file");
     if (pos_adducts_fname_.trim().empty()) pos_adducts_fname_ = (String)defaults_.getValue("positive_adducts_file");

--- a/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
+++ b/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
@@ -667,7 +667,7 @@ namespace OpenMS
       ams_result.setMZErrorPPM(std::numeric_limits<double>::quiet_NaN());
       ams_result.setMatchingIndex(-1); // this is checked to identify 'not-found'
       ams_result.setFoundAdduct("null");
-      ams_result.setEmpiricalFormula("null");
+      ams_result.setEmpiricalFormula("");
       ams_result.setMatchingHMDBids(std::vector<String>(1, "null"));
       results.push_back(ams_result);
     }

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -1160,11 +1160,11 @@ namespace OpenMS
     parameters_.push_back(ParameterInformation(name, ParameterInformation::OUTPUT_FILE_LIST, argument, default_value, description, required, advanced));
   }
 
-  void TOPPBase::registerInputFileList_(const String& name, const String& argument, StringList default_value, const String& description, bool required, bool advanced)
+  void TOPPBase::registerInputFileList_(const String& name, const String& argument, StringList default_value, const String& description, bool required, bool advanced, const StringList& tags)
   {
-    if (required && default_value.size() > 0)
+    if (required && default_value.size() > 0 && !ListUtils::contains(tags, "skipexists"))
       throw InvalidValue(__FILE__, __LINE__, __PRETTY_FUNCTION__, "Registering a required InputFileList param (" + name + ") with a non-empty default is forbidden!", ListUtils::concatenate(default_value, ","));
-    parameters_.push_back(ParameterInformation(name, ParameterInformation::INPUT_FILE_LIST, argument, default_value, description, required, advanced));
+    parameters_.push_back(ParameterInformation(name, ParameterInformation::INPUT_FILE_LIST, argument, default_value, description, required, advanced, tags));
   }
 
   void TOPPBase::registerStringList_(const String& name, const String& argument, StringList default_value, const String& description, bool required, bool advanced)

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -2933,9 +2933,9 @@ namespace OpenMS
     {
       IDMapper im;
       Param p = im.getParameters();
-      p.setValue("rt_tolerance", 5.0);
+      p.setValue("rt_tolerance", 30.0);
       im.setParameters(p);
-      showLogMessage_(LS_NOTICE, "Note", "Mapping matches with 5 sec tolerance and no m/z limit to spectra...");
+      showLogMessage_(LS_NOTICE, "Note", "Mapping matches with 30 sec tolerance and no m/z limit to spectra...");
       im.annotate((*layer.getPeakData()), identifications, true, true);
     }
     else

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -178,7 +178,9 @@ namespace OpenMS
           {
             name = name.substr(0, 17) + "...";
           }
-          formula_to_names[ith->getMetaValue("chemical_formula")].push_back(name);
+          String cf = ith->getMetaValue("chemical_formula");
+          if (cf.empty()) continue; // skip unannotated "null" peaks
+          formula_to_names[cf].push_back(name);
         }
         else
         {

--- a/src/tests/class_tests/openms/data/AccurateMassSearchEngine_output1.featureXML
+++ b/src/tests/class_tests/openms/data/AccurateMassSearchEngine_output1.featureXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <featureMap version="1.9" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<IdentificationRun id="PI_0" date="2015-10-28T15:49:28" search_engine="AccurateMassSearch" search_engine_version="">
+	<IdentificationRun id="PI_0" date="2016-08-11T17:13:55" search_engine="AccurateMassSearch" search_engine_version="">
 		<SearchParameters db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		</SearchParameters>
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0">
@@ -698,7 +698,7 @@
 					<UserParam type="stringList" name="identifier" value="[null]"/>
 					<UserParam type="stringList" name="description" value="[null]"/>
 					<UserParam type="string" name="modifications" value="null"/>
-					<UserParam type="string" name="chemical_formula" value="null"/>
+					<UserParam type="string" name="chemical_formula" value=""/>
 					<UserParam type="float" name="ppm_mz_error" value="nan"/>
 				</PeptideHit>
 			</PeptideIdentification>
@@ -1170,7 +1170,7 @@
 					<UserParam type="stringList" name="identifier" value="[null]"/>
 					<UserParam type="stringList" name="description" value="[null]"/>
 					<UserParam type="string" name="modifications" value="null"/>
-					<UserParam type="string" name="chemical_formula" value="null"/>
+					<UserParam type="string" name="chemical_formula" value=""/>
 					<UserParam type="float" name="ppm_mz_error" value="nan"/>
 				</PeptideHit>
 			</PeptideIdentification>
@@ -1370,7 +1370,7 @@
 					<UserParam type="stringList" name="identifier" value="[null]"/>
 					<UserParam type="stringList" name="description" value="[null]"/>
 					<UserParam type="string" name="modifications" value="null"/>
-					<UserParam type="string" name="chemical_formula" value="null"/>
+					<UserParam type="string" name="chemical_formula" value=""/>
 					<UserParam type="float" name="ppm_mz_error" value="nan"/>
 				</PeptideHit>
 			</PeptideIdentification>
@@ -1535,7 +1535,7 @@
 					<UserParam type="stringList" name="identifier" value="[null]"/>
 					<UserParam type="stringList" name="description" value="[null]"/>
 					<UserParam type="string" name="modifications" value="null"/>
-					<UserParam type="string" name="chemical_formula" value="null"/>
+					<UserParam type="string" name="chemical_formula" value=""/>
 					<UserParam type="float" name="ppm_mz_error" value="nan"/>
 				</PeptideHit>
 			</PeptideIdentification>
@@ -2318,7 +2318,7 @@
 					<UserParam type="stringList" name="identifier" value="[null]"/>
 					<UserParam type="stringList" name="description" value="[null]"/>
 					<UserParam type="string" name="modifications" value="null"/>
-					<UserParam type="string" name="chemical_formula" value="null"/>
+					<UserParam type="string" name="chemical_formula" value=""/>
 					<UserParam type="float" name="ppm_mz_error" value="nan"/>
 				</PeptideHit>
 			</PeptideIdentification>

--- a/src/tests/class_tests/openms/source/AccurateMassSearchEngine_test.cpp
+++ b/src/tests/class_tests/openms/source/AccurateMassSearchEngine_test.cpp
@@ -101,8 +101,8 @@ START_SECTION([EXTRA]AdductInfo)
 END_SECTION
 
 Param ams_param;
-ams_param.setValue("db:mapping", OPENMS_GET_TEST_DATA_PATH("reducedHMDBMapping.tsv"));
-ams_param.setValue("db:struct", OPENMS_GET_TEST_DATA_PATH("reducedHMDB2StructMapping.tsv"));
+ams_param.setValue("db:mapping", ListUtils::create<String>(String(OPENMS_GET_TEST_DATA_PATH("reducedHMDBMapping.tsv"))));
+ams_param.setValue("db:struct", ListUtils::create<String>(String(OPENMS_GET_TEST_DATA_PATH("reducedHMDB2StructMapping.tsv"))));
 ams_param.setValue("keep_unidentified_masses", "true");
 ams_param.setValue("mzTab:exportIsotopeIntensities", 3);
 AccurateMassSearchEngine ams;
@@ -351,8 +351,8 @@ START_SECTION([EXTRA] template <typename MAPTYPE> void resolveAutoMode_(const MA
   MzTab mzt;
   Param p;
   p.setValue("ionization_mode","auto");
-  p.setValue("db:mapping", OPENMS_GET_TEST_DATA_PATH("reducedHMDBMapping.tsv"));
-  p.setValue("db:struct", OPENMS_GET_TEST_DATA_PATH("reducedHMDB2StructMapping.tsv"));
+  p.setValue("db:mapping", ListUtils::create<String>(String(OPENMS_GET_TEST_DATA_PATH("reducedHMDBMapping.tsv"))));
+  p.setValue("db:struct", ListUtils::create<String>(String(OPENMS_GET_TEST_DATA_PATH("reducedHMDB2StructMapping.tsv"))));
   ams.setParameters(p);
   ams.init();
 

--- a/src/utils/AccurateMassSearch.cpp
+++ b/src/utils/AccurateMassSearch.cpp
@@ -109,9 +109,9 @@ protected:
         // move some params from algorithm section to top level (to support input file functionality)
         Param p = AccurateMassSearchEngine().getDefaults();
         registerTOPPSubsection_("db", "Database files which contain the identifications");
-        registerInputFile_("db:mapping", "<file>", p.getValue("db:mapping"), p.getDescription("db:mapping"), true, false, ListUtils::create<String>("skipexists"));
+        registerInputFileList_("db:mapping", "<file(s)>", p.getValue("db:mapping"), p.getDescription("db:mapping"), true, false, ListUtils::create<String>("skipexists"));
         setValidFormats_("db:mapping", ListUtils::create<String>("tsv"));
-        registerInputFile_("db:struct", "<file>", p.getValue("db:struct"), p.getDescription("db:struct"), true, false, ListUtils::create<String>("skipexists"));
+        registerInputFileList_("db:struct", "<file(s)>", p.getValue("db:struct"), p.getDescription("db:struct"), true, false, ListUtils::create<String>("skipexists"));
         setValidFormats_("db:struct", ListUtils::create<String>("tsv"));
         registerInputFile_("positive_adducts_file", "<file>", p.getValue("positive_adducts_file"), p.getDescription("positive_adducts_file"), true, false, ListUtils::create<String>("skipexists"));
         setValidFormats_("positive_adducts_file", ListUtils::create<String>("tsv"));
@@ -143,10 +143,10 @@ protected:
         String out = getStringOption_("out");
         String file_ann = getStringOption_("out_annotation");
 
-         Param ams_param = getParam_().copy("algorithm:", true);
+        Param ams_param = getParam_().copy("algorithm:", true);
         // copy top-level params to algorithm
-        ams_param.setValue("db:mapping", getStringOption_("db:mapping"));
-        ams_param.setValue("db:struct", getStringOption_("db:struct"));
+        ams_param.setValue("db:mapping", getStringList_("db:mapping"));
+        ams_param.setValue("db:struct", getStringList_("db:struct"));
         ams_param.setValue("positive_adducts_file", getStringOption_("positive_adducts_file"));
         ams_param.setValue("negative_adducts_file", getStringOption_("negative_adducts_file"));
 


### PR DESCRIPTION
 - allow to parse more than one DB during AccurateMassSearch

other minor fixes:
 - avoid Exception (e.g. in TOPPViewIdentification) for unidentified AMS peak
 - allow empty lines in Adduct.tsv file for AMS

