### PR TITLE
[BUILD] cython version

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -102,7 +102,7 @@ else()
        OUTPUT_VARIABLE CYTHON_VERSION
        OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-  message(STATUS "Looking for cython - found version ${CYTHON_VERSION}")
+  message(STATUS "Looking for cython - found version ${CYTHON_VERSION} (should be 0.23 or higher)")
 endif()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
we should include this hint as pyOpenMS does not seem to compile any more with lower Cython versions -- even better would be to have a strong check in cmake