### PR TITLE
Feature/Averagine approximation for fragment isotope distributions

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -36,8 +36,8 @@
 #define OPENMS_CHEMISTRY_EMPIRICALFORMULA_H
 
 #include <iosfwd>
-#include <vector>
 #include <map>
+#include <set>
 #include <algorithm>
 
 #include <OpenMS/CONCEPT/Types.h>
@@ -151,14 +151,14 @@ public:
 
     /**
       @brief returns the fragment isotope distribution of this given a precursor formula
-      and conditioned on a list of isolated precursor isotopes.
+      and conditioned on a set of isolated precursor isotopes.
 
       The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
       @param precursor: the empirical formula of the precursor
       @param precursor_isotopes: the precursor isotopes that were isolated
       @return the conditional IsotopeDistribution of the fragment
     */
-    IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const;
+    IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes) const;
 
     /// returns the number of atoms for a certain @p element (can be negative)
     SignedSize getNumberOf(const Element* element) const;

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -165,7 +165,7 @@ public:
         @param average_weight_fragment: average weight of the fragment
         @param precursor_isotopes: the precursor isotopes that were isolated
 
-        @pre average_weight_precursor > average_weight_fragment
+        @pre average_weight_precursor >= average_weight_fragment
         @pre average_weight_fragment > 0
         @pre average_weight_precursor > 0
         @pre precursor_isotopes.size() > 0
@@ -181,7 +181,7 @@ public:
         @param average_weight_fragment: average weight of the fragment
         @param precursor_isotopes: the precursor isotopes that were isolated
 
-        @pre average_weight_precursor > average_weight_fragment
+        @pre average_weight_precursor >= average_weight_fragment
         @pre average_weight_precursor > 0
         @pre average_weight_fragment > 0
         @pre precursor_isotopes.size() > 0
@@ -197,7 +197,7 @@ public:
         @param average_weight_fragment: average weight of the fragment
         @param precursor_isotopes: the precursor isotopes that were isolated
 
-        @pre average_weight_precursor > average_weight_fragment
+        @pre average_weight_precursor >= average_weight_fragment
         @pre average_weight_precursor > 0
         @pre average_weight_fragment > 0
         @pre precursor_isotopes.size() > 0
@@ -220,7 +220,7 @@ public:
         @param P: The approximate relative stoichiometry of Phosphoruses to other elements in this molecule
 
         @pre S, C, H, N, O, P >= 0
-        @pre average_weight_precursor > average_weight_fragment
+        @pre average_weight_precursor >= average_weight_fragment
         @pre average_weight_precursor > 0
         @pre average_weight_fragment > 0
         @pre precursor_isotopes.size() > 0

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -39,6 +39,7 @@
 
 #include <utility>
 #include <vector>
+#include <set>
 
 namespace OpenMS
 {
@@ -170,7 +171,7 @@ public:
         @pre average_weight_precursor > 0
         @pre precursor_isotopes.size() > 0
     */
-    void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes);
+    void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes);
 
     /**
         @brief Estimate RNA fragment IsotopeDistribution from the precursor's average weight,
@@ -186,7 +187,7 @@ public:
         @pre average_weight_fragment > 0
         @pre precursor_isotopes.size() > 0
     */
-    void estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes);
+    void estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes);
 
     /**
         @brief Estimate DNA fragment IsotopeDistribution from the precursor's average weight,
@@ -202,7 +203,7 @@ public:
         @pre average_weight_fragment > 0
         @pre precursor_isotopes.size() > 0
     */
-    void estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes);
+    void estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes);
 
     /**
         @brief Estimate fragment IsotopeDistribution from the precursor's average weight,
@@ -225,7 +226,7 @@ public:
         @pre average_weight_fragment > 0
         @pre precursor_isotopes.size() > 0
      */
-    void estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P);
+    void estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P);
 
     /**
         @brief Calculate isotopic distribution for a fragment molecule
@@ -240,7 +241,7 @@ public:
         @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
         @param precursor_isotopes a list of which precursor isotopes were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
     */
-    void calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes);
+    void calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes);
 
     /** @brief re-normalizes the sum of the probabilities of the isotopes to 1
 
@@ -328,9 +329,9 @@ protected:
 
         @param fragment_isotope_dist the isotopic distribution of the fragment (as if it was a precursor).
         @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
-        @param precursor_isotopes a list of which precursor isotopes were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
+        @param precursor_isotopes which precursor isotopes were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
      */
