### PR TITLE
[BUILD] remove OSX from continous testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: cpp
 os:
  - linux
- - osx
 cache: apt
 addons:
    apt:
@@ -62,8 +61,9 @@ matrix:
       os: linux
       compiler: clang
 
-## OS X tests
-    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=OFF DISABLE_WAVELET2DTEST=OFF ADDRESS_SANITIZER=Off BUILD_TYPE=Release
-      os: osx
-      compiler: clang
+### OS X tests
+#    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=OFF DISABLE_WAVELET2DTEST=OFF ADDRESS_SANITIZER=Off BUILD_TYPE=Release
+#      os: osx
+#      compiler: clang
+#
 


### PR DESCRIPTION
due to repeated timeouts and other issues with the OSX build, remove it
for now

I dont think there is much sense in having failed tests all the time. It makes more sense to have Windows and OSX in the nightly tests but I prefer to have quick Linux-only travis but at least they tell me when something is really broken instead of having false positive build failures all the time due to OSX timeouts