### PR TITLE
[FIX] move quantification parameter from FF-Metabo into MTD

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/MassTraceDetection.h
+++ b/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/MassTraceDetection.h
@@ -115,6 +115,7 @@ private:
     double mass_error_ppm_;
     double noise_threshold_int_;
     double chrom_peak_snr_;
+    MassTrace::MT_QUANTMETHOD quant_method_;
 
     String trace_termination_criterion_;
     Size trace_termination_outliers_;

--- a/src/openms/source/FILTERING/DATAREDUCTION/ElutionPeakDetection.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/ElutionPeakDetection.cpp
@@ -544,7 +544,7 @@ namespace OpenMS
           new_mt.updateSmoothedMaxRT();
           new_mt.updateWeightedMeanMZ();
           new_mt.updateWeightedMZsd();
-
+          new_mt.setQuantMethod(mt.getQuantMethod());
           if (pw_filtering_ != "fixed")
           {
             new_mt.estimateFWHM(true);

--- a/src/openms/source/FILTERING/DATAREDUCTION/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/FeatureFindingMetabo.cpp
@@ -243,8 +243,6 @@ namespace OpenMS
   FeatureFindingMetabo::FeatureFindingMetabo() :
     DefaultParamHandler("FeatureFindingMetabo"), ProgressLogger()
   {
-    defaults_.setValue("quant_method", String(MassTrace::names_of_quantmethod[0]), "Method of quantification for mass traces. For LC data 'area' is recommended, 'median' for direct injection data.");
-    defaults_.setValidStrings("quant_method", std::vector<String>(MassTrace::names_of_quantmethod, MassTrace::names_of_quantmethod +(int)MassTrace::SIZE_OF_MT_QUANTMETHOD));
     defaults_.setValue("local_rt_range", 10.0, "RT range where to look for coeluting mass traces", ListUtils::create<String>("advanced")); // 5.0
     defaults_.setValue("local_mz_range", 6.5, "MZ range where to look for isotopic mass traces", ListUtils::create<String>("advanced")); // 6.5
     defaults_.setValue("charge_lower_bound", 1, "Lowest charge state to consider"); // 1
@@ -723,18 +721,7 @@ namespace OpenMS
     this->startProgress(0, input_mtraces.size(), "assembling mass traces to features");
 
     // *********************************************************** //
-    // Step 1 configure quantification method
-    // *********************************************************** //
-    MassTrace::MT_QUANTMETHOD method = MassTrace::getQuantMethod((String)param_.getValue("quant_method"));
-    for (std::vector<MassTrace>::iterator it = input_mtraces.begin();
-      it != input_mtraces.end();
-      ++it)
-    {
-      it->setQuantMethod(method);
-    }
-
-    // *********************************************************** //
-    // Step 2 initialize SVM model for isotope ratio filtering
+    // Step 1 initialize SVM model for isotope ratio filtering
     // *********************************************************** //
     if (isotope_filtering_model_ == "metabolites (2% RMS)")
     {
@@ -754,7 +741,7 @@ namespace OpenMS
     }
 
     // *********************************************************** //
-    // Step 3 Iterate through all mass traces to find likely matches 
+    // Step 2 Iterate through all mass traces to find likely matches 
     // and generate isotopic / charge hypotheses
     // *********************************************************** //
     std::vector<FeatureHypothesis> feat_hypos;
@@ -808,7 +795,7 @@ namespace OpenMS
 #endif
 
     // *********************************************************** //
-    // Step 4 Iterate through all hypotheses, starting with the highest 
+    // Step 3 Iterate through all hypotheses, starting with the highest 
     // scoring one. Accept them if they do not contain traces that have 
     // already been used by a higher scoring hypothesis.
     // *********************************************************** //

--- a/src/openms/source/FILTERING/DATAREDUCTION/MassTraceDetection.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/MassTraceDetection.cpp
@@ -58,6 +58,9 @@ namespace OpenMS
     defaults_.setValue("reestimate_mt_sd", "true", "Enables dynamic re-estimation of m/z variance during mass trace collection stage.");
     defaults_.setValidStrings("reestimate_mt_sd", ListUtils::create<String>("true,false"));
 
+    defaults_.setValue("quant_method", String(MassTrace::names_of_quantmethod[0]), "Method of quantification for mass traces. For LC data 'area' is recommended, 'median' for direct injection data.");
+    defaults_.setValidStrings("quant_method", std::vector<String>(MassTrace::names_of_quantmethod, MassTrace::names_of_quantmethod +(int)MassTrace::SIZE_OF_MT_QUANTMETHOD));
+
     // advanced parameters
     defaults_.setValue("trace_termination_criterion", "outlier", "Termination criterion for the extension of mass traces. In 'outlier' mode, trace extension cancels if a predefined number of consecutive outliers are found (see trace_termination_outliers parameter). In 'sample_rate' mode, trace extension in both directions stops if ratio of found peaks versus visited spectra falls below the 'min_sample_rate' threshold.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("trace_termination_criterion", ListUtils::create<String>("outlier,sample_rate"));
@@ -93,8 +96,8 @@ namespace OpenMS
   }
 
   void MassTraceDetection::run(MSExperiment<Peak1D>::ConstAreaIterator& begin,
-                               MSExperiment<Peak1D>::ConstAreaIterator& end, std::vector<MassTrace>&
-                               found_masstraces)
+                               MSExperiment<Peak1D>::ConstAreaIterator& end,
+                               std::vector<MassTrace>& found_masstraces)
   {
     MSExperiment<Peak1D> map;
     MSSpectrum<Peak1D> current_spectrum;
@@ -267,7 +270,7 @@ namespace OpenMS
                                 const Size peak_count, 
                                 const MSExperiment<Peak1D>& work_exp, 
                                 const std::vector<Size>& spec_offsets,
-                                std::vector<MassTrace> & found_masstraces)
+                                std::vector<MassTrace>& found_masstraces)
   {
     // Size min_flank_scans(3);
     boost::dynamic_bitset<> peak_visited(peak_count);
@@ -525,6 +528,7 @@ namespace OpenMS
         new_trace.updateWeightedMeanRT();
         new_trace.updateWeightedMeanMZ();
         if (!fwhms_mz.empty()) new_trace.fwhm_mz_avg = Math::median(fwhms_mz.begin(), fwhms_mz.end());
+        new_trace.setQuantMethod(quant_method_);
 
         //new_trace.setCentroidSD(ftl_sd);
         new_trace.updateWeightedMZsd();
@@ -547,7 +551,7 @@ namespace OpenMS
     mass_error_ppm_ = (double)param_.getValue("mass_error_ppm");
     noise_threshold_int_ = (double)param_.getValue("noise_threshold_int");
     chrom_peak_snr_ = (double)param_.getValue("chrom_peak_snr");
-    // chrom_fwhm_ = (double)param_.getValue("chrom_fwhm");
+    quant_method_ = MassTrace::getQuantMethod((String)param_.getValue("quant_method"));
 
     trace_termination_criterion_ = (String)param_.getValue("trace_termination_criterion");
     trace_termination_outliers_ = (Size)param_.getValue("trace_termination_outliers");

--- a/src/tests/topp/FeatureFinderMetabo.ini
+++ b/src/tests/topp/FeatureFinderMetabo.ini
@@ -1,43 +1,50 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<PARAMETERS version="1.4" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <NODE name="FeatureFinderMetabo" description="Assembles metabolite features from singleton mass traces.">
-    <ITEM name="version" value="1.10.0" type="string" description="Version of the tool that generated this parameters file." tags="advanced" />
+<PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NODE name="FeatureFinderMetabo" description="Assembles metabolite features from centroided (LC-)MS data using the mass trace approach.">
+    <ITEM name="version" value="2.0.1" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;FeatureFinderMetabo&apos;">
-      <ITEM name="in" value="" type="string" description="input centroided mzML file" tags="input file,required" supported_formats="*.mzML" />
-      <ITEM name="out" value="" type="string" description="output featureXML file with metabolite features" tags="output file,required" supported_formats="*.featureXML" />
-      <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
-      <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
-      <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
-      <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
+      <ITEM name="in" value="" type="input-file" description="Centroided mzML file" required="true" advanced="false" supported_formats="*.mzML" />
+      <ITEM name="out" value="" type="output-file" description="FeatureXML file with metabolite features" required="true" advanced="false" supported_formats="*.featureXML" />
+      <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
+      <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">
-        <NODE name="common" description="">
-          <ITEM name="noise_threshold_int" value="10" type="float" description="Intensity threshold below which peaks are regarded as noise." />
-          <ITEM name="chrom_peak_snr" value="3" type="float" description="Minimum signal-to-noise a mass trace should have." />
-          <ITEM name="chrom_fwhm" value="5" type="float" description="Expected chromatographic peak width (in seconds)." />
+        <NODE name="common" description="Common parameters for all other subsections">
+          <ITEM name="noise_threshold_int" value="10" type="double" description="Intensity threshold below which peaks are regarded as noise." required="false" advanced="false" />
+          <ITEM name="chrom_peak_snr" value="3" type="double" description="Minimum signal-to-noise a mass trace should have." required="false" advanced="false" />
+          <ITEM name="chrom_fwhm" value="5" type="double" description="Expected chromatographic peak width (in seconds)." required="false" advanced="false" />
         </NODE>
-        <NODE name="mtd" description="">
-          <ITEM name="mass_error_ppm" value="20" type="float" description="Allowed mass deviation (in ppm)." />
-          <ITEM name="reestimate_mt_sd" value="true" type="string" description="Enables dynamic re-estimation of m/z variance during mass trace collection stage." restrictions="true,false" />
-          <ITEM name="min_sample_rate" value="0.5" type="float" description="Minimum fraction of scans along the mass trace that must contain a peak." tags="advanced" />
-          <ITEM name="min_trace_length" value="5" type="float" description="Minimum expected length of a mass trace (in seconds)." tags="advanced" />
+        <NODE name="mtd" description="Mass Trace Detection parameters">
+          <ITEM name="mass_error_ppm" value="20" type="double" description="Allowed mass deviation (in ppm)." required="false" advanced="false" />
+          <ITEM name="reestimate_mt_sd" value="true" type="string" description="Enables dynamic re-estimation of m/z variance during mass trace collection stage." required="false" advanced="false" restrictions="true,false" />
+          <ITEM name="quant_method" value="area" type="string" description="Method of quantification for mass traces. For LC data &apos;area&apos; is recommended, &apos;median&apos; for direct injection data." required="false" advanced="false" restrictions="area,median" />
+          <ITEM name="trace_termination_criterion" value="outlier" type="string" description="Termination criterion for the extension of mass traces. In &apos;outlier&apos; mode, trace extension cancels if a predefined number of consecutive outliers are found (see trace_termination_outliers parameter). In &apos;sample_rate&apos; mode, trace extension in both directions stops if ratio of found peaks versus visited spectra falls below the &apos;min_sample_rate&apos; threshold." required="false" advanced="true" restrictions="outlier,sample_rate" />
+          <ITEM name="trace_termination_outliers" value="5" type="int" description="Mass trace extension in one direction cancels if this number of consecutive spectra with no detectable peaks is reached." required="false" advanced="true" />
+          <ITEM name="min_sample_rate" value="0.5" type="double" description="Minimum fraction of scans along the mass trace that must contain a peak." required="false" advanced="true" />
+          <ITEM name="min_trace_length" value="5" type="double" description="Minimum expected length of a mass trace (in seconds)." required="false" advanced="true" />
+          <ITEM name="max_trace_length" value="300" type="double" description="Maximum expected length of a mass trace (in seconds). Set to a negative value to disable maximal length check during mass trace detection." required="false" advanced="true" />
         </NODE>
-        <NODE name="epd" description="">
-          <ITEM name="width_filtering" value="off" type="string" description="Enable filtering of unlikely peak widths. The fixed setting filters out mass traces outside the [min_fwhm, max_fwhm] interval (set parameters accordingly!). The auto setting filters with the 5 and 95% quantiles of the peak width distribution." restrictions="off,fixed,auto" />
-          <ITEM name="min_fwhm" value="3" type="float" description="Minimum full-width-at-half-maximum of chromatographic peaks (in seconds). Ignored if paramter width_filtering is off or auto." tags="advanced" />
-          <ITEM name="max_fwhm" value="60" type="float" description="Maximum full-width-at-half-maximum of chromatographic peaks (in seconds). Ignored if paramter width_filtering is off or auto." tags="advanced" />
-          <ITEM name="masstrace_snr_filtering" value="false" type="string" description="Apply post-filtering by signal-to-noise ratio after smoothing." tags="advanced" restrictions="false,true" />
-          <ITEM name="min_trace_length" value="5" type="float" description="Minimum length of a mass trace (in seconds)." tags="advanced" />
-          <ITEM name="max_trace_length" value="300" type="float" description="Maximum length of a mass trace (in seconds)." tags="advanced" />
+        <NODE name="epd" description="Elution Profile Detection (to separate isobaric Mass Traces by elution time).">
+          <ITEM name="enabled" value="true" type="string" description="Enable splitting of isobaric mass traces by chromatographic peak detection. Disable for direct injection." required="false" advanced="false" restrictions="true,false" />
+          <ITEM name="width_filtering" value="off" type="string" description="Enable filtering of unlikely peak widths. The fixed setting filters out mass traces outside the [min_fwhm, max_fwhm] interval (set parameters accordingly!). The auto setting filters with the 5 and 95% quantiles of the peak width distribution." required="false" advanced="false" restrictions="off,fixed,auto" />
+          <ITEM name="min_fwhm" value="3" type="double" description="Minimum full-width-at-half-maximum of chromatographic peaks (in seconds). Ignored if parameter width_filtering is off or auto." required="false" advanced="true" />
+          <ITEM name="max_fwhm" value="60" type="double" description="Maximum full-width-at-half-maximum of chromatographic peaks (in seconds). Ignored if parameter width_filtering is off or auto." required="false" advanced="true" />
+          <ITEM name="masstrace_snr_filtering" value="false" type="string" description="Apply post-filtering by signal-to-noise ratio after smoothing." required="false" advanced="true" restrictions="false,true" />
         </NODE>
-        <NODE name="ffm" description="">
-          <ITEM name="local_rt_range" value="10" type="float" description="RT range where to look for coeluting mass traces" tags="advanced" />
-          <ITEM name="local_mz_range" value="6.5" type="float" description="MZ range where to look for isotopic mass traces" tags="advanced" />
-          <ITEM name="charge_lower_bound" value="1" type="int" description="Lowest charge state to consider" />
-          <ITEM name="charge_upper_bound" value="3" type="int" description="Highest charge state to consider" />
-          <ITEM name="report_summed_ints" value="false" type="string" description="Set to true for a feature intensity summed up over all traces rather than using monoisotopic trace intensity alone." tags="advanced" restrictions="false,true" />
-          <ITEM name="mz_scoring_13C" value="true" type="string" description="Use the 13C isotope peak position (~1.003355 Da) as the expected shift in m/z for isotope mass traces. Disable to reproduce the behavior as described in Kenar et al. 2014, MCP." required="false" advanced="false" restrictions="false,true" />
-          <ITEM name="use_smoothed_intensities" value="true" type="string" description="Use LOWESS intensities instead of raw intensities." tags="advanced" restrictions="false,true" />
+        <NODE name="ffm" description="FeatureFinder parameters (assembling mass traces to charged features)">
+          <ITEM name="local_rt_range" value="10" type="double" description="RT range where to look for coeluting mass traces" required="false" advanced="true" />
+          <ITEM name="local_mz_range" value="6.5" type="double" description="MZ range where to look for isotopic mass traces" required="false" advanced="true" />
+          <ITEM name="charge_lower_bound" value="1" type="int" description="Lowest charge state to consider" required="false" advanced="false" />
+          <ITEM name="charge_upper_bound" value="3" type="int" description="Highest charge state to consider" required="false" advanced="false" />
+          <ITEM name="report_summed_ints" value="false" type="string" description="Set to true for a feature intensity summed up over all traces rather than using monoisotopic trace intensity alone." required="false" advanced="true" restrictions="false,true" />
+          <ITEM name="enable_RT_filtering" value="true" type="string" description="Require sufficient overlap in RT while assembling mass traces. Disable for direct injection data.." required="false" advanced="false" restrictions="false,true" />
+          <ITEM name="isotope_filtering_model" value="metabolites (5% RMS)" type="string" description="Remove/score candidate assemblies based on isotope intensities. SVM isotope models for metabolites were trained with either 2% or 5% RMS error. For peptides, an averagine cosine scoring is used. Select the appropriate noise model according to the quality of measurement or MS device." required="false" advanced="false" restrictions="metabolites (2% RMS),metabolites (5% RMS),peptides,none" />
+          <ITEM name="mz_scoring_13C" value="true" type="string" description="Use the 13C isotope peak position (~1.003355 Da) as the expected shift in m/z for isotope mass traces (highly recommended for lipidomics!). Disable for general metabolites (as described in Kenar et al. 2014, MCP.)." required="false" advanced="false" restrictions="false,true" />
+          <ITEM name="use_smoothed_intensities" value="true" type="string" description="Use LOWESS intensities instead of raw intensities." required="false" advanced="true" restrictions="false,true" />
+          <ITEM name="report_convex_hulls" value="false" type="string" description="Augment each reported feature with the convex hull of the underlying mass traces (increases featureXML file size considerably)." required="false" advanced="false" restrictions="false,true" />
         </NODE>
       </NODE>
     </NODE>

--- a/src/tests/topp/MassTraceExtractor.ini
+++ b/src/tests/topp/MassTraceExtractor.ini
@@ -1,35 +1,39 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<PARAMETERS version="1.4" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NODE name="MassTraceExtractor" description="Detects mass traces in centroided LC-MS data.">
-    <ITEM name="version" value="1.10.0" type="string" description="Version of the tool that generated this parameters file." tags="advanced" />
+    <ITEM name="version" value="2.0.1" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;MassTraceExtractor&apos;">
-      <ITEM name="in" value="" type="string" description="input centroided mzML file" tags="input file,required" supported_formats="*.mzML" />
-      <ITEM name="out" value="" type="string" description="output featureXML file with mass traces" tags="output file,required" supported_formats="*.featureXML" />
-      <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" tags="advanced" />
-      <ITEM name="debug" value="0" type="int" description="Sets the debug level" tags="advanced" />
-      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" />
-      <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" tags="advanced" restrictions="true,false" />
-      <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
+      <ITEM name="in" value="" type="input-file" description="input centroided mzML file" required="true" advanced="false" supported_formats="*.mzML" />
+      <ITEM name="out" value="" type="output-file" description="output featureXML file with mass traces" required="true" advanced="false" supported_formats="*.featureXML,*.consensusXML" />
+      <ITEM name="out_type" value="" type="string" description="output file type -- default: determined from file extension or content" required="false" advanced="false" restrictions="featureXML,consensusXML" />
+      <ITEM name="log" value="" type="string" description="Name of log file (created only when specified)" required="false" advanced="true" />
+      <ITEM name="debug" value="0" type="int" description="Sets the debug level" required="false" advanced="true" />
+      <ITEM name="threads" value="1" type="int" description="Sets the number of threads allowed to be used by the TOPP tool" required="false" advanced="false" />
+      <ITEM name="no_progress" value="false" type="string" description="Disables progress logging to command line" required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="force" value="false" type="string" description="Overwrite tool specific checks." required="false" advanced="true" restrictions="true,false" />
+      <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" required="false" advanced="true" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">
         <NODE name="common" description="">
-          <ITEM name="noise_threshold_int" value="10" type="float" description="Intensity threshold below which peaks are regarded as noise." />
-          <ITEM name="chrom_peak_snr" value="3" type="float" description="Minimum signal-to-noise a mass trace should have." />
-          <ITEM name="chrom_fwhm" value="5" type="float" description="Expected chromatographic peak width (in seconds)." />
+          <ITEM name="noise_threshold_int" value="10" type="double" description="Intensity threshold below which peaks are regarded as noise." required="false" advanced="false" />
+          <ITEM name="chrom_peak_snr" value="3" type="double" description="Minimum signal-to-noise a mass trace should have." required="false" advanced="false" />
+          <ITEM name="chrom_fwhm" value="5" type="double" description="Expected chromatographic peak width (in seconds)." required="false" advanced="false" />
         </NODE>
         <NODE name="mtd" description="">
-          <ITEM name="mass_error_ppm" value="20" type="float" description="Allowed mass deviation (in ppm)." />
-          <ITEM name="reestimate_mt_sd" value="true" type="string" description="Enables dynamic re-estimation of m/z variance during mass trace collection stage." restrictions="true,false" />
-          <ITEM name="min_sample_rate" value="0.5" type="float" description="Minimum fraction of scans along the mass trace that must contain a peak." tags="advanced" />
-          <ITEM name="min_trace_length" value="5" type="float" description="Minimum expected length of a mass trace (in seconds)." tags="advanced" />
+          <ITEM name="mass_error_ppm" value="20" type="double" description="Allowed mass deviation (in ppm)." required="false" advanced="false" />
+          <ITEM name="reestimate_mt_sd" value="true" type="string" description="Enables dynamic re-estimation of m/z variance during mass trace collection stage." required="false" advanced="false" restrictions="true,false" />
+          <ITEM name="quant_method" value="area" type="string" description="Method of quantification for mass traces. For LC data &apos;area&apos; is recommended, &apos;median&apos; for direct injection data." required="false" advanced="false" restrictions="area,median" />
+          <ITEM name="trace_termination_criterion" value="outlier" type="string" description="Termination criterion for the extension of mass traces. In &apos;outlier&apos; mode, trace extension cancels if a predefined number of consecutive outliers are found (see trace_termination_outliers parameter). In &apos;sample_rate&apos; mode, trace extension in both directions stops if ratio of found peaks versus visited spectra falls below the &apos;min_sample_rate&apos; threshold." required="false" advanced="true" restrictions="outlier,sample_rate" />
+          <ITEM name="trace_termination_outliers" value="5" type="int" description="Mass trace extension in one direction cancels if this number of consecutive spectra with no detectable peaks is reached." required="false" advanced="true" />
+          <ITEM name="min_sample_rate" value="0.5" type="double" description="Minimum fraction of scans along the mass trace that must contain a peak." required="false" advanced="true" />
+          <ITEM name="min_trace_length" value="5" type="double" description="Minimum expected length of a mass trace (in seconds)." required="false" advanced="true" />
+          <ITEM name="max_trace_length" value="-1" type="double" description="Maximum expected length of a mass trace (in seconds). Set to a negative value to disable maximal length check during mass trace detection." required="false" advanced="true" />
         </NODE>
         <NODE name="epd" description="">
-          <ITEM name="width_filtering" value="off" type="string" description="Enable filtering of unlikely peak widths. The fixed setting filters out mass traces outside the [min_fwhm, max_fwhm] interval (set parameters accordingly!). The auto setting filters with the 5 and 95% quantiles of the peak width distribution." restrictions="off,fixed,auto" />
-          <ITEM name="min_fwhm" value="3" type="float" description="Minimum full-width-at-half-maximum of chromatographic peaks (in seconds). Ignored if paramter width_filtering is off or auto." tags="advanced" />
-          <ITEM name="max_fwhm" value="60" type="float" description="Maximum full-width-at-half-maximum of chromatographic peaks (in seconds). Ignored if paramter width_filtering is off or auto." tags="advanced" />
-          <ITEM name="masstrace_snr_filtering" value="false" type="string" description="Apply post-filtering by signal-to-noise ratio after smoothing." tags="advanced" restrictions="false,true" />
-          <ITEM name="min_trace_length" value="5" type="float" description="Minimum length of a mass trace (in seconds)." tags="advanced" />
-          <ITEM name="max_trace_length" value="-1" type="float" description="Maximum length of a mass trace (in seconds)." tags="advanced" />
-          <ITEM name="enabled" value="true" type="string" description="Enables/disables the chromatographic peak detection of mass traces" restrictions="true,false" />
+          <ITEM name="width_filtering" value="off" type="string" description="Enable filtering of unlikely peak widths. The fixed setting filters out mass traces outside the [min_fwhm, max_fwhm] interval (set parameters accordingly!). The auto setting filters with the 5 and 95% quantiles of the peak width distribution." required="false" advanced="false" restrictions="off,fixed,auto" />
+          <ITEM name="min_fwhm" value="3" type="double" description="Minimum full-width-at-half-maximum of chromatographic peaks (in seconds). Ignored if parameter width_filtering is off or auto." required="false" advanced="true" />
+          <ITEM name="max_fwhm" value="60" type="double" description="Maximum full-width-at-half-maximum of chromatographic peaks (in seconds). Ignored if parameter width_filtering is off or auto." required="false" advanced="true" />
+          <ITEM name="masstrace_snr_filtering" value="false" type="string" description="Apply post-filtering by signal-to-noise ratio after smoothing." required="false" advanced="true" restrictions="false,true" />
+          <ITEM name="enabled" value="true" type="string" description="Enables/disables the chromatographic peak detection of mass traces" required="false" advanced="false" restrictions="true,false" />
         </NODE>
       </NODE>
     </NODE>

--- a/src/tests/topp/MassTraceExtractor_1_output.featureXML
+++ b/src/tests/topp/MassTraceExtractor_1_output.featureXML
@@ -10,7 +10,7 @@
 		<feature id="f_4835329514588776807">
 			<position dim="0">2463.9564</position>
 			<position dim="1">1580.19785941061</position>
-			<intensity>621448</intensity>
+			<intensity>381401</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.966667</overallquality>
@@ -83,7 +83,7 @@
 		<feature id="f_17749660155506638460">
 			<position dim="0">2458.847</position>
 			<position dim="1">1505.00996696247</position>
-			<intensity>593883</intensity>
+			<intensity>453878</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.962963</overallquality>
@@ -150,7 +150,7 @@
 		<feature id="f_7804704400743266335">
 			<position dim="0">2465.6642</position>
 			<position dim="1">1663.31735046497</position>
-			<intensity>528909</intensity>
+			<intensity>368976</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.962963</overallquality>
@@ -217,7 +217,7 @@
 		<feature id="f_15004869347769368353">
 			<position dim="0">2465.6642</position>
 			<position dim="1">1436.62662092549</position>
-			<intensity>498162</intensity>
+			<intensity>386339</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.961538</overallquality>
@@ -282,7 +282,7 @@
 		<feature id="f_3332699010107892018">
 			<position dim="0">2295.4041</position>
 			<position dim="1">1541.14987387243</position>
-			<intensity>373030</intensity>
+			<intensity>308023</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.954545</overallquality>
@@ -339,7 +339,7 @@
 		<feature id="f_13440783915218733453">
 			<position dim="0">2330.2597</position>
 			<position dim="1">1541.16946984182</position>
-			<intensity>49983.6</intensity>
+			<intensity>42298</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.8</overallquality>
@@ -362,7 +362,7 @@
 		<feature id="f_15916652588957785155">
 			<position dim="0">2457.1369</position>
 			<position dim="1">1593.02290566302</position>
-			<intensity>357051</intensity>
+			<intensity>239684</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -405,7 +405,7 @@
 		<feature id="f_15157403601844400700">
 			<position dim="0">2155.4741</position>
 			<position dim="1">1497.85093371701</position>
-			<intensity>422248</intensity>
+			<intensity>247791</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.966667</overallquality>
@@ -478,7 +478,7 @@
 		<feature id="f_6408859317243173796">
 			<position dim="0">2236.4495</position>
 			<position dim="1">1618.6387043653</position>
-			<intensity>402715</intensity>
+			<intensity>369703</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.947368</overallquality>
@@ -529,7 +529,7 @@
 		<feature id="f_474525871221756682">
 			<position dim="0">2463.9564</position>
 			<position dim="1">1755.65699697199</position>
-			<intensity>384535</intensity>
+			<intensity>239129</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.962963</overallquality>
@@ -596,7 +596,7 @@
 		<feature id="f_12999979801269632061">
 			<position dim="0">2455.4355</position>
 			<position dim="1">1517.1926445601</position>
-			<intensity>294580</intensity>
+			<intensity>231316</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.916667</overallquality>
@@ -633,7 +633,7 @@
 		<feature id="f_17413765565443951891">
 			<position dim="0">2236.4495</position>
 			<position dim="1">1545.09236246071</position>
-			<intensity>333235</intensity>
+			<intensity>303269</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.941176</overallquality>
@@ -680,7 +680,7 @@
 		<feature id="f_2927519776102075938">
 			<position dim="0">2304.0212</position>
 			<position dim="1">1622.21247604866</position>
-			<intensity>382619</intensity>
+			<intensity>281669</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.95</overallquality>
@@ -733,7 +733,7 @@
 		<feature id="f_16907355690727166316">
 			<position dim="0">2050.5696</position>
 			<position dim="1">1650.6116309063</position>
-			<intensity>439545</intensity>
+			<intensity>293449</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.96875</overallquality>
@@ -810,7 +810,7 @@
 		<feature id="f_10306100746905639127">
 			<position dim="0">2300.5738</position>
 			<position dim="1">1712.24711838441</position>
-			<intensity>319728</intensity>
+			<intensity>215773</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.956522</overallquality>
@@ -869,7 +869,7 @@
 		<feature id="f_12524258085768770586">
 			<position dim="0">2298.845</position>
 			<position dim="1">1467.81058170158</position>
-			<intensity>386611</intensity>
+			<intensity>253162</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.962963</overallquality>
@@ -936,7 +936,7 @@
 		<feature id="f_1755235105885170967">
 			<position dim="0">2234.7232</position>
 			<position dim="1">1477.97989588568</position>
-			<intensity>341631</intensity>
+			<intensity>316285</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.947368</overallquality>
@@ -987,7 +987,7 @@
 		<feature id="f_14811341817612382122">
 			<position dim="0">2387.5374</position>
 			<position dim="1">1603.36660146052</position>
-			<intensity>220676</intensity>
+			<intensity>143729</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.947368</overallquality>
@@ -1038,7 +1038,7 @@
 		<feature id="f_2684106197423007927">
 			<position dim="0">2048.7927</position>
 			<position dim="1">1575.65796589313</position>
-			<intensity>432597</intensity>
+			<intensity>300242</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.969697</overallquality>
@@ -1117,7 +1117,7 @@
 		<feature id="f_8119044117483804262">
 			<position dim="0">2153.7001</position>
 			<position dim="1">1655.41015690488</position>
-			<intensity>362677</intensity>
+			<intensity>219317</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.966667</overallquality>
@@ -1190,7 +1190,7 @@
 		<feature id="f_17314619952666245179">
 			<position dim="0">2465.6642</position>
 			<position dim="1">1374.21534348336</position>
-			<intensity>337752</intensity>
+			<intensity>273395</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9375</overallquality>
@@ -1235,7 +1235,7 @@
 		<feature id="f_3023658190814908261">
 			<position dim="0">2153.7001</position>
 			<position dim="1">1572.69562501365</position>
-			<intensity>414659</intensity>
+			<intensity>295275</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.969697</overallquality>
@@ -1314,7 +1314,7 @@
 		<feature id="f_7898004582401008768">
 			<position dim="0">2255.4493</position>
 			<position dim="1">1544.81875231984</position>
-			<intensity>399381</intensity>
+			<intensity>317970</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.958333</overallquality>
@@ -1375,7 +1375,7 @@
 		<feature id="f_15050004366391181853">
 			<position dim="0">2479.3861</position>
 			<position dim="1">1498.91130002317</position>
-			<intensity>186688</intensity>
+			<intensity>134338</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9</overallquality>
@@ -1408,7 +1408,7 @@
 		<feature id="f_17716858074023296841">
 			<position dim="0">2052.3418</position>
 			<position dim="1">1507.18261216863</position>
-			<intensity>415371</intensity>
+			<intensity>278344</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.96875</overallquality>
@@ -1485,7 +1485,7 @@
 		<feature id="f_16250062551099875712">
 			<position dim="0">2305.7472</position>
 			<position dim="1">1401.16124326357</position>
-			<intensity>220648</intensity>
+			<intensity>173738</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9375</overallquality>
@@ -1530,7 +1530,7 @@
 		<feature id="f_16177748921272733768">
 			<position dim="0">2450.3192</position>
 			<position dim="1">1448.26184437381</position>
-			<intensity>210253</intensity>
+			<intensity>161515</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.941176</overallquality>
@@ -1577,7 +1577,7 @@
 		<feature id="f_7276556891837796968">
 			<position dim="0">2475.9407</position>
 			<position dim="1">1573.80917510917</position>
-			<intensity>225886</intensity>
+			<intensity>190153</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.923077</overallquality>
@@ -1616,7 +1616,7 @@
 		<feature id="f_1147219038608936718">
 			<position dim="0">2453.7277</position>
 			<position dim="1">1676.81666192575</position>
-			<intensity>142447</intensity>
+			<intensity>127273</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.875</overallquality>
@@ -1645,7 +1645,7 @@
 		<feature id="f_11115414975438642789">
 			<position dim="0">2450.3192</position>
 			<position dim="1">1769.84820359795</position>
-			<intensity>144956</intensity>
+			<intensity>112035</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.909091</overallquality>
@@ -1680,7 +1680,7 @@
 		<feature id="f_14509930621887606273">
 			<position dim="0">2258.9136</position>
 			<position dim="1">1618.33521514398</position>
-			<intensity>338357</intensity>
+			<intensity>280310</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9375</overallquality>
@@ -1746,7 +1746,7 @@
 		<feature id="f_12665713047548007769">
 			<position dim="0">2460.5445</position>
 			<position dim="1">1858.86239851614</position>
-			<intensity>234752</intensity>
+			<intensity>89058.7</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.95</overallquality>
@@ -1799,7 +1799,7 @@
 		<feature id="f_17092894204355333314">
 			<position dim="0">2231.2626</position>
 			<position dim="1">1699.46797609488</position>
-			<intensity>266231</intensity>
+			<intensity>245680</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -1869,7 +1869,7 @@
 		<feature id="f_10627069796380146481">
 			<position dim="0">2458.847</position>
 			<position dim="1">1264.33407597974</position>
-			<intensity>241326</intensity>
+			<intensity>159984</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.952381</overallquality>
@@ -1924,7 +1924,7 @@
 		<feature id="f_10052793688680741109">
 			<position dim="0">2458.847</position>
 			<position dim="1">1316.97934406145</position>
-			<intensity>288747</intensity>
+			<intensity>228250</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.96</overallquality>
@@ -1987,7 +1987,7 @@
 		<feature id="f_15166508592180818156">
 			<position dim="0">2150.1436</position>
 			<position dim="1">1429.79694316054</position>
-			<intensity>282371</intensity>
+			<intensity>229438</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.958333</overallquality>
@@ -2142,7 +2142,7 @@
 		<feature id="f_893904610286969204">
 			<position dim="0">2238.1823</position>
 			<position dim="1">1416.44704336669</position>
-			<intensity>266872</intensity>
+			<intensity>240802</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.928571</overallquality>
@@ -2183,7 +2183,7 @@
 		<feature id="f_14851350658635457156">
 			<position dim="0">2050.5696</position>
 			<position dim="1">1733.09364171407</position>
-			<intensity>315439</intensity>
+			<intensity>235169</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.969697</overallquality>
@@ -2262,7 +2262,7 @@
 		<feature id="f_17447818880105247092">
 			<position dim="0">2260.6347</position>
 			<position dim="1">1416.22218519426</position>
-			<intensity>347887</intensity>
+			<intensity>292462</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.947368</overallquality>
@@ -2313,7 +2313,7 @@
 		<feature id="f_1003624456647096845">
 			<position dim="0">2391.0357</position>
 			<position dim="1">1527.04134234514</position>
-			<intensity>158393</intensity>
+			<intensity>142805</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.916667</overallquality>
@@ -2350,7 +2350,7 @@
 		<feature id="f_15120290131060441429">
 			<position dim="0">2498.3931</position>
 			<position dim="1">1662.19447361598</position>
-			<intensity>72947.9</intensity>
+			<intensity>64655</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.8</overallquality>
@@ -2373,7 +2373,7 @@
 		<feature id="f_11275867043381640475">
 			<position dim="0">2498.3931</position>
 			<position dim="1">1435.71916171125</position>
-			<intensity>73261.8</intensity>
+			<intensity>66999.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.875</overallquality>
@@ -2402,7 +2402,7 @@
 		<feature id="f_3713543811689521337">
 			<position dim="0">2054.1124</position>
 			<position dim="1">1444.41395461011</position>
-			<intensity>300803</intensity>
+			<intensity>183248</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.961538</overallquality>
@@ -2467,7 +2467,7 @@
 		<feature id="f_8666254306116808202">
 			<position dim="0">2453.7277</position>
 			<position dim="1">1385.38706039707</position>
-			<intensity>139132</intensity>
+			<intensity>89990.3</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.909091</overallquality>
@@ -2529,7 +2529,7 @@
 		<feature id="f_4584897071539917580">
 			<position dim="0">2408.4245</position>
 			<position dim="1">1552.66689955614</position>
-			<intensity>161220</intensity>
+			<intensity>131824</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9</overallquality>
@@ -2579,7 +2579,7 @@
 		<feature id="f_17569764383250687096">
 			<position dim="0">2236.4495</position>
 			<position dim="1">1359.8203404743</position>
-			<intensity>226737</intensity>
+			<intensity>209039</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.95</overallquality>
@@ -2632,7 +2632,7 @@
 		<feature id="f_14317784148091680644">
 			<position dim="0">2404.9536</position>
 			<position dim="1">1478.6930923822</position>
-			<intensity>141009</intensity>
+			<intensity>108433</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -2675,7 +2675,7 @@
 		<feature id="f_17671779025680303814">
 			<position dim="0">2404.9536</position>
 			<position dim="1">1411.53605692443</position>
-			<intensity>156530</intensity>
+			<intensity>111282</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9375</overallquality>
@@ -2739,7 +2739,7 @@
 		<feature id="f_7539502987715517688">
 			<position dim="0">2265.8264</position>
 			<position dim="1">1699.0826769528</position>
-			<intensity>239629</intensity>
+			<intensity>220350</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.928571</overallquality>
@@ -2828,7 +2828,7 @@
 		<feature id="f_7316644956366259183">
 			<position dim="0">2394.5305</position>
 			<position dim="1">1687.71842146293</position>
-			<intensity>209499</intensity>
+			<intensity>162454</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.916667</overallquality>
@@ -2865,7 +2865,7 @@
 		<feature id="f_6182960951962378739">
 			<position dim="0">2232.9951</position>
 			<position dim="1">1307.56202829724</position>
-			<intensity>179576</intensity>
+			<intensity>160161</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -2908,7 +2908,7 @@
 		<feature id="f_14891455924036538147">
 			<position dim="0">2401.4906</position>
 			<position dim="1">1350.25604617047</position>
-			<intensity>114615</intensity>
+			<intensity>83140.5</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.916667</overallquality>
@@ -2945,7 +2945,7 @@
 		<feature id="f_5860084234476467938">
 			<position dim="0">2481.1011</position>
 			<position dim="1">1430.78964983428</position>
-			<intensity>151871</intensity>
+			<intensity>126704</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.888889</overallquality>
@@ -2976,7 +2976,7 @@
 		<feature id="f_12758854762884412659">
 			<position dim="0">2401.4906</position>
 			<position dim="1">1242.31518418958</position>
-			<intensity>141722</intensity>
+			<intensity>114078</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.923077</overallquality>
@@ -3069,7 +3069,7 @@
 		<feature id="f_5495827884756377090">
 			<position dim="0">2055.8863</position>
 			<position dim="1">1386.70596345712</position>
-			<intensity>226248</intensity>
+			<intensity>150644</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.965517</overallquality>
@@ -3140,7 +3140,7 @@
 		<feature id="f_4143272592559840046">
 			<position dim="0">2401.4906</position>
 			<position dim="1">1634.28816084261</position>
-			<intensity>148503</intensity>
+			<intensity>136357</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9</overallquality>
@@ -3173,7 +3173,7 @@
 		<feature id="f_7870901012988979006">
 			<position dim="0">2304.0212</position>
 			<position dim="1">1340.26147619726</position>
-			<intensity>173720</intensity>
+			<intensity>145097</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.941176</overallquality>
@@ -3220,7 +3220,7 @@
 		<feature id="f_5342974036930030800">
 			<position dim="0">2458.847</position>
 			<position dim="1">1215.78509963182</position>
-			<intensity>198334</intensity>
+			<intensity>132710</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.952381</overallquality>
@@ -3275,7 +3275,7 @@
 		<feature id="f_11399299100673837381">
 			<position dim="0">2153.7001</position>
 			<position dim="1">1747.33391944797</position>
-			<intensity>248259</intensity>
+			<intensity>210176</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.947368</overallquality>
@@ -3326,7 +3326,7 @@
 		<feature id="f_16164338904207598736">
 			<position dim="0">2258.9136</position>
 			<position dim="1">1477.64266476881</position>
-			<intensity>185658</intensity>
+			<intensity>82801.5</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9375</overallquality>
@@ -3371,7 +3371,7 @@
 		<feature id="f_4410447320637600518">
 			<position dim="0">2404.9536</position>
 			<position dim="1">1194.54314937076</position>
-			<intensity>155791</intensity>
+			<intensity>122769</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.909091</overallquality>
@@ -3423,7 +3423,7 @@
 		<feature id="f_8795943655088158336">
 			<position dim="0">2239.8997</position>
 			<position dim="1">1788.8928938874</position>
-			<intensity>261379</intensity>
+			<intensity>237608</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.952381</overallquality>
@@ -3497,7 +3497,7 @@
 		<feature id="f_4021463513649428920">
 			<position dim="0">2477.6586</position>
 			<position dim="1">1368.57981094658</position>
-			<intensity>69020.5</intensity>
+			<intensity>62324.1</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.875</overallquality>
@@ -3526,7 +3526,7 @@
 		<feature id="f_3386388678910226661">
 			<position dim="0">2150.1436</position>
 			<position dim="1">1367.66555577526</position>
-			<intensity>227423</intensity>
+			<intensity>157113</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.962963</overallquality>
@@ -3676,7 +3676,7 @@
 		<feature id="f_11221884879889731173">
 			<position dim="0">2401.4906</position>
 			<position dim="1">1150.33792200589</position>
-			<intensity>105992</intensity>
+			<intensity>101609</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9</overallquality>
@@ -3726,7 +3726,7 @@
 		<feature id="f_5805590394902791448">
 			<position dim="0">2401.4906</position>
 			<position dim="1">1496.4552161095</position>
-			<intensity>84300.9</intensity>
+			<intensity>73379.9</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.875</overallquality>
@@ -3755,7 +3755,7 @@
 		<feature id="f_11586291247413769442">
 			<position dim="0">2264.0944</position>
 			<position dim="1">1307.22164255963</position>
-			<intensity>100640</intensity>
+			<intensity>62582</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.909091</overallquality>
@@ -3854,7 +3854,7 @@
 		<feature id="f_3395379003172100421">
 			<position dim="0">2300.5738</position>
 			<position dim="1">1812.92295369503</position>
-			<intensity>168941</intensity>
+			<intensity>135003</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -3897,7 +3897,7 @@
 		<feature id="f_11630589982317102322">
 			<position dim="0">2048.7927</position>
 			<position dim="1">1824.30648770151</position>
-			<intensity>214117</intensity>
+			<intensity>130388</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.969697</overallquality>
@@ -3976,7 +3976,7 @@
 		<feature id="f_1339341489815824759">
 			<position dim="0">2295.4041</position>
 			<position dim="1">1284.47230395823</position>
-			<intensity>125102</intensity>
+			<intensity>113431</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.923077</overallquality>
@@ -4036,7 +4036,7 @@
 		<feature id="f_13641829453453140763">
 			<position dim="0">2300.5738</position>
 			<position dim="1">1577.7217052006</position>
-			<intensity>157136</intensity>
+			<intensity>96695.8</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -4096,7 +4096,7 @@
 		<feature id="f_4041634828915281168">
 			<position dim="0">2264.0944</position>
 			<position dim="1">1307.31238086977</position>
-			<intensity>36367.4</intensity>
+			<intensity>29517.9</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.75</overallquality>
@@ -4174,7 +4174,7 @@
 		<feature id="f_15721057298497490036">
 			<position dim="0">2257.1777</position>
 			<position dim="1">1624.24998579271</position>
-			<intensity>165438</intensity>
+			<intensity>154392</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.916667</overallquality>
@@ -4211,7 +4211,7 @@
 		<feature id="f_2608380305220684729">
 			<position dim="0">2248.5422</position>
 			<position dim="1">1359.51502978855</position>
-			<intensity>165319</intensity>
+			<intensity>115518</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -4254,7 +4254,7 @@
 		<feature id="f_11422463686885200558">
 			<position dim="0">2408.4245</position>
 			<position dim="1">1725.00419842022</position>
-			<intensity>112966</intensity>
+			<intensity>63190.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.923077</overallquality>
@@ -4385,7 +4385,7 @@
 		<feature id="f_12049315334424432437">
 			<position dim="0">2050.5696</position>
 			<position dim="1">1238.2263371868</position>
-			<intensity>153181</intensity>
+			<intensity>68763.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.961538</overallquality>
@@ -4450,7 +4450,7 @@
 		<feature id="f_9868242461570157420">
 			<position dim="0">2232.9951</position>
 			<position dim="1">1259.16180774031</position>
-			<intensity>147557</intensity>
+			<intensity>139512</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.916667</overallquality>
@@ -4545,7 +4545,7 @@
 		<feature id="f_1621338151966755474">
 			<position dim="0">2055.8863</position>
 			<position dim="1">1333.37987505159</position>
-			<intensity>182509</intensity>
+			<intensity>135035</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.96</overallquality>
@@ -4608,7 +4608,7 @@
 		<feature id="f_25974125700937907">
 			<position dim="0">2438.2814</position>
 			<position dim="1">1502.41371616082</position>
-			<intensity>55014.6</intensity>
+			<intensity>45703.8</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.833333</overallquality>
@@ -4633,7 +4633,7 @@
 		<feature id="f_7444998229116103684">
 			<position dim="0">2255.4493</position>
 			<position dim="1">1788.49520907975</position>
-			<intensity>149360</intensity>
+			<intensity>113315</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.944444</overallquality>
@@ -4682,7 +4682,7 @@
 		<feature id="f_11583213259935596392">
 			<position dim="0">2401.4906</position>
 			<position dim="1">1571.4669830935</position>
-			<intensity>53498.4</intensity>
+			<intensity>46614.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.75</overallquality>
@@ -4720,7 +4720,7 @@
 		<feature id="f_3619468215685938204">
 			<position dim="0">2477.6586</position>
 			<position dim="1">1374.303992702</position>
-			<intensity>65465.1</intensity>
+			<intensity>45455.5</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.833333</overallquality>
@@ -4776,7 +4776,7 @@
 		<feature id="f_17876486934271562208">
 			<position dim="0">2052.3418</position>
 			<position dim="1">1284.0313213858</position>
-			<intensity>176177</intensity>
+			<intensity>82658.1</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.964286</overallquality>
@@ -4916,7 +4916,7 @@
 		<feature id="f_3607574553438867574">
 			<position dim="0">2150.1436</position>
 			<position dim="1">1310.69037807615</position>
-			<intensity>160209</intensity>
+			<intensity>125563</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.941176</overallquality>
@@ -4963,7 +4963,7 @@
 		<feature id="f_4906628401344677738">
 			<position dim="0">2418.9377</position>
 			<position dim="1">1248.74677006961</position>
-			<intensity>23621.6</intensity>
+			<intensity>14421.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -5034,7 +5034,7 @@
 		<feature id="f_11902665203725986836">
 			<position dim="0">2234.7232</position>
 			<position dim="1">1214.20694971584</position>
-			<intensity>115541</intensity>
+			<intensity>82507.6</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9</overallquality>
@@ -5202,7 +5202,7 @@
 		<feature id="f_1253235807487386477">
 			<position dim="0">2238.1823</position>
 			<position dim="1">1214.29192180917</position>
-			<intensity>34085.1</intensity>
+			<intensity>14426.1</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -5238,7 +5238,7 @@
 		<feature id="f_9657195323739211621">
 			<position dim="0">2239.8997</position>
 			<position dim="1">1888.18097999953</position>
-			<intensity>82775.8</intensity>
+			<intensity>46523.9</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.875</overallquality>
@@ -5267,7 +5267,7 @@
 		<feature id="f_15595829921891090644">
 			<position dim="0">2462.2518</position>
 			<position dim="1">1170.75588995277</position>
-			<intensity>97943</intensity>
+			<intensity>85234.9</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9</overallquality>
@@ -5300,7 +5300,7 @@
 		<feature id="f_9693516254110939661">
 			<position dim="0">2406.691</position>
 			<position dim="1">1109.33678670612</position>
-			<intensity>76837.5</intensity>
+			<intensity>72760.1</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.888889</overallquality>
@@ -5499,7 +5499,7 @@
 		<feature id="f_7273255783824449336">
 			<position dim="0">2160.7929</position>
 			<position dim="1">1850.08286481696</position>
-			<intensity>161883</intensity>
+			<intensity>145759</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.928571</overallquality>
@@ -5629,7 +5629,7 @@
 		<feature id="f_4804931408721345291">
 			<position dim="0">2153.7001</position>
 			<position dim="1">1258.38641041345</position>
-			<intensity>144664</intensity>
+			<intensity>78088.5</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.941176</overallquality>
@@ -5699,7 +5699,7 @@
 		<feature id="f_16987762588190708774">
 			<position dim="0">2062.9985</position>
 			<position dim="1">1284.06410663577</position>
-			<intensity>29905</intensity>
+			<intensity>20960.1</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -5852,7 +5852,7 @@
 		<feature id="f_17623301629315165502">
 			<position dim="0">2295.4041</position>
 			<position dim="1">1502.60291617177</position>
-			<intensity>134379</intensity>
+			<intensity>83299.7</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9</overallquality>
@@ -5902,7 +5902,7 @@
 		<feature id="f_15355009979912333657">
 			<position dim="0">2253.7202</position>
 			<position dim="1">1258.88178469081</position>
-			<intensity>137743</intensity>
+			<intensity>98323.6</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9375</overallquality>
@@ -6186,7 +6186,7 @@
 		<feature id="f_3985464472191994486">
 			<position dim="0">2264.0944</position>
 			<position dim="1">1887.82393960486</position>
-			<intensity>120500</intensity>
+			<intensity>90712.9</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9375</overallquality>
@@ -6383,7 +6383,7 @@
 		<feature id="f_15137961832517596447">
 			<position dim="0">2298.845</position>
 			<position dim="1">1926.22245531896</position>
-			<intensity>117588</intensity>
+			<intensity>86364.9</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.923077</overallquality>
@@ -6605,7 +6605,7 @@
 		<feature id="f_3500354167110536664">
 			<position dim="0">2153.7001</position>
 			<position dim="1">1209.96949878398</position>
-			<intensity>99260.1</intensity>
+			<intensity>64242.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -6741,7 +6741,7 @@
 		<feature id="f_1380230199713784757">
 			<position dim="0">2295.4041</position>
 			<position dim="1">1185.71367727379</position>
-			<intensity>67822.2</intensity>
+			<intensity>50604.9</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.875</overallquality>
@@ -6991,7 +6991,7 @@
 		<feature id="f_2477368416748083016">
 			<position dim="0">2364.3859</position>
 			<position dim="1">1763.4678193589</position>
-			<intensity>24283.9</intensity>
+			<intensity>21251.8</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -7061,7 +7061,7 @@
 		<feature id="f_2935923263525422257">
 			<position dim="0">2159.018</position>
 			<position dim="1">1849.91115288386</position>
-			<intensity>129759</intensity>
+			<intensity>108852</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.909091</overallquality>
@@ -7201,7 +7201,7 @@
 		<feature id="f_4287466236848599457">
 			<position dim="0">2047.0178</position>
 			<position dim="1">1195.56868326892</position>
-			<intensity>90085.7</intensity>
+			<intensity>76890</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.933333</overallquality>
@@ -7244,7 +7244,7 @@
 		<feature id="f_5494749430262800962">
 			<position dim="0">2055.8863</position>
 			<position dim="1">1925.53573538873</position>
-			<intensity>114693</intensity>
+			<intensity>79940.3</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.952381</overallquality>
@@ -7610,7 +7610,7 @@
 		<feature id="f_2196373945720374912">
 			<position dim="0">2075.7091</position>
 			<position dim="1">1507.33297536951</position>
-			<intensity>42132.8</intensity>
+			<intensity>32350</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.8</overallquality>
@@ -7978,7 +7978,7 @@
 		<feature id="f_3404719972762258001">
 			<position dim="0">2293.6847</position>
 			<position dim="1">1032.77954384873</position>
-			<intensity>40784.4</intensity>
+			<intensity>35049.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.833333</overallquality>
@@ -8215,7 +8215,7 @@
 		<feature id="f_12383683518728261590">
 			<position dim="0">2146.596</position>
 			<position dim="1">1965.61821552944</position>
-			<intensity>69155.3</intensity>
+			<intensity>66547.8</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.916667</overallquality>
@@ -8341,7 +8341,7 @@
 		<feature id="f_1306039369812879929">
 			<position dim="0">2054.1124</position>
 			<position dim="1">1734.07463322593</position>
-			<intensity>98544.3</intensity>
+			<intensity>85423</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.916667</overallquality>
@@ -9552,7 +9552,7 @@
 		<feature id="f_9371243749883817737">
 			<position dim="0">2243.3506</position>
 			<position dim="1">1999.20807084341</position>
-			<intensity>142775</intensity>
+			<intensity>107151</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.9375</overallquality>
@@ -10397,7 +10397,7 @@
 		<feature id="f_17623414133510866146">
 			<position dim="0">2150.1436</position>
 			<position dim="1">1600.09784845856</position>
-			<intensity>31698.8</intensity>
+			<intensity>23573.1</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -10863,7 +10863,7 @@
 		<feature id="f_15388517483644187191">
 			<position dim="0">2316.1886</position>
 			<position dim="1">962.640170725991</position>
-			<intensity>42379.7</intensity>
+			<intensity>19399.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.875</overallquality>
@@ -11452,7 +11452,7 @@
 		<feature id="f_10147015604772775807">
 			<position dim="0">2036.2596</position>
 			<position dim="1">1444.62693181998</position>
-			<intensity>21076</intensity>
+			<intensity>19037.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>

--- a/src/tests/topp/MassTraceExtractor_2_output.featureXML
+++ b/src/tests/topp/MassTraceExtractor_2_output.featureXML
@@ -37,7 +37,7 @@
 		<feature id="f_17749660155506638460">
 			<position dim="0">2498.3931</position>
 			<position dim="1">1662.19447361598</position>
-			<intensity>72947.9</intensity>
+			<intensity>64655</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.8</overallquality>
@@ -102,7 +102,7 @@
 		<feature id="f_3332699010107892018">
 			<position dim="0">2494.9337</position>
 			<position dim="1">1373.33354496676</position>
-			<intensity>52839.8</intensity>
+			<intensity>46556.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.857143</overallquality>
@@ -177,7 +177,7 @@
 		<feature id="f_15157403601844400700">
 			<position dim="0">2401.4906</position>
 			<position dim="1">1571.4669830935</position>
-			<intensity>53498.4</intensity>
+			<intensity>46614.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.75</overallquality>
@@ -240,7 +240,7 @@
 		<feature id="f_12999979801269632061">
 			<position dim="0">2418.9377</position>
 			<position dim="1">1248.74677006961</position>
-			<intensity>23621.6</intensity>
+			<intensity>14421.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -553,7 +553,7 @@
 		<feature id="f_16250062551099875712">
 			<position dim="0">2264.0944</position>
 			<position dim="1">1307.31385990916</position>
-			<intensity>39031.4</intensity>
+			<intensity>25446.5</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.833333</overallquality>
@@ -780,7 +780,7 @@
 		<feature id="f_10052793688680741109">
 			<position dim="0">2364.3859</position>
 			<position dim="1">1763.4678193589</position>
-			<intensity>24283.9</intensity>
+			<intensity>21251.8</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -1379,7 +1379,7 @@
 		<feature id="f_17287849381738438716">
 			<position dim="0">2438.2814</position>
 			<position dim="1">1502.42230097226</position>
-			<intensity>45565</intensity>
+			<intensity>36254.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.8</overallquality>
@@ -1756,7 +1756,7 @@
 		<feature id="f_5805590394902791448">
 			<position dim="0">2150.1436</position>
 			<position dim="1">1600.09784845856</position>
-			<intensity>31698.8</intensity>
+			<intensity>23573.1</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -1912,7 +1912,7 @@
 		<feature id="f_13641829453453140763">
 			<position dim="0">2175.0676</position>
 			<position dim="1">1367.75574906974</position>
-			<intensity>19253.7</intensity>
+			<intensity>13619.8</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>
@@ -2068,7 +2068,7 @@
 		<feature id="f_11422463686885200558">
 			<position dim="0">2036.2596</position>
 			<position dim="1">1444.62693181998</position>
-			<intensity>21076</intensity>
+			<intensity>19037.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>0.666667</overallquality>

--- a/src/topp/MassTraceExtractor.cpp
+++ b/src/topp/MassTraceExtractor.cpp
@@ -259,7 +259,7 @@ protected:
 
         fcons.setRT(m_traces_final[i].getCentroidRT());
         fcons.setMZ(m_traces_final[i].getCentroidMZ());
-        fcons.setIntensity(m_traces_final[i].computePeakArea());
+        fcons.setIntensity(m_traces_final[i].getIntensity(false));
         consensus_map.push_back(fcons);
       }
       consensus_map.applyMemberFunction(&UniqueIdInterface::setUniqueId);
@@ -289,7 +289,7 @@ protected:
         f.setMetaValue(3, m_traces_final[i].getLabel());
         f.setCharge(0);
         f.setMZ(m_traces_final[i].getCentroidMZ());
-        f.setIntensity(m_traces_final[i].computePeakArea());
+        f.setIntensity(m_traces_final[i].getIntensity(false));
         f.setRT(m_traces_final[i].getCentroidRT());
         f.setWidth(m_traces_final[i].estimateFWHM(use_epd));
         f.setOverallQuality(1 - (1.0 / m_traces_final[i].getSize()));


### PR DESCRIPTION
[FIX] move quantification parameter from FF-Metabo into MTD (where it belongs)
As a side effect, TOPP-MTD also gets the option to quantify via either AREA (default) or MEDIAN (for direct injection)
Quantification values of TOPP_MTD are now consistent with TOPP_FF-Metabo (since both use trace.getIntensity() now).

New intensities are a little bit smaller, since getIntensity() uses the area under the FWHM, whereas the old method integrated the whole peak area (less robust).