-    void calcFragmentIsotopeDist_(ContainerType& result, const ContainerType& fragment_isotope_dist, const ContainerType& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes);
+    void calcFragmentIsotopeDist_(ContainerType& result, const ContainerType& fragment_isotope_dist, const ContainerType& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes);
 
     /// fill a gapped isotope pattern (i.e. certain masses are missing), with zero probability masses
     ContainerType fillGaps_(const ContainerType& id) const;

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -163,7 +163,7 @@ public:
         The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
         @param average_weight_precursor: average weight of the precursor peptide
         @param average_weight_fragment: average weight of the fragment
-        @param precursor_isotopes: the precursor isotopes that were isolated
+        @param precursor_isotopes: the precursor isotopes that were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
 
         @pre average_weight_precursor >= average_weight_fragment
         @pre average_weight_fragment > 0
@@ -179,7 +179,7 @@ public:
         The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
         @param average_weight_precursor: average weight of the precursor nucleotide
         @param average_weight_fragment: average weight of the fragment
-        @param precursor_isotopes: the precursor isotopes that were isolated
+        @param precursor_isotopes: the precursor isotopes that were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
 
         @pre average_weight_precursor >= average_weight_fragment
         @pre average_weight_precursor > 0
@@ -195,7 +195,7 @@ public:
         The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
         @param average_weight_precursor: average weight of the precursor nucleotide
         @param average_weight_fragment: average weight of the fragment
-        @param precursor_isotopes: the precursor isotopes that were isolated
+        @param precursor_isotopes: the precursor isotopes that were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
 
         @pre average_weight_precursor >= average_weight_fragment
         @pre average_weight_precursor > 0
@@ -211,7 +211,7 @@ public:
         The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
         @param average_weight_precursor: average weight of the precursor molecule
         @param average_weight_fragment: average weight of the fragment molecule
-        @param precursor_isotopes: the precursor isotopes that were isolated
+        @param precursor_isotopes: the precursor isotopes that were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
         @param C: The approximate relative stoichiometry of Carbons to other elements in this molecule
         @param H: The approximate relative stoichiometry of Hydrogens to other elements in this molecule
         @param N: The approximate relative stoichiometry of Nitrogens to other elements in this molecule
@@ -238,7 +238,7 @@ public:
         "Dissociation of Individual Isotopic Peaks: Predicting Isotopic Distributions of Product Ions in MSn"
         @param fragment_isotope_dist the isotopic distribution of the fragment (as if it was a precursor).
         @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
-        @param precursor_isotopes a list of which precursor isotopes were isolated
+        @param precursor_isotopes a list of which precursor isotopes were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
     */
     void calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes);
 
@@ -328,7 +328,7 @@ protected:
 
         @param fragment_isotope_dist the isotopic distribution of the fragment (as if it was a precursor).
         @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
-        @param precursor_isotopes a list of which precursor isotopes were isolated
+        @param precursor_isotopes a list of which precursor isotopes were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
      */
     void calcFragmentIsotopeDist_(ContainerType& result, const ContainerType& fragment_isotope_dist, const ContainerType& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes);
 

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -155,6 +155,78 @@ public:
     */
     void estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P);
 
