### PR TITLE
Minor fixes for MSSimulator ID handling

### DIFF
--- a/src/openms/include/OpenMS/SIMULATION/MSSim.h
+++ b/src/openms/include/OpenMS/SIMULATION/MSSim.h
@@ -109,12 +109,33 @@ public:
     const SimTypes::MSSimExperiment& getPeakMap() const;
 
     /**
+      @brief Access the simulated identifications (proteins and peptides)
+
+      If an MS2 signal has been simulated, identifications are generated based on
+      their corresponding MS2 spectra. If MS2 simulation has been disabled,
+      peptide IDs are generated from feature annotations. Otherwise, the -out_id
+      idXML file would be empty if MS2 simulation is disabled (which is the default).
+
+      @param proteins Will be filled with a single ProteinIdentification holding all ProteinHits.
+      @param peptides Will be filled with PeptideIdentifications.
+    */
+    void getIdentifications(std::vector<ProteinIdentification>& proteins, std::vector<PeptideIdentification>& peptides) const;
+
+    /**
       @brief Access the simulated MS2 identifications (proteins and peptides)
 
       @param proteins Will be filled with a single ProteinIdentification holding all ProteinHits used in the simulated MS2 spectra.
       @param peptides Will be filled with PeptideIdentifications for each simulated MS2 spectra holding all contributing peptides scored by their intensity contribution.
     */
     void getMS2Identifications(std::vector<ProteinIdentification>& proteins, std::vector<PeptideIdentification>& peptides) const;
+
+    /**
+      @brief Access the simulated identifications (proteins and peptides) from feature annotations
+
+      @param proteins Will be filled with a single ProteinIdentification holding all ProteinHits.
+      @param peptides Will be filled with PeptideIdentifications for all simulated features.
+    */
+    void getFeatureIdentifications(std::vector<ProteinIdentification>& proteins, std::vector<PeptideIdentification>& peptides) const;
 
     /// Returns the default parameters for simulation including the labeling technique with name @p labeling_name
     Param getParameters() const;

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -420,6 +420,18 @@ namespace OpenMS
     return peak_map_;
   }
 
+  void MSSim::getIdentifications(vector<ProteinIdentification>& proteins, vector<PeptideIdentification>& peptides) const
+  {
+    if (param_.getValue("RawTandemSignal:status") == "disabled")
+    {
+      getFeatureIdentifications(proteins, peptides);
+    }
+    else
+    {
+      getMS2Identifications(proteins, peptides);
+    }
+  }
+
   void MSSim::getMS2Identifications(vector<ProteinIdentification>& proteins, vector<PeptideIdentification>& peptides) const
   {
     // test if we have a feature map at all .. if not, no simulation was performed
@@ -497,6 +509,31 @@ namespace OpenMS
           proteins[0].insertHit(*prot_it);
         }
       }
+    }
+  }
+
+  void MSSim::getFeatureIdentifications(vector<ProteinIdentification>& proteins, vector<PeptideIdentification>& peptides) const
+  {
+    // test if we have a feature map at all .. if not, no simulation was performed
+    if (feature_maps_.empty()) return;
+
+    // clear incoming vectors
+    proteins.clear();
+    peptides.clear();
+
+    // protein IDs
+    const FeatureMap& fmap = feature_maps_[0];
+    const vector<ProteinIdentification>& prot_ids = fmap.getProteinIdentifications();
+    proteins.reserve(prot_ids.size());
+    proteins.insert(proteins.end(), prot_ids.begin(), prot_ids.end());
+
+    // peptide IDs
+    for (FeatureMap::ConstIterator it = fmap.begin(); it != fmap.end(); ++it)
+    {
+      const Feature& f = *it;
+      const vector<PeptideIdentification>& pep_ids = f.getPeptideIdentifications();
+      peptides.reserve(peptides.size() + pep_ids.size());
+      peptides.insert(peptides.end(), pep_ids.begin(), pep_ids.end());
     }
   }
 

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -299,6 +299,7 @@ namespace OpenMS
       SignedSize scan_index = distance<SimTypes::MSSimExperiment::ConstIterator>(experiment_.begin(), it_rt);
       pi.setMetaValue("RT_index", scan_index);
       pi.setRT(f.getRT());
