### PR TITLE
[FIX] fixes for parsing modification information in pepXML files

### DIFF
--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -110,7 +110,15 @@ namespace OpenMS
   const ResidueModification& ModificationsDB::getModification(const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const
   {
     set<const ResidueModification*> mods;
-    searchModifications(mods, mod_name, residue, term_spec);
+    // if residue is specified, try residue-specific search first to avoid
+    // ambiguities (e.g. "Carbamidomethyl (N-term)"/"Carbamidomethyl (C)"):
+    if (!residue.empty() &&
+        (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY))
+    {
+      searchModifications(mods, mod_name, residue,
+                          ResidueModification::ANYWHERE);
+    }
+    if (mods.empty()) searchModifications(mods, mod_name, residue, term_spec);
 
     if (mods.empty())
     {

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -112,15 +112,15 @@ namespace OpenMS
     String raw_data;
     String base_name;
     SpectrumMetaDataLookup lookup;
-    
+
     // The mz-File (if given)
     if (!mz_file.empty())
     {
       base_name = File::removeExtension(File::basename(mz_file));
       raw_data = FileTypes::typeToName(FileHandler().getTypeByFileName(mz_file));
-      
+
       MSExperiment<> experiment;
-      FileHandler fh;      
+      FileHandler fh;
       fh.loadExperiment(mz_file, experiment, FileTypes::UNKNOWN, ProgressLogger::NONE, false, false);
       lookup.readSpectra(experiment.getSpectra());
     }
@@ -138,7 +138,7 @@ namespace OpenMS
     {
       replace(base_name.begin(), base_name.end(), '.', '_');
     }
-    
+
     f << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << "\n";
     f << "<msms_pipeline_analysis date=\"2007-12-05T17:49:46\" xmlns=\"http://regis-web.systemsbiology.net/pepXML\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://sashimi.sourceforge.net/schema_revision/pepXML/pepXML_v117.xsd\" summary_xml=\".xml\">" << "\n";
     f << "<msms_run_summary base_name=\"" << base_name << "\" raw_data_type=\"raw\" raw_data=\"." << raw_data << "\" search_engine=\"" << search_engine_name << "\">" << "\n";
@@ -284,35 +284,35 @@ namespace OpenMS
 
         int scan_index = count;
         int scan_nr = 0;
-        
+
         if (lookup.empty())
         {
           if (it->metaValueExists("RT_index")) // Setting metaValue "RT_index" in XTandemXMLFile in the case of X! Tandem.
           {
-            scan_index = it->getMetaValue("RT_index");            
+            scan_index = it->getMetaValue("RT_index");
           }
-          scan_nr = scan_index + 1;          
+          scan_nr = scan_index + 1;
         }
         else
         {
           scan_index = lookup.findByRT(it->getRT());
-          
+
           SpectrumMetaDataLookup::SpectrumMetaData meta;
           lookup.getSpectrumMetaData(scan_index, meta);
-          scan_nr = meta.scan_number;          
+          scan_nr = meta.scan_number;
         }
         // PeptideProphet requires this format for "spectrum" attribute (otherwise TPP parsing error)
         //  - see also the parser code if iProphet at http://sourceforge.net/p/sashimi/code/HEAD/tree/trunk/trans_proteomic_pipeline/src/Validation/InterProphet/InterProphetParser/InterProphetParser.cxx#l180
         //  strictly required attributes:
         //    - spectrum
         //    - assumed_charge
-        //  optional attributes 
+        //  optional attributes
         //    - retention_time_sec
         //    - swath_assay
         //    - experiment_label
 
         String spectrum_name = base_name + "." + scan_nr + "." + scan_nr + ".";
-        if (it->metaValueExists("pepxml_spectrum_name") && keep_native_name_) 
+        if (it->metaValueExists("pepxml_spectrum_name") && keep_native_name_)
         {
           spectrum_name = it->getMetaValue("pepxml_spectrum_name");
         }
@@ -486,7 +486,7 @@ namespace OpenMS
               f << "\t\t\t\t\t</search_score_summary>" << "\n";
             }
             f << "\t\t\t\t</" << tagname << ">" << "\n";
-            
+
             f << "\t\t\t</analysis_result>" << "\n";
           }
         }
