### PR TITLE
Revert "[FIX] address missing OpenMS.ini problem"

### DIFF
--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2139,7 +2139,11 @@ namespace OpenMS
     tmp.update(tool_user_defaults);
 
     // 3rd stage, use OpenMS.ini from library to override settings
-    // -> currently disabled as we cannot write back those values to the params
+    Param system_defaults(File::getSystemParameters());
+    // this currently writes to the wrong part of the ini-file (revise) or remove altogether:
+    //   there should be no section which already contains these params (-> thus a lot of warnings are emitted)
+    //   furthermore, entering those params will not allow us to change settings in OpenMS.ini and expect them to be effective, as they will be overridden by the tools' ini file
+    //tmp.update(system_defaults);
 
     return tmp;
   }

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -184,9 +184,7 @@ END_SECTION
 START_SECTION(static String getUserDirectory())
   TEST_NOT_EQUAL(File::getUserDirectory(), String())
   TEST_EQUAL(File::exists(File::getUserDirectory()), true)
-
-  // set user directory to a path set by environmental variable and test that
-  // it is correctly set (no changes on the file system occur)
+  // create OpenMS ini in path set by evironmental variable
   QDir d;
   String dirname = File::getTempDirectory() + "/" + File::getUniqueName() + "/";
   TEST_EQUAL(d.mkpath(dirname.toQString()), TRUE);
@@ -196,8 +194,7 @@ START_SECTION(static String getUserDirectory())
   setenv("OPENMS_HOME_PATH", dirname.c_str(), 0);  
 #endif
   TEST_EQUAL(File::getUserDirectory(), dirname)
-  // Note: this does not guarantee any more that the user directory or an
-  // OpenMS.ini file exists at the new location.
+  TEST_EQUAL(File::exists(File::getUserDirectory() + ".OpenMS/OpenMS.ini"), true)
 END_SECTION
 
 START_SECTION(static Param getSystemParameters())
@@ -214,6 +211,7 @@ START_SECTION(static String findDatabase(const String &db_name))
   TEST_EQUAL(db.hasSubstring("share/OpenMS"), true)
 
 END_SECTION
+
 
 START_SECTION(static String findExecutable(const OpenMS::String& toolName))
 {


### PR DESCRIPTION
Reverts OpenMS/OpenMS#1967
I clicked merge to fast... sorry.

@hroest could you please check Param File::getSystemParameters() again?
Right now it doesn't create the folder for the .ver files in the UpdateChecker.
This is bad as it effectively disables the update check