### PR TITLE
Feature/fragment isotope distribution

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -38,6 +38,7 @@
 #include <iosfwd>
 #include <vector>
 #include <map>
+#include <algorithm>
 
 #include <OpenMS/CONCEPT/Types.h>
 
@@ -140,6 +141,7 @@ public:
       The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
       @param precursor: the empirical formula of the precursor
       @param precursor_isotopes: the precursor isotopes that were isolated
+      @return the conditional IsotopeDistribution of the fragment
     */
     IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const;
 

--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -133,6 +133,16 @@ public:
     */
     IsotopeDistribution getIsotopeDistribution(UInt max_depth) const;
 
+    /**
+      @brief returns the fragment isotope distribution of this given a precursor formula
+      and conditioned on a list of isolated precursor isotopes.
+
+      The max_depth of the isotopic distribution is set to max(precursor_isotopes).
+      @param precursor: the empirical formula of the precursor
+      @param precursor_isotopes: the precursor isotopes that were isolated
+    */
+    IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const;
+
     /// returns the number of atoms for a certain @p element (can be negative)
     SignedSize getNumberOf(const Element* element) const;
 

--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -137,7 +137,7 @@ public:
       @brief returns the fragment isotope distribution of this given a precursor formula
       and conditioned on a list of isolated precursor isotopes.
 
-      The max_depth of the isotopic distribution is set to max(precursor_isotopes).
+      The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
       @param precursor: the empirical formula of the precursor
       @param precursor_isotopes: the precursor isotopes that were isolated
     */

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -157,7 +157,7 @@ public:
         the isotopic distribution of the fragment and complementary fragment
         (as if they were precursors), and which precursor isotopes were isolated.
         Do consider normalising the distribution afterwards to get conditional probabilities.
-        from Rockwood, AL; Kushnir, MA; Nelson, GJ. in
+        Equations come from Rockwood, AL; Kushnir, MA; Nelson, GJ. in
         "Dissociation of Individual Isotopic Peaks: Predicting Isotopic Distributions of Product Ions in MSn"
         @param fragment_isotope_dist the isotopic distribution of the fragment (as if it was a precursor).
         @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
@@ -239,10 +239,11 @@ protected:
     /// convolves the distribution @p input with itself and stores the result in @p result
     void convolveSquare_(ContainerType & result, const ContainerType & input) const;
 
-    /** @brief calculates the fragment distribution for a fragment molecule given @p fragment_isotope_distribution,
-        @p comp_fragment_isotope_distribution, and @p isolated_precursor_isotopes, and stores it in @p result
-        @p fragment_isotope_dist is the isotopic distribution of the fragment (as if it was a precursor),
-        @p comp_fragment_isotope_dist is the isotopic distribution of the complementary fragment (as if it was a precursor)
+    /** @brief calculates the fragment distribution for a fragment molecule and stores it in @p result.
+
+        @param fragment_isotope_dist the isotopic distribution of the fragment (as if it was a precursor).
+        @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
+        @param precursor_isotopes a list of which precursor isotopes were isolated
      */
     void calcFragmentIsotopeDist_(ContainerType& result, const ContainerType& fragment_isotope_dist, const ContainerType& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes);
 

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -150,6 +150,21 @@ public:
     */
     void estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P);
 
