### PR TITLE
DataArrays in MSSpectrum are now always sorted

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -389,7 +389,7 @@ public:
     */
     void sortByPosition()
     {
-      if (float_data_arrays_.empty())
+      if (float_data_arrays_.empty() && string_data_arrays_.empty() && integer_data_arrays_.empty())
       {
         std::sort(ContainerType::begin(), ContainerType::end(), typename PeakType::PositionLess());
       }


### PR DESCRIPTION
The MSSpectrum function sortByPosition only sorted DataArrays,
if a FloatDataArray is present and did not check for StringDataArrays
or IntegerDataArrays.