@@ -496,7 +496,7 @@ namespace OpenMS
         // peptide prophet results above through AnalysisResults
         if (peptideprophet_analyzed && !peptideprophet_written)
         {
-          // if (!h.getAnalysisResults().empty()) { WARNING / } 
+          // if (!h.getAnalysisResults().empty()) { WARNING / }
           f << "\t\t\t<analysis_result analysis=\"peptideprophet\">" << "\n";
           f << "\t\t\t<peptideprophet_result probability=\"" << h.getScore()
             << "\" all_ntt_prob=\"(" << h.getScore() << "," << h.getScore()
@@ -940,7 +940,7 @@ namespace OpenMS
       current_proteins_[min(UInt(current_proteins_.size()), search_id_) - 1]->insertHit(hit);
     }
     else if (element == "search_result") // parent: "spectrum_query"
-    { 
+    {
       // creates a new PeptideIdentification
       current_peptide_ = PeptideIdentification();
       current_peptide_.setRT(rt_);
@@ -955,7 +955,7 @@ namespace OpenMS
       current_peptide_.setIdentifier(identifier);
 
       // set optional attributes
-      if (!native_spectrum_name_.empty() && keep_native_name_) 
+      if (!native_spectrum_name_.empty() && keep_native_name_)
       {
         current_peptide_.setMetaValue("pepxml_spectrum_name", native_spectrum_name_);
       }
@@ -968,11 +968,11 @@ namespace OpenMS
       {
         current_peptide_.setExperimentLabel(experiment_label_);
       }
-      if (!swath_assay_.empty()) 
+      if (!swath_assay_.empty())
       {
         current_peptide_.setMetaValue("swath_assay", swath_assay_);
       }
-      if (!status_.empty()) 
+      if (!status_.empty())
       {
         current_peptide_.setMetaValue("status", status_);
       }
@@ -980,8 +980,10 @@ namespace OpenMS
     else if (element == "spectrum_query") // parent: "msms_run_summary"
     {
       // sample:
-      // <spectrum_query spectrum="foobar.02552.02552.2" start_scan="2552" end_scan="2552" precursor_neutral_mass="1168.6176" assumed_charge="2" 
-      //    index="10" retention_time_sec="488.652" experiment_label="urine" swath_assay="EIVLTQSPGTL2:9" status="target">
+      // <spectrum_query spectrum="foobar.02552.02552.2" start_scan="2552"
+      // end_scan="2552" precursor_neutral_mass="1168.6176" assumed_charge="2"
+      // index="10" retention_time_sec="488.652" experiment_label="urine"
+      // swath_assay="EIVLTQSPGTL2:9" status="target">
 
       readRTMZCharge_(attributes); // sets "rt_", "mz_", "charge_"
 
@@ -998,7 +1000,7 @@ namespace OpenMS
 
 
     }
-    else if (element == "analysis_result") // parent: "search_hit" 
+    else if (element == "analysis_result") // parent: "search_hit"
     {
       current_analysis_result_ = PeptideHit::PepXMLAnalysisResult();
       current_analysis_result_.score_type = attributeAsString_(attributes, "analysis");
@@ -1007,7 +1009,7 @@ namespace OpenMS
     {
       search_score_summary_ = true;
     }
-    else if (element == "parameter") // parent: "search_score_summary" 
+    else if (element == "parameter") // parent: "search_score_summary"
     {
       // If we are within a search_score_summary, add the read in values to the current AnalysisResult
       if (search_score_summary_)

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -69,7 +69,7 @@ namespace OpenMS
     hydrogen_ = *db->getElement("Hydrogen");
   }
 
-  const double PepXMLFile::mod_tol_ = 0.0001;
+  const double PepXMLFile::mod_tol_ = 0.001;
   const double PepXMLFile::xtandem_artificial_mod_tol_ = 0.0005; // according to cpp in some old version of xtandem somehow very small fixed modification (electron mass?) gets annotated by X!Tandem. Don't add them as they interfere with other modifications.
 
   PepXMLFile::~PepXMLFile()
@@ -1201,24 +1201,11 @@ namespace OpenMS
       {
         try
         {
-          desc = ModificationsDB::getInstance()->getModification(aa_mod.description, aa_mod.aminoacid, term_spec).getName();
-          if (!desc.empty())
-          {
-            if (is_variable == "Y")
-            {
-              variable_modifications_.push_back(aa_mod);
-              params_.variable_modifications.push_back(desc);
-            }
-            else
-            {
-              fixed_modifications_.push_back(aa_mod);
-              params_.fixed_modifications.push_back(desc);
-            }
-          }
+          desc = ModificationsDB::getInstance()->getModification(aa_mod.description, aa_mod.aminoacid, term_spec).getFullId();
         }
-        catch (Exception::ElementNotFound)
+        catch (Exception::BaseException)
         {
-          error(LOAD, "Modification '" + String(aa_mod.description) + "' is not uniquely defined by the given data. Trying by modification mass.");
+          error(LOAD, "Modification '" + aa_mod.description + "' of residue '" + aa_mod.aminoacid + "' could not be matched. Trying by modification mass.");
         }
       }
       else

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -730,6 +730,10 @@ set_tests_properties("TOPP_IDFileConverter_14_out1" PROPERTIES DEPENDS "TOPP_IDF
 add_test("TOPP_IDFileConverter_15" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${DATA_DIR_TOPP}/THIRDPARTY/MSGFPlusAdapter_1_out.mzid -out IDFileConverter_15_output.tmp -out_type idXML -mz_file ${DATA_DIR_TOPP}/THIRDPARTY/spectra.mzML)
 add_test("TOPP_IDFileConverter_15_out1" ${DIFF} -in1 IDFileConverter_15_output.tmp -in2 ${DATA_DIR_TOPP}/IDFileConverter_15_output.idXML -whitelist "IdentificationRun date" )
 set_tests_properties("TOPP_IDFileConverter_15_out1" PROPERTIES DEPENDS "TOPP_IDFileConverter_15")
+# pepXML (from iProphet) to idXML:
+add_test("TOPP_IDFileConverter_16" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${DATA_DIR_TOPP}/IDFileConverter_16_input.pepXML -out IDFileConverter_16_output.tmp -out_type idXML)
+add_test("TOPP_IDFileConverter_16_out1" ${DIFF} -in1 IDFileConverter_16_output.tmp -in2 ${DATA_DIR_TOPP}/IDFileConverter_16_output.idXML)
+set_tests_properties("TOPP_IDFileConverter_16_out1" PROPERTIES DEPENDS "TOPP_IDFileConverter_16")
 
 #------------------------------------------------------------------------------
 # IDFilter tests

--- a/src/tests/topp/IDFileConverter_16_input.pepXML
+++ b/src/tests/topp/IDFileConverter_16_input.pepXML
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<msms_pipeline_analysis date="2014-10-27T15:00:44" xmlns="http://regis-web.systemsbiology.net/pepXML" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://regis-web.systemsbiology.net/pepXML /tools/bin/TPP/tpp/schema/pepXML_v18.xsd" summary_xml="/data/lamgroup/iPRG2014/study/iP/ipro3-1A.pep.xml">
+<analysis_summary analysis="interprophet" time="2014-10-27T15:00:44">
+<interprophet_summary version="TPP v0.0.0 TRUNK (DEV), Build 201407221546-6570M (Ubuntu-x86_64)" options="MINPROB=0"  est_tot_num_correct_psm="25705.4"  est_tot_num_correct_pep="20469.1">
+<inputfile name="../oms/interact-1A.pep.xml"/>
+<inputfile name="../cmt/interact-1A.pep.xml"/>
+<inputfile name="../msgf/interact-1A.pep.xml"/>
+<roc_error_data charge="all">
+<roc_data_point min_prob="0.9999" sensitivity="0.8176" error="0.0000" num_corr="21017" num_incorr="0"/>
+<roc_data_point min_prob="0.9990" sensitivity="0.8568" error="0.0000" num_corr="22025" num_incorr="1"/>
+<roc_data_point min_prob="0.9900" sensitivity="0.9028" error="0.0002" num_corr="23207" num_incorr="5"/>
+<roc_data_point min_prob="0.9800" sensitivity="0.9176" error="0.0005" num_corr="23587" num_incorr="11"/>
+<error_point error="0.0000" min_prob="1.0000" num_corr="2" num_incorr="0"/>
+<error_point error="0.0001" min_prob="0.9957" num_corr="22770" num_incorr="2"/>
+<error_point error="0.0002" min_prob="0.9911" num_corr="23141" num_incorr="5"/>
+<error_point error="0.0003" min_prob="0.9870" num_corr="23358" num_incorr="7"/>
+<error_point error="0.0004" min_prob="0.9827" num_corr="23515" num_incorr="9"/>
+</roc_error_data>
+
+<mixturemodel name="NSS" pos_bandwidth="0.509999" neg_bandwidth="0.509999">
+<point value="-0.01" pos_dens="0.145023" neg_dens="1.11123" neg_obs_dens="1.11601" pos_obs_dens="0.126615"/>
+<point value="-0.00795591" pos_dens="0.145842" neg_dens="1.11145" neg_obs_dens="1.1162" pos_obs_dens="0.127432"/>
+<point value="-0.00591183" pos_dens="0.146666" neg_dens="1.11164" neg_obs_dens="1.11637" pos_obs_dens="0.128253"/>
+</mixturemodel>
+<mixturemodel name="NRS" pos_bandwidth="1.41983" neg_bandwidth="1.41983">
+<point value="-5.01" pos_dens="0.000498925" neg_dens="0.000622044" neg_obs_dens="0.000630156" pos_obs_dens="0.000500468"/>
+<point value="-4.98155" pos_dens="0.000535429" neg_dens="0.000663988" neg_obs_dens="0.000672304" pos_obs_dens="0.000537083"/>
+<point value="-4.95309" pos_dens="0.000574375" neg_dens="0.000708665" neg_obs_dens="0.000717193" pos_obs_dens="0.000576147"/>
+</mixturemodel>
+<mixturemodel name="NSI" pos_bandwidth="0.603999" neg_bandwidth="0.603999">
+<point value="-0.01" pos_dens="0.549546" neg_dens="0.655985" neg_obs_dens="0.65739" pos_obs_dens="0.549929"/>
+<point value="-0.0039479" pos_dens="0.550213" neg_dens="0.656088" neg_obs_dens="0.657483" pos_obs_dens="0.550594"/>
+<point value="0.0021042" pos_dens="0.550835" neg_dens="0.656125" neg_obs_dens="0.657511" pos_obs_dens="0.551213"/>
+</mixturemodel>
+<mixturemodel name="NSM" pos_bandwidth="0.501999" neg_bandwidth="0.501999">
+<point value="-0.01" pos_dens="0.736416" neg_dens="0.79083" neg_obs_dens="0.791921" pos_obs_dens="0.73702"/>
+<point value="6.01102e-05" pos_dens="0.736895" neg_dens="0.791015" neg_obs_dens="0.792098" pos_obs_dens="0.737497"/>
+<point value="0.0101202" pos_dens="0.737092" neg_dens="0.790883" neg_obs_dens="0.791957" pos_obs_dens="0.737691"/>
+</mixturemodel>
+<mixturemodel name="NSP" pos_bandwidth="2.002" neg_bandwidth="2.002">
+<point value="-0.01" pos_dens="0.0187254" neg_dens="0.14634" neg_obs_dens="0.148671" pos_obs_dens="0.0194532"/>
+<point value="0.0301202" pos_dens="0.0190238" neg_dens="0.146857" neg_obs_dens="0.149182" pos_obs_dens="0.0197594"/>
+<point value="0.0702405" pos_dens="0.0193224" neg_dens="0.147324" neg_obs_dens="0.149643" pos_obs_dens="0.0200657"/>
+</mixturemodel>
+</interprophet_summary>
+</analysis_summary>
+<analysis_summary analysis="peptideprophet" time="2014-10-26T13:20:49"/>
+<analysis_summary analysis="peptideprophet" time="2014-10-26T13:27:01"/>
+<analysis_summary analysis="peptideprophet" time="2014-10-27T14:05:17"/>
+<analysis_summary analysis="database_refresh" time="2014-10-26T13:20:41"/>
+<analysis_summary analysis="interact" time="2014-10-26T13:20:32">
+<interact_summary filename="/data/lamgroup/iPRG2014/study/oms/interact-1A.pep.xml" directory="/data/lamgroup/iPRG2014/study/oms">
+<inputfile name="JD_06232014_sample1-A.pep.xml" directory="/data/lamgroup/iPRG2014/study/oms"/>
+</interact_summary>
+</analysis_summary>
+<msms_run_summary base_name="/data/lamgroup/iPRG2014/study/oms/JD_06232014_sample1-A" raw_data_type="raw" raw_data=".mzML">
+<sample_enzyme name="trypsin" fidelity="semispecific">
+<specificity cut="KR" no_cut="P" sense="C"/>
+</sample_enzyme>
+<search_summary base_name="/data/lamgroup/iPRG2014/study/oms/JD_06232014_sample1-A.pep.xml" search_engine="OMSSA" precursor_mass_type="monoisotopic" fragment_mass_type="monoisotopic" out_data_type="n/a" out_data="n/a" search_id="1">
+<search_database local_path="/dbase/Misc/iPRG2014/iPRG2015.TargDecoy.fasta" size_in_db_entries="13256" type="AA"/>
+<enzymatic_search_constraint enzyme="Semi-Tryptic" max_num_internal_cleavages="2" min_number_termini="2"/>
+<aminoacid_modification aminoacid="C" massdiff="57.021000000000001" mass="160.03019" variable="N" description="Carbamidomethyl"/>
+<aminoacid_modification aminoacid="M" massdiff="15.995000000000001" mass="147.03549" variable="Y" description="Oxidation"/>
+<aminoacid_modification aminoacid="C" massdiff="-17.026" mass="143.00419" variable="Y" peptide_terminus="N" description="Ammonia-loss"/>
+<aminoacid_modification aminoacid="E" massdiff="-18.010000000000002" mass="111.03259" variable="Y" peptide_terminus="N" description="Glu-&gt;pyro-Glu"/>
+<aminoacid_modification aminoacid="Q" massdiff="-17.026" mass="111.03258" variable="Y" peptide_terminus="N" description="Ammonia-loss"/>
+<terminal_modification terminus="n" massdiff="42.011000000000003" mass="43.01894" variable="Y" protein_terminus="Y" description="Acetyl"/>
+</search_summary>
+<analysis_timestamp analysis="interprophet" time="2014-10-27T15:00:44" id="1"/>
+<analysis_timestamp analysis="peptideprophet" time="2014-10-26T13:20:49" id="1"/>
+<analysis_timestamp analysis="database_refresh" time="2014-10-26T13:20:41" id="1">
+<database_refresh_timestamp database="/dbase/Misc/iPRG2014/iPRG2015.TargDecoy.fasta" min_num_enz_term="0"/>
+</analysis_timestamp>
+<spectrum_query spectrum="JD_06232014_sample1-A.00006.00006.2" start_scan="6" end_scan="6" precursor_neutral_mass="870.405029296875" assumed_charge="2" index="1">
+<search_result>
+<search_hit hit_rank="1" peptide="HEEIDTK" peptide_prev_aa="K" peptide_next_aa="N" protein="sp|Q08745|RS10A_YEAST" num_tot_proteins="2" num_matched_ions="3" tot_num_ions="12" calc_neutral_pep_mass="870.409973144531" massdiff="-0.00494384765625" is_rejected="0" protein_descr="40S ribosomal protein S10-A OS=Saccharomyces cerevisiae (strain ATCC 204508 \ S288c) GN=RPS10A PE=1 SV=1" num_tol_term="2" num_missed_cleavages="0">
+<alternative_protein protein="sp|P46784|RS10B_YEAST" protein_descr="40S ribosomal protein S10-B OS=Saccharomyces cerevisiae (strain ATCC 204508 \ S288c) GN=RPS10B PE=1 SV=1" num_tol_term="2" peptide_prev_aa="K" peptide_next_aa="N"/>
+<search_score name="pvalue" value="0.0165201857351"/>
+<search_score name="expect" value="141.561471564068938"/>
+<analysis_result analysis="peptideprophet">
+<peptideprophet_result probability="0.9208" all_ntt_prob="(0.0000,0.0828,0.9208)">
+<search_score_summary>
+<parameter name="fval" value="-1.4340"/>
+<parameter name="ntt" value="2"/>
+<parameter name="nmc" value="0"/>
+<parameter name="massd" value="-0.005"/>
+<parameter name="isomassd" value="0"/>
+</search_score_summary>
+</peptideprophet_result>
+</analysis_result>
+<analysis_result analysis="interprophet">
+<interprophet_result probability="0.806668" all_ntt_prob="(0,0.0313812,0.806668)">
+<search_score_summary>
+<parameter name="nss" value="0"/>
+<parameter name="nrs" value="8.728"/>
+<parameter name="nsi" value="0"/>
+<parameter name="nsm" value="0"/>
+<parameter name="nsp" value="4.1724"/>
+</search_score_summary>
+</interprophet_result>
+</analysis_result>
+</search_hit>
+</search_result>
+</spectrum_query>
+<spectrum_query spectrum="JD_06232014_sample1-A.02770.02770.2" start_scan="2770" end_scan="2770" precursor_neutral_mass="719.385009765625" assumed_charge="2" index="59">
+<search_result>
+<search_hit hit_rank="1" peptide="GLVCGSK" peptide_prev_aa="A" peptide_next_aa="F" protein="sp|P43583|BLM10_YEAST" num_tot_proteins="1" num_matched_ions="3" tot_num_ions="12" calc_neutral_pep_mass="719.361999511719" massdiff="0.02301025390625" is_rejected="0" protein_descr="Proteasome activator BLM10 OS=Saccharomyces cerevisiae (strain ATCC 204508 \ S288c) GN=BLM10 PE=1 SV=2" num_tol_term="1" num_missed_cleavages="0">
+<modification_info modified_peptide="GLVCGSK">
+<mod_aminoacid_mass position="4" mass="160.03019"/>
+</modification_info>
+<search_score name="pvalue" value="16.309980374680311"/>
+<search_score name="expect" value="208914.538619280094281"/>
+<analysis_result analysis="peptideprophet">
+<peptideprophet_result probability="0.0000" all_ntt_prob="(0.0000,0.0000,0.0000)">
+<search_score_summary>
+<parameter name="fval" value="-3.5466"/>
+<parameter name="ntt" value="1"/>
+<parameter name="nmc" value="0"/>
+<parameter name="massd" value="0.023"/>
+<parameter name="isomassd" value="0"/>
+</search_score_summary>
+</peptideprophet_result>
+</analysis_result>
+<analysis_result analysis="interprophet">
+<interprophet_result probability="0" all_ntt_prob="(0,0,0)">
+<search_score_summary>
+<parameter name="nss" value="0"/>
+<parameter name="nrs" value="0"/>
+<parameter name="nsi" value="0"/>
+<parameter name="nsm" value="0"/>
+<parameter name="nsp" value="6.9737"/>
+</search_score_summary>
+</interprophet_result>
+</analysis_result>
+</search_hit>
+</search_result>
+</spectrum_query>
+<spectrum_query spectrum="JD_06232014_sample1-A.02999.02999.3" start_scan="2999" end_scan="2999" precursor_neutral_mass="1048.56799316406" assumed_charge="3" index="71">
+<search_result>
+<search_hit hit_rank="1" peptide="LIWTMIGIS" peptide_prev_aa="R" peptide_next_aa="F" protein="sp|Q04602|VBA4_YEAST" num_tot_proteins="1" num_matched_ions="5" tot_num_ions="16" calc_neutral_pep_mass="1048.56201171875" massdiff="0.0059814453125" is_rejected="0" protein_descr="Vacuolar basic amino acid transporter 4 OS=Saccharomyces cerevisiae (strain ATCC 204508 \ S288c) GN=VBA4 PE=1 SV=1" num_tol_term="1" num_missed_cleavages="0">
+<modification_info modified_peptide="LIWTM[147]IGIS">
+<mod_aminoacid_mass position="5" mass="147.03549"/>
+</modification_info>
+<search_score name="pvalue" value="0.000004789193846"/>
+<search_score name="expect" value="0.062867747613235"/>
+<analysis_result analysis="peptideprophet">
+<peptideprophet_result probability="0.2170" all_ntt_prob="(0.0000,0.2170,0.9875)">
+<search_score_summary>
+<parameter name="fval" value="0.8010"/>
+<parameter name="ntt" value="1"/>
+<parameter name="nmc" value="0"/>
+<parameter name="massd" value="0.006"/>
+<parameter name="isomassd" value="0"/>
+</search_score_summary>
+</peptideprophet_result>
+</analysis_result>
+<analysis_result analysis="interprophet">
+<interprophet_result probability="0.0223989" all_ntt_prob="(0,0.0223989,0.867219)">
+<search_score_summary>
+<parameter name="nss" value="0"/>
+<parameter name="nrs" value="0"/>
+<parameter name="nsi" value="0"/>
+<parameter name="nsm" value="0"/>
+<parameter name="nsp" value="4.0003"/>
+</search_score_summary>
+</interprophet_result>
+</analysis_result>
+</search_hit>
+</search_result>
+</spectrum_query>
+<spectrum_query spectrum="JD_06232014_sample1-A.03084.03084.2" start_scan="3084" end_scan="3084" precursor_neutral_mass="1131.52502441406" assumed_charge="2" index="75">
+<search_result>
+<search_hit hit_rank="1" peptide="EAGIVDELAYA" peptide_prev_aa="K" peptide_next_aa="V" protein="sp|P38764|RPN1_YEAST" num_tot_proteins="1" num_matched_ions="3" tot_num_ions="20" calc_neutral_pep_mass="1131.54504394531" massdiff="-0.02001953125" is_rejected="0" protein_descr="26S proteasome regulatory subunit RPN1 OS=Saccharomyces cerevisiae (strain ATCC 204508 \ S288c) GN=RPN1 PE=1 SV=3" num_tol_term="1" num_missed_cleavages="0">
+<modification_info modified_peptide="E[111]AGIVDELAYA">
+<mod_aminoacid_mass position="1" mass="111.03259"/>
+</modification_info>
+<search_score name="pvalue" value="0.007360701965562"/>
+<search_score name="expect" value="92.693319852322418"/>
+<analysis_result analysis="peptideprophet">
+<peptideprophet_result probability="0.0700" all_ntt_prob="(0.0000,0.0700,0.9064)">
+<search_score_summary>
+<parameter name="fval" value="-1.3114"/>
+<parameter name="ntt" value="1"/>
+<parameter name="nmc" value="0"/>
+<parameter name="massd" value="-0.020"/>
+<parameter name="isomassd" value="0"/>
+</search_score_summary>
+</peptideprophet_result>
+</analysis_result>
+<analysis_result analysis="interprophet">
+<interprophet_result probability="0.0505509" all_ntt_prob="(0,0.0505509,0.87261)">
+<search_score_summary>
+<parameter name="nss" value="0"/>
+<parameter name="nrs" value="0"/>
+<parameter name="nsi" value="0"/>
+<parameter name="nsm" value="0"/>
+<parameter name="nsp" value="20"/>
+</search_score_summary>
+</interprophet_result>
+</analysis_result>
+</search_hit>
+</search_result>
+</spectrum_query>
+<spectrum_query spectrum="JD_06232014_sample1-A.03905.03905.3" start_scan="3905" end_scan="3905" precursor_neutral_mass="1823.84899902344" assumed_charge="3" index="110">
+<search_result>
+<search_hit hit_rank="1" peptide="SASAQHSQAQQQQQQK" peptide_prev_aa="M" peptide_next_aa="S" protein="sp|Q04947|RTN1_YEAST" num_tot_proteins="1" num_matched_ions="12" tot_num_ions="30" calc_neutral_pep_mass="1823.85498046875" massdiff="-0.0059814453125" is_rejected="0" protein_descr="Reticulon-like protein 1 OS=Saccharomyces cerevisiae (strain ATCC 204508 \ S288c) GN=RTN1 PE=1 SV=1" num_tol_term="2" num_missed_cleavages="0">
+<modification_info mod_nterm_mass="43.0188" modified_peptide="n[43]SASAQHSQAQQQQQQK">
+</modification_info>
+<search_score name="pvalue" value="0.000000000004498"/>
+<search_score name="expect" value="0.000000064090788"/>
+<analysis_result analysis="peptideprophet">
+<peptideprophet_result probability="1.0000" all_ntt_prob="(0.0000,1.0000,1.0000)">
+<search_score_summary>
+<parameter name="fval" value="4.7950"/>
+<parameter name="ntt" value="2"/>
+<parameter name="nmc" value="0"/>
+<parameter name="massd" value="-0.006"/>
+<parameter name="isomassd" value="0"/>
+</search_score_summary>
+</peptideprophet_result>
+</analysis_result>
+<analysis_result analysis="interprophet">
+<interprophet_result probability="0.999999" all_ntt_prob="(0,1,1)">
+<search_score_summary>
+<parameter name="nss" value="0.4998"/>
+<parameter name="nrs" value="0"/>
+<parameter name="nsi" value="0.999999"/>
+<parameter name="nsm" value="0"/>
+<parameter name="nsp" value="9.90429"/>
+</search_score_summary>
+</interprophet_result>
+</analysis_result>
+</search_hit>
+</search_result>
+</spectrum_query>
+<spectrum_query spectrum="JD_06232014_sample1-A.07319.07319.2" start_scan="7319" end_scan="7319" precursor_neutral_mass="1360.57104492188" assumed_charge="2" index="256">
+<search_result>
+<search_hit hit_rank="1" peptide="CLPGPATASIYQT" peptide_prev_aa="K" peptide_next_aa="L" protein="sp|P25642|IMG2_YEAST" num_tot_proteins="1" num_matched_ions="2" tot_num_ions="24" calc_neutral_pep_mass="1360.63403320312" massdiff="-0.06298828125" is_rejected="0" protein_descr="54S ribosomal protein IMG2, mitochondrial OS=Saccharomyces cerevisiae (strain ATCC 204508 \ S288c) GN=IMG2 PE=1 SV=2" num_tol_term="1" num_missed_cleavages="0">
+<modification_info modified_peptide="C[143]LPGPATASIYQT">
+<mod_aminoacid_mass position="1" mass="143.00419"/>
+</modification_info>
+<search_score name="pvalue" value="0.012783531919578"/>
+<search_score name="expect" value="111.868687828230392"/>
+<analysis_result analysis="peptideprophet">
+<peptideprophet_result probability="0.0007" all_ntt_prob="(0.0000,0.0007,0.0848)">
+<search_score_summary>
+<parameter name="fval" value="-1.3658"/>
+<parameter name="ntt" value="1"/>
+<parameter name="nmc" value="0"/>
+<parameter name="massd" value="-0.063"/>
+<parameter name="isomassd" value="0"/>
+</search_score_summary>
+</peptideprophet_result>
+</analysis_result>
+<analysis_result analysis="interprophet">
+<interprophet_result probability="2.01282e-05" all_ntt_prob="(0,2.01282e-05,0.00265544)">
+<search_score_summary>
+<parameter name="nss" value="0"/>
+<parameter name="nrs" value="0"/>
+<parameter name="nsi" value="0"/>
+<parameter name="nsm" value="0"/>
+<parameter name="nsp" value="2"/>
+</search_score_summary>
+</interprophet_result>
+</analysis_result>
+</search_hit>
+</search_result>
+</spectrum_query>
+</msms_run_summary>
+</msms_pipeline_analysis>

--- a/src/tests/topp/IDFileConverter_16_output.idXML
+++ b/src/tests/topp/IDFileConverter_16_output.idXML
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<IdXML version="1.4" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="/dbase/Misc/iPRG2014/iPRG2015.TargDecoy.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="2" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+		<FixedModification name="Carbamidomethyl (C)" />
+		<VariableModification name="Oxidation (M)" />
+		<VariableModification name="Ammonia-loss (N-term C)" />
+		<VariableModification name="Glu-&gt;pyro-Glu (N-term E)" />
+		<VariableModification name="Gln-&gt;pyro-Glu (N-term Q)" />
+		<VariableModification name="Acetyl (N-term)" />
+	</SearchParameters>
+	<IdentificationRun date="2014-10-27T15:00:44" search_engine="OMSSA" search_engine_version="" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="sp|Q08745|RS10A_YEAST" score="0" sequence="" >
+			</ProteinHit>
+			<ProteinHit id="PH_1" accession="sp|P46784|RS10B_YEAST" score="0" sequence="" >
+			</ProteinHit>
+			<ProteinHit id="PH_2" accession="sp|P43583|BLM10_YEAST" score="0" sequence="" >
+			</ProteinHit>
+			<ProteinHit id="PH_3" accession="sp|Q04602|VBA4_YEAST" score="0" sequence="" >
+			</ProteinHit>
+			<ProteinHit id="PH_4" accession="sp|P38764|RPN1_YEAST" score="0" sequence="" >
+			</ProteinHit>
+			<ProteinHit id="PH_5" accession="sp|Q04947|RTN1_YEAST" score="0" sequence="" >
+			</ProteinHit>
+			<ProteinHit id="PH_6" accession="sp|P25642|IMG2_YEAST" score="0" sequence="" >
+			</ProteinHit>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="436.210339680337" RT="0" >
+			<PeptideHit score="0.806668" sequence="HEEIDTK" charge="2" aa_before="K X" aa_after="N X" protein_refs="PH_0 PH_1" >
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="360.700329914712" RT="0" >
+			<PeptideHit score="0" sequence="GLVC(Carbamidomethyl)GSK" charge="2" aa_before="A" aa_after="F" protein_refs="PH_2" >
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="350.53048941992" RT="0" >
+			<PeptideHit score="0.0223989" sequence="LIWTM(Oxidation)IGIS" charge="3" aa_before="R" aa_after="F" protein_refs="PH_3" >
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="566.77033723893" RT="0" >
+			<PeptideHit score="0.0505509" sequence="(Glu->pyro-Glu)EAGIVDELAYA" charge="2" aa_before="K" aa_after="V" protein_refs="PH_4" >
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="608.957491373047" RT="0" >
+			<PeptideHit score="0.999999" sequence="SASAQHSQAQQQQQQK" charge="3" aa_before="M" aa_after="S" protein_refs="PH_5" >
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="681.29334749284" RT="0" >
+			<PeptideHit score="2.01282e-05" sequence="(Pyro-carbamidomethyl)C(Carbamidomethyl)LPGPATASIYQT" charge="2" aa_before="K" aa_after="L" protein_refs="PH_6" >
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>


### PR DESCRIPTION
Note to reviewers: The part that was deleted in PepXMLFile.cpp (`if (!desc.empty()) ...`) is repeated later (https://github.com/OpenMS/OpenMS/compare/develop...hendrikweisser:fix-pepxml-mods?expand=1#diff-0ce89f78310b558a3cb2058c1337de32L1269). It was redundant after I fixed the `desc = ...` line.
