### PR TITLE
[FIX, TEST] fix checker script for files that contain 'source' as in

### DIFF
--- a/tools/checker.php
+++ b/tools/checker.php
@@ -831,7 +831,7 @@ foreach ($files_todo as $f)
       elseif (endsWith($f, ".cpp"))
       {
         # $h_file = substr($f, 7,-2).".h";
-        $h_file = $src_path."/".str_replace("source", "include/OpenMS", $f);
+        $h_file = $src_path."/".str_replace("/source", "/include/OpenMS", $f);
         $h_file = preg_replace("/cpp$/", "h", $h_file);
         if (!file_exists($h_file))
         {


### PR DESCRIPTION
Re'source'

may fix:
````
Test output
Outdated source file 'src/openms_gui/source/VISUAL/TOPPASResource.cpp' (no header -> /group/ag_abi/OpenMS/nightly-builds/HEAD/src/openms_gui/include/OpenMS/VISUAL/TOPPASRe**include**/OpenMS.h)                
```
CDASH errors