### PR TITLE
[FIX] "normal" mode for intensity axis in 3D view

### DIFF
--- a/src/openms_gui/source/VISUAL/Spectrum3DOpenGLCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum3DOpenGLCanvas.cpp
@@ -81,7 +81,7 @@ namespace OpenMS
       break;
 
     case SpectrumCanvas::IM_NONE:
-      AxisTickCalculator::calcGridLines(canvas_3d_.overall_data_range_.min_[2], canvas_3d_.overall_data_range_.max_[2], grid_intensity_);
+      AxisTickCalculator::calcGridLines(std::max(0.0, canvas_3d_.overall_data_range_.min_[2]), canvas_3d_.overall_data_range_.max_[2], grid_intensity_);
       break;
 
     case SpectrumCanvas::IM_PERCENTAGE:


### PR DESCRIPTION
![screen shot 2016-10-03 at 13 47 38](https://cloud.githubusercontent.com/assets/5813121/19056662/7ad5c7a6-897f-11e6-9a73-2e0e0786478b.png)

In "normal" intensity mode (IM_NONE), the intensity axis shows "inf" values and a bogus exponent if negative intensities are present in the dataset (as is the case, e.g., in the TOPPView example `LCMS-centroided.mzML`). This fixes it.