+    /**
+        @brief Calculate isotopic distribution for a fragment molecule
+
+        This calculates the isotopic distribution for a fragment molecule given
+        the isotopic distribution of the fragment and complementary fragment
+        (as if they were precursors), and which precursor isotopes were isolated.
+        Do consider normalising the distribution afterwards to get conditional probabilities.
+        from Rockwood, AL; Kushnir, MA; Nelson, GJ. in
+        "Dissociation of Individual Isotopic Peaks: Predicting Isotopic Distributions of Product Ions in MSn"
+        @param fragment_isotope_dist the isotopic distribution of the fragment (as if it was a precursor).
+        @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
+        @param precursor_isotopes a list of which precursor isotopes were isolated
+    */
+    void calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes);
+
     /** @brief re-normalizes the sum of the probabilities of the isotopes to 1
 
             The re-normalisation is needed as in distributions with a lot of isotopes (and with high max isotope)
@@ -223,6 +238,13 @@ protected:
 
     /// convolves the distribution @p input with itself and stores the result in @p result
     void convolveSquare_(ContainerType & result, const ContainerType & input) const;
+
+    /** @brief calculates the fragment distribution for a fragment molecule given @p fragment_isotope_distribution,
+        @p comp_fragment_isotope_distribution, and @p isolated_precursor_isotopes, and stores it in @p result
+        @p fragment_isotope_dist is the isotopic distribution of the fragment (as if it was a precursor),
+        @p comp_fragment_isotope_dist is the isotopic distribution of the complementary fragment (as if it was a precursor)
+     */
+    void calcFragmentIsotopeDist_(ContainerType& result, const ContainerType& fragment_isotope_dist, const ContainerType& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes);
 
     /// fill a gapped isotope pattern (i.e. certain masses are missing), with zero probability masses
     ContainerType fillGaps_(const ContainerType& id) const;

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -70,6 +70,11 @@ public:
     typedef ContainerType::iterator Iterator;
     typedef ContainerType::const_iterator const_iterator;
     typedef ContainerType::const_iterator ConstIterator;
+
+    typedef ContainerType::reverse_iterator reverse_iterator;
+    typedef ContainerType::reverse_iterator ReverseIterator;
+    typedef ContainerType::const_reverse_iterator const_reverse_iterator;
+    typedef ContainerType::const_reverse_iterator ConstReverseIterator;
     //@}
 
     /// @name Constructors and Destructors
@@ -226,6 +231,14 @@ public:
     inline ConstIterator begin() const { return distribution_.begin(); }
 
     inline ConstIterator end() const { return distribution_.end(); }
+
+    inline ReverseIterator rbegin() { return distribution_.rbegin(); }
+
+    inline ReverseIterator rend()   { return distribution_.rend(); }
+
+    inline ConstReverseIterator rbegin() const { return distribution_.rbegin(); }
+
+    inline ConstReverseIterator rend() const { return distribution_.rend(); }
     //@}
 
 protected:

--- a/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
+++ b/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
@@ -114,6 +114,26 @@ namespace OpenMS
     return result;
   }
 
