### PR TITLE
[Fix] Since Gcc7 dumpversion might not have a minor version

### DIFF
--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -36,11 +36,6 @@
 # This cmake file handles all the project specific compiler flags
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-	# Determine gcc version
-	execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion OUTPUT_VARIABLE GNUCXX_VERSION)
-	string(REGEX MATCHALL "[0-9]+" GCC_VERSION_COMPONENTS ${GNUCXX_VERSION})
-	list(GET GCC_VERSION_COMPONENTS 0 GNUCXX_MAJOR_VERSION)
-	list(GET GCC_VERSION_COMPONENTS 1 GNUCXX_MINOR_VERSION)
 
   add_definitions(-Wall -Wextra 
     -fvisibility=hidden
@@ -66,7 +61,8 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 		add_definitions(-fmessage-length=0)
 	endif()
 
-	if (NOT OPENMS_64BIT_ARCHITECTURE AND ${GNUCXX_MAJOR_VERSION} MATCHES "4" AND ${GNUCXX_MINOR_VERSION} MATCHES "3")
+	# Is this still needed? Why? Only on 4.3?
+	if (NOT OPENMS_64BIT_ARCHITECTURE AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.3.0" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.4.0")
 		add_definitions(-march=i486)
 	endif()
   


### PR DESCRIPTION
Using CMAKE_CXX_COMPILER_VERSION, available since CMAKE 2.8.10.
Addresses https://github.com/OpenMS/OpenMS/issues/2372.