### PR TITLE
[PARAM] set default for FLQT nr_partitions to 100

### DIFF
--- a/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/QTClusterFinder.cpp
@@ -61,7 +61,7 @@ namespace OpenMS
 
     defaults_.setValue("use_identifications", "false", "Never link features that are annotated with different peptides (only the best hit per peptide identification is taken into account).");
     defaults_.setValidStrings("use_identifications", ListUtils::create<String>("true,false"));
-    defaults_.setValue("nr_partitions", 1, "How many partitions in m/z space should be used for the algorithm (more partitions means faster runtime and more memory efficient execution )");
+    defaults_.setValue("nr_partitions", 100, "How many partitions in m/z space should be used for the algorithm (more partitions means faster runtime and more memory efficient execution )");
     defaults_.setMinInt("nr_partitions", 1);
 
 

--- a/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
+++ b/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
@@ -132,7 +132,8 @@ START_SECTION((void run(const std::vector<FeatureMap >& input_maps, ConsensusMap
   QTClusterFinder finder;
 	Param param = finder.getDefaults();
 	param.setValue("distance_RT:max_difference", 5.1);
-	param.setValue("distance_MZ:max_difference", 0.1);
+  param.setValue("distance_MZ:max_difference", 0.1);
+  param.setValue("nr_partitions", 1);
 	finder.setParameters(param);
 	ConsensusMap result;
 	finder.run(input, result);

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_2_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_2_parameters.ini
@@ -14,6 +14,7 @@
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">
         <ITEM name="use_identifications" value="false" type="string" description="Never link features that are annotated with different peptides (only the best hit per peptide identification is taken into account)." restrictions="true,false" />
+        <ITEM name="nr_partitions" value="100" type="int" description="How many partitions in m/z space should be used for the algorithm (more partitions means faster runtime and more memory efficient execution )" required="false" advanced="false" restrictions="1:" />
         <ITEM name="ignore_charge" value="false" type="string" description="Compare features normally even if their charge states are different" restrictions="true,false" />
         <NODE name="distance_RT" description="Distance component based on RT differences">
           <ITEM name="max_difference" value="100" type="float" description="Maximum allowed difference in RT" restrictions="0:" />

--- a/src/tests/topp/FeatureLinkerUnlabeledQT_3_parameters.ini
+++ b/src/tests/topp/FeatureLinkerUnlabeledQT_3_parameters.ini
@@ -14,6 +14,7 @@
       <ITEM name="test" value="false" type="string" description="Enables the test mode (needed for internal use only)" tags="advanced" restrictions="true,false" />
       <NODE name="algorithm" description="Algorithm parameters section">
         <ITEM name="use_identifications" value="false" type="string" description="Never link features that are annotated with different peptides (only the best hit per peptide identification is taken into account)." restrictions="true,false" />
+        <ITEM name="nr_partitions" value="99999" type="int" description="How many partitions in m/z space should be used for the algorithm (more partitions means faster runtime and more memory efficient execution )" required="false" advanced="false" restrictions="1:" />
         <ITEM name="ignore_charge" value="false" type="string" description="Compare features normally even if their charge states are different" restrictions="true,false" />
         <NODE name="distance_RT" description="Distance component based on RT differences">
           <ITEM name="max_difference" value="100" type="float" description="Maximum allowed difference in RT in seconds" restrictions="0:" />


### PR DESCRIPTION
I have run a couple of benchmarks that showed rather consistently that 100 is a good number of partitions. In most cases, 100 was faster than 20 or 9999 partitions. In general, values of 100+ seem to be good and result in similar runtimes. The performance of FLQT if only 1 partition is used (the current default) is extremely poor for larger datasets. Thus I would strongly suggest to change the default of this parameter. For a number of small and large datasets, I have verified that the number of partitions does not have an impact on the results (anymore, since https://github.com/OpenMS/OpenMS/pull/2207).