### PR TITLE
fix TOPPAS & ExecutePipeline errors

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/Exception.h
+++ b/src/openms/include/OpenMS/CONCEPT/Exception.h
@@ -557,6 +557,21 @@ public:
     };
 
     /**
+    @brief Filename is too long to be writable/readable by the filesystem
+
+    This exception usually occurs when output filenames are automatically generated 
+    and are found to be too long. Usually 255 characters is the limit (NTFS, Ext2/3/4,...).
+
+    @ingroup Exceptions
+    */
+    class OPENMS_DLLAPI FileNameTooLong :
+      public BaseException
+    {
+    public:
+      FileNameTooLong(const char* file, int line, const char* function, const std::string& filename, int max_length) throw();
+    };
+
+    /**
       @brief General IOException.
 
       General error for IO operations, that can not be associated to the more specific exceptions (e.g. FileNotWritable)

--- a/src/openms/source/CONCEPT/Exception.cpp
+++ b/src/openms/source/CONCEPT/Exception.cpp
@@ -274,6 +274,17 @@ namespace OpenMS
       GlobalExceptionHandler::getInstance().setMessage(what_);
     }
 
+    FileNameTooLong::FileNameTooLong(const char* file, int line, const char* function, const std::string& filename, int max_length) throw() :
+      BaseException(file, line, function, "FileNameTooLong", "")
+    {
+      stringstream ss;
+      ss << "the file '" << filename << "' is too long (" << filename.size() << " chars) "
+         << "and exceeds the allowed limit of " << max_length << ". "
+         << "Use shorter filenames and/or less sub-directories.";
+      what_ = ss.str();
+      GlobalExceptionHandler::getInstance().setMessage(what_);
+    }
+
     IOException::IOException(const char* file, int line, const char* function, const std::string& filename) throw() :
       BaseException(file, line, function, "IOException", "")
     {

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASScene.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASScene.h
@@ -231,6 +231,10 @@ public:
     bool wasChanged();
     /// Refreshes the parameters of the TOPP tools in this workflow
     RefreshStatus refreshParameters();
+    
+    /// is TOPPASScene run in GUI or non-GUI (ExecutePipeline) mode, i.e. are MessageBoxes allowed?
+    bool isGUIMode() const;
+
     /// determine dry run status (are tools actually called?)
     bool isDryRun() const;
     /// workflow description (to be displayed in TOPPAS window)

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASToolVertex.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASToolVertex.h
@@ -45,6 +45,8 @@
 
 namespace OpenMS
 {
+  class TOPPASScene;
+
   /**
       @brief A vertex representing a TOPP tool
 
@@ -238,6 +240,10 @@ protected:
     //@{
     void mouseDoubleClickEvent(QGraphicsSceneMouseEvent* e);
     //@}
+	
+
+    /// get parent Scene
+    TOPPASScene* getScene_() const;
 
     /// determines if according to current status_, a parameter change would invalidate the pipeline status (e.g., because this node was already processed)
     bool doesParamChangeInvalidate_();

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASVertex.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASVertex.h
@@ -113,7 +113,39 @@ public:
     typedef EdgeContainer::iterator EdgeIterator;
     /// A const iterator for in/out edges
     typedef EdgeContainer::const_iterator ConstEdgeIterator;
-    /// Info for one edge and round, to be passed to next node
+	/// A class which interfaces with QStringList for holding filenames
+	/// Incoming filenames are checked, and an exception is thrown if they are too long
+	/// to avoid issues with common filesystems (due to filesystem limits).
+	class TOPPASFilenames
+	{
+	  public:
+		TOPPASFilenames()
+		{
+		}
+	  
+		int size() const;
+		const QStringList& get() const;
+		const QString& operator[](int i) const;
+
+		///@name Setters; their all use check_() and can throw!
+		//@{
+		void set(const QStringList& filenames);
+		void set(const QString& filename, int i);
+		void push_back(const QString& filename);
+		void append(const QStringList& filenames);
+		//@}
+
+	  private:
+		/*
+		@brief Check length of filename and throw Exception::FileNotWritable() if too long
+		
+		@param filename Full path to file (using relative paths will circumvent the effectiveness)
+		@throw Exception::FileNotWritable() if too long (>=255 chars)
+		*/
+		void check_(const QString& filename);
+		QStringList filenames_;   //< filenames passed from upstream node in this round
+	};
+	/// Info for one edge and round, to be passed to next node
     struct VertexRoundPackage
     {
       VertexRoundPackage() :
@@ -122,9 +154,12 @@ public:
       {
       }
 
-      QStringList filenames;   //< filenames passed from upstream node in this round
-      TOPPASEdge * edge;  //< edge that connects the upstream node to the current one
+	  TOPPASFilenames filenames; //< filenames passed from upstream node in this round
+      TOPPASEdge* edge;  //< edge that connects the upstream node to the current one
     };
