### PR TITLE
[FEAT] TOPPView: identical color for connecting lines

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DCaret.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotation1DCaret.h
@@ -47,8 +47,8 @@ namespace OpenMS
 {
   /** @brief An annotation item which paints a set of carets on the canvas.
 
-      Most useful to visualize (theoretical) isotope distributions.
-      Additionally, a text annotation can be provided
+      Most useful to visualize (theoretical) isotope distributions (one caret per isotope position).
+      Additionally, a text annotation can be provided.
 
       @see Annotation1DItem
   */
@@ -61,7 +61,7 @@ public:
     typedef std::vector<PointType> PositionsType;
 
     /// Constructor
-    Annotation1DCaret(const PositionsType& poly_positions, const QString& text, const QColor& colour);
+    Annotation1DCaret(const PositionsType& poly_positions, const QString& text, const QColor& colour, const QColor& connection_line_color);
 
     /// Copy constructor
     Annotation1DCaret(const Annotation1DCaret& rhs);
@@ -109,9 +109,11 @@ protected:
     /// The colour of the label
     QColor color_;
 
+    /// The colour of the (optional) dashed line connecting peak and label
+    QColor connection_line_color_;
+
     /// Holds the (rich) text
     QStaticText st_;
-    //QTextDocument doc_;
 
   };
 } // namespace OpenMS

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DCaret.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotation1DCaret.cpp
@@ -42,11 +42,15 @@
 namespace OpenMS
 {
 
-  Annotation1DCaret::Annotation1DCaret(const Annotation1DCaret::PositionsType& caret_positions, const QString& text, const QColor& colour) :
+  Annotation1DCaret::Annotation1DCaret(const Annotation1DCaret::PositionsType& caret_positions, 
+                                       const QString& text,
+                                       const QColor& colour,
+                                       const QColor& connection_line_color) :
     Annotation1DItem(text),
     caret_positions_(caret_positions),
     position_(caret_positions[0]),
-    color_(colour)
+    color_(colour),
+    connection_line_color_(connection_line_color)
   {
     st_.setText(text);
   }
@@ -57,6 +61,7 @@ namespace OpenMS
     caret_positions_ = rhs.caret_positions_;
     position_ = rhs.position_;
     color_ = rhs.color_;
+    connection_line_color_ = rhs.connection_line_color_;
     st_ = rhs.st_;
   }
 
@@ -188,7 +193,9 @@ namespace OpenMS
       }
 
       painter.save();
-      painter.setPen(Qt::DashLine);
+      QPen qp(Qt::DashLine);
+      qp.setColor(connection_line_color_);
+      painter.setPen(qp);
       if (!found_intersection) // no intersection with bounding box of text -> normal drawing
       {
         painter.drawLine(caret_position_widget, position_widget);

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -216,8 +216,9 @@ namespace OpenMS
           ++itic;
         }
         Annotation1DCaret* ditem = new Annotation1DCaret(points,
-                                                          QString(),
-                                                          cols[i]);
+                                                         QString(),
+                                                         cols[i],
+                                                         current_layer.param.getValue("peak_color").toQString());
         ditem->setSelected(false);
         temporary_annotations_.push_back(ditem); // for removal (no ownership)
         current_layer.getCurrentAnnotations().push_front(ditem); // for visualization (ownership)
@@ -327,14 +328,14 @@ namespace OpenMS
         DPosition<2> upper_position = DPosition<2>(isolation_window_upper_mz, max_intensity);
 
         Annotation1DDistanceItem * item = new Annotation1DDistanceItem(QString::number(it->getCharge()), lower_position, upper_position);
-        // add additional tick at precursor target position (e.g. to show if isolation window is assymetric)
+        // add additional tick at precursor target position (e.g. to show if isolation window is asymmetric)
         vector<double> ticks;
         ticks.push_back(it->getMZ());
         item->setTicks(ticks);
         item->setSelected(false);
 
         temporary_annotations_.push_back(item); // for removal (no ownership)
-        current_layer.getCurrentAnnotations().push_front(item); // for visualisation (ownership)
+        current_layer.getCurrentAnnotations().push_front(item); // for visualization (ownership)
       }
     }
     else if (current_layer.type == LayerData::DT_CHROMATOGRAM)


### PR DESCRIPTION
draw the connecting line of identifications using the color of the layer instead of black -- makes it much easier to discern multiple layers
![image](https://cloud.githubusercontent.com/assets/6008722/19065171/3f620796-8a12-11e6-9ad5-7416bc7517c6.png)