+
+    /**
+        @brief Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
+        fragment's average weight, and a list of isolated precursor isotopes.
+
+        The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
+        @param average_weight_precursor: average weight of the precursor peptide
+        @param average_weight_fragment: average weight of the fragment
+        @param precursor_isotopes: the precursor isotopes that were isolated
+
+        @pre average_weight_precursor > average_weight_fragment
+        @pre average_weight_fragment > 0
+        @pre average_weight_precursor > 0
+        @pre precursor_isotopes.size() > 0
+    */
+    void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes);
+
+    /**
+        @brief Estimate RNA fragment IsotopeDistribution from the precursor's average weight,
+        fragment's average weight, and a list of isolated precursor isotopes.
+
+        The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
+        @param average_weight_precursor: average weight of the precursor nucleotide
+        @param average_weight_fragment: average weight of the fragment
+        @param precursor_isotopes: the precursor isotopes that were isolated
+
+        @pre average_weight_precursor > average_weight_fragment
+        @pre average_weight_precursor > 0
+        @pre average_weight_fragment > 0
+        @pre precursor_isotopes.size() > 0
+    */
+    void estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes);
+
+    /**
+        @brief Estimate DNA fragment IsotopeDistribution from the precursor's average weight,
+        fragment's average weight, and a list of isolated precursor isotopes.
+
+        The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
+        @param average_weight_precursor: average weight of the precursor nucleotide
+        @param average_weight_fragment: average weight of the fragment
+        @param precursor_isotopes: the precursor isotopes that were isolated
+
+        @pre average_weight_precursor > average_weight_fragment
+        @pre average_weight_precursor > 0
+        @pre average_weight_fragment > 0
+        @pre precursor_isotopes.size() > 0
+    */
+    void estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes);
+
+    /**
+        @brief Estimate fragment IsotopeDistribution from the precursor's average weight,
+        fragment's average weight, a list of isolated precursor isotopes, and average composition
+
+        The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
+        @param average_weight_precursor: average weight of the precursor molecule
+        @param average_weight_fragment: average weight of the fragment molecule
+        @param precursor_isotopes: the precursor isotopes that were isolated
+        @param C: The approximate relative stoichiometry of Carbons to other elements in this molecule
+        @param H: The approximate relative stoichiometry of Hydrogens to other elements in this molecule
+        @param N: The approximate relative stoichiometry of Nitrogens to other elements in this molecule
+        @param O: The approximate relative stoichiometry of Oxygens to other elements in this molecule
+        @param S: The approximate relative stoichiometry of Sulfurs to other elements in this molecule
+        @param P: The approximate relative stoichiometry of Phosphoruses to other elements in this molecule
+
+        @pre S, C, H, N, O, P >= 0
+        @pre average_weight_precursor > average_weight_fragment
+        @pre average_weight_precursor > 0
+        @pre average_weight_fragment > 0
+        @pre precursor_isotopes.size() > 0
+     */
+    void estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P);
+
     /**
         @brief Calculate isotopic distribution for a fragment molecule
 

--- a/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
+++ b/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
@@ -152,7 +152,7 @@ namespace OpenMS
     return result;
   }
 
-  IsotopeDistribution EmpiricalFormula::getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const
+  IsotopeDistribution EmpiricalFormula::getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes) const
   {
     // A fragment's isotopes can only be as high as the largest isolated precursor isotope.
     UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end())+1;

--- a/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
@@ -187,6 +187,37 @@ namespace OpenMS
       distribution_ = ef.getIsotopeDistribution(max_isotope_).getContainer();
   }
 
+  void IsotopeDistribution::estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes)
+  {
+    // Element counts are from Senko's Averagine model
+    estimateForFragmentFromWeightAndComp(average_weight_precursor, average_weight_fragment, precursor_isotopes, 4.9384, 7.7583, 1.3577, 1.4773, 0.0417, 0);
+  }
+
+  void IsotopeDistribution::estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes)
+  {
+    estimateForFragmentFromWeightAndComp(average_weight_precursor, average_weight_fragment, precursor_isotopes, 9.75, 12.25, 3.75, 7, 0, 1);
+  }
+
+  void IsotopeDistribution::estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes)
+  {
+    estimateForFragmentFromWeightAndComp(average_weight_precursor, average_weight_fragment, precursor_isotopes, 9.75, 12.25, 3.75, 6, 0, 1);
+  }
+
+  void IsotopeDistribution::estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P)
+  {
+    UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end())+1;
+
+    EmpiricalFormula ef_fragment;
+    ef_fragment.estimateFromWeightAndComp(average_weight_fragment, C, H, N, O, S, P);
+    IsotopeDistribution id_fragment = ef_fragment.getIsotopeDistribution(max_depth);
+
+    EmpiricalFormula ef_comp_frag;
+    ef_comp_frag.estimateFromWeightAndComp(average_weight_precursor-average_weight_fragment, C, H, N, O, S, P);
+    IsotopeDistribution id_comp_fragment = ef_comp_frag.getIsotopeDistribution(max_depth);
+
+    calcFragmentIsotopeDist(id_fragment, id_comp_fragment, precursor_isotopes);
+  }
+
   void IsotopeDistribution::calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes)
   {
     ContainerType result;

--- a/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
@@ -205,7 +205,7 @@ namespace OpenMS
 
   void IsotopeDistribution::estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P)
   {
-    UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end())+1;
+    UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end()) + 1;
 
     EmpiricalFormula ef_fragment;
     ef_fragment.estimateFromWeightAndComp(average_weight_fragment, C, H, N, O, S, P);

--- a/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
@@ -187,23 +187,23 @@ namespace OpenMS
       distribution_ = ef.getIsotopeDistribution(max_isotope_).getContainer();
   }
 
-  void IsotopeDistribution::estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes)
+  void IsotopeDistribution::estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes)
   {
     // Element counts are from Senko's Averagine model
     estimateForFragmentFromWeightAndComp(average_weight_precursor, average_weight_fragment, precursor_isotopes, 4.9384, 7.7583, 1.3577, 1.4773, 0.0417, 0);
   }
 
-  void IsotopeDistribution::estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes)
+  void IsotopeDistribution::estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes)
   {
     estimateForFragmentFromWeightAndComp(average_weight_precursor, average_weight_fragment, precursor_isotopes, 9.75, 12.25, 3.75, 7, 0, 1);
   }
 
-  void IsotopeDistribution::estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes)
+  void IsotopeDistribution::estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes)
   {
     estimateForFragmentFromWeightAndComp(average_weight_precursor, average_weight_fragment, precursor_isotopes, 9.75, 12.25, 3.75, 6, 0, 1);
   }
 
-  void IsotopeDistribution::estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P)
+  void IsotopeDistribution::estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P)
   {
     UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end()) + 1;
 
@@ -218,7 +218,7 @@ namespace OpenMS
     calcFragmentIsotopeDist(id_fragment, id_comp_fragment, precursor_isotopes);
   }
 
-  void IsotopeDistribution::calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes)
+  void IsotopeDistribution::calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes)
   {
     ContainerType result;
     calcFragmentIsotopeDist_(result, fragment_isotope_dist.distribution_, comp_fragment_isotope_dist.distribution_, precursor_isotopes);
@@ -382,7 +382,7 @@ namespace OpenMS
     return;
   }
 
-  void IsotopeDistribution::calcFragmentIsotopeDist_(ContainerType& result, const ContainerType& fragment_isotope_dist, const ContainerType& comp_fragment_isotope_dist, const std::vector<UInt>& precursor_isotopes)
+  void IsotopeDistribution::calcFragmentIsotopeDist_(ContainerType& result, const ContainerType& fragment_isotope_dist, const ContainerType& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes)
   {
     if (fragment_isotope_dist.empty() || comp_fragment_isotope_dist.empty())
     {
@@ -445,7 +445,7 @@ namespace OpenMS
     //
     for (Size i = 0; i < fragment_isotope_dist_l.size(); ++i)
     {
-      for (std::vector<UInt>::const_iterator precursor_itr = precursor_isotopes.begin(); precursor_itr != precursor_isotopes.end(); ++precursor_itr)
+      for (std::set<UInt>::const_iterator precursor_itr = precursor_isotopes.begin(); precursor_itr != precursor_isotopes.end(); ++precursor_itr)
       {
         if (*precursor_itr >= i &&
                 (*precursor_itr-i) < comp_fragment_isotope_dist_l.size())

--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -35,8 +35,8 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
         # @brief returns the fragment isotope distribution of this conditioned
         # on a precursor formula and a list of isolated precursor isotopes.
         # @param precursor: the empirical formula of the precursor
-        # @param precursor_isotopes: the list of precursor isotopes that were isolated
-        IsotopeDistribution getConditionalFragmentIsotopeDist(EmpiricalFormula& precursor, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
+        # @param precursor_isotopes: the set of precursor isotopes that were isolated
+        IsotopeDistribution getConditionalFragmentIsotopeDist(EmpiricalFormula& precursor, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # returns the number of atoms
         Size getNumberOf(Element * element) nogil except +

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -49,6 +49,22 @@ cdef extern from "<OpenMS/CHEMISTRY/IsotopeDistribution.h>" namespace "OpenMS":
 
         void estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P) nogil except +
 
+        # Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
+        # fragment's average weight, and a list of isolated precursor isotopes.
+        void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
+
+        # Estimate RNA fragment IsotopeDistribution from the precursor's average weight,
+        # fragment's average weight, and a list of isolated precursor isotopes.
+        void estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
+
+        # Estimate DNA fragment IsotopeDistribution from the precursor's average weight,
+        # fragment's average weight, and a list of isolated precursor isotopes.
+        void estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
+
+        # Estimate fragment IsotopeDistribution from the precursor's average weight,
+        # fragment's average weight, a list of isolated precursor isotopes, and average composition
+        void estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, libcpp_vector[ unsigned int ]& precursor_isotopes, double C, double H, double N, double O, double S, double P) nogil except +
+
         # Calculate isotopic distribution for a fragment molecule
 
         void calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -50,24 +50,24 @@ cdef extern from "<OpenMS/CHEMISTRY/IsotopeDistribution.h>" namespace "OpenMS":
         void estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P) nogil except +
 
         # Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
-        # fragment's average weight, and a list of isolated precursor isotopes.
-        void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
+        # fragment's average weight, and a set of isolated precursor isotopes.
+        void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # Estimate RNA fragment IsotopeDistribution from the precursor's average weight,
-        # fragment's average weight, and a list of isolated precursor isotopes.
-        void estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
+        # fragment's average weight, and a set of isolated precursor isotopes.
+        void estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # Estimate DNA fragment IsotopeDistribution from the precursor's average weight,
-        # fragment's average weight, and a list of isolated precursor isotopes.
-        void estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
+        # fragment's average weight, and a set of isolated precursor isotopes.
+        void estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # Estimate fragment IsotopeDistribution from the precursor's average weight,
-        # fragment's average weight, a list of isolated precursor isotopes, and average composition
-        void estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, libcpp_vector[ unsigned int ]& precursor_isotopes, double C, double H, double N, double O, double S, double P) nogil except +
+        # fragment's average weight, a set of isolated precursor isotopes, and average composition
+        void estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, libcpp_set unsigned int ]& precursor_isotopes, double C, double H, double N, double O, double S, double P) nogil except +
 
         # Calculate isotopic distribution for a fragment molecule
 
-        void calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_vector[ unsigned int ]& precursor_isotopes) nogil except +
+        void calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # renormalizes the sum of the probabilities of the isotopes to 1
         void renormalize() nogil except +

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -332,12 +332,12 @@ START_SECTION(IsotopeDistribution getIsotopeDistribution(UInt max_depth) const)
   }
 END_SECTION
 
-START_SECTION(IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::vector<UInt>& precursor_isotopes) const)
+START_SECTION(IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes) const)
   EmpiricalFormula precursor("C2");
   EmpiricalFormula fragment("C");
-  std::vector<UInt> precursor_isotopes;
+  std::set<UInt> precursor_isotopes;
 
-  precursor_isotopes.push_back(0);
+  precursor_isotopes.insert(0);
   // isolated precursor isotope is M0
   IsotopeDistribution iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
   double result[] = { 1.0 };
@@ -347,8 +347,8 @@ START_SECTION(IsotopeDistribution getConditionalFragmentIsotopeDist(const Empiri
     TEST_REAL_SIMILAR(it->second, result[i])
   }
 
-  precursor_isotopes.pop_back();
-  precursor_isotopes.push_back(1);
+  precursor_isotopes.clear();
+  precursor_isotopes.insert(1);
   // isolated precursor isotope is M+1
   iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
   double result2[] = { 0.5, 0.5};
@@ -358,7 +358,7 @@ START_SECTION(IsotopeDistribution getConditionalFragmentIsotopeDist(const Empiri
     TEST_REAL_SIMILAR(it->second, result2[i])
   }
 
-  precursor_isotopes.push_back(0);
+  precursor_isotopes.insert(0);
   // isolated precursor isotopes are M0 and M+1
   iso = fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
   double result3[] = { 0.98941, 0.01059};
@@ -368,7 +368,7 @@ START_SECTION(IsotopeDistribution getConditionalFragmentIsotopeDist(const Empiri
     TEST_REAL_SIMILAR(it->second, result3[i])
   }
 
-  precursor_isotopes.push_back(2);
+  precursor_isotopes.insert(2);
   // isolated precursor isotopes are M0, M+1, and M+2
   // This is the example found in the comments of the getConditionalFragmentIsotopeDist function.
   // Since we're isolating all the possible precursor isotopes, the fragment isotope distribution
@@ -381,7 +381,7 @@ START_SECTION(IsotopeDistribution getConditionalFragmentIsotopeDist(const Empiri
     TEST_REAL_SIMILAR(it->second, result4[i])
   }
 
-  precursor_isotopes.push_back(3);
+  precursor_isotopes.insert(3);
   // isolated precursor isotopes are M0, M+1, M+2, and M+3
   // It's impossible for precursor C2 to have 3 extra neutrons (assuming only natural stable isotopes)
   // Invalid precursor isotopes are ignored and should give the answer as if they were not there
@@ -397,7 +397,7 @@ START_SECTION(IsotopeDistribution getConditionalFragmentIsotopeDist(const Empiri
   EmpiricalFormula small_fragment = EmpiricalFormula("C1H1N1O1S1");
 
   precursor_isotopes.clear();
-  precursor_isotopes.push_back(1);
+  precursor_isotopes.insert(1);
   // isolated precursor isotope is M+1
   IsotopeDistribution big_iso = big_fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);
   IsotopeDistribution small_iso = small_fragment.getConditionalFragmentIsotopeDist(precursor,precursor_isotopes);

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -293,12 +293,12 @@ START_SECTION(void estimateFromDNAWeight(double average_weight))
     TEST_REAL_SIMILAR(iso.begin()->second, 0.075138)
 END_SECTION
 
-START_SECTION(void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes))
+START_SECTION(void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes))
 	IsotopeDistribution iso;
-	std::vector<UInt> precursor_isotopes;
+	std::set<UInt> precursor_isotopes;
 	// We're isolating the M0 and M+1 precursor isotopes
-	precursor_isotopes.push_back(0);
-	precursor_isotopes.push_back(1);
+	precursor_isotopes.insert(0);
+	precursor_isotopes.insert(1);
 	// These are regression tests, but the results also follow an expected pattern.
 
 	// All the fragments from the M0 precursor will also be monoisotopic, while a fragment
@@ -361,12 +361,12 @@ START_SECTION(void estimateForFragmentFromPeptideWeight(double average_weight_pr
 
 END_SECTION
 
-START_SECTION(void estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes))
+START_SECTION(void estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes))
 	IsotopeDistribution iso;
-	std::vector<UInt> precursor_isotopes;
+	std::set<UInt> precursor_isotopes;
 	// We're isolating the M0 and M+1 precursor isotopes
-	precursor_isotopes.push_back(0);
-	precursor_isotopes.push_back(1);
+	precursor_isotopes.insert(0);
+	precursor_isotopes.insert(1);
 
 	// These are regression tests, but the results also follow an expected pattern.
 	// See the comments in estimateForFragmentFromPeptideWeight for an explanation.
@@ -407,12 +407,12 @@ START_SECTION(void estimateForFragmentFromDNAWeight(double average_weight_precur
 
 END_SECTION
 
-START_SECTION(void estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes))
+START_SECTION(void estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes))
 	IsotopeDistribution iso;
-	std::vector<UInt> precursor_isotopes;
+	std::set<UInt> precursor_isotopes;
 	// We're isolating the M0 and M+1 precursor isotopes
-	precursor_isotopes.push_back(0);
-	precursor_isotopes.push_back(1);
+	precursor_isotopes.insert(0);
+	precursor_isotopes.insert(1);
 
 	// These are regression tests, but the results also follow an expected pattern.
 	// See the comments in estimateForFragmentFromPeptideWeight for an explanation.
@@ -453,13 +453,13 @@ START_SECTION(void estimateForFragmentFromRNAWeight(double average_weight_precur
 
 END_SECTION
 
-START_SECTION(void estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::vector<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P))
+START_SECTION(void estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes, double C, double H, double N, double O, double S, double P))
 	// We are testing that the parameterized version matches the hardcoded version.
 	IsotopeDistribution iso(3);
 	IsotopeDistribution iso2(3);
-	std::vector<UInt> precursor_isotopes;
-	precursor_isotopes.push_back(0);
-	precursor_isotopes.push_back(1);
+	std::set<UInt> precursor_isotopes;
+	precursor_isotopes.insert(0);
+	precursor_isotopes.insert(1);
 
 	iso.estimateForFragmentFromWeightAndComp(2000.0, 1000.0, precursor_isotopes, 4.9384, 7.7583, 1.3577, 1.4773, 0.0417, 0.0);
 	iso2.estimateForFragmentFromPeptideWeight(2000.0, 1000.0, precursor_isotopes);
@@ -549,14 +549,14 @@ START_SECTION(bool operator!=(const IsotopeDistribution &isotope_distribution) c
   TEST_EQUAL(iso3 != iso4, false)
 END_SECTION
 
-START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribution & comp_fragment_isotope_distribution, const std::vector<UInt>& precursor_isotopes))
+START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribution & comp_fragment_isotope_distribution, const std::set<UInt>& precursor_isotopes))
   IsotopeDistribution iso1(EmpiricalFormula("C1").getIsotopeDistribution(11)); // fragment
   IsotopeDistribution iso2(EmpiricalFormula("C2").getIsotopeDistribution(11)); // complementary fragment
 
-  std::vector<UInt> precursor_isotopes;
-  precursor_isotopes.push_back(0);
-  precursor_isotopes.push_back(1);
-  precursor_isotopes.push_back(2);
+  std::set<UInt> precursor_isotopes;
+  precursor_isotopes.insert(0);
+  precursor_isotopes.insert(1);
+  precursor_isotopes.insert(2);
   IsotopeDistribution iso3;
   iso3.calcFragmentIsotopeDist(iso1,iso2,precursor_isotopes);
   iso3.renormalize();
@@ -571,7 +571,7 @@ START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribut
 	TEST_REAL_SIMILAR(it1->second, it2->second)
   }
 
-  precursor_isotopes.pop_back();
+  precursor_isotopes.erase(precursor_isotopes.find(2));
   IsotopeDistribution iso4;
   iso4.calcFragmentIsotopeDist(iso1,iso2,precursor_isotopes);
   iso4.renormalize();

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -463,7 +463,7 @@ START_SECTION(void estimateForFragmentFromWeightAndComp(double average_weight_pr
 
 	iso.estimateForFragmentFromWeightAndComp(2000.0, 1000.0, precursor_isotopes, 4.9384, 7.7583, 1.3577, 1.4773, 0.0417, 0.0);
 	iso2.estimateForFragmentFromPeptideWeight(2000.0, 1000.0, precursor_isotopes);
-	TEST_EQUAL(iso.begin()->second,iso2.begin()->second);
+	TEST_EQUAL(iso.begin()->second, iso2.begin()->second);
 END_SECTION
 
 


### PR DESCRIPTION
Hi OpenMS Team,

I added functionality to approximate isotope distributions of fragment molecules when the molecular formula of the precursor and fragment are unknown, but the set of isolated precursor isotopes are known. One of the applications of this is to improve the identification of isotopic distributions in MS/MS spectra. This, for example, could help differentiate between fragments from the intended precursor target vs co-eluting precursors where a different set of precursor isotopes fell within the isolation window. 

The method is simple: normally to calculate expected isotope distribution of a fragment one needs to know the formula of the fragment and the complementary fragment, then calculate their expected isotope distributions as if they were precursors, and do a little math with them. If we don't know the formulas, but we know their masses, we can instead use the usual averagine method to approximate the formulas and then apply the original method. 

A caveat here is that the averagine method expects the average mass as input, but we won't know what that is for the fragment. For example, if you isolated only precursor isotope M2 and calculated the average mass for a particular fragment then it would be different from the average mass of the same fragment if you isolated all the precursor isotopes. In practice the difference between the actual average mass and what we observed should be less than a few daltons anyway so it shouldn't really matter.

Here are histograms of differences between the expected isotope probabilities and the approximated ones. These were made for every b/y ion fragment from every tryptic peptide in the human proteome (between 5-80 amino acids and no selenocystines). In this case the correct average mass was known. There's a separate histogram for each isolated precursor isotope (1-4).

![residuals](https://cloud.githubusercontent.com/assets/8868522/21513473/0a385c20-cc87-11e6-9295-38845e4f5722.png)

There are certainly cases where the approximation isn't great. These cases are essentially the same as those described in figure 1 of this paper: http://www.proteinspector.com/pdf/ghavidel2014a.pdf where it shows the averagine method does poorly when a small molecule contains a sulfur because the pattern forks. In the case of fragments, the pattern forks when either the fragment or the complementary fragment is small and contains a sulfur. 

This particular method hasn't been published yet, but I plan on submitting a manuscript on it and a couple more things very soon. I'm not sure what your policy is in this case, for example maybe you'll want to wait for it to be peer-reviewed before you accept it into the core library.

Please let me know what you think, and thank you!