### PR TITLE
[FIX] InternalCalibration: calibrate m/z of precursor peaks as well

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
+++ b/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
@@ -202,12 +202,11 @@ namespace OpenMS
                    const String& file_residuals_plot = "");
 
     /*
-      @brief Transform a spectrum (data+precursor)
+      @brief Transform a precursor's m/z
 
-      All peaks are calibrated in m/z.
-      Precursor m/z remains untouched (if present).
+      Calibrate m/z of precursors.
 
-      @param spec Uncalibrated MSSpectrum
+      @param pcs Uncalibrated Precursors
       @param trafo The calibration function to apply
     */
     static void applyTransformation(std::vector<Precursor>& pcs, const MZTrafoModel& trafo);
@@ -215,13 +214,13 @@ namespace OpenMS
     /*
       @brief Transform a spectrum (data+precursor)
 
-      All peaks are calibrated in m/z.
-      Precursor m/z remains untouched (if present).
+      See applyTransformation(MSExperiment, ...) for details.
 
       @param spec Uncalibrated MSSpectrum
+      @param target_mslvl List (can be unsorted) of MS levels to calibrate
       @param trafo The calibration function to apply
     */
-    static void applyTransformation(MSExperiment<>::SpectrumType& spec, const MZTrafoModel& trafo);
+    static void applyTransformation(MSExperiment<>::SpectrumType& spec, const IntList& target_mslvl, const MZTrafoModel& trafo);
 
     /*
       @brief Transform spectra from a whole map (data+precursor)
@@ -229,7 +228,7 @@ namespace OpenMS
       All data peaks and precursor information (if present) are calibrated in m/z.
 
       Only spectra whose MS-level is contained in 'target_mslvl' are calibrated.
-      If a fragmentation spectrum's precursor information originates from an MS level in 'target_mslvl',
+      In addition, if a fragmentation spectrum's precursor information originates from an MS level in 'target_mslvl',
       the precursor (not the spectrum itself) is also subjected to calibration.
       E.g., If we only have MS and MS/MS spectra: for 'target_mslvl' = {1} then all MS1 spectra and MS2 precursors are calibrated.
       If 'target_mslvl' = {2}, only MS2 spectra (not their precursors) are calibrated.
@@ -259,6 +258,13 @@ namespace OpenMS
 
     */
     void fillIDs_( const std::vector<PeptideIdentification>& pep_ids, double tol_ppm );
+
+    /*
+     @brief Calibrate m/z of a spectrum, ignoring precursors!
+
+     This method is not exposed as public, because its easy to be misused on spectra while forgetting about the precursors of high-level spectra.
+    */
+    static void applyTransformation_(MSExperiment<>::SpectrumType& spec, const MZTrafoModel& trafo);
 
   private:
     CalibrationData cal_data_;

--- a/src/openms/source/FILTERING/CALIBRATION/InternalCalibration.cpp
+++ b/src/openms/source/FILTERING/CALIBRATION/InternalCalibration.cpp
@@ -65,7 +65,7 @@ namespace OpenMS
     }
   }
 
-  void InternalCalibration::applyTransformation(MSExperiment<>::SpectrumType& spec, const MZTrafoModel& trafo)
+  void InternalCalibration::applyTransformation_(MSExperiment<>::SpectrumType& spec, const MZTrafoModel& trafo)
   {
     typedef MSExperiment<>::SpectrumType::Iterator SpecIt;
 
@@ -76,20 +76,25 @@ namespace OpenMS
     }
   }
 
+  void InternalCalibration::applyTransformation(MSExperiment<>::SpectrumType& spec, const IntList& target_mslvl, const MZTrafoModel& trafo)
+  {
+    // calibrate the peaks?
+    if (ListUtils::contains(target_mslvl, spec.getMSLevel()))
+    {
+      applyTransformation_(spec, trafo);
+    }
+    // apply PC correction (only if target is MS1, and current spec is MS2; or target is MS2 and cs is MS3,...)
+    if (ListUtils::contains(target_mslvl, spec.getMSLevel() - 1))
+    {
+      applyTransformation(spec.getPrecursors(), trafo);
+    }     
+  }
+
   void InternalCalibration::applyTransformation(MSExperiment<>& exp, const IntList& target_mslvl, const MZTrafoModel& trafo)
   {
     for (MSExperiment<>::Iterator it = exp.begin(); it != exp.end(); ++it)
     {
-      // calibrate the peaks?
-      if (ListUtils::contains(target_mslvl, it->getMSLevel()))
-      {
-        applyTransformation(*it, trafo);
-      }
-      // apply PC correction (only if target is MS1, and current spec is MS2; or target is MS2 and cs is MS3,...)
-      if (ListUtils::contains(target_mslvl, it->getMSLevel() - 1))
-      {
-        applyTransformation(it->getPrecursors(), trafo);
-      }     
+      applyTransformation(*it, target_mslvl, trafo);
     }
   }
 
@@ -293,7 +298,11 @@ namespace OpenMS
         setProgress(i);
 
         // skip this MS level?
-        if (!ListUtils::contains(target_mslvl, it->getMSLevel())) continue;
+        if (!(ListUtils::contains(target_mslvl, it->getMSLevel()) ||     // scan m/z needs correction
+              ListUtils::contains(target_mslvl, it->getMSLevel() - 1)))  // precursor m/z needs correction
+        {
+          continue;
+        }
 
         //
         // build model
@@ -306,7 +315,7 @@ namespace OpenMS
         }
         else
         {
-          applyTransformation(*it, tms.back());
+          applyTransformation(*it, target_mslvl, tms.back());
         }
         ++i_mslvl;
       } // MSExp::iter
@@ -345,7 +354,7 @@ namespace OpenMS
           {
             model_index = p + dist_right;
           }
-          applyTransformation(exp[it->second], tms[model_index]);
+          applyTransformation(exp[it->second], target_mslvl, tms[model_index]);
           tms_new[p].setCoefficients(tms[model_index]); // overwrite invalid model
         }
         tms_new.swap(tms);

--- a/src/topp/InternalCalibration.cpp
+++ b/src/topp/InternalCalibration.cpp
@@ -133,6 +133,8 @@ using namespace std;
   Usually, peptide ID's provide calibration points for MS1 precursors, i.e. are suitable for MS1. They are applicable for MS2 only if
   the same mass analyzer was used (e.g. Q-Exactive). In other words, MS/MS spectra acquired using the ion trap analyzer of a Velos cannot be calibrated using
   peptide ID's.
+  Precursor m/z associated to higher-level MS spectra are corrected if their precursor spectra are subject to calibration, 
+  e.g. precursor information within MS2 spectra is calibrated if target ms-level is set to 1.
   Lock masses ('cal:lock_in') can be specified freely for MS1 and/or MS2.
 
 


### PR DESCRIPTION
This PR fixes the overlooked correction of precursor m/z for spectra which are not explicitly targeted,
e.g. if -ms_level == 1, then MS2 precursor information now gets calibrated according to the model applied to MS1. MS2 m/z itself is not changed (unless -ms_level 1 2).
