### PR TITLE
[DOC] Made changes to package loading in tutorials backwards compatible

### DIFF
--- a/doc/OpenMS_tutorial/refman_overwrite.tex.in
+++ b/doc/OpenMS_tutorial/refman_overwrite.tex.in
@@ -11,9 +11,7 @@
 \usepackage{float}
 \usepackage{alltt}
 \usepackage{newtxtext, newtxmath}
-\@ifpackageloaded{textcomp} % newtxtext loads textcomp only in newer versions
-  {} % do nothing if loaded by the previous package to avoid option clashes
-  {\usepackage{textcomp}} % otherwise load the package
+\usepackage[full]{textcomp} %Careful: newtxttext also loads textcomp. Option full needs to match.
 \ifx\pdfoutput\undefined
 \usepackage[ps2pdf,
             pagebackref=true,

--- a/doc/OpenMS_tutorial/refman_overwrite.tex.in
+++ b/doc/OpenMS_tutorial/refman_overwrite.tex.in
@@ -11,7 +11,9 @@
 \usepackage{float}
 \usepackage{alltt}
 \usepackage{newtxtext, newtxmath}
-%\usepackage{textcomp} Is included through the above newtxtext. Comment to avoid option clashes.
+\@ifpackageloaded{textcomp} % newtxtext loads textcomp only in newer versions
+  {} % do nothing if loaded by the previous package to avoid option clashes
+  {\usepackage{textcomp}} % otherwise load the package
 \ifx\pdfoutput\undefined
 \usepackage[ps2pdf,
             pagebackref=true,

--- a/doc/TOPP_tutorial/refman_overwrite.tex.in
+++ b/doc/TOPP_tutorial/refman_overwrite.tex.in
@@ -11,9 +11,7 @@
 \usepackage{float}
 \usepackage{alltt}
 \usepackage{newtxtext, newtxmath}
-\@ifpackageloaded{textcomp} % newtxtext loads textcomp only in newer versions
-  {} % do nothing if loaded by the previous package to avoid option clashes
-  {\usepackage{textcomp}} % otherwise load the package
+\usepackage[full]{textcomp} %Careful: newtxttext also loads textcomp. Option full needs to match.
 \ifx\pdfoutput\undefined
 \usepackage[ps2pdf,
             pagebackref=true,

--- a/doc/TOPP_tutorial/refman_overwrite.tex.in
+++ b/doc/TOPP_tutorial/refman_overwrite.tex.in
@@ -11,7 +11,9 @@
 \usepackage{float}
 \usepackage{alltt}
 \usepackage{newtxtext, newtxmath}
-%\usepackage{textcomp} Is included through the above newtxtext. Comment to avoid option clashes.
+\@ifpackageloaded{textcomp} % newtxtext loads textcomp only in newer versions
+  {} % do nothing if loaded by the previous package to avoid option clashes
+  {\usepackage{textcomp}} % otherwise load the package
 \ifx\pdfoutput\undefined
 \usepackage[ps2pdf,
             pagebackref=true,


### PR DESCRIPTION
Only newer versions of the newly introduced newtxtext package include the textcomp package but load it with options. I looked up the options and activated the include. If the package is loaded previously with the same options, Latex will skip it.