### PR TITLE
Feature/qc S/N ...

### DIFF
--- a/share/OpenMS/CV/qc-cv.obo
+++ b/share/OpenMS/CV/qc-cv.obo
@@ -455,3 +455,17 @@ remark: TIC plot is MS:1000235
  def: "The number of identified features reported." [PXS:QC]
  is_a: QC:0000045 ! MS quantification result details
  is_a: QC:0000025 ! MS identification result details
+
+[Term]
+ id: QC:0000059
+ name: IS-1A
+ def: "The number of 10fold jumps in MS1 Intensity" [PXS:QC]
+ is_a: QC:0000045 ! MS quantification result details
+ is_a: QC:0000025 ! MS identification result details
+
+[Term]
+ id: QC:0000060
+ name: IS-1B
+ def: "The number of 10fold dumps in MS1 Intensity" [PXS:QC]
+ is_a: QC:0000045 ! MS quantification result details
+ is_a: QC:0000025 ! MS identification result details

--- a/src/utils/QCCalculator.cpp
+++ b/src/utils/QCCalculator.cpp
@@ -149,10 +149,10 @@ protected:
     return error;
   }
 
-  void calculateSNident (PeptideHit& hit, MSSpectrum<Peak1D>& spec)
-  {
+//  void calculateSNident (PeptideHit& hit, MSSpectrum<Peak1D>& spec)
+//  {
     // TODO
-  }
+//  }
 
   float calculateSNmedian (MSSpectrum<Peak1D>& spec, bool norm = true)
   {
@@ -302,6 +302,7 @@ protected:
     at.colTypes.push_back("MS:1000040");  // MZ
     at.colTypes.push_back("MS:1000041");  // charge
     at.colTypes.push_back("S/N");  // S/N
+    at.colTypes.push_back("peak count");  // peak count
     for (Size i = 0; i < exp.size(); ++i)
     {
       mslevelcounts[exp[i].getMSLevel()]++;
@@ -320,8 +321,8 @@ protected:
         row.push_back(exp[i].getPrecursors().front().getMZ());
         row.push_back(exp[i].getPrecursors().front().getCharge());
         row.push_back(calculateSNmedian(exp[i]));
+        row.push_back(exp[i].size());
         at.tableRows.push_back(row);
-
       }
     }
     qcmlfile.addRunAttachment(base_name, at);
@@ -501,6 +502,8 @@ protected:
 
     at.colTypes.push_back("MS:1000894_[sec]");
     at.colTypes.push_back("MS:1000285");
+    at.colTypes.push_back("S/N");
+    at.colTypes.push_back("peak count");
     Size prev = 0;
     below_10k = 0;
     Size jumps = 0;
@@ -531,6 +534,8 @@ protected:
         std::vector<String> row;
         row.push_back(exp[i].getRT());
         row.push_back(sum);
+        row.push_back(calculateSNmedian(exp[i]));
+        row.push_back(exp[i].size());
         at.tableRows.push_back(row);
       }
     }
@@ -572,7 +577,7 @@ protected:
     qp.id = base_name + "_ricdump"; ///< Identifier
     qp.cvRef = "QC"; ///< cv reference
     qp.cvAcc = "QC:0000060";
-    qp.value = String(jumps);
+    qp.value = String(drops);
     try
     {
       const ControlledVocabulary::CVTerm& term = cv.getTerm(qp.cvAcc);
@@ -844,6 +849,7 @@ protected:
       at.colTypes.push_back("Charge");
       at.colTypes.push_back("TheoreticalWeight");
       at.colTypes.push_back("delta_ppm");
+//      at.colTypes.push_back("S/N");
       for (UInt w = 0; w < var_mods.size(); ++w)
       {
         at.colTypes.push_back(String(var_mods[w]).substitute(' ', '_'));
@@ -882,21 +888,20 @@ protected:
               }
             }
           }
+
           row.push_back(tmp.getScore());
           row.push_back(tmp.getSequence().toString().removeWhitespaces());
           row.push_back(tmp.getCharge());
           row.push_back(String((tmp.getSequence().getMonoWeight() + tmp.getCharge() * Constants::PROTON_MASS_U) / tmp.getCharge()));
           double dppm = /* std::abs */ (getMassDifference(((tmp.getSequence().getMonoWeight() + tmp.getCharge() * Constants::PROTON_MASS_U) / tmp.getCharge()), it->getMZ(), true));
           row.push_back(String(dppm));
+//          row.push_back(String(calculateSNident(tmp)));
           deltas.push_back(dppm);
           for (UInt w = 0; w < var_mods.size(); ++w)
           {
             row.push_back(pep_mods[w]);
           }
           at.tableRows.push_back(row);
-
-          // S/N calc
-          // TODO calcSNident
         }
       }
       qcmlfile.addRunAttachment(base_name, at);

--- a/src/utils/QCCalculator.cpp
+++ b/src/utils/QCCalculator.cpp
@@ -569,7 +569,7 @@ protected:
     qcmlfile.addRunQualityParameter(base_name, qp);
 
     qp = QcMLFile::QualityParameter();
-    qp.id = base_name + "_ricjump"; ///< Identifier
+    qp.id = base_name + "_ricdump"; ///< Identifier
     qp.cvRef = "QC"; ///< cv reference
     qp.cvAcc = "QC:0000060";
     qp.value = String(jumps);

