### PR TITLE
Fix/numpress pwiz

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -185,11 +185,15 @@ namespace OpenMS
       {
         if (data_[i].np_compression != MSNumpressCoder::NONE)
         {
-          // If its numpress, we don't care about 32 / 64 bit but the numpress
-          // decoder expects std::vector<double> which are 64 bit.
+          // If its numpress, we don't distinguish 32 / 64 bit as the numpress
+          // decoder always works with 64 bit (takes std::vector<double>)
           MSNumpressCoder::NumpressConfig config;
           config.np_compression = data_[i].np_compression;
           MSNumpressCoder().decodeNP(data_[i].base64, data_[i].floats_64,  data_[i].compression, config);
+
+          // Next, ensure that we only look at the float array even if the
+          // mzML tags say 32 bit data (I am looking at you, proteowizard)
+          data_[i].precision = BinaryData::PRE_64;
         }
         else if (data_[i].precision == BinaryData::PRE_64)
         {

--- a/src/tests/topp/FileFilter_44_input.mzML
+++ b/src/tests/topp/FileFilter_44_input.mzML
@@ -74,6 +74,46 @@
               <binary>57h9NJ4keUA0c267qSR5QCtGWEx2jHlA7SMB64GMeUCvAaqJjYx5QOODVSiZjHlAiKoDx6SMeUBzReLpEgx8QNzomRYfDHxARYxRQysMfEDSXBqnSVx8QGpyLuVVXHxAAohCI2JcfED02BwZdRt+QM2wQ7aBG35ApohqU44bfkCVad5qpHWAQK07KAOrdYBA</binary>
             </binaryDataArray>
             <binaryDataArray encodedLength="28">
+                <!-- note that according to the standard, either MS:1000521 (32 bit) or MS:1000521 (64 bit) is required here,
+                     but we also want to be able to parse invalid files -->
+              <cvParam cvRef="MS" accession="MS:1002313" name="MS-Numpress positive integer compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+              <binary>WrOIWrNas1N3iFqziFqziFqziFqz</binary>
+            </binaryDataArray>
+          </binaryDataArrayList>
+        </spectrum>
+        <spectrum index="0" id="sample=2 period=2 cycle=2 experiment=2" defaultArrayLength="18">
+          <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1"/>
+          <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" value=""/>
+          <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="1907.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="408.787391981167" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+          <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="8585.0" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
+          <scanList count="1">
+            <cvParam cvRef="MS" accession="MS:1000795" name="no combination" value=""/>
+            <scan>
+              <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.00455" unitCvRef="UO" unitAccession="UO:0000031" unitName="minute"/>
+              <cvParam cvRef="MS" accession="MS:1000616" name="preset scan configuration" value="1"/>
+              <scanWindowList count="1">
+                <scanWindow>
+                  <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="400.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                  <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1500.0" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+                </scanWindow>
+              </scanWindowList>
+            </scan>
+          </scanList>
+          <binaryDataArrayList count="2">
+            <binaryDataArray encodedLength="192">
+              <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000576" name="no compression" value=""/>
+              <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" value="" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+              <binary>57h9NJ4keUA0c267qSR5QCtGWEx2jHlA7SMB64GMeUCvAaqJjYx5QOODVSiZjHlAiKoDx6SMeUBzReLpEgx8QNzomRYfDHxARYxRQysMfEDSXBqnSVx8QGpyLuVVXHxAAohCI2JcfED02BwZdRt+QM2wQ7aBG35ApohqU44bfkCVad5qpHWAQK07KAOrdYBA</binary>
+            </binaryDataArray>
+            <binaryDataArray encodedLength="28">
+                <!-- note that using MS:1000521 (32 bit) instead of MS:1000521 (64 bit) is invalid or at least highly 
+                     inconsistent here as numpress arrays are always 64 bit, but we also want to be able to parse invalid files -->
+              <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" value=""/>
               <cvParam cvRef="MS" accession="MS:1002313" name="MS-Numpress positive integer compression" value=""/>
               <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" value="" unitCvRef="MS" unitAccession="MS:1000131" unitName="number of detector counts"/>
               <binary>WrOIWrNas1N3iFqziFqziFqziFqz</binary>

--- a/src/tests/topp/FileFilter_44_output.mzML
+++ b/src/tests/topp/FileFilter_44_output.mzML
@@ -1,102 +1,138 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession="" version="1.1.0">
-  <cvList count="5">
-    <cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
-    <cv id="UO" fullName="Unit Ontology" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
-    <cv id="BTO" fullName="BrendaTissue545" version="unknown" URI="http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO"/>
-    <cv id="GO" fullName="Gene Ontology - Slim Versions" version="unknown" URI="http://www.geneontology.org/GO_slims/goslim_goa.obo"/>
-    <cv id="PATO" fullName="Quality ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo"/>
-  </cvList>
-  <fileDescription>
-    <fileContent>
-      <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" />
-    </fileContent>
-    <sourceFileList count="1">
-      <sourceFile id="sf_ru_0" name="SILAC_2.wiff" location="file://.">
-        <cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="457f5ed2a86fb242eb77e0db784938d85c506912" />
-        <cvParam cvRef="MS" accession="MS:1000562" name="ABI WIFF format" />
-        <cvParam cvRef="MS" accession="MS:1000770" name="WIFF nativeID format" />
-      </sourceFile>
-    </sourceFileList>
-  </fileDescription>
-  <sampleList count="1">
-    <sample id="sa_0" name="">
-      <cvParam cvRef="MS" accession="MS:1000004" name="sample mass" value="0" unitAccession="UO:0000021" unitName="gram" unitCvRef="UO" />
-      <cvParam cvRef="MS" accession="MS:1000005" name="sample volume" value="0" unitAccession="UO:0000098" unitName="milliliter" unitCvRef="UO" />
-      <cvParam cvRef="MS" accession="MS:1000006" name="sample concentration" value="0" unitAccession="UO:0000175" unitName="gram per liter" unitCvRef="UO" />
-    </sample>
-  </sampleList>
-  <softwareList count="4">
-    <software id="so_in_0" version="unknown" >
-      <cvParam cvRef="MS" accession="MS:1000551" name="Analyst" />
-    </software>
-    <software id="so_default" version="" >
-      <cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
-    </software>
-    <software id="so_dp_sp_0_pm_0" version="3.0.7135" >
-      <cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" />
-    </software>
-    <software id="so_dp_sp_0_pm_1" version="version_string" >
-      <cvParam cvRef="MS" accession="MS:1000757" name="FileFilter" />
-    </software>
-  </softwareList>
-  <instrumentConfigurationList count="1">
-    <instrumentConfiguration id="ic_0">
-      <cvParam cvRef="MS" accession="MS:1000495" name="Applied Biosystems instrument model" />
-      <softwareRef ref="so_in_0" />
-    </instrumentConfiguration>
-  </instrumentConfigurationList>
-  <dataProcessingList count="1">
-    <dataProcessing id="dp_sp_0">
-      <processingMethod order="0" softwareRef="so_dp_sp_0_pm_0">
-        <cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
-      </processingMethod>
-      <processingMethod order="0" softwareRef="so_dp_sp_0_pm_1">
-        <cvParam cvRef="MS" accession="MS:1001486" name="data filtering" />
-        <cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="1999-12-31+23:59" />
-        <userParam name="parameter: mode" type="xsd:string" value="test_mode"/>
-      </processingMethod>
-    </dataProcessing>
-  </dataProcessingList>
-  <run id="ru_0" defaultInstrumentConfigurationRef="ic_0" sampleRef="sa_0" startTimeStamp="2015-06-19T00:26:28" defaultSourceFileRef="sf_ru_0">
-    <userParam name="mzml_id" type="xsd:string" value="SILAC_2-SILAC 2"/>
-    <spectrumList count="1" defaultDataProcessingRef="dp_sp_0">
-      <spectrum id="sample=1 period=1 cycle=1 experiment=1" index="0" defaultArrayLength="18" dataProcessingRef="dp_sp_0">
-        <cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" />
-        <cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
-        <cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" />
-        <cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
-        <cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="1907" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-        <cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="408.787391981167" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
-        <cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="8585" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-        <userParam name="preset scan configuration" type="xsd:string" value="1"/>
-        <scanList count="1">
-          <cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
-          <scan >
-            <cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.273" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
-            <scanWindowList count="1">
-              <scanWindow>
-                <cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="400" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-                <cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1500" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-              </scanWindow>
-            </scanWindowList>
-          </scan>
-        </scanList>
-        <binaryDataArrayList count="2">
-          <binaryDataArray encodedLength="192">
-            <cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
-            <cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
-            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-            <binary>57h9NJ4keUA0c267qSR5QCtGWEx2jHlA7SMB64GMeUCvAaqJjYx5QOODVSiZjHlAiKoDx6SMeUBzReLpEgx8QNzomRYfDHxARYxRQysMfEDSXBqnSVx8QGpyLuVVXHxAAohCI2JcfED02BwZdRt+QM2wQ7aBG35ApohqU44bfkCVad5qpHWAQK07KAOrdYBA</binary>
-          </binaryDataArray>
-          <binaryDataArray encodedLength="96">
-            <cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
-            <cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
-            <cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
-            <binary>AIBuRAAAAAAAAAAAAIBuRACAbkQAYO5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5E</binary>
-          </binaryDataArray>
-        </binaryDataArrayList>
-      </spectrum>
-    </spectrumList>
-  </run>
+	<cvList count="5">
+		<cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+		<cv id="UO" fullName="Unit Ontology" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
+		<cv id="BTO" fullName="BrendaTissue545" version="unknown" URI="http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO"/>
+		<cv id="GO" fullName="Gene Ontology - Slim Versions" version="unknown" URI="http://www.geneontology.org/GO_slims/goslim_goa.obo"/>
+		<cv id="PATO" fullName="Quality ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo"/>
+	</cvList>
+	<fileDescription>
+		<fileContent>
+			<cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" />
+		</fileContent>
+		<sourceFileList count="1">
+			<sourceFile id="sf_ru_0" name="SILAC_2.wiff" location="file://.">
+				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="457f5ed2a86fb242eb77e0db784938d85c506912" />
+				<cvParam cvRef="MS" accession="MS:1000562" name="ABI WIFF format" />
+				<cvParam cvRef="MS" accession="MS:1000770" name="WIFF nativeID format" />
+			</sourceFile>
+		</sourceFileList>
+	</fileDescription>
+	<sampleList count="1">
+		<sample id="sa_0" name="">
+			<cvParam cvRef="MS" accession="MS:1000004" name="sample mass" value="0" unitAccession="UO:0000021" unitName="gram" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000005" name="sample volume" value="0" unitAccession="UO:0000098" unitName="milliliter" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000006" name="sample concentration" value="0" unitAccession="UO:0000175" unitName="gram per liter" unitCvRef="UO" />
+		</sample>
+	</sampleList>
+	<softwareList count="4">
+		<software id="so_in_0" version="unknown" >
+			<cvParam cvRef="MS" accession="MS:1000551" name="Analyst" />
+		</software>
+		<software id="so_default" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_0" version="3.0.7135" >
+			<cvParam cvRef="MS" accession="MS:1000615" name="ProteoWizard software" />
+		</software>
+		<software id="so_dp_sp_0_pm_1" version="version_string" >
+			<cvParam cvRef="MS" accession="MS:1000757" name="FileFilter" />
+		</software>
+	</softwareList>
+	<instrumentConfigurationList count="1">
+		<instrumentConfiguration id="ic_0">
+			<cvParam cvRef="MS" accession="MS:1000495" name="Applied Biosystems instrument model" />
+			<softwareRef ref="so_in_0" />
+		</instrumentConfiguration>
+	</instrumentConfigurationList>
+	<dataProcessingList count="1">
+		<dataProcessing id="dp_sp_0">
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_0">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_1">
+				<cvParam cvRef="MS" accession="MS:1001486" name="data filtering" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="1999-12-31+23:59" />
+				<userParam name="parameter: mode" type="xsd:string" value="test_mode"/>
+			</processingMethod>
+		</dataProcessing>
+	</dataProcessingList>
+	<run id="ru_0" defaultInstrumentConfigurationRef="ic_0" sampleRef="sa_0" startTimeStamp="2015-06-19T00:26:28" defaultSourceFileRef="sf_ru_0">
+		<userParam name="mzml_id" type="xsd:string" value="SILAC_2-SILAC 2"/>
+		<spectrumList count="2" defaultDataProcessingRef="dp_sp_0">
+			<spectrum id="sample=1 period=1 cycle=1 experiment=1" index="0" defaultArrayLength="18" dataProcessingRef="dp_sp_0">
+				<cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="1907" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+				<cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="408.787391981167" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+				<cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="8585" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+				<userParam name="preset scan configuration" type="xsd:string" value="1"/>
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.273" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+						<scanWindowList count="1">
+							<scanWindow>
+								<cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="400" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1500" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							</scanWindow>
+						</scanWindowList>
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="192">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>57h9NJ4keUA0c267qSR5QCtGWEx2jHlA7SMB64GMeUCvAaqJjYx5QOODVSiZjHlAiKoDx6SMeUBzReLpEgx8QNzomRYfDHxARYxRQysMfEDSXBqnSVx8QGpyLuVVXHxAAohCI2JcfED02BwZdRt+QM2wQ7aBG35ApohqU44bfkCVad5qpHWAQK07KAOrdYBA</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="96">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AIBuRAAAAAAAAAAAAIBuRACAbkQAYO5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5E</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="sample=2 period=2 cycle=2 experiment=2" index="1" defaultArrayLength="18">
+				<cvParam cvRef="MS" accession="MS:1000128" name="profile spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000579" name="MS1 spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<cvParam cvRef="MS" accession="MS:1000505" name="base peak intensity" value="1907" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+				<cvParam cvRef="MS" accession="MS:1000504" name="base peak m/z" value="408.787391981167" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS"/>
+				<cvParam cvRef="MS" accession="MS:1000285" name="total ion current" value="8585" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+				<userParam name="preset scan configuration" type="xsd:string" value="1"/>
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="0.273" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+						<scanWindowList count="1">
+							<scanWindow>
+								<cvParam cvRef="MS" accession="MS:1000501" name="scan window lower limit" value="400" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+								<cvParam cvRef="MS" accession="MS:1000500" name="scan window upper limit" value="1500" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+							</scanWindow>
+						</scanWindowList>
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="192">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>57h9NJ4keUA0c267qSR5QCtGWEx2jHlA7SMB64GMeUCvAaqJjYx5QOODVSiZjHlAiKoDx6SMeUBzReLpEgx8QNzomRYfDHxARYxRQysMfEDSXBqnSVx8QGpyLuVVXHxAAohCI2JcfED02BwZdRt+QM2wQ7aBG35ApohqU44bfkCVad5qpHWAQK07KAOrdYBA</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="96">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000576" name="no compression" />
+						<binary>AIBuRAAAAAAAAAAAAIBuRACAbkQAYO5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5EAAAAAAAAAAAAgG5E</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+		</spectrumList>
+	</run>
 </mzML>


### PR DESCRIPTION
- provides a workaround for broken proteowizard files containing numpress arrays
- add a test that ensures that we can parse multiple types of invalid numpress-containing files

apparently proteowizard writes "32-bit float" (MS:1000521) cvParams into the numpress compressed arrays which are *by definition* 64 bit. This workaround ensures that OpenMS treats them always as 64 bit arrays and uses the right data structure (floats_64) to access the data.