### PR TITLE
[Fix/Doc] CDash reported option clash in building tutorials

### DIFF
--- a/doc/OpenMS_tutorial/refman_overwrite.tex.in
+++ b/doc/OpenMS_tutorial/refman_overwrite.tex.in
@@ -11,7 +11,10 @@
 \usepackage{float}
 \usepackage{alltt}
 \usepackage{newtxtext, newtxmath}
-\usepackage[full]{textcomp} %Careful: newtxttext also loads textcomp. Option full needs to match.
+% newtxtext loads textcomp only in newer versions and with differing options between versions
+\@ifpackageloaded{textcomp} 
+  {} % do nothing if loaded by the previous package to avoid option clashes
+  {\usepackage{textcomp}} % otherwise load the package
 \ifx\pdfoutput\undefined
 \usepackage[ps2pdf,
             pagebackref=true,

--- a/doc/TOPP_tutorial/refman_overwrite.tex.in
+++ b/doc/TOPP_tutorial/refman_overwrite.tex.in
@@ -11,7 +11,10 @@
 \usepackage{float}
 \usepackage{alltt}
 \usepackage{newtxtext, newtxmath}
-\usepackage[full]{textcomp} %Careful: newtxttext also loads textcomp. Option full needs to match.
+% newtxtext loads textcomp only in newer versions and with differing options between versions
+\@ifpackageloaded{textcomp} 
+  {} % do nothing if loaded by the previous package to avoid option clashes
+  {\usepackage{textcomp}} % otherwise load the package
 \ifx\pdfoutput\undefined
 \usepackage[ps2pdf,
             pagebackref=true,


### PR DESCRIPTION
It seems like the newtxtext package actually changes a LOT.
Early versions do not load textcomp.
Medium old versions load it with standard options.
Newest versions load it with full option.
So we have to stick to the most general option and include an if statement.