### PR TITLE
[TEST] fix pyopenms test

### DIFF
--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -4347,9 +4347,10 @@ def testEnzymesDB():
     assert edb.hasEnzyme(s(b"testEnzyme"))
     assert edb.hasRegEx(s(b"someregex"))
 
-    edb.clear()
-    assert not edb.hasEnzyme(pyopenms.String("testEnzyme"))
-    assert not edb.hasEnzyme(pyopenms.String("Trypsin"))
+    # cannot clear a global variable and expect things to stay the same!!
+    # edb.clear()
+    # assert not edb.hasEnzyme(pyopenms.String("testEnzyme"))
+    # assert not edb.hasEnzyme(pyopenms.String("Trypsin"))
 
 
 @report


### PR DESCRIPTION
fix an error in the pyOpenMS tests

basically, nose imports everything once and then runs all the tests. This, however, has severe problems when we change a global variable. In essence, what happened was that we (for testing) deleted the whole, global, enzyme database and when we later wanted to access it when loading pepXML, there were no more Enzymes :-) 

- reported, among others, in #2246 

possible solutions

- do not run nose tests any more
- do not delete enzyme db any more