### PR TITLE
Remove Warnings for CMake 3.7.2

### DIFF
--- a/cmake/add_library_macros.cmake
+++ b/cmake/add_library_macros.cmake
@@ -81,12 +81,6 @@ endfunction(convert_to_unity_build)
 ## @note This macro will do nothing with non MSVC generators.
 macro(copy_dll_to_extern_bin targetname)
   if(MSVC)
-    get_target_property(WIN32_DLLLOCATION ${targetname} LOCATION)
-    get_filename_component(WIN32_DLLPATH ${WIN32_DLLLOCATION} PATH)
-
-    ## copy OpenMS.dll to test executables dir "$(TargetFileName)" is a placeholder filled by VS at runtime
-    file(TO_NATIVE_PATH "${WIN32_DLLPATH}/$(TargetFileName)" DLL_SOURCE)
-
     file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/$(ConfigurationName)/$(TargetFileName)" DLL_TEST_TARGET)
     file(TO_NATIVE_PATH "${OPENMS_HOST_BINARY_DIRECTORY}/src/tests/class_tests/bin/$(ConfigurationName)" DLL_TEST_TARGET_PATH)
 
@@ -97,9 +91,9 @@ macro(copy_dll_to_extern_bin targetname)
     add_custom_command(TARGET ${targetname}
                       POST_BUILD
                       COMMAND ${CMAKE_COMMAND} -E make_directory "${DLL_TEST_TARGET_PATH}"
-                      COMMAND ${CMAKE_COMMAND} -E copy ${DLL_SOURCE} ${DLL_TEST_TARGET}
+                      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${targetname}> ${DLL_TEST_TARGET}
                       COMMAND ${CMAKE_COMMAND} -E make_directory "${DLL_DOC_TARGET_PATH}"
-                      COMMAND ${CMAKE_COMMAND} -E copy ${DLL_SOURCE} ${DLL_DOC_TARGET})
+                      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${targetname}> ${DLL_DOC_TARGET})
   endif(MSVC)
 endmacro()
 


### PR DESCRIPTION
[FIX] remove policy warning when using get_target_property [deprecated function]

lets hope the old cmake 2.8.x can cope...

