### PR TITLE
replace absolute by machine-epsilon-dependent margin in MultiplexClustering

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexClustering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexClustering.cpp
@@ -73,13 +73,11 @@ namespace OpenMS
     double rt_min = exp_profile.getMinRT();
     double rt_max = exp_profile.getMaxRT();
     
-    // extend the grid by a small absolute margin
-    double mz_margin = 1e-10;
-    double rt_margin = 1e-10;
-    mz_min -= mz_margin; 
-    mz_max += mz_margin; 
-    rt_min -= rt_margin;
-    rt_max += rt_margin;
+    // extend the grid by a small machine-epsilon-dependent margin
+    mz_min -= 2 * mz_min * std::numeric_limits<double>::epsilon();
+    mz_max += 2 * mz_max * std::numeric_limits<double>::epsilon();
+    rt_min -= 2 * rt_min * std::numeric_limits<double>::epsilon();
+    rt_max += 2 * rt_max * std::numeric_limits<double>::epsilon();
     
     // generate grid spacing
     PeakWidthEstimator estimator(exp_picked, boundaries);
@@ -123,13 +121,11 @@ namespace OpenMS
     double rt_min = exp.getMinRT();
     double rt_max = exp.getMaxRT();
     
-    // extend the grid by a small absolute margin
-    double mz_margin = 1e-10;
-    double rt_margin = 1e-10;
-    mz_min -= mz_margin; 
-    mz_max += mz_margin; 
-    rt_min -= rt_margin; 
-    rt_max += rt_margin;
+    // extend the grid by a small machine-epsilon-dependent margin
+    mz_min -= 2 * mz_min * std::numeric_limits<double>::epsilon();
+    mz_max += 2 * mz_max * std::numeric_limits<double>::epsilon();
+    rt_min -= 2 * rt_min * std::numeric_limits<double>::epsilon();
+    rt_max += 2 * rt_max * std::numeric_limits<double>::epsilon();
     
     // generate grid spacing
     // We assume that the jitter of the peak centres are less than <scaling> times the user specified m/z tolerance.

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexClustering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexClustering.cpp
@@ -74,10 +74,10 @@ namespace OpenMS
     double rt_max = exp_profile.getMaxRT();
     
     // extend the grid by a small machine-epsilon-dependent margin
-    mz_min -= 2 * mz_min * std::numeric_limits<double>::epsilon();
-    mz_max += 2 * mz_max * std::numeric_limits<double>::epsilon();
-    rt_min -= 2 * rt_min * std::numeric_limits<double>::epsilon();
-    rt_max += 2 * rt_max * std::numeric_limits<double>::epsilon();
+    mz_min -= 2 * std::abs(mz_min) * std::numeric_limits<double>::epsilon();
+    mz_max += 2 * std::abs(mz_max) * std::numeric_limits<double>::epsilon();
+    rt_min -= 2 * std::abs(rt_min) * std::numeric_limits<double>::epsilon();
+    rt_max += 2 * std::abs(rt_max) * std::numeric_limits<double>::epsilon();
     
     // generate grid spacing
     PeakWidthEstimator estimator(exp_picked, boundaries);
@@ -122,10 +122,10 @@ namespace OpenMS
     double rt_max = exp.getMaxRT();
     
     // extend the grid by a small machine-epsilon-dependent margin
-    mz_min -= 2 * mz_min * std::numeric_limits<double>::epsilon();
-    mz_max += 2 * mz_max * std::numeric_limits<double>::epsilon();
-    rt_min -= 2 * rt_min * std::numeric_limits<double>::epsilon();
-    rt_max += 2 * rt_max * std::numeric_limits<double>::epsilon();
+    mz_min -= 2 * std::abs(mz_min) * std::numeric_limits<double>::epsilon();
+    mz_max += 2 * std::abs(mz_max) * std::numeric_limits<double>::epsilon();
+    rt_min -= 2 * std::abs(rt_min) * std::numeric_limits<double>::epsilon();
+    rt_max += 2 * std::abs(rt_max) * std::numeric_limits<double>::epsilon();
     
     // generate grid spacing
     // We assume that the jitter of the peak centres are less than <scaling> times the user specified m/z tolerance.


### PR DESCRIPTION
The clustering grid allows for data points that lie on its border. Due to rounding errors, it is necessary to define a small margin around the clustering grid.

Previously, this margin was an absolute (magic) constant. In this pull request, this constant is replaced by a machine-epsilon-dependent margin.

@jpfeuffer Thanks for this good idea.