### PR TITLE
[FIX] fix #2328 by handling unit attributes in mzid with a little slack

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -495,7 +495,11 @@ namespace OpenMS
           u = CVTerm::Unit(unitAcc, unitCvRef, unitName);
           if (unitCvRef.empty())
           {
-            LOG_WARN << "MZID retention times with units but without unit cv reference encountered!" << endl;
+            LOG_WARN << "This mzid file uses a cv term with units, but without "
+                     << "unit cv reference (required)! Please notify the mzid "
+                     << "producer of this file. \"" << name << "\" will be read as \""
+                     << unitName << "\" but further actions on this unit may fail."
+                     << endl;
           }
         }
         return CVTerm(accession, name, cvRef, value, u);

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -490,11 +490,14 @@ namespace OpenMS
         String unitCvRef = XMLString::transcode(param->getAttribute(XMLString::transcode("unitCvRef")));
 
         CVTerm::Unit u; // TODO @mths : make DataValue usage safe!
-        if (!unitAcc.empty() && !unitCvRef.empty() && !unitName.empty())
+        if (!unitAcc.empty() && !unitName.empty())
         {
           u = CVTerm::Unit(unitAcc, unitCvRef, unitName);
+          if (unitCvRef.empty())
+          {
+            LOG_WARN << "MZID retention times with units but without unit cv reference encountered!" << endl;
+          }
         }
-        // TODO: warn if only a part of the unit attributes are not empty?
         return CVTerm(accession, name, cvRef, value, u);
       }
       else


### PR DESCRIPTION
might be a fix for #2328  and extended #2134 with the drawback, that further processing might turn sour when some exotic ontology is used as unit reference, which I'd deem unlikely, but still, possible.