### PR TITLE
[FIX] MapAlignerIdentification: allow 'lowess' as 'model:type'

### DIFF
--- a/src/openms/include/OpenMS/APPLICATIONS/MapAlignerBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/MapAlignerBase.h
@@ -85,7 +85,7 @@ public:
     Param params;
     params.setValue("type", default_model, "Type of model");
     // TODO: avoid referring to each TransformationModel subclass explicitly
-    StringList model_types = ListUtils::create<String>("linear,b_spline,interpolated");
+    StringList model_types = ListUtils::create<String>("linear,b_spline,lowess,interpolated");
     if (!ListUtils::contains(model_types, default_model))
     {
       model_types.insert(model_types.begin(), default_model);


### PR DESCRIPTION
Fixes oversight in PR #2112.

I've already opened a separate pull request against "master" for this (#2228). Don't know if it makes sense to merge both.