--- a/src/utils/QCCalculator.cpp
+++ b/src/utils/QCCalculator.cpp
@@ -88,8 +88,8 @@ using namespace std;
     The calculated quality parameters or data compiled as attachments for easy plotting input include file origin, spectra distribution, aquisition details, ion current stability ( & TIC ), id accuracy statistics and feature statistics.
     The MS experiments base name is used as name to the qcML element that is comprising all quality parameter values for the given run (including the given downstream analysis data).
     
-    - @p id produces quality parameter values for the identification file;
-    - @p feature produces quality parameter values for the feature file;
+    - @p id produces quality parameter values for the identification file; this file should contain either only the final psm to each spectrum (1 PeptideHit per identified spectrum) or have the PeptideHits sorted to 'best' first, where 'best' depends on the use case.
+    - @p feature produces quality parameter values for the feature file; this file can be either mapped or unmapped, the latter reulting in less metrics available.
     - @p consensus produces quality parameter values for the consensus file;
     some quality parameter calculation are only available if both feature and ids are given.
     - @p remove_duplicate_features only needed when you work with a set of merged features. Then considers duplicate features only once.
@@ -161,16 +161,16 @@ protected:
     spec.sortByIntensity();
     if(spec.size() % 2 == 0)
     {
-      median = (spec[spec.size()/2 - 1].getIntensity() + spec[spec.size()/2].getIntensity()) / 2;
+      median = (spec[spec.size() / 2 - 1].getIntensity() + spec[spec.size() / 2].getIntensity()) / 2;
     }
     else
     {
-      median = spec[spec.size()/2].getIntensity();
+      median = spec[spec.size() / 2].getIntensity();
     }
     maxi = spec.back().getIntensity();
     if (!norm)
     {
-      float sn_by_max2median = maxi/median;
+      float sn_by_max2median = maxi / median;
       return sn_by_max2median;
     }
 
@@ -191,7 +191,7 @@ protected:
         sign_int += pt->getIntensity();
       }
     }
-    float sn_by_max2median_norm = (sign_int/sign_cnt)/(nois_int/nois_cnt);
+    float sn_by_max2median_norm = (sign_int / sign_cnt) / (nois_int / nois_cnt);
 
     return sn_by_max2median_norm;
   }
@@ -458,7 +458,7 @@ protected:
               ++below_10k;
             }
             std::vector<String> row;
-            row.push_back(chroms[t][i].getRT()*60);
+            row.push_back(chroms[t][i].getRT() * 60);
             row.push_back(sum);
             at.tableRows.push_back(row);
           }
@@ -518,7 +518,7 @@ protected:
         {
           sum += exp[i][j].getIntensity();
         }
-        if (prev > 0 && sum > fact*prev)  // no jumps after complete drops (or [re]starts)
+        if (prev > 0 && sum > fact * prev)  // no jumps after complete drops (or [re]starts)
         {
           ++jumps;
         }
@@ -864,7 +864,7 @@ protected:
           std::vector<String> row;
           row.push_back(it->getRT());
           row.push_back(it->getMZ());
-          PeptideHit tmp = it->getHits().front(); //TODO depends on score & sort -> documentation: input must be accepted PSM first sorted
+          PeptideHit tmp = it->getHits().front();  //N.B.: depends on score & sort
           vector<UInt> pep_mods;
           for (UInt w = 0; w < var_mods.size(); ++w)
           {

--- a/src/utils/QCCalculator.cpp
+++ b/src/utils/QCCalculator.cpp
@@ -301,6 +301,7 @@ protected:
     at.colTypes.push_back("MS:1000894_[sec]");  // RT
     at.colTypes.push_back("MS:1000040");  // MZ
     at.colTypes.push_back("MS:1000041");  // charge
+    at.colTypes.push_back("S/N");  // S/N
     for (Size i = 0; i < exp.size(); ++i)
     {
       mslevelcounts[exp[i].getMSLevel()]++;
@@ -318,10 +319,9 @@ protected:
         row.push_back(exp[i].getRT());
         row.push_back(exp[i].getPrecursors().front().getMZ());
         row.push_back(exp[i].getPrecursors().front().getCharge());
+        row.push_back(calculateSNmedian(exp[i]));
         at.tableRows.push_back(row);
 
-        // S/N
-        calculateSNmedian(exp[i]);
       }
     }
     qcmlfile.addRunAttachment(base_name, at);

--- a/src/utils/QCCalculator.cpp
+++ b/src/utils/QCCalculator.cpp
@@ -159,7 +159,7 @@ protected:
     float median = 0;
     float maxi = 0;
     spec.sortByIntensity();
-    if(spec.size() % 2 == 0)
+    if (spec.size() % 2 == 0)
     {
       median = (spec[spec.size() / 2 - 1].getIntensity() + spec[spec.size() / 2].getIntensity()) / 2;
     }


### PR DESCRIPTION
including spectrum peak count stats.
Prettify has to wait until PSI has settled on metric and accompan. stats representation.
Our [SignalToNoiseEstimatorMedian](https://github.com/OpenMS/OpenMS/blob/develop/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h#L51) calculates (S/N) ratio of each data point in a scan, whereas I need S/N ration of a scan. Also, main field of application for the estimator I guess is unpicked data, whereas I assume picked data. I decided to let the S/N calc reside within QCCalculator.cpp for now, though I think this would be nice to have in the lib.
In the end (steps omitted) it looks something like:
![ms2sn](https://cloud.githubusercontent.com/assets/5859205/22933352/4ade4458-f2c3-11e6-83e0-cd5b16991680.png)
![ms1peakcount](https://cloud.githubusercontent.com/assets/5859205/22933367/5a890640-f2c3-11e6-87ee-81dc6684732d.png)