+
+	
+
 
     /// all infos to process one round for a vertex (from all incoming vertices)
     /// indexing via "parameter_index" of adjacent edge (could later be param_name) -> filenames

--- a/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASInputFileListVertex.cpp
@@ -264,7 +264,7 @@ namespace OpenMS
     output_files_.resize(files.size()); // for now, assume one file per round (we could later extend that)
     for (int f = 0; f < files.size(); ++f)
     {
-      output_files_[f][-1].filenames << QDir::toNativeSeparators(files[f]);
+      output_files_[f][-1].filenames.push_back(QDir::toNativeSeparators(files[f]));
     }
 
     setToolTip(files.join("\n"));

--- a/src/openms_gui/source/VISUAL/TOPPASMergerVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASMergerVertex.cpp
@@ -208,7 +208,7 @@ namespace OpenMS
       for (RoundPackageConstIt ite = pkg[round].begin();
            ite != pkg[round].end(); ++ite)
       {
-        files.append(ite->second.filenames); // concat filenames from all incoming edges
+        files.append(ite->second.filenames.get()); // concat filenames from all incoming edges
       }
       Size round_index = (round_based_mode_ ? round : 0);
       output_files_[round_index][-1].filenames.append(files); // concat over all rounds (if required)

--- a/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
@@ -195,16 +195,16 @@ namespace OpenMS
     int param_index_me = e->getTargetInParam();
     for (Size round = 0; round < pkg.size(); ++round)
     {
-      foreach(const QString &f, pkg[round][param_index_src].filenames)
+      foreach(const QString &f, pkg[round][param_index_src].filenames.get())
       {
         if (!dry_run && !File::exists(f))
         {
           std::cerr << "The file '" << String(f) << "' does not exist!" << std::endl;
           continue;
         }
-        QString new_file = full_dir.toQString()
-                           + QDir::separator()
-                           + File::basename(f).toQString().left(190); // ensure 190 char filename (we might append more and reach ~NTFS limit)
+		QString new_file = full_dir.toQString()
+			+ QDir::separator()
+			+ File::basename(f).toQString();
 
         // remove "_tmp<number>" if its a suffix
         QRegExp rx("_tmp\\d+$");

--- a/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
@@ -202,9 +202,9 @@ namespace OpenMS
           std::cerr << "The file '" << String(f) << "' does not exist!" << std::endl;
           continue;
         }
-		QString new_file = full_dir.toQString()
-			+ QDir::separator()
-			+ File::basename(f).toQString();
+        QString new_file = full_dir.toQString()
+            + QDir::separator()
+            + File::basename(f).toQString();
 
         // remove "_tmp<number>" if its a suffix
         QRegExp rx("_tmp\\d+$");

--- a/src/openms_gui/source/VISUAL/TOPPASScene.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASScene.cpp
@@ -2155,7 +2155,10 @@ namespace OpenMS
       if (allowUserOverride)
       {
         QMessageBox::StandardButton ret;
-        ret = QMessageBox::warning(views().first(), "Nodes without outgoing edges", QString("Node") + (strange_vertices.size() > 1 ? "s " : " ") + strange_vertices.join(", ") + (strange_vertices.size() > 1 ? " have " : " has ") + "no outgoing edges.\n\nDo you still want to run the pipeline?", QMessageBox::Yes | QMessageBox::No);
+        ret = QMessageBox::warning(views().first(), "Nodes without outgoing edges", QString("Node") +
+                                   (strange_vertices.size() > 1 ? "s " : " ") + strange_vertices.join(", ") +
+                                   (strange_vertices.size() > 1 ? " have " : " has ") +
+                                   "no outgoing edges.\n\nDo you still want to run the pipeline?", QMessageBox::Yes | QMessageBox::No);
         if (ret == QMessageBox::No)
         {
           return false;
@@ -2344,11 +2347,16 @@ namespace OpenMS
     allowed_threads_ = num_jobs;
   }
 
+  bool TOPPASScene::isGUIMode() const
+  {
+    return gui_;
+  }
+
   bool TOPPASScene::isDryRun() const
   {
     return dry_run_;
   }
-
+  
   void TOPPASScene::quitWithError()
   {
     exit(1);

--- a/src/openms_gui/source/VISUAL/TOPPASSplitterVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASSplitterVertex.cpp
@@ -185,7 +185,7 @@ namespace OpenMS
          ++pkg_it)
     {
       // there can only be one upstream (input) node:
-      QStringList files = pkg_it->begin()->second.filenames;
+      QStringList files = pkg_it->begin()->second.filenames.get();
       for (QStringList::iterator file_it = files.begin();
            file_it != files.end(); ++file_it)
       {

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -176,7 +176,9 @@ namespace OpenMS
     {
       if (!File::exists(old_ini_file))
       {
-        QMessageBox::critical(0, "Error", (String("Could not open '") + old_ini_file + "'!").c_str());
+        String msg = String("Could not open old INI file '") + old_ini_file + "'! File does not exist!";
+        if (getScene_()->isGUIMode()) QMessageBox::critical(0, "Error", msg.c_str());
+        else LOG_ERROR << msg << std::endl;
         tool_ready_ = false;
         return false;
       }
@@ -187,15 +189,22 @@ namespace OpenMS
     // actually request the INI
     QProcess p;
     p.start(program, arguments);
-    if (!p.waitForFinished(-1))
+    if (!p.waitForFinished(-1) || p.exitStatus() != 0 || p.exitCode() != 0)
     {
-      QMessageBox::critical(0, "Error", (String("Could not execute '") + program + " " + String(arguments.join(" ")) + "'!\n\nMake sure the TOPP tools are present in '" + File::getExecutablePath() + "', that you have permission to write to the temporary file path, and that there is space left in the temporary file path.").c_str());
+		String msg = String("Error! Call to '") + program + "' '" + String(arguments.join("' '")) +
+			" returned with exit code (" + String(p.exitCode()) + "), exit status (" + String(p.exitStatus()) + ")." +
+			"\noutput:\n" + String(QString(p.readAll())) +
+			"\n";
+      if (getScene_()->isGUIMode()) QMessageBox::critical(0, "Error", msg.c_str());
+      else LOG_ERROR << msg << std::endl;
       tool_ready_ = false;
       return false;
     }
     if (!File::exists(ini_file))
-    {
-      QMessageBox::critical(0, "Error", (String("Could not open '") + ini_file + "'!").c_str());
+    { // it would be weird to get here, since the TOPP tool ran successfully above, so INI file should exist, but nevertheless:
+      String msg = String("Could not open '") + ini_file + "'! It does not exist!";
+      if (getScene_()->isGUIMode()) QMessageBox::critical(0, "Error", msg.c_str());
+      else LOG_ERROR << msg << std::endl;
       tool_ready_ = false;
       return false;
     }
@@ -289,7 +298,12 @@ namespace OpenMS
       emit parameterChanged(doesParamChangeInvalidate_());
     }
 
-    qobject_cast<TOPPASScene*>(scene())->updateEdgeColors();
+    getScene_()->updateEdgeColors();
+  }
+
+  TOPPASScene* TOPPASToolVertex::getScene_() const
+  {
+    return qobject_cast<TOPPASScene*>(scene());
   }
 
   bool TOPPASToolVertex::doesParamChangeInvalidate_()
@@ -529,7 +543,7 @@ namespace OpenMS
       LOG_ERROR << "This should not happen. Calling an already finished node '" << this->name_ << "' (#" << this->getTopoNr() << ")!" << std::endl;
       throw Exception::IllegalSelfOperation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }
-    TOPPASScene* ts = qobject_cast<TOPPASScene*>(scene());
+    TOPPASScene* ts = getScene_();
 
     QString ini_file = ts->getTempDir()
                        + QDir::separator()
@@ -610,7 +624,7 @@ namespace OpenMS
         if (!store_to_ini)
           args << "-" + param_name.toQString();
 
-        QStringList file_list = ite->second.filenames;
+        const QStringList& file_list = ite->second.filenames.get();
 
         if (store_to_ini)
         {
@@ -654,7 +668,7 @@ namespace OpenMS
         if (!store_to_ini)
           args << "-" + param_name.toQString();
 
-        const QStringList& output_files = output_files_[round][param_index].filenames;
+        const QStringList& output_files = output_files_[round][param_index].filenames.get();
 
         if (store_to_ini)
         {
@@ -735,7 +749,7 @@ namespace OpenMS
   {
     __DEBUG_BEGIN_METHOD__
 
-    TOPPASScene* ts = qobject_cast<TOPPASScene*>(scene());
+    TOPPASScene* ts = getScene_();
 
     //** ERROR handling
     if (es != QProcess::NormalExit)
@@ -849,7 +863,7 @@ namespace OpenMS
             LOG_ERROR << "Could not rename " << String(it->second.filenames[fi]) << " to " << new_filename << "\n";
             return false;
           }
-          it->second.filenames[fi] = new_filename.toQString();
+          it->second.filenames.set(new_filename.toQString(), fi);
         }
       }
     }
@@ -933,7 +947,7 @@ namespace OpenMS
     std::vector<QStringList> per_round_basenames;
     for (Size i = 0; i < pkg.size(); ++i)
     {
-      per_round_basenames.push_back(pkg[i].find(max_size_index)->second.filenames);
+      per_round_basenames.push_back(pkg[i].find(max_size_index)->second.filenames.get());
       //std::cerr << "  output filenames (round " << i  <<"): " << per_round_basenames.back().join(", ") << std::endl;
     }
 
@@ -944,7 +958,7 @@ namespace OpenMS
     output_files_.clear();
     output_files_.resize(pkg.size()); // #rounds
 
-    const TOPPASScene* ts = qobject_cast<const TOPPASScene*>(scene());
+    const TOPPASScene* ts = getScene_();
     
     // output names for each outgoing edge
     for (int i = 0; i < out_params.size(); ++i)
@@ -988,15 +1002,10 @@ namespace OpenMS
       // create common path of output files
       QString path = ts->getTempDir()
                      + QDir::separator()
-                     + getOutputDir().toQString()
+                     + getOutputDir().toQString() // includes TopoNr
                      + QDir::separator()
                      + out_params[param_index].param_name.remove(':').toQString().left(50) // max 50 chars per subdir
                      + QDir::separator();
-      if (path.length() > 150)
-      {
-        LOG_WARN << "Warning: the temporary path '" << String(path) << "' used in TOPPAS has many characters.\n"
-                 << "         TOPPAS might not be able to write files properly.\n";
-      }
 
       VertexRoundPackage vrp;
       vrp.edge = edge_out;
@@ -1017,7 +1026,6 @@ namespace OpenMS
           {
             fn += "_to_" + QFileInfo(per_round_basenames[r].last()).fileName() + "_merged";
           }
-          fn = fn.left(220); // allow max of 220 chars per path+filename (~NTFS limit)
           fn += file_suffix.toQString();
           fn = QDir::toNativeSeparators(fn);
           if (filename_output_set.count(fn) > 0)
@@ -1150,13 +1158,13 @@ namespace OpenMS
 
   String TOPPASToolVertex::getFullOutputDirectory() const
   {
-    TOPPASScene* ts = qobject_cast<TOPPASScene*>(scene());
+    TOPPASScene* ts = getScene_();
     return QDir::toNativeSeparators(ts->getTempDir() + QDir::separator() + getOutputDir().toQString());
   }
 
   String TOPPASToolVertex::getOutputDir() const
   {
-    TOPPASScene* ts = qobject_cast<TOPPASScene*>(scene());
+    TOPPASScene* ts = getScene_();
     String workflow_dir = File::removeExtension(File::basename(ts->getSaveFileName()));
     if (workflow_dir == "")
     {
@@ -1235,7 +1243,7 @@ namespace OpenMS
 
   bool TOPPASToolVertex::refreshParameters()
   {
-    TOPPASScene* ts = qobject_cast<TOPPASScene*>(scene());
+    TOPPASScene* ts = getScene_();
     QString old_ini_file = ts->getTempDir() + QDir::separator() + "TOPPAS_" + name_.toQString() + "_";
     if (type_ != "")
     {

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -191,10 +191,10 @@ namespace OpenMS
     p.start(program, arguments);
     if (!p.waitForFinished(-1) || p.exitStatus() != 0 || p.exitCode() != 0)
     {
-		String msg = String("Error! Call to '") + program + "' '" + String(arguments.join("' '")) +
-			" returned with exit code (" + String(p.exitCode()) + "), exit status (" + String(p.exitStatus()) + ")." +
-			"\noutput:\n" + String(QString(p.readAll())) +
-			"\n";
+      String msg = String("Error! Call to '") + program + "' '" + String(arguments.join("' '")) +
+          " returned with exit code (" + String(p.exitCode()) + "), exit status (" + String(p.exitStatus()) + ")." +
+          "\noutput:\n" + String(QString(p.readAll())) +
+          "\n";
       if (getScene_()->isGUIMode()) QMessageBox::critical(0, "Error", msg.c_str());
       else LOG_ERROR << msg << std::endl;
       tool_ready_ = false;

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -47,57 +47,55 @@ namespace OpenMS
   int TOPPASVertex::global_debug_indent_ = 0;
 #endif
 
-  	int TOPPASVertex::TOPPASFilenames::size() const
-	{
-		return filenames_.size();
-	}
+    int TOPPASVertex::TOPPASFilenames::size() const
+  {
+    return filenames_.size();
+  }
 
-	const QStringList& TOPPASVertex::TOPPASFilenames::get() const
-	{
-		return filenames_;
-	}
-	const QString& TOPPASVertex::TOPPASFilenames::operator[](int i) const
-	{
-		return filenames_[i];
-	}
+  const QStringList& TOPPASVertex::TOPPASFilenames::get() const
+  {
+    return filenames_;
+  }
+  const QString& TOPPASVertex::TOPPASFilenames::operator[](int i) const
+  {
+    return filenames_[i];
+  }
 
-	void TOPPASVertex::TOPPASFilenames::set(const QStringList& filenames)
-	{
-		filenames_.clear();
-		this->append(filenames);
-	}
+  void TOPPASVertex::TOPPASFilenames::set(const QStringList& filenames)
+  {
+    filenames_.clear();
+    this->append(filenames);
+  }
 
-	void TOPPASVertex::TOPPASFilenames::set(const QString& filename, int i)
-	{
-		check_(filename);
-		filenames_[i] = filename;
-	}
+  void TOPPASVertex::TOPPASFilenames::set(const QString& filename, int i)
+  {
+    check_(filename);
+    filenames_[i] = filename;
+  }
 
-	void TOPPASVertex::TOPPASFilenames::push_back(const QString& filename)
-	{
-		check_(filename);
-		filenames_.push_back(filename);
-	}
+  void TOPPASVertex::TOPPASFilenames::push_back(const QString& filename)
+  {
+    check_(filename);
+    filenames_.push_back(filename);
+  }
 
-	void TOPPASVertex::TOPPASFilenames::append(const QStringList& filenames)
-	{
-		foreach(const QString& fn, filenames)
-		{
-			check_(fn);
-			push_back(fn);
-		}
-	}
+  void TOPPASVertex::TOPPASFilenames::append(const QStringList& filenames)
+  {
+    foreach(const QString& fn, filenames)
+    {
+      check_(fn);
+      push_back(fn);
+    }
+  }
 
-	void TOPPASVertex::TOPPASFilenames::check_(const QString& filename)
-	{
-		const int max_filename_length = 255; // the usual NTFS and Ext2/3/4 limit
-		if (filename.count() >= max_filename_length)
-		{
-			throw Exception::FileNotWritable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("'")
-				+ String(filename) 
-				+ " [too long (>" + max_filename_length + " characters) - please use shorter filenames and/or less sub-directories]'");
-		}
-	}
+  void TOPPASVertex::TOPPASFilenames::check_(const QString& filename)
+  {
+    const int max_filename_length = 255; // the usual NTFS and Ext2/3/4 limit
+    if (filename.count() >= max_filename_length)
+    {
+      throw Exception::FileNameTooLong(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename.toStdString(), max_filename_length);
+    }
+  }
 
 
   TOPPASVertex::TOPPASVertex() :

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -47,6 +47,59 @@ namespace OpenMS
   int TOPPASVertex::global_debug_indent_ = 0;
 #endif
 
+  	int TOPPASVertex::TOPPASFilenames::size() const
+	{
+		return filenames_.size();
+	}
+
+	const QStringList& TOPPASVertex::TOPPASFilenames::get() const
+	{
+		return filenames_;
+	}
+	const QString& TOPPASVertex::TOPPASFilenames::operator[](int i) const
+	{
+		return filenames_[i];
+	}
+
+	void TOPPASVertex::TOPPASFilenames::set(const QStringList& filenames)
+	{
+		filenames_.clear();
+		this->append(filenames);
+	}
+
+	void TOPPASVertex::TOPPASFilenames::set(const QString& filename, int i)
+	{
+		check_(filename);
+		filenames_[i] = filename;
+	}
+
+	void TOPPASVertex::TOPPASFilenames::push_back(const QString& filename)
+	{
+		check_(filename);
+		filenames_.push_back(filename);
+	}
+
+	void TOPPASVertex::TOPPASFilenames::append(const QStringList& filenames)
+	{
+		foreach(const QString& fn, filenames)
+		{
+			check_(fn);
+			push_back(fn);
+		}
+	}
+
+	void TOPPASVertex::TOPPASFilenames::check_(const QString& filename)
+	{
+		const int max_filename_length = 255; // the usual NTFS and Ext2/3/4 limit
+		if (filename.count() >= max_filename_length)
+		{
+			throw Exception::FileNotWritable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, String("'")
+				+ String(filename) 
+				+ " [too long (>" + max_filename_length + " characters) - please use shorter filenames and/or less sub-directories]'");
+		}
+	}
+
+
   TOPPASVertex::TOPPASVertex() :
     QObject(),
     QGraphicsItem(),
@@ -222,7 +275,7 @@ namespace OpenMS
         {
           upstream_round %= tv_upstream->round_total_;
         }
-        rpg.filenames = tv_upstream->getFileNames(param_index_src_out, upstream_round);
+        rpg.filenames.set(tv_upstream->getFileNames(param_index_src_out, upstream_round));
 
         // hack for merger vertices, as they have multiple incoming edges with -1 as index
         while (pkg[round].count(param_index_tgt_in))
@@ -248,7 +301,7 @@ namespace OpenMS
       throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, param_index, rp.size());  // index could be larger (its a map, but nevertheless)
     }
     //String s = String(rp[param_index].filenames.join("\" \""));
-    return rp[param_index].filenames;
+    return rp[param_index].filenames.get();
   }
 
   QStringList TOPPASVertex::getFileNames() const
@@ -262,7 +315,7 @@ namespace OpenMS
            it != output_files_[r].end();
            ++it)
       {
-        fl.append(it->second.filenames);
+        fl.append(it->second.filenames.get());
       }
     }
     return fl;


### PR DESCRIPTION
Some GUI elements were not disabled in non-GUI mode (i.e. when running a Pipeline with ExecutePipeline).
The console would only show:
`"QWidget: Cannot create a QWidget when no GUI is being used"` and quit without showing the actual error.
This PR fixes it (see #954).

Additionally, filenames longer than 255 chars were truncated (with a warning, but still), which could lead to silently overwriting output files. This PR will throw an error message, asking the user to use less sub-directories or shorter input basenames (both will decrease the total filename length).

