### PR TITLE
Fixes/Features for TOPPAS/TOPPView

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ListUtils.h
@@ -169,16 +169,28 @@ public:
     /**
       @brief Concatenates all elements of the @p container and puts the @p glue string between elements.
 
-      @param container The container to concatenate.
+      @param container The container to concatenate;
       @param glue The string to add in between elements.
     */
     template <typename T>
     static String concatenate(const std::vector<T>& container, const String& glue = "")
     {
+      return concatenate< std::vector<T> >(container, glue);
+    }
+
+    /**
+      @brief Concatenates all elements of the @p container and puts the @p glue string between elements.
+
+      @param container The container <T> to concatenate; must have begin() and end() iterator.
+      @param glue The string to add in between elements.
+    */
+    template <typename T>
+    static String concatenate(const T& container, const String& glue = "")
+    {
       // handle empty containers
       if (container.empty()) return "";
 
-      typename std::vector<T>::const_iterator it = container.begin();
+      typename T::const_iterator it = container.begin();
       String ret = String(*it);
       // we have handled the first element
       ++it;

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASScene.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASScene.h
@@ -192,9 +192,9 @@ public:
     /// Performs a topological sort of all vertices
     void topoSort();
     /// Returns the name of the directory for output files
-    const QString & getOutDir();
+    const QString & getOutDir() const;
     /// Returns the name of the directory for temporary files
-    const QString & getTempDir();
+    const QString & getTempDir() const;
     /// Sets the name of the directory for output files
     void setOutDir(const QString & dir);
     /// Saves the pipeline if it has been changed since the last save.

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASToolVertex.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASToolVertex.h
@@ -265,9 +265,6 @@ protected:
     /// tool initialization status: if C'tor was successful in finding the TOPP tool, this is set to 'true'
     bool tool_ready_;
 
-    /// UID for output files
-    static UInt uid_;
-
     /// Breakpoint set?
     bool breakpoint_set_;
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
@@ -60,6 +60,7 @@
 #include <QtCore/QFile>
 #include <QtCore/QMap>
 #include <QtCore/QSet>
+#include <QtCore/QSettings>
 #include <QtCore/QUrl>
 #include <QtGui/QApplication>
 #include <QtGui/QCheckBox>
@@ -75,7 +76,6 @@
 #include <QtGui/QMenu>
 #include <QtGui/QMenuBar>
 #include <QtGui/QMessageBox>
-#include <QtCore/QSettings>
 #include <QtGui/QSplashScreen>
 #include <QtGui/QStatusBar>
 #include <QtGui/QTextEdit>

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
@@ -75,6 +75,7 @@
 #include <QtGui/QMenu>
 #include <QtGui/QMenuBar>
 #include <QtGui/QMessageBox>
+#include <QtCore/QSettings>
 #include <QtGui/QSplashScreen>
 #include <QtGui/QStatusBar>
 #include <QtGui/QTextEdit>
@@ -271,6 +272,10 @@ namespace OpenMS
 
     // update the menu
     updateMenu(); 
+
+    QSettings settings("OpenMS", "TOPPAS");
+    restoreGeometry(settings.value("geometry").toByteArray());
+    restoreState(settings.value("windowState").toByteArray());
   }
 
 