+  IsotopeDistribution EmpiricalFormula::getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const
+  {
+    // A fragment's isotopes can only be as high as the largest isolated precursor isotope.
+    UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end())+1;
+
+    // Treat *this as the fragment molecule
+    EmpiricalFormula complementary_fragment = precursor-*this;
+
+    IsotopeDistribution fragment_isotope_dist = getIsotopeDistribution(max_depth);
+    IsotopeDistribution comp_fragment_isotope_dist = complementary_fragment.getIsotopeDistribution(max_depth);
+
+    IsotopeDistribution result;
+    result.calcFragmentIsotopeDist(fragment_isotope_dist, comp_fragment_isotope_dist, precursor_isotopes);
+
+    // Renormalize to make these conditional probabilities (conditioned on the isolated precursor isotopes)
+    result.renormalize();
+
+    return result;
+  }
+
   SignedSize EmpiricalFormula::getNumberOf(const Element* element) const
   {
     MapType_::const_iterator it  = formula_.find(element);

--- a/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
@@ -473,13 +473,13 @@ namespace OpenMS
     //
     // normalization is needed to get true conditional probabilities if desired.
     //
-    for (SignedSize i = 0; i < fragment_isotope_dist_l.size(); ++i)
+    for (Size i = 0; i < fragment_isotope_dist_l.size(); ++i)
     {
-      for (const UInt & precursor_isotope : precursor_isotopes)
+      for (std::vector<UInt>::const_iterator precursor_itr = precursor_isotopes.begin(); precursor_itr != precursor_isotopes.end(); ++precursor_itr)
       {
-        if (precursor_isotope-i >= 0 && precursor_isotope-i < comp_fragment_isotope_dist_l.size())
+        if (*precursor_itr >= i && *precursor_itr-i < comp_fragment_isotope_dist_l.size())
         {
-          result[i].second += comp_fragment_isotope_dist_l[precursor_isotope-i].second;
+          result[i].second += comp_fragment_isotope_dist_l[*precursor_itr-i].second;
         }
       }
       result[i].second *= fragment_isotope_dist_l[i].second;

--- a/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
@@ -445,13 +445,13 @@ namespace OpenMS
       result[i] = make_pair(fragment_isotope_dist_l[0].first + i, 0);
     }
 
-    // Example: Let the Precursor formula be C2, and assume precursors 0, 1, and 2 were isolated.
+    // Example: Let the Precursor formula be C2, and assume precursors M0, M+1, and M+2 were isolated.
     // Let the fragment formula be C1, and therefore the complementary fragment formula is also C1
     //
     // let fi = fragment formula's isotope, pi = precursor formula's isotope, ci = complementary fragment formula's isotope
     // let P(fi=x) be the probability of the formula existing as isotope x in precursor form (i.e. random sample from the universe)
     //
-    // We want to calculate the probability the fragment will be isotope x given that we isolated precursors 0,1,2
+    // We want to calculate the probability the fragment will be isotope x given that we isolated precursors M0,M+1,M+2
     //
     // P(fi=0|pi=0 or pi=1 or pi=2) = P(fi=0) * P(pi=0 or pi=1 or pi=2|fi=0) / P(pi=0 or pi=1 or pi=2)  // bayes' theorem
     //        = P(fi=0) * (P(pi=0|fi=0) + P(pi=1|fi=0) + P(pi=2|fi=0)) / (P(pi=0) + P(pi=1) + P(pi=2))  // mutually exclusive events
@@ -483,7 +483,8 @@ namespace OpenMS
     {
       for (std::vector<UInt>::const_iterator precursor_itr = precursor_isotopes.begin(); precursor_itr != precursor_isotopes.end(); ++precursor_itr)
       {
-        if (*precursor_itr >= i && *precursor_itr-i < comp_fragment_isotope_dist_l.size())
+        if (*precursor_itr >= i &&
+                (*precursor_itr-i) < comp_fragment_isotope_dist_l.size())
         {
           result[i].second += comp_fragment_isotope_dist_l[*precursor_itr-i].second;
         }

--- a/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
@@ -457,7 +457,7 @@ namespace OpenMS
     //        = P(fi=0) * (P(pi=0|fi=0) + P(pi=1|fi=0) + P(pi=2|fi=0)) / (P(pi=0) + P(pi=1) + P(pi=2))  // mutually exclusive events
     //        = P(fi=0) * (P(ci=0) + P(ci=1) + P(ci=2)) / (P(pi=0) + P(pi=1) + P(pi=2))                 // The only way pi=x|fi=y, is if ci=x-y
     //        = P(fi=0) * (P(ci=0) + P(ci=1) + P(ci=2))                                                 // ignore normalization for now
-    //          ^this is the form we're calculating^
+    //          ^this is the form we're calculating^ which is technically P(fi=0 and (pi=0 or pi=1 or pi=2)) because we didn't normalize
     //
     // P(fi=1|pi=0 or pi=1 or pi=2) = P(fi=1) * P(pi=0 or pi=1 or pi=2|fi=1) / P(pi=0 or pi=1 or pi=2)
     //        = P(fi=1) * (P(pi=0|fi=1) + P(pi=1|fi=1) + P(pi=2|fi=1)) / (P(pi=0) + P(pi=1) + P(pi=2))

--- a/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
@@ -457,19 +457,25 @@ namespace OpenMS
     //        = P(fi=0) * (P(pi=0|fi=0) + P(pi=1|fi=0) + P(pi=2|fi=0)) / (P(pi=0) + P(pi=1) + P(pi=2))  // mutually exclusive events
     //        = P(fi=0) * (P(ci=0) + P(ci=1) + P(ci=2)) / (P(pi=0) + P(pi=1) + P(pi=2))                 // The only way pi=x|fi=y, is if ci=x-y
     //        = P(fi=0) * (P(ci=0) + P(ci=1) + P(ci=2))                                                 // ignore normalization for now
-    //          ^this is the form we're calculating^ which is technically P(fi=0 and (pi=0 or pi=1 or pi=2)) because we didn't normalize
+    //          ^this is the form we're calculating in the code, which is technically P(fi=0 and (pi=0 or pi=1 or pi=2)) because we didn't normalize
+    //        = 0.9893 * (0.9893 + 0.0107 + 0)
+    //          Note: In this example, P(ci=2)=0 because the complementary fragment is just C and cannot exist with 2 extra neutrons
     //
     // P(fi=1|pi=0 or pi=1 or pi=2) = P(fi=1) * P(pi=0 or pi=1 or pi=2|fi=1) / P(pi=0 or pi=1 or pi=2)
     //        = P(fi=1) * (P(pi=0|fi=1) + P(pi=1|fi=1) + P(pi=2|fi=1)) / (P(pi=0) + P(pi=1) + P(pi=2))
-    //        = P(fi=1) * (0 + P(ci=1) + P(ci=2)) / (P(pi=0) + P(pi=1) + P(pi=2))
-    //        = P(fi=1) * (P(ci=1) + P(ci=2))
-    //          ^this is the form we're calculating^
+    //        = P(fi=1) * (P(ci=-1) + P(ci=0) + P(ci=1)) / (P(pi=0) + P(pi=1) + P(pi=2))
+    //          Note: P(ci<0)=0
+    //        = P(fi=1) * (P(ci=0) + P(ci=1))
+    //          ^this is the form we're calculating in the code
+    //        = 0.0107 * (0.9893 + 0.0107)
     //
     // P(fi=2|pi=0 or pi=1 or pi=2) = P(fi=2) * P(pi=0 or pi=1 or pi=2|fi=2) / P(pi=0 or pi=1 or pi=2)
     //        = P(fi=2) * (P(pi=0|fi=2) + P(pi=1|fi=2) + P(pi=2|fi=2)) / (P(pi=0) + P(pi=1) + P(pi=2))
-    //        = P(fi=2) * (0 + 0 + P(ci=2)) / (P(pi=0) + P(pi=1) + P(pi=2))
+    //        = P(fi=2) * (P(ci=-2) + P(ci=-1) + P(ci=0)) / (P(pi=0) + P(pi=1) + P(pi=2))
     //        = P(fi=2) * P(ci=0)
-    //          ^this is the form we're calculating^
+    //          ^this is the form we're calculating in the code
+    //        = 0 * (0.9893)
+    //          Note: In this example, P(fi=2)=0 because the fragment is just C and cannot exist with 2 extra neutrons.
     //
     // normalization is needed to get true conditional probabilities if desired.
     //

--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -33,7 +33,7 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
         # on a precursor formula and a list of isolated precursor isotopes.
         # @param precursor: the empirical formula of the precursor
         # @param precursor_isotopes: the list of precursor isotopes that were isolated
-        IsotopeDistribution getConditionalFragmentIsotopeDist(EmpiricalFormula& precursor, libcpp_vector[ UInt ]& precursor_isotopes) nogil except +
+        IsotopeDistribution getConditionalFragmentIsotopeDist(EmpiricalFormula& precursor, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
 
         # returns the number of atoms
         Size getNumberOf(Element * element) nogil except +

--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -29,6 +29,12 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
         #   *	@param max_depth: this parameter gives the max isotope which is considered, if 0 all are reported
         IsotopeDistribution getIsotopeDistribution(UInt max_depth) nogil except +
 
+        # @brief returns the fragment isotope distribution of this conditioned
+        # on a precursor formula and a list of isolated precursor isotopes.
+        # @param precursor: the empirical formula of the precursor
+        # @param precursor_isotopes: the list of precursor isotopes that were isolated
+        IsotopeDistribution getConditionalFragmentIsotopeDist(EmpiricalFormula& precursor, libcpp_vector[ UInt ]& precursor_isotopes) nogil except +
+
         # returns the number of atoms
         Size getNumberOf(Element * element) nogil except +
 

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -51,7 +51,7 @@ cdef extern from "<OpenMS/CHEMISTRY/IsotopeDistribution.h>" namespace "OpenMS":
 
         # Calculate isotopic distribution for a fragment molecule
 
-        void calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_vector[ UInt ]& precursor_isotopes) nogil except +
+        void calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
 
         # renormalizes the sum of the probabilities of the isotopes to 1
         void renormalize() nogil except +

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -49,6 +49,9 @@ cdef extern from "<OpenMS/CHEMISTRY/IsotopeDistribution.h>" namespace "OpenMS":
 
         void estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P) nogil except +
 
+        # Calculate isotopic distribution for a fragment molecule
+
+        void calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_vector[ UInt ]& precursor_isotopes) nogil except +
 
         # renormalizes the sum of the probabilities of the isotopes to 1
         void renormalize() nogil except +

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -347,7 +347,7 @@ START_SECTION(IsotopeDistribution getFragmentIsotopeDistribution(const Empirical
   i = 0;
   for (IsotopeDistribution::ConstIterator it = iso.begin(); it != iso.end(); ++it, ++i)
   {
-    TEST_REAL_SIMILAR(it->second, result4[4])
+    TEST_REAL_SIMILAR(it->second, result4[i])
   }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -293,6 +293,64 @@ START_SECTION(IsotopeDistribution getIsotopeDistribution(UInt max_depth) const)
   }
 END_SECTION
 
+START_SECTION(IsotopeDistribution getFragmentIsotopeDistribution(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const)
+  EmpiricalFormula precursor("C2");
+  EmpiricalFormula fragment("C");
+  std::vector<UInt> precursor_isotopes;
+
+  precursor_isotopes.push_back(0);
+  // isolated precursor isotope is 0
+  IsotopeDistribution iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
+  double result[] = { 1.0 };
+  Size i = 0;
+  for (IsotopeDistribution::ConstIterator it = iso.begin(); it != iso.end(); ++it, ++i)
+  {
+    TEST_REAL_SIMILAR(it->second, result[i])
+  }
+
+  precursor_isotopes.pop_back();
+  precursor_isotopes.push_back(1);
+  // isolated precursor isotope is 1
+  iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
+  double result2[] = { 0.5, 0.5};
+  i = 0;
+  for (IsotopeDistribution::ConstIterator it = iso.begin(); it != iso.end(); ++it, ++i)
+  {
+    TEST_REAL_SIMILAR(it->second, result2[i])
+  }
+
+  precursor_isotopes.push_back(0);
+  // isolated precursor isotopes are 0 and 1
+  iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
+  double result3[] = { 0.98941, 0.01059};
+  i = 0;
+  for (IsotopeDistribution::ConstIterator it = iso.begin(); it != iso.end(); ++it, ++i)
+  {
+    TEST_REAL_SIMILAR(it->second, result3[i])
+  }
+
+  precursor_isotopes.push_back(2);
+  // isolated precursor isotopes are 0, 1, and 2
+  iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
+  double result4[] = { 0.9893, 0.0107};
+  i = 0;
+  for (IsotopeDistribution::ConstIterator it = iso.begin(); it != iso.end(); ++it, ++i)
+  {
+    TEST_REAL_SIMILAR(it->second, result4[i])
+  }
+
+  precursor_isotopes.push_back(3);
+  // isolated precursor isotopes are 0, 1, 2, and 3
+  // It's impossible for precursor C2 to have 3 extra neutrons (assuming only natural stable isotopes)
+  // Invalid precursor isotopes are ignored and should give the answer as if they were not there
+  iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
+  i = 0;
+  for (IsotopeDistribution::ConstIterator it = iso.begin(); it != iso.end(); ++it, ++i)
+  {
+    TEST_REAL_SIMILAR(it->second, result4[4])
+  }
+END_SECTION
+
 START_SECTION(([EXTRA] Check correct charge semantics))
   EmpiricalFormula ef1("H4C+"); // CH4 +1 charge
   const Element * H = db->getElement("H");

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -293,13 +293,13 @@ START_SECTION(IsotopeDistribution getIsotopeDistribution(UInt max_depth) const)
   }
 END_SECTION
 
-START_SECTION(IsotopeDistribution getFragmentIsotopeDistribution(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const)
+START_SECTION(IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const)
   EmpiricalFormula precursor("C2");
   EmpiricalFormula fragment("C");
   std::vector<UInt> precursor_isotopes;
 
   precursor_isotopes.push_back(0);
-  // isolated precursor isotope is 0
+  // isolated precursor isotope is M0
   IsotopeDistribution iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
   double result[] = { 1.0 };
   Size i = 0;
@@ -310,7 +310,7 @@ START_SECTION(IsotopeDistribution getFragmentIsotopeDistribution(const Empirical
 
   precursor_isotopes.pop_back();
   precursor_isotopes.push_back(1);
-  // isolated precursor isotope is 1
+  // isolated precursor isotope is M+1
   iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
   double result2[] = { 0.5, 0.5};
   i = 0;
@@ -320,7 +320,7 @@ START_SECTION(IsotopeDistribution getFragmentIsotopeDistribution(const Empirical
   }
 
   precursor_isotopes.push_back(0);
-  // isolated precursor isotopes are 0 and 1
+  // isolated precursor isotopes are M0 and M+1
   iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
   double result3[] = { 0.98941, 0.01059};
   i = 0;
@@ -330,7 +330,10 @@ START_SECTION(IsotopeDistribution getFragmentIsotopeDistribution(const Empirical
   }
 
   precursor_isotopes.push_back(2);
-  // isolated precursor isotopes are 0, 1, and 2
+  // isolated precursor isotopes are M0, M+1, and M+2
+  // This is the example found in the comments of the getConditionalFragmentIsotopeDist function.
+  // Since we're isolating all the possible precursor isotopes, the fragment isotope distribution
+  // should be equivalent to the natural isotope abundances.
   iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
   double result4[] = { 0.9893, 0.0107};
   i = 0;
@@ -340,7 +343,7 @@ START_SECTION(IsotopeDistribution getFragmentIsotopeDistribution(const Empirical
   }
 
   precursor_isotopes.push_back(3);
-  // isolated precursor isotopes are 0, 1, 2, and 3
+  // isolated precursor isotopes are M0, M+1, M+2, and M+3
   // It's impossible for precursor C2 to have 3 extra neutrons (assuming only natural stable isotopes)
   // Invalid precursor isotopes are ignored and should give the answer as if they were not there
   iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
@@ -349,6 +352,33 @@ START_SECTION(IsotopeDistribution getFragmentIsotopeDistribution(const Empirical
   {
     TEST_REAL_SIMILAR(it->second, result4[i])
   }
+
+  precursor = EmpiricalFormula("C10H10N10O10S2");
+  EmpiricalFormula big_fragment = EmpiricalFormula("C9H9N9O9S1");
+  EmpiricalFormula small_fragment = EmpiricalFormula("C1H1N1O1S1");
+
+  precursor_isotopes.clear();
+  precursor_isotopes.push_back(1);
+  // isolated precursor isotope is M+1
+  IsotopeDistribution big_iso = big_fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
+  IsotopeDistribution small_iso = small_fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
+
+  // When we isolate only the M+1 precursor isotope, the big_fragment is more likely to exist as M+1 than M0.
+  TEST_EQUAL(big_iso.getContainer()[0].second < 0.2, true)
+  TEST_EQUAL(big_iso.getContainer()[1].second > 0.8, true)
+
+  // The small_fragment, however, is more likely to exist as M0 than M+1.
+  TEST_EQUAL(small_iso.getContainer()[0].second > 0.8, true)
+  TEST_EQUAL(small_iso.getContainer()[1].second < 0.2, true)
+
+  // Since the two fragments also happen to be complementary, their probabilities are perfectly reversed.
+  IsotopeDistribution::ConstIterator big_it = big_iso.begin();
+  IsotopeDistribution::ConstReverseIterator small_it = small_iso.rbegin();
+  for (; big_it != big_iso.end(); ++big_it, ++small_it)
+  {
+    TEST_REAL_SIMILAR(big_it->second, small_it->second)
+  }
+
 END_SECTION
 
 START_SECTION(([EXTRA] Check correct charge semantics))

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -378,6 +378,45 @@ START_SECTION(bool operator!=(const IsotopeDistribution &isotope_distribution) c
   TEST_EQUAL(iso3 != iso4, false)
 END_SECTION
 
+START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribution & comp_fragment_isotope_distribution, const std::vector<UInt>& precursor_isotopes))
+  IsotopeDistribution iso1(EmpiricalFormula("C1").getIsotopeDistribution(11)); // fragment
+  IsotopeDistribution iso2(EmpiricalFormula("C2").getIsotopeDistribution(11)); // complementart fragment
+
+  std::vector<UInt> precursor_isotopes;
+  precursor_isotopes.push_back(0);
+  precursor_isotopes.push_back(1);
+  precursor_isotopes.push_back(2);
+  IsotopeDistribution iso3;
+  iso3.calcFragmentIsotopeDist(iso1,iso2,precursor_isotopes);
+  iso3.renormalize();
+
+  IsotopeDistribution::ConstIterator it1(iso1.begin()), it2(iso3.begin());
+  // By isolating all the precursor isotopes, the fragment isotopic distribution of a fragment molecule
+  // should be the same as if it was the precursor. The probabilities can be slightly different due to
+  // numerical issues.
+  for (; it1 != iso1.end(); ++it1, ++it2)
+  {
+	TEST_EQUAL(it1->first, it2->first)
+	TEST_REAL_SIMILAR(it1->second, it2->second)
+  }
+
+  precursor_isotopes.pop_back();
+  IsotopeDistribution iso4;
+  iso4.calcFragmentIsotopeDist(iso1,iso2,precursor_isotopes);
+  iso4.renormalize();
+
+
+  TEST_EQUAL(iso1.getContainer()[0].first, iso4.getContainer()[0].first)
+  TEST_EQUAL(iso1.getContainer()[1].first, iso4.getContainer()[1].first)
+  // Now that we're not isolating every precursor isotope, the probabilties should NOT be similar.
+  // Since there's no TEST_REAL_NOT_SIMILAR, we test their similiarity to the values they should be
+  TEST_REAL_SIMILAR(iso1.getContainer()[0].second, 0.989300)
+  TEST_REAL_SIMILAR(iso1.getContainer()[1].second, 0.010700)
+
+  TEST_REAL_SIMILAR(iso4.getContainer()[0].second, 0.989524)
+  TEST_REAL_SIMILAR(iso4.getContainer()[1].second, 0.010479)
+END_SECTION
+
 START_SECTION(Iterator begin())
 	NOT_TESTABLE
 END_SECTION

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -380,7 +380,7 @@ END_SECTION
 
 START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribution & comp_fragment_isotope_distribution, const std::vector<UInt>& precursor_isotopes))
   IsotopeDistribution iso1(EmpiricalFormula("C1").getIsotopeDistribution(11)); // fragment
-  IsotopeDistribution iso2(EmpiricalFormula("C2").getIsotopeDistribution(11)); // complementart fragment
+  IsotopeDistribution iso2(EmpiricalFormula("C2").getIsotopeDistribution(11)); // complementary fragment
 
   std::vector<UInt> precursor_isotopes;
   precursor_isotopes.push_back(0);
@@ -408,8 +408,8 @@ START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribut
 
   TEST_EQUAL(iso1.getContainer()[0].first, iso4.getContainer()[0].first)
   TEST_EQUAL(iso1.getContainer()[1].first, iso4.getContainer()[1].first)
-  // Now that we're not isolating every precursor isotope, the probabilties should NOT be similar.
-  // Since there's no TEST_REAL_NOT_SIMILAR, we test their similiarity to the values they should be
+  // Now that we're not isolating every precursor isotope, the probabilities should NOT be similar.
+  // Since there's no TEST_REAL_NOT_SIMILAR, we test their similarity to the values they should be
   TEST_REAL_SIMILAR(iso1.getContainer()[0].second, 0.989300)
   TEST_REAL_SIMILAR(iso1.getContainer()[1].second, 0.010700)
 
@@ -430,6 +430,22 @@ START_SECTION(ConstIterator begin() const)
 END_SECTION
 
 START_SECTION(ConstIterator end() const)
+	NOT_TESTABLE
+END_SECTION
+
+START_SECTION(ReverseIterator rbegin())
+	NOT_TESTABLE
+END_SECTION
+
+START_SECTION(ReverseIterator rend())
+	NOT_TESTABLE
+END_SECTION
+
+START_SECTION(ConstReverseIterator rbegin() const)
+	NOT_TESTABLE
+END_SECTION
+
+START_SECTION(ConstReverseIterator rend() const)
 	NOT_TESTABLE
 END_SECTION
 


### PR DESCRIPTION
Hi OpenMS team,
		
I added functionality to compute expected isotope distributions of fragment molecules conditioned on which precursor isotopes were isolated. It is based off of this paper: https://www.ncbi.nlm.nih.gov/pubmed/12686478 

The gist is that if you were to isolate and fragment only the monoisotopic precursor of a molecule, then all of its fragments would be exclusively monoisotopic. However, if you isolated both the monoisotopic and M1 precursors, then the fragments would also contain only monoisotopic and M1 fragments. The expected probabilities can be computed when you know the precursor's elemental composition, the fragment's elemental composition, and which precursor isotopes were isolated.


Implementation comments:

The functions currently do not check if a fragment's EmpiricalFormula is plausible (e.g. it would be invalid if it had more carbons than the precursor). If an invalid EmpiricalFormula for a fragment is used, then the EmpiricalFormula of the complementary fragment (i.e. Precursor-Fragment, which is required for the calculation) will have negative counts for an element. This leads to the output having NaN probabilities. This is the same behavior that the current IsotopeDistribution calculations have when given an EmpiricalFormula with negative element counts, so I kept it consistent, but I can also check validity and throw an exception if preferred.

The max_depth of the IsotopeDistribution is set to max(isolated precursor isotopes)+1. I don't think it makes sense to ask for more because it should be impossible for a fragment to have a higher isotope than the precursor. Due to the necessary equations, asking for less would still require calculating the isotope distributions with max_depth = max(precursor isotope)+1 for the fragment and complementary fragments (as if they were precursors), so there would be virtually no improvement in computation time.

Currently, the functions take as input a vector<Uint> to specify which precursor isotopes were isolated. I can make it more generic using iterators as the input, but I wasn't sure if that would work with the python bindings.


Other thoughts:

These functions could be used in the TheoreticalSpectrumGenerator functions that add isotopes, which currently compute the isotope distributions as if they were precursors. The conditional fragment isotope distributions and the usual isotope distributions are equivalent only if all the precursor isotopes were isolated.

I'm also working on approximating the fragment isotope distributions when the elemental compositions are unknown, and some applications of that. Hopefully those pull requests will come soon.

Please let me know what you think! Thanks.