+      pi.setMZ(f.getMZ());
     }
 
     LOG_INFO << "Final number of simulated features: " << feature_maps_[0].size() << "\n";

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -299,7 +299,10 @@ namespace OpenMS
       SignedSize scan_index = distance<SimTypes::MSSimExperiment::ConstIterator>(experiment_.begin(), it_rt);
       pi.setMetaValue("RT_index", scan_index);
       pi.setRT(f.getRT());
-      pi.setMZ(f.getMZ());
+      if (!pi.hasMZ())
+      {
+        pi.setMZ(f.getMZ());
+      }
     }
 
     LOG_INFO << "Final number of simulated features: " << feature_maps_[0].size() << "\n";
@@ -434,12 +437,12 @@ namespace OpenMS
 
   void MSSim::getMS2Identifications(vector<ProteinIdentification>& proteins, vector<PeptideIdentification>& peptides) const
   {
-    // test if we have a feature map at all .. if not, no simulation was performed
-    if (feature_maps_.empty()) return;
-
     // clear incoming vectors
     proteins.clear();
     peptides.clear();
+
+    // test if we have a feature map at all .. if not, no simulation was performed
+    if (feature_maps_.empty()) return;
 
     // we need to keep track of the proteins we write out
     set<String> accessions;
@@ -514,12 +517,12 @@ namespace OpenMS
 
   void MSSim::getFeatureIdentifications(vector<ProteinIdentification>& proteins, vector<PeptideIdentification>& peptides) const
   {
-    // test if we have a feature map at all .. if not, no simulation was performed
-    if (feature_maps_.empty()) return;
-
     // clear incoming vectors
     proteins.clear();
     peptides.clear();
+
+    // test if we have a feature map at all .. if not, no simulation was performed
+    if (feature_maps_.empty()) return;
 
     // protein IDs
     const FeatureMap& fmap = feature_maps_[0];

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -528,12 +528,10 @@ namespace OpenMS
     proteins.insert(proteins.end(), prot_ids.begin(), prot_ids.end());
 
     // peptide IDs
+    peptides.reserve(fmap.size());
     for (FeatureMap::ConstIterator it = fmap.begin(); it != fmap.end(); ++it)
     {
-      const Feature& f = *it;
-      const vector<PeptideIdentification>& pep_ids = f.getPeptideIdentifications();
-      peptides.reserve(peptides.size() + pep_ids.size());
-      peptides.insert(peptides.end(), pep_ids.begin(), pep_ids.end());
+      peptides.push_back(it->getPeptideIdentifications()[0]);
     }
   }
 

--- a/src/utils/MSSimulator.cpp
+++ b/src/utils/MSSimulator.cpp
@@ -345,7 +345,7 @@ protected:
       writeLog_(String("Storing ground-truth peptide IDs in: ") + id_out);
       vector<ProteinIdentification> proteins;
       vector<PeptideIdentification> peptides;
-      ms_simulation.getMS2Identifications(proteins, peptides);
+      ms_simulation.getIdentifications(proteins, peptides);
       IdXMLFile().store(id_out, proteins, peptides);
     }
 


### PR DESCRIPTION
This fixes two minor flaws in MSSimulator:

- When RawTandemSignal is disabled (the default setting), the idXML file generated for the -out_id parameter is always empty. This is because identifications are generated for each MS2 spectrum (so not at all if no MS2 spectra are present). This PR makes MSSimulator generate an idXML containing all protein identifications and one peptide identification per feature (precursor at feature centroid position) if RawTandemSignal is disabled. This is useful if you want to, e.g., benchmark label-free workflows on simulated data and you want to be able to map peptide identifications to your quantification results but don't care for simulated MS2 spectra.

- The features' peptide annotations are missing the precursor m/z. Noticed this because I wanted to use IDSplitter on the annotated featureXMLs from -out_fm to get an idXML, as a workaround for the problem described above. ID mapping failed because the split idXMLs were missing precursor m/z.