@@ -898,8 +903,10 @@ namespace OpenMS
     }
     if (close)
     {
-      //ws_->closeAllWindows();
       event->accept();
+      QSettings settings("OpenMS", "TOPPAS");
+      settings.setValue("geometry", saveGeometry());
+      settings.setValue("windowState", saveState());
     }
     else
     {

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1315,7 +1315,7 @@ namespace OpenMS
             filter.field = DataFilters::INTENSITY;
             filter.op = DataFilters::GREATER_EQUAL;
             filter.value = 0.001;
-            QMessageBox::question(this, "Note:", "Data contains zero values.\nA filter will be added to hide these values.\nYou can reenable data points with zero intensity by removing the filter.");
+            statusBar()->showMessage("Note: Data contains zero values.\nA filter will be added to hide these values.\nYou can reenable data points with zero intensity by removing the filter.");
             ///add filter
             DataFilters filters;
             filters.add(filter);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -81,6 +81,7 @@
 
 
 //Qt
+#include <QtCore/QSettings>
 #include <QtCore/QDate>
 #include <QtCore/QDir>
 #include <QtCore/QTime>
@@ -569,6 +570,10 @@ namespace OpenMS
     //update the menu
     updateMenu();
 
+    QSettings settings("OpenMS", "TOPPView");
+    restoreGeometry(settings.value("geometry").toByteArray());
+    restoreState(settings.value("windowState").toByteArray());
+
     topp_.process = 0;
 
     //######################### File System Watcher ###########################################
@@ -623,6 +628,9 @@ namespace OpenMS
   void TOPPViewBase::closeEvent(QCloseEvent* event)
   {
     ws_->closeAllWindows();
+    QSettings settings("OpenMS", "TOPPView");
+    settings.setValue("geometry", saveGeometry());
+    settings.setValue("windowState", saveState());
     event->accept();
   }
 

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -1153,10 +1153,10 @@ namespace OpenMS
     QRectF new_bounding_rect = tmp_scene->itemsBoundingRect();
     QRectF our_bounding_rect = itemsBoundingRect();
     qreal x_offset, y_offset;
-    if (pos == QPointF())
+    if (pos == QPointF()) // pasted via Ctrl-V (no mouse position given)
     {
-      y_offset = our_bounding_rect.bottom() - new_bounding_rect.top() + 40.0;
-      x_offset = our_bounding_rect.left() - new_bounding_rect.left();
+      x_offset = 30.0; // move just a tad (in relation to old content)
+      y_offset = 30.0;
     }
     else
     {
@@ -1229,11 +1229,11 @@ namespace OpenMS
     // add all edges (are not copied by copy constructors of vertices)
     for (EdgeIterator it = tmp_scene->edgesBegin(); it != tmp_scene->edgesEnd(); ++it)
     {
-      TOPPASEdge* new_e = new TOPPASEdge();
       TOPPASVertex* old_source = (*it)->getSourceVertex();
       TOPPASVertex* old_target = (*it)->getTargetVertex();
       TOPPASVertex* new_source = vertex_map[old_source];
       TOPPASVertex* new_target = vertex_map[old_target];
+      TOPPASEdge* new_e = new TOPPASEdge();
       new_e->setSourceVertex(new_source);
       new_e->setTargetVertex(new_target);
       new_e->setSourceOutParam((*it)->getSourceOutParam());
@@ -1246,17 +1246,11 @@ namespace OpenMS
       addEdge(new_e);
     }
 
-    if (!views().empty())
+    // select new items (so the user can move them); edges do not need to be selected, only vertices
+    unselectAll();
+    for (Map<TOPPASVertex*, TOPPASVertex*>::Iterator it = vertex_map.begin(); it != vertex_map.end(); ++it)
     {
-      TOPPASWidget* tw = qobject_cast<TOPPASWidget*>(views().first());
-      if (tw)
-      {
-        QRectF scene_rect = itemsBoundingRect();
-
-        tw->fitInView(scene_rect, Qt::KeepAspectRatio);
-        tw->scale(0.75, 0.75);
-        setSceneRect(tw->mapToScene(tw->rect()).boundingRect());
-      }
+      it->second->setSelected(true);
     }
 
     topoSort();

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -1528,12 +1528,12 @@ namespace OpenMS
     update(sceneRect());
   }
 
-  const QString& TOPPASScene::getOutDir()
+  const QString& TOPPASScene::getOutDir() const
   {
     return out_dir_;
   }
 
-  const QString& TOPPASScene::getTempDir()
+  const QString& TOPPASScene::getTempDir() const
   {
     return tmp_path_;
   }

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -1150,8 +1150,6 @@ namespace OpenMS
 
   void TOPPASScene::include(TOPPASScene* tmp_scene, QPointF pos)
   {
-    QRectF new_bounding_rect = tmp_scene->itemsBoundingRect();
-    QRectF our_bounding_rect = itemsBoundingRect();
     qreal x_offset, y_offset;
     if (pos == QPointF()) // pasted via Ctrl-V (no mouse position given)
     {
@@ -1160,6 +1158,7 @@ namespace OpenMS
     }
     else
     {
+      QRectF new_bounding_rect = tmp_scene->itemsBoundingRect();
       x_offset = pos.x() - new_bounding_rect.left();
       y_offset = pos.y() - new_bounding_rect.top();
     }

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -908,7 +908,7 @@ namespace OpenMS
         if (has_only_singlefile_output)
         {
           if (it->second.filenames.size() == 1 && 
-              (max_size < 1 || (it->second.edge->getTargetInParamName() == "in") && (use_recycling == 0)))
+             ((max_size < 1 || (it->second.edge->getTargetInParamName() == "in")) && (use_recycling == 0)))
           {
             max_size_index = it->first;
             max_size       = 1;

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -79,8 +79,6 @@ namespace OpenMS
 
   };
 
-  UInt TOPPASToolVertex::uid_ = 1;
-
   TOPPASToolVertex::TOPPASToolVertex() :
     TOPPASVertex(),
     name_(),
@@ -547,7 +545,7 @@ namespace OpenMS
     bool success = buildRoundPackages(pkg, error_msg);
     if (!success)
     {
-      std::cerr << "Could not retrieve input files from upstream nodes...\n";
+      LOG_ERROR << "Could not retrieve input files from upstream nodes...\n";
       emit toolFailed(error_msg.toQString());
       return;
     }
@@ -596,7 +594,7 @@ namespace OpenMS
         int param_index = incoming_edge.getTargetInParam();
         if (param_index < 0 || param_index >= in_params.size())
         {
-          std::cerr << "TOPPAS: Input parameter index out of bounds!" << std::endl;
+          LOG_ERROR << "TOPPAS: Input parameter index out of bounds!" << std::endl;
           return;
         }
 
@@ -841,14 +839,14 @@ namespace OpenMS
             bool success = File::remove(new_filename);
             if (!success)
             {
-              std::cerr << "Could not remove '" << new_filename << "'.\n";
+              LOG_ERROR << "Could not remove '" << new_filename << "'.\n";
               return false;
             }
           }
           bool success = file.rename(new_filename.toQString());
           if (!success)
           {
-            std::cerr << "Could not rename " << String(it->second.filenames[fi]) << " to " << new_filename << "\n";
+            LOG_ERROR << "Could not rename " << String(it->second.filenames[fi]) << " to " << new_filename << "\n";
             return false;
           }
           it->second.filenames[fi] = new_filename.toQString();
@@ -875,19 +873,26 @@ namespace OpenMS
 
   bool TOPPASToolVertex::updateCurrentOutputFileNames(const RoundPackages& pkg, String& error_msg)
   {
-    if (pkg.size() < 1)
+    if (pkg.empty())
     {
       error_msg = "Less than one round received from upstream tools. Something is fishy!\n";
-      std::cerr << error_msg;
+      LOG_ERROR << error_msg;
       return false;
     }
+
+
+    QVector<IOInfo> out_params;
+    getOutputParameters(out_params);
+    // check if this tool outputs a list of files, or only single files
+    bool has_only_singlefile_output = !IOInfo::isAnyList(out_params);
 
     // look for the input with the most files in round 0 (as this is the maximal number of output files we can produce)
     // we assume the number of files is equal in all rounds...
     // However, we delay using nodes which use 'recycling' of input, as the names will always be the same.
     //          Only if a recycling node gives the most input files we use its names
-    int max_size_index = -1;
-    int max_size = -1;
+    int max_size_index(-1);
+    int max_size(-1);
+
     for (int use_recycling = 0; use_recycling < 2; ++use_recycling)
     {
       for (RoundPackageConstIt it  = pkg[0].begin();
@@ -898,8 +903,19 @@ namespace OpenMS
         { // first test all input nodes with disabled recycling
           continue;
         }
-        //std::cerr << "Edge: " << (it->second.edge->toString()) << "\n";
-        if ((it->second.filenames.size() > max_size) ||   // either just larger 
+
+        // we only need to find a good upstream node with a single file -- since we only output single files
+        if (has_only_singlefile_output)
+        {
+          if (it->second.filenames.size() == 1 && 
+              (max_size < 1 || (it->second.edge->getTargetInParamName() == "in") && (use_recycling == 0)))
+          {
+            max_size_index = it->first;
+            max_size       = 1;
+          }
+
+        }
+        else if ((it->second.filenames.size() > max_size) ||   // either just larger 
             // ... or it's from '-in' (which we prefer as naming source).. only for non-recycling -in though
             ((it->second.filenames.size () == max_size) && (it->second.edge->getTargetInParamName() == "in") && (use_recycling == 0)))
         {
@@ -922,42 +938,56 @@ namespace OpenMS
     for (Size i = 0; i < pkg.size(); ++i)
     {
       per_round_basenames.push_back(pkg[i].find(max_size_index)->second.filenames);
-      //String s = String(pkg[i].find(max_size_index)->second.filenames.join(" + "));
+      //std::cerr << "  output filenames (round " << i  <<"): " << per_round_basenames.back().join(", ") << std::endl;
     }
 
     // maybe we find something more unique, e.g. last base directory if all filenames are equal
     smartFileNames_(per_round_basenames);
 
-    QRegExp rx_tmp_suffix("_tmp\\d+$"); // regex to remove "_tmp<number>" if its a suffix
-
     // clear output file list
     output_files_.clear();
     output_files_.resize(pkg.size()); // #rounds
 
-    TOPPASScene* ts = qobject_cast<TOPPASScene*>(scene());
-    QVector<IOInfo> out_params;
-    getOutputParameters(out_params);
+    const TOPPASScene* ts = qobject_cast<const TOPPASScene*>(scene());
+    
     // output names for each outgoing edge
     for (int i = 0; i < out_params.size(); ++i)
     {
       // search for an out edge for this parameter (not required to exist)
-      bool found(false);
       int param_index;
-      TOPPASEdge* edge_out;
-      for (ConstEdgeIterator it = outEdgesBegin(); it != outEdgesEnd(); ++it)
+      TOPPASEdge* edge_out(NULL);
+      for (ConstEdgeIterator it_edge = outEdgesBegin(); it_edge != outEdgesEnd(); ++it_edge)
       {
-        param_index = (*it)->getSourceOutParam();
+        param_index = (*it_edge)->getSourceOutParam();
         if (i == param_index) // corresponding out edge found
         {
-          edge_out = *it;
-          found = true;
+          edge_out = *it_edge;
           break;
         }
       }
-      if (!found)
+      if (!edge_out)
       {
         continue;
       }
+
+      // determine output file format if possible (for suffix)
+      String file_suffix;
+      String p_out_format = out_params[i].param_name + "_type"; // expected parameter name which determines output format
+      if (out_params[i].valid_types.size() == 1)
+      { // only one format allowed
+        file_suffix = "." + out_params[i].valid_types[0];
+      }
+      else if (param_.exists(p_out_format))
+      { // 'out_type' or alike is specified
+        if (!param_.getValue(p_out_format).toString().empty()) file_suffix = "." + param_.getValue(p_out_format).toString();
+        else LOG_WARN << "TOPPAS cannot determine output file format for param '" << out_params[i].param_name
+                      << "' of Node " + this->name_ + "(" + String(this->getTopoNr()) + "). Format is ambiguous. Use parameter '" + p_out_format + "' to name intermediate output correctly!\n";
+      }
+      if (file_suffix.empty())
+      { // tag as unknown (TOPPAS will try to rename the output file once its written - see renameOutput_())
+        file_suffix = ".unknown";
+      }
+      //std::cerr << "suffix is: " << file_suffix << "\n\n";
 
       // create common path of output files
       QString path = ts->getTempDir()
@@ -974,41 +1004,43 @@ namespace OpenMS
 
       VertexRoundPackage vrp;
       vrp.edge = edge_out;
+
+      std::set<QString> filename_output_set; // verify that output files are unique (avoid overwriting)
+
       for (Size r = 0; r < per_round_basenames.size(); ++r)
       {
         // store edge for this param for all rounds
         output_files_[r][param_index] = vrp; // index by index of source-out param
 
-        // check if tool consumes list and outputs single file (such as IDMerger or FileMerger)
-        if (per_round_basenames[r].size() > 1 && out_params[param_index].type == IOInfo::IOT_FILE)
+        // list --> single file (e.g. IDMerger or FileMerger)
+        bool list_to_single = (per_round_basenames[r].size() > 1 && out_params[param_index].type == IOInfo::IOT_FILE);
+        foreach(const QString &input_file, per_round_basenames[r])
         {
-          QString fn = path + QString(QFileInfo(per_round_basenames[r].first()).fileName()
-                            + "_to_"
-                            + QFileInfo(per_round_basenames[r].last()).fileName()
-                            + "_merged");
-          fn = fn.left(220); // allow max of 220 chars per path+filename (~NTFS limit)
-          fn += "_tmp" + QString::number(uid_++);
-          fn = QDir::toNativeSeparators(fn);
-          output_files_[r][param_index].filenames.push_back(fn);
-        }
-        else // each input file will have a corresponding output file
-        {
-          foreach(const QString &input_file, per_round_basenames[r])
+          QString fn = path + QFileInfo(input_file).fileName(); // out_path + filename
+          if (list_to_single)
           {
-            QString fn = path + QFileInfo(input_file).fileName(); // out_path + filename
-            int tmp_index = rx_tmp_suffix.indexIn(fn);
-            if (tmp_index != -1)
-            {
-              fn = fn.left(tmp_index);
-            }
-            fn = fn.left(220); // allow max of 220 chars per path+filename (~NTFS limit)
-            fn += "_tmp" +  QString("%1").arg(uid_++, 3, 10, QChar('0')); // pad with zeros '00X' etc...
-            fn = QDir::toNativeSeparators(fn);
-            output_files_[r][param_index].filenames.push_back(fn);
+            fn += "_to_" + QFileInfo(per_round_basenames[r].last()).fileName() + "_merged";
           }
+          fn = fn.left(220); // allow max of 220 chars per path+filename (~NTFS limit)
+          fn += file_suffix.toQString();
+          fn = QDir::toNativeSeparators(fn);
+          if (filename_output_set.count(fn) > 0)
+          {
+            error_msg = "TOPPAS failed to build correct filenames. Please report this bug, along with your Pipeline\n!";
+            LOG_ERROR << error_msg;
+            return false;
+          }
+          output_files_[r][param_index].filenames.push_back(fn);
+          filename_output_set.insert(fn);
+          if (list_to_single) break; // only one iteration required
         }
       }
+          
+      //std::cerr << "output filenames (" << out_params[i].param_name <<") final: " << ListUtils::concatenate< std::set<QString> >(filename_output_set, ", ") << std::endl;
     }
+
+
+
     return true;
   }
 
@@ -1154,7 +1186,7 @@ namespace OpenMS
 
     if (!ok)
     {
-      std::cerr << "TOPPAS: Could not create path " << getFullOutputDirectory() << std::endl;
+      LOG_ERROR << "TOPPAS: Could not create path " << getFullOutputDirectory() << std::endl;
     }
 
     // subsdirectories named after the output parameter name
@@ -1166,7 +1198,7 @@ namespace OpenMS
       {
         if (!dir.mkpath(sdir))
         {
-          std::cerr << "TOPPAS: Could not create path " << String(sdir) << std::endl;
+          LOG_ERROR << "TOPPAS: Could not create path " << String(sdir) << std::endl;
         }
       }
     }
@@ -1198,8 +1230,6 @@ namespace OpenMS
       {
         File::removeDirRecursively(remove_dir);
       }
-      // reset UID for tmp files
-      uid_ = 1;
     }
 
     TOPPASVertex::reset(reset_all_files);

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -208,7 +208,7 @@ namespace OpenMS
     // all incoming edges should have the same number of rounds!
     for (ConstEdgeIterator it = inEdgesBegin(); it != inEdgesEnd(); ++it)
     {
-      TOPPASVertex* tv = (*it)->getSourceVertex();
+      TOPPASVertex* tv_upstream = (*it)->getSourceVertex();
 
       // fill files for each round
       int param_index_src_out = (*it)->getSourceOutParam();
@@ -218,16 +218,16 @@ namespace OpenMS
         VertexRoundPackage rpg;
         rpg.edge = *it;
         int upstream_round = round;
-        if (tv->allow_output_recycling_ && upstream_round >= tv->round_total_)
+        if (tv_upstream->allow_output_recycling_ && upstream_round >= tv_upstream->round_total_)
         {
-          upstream_round %= tv->round_total_;
+          upstream_round %= tv_upstream->round_total_;
         }
-        rpg.filenames = tv->getFileNames(param_index_src_out, upstream_round);
+        rpg.filenames = tv_upstream->getFileNames(param_index_src_out, upstream_round);
 
         // hack for merger vertices, as they have multiple incoming edges with -1 as index
         while (pkg[round].count(param_index_tgt_in))
         {
-          --param_index_tgt_in;
+          --param_index_tgt_in; // find free slot, i.e. -2, -3 ....
         }
 
         pkg[round][param_index_tgt_in] = rpg; // index by incoming edge number


### PR DESCRIPTION
[FIX] TOPPAS: name temporary files with correct suffix if possible (when TOPPAS stops, the intermediate files will have a correct suffix); better error checking; better name choice for output files (source edge)

[FIX] TOPPAS: when copy&pasting nodes, insert new nodes next to existing ones & select the new nodes (to readily move them)

[FEATURE] TOPPAS: remember last main Window position for next start			

[FIX] TOPPView: omit modal & blocking Messagebox which warns for values <=0 (delays showing data, especially on large sets); instead show message in the status bar.

[FEATURE] TOPPView: remember last main Window position for next start			