### PR TITLE
[FIX] convert minutes to seconds

### DIFF
--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -748,6 +748,9 @@ protected:
         for (vector<PeptideIdentification>::iterator pep_it = peptide_ids.begin(); pep_it != peptide_ids.end(); ++pep_it)
         {
           switchScores_(*pep_it);
+
+          // MSGFPlus doesn't store the unit (minutes) used for retention times. Convert it to the default (seconds).
+          pep_it.setRT(pep_it.getRT() * 60.0);
         }
         SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptide_ids, in, false);
         IdXMLFile().store(out, protein_ids, peptide_ids);


### PR DESCRIPTION
on non-legacy import of MzID files generated by MSGFPlus, the unit of retention times is minutes.
Convert it to the default (seconds).