### PR TITLE
[LOG] more logging output for MapAlignerIdentification

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.h
+++ b/src/openms/include/OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.h
@@ -222,7 +222,8 @@ protected:
             if (!pep_it->getHits().empty())
             {
               any_hit = true;
-              double current_distance = abs(pep_it->getRT() - feat_it->getRT());
+              double current_distance = fabs(pep_it->getRT() -
+                                             feat_it->getRT());
               if (current_distance < rt_distance)
               {
                 pep_it->sort();

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.cpp
@@ -90,14 +90,12 @@ namespace OpenMS
                                                             bool sorted)
   {
     medians.clear();
-    SeqToValue::iterator pos = medians.begin(); // prevent segfault (see below)
     for (SeqToList::iterator rt_it = rt_data.begin();
          rt_it != rt_data.end(); ++rt_it)
     {
       double median = Math::median(rt_it->second.begin(),
                                    rt_it->second.end(), sorted);
-      medians.insert(pos, make_pair(rt_it->first, median));
-      pos = --medians.end(); // would cause segfault if "medians" were empty
+      medians.insert(medians.end(), make_pair(rt_it->first, median));
     }
   }
 
@@ -167,7 +165,6 @@ namespace OpenMS
       // remove peptides that don't occur in enough runs:
       LOG_DEBUG << "Removing peptides that occur in too few runs..." << endl;
       SeqToValue temp;
-      SeqToValue::iterator pos = temp.begin(); // to prevent segfault below
       for (SeqToValue::iterator ref_it = reference_.begin();
            ref_it != reference_.end(); ++ref_it)
       {
@@ -175,10 +172,11 @@ namespace OpenMS
         if ((med_it != medians_per_seq.end()) &&
             (med_it->second.size() + 1 >= min_run_occur_))
         {
-          temp.insert(pos, *ref_it); // we know new items should go at the end
-          pos = --temp.end(); // would cause segfault if "temp" was empty
+          temp.insert(temp.end(), *ref_it); // new items should go at the end
         }
       }
+      LOG_DEBUG << "Removed " << reference_.size() - temp.size() << " of "
+                << reference_.size() << " peptides." << endl;
       temp.swap(reference_);
     }
     else // compute overall RT median per sequence (median of medians per run)
@@ -188,16 +186,16 @@ namespace OpenMS
       // remove peptides that don't occur in enough runs (at least two):
       LOG_DEBUG << "Removing peptides that occur in too few runs..." << endl;
       SeqToList temp;
-      SeqToList::iterator pos = temp.begin(); // to prevent segfault below
       for (SeqToList::iterator med_it = medians_per_seq.begin();
            med_it != medians_per_seq.end(); ++med_it)
       {
         if (med_it->second.size() >= min_run_occur_)
         {
-          temp.insert(pos, *med_it);
-          pos = --temp.end(); // would cause segfault if "temp" was empty
+          temp.insert(temp.end(), *med_it);
         }
       }
+      LOG_DEBUG << "Removed " << medians_per_seq.size() - temp.size() << " of "
+                << medians_per_seq.size() << " peptides." << endl;
       temp.swap(medians_per_seq);
       computeMedians_(medians_per_seq, reference_);
     }
@@ -251,19 +249,28 @@ namespace OpenMS
       // current run ("medians_per_run[i]"), but also in at least one other run
       // ("medians_overall"):
       TransformationDescription::DataPoints data;
+      Size n_outliers = 0;
       for (SeqToValue::iterator med_it = medians_per_run[i].begin();
            med_it != medians_per_run[i].end(); ++med_it)
       {
         SeqToValue::const_iterator pos = reference_.find(med_it->first);
-        if ((pos != reference_.end()) &&
-            (abs(med_it->second - pos->second) <= max_rt_shift))
-        { // found, and satisfies "max_rt_shift" condition!
-          data.push_back(make_pair(med_it->second, pos->second));
+        if (pos != reference_.end())
+        {
+          if (abs(med_it->second - pos->second) <= max_rt_shift)
+          { // found, and satisfies "max_rt_shift" condition!
+            data.push_back(make_pair(med_it->second, pos->second));
+          }
+          else
+          {
+            n_outliers++;
+          }
         }
       }
       transforms.push_back(TransformationDescription(data));
       LOG_INFO << "- " << data.size() << " data points for sample "
-               << i + offset + 1 << "\n";
+               << i + offset + 1;
+      if (n_outliers) LOG_INFO << " (" << n_outliers << " outliers removed)";
+      LOG_INFO << "\n";
     }
     LOG_INFO << endl;
 


### PR DESCRIPTION
Inspired by #2201, this logs the number of potential data points (peptides) that were removed as outliers during the alignment. Might help to avoid some confusion.

(I also simplified parts of the code for inserting elements at the end of maps. Interestingly, the semantics for insertion hints changed between C++98 and C++11: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1780.html
I switched to the saner C++11 version.)