### PR TITLE
Feature/ms numpress

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MSNumpressCoder.h
+++ b/src/openms/include/OpenMS/FORMAT/MSNumpressCoder.h
@@ -72,12 +72,14 @@ public:
       double numpressErrorTolerance;  /// check error tolerance after encoding, guarantee abs(1.0-(encoded/decoded)) <= this, 0=do not guarantee anything
       NumpressCompression np_compression; /// which compression schema to use
       bool estimate_fixed_point; /// whether to estimate the fixed point or use the one proved with numpressFixedPoint
+      double linear_fp_mass_acc; /// desired mass accuracy for linear encoding (-1 no effect, use 0.0001 for 0.2 ppm accuracy @ 500 m/z)
 
       NumpressConfig () :
         numpressFixedPoint(0.0),
         numpressErrorTolerance(BinaryDataEncoder_default_numpressErrorTolerance),
         np_compression(NONE),
-        estimate_fixed_point(false)
+        estimate_fixed_point(false),
+        linear_fp_mass_acc(-1)
       {
       }
 

--- a/src/openms/include/OpenMS/MATH/MISC/MSNumpress.h
+++ b/src/openms/include/OpenMS/MATH/MISC/MSNumpress.h
@@ -35,20 +35,33 @@
 	
 	encodeInt()
  
+	The algorithm is similar to other variable length integer encodings,
+	such as the SQLite Variable-Length Integers encoding, but it uses half
+	bytes in its encoding procedure.
+
 	This encoding works on a 4 byte integer, by truncating initial zeros or ones.
 	If the initial (most significant) half byte is 0x0 or 0xf, the number of such 
 	halfbytes starting from the most significant is stored in a halfbyte. This initial 
 	count is then followed by the rest of the ints halfbytes, in little-endian order. 
 	A count halfbyte c of
-	
+
 		0 <= c <= 8 		is interpreted as an initial c 		0x0 halfbytes 
 		9 <= c <= 15		is interpreted as an initial (c-8) 	0xf halfbytes
 
-	Ex:
+	Example:
+
 	int		c		rest
 	0 	=> 	0x8
 	-1	=>	0xf		0xf
+	 2	=>	0x7		0x2
 	23	=>	0x6 	0x7	0x1
+	2047	=>	0x5 	0xf 0xf	0xf
+
+	Note that the algorithm returns a char array in which the half bytes are
+	stored in the lower 4 bits of each element. Since the first element is a
+	count half byte, the maximal length of the encoded data is 9 half bytes
+	(1 count half byte + 8 half bytes for a 4-byte integer).
+
  */
 
 #ifndef OPENMS_MATH_MISC_MSNUMPRESS_H
@@ -219,7 +232,7 @@ namespace MSNumpress {
 	 *
 	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
 	 * @dataSize	number of doubles from *data to encode
-	 * @result		pointer to were resulting bytes should be stored
+	 * @result		pointer to where resulting bytes should be stored
 	 * @return		the number of encoded bytes
 	 */
 	size_t encodePic(

--- a/src/openms/include/OpenMS/MATH/MISC/MSNumpress.h
+++ b/src/openms/include/OpenMS/MATH/MISC/MSNumpress.h
@@ -68,10 +68,37 @@ namespace numpress {
 
 namespace MSNumpress {
 	
+	/**
+	 * Compute the maximal linear fixed point that prevents integer overflow.
+     *
+	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @dataSize	number of doubles from *data to encode
+     *
+	 * @return		the linear fixed point safe to use
+	 */
 	double optimalLinearFixedPoint(
-		const double *data, 
+		const double *data,
 		size_t dataSize);
 	
+	/**
+	 * Compute the optimal linear fixed point with a desired ppm accuracy.
+     *
+     * @note If the desired accuracy cannot be reached without overflowing 64
+     * bit integers, then a negative value is returned. You need to check for
+     * this and in that case abandon numpress or use optimalLinearFixedPoint
+     * which returns the largest safe value.
+     *
+	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @dataSize	number of doubles from *data to encode
+	 * @ppm			desired accuracy in ppm
+     *
+	 * @return		the linear fixed point that satisfies the accuracy requirement (or -1 in case of failure).
+	 */
+    double optimalLinearFixedPointPPM(
+            const double *data,
+            size_t dataSize,
+            double ppm);
+
 	/**
 	 * Encodes the doubles in data by first using a 
 	 *   - lossy conversion to a 4 byte 5 decimal fixed point representation

--- a/src/openms/include/OpenMS/MATH/MISC/MSNumpress.h
+++ b/src/openms/include/OpenMS/MATH/MISC/MSNumpress.h
@@ -81,7 +81,7 @@ namespace MSNumpress {
 		size_t dataSize);
 	
 	/**
-	 * Compute the optimal linear fixed point with a desired ppm accuracy.
+	 * Compute the optimal linear fixed point with a desired m/z accuracy.
      *
      * @note If the desired accuracy cannot be reached without overflowing 64
      * bit integers, then a negative value is returned. You need to check for
@@ -90,14 +90,14 @@ namespace MSNumpress {
      *
 	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
 	 * @dataSize	number of doubles from *data to encode
-	 * @ppm			desired accuracy in ppm
+	 * @mass_acc	desired m/z accuracy in Th
      *
 	 * @return		the linear fixed point that satisfies the accuracy requirement (or -1 in case of failure).
 	 */
-    double optimalLinearFixedPointPPM(
+    double optimalLinearFixedPointMass(
             const double *data,
             size_t dataSize,
-            double ppm);
+            double mass_acc);
 
 	/**
 	 * Encodes the doubles in data by first using a 

--- a/src/openms/source/FORMAT/MSNumpressCoder.cpp
+++ b/src/openms/source/FORMAT/MSNumpressCoder.cpp
@@ -98,6 +98,8 @@ namespace OpenMS
           if (config.linear_fp_mass_acc > 0)
           {
             fixedPoint = numpress::MSNumpress::optimalLinearFixedPointMass(&in[0], dataSize, config.linear_fp_mass_acc);
+            // catch failure
+            if (fixedPoint < 0.0) fixedPoint = numpress::MSNumpress::optimalLinearFixedPoint(&in[0], dataSize);
           }
           else
           {

--- a/src/openms/source/FORMAT/MSNumpressCoder.cpp
+++ b/src/openms/source/FORMAT/MSNumpressCoder.cpp
@@ -92,10 +92,21 @@ namespace OpenMS
       {
       case LINEAR:
       {
-        if (config.estimate_fixed_point) {fixedPoint = numpress::MSNumpress::optimalLinearFixedPoint(&in[0], dataSize); }
+        if (config.estimate_fixed_point)
+        {
+          // estimate fixed point either by mass accuracy or by using maximal permissable value
+          if (config.linear_fp_mass_acc > 0)
+          {
+            fixedPoint = numpress::MSNumpress::optimalLinearFixedPointMass(&in[0], dataSize, config.linear_fp_mass_acc);
+          }
+          else
+          {
+            fixedPoint = numpress::MSNumpress::optimalLinearFixedPoint(&in[0], dataSize);
+          }
+        }
         byteCount = numpress::MSNumpress::encodeLinear(&in[0], dataSize, &numpressed[0], fixedPoint);
         numpressed.resize(byteCount);
-        if (config.numpressErrorTolerance)   // decompress to check accuracy loss
+        if (config.numpressErrorTolerance > 0.0)   // decompress to check accuracy loss
         {
           numpress::MSNumpress::decodeLinear(numpressed, unpressed);
         }
@@ -106,7 +117,7 @@ namespace OpenMS
       {
         byteCount = numpress::MSNumpress::encodePic(&in[0], dataSize, &numpressed[0]);
         numpressed.resize(byteCount);
-        if (config.numpressErrorTolerance)   // decompress to check accuracy loss
+        if (config.numpressErrorTolerance > 0.0)   // decompress to check accuracy loss
         {
           numpress::MSNumpress::decodePic(numpressed, unpressed);
         }
@@ -118,7 +129,7 @@ namespace OpenMS
         if (config.estimate_fixed_point) {fixedPoint = numpress::MSNumpress::optimalSlofFixedPoint(&in[0], dataSize); }
         byteCount = numpress::MSNumpress::encodeSlof(&in[0], dataSize, &numpressed[0], fixedPoint);
         numpressed.resize(byteCount);
-        if (config.numpressErrorTolerance)   // decompress to check accuracy loss
+        if (config.numpressErrorTolerance > 0.0)   // decompress to check accuracy loss
         {
           numpress::MSNumpress::decodeSlof(numpressed, unpressed);
         }
@@ -146,7 +157,7 @@ namespace OpenMS
 
       // 3. Now check to see if encoding introduces excessive error
       int n = -1;
-      if (config.numpressErrorTolerance)
+      if (config.numpressErrorTolerance > 0.0)
       {
         if (PIC == config.np_compression) // integer rounding, abs accuracy is +- 0.5
         {

--- a/src/openms/source/FORMAT/MSNumpressCoder.cpp
+++ b/src/openms/source/FORMAT/MSNumpressCoder.cpp
@@ -217,7 +217,11 @@ namespace OpenMS
     }
     catch (int e)
     {
-      std::cerr << "MZNumpress encoder threw exception: " << e << std::endl;
+      std::cerr << "MSNumpress encoder threw exception: " << e << std::endl;
+    }
+    catch (char const * e)
+    {
+      std::cerr << "MSNumpress encoder threw exception: " << e << std::endl;
     }
     catch (...)
     {

--- a/src/openms/source/MATH/MISC/MSNumpress.cpp
+++ b/src/openms/source/MATH/MISC/MSNumpress.cpp
@@ -209,9 +209,31 @@ static void decodeInt(
 
 /////////////////////////////////////////////////////////////
 
+double optimalLinearFixedPointPPM(
+		const double *data, 
+		size_t dataSize,
+        double ppm
+) {
+	if (dataSize < 3) return 0; // we just encode the first two points as floats
+
+    // We calculate the maximal fixedPoint we need to achieve a specific ppm
+    // accuracy. Note that the maximal error we will make by encoding as int is
+    // 0.5 due to rounding errors. We will make the largest rounding error for
+    // the third datapoint, therefore we only need to look at it.
+    double maxFP = 0.5 / (data[2] * ppm * 1e-6);
+
+    // There is a maximal value for the FP given by the int length (32bit)
+    // which means we cannot choose a value higher than that. In case we cannot
+    // achieve the desired accuracy, return failure (-1).
+    double maxFP_overflow = optimalLinearFixedPoint(data, dataSize);
+    if (maxFP > maxFP_overflow) return -1;
+
+    return maxFP;
+}
+
 
 double optimalLinearFixedPoint(
-		const double *data, 
+		const double *data,
 		size_t dataSize
 ) {
 	/*

--- a/src/openms/source/MATH/MISC/MSNumpress.cpp
+++ b/src/openms/source/MATH/MISC/MSNumpress.cpp
@@ -209,18 +209,17 @@ static void decodeInt(
 
 /////////////////////////////////////////////////////////////
 
-double optimalLinearFixedPointPPM(
+double optimalLinearFixedPointMass(
 		const double *data, 
 		size_t dataSize,
-        double ppm
+        double mass_acc
 ) {
 	if (dataSize < 3) return 0; // we just encode the first two points as floats
 
-    // We calculate the maximal fixedPoint we need to achieve a specific ppm
+    // We calculate the maximal fixedPoint we need to achieve a specific mass
     // accuracy. Note that the maximal error we will make by encoding as int is
-    // 0.5 due to rounding errors. We will make the largest rounding error for
-    // the third datapoint, therefore we only need to look at it.
-    double maxFP = 0.5 / (data[2] * ppm * 1e-6);
+    // 0.5 due to rounding errors.
+    double maxFP = 0.5 / mass_acc;
 
     // There is a maximal value for the FP given by the int length (32bit)
     // which means we cannot choose a value higher than that. In case we cannot
@@ -230,7 +229,6 @@ double optimalLinearFixedPointPPM(
 
     return maxFP;
 }
-
 
 double optimalLinearFixedPoint(
 		const double *data,

--- a/src/openms/source/MATH/MISC/MSNumpress.cpp
+++ b/src/openms/source/MATH/MISC/MSNumpress.cpp
@@ -93,6 +93,8 @@ static double decodeFixedPoint(
  * Encodes the int x as a number of halfbytes in res. 
  * res_length is incremented by the number of halfbytes, 
  * which will be 1 <= n <= 9
+ *
+ * see header file for a detailed description of the algorithm.
  */
 static void encodeInt(
 		const unsigned int x,

--- a/src/openms/source/MATH/MISC/MSNumpress.cpp
+++ b/src/openms/source/MATH/MISC/MSNumpress.cpp
@@ -712,14 +712,14 @@ size_t encodeSlof(
 
 	ri = 8;
 	for (i=0; i<dataSize; i++) {
-		temp = log(data[i]+1) * fixedPoint + 0.5;
+		temp = log(data[i]+1) * fixedPoint;
 
 		if (MS_NUMPRESS_THROW_ON_OVERFLOW && 
 				temp > USHRT_MAX		) {
 			throw "[MSNumpress::encodeSlof] Cannot encode a number that overflows USHRT_MAX.";
 		}
 
-		x = static_cast<unsigned short>(temp);
+		x = static_cast<unsigned short>(temp + 0.5);
 		result[ri++] = x & 0xff;
 		result[ri++] = (x >> 8) & 0xff; 
 	}

--- a/src/openms/source/MATH/MISC/MSNumpress.cpp
+++ b/src/openms/source/MATH/MISC/MSNumpress.cpp
@@ -376,6 +376,8 @@ size_t decodeLinear(
 	
 	//printf("Decoding %d bytes with fixed point %f\n", (int)dataSize, fixedPoint);
 
+	if (dataSize == 8) return 0;
+
 	if (dataSize < 8) 
 		throw "[MSNumpress::decodeLinear] Corrupt input data: not enough bytes to read fixed point! ";
 	

--- a/src/openms/source/MATH/MISC/MSNumpress.cpp
+++ b/src/openms/source/MATH/MISC/MSNumpress.cpp
@@ -668,7 +668,8 @@ double optimalSlofFixedPoint(
 		maxDouble = max(maxDouble, x);
 	}
 
-	fp = floor(0xFFFF / maxDouble);
+	// here we use 0xFFFE as maximal value as we add 0.5 during encoding (see encodeSlof)
+	fp = floor(0xFFFE / maxDouble);
 
 	//cout << "    max val: " << maxDouble << endl;
 	//cout << "fixed point: " << fp << endl;

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -410,6 +410,13 @@ set_tests_properties("TOPP_FileConverter_22" PROPERTIES WILL_FAIL 1) ## low memo
 add_test("TOPP_FileConverter_23" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA_DIR_TOPP}/FileConverter_23_input.mzML -out FileConverter_23.tmp -out_type mzML)
 add_test("TOPP_FileConverter_23_out" ${DIFF} -in1 FileConverter_23.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_23_output.mzML -whitelist "location=")
 set_tests_properties("TOPP_FileConverter_23_out" PROPERTIES DEPENDS "TOPP_FileConverter_23")
+# Purpose: test the numpress conversion options (using full accuracy and 1ppm accuracy @ 100 m/z)
+add_test("TOPP_FileConverter_24" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA_DIR_TOPP}/FileFilter_1_input.mzML -out FileConverter_24.tmp  -write_mzML_index -process_lowmemory -in_type mzML -out_type mzML -lossy_compression -lossy_mass_accuracy 0.0001)
+add_test("TOPP_FileConverter_24_out" ${DIFF} -in1 FileConverter_24.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_24_output.mzML )
+set_tests_properties("TOPP_FileConverter_24_out" PROPERTIES DEPENDS "TOPP_FileConverter_24")
+add_test("TOPP_FileConverter_25" ${TOPP_BIN_PATH}/FileConverter -test -in ${DATA_DIR_TOPP}/FileFilter_1_input.mzML -out FileConverter_25.tmp  -write_mzML_index -process_lowmemory -in_type mzML -out_type mzML -lossy_compression)
+add_test("TOPP_FileConverter_25_out" ${DIFF} -in1 FileConverter_25.tmp -in2 ${DATA_DIR_TOPP}/FileConverter_25_output.mzML )
+set_tests_properties("TOPP_FileConverter_25_out" PROPERTIES DEPENDS "TOPP_FileConverter_25")
 
 #------------------------------------------------------------------------------
 # FileFilter tests

--- a/src/tests/topp/FileConverter_24_output.mzML
+++ b/src/tests/topp/FileConverter_24_output.mzML
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<indexedmzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd">
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession="" version="1.1.0">
+	<cvList count="5">
+		<cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+		<cv id="UO" fullName="Unit Ontology" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
+		<cv id="BTO" fullName="BrendaTissue545" version="unknown" URI="http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO"/>
+		<cv id="GO" fullName="Gene Ontology - Slim Versions" version="unknown" URI="http://www.geneontology.org/GO_slims/goslim_goa.obo"/>
+		<cv id="PATO" fullName="Quality ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo"/>
+	</cvList>
+	<fileDescription>
+		<fileContent>
+			<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+		</fileContent>
+		<contact>
+			<cvParam cvRef="MS" accession="MS:1000586" name="contact name" value=", " />
+			<cvParam cvRef="MS" accession="MS:1000590" name="contact affiliation" value="" />
+		</contact>
+	</fileDescription>
+	<sampleList count="1">
+		<sample id="sa_0" name="">
+			<cvParam cvRef="MS" accession="MS:1000004" name="sample mass" value="0" unitAccession="UO:0000021" unitName="gram" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000005" name="sample volume" value="0" unitAccession="UO:0000098" unitName="milliliter" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000006" name="sample concentration" value="0" unitAccession="UO:0000175" unitName="gram per liter" unitCvRef="UO" />
+		</sample>
+	</sampleList>
+	<softwareList count="5">
+		<software id="so_in_0" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_default" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_0" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_1" version="version_string" >
+			<cvParam cvRef="MS" accession="MS:1000756" name="FileConverter" />
+		</software>
+		<software id="so_dp_sp_0_pm_2" version="version_string" >
+			<cvParam cvRef="MS" accession="MS:1000756" name="FileConverter" />
+		</software>
+	</softwareList>
+	<instrumentConfigurationList count="1">
+		<instrumentConfiguration id="ic_0">
+			<cvParam cvRef="MS" accession="MS:1000031" name="instrument model" />
+			<componentList count="3">
+				<source order="0">
+					<cvParam cvRef="MS" accession="MS:1000008" name="ionization type" />
+				</source>
+				<analyzer order="0">
+					<cvParam cvRef="MS" accession="MS:1000014" name="accuracy" value="0" unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO" />
+					<cvParam cvRef="MS" accession="MS:1000022" name="TOF Total Path Length" value="0" unitAccession="UO:0000008" unitName="meter" unitCvRef="UO" />
+					<cvParam cvRef="MS" accession="MS:1000024" name="final MS exponent" value="0" />
+					<cvParam cvRef="MS" accession="MS:1000025" name="magnetic field strength" value="0" unitAccession="UO:0000228" unitName="tesla" unitCvRef="UO" />
+					<cvParam cvRef="MS" accession="MS:1000443" name="mass analyzer type" />
+				</analyzer>
+				<detector order="0">
+					<cvParam cvRef="MS" accession="MS:1000028" name="detector resolution" value="0" />
+					<cvParam cvRef="MS" accession="MS:1000029" name="sampling frequency" value="0" unitAccession="UO:0000106" unitName="hertz" unitCvRef="UO" />
+					<cvParam cvRef="MS" accession="MS:1000026" name="detector type" />
+				</detector>
+			</componentList>
+			<softwareRef ref="so_in_0" />
+		</instrumentConfiguration>
+	</instrumentConfigurationList>
+	<dataProcessingList count="1">
+		<dataProcessing id="dp_sp_0">
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_0">
+				<cvParam cvRef="MS" accession="MS:1000543" name="data processing action" />
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_1">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="1999-12-31+23:59" />
+				<userParam name="parameter: mode" type="xsd:string" value="test_mode"/>
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_2">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="1999-12-31+23:59" />
+				<userParam name="parameter: mode" type="xsd:string" value="test_mode"/>
+			</processingMethod>
+		</dataProcessing>
+	</dataProcessingList>
+	<run id="ru_0" defaultInstrumentConfigurationRef="ic_0" sampleRef="sa_0">
+		<spectrumList count="10" defaultDataProcessingRef="dp_sp_0">
+			<spectrum id="spectrum=1" index="0" defaultArrayLength="787" dataProcessingRef="dp_sp_0">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="20.8713" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="2196">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAAB5KCYAQzomANNCVN9c0tV32w1ew9i8W+LRWVhi1s1dalg02LfQvlXi0zleytcr3/7ViVkMXrLQPEfgHExuV2FfoV6U0hVXXtLHWsJX+NcLXXLf3tQ+1FlAXxy7LlrT5M1JpWsVsyV1LWDtj+2+ReXNGqWnnYwF+M4V383VTtK8XsLWzNiNX5zQ2m4+idz6XrFXZtM545W+fTGdkZWPrd+FTx2etSaeTN4ZWbba+VSv0BRSR9R9XPLOfuUKpYk9RM3vdcidd+W8baSOwdic6xVIXauVPs1mZThtlKWxJTEVaCXuPayO9NN+at3XxeCt8sW5TWIlyzX0bQLNl7UqhbwdUFV5za+kwSHGZ+XyXivfXF9s3rPnNcdlKy0mNVDt8DXeRUV9oX1n5UidRH321cm9Qn2HxIciURLFau28rVyVoF3TrqZUK9qL0ShVt1ZiXhXXHFLvyXvtttU9Pc3OzV9k0W3cylmJ3RnUrlZYUPbbJdVaWmNfpOCu0tkMTEwcGJ7S6Fhi2K3fbl5i2JpE4B3dpeRN3p4X09ZZ29PuVL7RU9Yn4CUvjS11+CWlVsnb+9XXVkleIlW42/PSDdi+Us/KDeTFYcWc5VMlIy2hzhhNkB1bBaoVQRa6X4rhrWaNj6WAnWEFsJUs3WAeEtoMWIva/VfSyD3kJuHTeNRs1rjdfVzkXUFSMd6iRLYcbu5c89x61u5X3d3M05nXvFziTwEcOO5d0d5e0X7sNVbNJFXgbV7tKZU+nU6NQdWtnYLtd+1k3crddNWupV2teRVQjb59le1j1V9mzdZuU+NbodWo2Khbs+V1/ebf2XXWjttrWLFV4dKaUsXYTNBNXBfVflxhZbVUfSOFWj2J7eZeuVtyV8bR2FXlUQfUHNe812peLFj0UVjBi+X+TelVyc3EVPgxxv7tYOaBWU3QIUngHUglHF1AZUetaRVFha21rdw2rl06yl7lxe2hjXOlHSU7Prbdil6BXufajtPgTOIdRXU7fQCdv74EXKvUWO7lbs1sLf2lBd6y34Vb29wjYrQxscVT5et9SJXobnjdXF/m31pFlxzGHlCJ23hSiOlWBt3lT+AdZ2UhvUiNu4VyLq3aXlJq1A7cV14M0d3faVo515xi/TGVXWXLPSMmOl4P2lJZWOq9PJS4ocVp7YS9VcXenQp1NyUzvQwVT/2dJbRdOBUW3ZrVv0343WeVckW2JnTTnNsXUhxYd1zF18rbkFOX0DhYBFUJWlLUQGMV7RXInWrt/zQagcUO7bZlwM0FvVu2C9qeUOpVpNtJ2Aha29clUPtYQsf+5YCFIW2+1t1Yd8zf5DtBzdvlO4393QZkm2HGLe3DxROd2dWXnYQ1mx3HpFwhyM/mu0SgHA7eXszdRtVeWANrZTedU5QYQdBA1jzZdtWNXF3dFFAJV3TfWF0J7w18ldek12HLkuUAJBASw7HVcy7wXmffSlaU3B1ew9+4WwzS/N9pbx1r5R395mWIjd5dUHX1hS6NmZ0rtFRTzwvF0RW5XQllAz2NpUeVekUR3Zst0s27tB4SzebVlEUBXQPk1DHBvOX0PZm1nr3/zaLdl61w7SblUt0opbWc5+5ICByyfk+RHZ8l5EROMdnE35BOEBVrbWmdtFbWTSksmM3SzELFHXhlhVy47kKTHPxuQ1YsrT1Rid/kRsAdnlT4IdSr2DxfpNbGWRfYlt96YPaVUh7RI9ctRrQtOmXlXH+OQ5Qs2I3SvV1H06JPZxyrrkB/HMlO5pVmzQBVZhX/FYTsMk5RftWGQEI8m11LKSyQTdZxV79WYlYPwVbk9gHXYU5zHdtUcnJGSixwDFj7QIAs5o3EHNWJRPqizLntZQXlxpHcAk/JjJynTCQsXw1aqtvJ11tf9dKeSSxM4d3MiNQqQcjG5C9hwF/kTTPOC8QAolbtzuzdhJ1/JOOhTB0cT9tfiECwXHaL1yxMkx2B1EMTyca0uQjHMY3htQk0LgJPJEx6ncrw3XMWVVCBQkwdfaUDhQxFpUXyXUeM265LpSyFXdPSUJNHvzxdXdZeQBEVf1S7iMaQYyrVG5Tf7LUJVX9C1ExFe0JXXKlLzz3tebTpoc7H7cClfH2K5OJ+wO+8oM3CT62JdHADywilJtMYgBycd8/Q3GCbVWzbi97wM5tCtvu9TX8k7SzJdnzfaUgsY2Z4GytB4A==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="2112">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QL5KAAAAAADI06Cx9pAY/J3f0sAGyfaZq8tO1ESyWpCBpx7cjb9EvQKtZcAm2C+xiq4tjVaf7cRyht281r9slv6zYsKmxP/uW+dzmsmOPaTxtLKrGcGdyXubIp0Ik8TQJr3kyxeYZ+j8/0jR9NTHxnPHMeDDxtPY39nJmC60Xr9dwjW1yKwQujDW67m8zAm5l6y0wTS8KMXo2D/TNe2V2US2M+gRxLHSR42ixYuwpKct0NbN2aXStEFiYK+joTy0mngrmuezUrSm0xqo/JA10U6wk71Imbd9Jahs9w7V6tNG0da6NbkPkOG1PL06zM/GjLYllVGwv7f0nIaqhpYmtPeo/5rHxlrFAbHzxjea8L3bkyS/u9SvoT+hq4AcvqukgJQdpRqJq4y8vHDElJrewGq+G8vmorSrOJubnPnPDYw1g+93MKrqkC9+LZtvqMqtSrfJ72CTM6OgruCyhpkTytW1aH0krdSOA8CR3NKlvLOjqzuyPs9FxuC4d4SBqL+KRpkovvGpHb8op/3CzbJZr9B9+8GOdyq7rrXZuWeoq9LOvTG/EJ9Tn/PDm5IzhIC5T8TPmsHGQKzamMeCSowws6G+QrfVvM6dHK2boH6kX6VnlRCaOIoHvL6WI6bCtsi0LYAexfqyw7HevJq6OLFWmC2ovroPw3C5g6SfgIzmLcqwvgm3Va4ur1mrP5vtiTyqsqFPkdqM5bV/u5y7aal5mOnA2ZXDzKWYeK5rq2O8WazFwaCCYMBjzOG7IJjjq1/Jj6USmeeYeobuhVmyRbh2ljixsbalpC+DFrJnnxPapqQQqBGb6Hmhke1/ssJ7mrzBR5z1rw69JK/1jEHIx5xek1mSEn4at/TKULrcwnKnL7EpkoN5N2ZfpraZS5FcsJqUE4+Ur5y9XKSTq6CMIIoWg2mperVwi7qw/JRCtmWg/Jqds0ixwpHraaGyJ3m5r7qxnpN8q6KHIqQthDe06qdXtY2z7qSetfK8FqrbsRmd44G/ohGbgMgUwimj1KL2cIWllsCZqFdWaogupK2wsMdhosext5abv8ycnL3mjIm6J72KnVmtqp+Ue6OS36qbh6SL/p90lPCvZaBIsGuvO4ePngS/X61Kr+ScE6ZRxa2+EtzbunTTQ6cSwpfFZbizpjSZf6WrbhnR1pnRxn6dPJ1Xm1zKArhosvumEMWgrO6WTMqKxbegfaXpeh2pLpWCpW/NdoFYpUSa0HiFt/WpeZm5t8eGc5yM0zB6kLMTjsq/iqrsujjJmq5uljl2daAzbs6geKLMZpqCbYNHmqNyKKaGuRl8W8SFcpzGJ64YlUuc5qzCnoWjIoYTxn+9xq8envZ6X54joQJ+DHafutnISqhLsNeHbIw+f521Eng5jjqw9cDeheWSl3qyuDuxPKkQgJC7MIydgkmDDXREmUivKZJCvUW4XokmstS7t4lQnUCVGJMIg7asVaMKo9ZwjrGQhm58JYuDr4GvxqXlkwB0x4IhpQyPS3QTfQCiBI2BWAKNvZ/gbGqplM+SqIGeM6HQonFvT8X0wryumLRVokyYDKMmja69Lp72pqla3nCMfFSKx5bxeN+a1rCEoueWbajQiqh7rKGpjUKcDHZ5eP5t56pYusmk35p3ex2zO5afqDOh3r0/qrKhfY42tjWl3KdDwQWWP5kDkRufmWkTfceugbnznI2g2qSRfftmO651rFmFUZZgsxeSk4cJfBBrS5GEq/y04Zdfc5+l4GzHdAezRroPmQx2A7PTemOuA3R/bIK2qqZ0qe6WznFZkiqawZxPmWmel5UMXX6dR5rVlB6xHWuLlNKNDIF6mlOlZ8QcX5xuxYnnkg9rdquhmxujDpYhYcKCaGzBbUqDk6FXglVwF5KLxyeBLWrgZQKrqb98jhCAzqIXkoqE91z7c8OsZ2UUmi15EI1licaM9o1iheSNJYubfpGOgqsOg7tkbmYSalqFu4praO5tKH3mgQWJCnK2u/hrCnFek1iFO5YWkvOT+GuvloiAWHqtmh1hD2eydHarYJ5jiCqH+4EqndKNzHHjoBt+r5aFaaSPkJHGb16JG37penqQEIAofSKs9GqKY7eLDYT7aseCSXOrhYmbt4mxbg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=2" index="1" defaultArrayLength="683">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="22.4373" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="1940">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAAD2JiYA/D4mANd71e1eMd14V/3FbOVXhbVW39ygQWMc995XHVOi0FFOihxQ3uAOi9I6TcUd6J2ClfV9LWVujKH+U2ldV8oP5aO16y1sRSI1v72pRbJFOUVXzZNN7XY/bG05laclfGWoFgPWrNZoU8PeLtEOWNrWR2j1oTWnRk5NUhyCztNaX/lf0sXe7otG4CymPtctU3JctdJ3XjpZ4darXvvKXeW3rQ1lEV2JRYa9CZUfLcrVkN3jlQoVtB3x7ZZVFCWTFfm9kSRdkcsT5dT9pMUGPVmFKH4a1u3SyFMhRhQd6o1XbYCU2FHTbNmi0epSY1onWgvSK9hjUSFWNmb1+fyIDlb3W1ndslxlUsJaRd70Xmnb0lJkQ0kc3Q5GVByZ/lXO3jZer82L5g/lFZl1sW1Ghf1NnE1x1Tu1H20ejaCl4O3DJXG9zzQVgc8V5RmdkN3h5aVdLDWJNXv9sEXfLemGN1TPxj/l7BRAAccs5m9lJM+ByBfuO1Jm4uTEYdzYxV/ljo0w7UIVNrUwFRUtGo0U3jtYHtr2UnpRsdxD2FxYNNIrVZPZ3V/D2Q5XBN3XUypUQdBEbrVHVQKdlJ2apcKt1CUIXRjV1CUs7CbeWhzVkVZDUvrTKe29Jt4HWDHhpYy9Ma3+lRCt7r1EdTJ0+iHekGk1+C1QBZqNDLQ+Ac8c5TMlkX0c7bGF5hX8pRddcgW87YYl0xQfYdhQ7I31vVClR4XjPZplQSSlQcV57bS1mNUK7EWu20pcM1/R06xfqVPhUYXAruVXJY5F3SWjJVXMeH5Q1lym0xXW7VOiX7bfOmw02jLLVdRkwVw0wzPlOJ33rXOl3j1btdVHlbM1zL3wRKdhzrLkiLHF6uVaLUrkCiHNdOVRddotozXH1c4lf4z33lHo3BfYvFQc3UxI6hyF/tegUL7N3OWoFWHGRdnrVUJDQRynLl8rZe2q7b51iqUWLU6utN/IVXdTrNPG3udSK+o9a56LT9Uc/n5Yq9nm3w5vXbi11KXRzYTNglW03LHuVJPQJE6EFJIxyAXldR3iJdG9u+QQAcy65T2N/c18RDhh0sBUFtxIVafa6uu0r2HFme3SdDhxzUnlYOVkzXslRT2f7cBUkQHbrtBM1lrc3FM12dxVY1RkX9PWkFoCXPdM+Bx9vVz/22vWdlT61jxSg1bqXcTPaOXMncNF1I1PBbjdm1SoYd4sw17uzUKGHYNtAOW9nWs0dFHKz+3CnepkHRFXpsbf7Wa1F/3WNa0dAsUDRUGdf50j1Vk9yFQngdRX2SZZ8VT0WJTaWlZx35xZ893LVrVOZBzf3VIO3KdaA+U1UXwL7lP0VyRUWNZ+0OvXl1efyX7lMh185bCFCe7uxqbkxiLOeu1F5arssa7ixJuy1azOpO7q2l5UYc8O5bl15I1gjZG1sb2klipZU9SZSrMdjX2d5Wod++WwPWs0pTHEju0AxMwhTx8dIEy0LkbhPKC8X2jYE9l9WXzd+kXVHfqNACXWFTskq3FurAje06VAbRxZrUhiFd39LXaTxX/l9d1sNVKtIYT9cUZXLF772MvTfU3TLFb+W9zGM+WwvNXuVxtB/hwM7df8RS4chd1HgB31D3T7AVZq3SjXhUWsLOGtXPjUEUMZFWtMwh5aadtiWI1L5Bwnrt73760l5cVlW/wDLk/5TGWrSCs8vJzcA1VmY3QngUO3HMp+Rows6btNixSEwVkSTJ8c7lvdS9T2T08UR0TPFLw6rk22HZrtNMS0483SvSXkTCbCZMTGd8pp7LyL36nObsRNUU7FHKNd2gBLfjSJG8FpXEuLWyhHybyCR0QmvICYRW0c54hJW2yZ6cq77Cz+Wn5fM0MeXAYKP+IRveD+RyR8OepJq6yXckwAbJt9yWbESUnDDIRZwkWkE/xHK5YT1ODBNqIhRj1MEuY=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1832">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QLvYAAAAAAC4rsO/9/9C6uPOq7+w0VfMLr8c0ODUybTRqQ2KTMGzwGPVDrLok5udMNCKtSO5ocIclbLGc84P3ujaLNfXy5Cby8edqVjAFofzrk3bKZ8Zz0mOX8HzylWT7a8wtwK+SOdu467eqrn+mxDRQMwPupy93chrySK+d75MsY2jQcnRopep36VcmwqbeM23w1zeZOewkMvTmNgfxj+lDLo2rcq3971knRORhKXWfx/LB8dtg3KzCZB5weagNsVGxIjSIs31zAnmsd/R4EXcHM9+uSe76chkwBbdacu9sJfDdrgDeEilUMAC2JC9b8h4urTSgKJt2DjV09rN0nC7VISHimHNhZ9xwuqig7ZKy8SdR7eCvS+6nMU4tkrVKYD7w3euXchyw1y1XtFquGq9h7NrqcPAwafmqWmNqqVfsufE1ZkosWiZJ8R3zIm5d6cFte6Sw2cHn4+1jqg5xtOwGtLvtpaUhLGPcsuSVILRnryyaqRohNWmdsVGwE3Cw6jdsQKYv9oPwO+vL6CzwXakFoIFsj+ylIVpl6WulLGiuTSnv8EKwMqY/rmXseixu52AhpvEmHuQhy2njJeesHe0vLK0tRi16rY9pFKbPbDxl12jJeSGj2DB15nXqNXIYscyqvvFE4+oo5et8pLetIO+9Jl/uf+w0IRo2PvRI7ecyELDwaTWfiKQT+rMujioj5j8vYe+ArNDjw20L4iQhZ+onH7Bg3KjvKFkoe2QLcuEpVTJ3aM0iQ+K0qFfsGXIOsn4py2l8cDKn1imA7V7n/aAqqPHvnSVmG1RmJqGm669s1Cuiqeulva4FsQ/t/yXtraFlVSRgLOrne6K633IlOepiaLLk/yJA5XQxny0HZHl1R26pL6cfeqQ8JcGmXqF5M2LkRWpUnsypFR5trhHsiyLbIKUyhuw3357nXGkR3y7mm6Zjo47xSq0ebV2riXUh5fmwAGH58p1yEO1RJL7t26qcqbmybCyPrUCcSK0MZlBsiKlL8khrGXDxMJwsmujgcvypsKxm5sOev9u8Z9Px4Cek8fLs3q7c8IKn2pp3s4RjKOpGp9b1Y63jq/KioeTosC6b9bL9aNSqaegcrx0nzqo+qfCjU2pDbuUxhitm4KNi2ehzc1JypW8C7BrqtiTbIJ9rVmwRrb5pJ2Csqi9tQuU1556xo2YzbQyqkWl2KEWgy2bmJUFuI61I76WyROd8qqEtta03LL6o96k3Z/vi7WXCYedoWqbrbP/o42z+rsJlaGoEn/Rs3uaf76AxfaoMMQ0qSiR/H1BsgivK4PYuh+jM5Wad0KPyKp8nA2jaI7gd0B9ypx9lEWA6HKztdiCWKXfsjDEraNRrwiX2ZDolJW3LrsojwiuUpDDe9CfS6kukG2O8q63sBnAxYzZxxqgloiUjAK3PMCeqZGp8I39dy+7xqEFkQmWw6OonOmh96QZjfaA14qJmlytM5pYrkOWO6rkg+LH5J2cl3OKX320p/F4eZhenwmCQGn6uQuBVbkJi8e0hpGpnSehi57bonaIJamIsM6VOqZjxSOvQrahc3OduI8/mcWfcZvykrG1L75GeRei9pybktmznbENe6WXpbEOiuiURJ0LnZKS04QlnF2H45TogFO2NaI4juuwOoUapJuWLqxpcih1YaFXmfR6VKBZwGt+fZ6Gb2GBQYCNn9yY+ZpWwUmS3nqVs4OJEabSeNd0+7jniKZ9KIAHkC6kJJc/eEG8kH6YlfRuh39xfFGgY3j9nf1z2MMwfFWJFYkQgZ2t7pX9c4B6v6SZhVqLo3QwfMS0loiAqqilwo2ypq2Qc6OUj+V8w3HCj1qz</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=3" index="2" defaultArrayLength="3">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="30.2243" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAACQ9ykAWxwrAEdgEA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMY/AAAAAADo38vK/P8=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=4" index="3" defaultArrayLength="5">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="27.8168" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="36">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAAC4mCcA6a85AKUyLuw5zjOxcQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="24">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMZeAAAAAABtj/3/gcBtj0+c</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=5" index="4" defaultArrayLength="8">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="25.3972" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="44">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAADeRSYA11kmAEcyFMECR5GM0E5FX+KeLzE=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="32">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMUdgAAAAAAp5U2g8Lah4fr/odMn5PrV</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=6" index="5" defaultArrayLength="885">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="31.2627" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="2432">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAADbLCYAoD0mAFBU0txaMtZjbNRhAdlk3Z5T99ZaVYTb5Wd1m4USLdd2iVzW0rnu1eeODtNaUOfU5tXXU13XrV7k4J2cTYvVFN0DvUvt6pU1rY/dEHU2zZ2esWomKtFMUPHVfNPuXazVlVknXoPZzmeNNsXDnd1Fkpy13kDQHeaFXG6Q2uhYudqK2PhTeNI8XoPXZlf1XvbTt0vAHJHuXTLR/F2E10ZdTGtlEi03fRrVP52JnmTaG10bXdbRsOzVE90WRSFtUd3I1YI9x930tZntOD4BWgJSwt4pUzbUileYWWFW4+q931VebSatd+XQbVYFhq0p7ejl7KVuPYkl4CWnXV911OwA7lq0W0/S5Vp108fc7ehVfT2bdWbNwb1c7aelCo0Wheo9PJWdvdXd/bUgJYUtr6U6LbDluzXhHf/tTu3Gtf6FWD2JRZdds71/1f591cVpPbN1H5XIPR9tWuX/XfPl5Y07vWedXaU5VVRtjmXqRdlNgpVPPfqlkT26tqFW99MO37lXVNE5WsZUAtHK2D5d0tKOU0vc5F5c2jJYEuJNxrWCvWSVwV0GhX1t6+3slcAVfjUKHuHUOEMDHc0lQ30XVRZd+cXIjcLNmJW4bcvuFVS20+VEdhwfflJn39dXp9783Y5dWd4e1/bebVsK3itUgtGLV1zXxFHRUX3YF9d71x7V3ELSHB/eVkJX4dhtXLrYWde7SvAd30VsbV6dSYWdVQktZmVsbQC14S7o6YWynYRFNn2k7Se0EgFR5cUf7sJTodp6VjPcPuRldCXQJQEdc7W/fRyNIGUivda1VJ0C5pPZmEGBHSFtjK4FVtPYyF/627ZaFkE2HQ88xP5Pwh25PYil7k02xSQ1Uz1J3e2lra0ajXTFIiWJLRrdgsUxnTrtI8XjJYInLRC1OjWcHX+VokXirUVd7sV7PYrNwMUXjdZV+K313a/trNTQEdqi1AxZNN5dYLVMPdDGplZX0r1ast8EXuXTzdTNSEAdUb1WlfmtAVWlXcDtYZVnPZGFubUiJdAlNy0/NYVttVVwfQjtedb0XhXm5Q9OgNa4SSccYj5BMx0wDpxRf8dv5eQVfn0drVrd1bUpxdwtO+2CZXY9gJRcgcP35dp1p9X5zD9+0L7nTbeFym0j7ZnlNk7QU+jWZtieaHU3zftlml3BZSs9wpXHNubTjtaOapY12n5RUlV632zXLF5E0ZpVZt4AV6dQSNfe2ExcVOhldC0YVc92f9v403pcGNc8VAJcklfB29ravttrVSZTcVz2xP7lV3br2S5RF9J8V8Ld91IF2p1fpNOu0n7vpW49g6071TCNbZaf1U5cNtV7Vu5E0RzBft/M1rZWWdQaUIbah1WxWAZV1tUaVNPf+treWtPXd9I9S4MdwQbFVmrZM0CCHcgF3Y3JFTB1xE1ShUKNKXSoIcNc7evVQ2XtHW3FwX36nuFRpFLB2tvbnlGj0qve7VgkWoNYeNBQUDrWC0a0HFteUzXeS1Ks0wVTLtqBWzrZONfKUyNaWdYYU1HQ5lOc3XzUOVWEWBzUKt8oWAFS4dSuVEldlt4a2fJcrdPsXw3NbuUBLRPk8GHMkuWK/ep1PT0rpfkm+dGNTaocnm7bmVmo2ytQ0t377D1l1S+te62O1kJcEVfY19T2ZsVDVf9cpv5Wqt/a14pbzF9oxs3l1m02ZfX9vKU0bMHuXJ/eRF2jUHjSDN4HQ5UdbS2cZTidV90utSPVrqxWfkVOPK/s3PnYh12nVBNTB9fm1xxXCs7/5Uolqx325Cxh1rXZqFQiWJVbzsu57WaU+NFaadtAx2vlkFRm0s1+3NyuUSbjTTDkvFHWAdPGUFZqFdR9gXThIVY/zrvUTzLMftXwteQdY1WghQEd6Lcl4SadXLpXw8f65dSNoGTyYdkEVCPRBFWoW/PAn+XtZkXcydNbWAVTZUDHHDgu3StZPVKCSYccna1ALRYzw+ftzqXhzY80fJHQpt+yQ5kcmM5dOd8V+V9G0DlSNFkWaFTIcc1o1cRFLC0upKXxyeXtW3X0FRdtmrSHA9sx2yFW3sVd5uLcFFRPTxAcIM1WhW2U6jHDte6SRJM837xcRUW9PHg829hJ4B3mZa+FX+0xpdFF+IRUcc1z3PHeR/gdgpbuzt/lWcVH3dmdR30H5mvQrN9XXChKEh2ytDSxVX3OI80K5CNB2tXVHtUOVpFcidUEUSFPPjzibN/oSA1cNsldjkQLTNh80UHa/tj1SgYUhwTKlqRpFMNX7C/eTVQc1k5eGEVVFIKzUufM4K1c1U8UcavDXVWKXAe+VqNDGRwj7EEyVRBMCXxJNE38RBJIzIkkmwNEAayySEgIXMfkTCpsKXlFWIQoYs2wpPI3zk7cBCZCrGyR7Nl908w32mHMCSxB8leORtsTMSAryGfsQutFoRA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="2372">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QLm1AAAAAABCtmnSEfJj3urXd7ZrvuK3Fry7sgaXfNITutmUdLEOxVi7E5+Ox+PD0IsL1Pn/79uYuJSnDLTsilv1aM6s45fIl6JoxmfRQMVnjam4qMglzujYf8s3zvKqyKepv9GafbpJsNmoVZnDqZ/okdmG30LHnIUK36jUu9e8tzLXh7tFsuSS6qneqDmjHI5hv2TCOLGTqWaka4/4x5rGgNaku2bUCMV7sa+3eMwgwsnT1MojxpOyP5x2wQad5cXctBqteM63upWXu8BromSy/qwOxaOzesO8qAO7BPEo2sjPnMoFyUTDN8gI1svc7srtuFzO4L3Bc8yYPZDvh6+v/L7Bh2STmcDB4GS6WrhYwgHercYMytXf5L5GxFuy6poUoG+V66GehQjN0ck1u/OvJtN6rR6+DsCSWISeiL9bn0q50LQjogm/kbJdf1Gul5Ckv/jIW8/uqLHcc8jDsmC7fZULosqaO8SsxbzAfqhVufut3MErmG+Np6d0j6DOVKsgonzEpsd2renKeKmEv2+/XLVvqlfO4a+vrjKeO7BzvPO9Ha9/uVHJTbMTplqVtq7N1gOx0MI+u+fEW6qkxsHE86lJo0/CDK33s7TFG8BSi9vEkrmnqo+rBsOvsAKr5K/np/2sLbRtxiS4LLYEvdO5ycOpvLi+qZ0TuEqtI6o9mUq+Nak7sKuPxbm6mOmnUqM1yKOiW8UPrguZ+IsGo1faOrkrkrymyaWcubGjZJcVvpm2243Pm+fIdagTtFrLxKaCpDKdwpJEi3qUt7o7s++uU40FiUGARrM9tSiqJMoJyBOkZbP4njDAIoqtsnaDSbR8i5iRBcAvrFSy/qy2dsiwybaZliKOXq8H0Dm9q8OgnTe5Y7DDm0Sqk58vtj6ywLqcwMS2fJS7u9q4NbPtj/e836n4qZTAnpjPh0+xZb1SrlKOcZZzpuKsrbkJvNjAEaXZw6qQz8Lzpd2ggrBAtru5Na6CtzOlz4k9qk+1UrWxuwKfTqxHuNPBUr3No22Z+buZp1Wu07bOkeXAeq5UlGWc069zlZ67H7Yfs0i1ibT5wt+wBsCpsvWnmI49p9WsCsHxoQughKz+dNzSm6A9ljqee6/exy20WrWdpCWM1MSNxTqtFbW/tHOE/6llr+maWIs3rVKb1L3tvlK8J7bSs0/DnsMZiZN73ay8tkPNPJZPsWiczangpJ3OT5BcszmvdrNsrtq6lKhjqESZCscLpaGmZHQ4tHGe/qWs0EijA7wYn4aZDrALqfV3uML4e32gcrUjnJOFSMdFwu6Qy609tW20jabduimhU59Wm3Gpwa0Rp82WrKBRrKma5pUDtHWY76ivqqGvx55CnIxwpoVTyHu1F79krkPACJvSxrWnYq+JwEytkbcTqgqdOrJihGqnwL8Gr3WZM6kSuaXFibiDj2rENaw0syhsm2w/ue+M9H9goruqurSNtDidCJHllp2vpLXgq6qkoYxMnqyTxZyfg62LcLAPs2ajnq6HmQVuS6YMfy+qqKTMnE61vogsom+xfqe6s7ePzbGIuqipbZrWnamRL6lao52D75+9o1ePQpV+w4iodqp/qpJpHInbrVCYrIa8o/DAiZPmwd+ccHq2l2OUNquqm4qhIJEQpzt5fn+Fp9Oj/J1RiyCi56E4l8+bhI1bqg2c57OVqf+MVJfNelGOP5VGso6nfqmoh/Wyu6apqmSUsn9Kqe2H8IwTe8yGCK1ypaSg97ajjNS9R7sxo/yvd25VxZeYW4pZgq2LUJ0VgmO1Za5rrYDHMbDhe0OwKKWurYWU+cmsfcaPm4zGoF2ndIS9qASIwqNxpTWEGqGCoTWmfZ8ZmqahVJ6fgKFxGKW2q6iaCpAVege0mo/UeNiA03jnwdiRhoW7ebGRxaIdgOJ6jZz9cSibP5jUWiJy65AIfQC2cJh5hah6RY63dQWqgpbwfUJ8Gm7wovqcRrj+kymgnKj4jk+VrZP/pytyo6bHbLOHlqCrsP6WEo1cnYh6kqXksLSsO28Xiy56pJL9otOikqUFohJ917HGtI6IXbTidJqBQqQ1h6SMxJ5eimuO+YFKiEeASn0blvBsk4M8pGl4tIhjcLKZv6KVgv6eFJJnnP+Q/paEpI5fioW6hQWSUWmipIieLadbeqKkwnXPd+iZ95FuhKmMEJX3ja6HnoY9nG19UYiokwdw0nY3kOuEM4H0oxKMp6mYs+uClnTMeGqKmorscQ9wBIimlRSl2IDLblNraGuZf3CnToGeo0SSlpZIdhGcc3shmGWbzpCOgZ6VEnVYcb5/9IyJaO13P3P8j9p8tKJxelqSlYJOgd15bGutZRiROHWka0qsqXAbcVFqnoBMprhilXFjhBJq0Yo=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=7" index="6" defaultArrayLength="5">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="36.7164" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="36">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAAAINCYAtYImAEYvwz50M1ts0A==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="24">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMUDgAAAAADPlXzzzov9/xbU</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=8" index="7" defaultArrayLength="7">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="34.2968" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="40">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAACUJyYAceAnAMZCxFnGPyRbtrXKuKhY</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="32">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMNpAAAAAAD7/4rRTpsUtZ625IwGgA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=9" index="8" defaultArrayLength="3">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="39.1126" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAAA99yYAtC4qALmCvQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QM8ggAAAAAD9/0b12e8=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=10" index="9" defaultArrayLength="763">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="39.9708" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="2116">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QLOIAAAAAAD5JyYAJjEmAGS1Cu23jc/lho2wdVgtscRsAdki2ajtldiVUh1f3Yme3FhT2npdx11y5xUsLW11yZ0ypVst+xVh7Seds9c1LnXvXXKNCnWxtTTsqk5e6Fcy1vhUg9sMbvVubbm2zVWy4N3sNeT97zWAJXKdIHVUNeKtcHUiXVvVWF2vNZLcrO5VWtIVXJdZy9hn1Y5dBtP63vheBFnD0P3TSlWj27xaHNqaWUbfxtqJWhrQbljzZDX4XLz+UQ3QMVDW1spSWt3M3avtjS7F2TZE1WpJIB3eZgXSq1y51XRe11iW31hXS9YQ0dtT3NA0XOVZgtYHW8FV9lwT1Svcbl1IZ+1SrW7tH+X3FcGOA9IM1Q3eWV1FVyTX9Fmn1vtZxfhV5d2X1QteGewNYMU3JYIVlk3NZSON1sbSVaLZy9NcW/Fak1xT2iVQ49TqULrY3Vsh3LdW4VX42qvS105wHcgVOu1jbRK1L10H3cfFqu0/FtNYyNhY2rxjdRg14C305YbNIs23nde1yxWpHtrubZzlYSVAjb0lchVXRptR8V/B2GdZBtqt2mtQ7d6E3i5X99CDVe/R6l6p31JZstb7YYQsIcpv5dedc5V0dXKsF+5bgtFIVNrTRFUUUeJeJ9C51FdflVAE1llXRNUMULvSWFfS34NWVtLe1wxTrNWjXxVXxFz52uNYHdyT491DlcttLM2czSnV314p1HtaE1Co3tJYx9P7XeFealLk05BfSN1SVyVUC9i1VqbZ5myEMJLPPN0JdNEB3xnXx1SG4zQ0wct27T2VLC3kxZc9dcUfvUrWA91ITmQcRc7dylBc6w2UnR7W314Z09ZYB1vC0NtSUlDE3VzW7ViC31rZWl7F1z1lFaAdAJXUnd3N7uXlVcZtzH1thZidg+arW4HbelUyYS0RpiVbeddHVrfZTFbyYL3jhQfU8AHDweQ9gcz65YL8aO5cu9HFXKPUjFt43WfvFUhFQW3bLaPlKu1LpApSzr/EazHNzOUJlfUtHWVTvYZkujLAeO0CnZh17K0xVYidh+0e3YCl973JhOxByCnliG3C7mPau1p2WAjP/eUtxt1lPVaOxFl0VVJX9dioXRnZJlybys/lZ+0QpRc88P5SzNWsUHjY4dkOUGdfBty7VKbU01KC1LxYy9SSWKVKHBxcTtu8X3HaXFHhXcZJciyj/dqm3g5SsV+0XRHdCFWZ2WheVVNp04be6VTSXfNWY9Yb3cpWdVS80eh83JnVrtorU6He3lBG2cdXT9q83SBdOth6V7vNfuUrrfjU2wHQNljkWIHRpFYG1YfuVXutUHUtFLJhyX3mqmtddlVBndCVLI0QpZ00LFHCZOWKXSvV830qZPGBwNrtDaXWrQdlbyVTvbbueFn4UgbAxuVCRRBtFt2+5TFdgb5m1Zlcv93n3nVCoR1OvcU1jq3h1dr97EUeLjXVxGil3L2NVY8t/sQJIcsq7dDVbaXRrIiuRLkdhg3ipfONWCQ6gcrY5OgB3LPZrVbe3IPQulylQlUtZnwvHuRV3ZUPLT2Gf0caHRnshD5b6kTgLENtXdJe5t06ZB1JtChB2JVe3c0Z7Xx0REHOquSg4cUC5TtVRD3xlE3zwy7NhKUwXQlkGdLF/9UYLvXRidj1V6jQB1AY0z1Q0tm3RuMdkAVUfZeVwW3k1WTkMQHFvO2ZbU990tST0ccJ5mlChhW5TJRe0U5fb06aHGhuwh/kHuHXttgiQQg8gFxXTcu75ciNoHT5ccd35apNspWoZd6tvGTbYdIY1uFCyhyjXk6RFcyFRe3nrPbdTMwshg1Q0tSsTtZMSv3TgsrN7VKUR3HaWVBIWyHey1GxyzDlKXU6VD/jauyw3FX+wMXlBc2zdKuxVUXL691KdcSdfYRJR8qwpVNcP57autVaVhJJAy1sPD7+TTAVO3zvTlt0RLIU8FbOLpWC1BR4yMtEL3FGCiyD/jxmMcd4HJu7S08sKcxmXdglL93zrVnESobKV+wI+9gpVijTh8IF5O1lSDgc7qlL24xkV0MFfIK4TD/rm1/k2QTfFMpM5KnRRU0cHXlOGEw1zUPrJJyIyyiUEcLEwYR5EU2LlCRNzU0jbk8Q</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="2048">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QLg4AAAAAAD9xd6ZxJMS6SXSu6kBwfGsRMcjrpPULct4izWvXsaZxdTFQLsTtV28v7/6/7rZNJBNwU7A9N1IzfTA7NtV0oGyT5mcu9Wqp77lxQy25826wxW6Z49CmzSKJa3ErUy9254qrvPeGtY01dbGfrpdj3em7shRr/SwIc1BuU+7wsRXhyGBL6BnvIK0f9FIuNPaLqpCr3mihqKmlse53d20sXbJyK1QyAyvVrncz2PKVsiar9+4oYqRiOvJRXIbveu1I7kEoGvDDr8hrRG4O5qjrMihdaBMw9C2asgp13q/l7Ojx926sLuBv++6v5hZwXeotKQttDi1q6XzvJO6Ca1lhwnUNshkrtvRcK03u3iozMRps6fC27zz1jOxMrlmrTGh+al5rQLEGb94tH+1UKbDvAjFQKXCio2eTZykxjy1qa9UxeO4CKnatdetq7SRx5TMLcmZv5GgQK0+lEuaR5ocnlS/qMFTuCe0CbHXwHivOqD1p7GhMZs7uv2lbbZteYWn9scSvSTI2aglsvy7asM0rWW/zofVkR63kaKgfPWSfKTwntC1fLcPqCibZ6YU0Ay5usKV2SbA1q0suCicdcoMlzykp6R6rJ6++YQjqpCiCn7Zp2XBa70mmInFabclwYZvZrrhqc+AeqwstxyiDaT8vq2LK7cvoROkc68mny2rG5EZrOmyCpJNi8K2ttVqs/SxCrMQtRqqn8PPqiy7/bX9mqK8p75hyjaqL8Q9vmamUKEyp16ehYten+jNqM4Rx6KgCKZ3pxm6osA4wUCnJJWVkv2nfLRVnj6fz6I4ma6t5I3Xp0G+nrEPvanLcLwEpwS2zLM+lcOthKu6qpm/EbV3na21yqGUxPOXtrYvseSYcIIooaS67Y4/rmfHGKZrszSClqbQjb3QF64XwDy8FbpkqU+iBahwx4yQQbM8m1Ok/pGIqWS8Cqx0pkq2MpUCjv65ibXNhQuow6BgmienWZ7Fo2KPOaRtpeq2pL/pwnmmss6Srhyi1at+fRugoKqTpWGr66a6kRe/lZYQil2ot6IKmZ2aGKmDiPiXsIg9wre4tJOomiuf+qOLjdi4XJ6adUyy76WSp7HCBbK+svecz6/ss++wWobwdJh1zpSouZ6g9pN5uJmZJpH5hU2QGaHCu4+mI7mor+Wa6J40qQig2Jf0o12Ebo1wnjyhGZc2mUOi/7Zlus+KgqRmt1a0qprEppqLobXJsfulhJ+uiQiUGYxnjGyaep/eonu1N5b1pGWk8YbQq8aLJIZhoUC1650kst2jhLhneR2fWo6Gc2d+ca1Wq5SuH6Y6gM+GOagHmc2o4aRQsdajwLHYlo6azaGGmKCAwn5/rb6OAXqEhHiXwcS+rXai9qwBp8KjupqPh0R3A4FJp/+ZZIjjtGV7sI5Ot3Ge0pLOvwp8SaLfsB62zrmwk5CjAKlCn6CvupySnF+4iZf9lnGh57N9qlKsgp50o9KWO4cwlLB6lsQlfd2tW6Ivdf60Pq2Bp+iaLaQ1pmCgDmPCdvWWAKdMnnCqLovGlHeCO4k7r/2qnHIIpuGuXKEdlQ6fyKI0r8mO+ZdBmoyYTqQtnZ6ovJlRuUSMP30Jov2KoHvbrPykAZxOgA2M0Kv/rPh5bZnOoLWAiJGAq250XazUj+iWCX+spmukN4Aepk6kd4u+gzSRF5dilj+RWY7lpZajuaOpec6nA4xSifGdfXXqrsqUrLZ+huBzAq7rdWiUm3pbgJeY1pSAmu6g/pRCoP2gU3paqp6fMKlar5p2VIZ1lih+MHOdm2Ru7XVmpMB16XmNgCiE1IiJhE1/9ZZMhmWdW4iDbM91WXkkj21qK4O4mb+Qo5GdfVymeno6cu6J8YBmbb2Jk6DVsyGEW6FreZ58mnnyksmk+paDpC6groxOjoNszqvOlauQnJNfkZ6J1HTtpL2LZo+RcmN7bWqalOeTkoGAokZ6a5cTnPmXVJvmgttzd4IjruOPCprhhOynv4CwhiCcL4sRvNCrSoVnkF2lHpWxaYOktYEJoI+HE407jEJ4iZSRdA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+		</spectrumList>
+	</run>
+</mzML>
+<indexList count="1">
+	<index name="spectrum">
+		<offset idRef="spectrum=1">5379</offset>
+		<offset idRef="spectrum=2">11258</offset>
+		<offset idRef="spectrum=3">16573</offset>
+		<offset idRef="spectrum=4">18158</offset>
+		<offset idRef="spectrum=5">19755</offset>
+		<offset idRef="spectrum=6">21368</offset>
+		<offset idRef="spectrum=7">27715</offset>
+		<offset idRef="spectrum=8">29312</offset>
+		<offset idRef="spectrum=9">30921</offset>
+		<offset idRef="spectrum=10">32506</offset>
+	</index>
+</indexList>
+<indexListOffset>38244</indexListOffset>
+<fileChecksum>0</fileChecksum>
+</indexedmzML>

--- a/src/tests/topp/FileConverter_25_output.mzML
+++ b/src/tests/topp/FileConverter_25_output.mzML
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<indexedmzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd">
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession="" version="1.1.0">
+	<cvList count="5">
+		<cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+		<cv id="UO" fullName="Unit Ontology" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
+		<cv id="BTO" fullName="BrendaTissue545" version="unknown" URI="http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO"/>
+		<cv id="GO" fullName="Gene Ontology - Slim Versions" version="unknown" URI="http://www.geneontology.org/GO_slims/goslim_goa.obo"/>
+		<cv id="PATO" fullName="Quality ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo"/>
+	</cvList>
+	<fileDescription>
+		<fileContent>
+			<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+		</fileContent>
+		<contact>
+			<cvParam cvRef="MS" accession="MS:1000586" name="contact name" value=", " />
+			<cvParam cvRef="MS" accession="MS:1000590" name="contact affiliation" value="" />
+		</contact>
+	</fileDescription>
+	<sampleList count="1">
+		<sample id="sa_0" name="">
+			<cvParam cvRef="MS" accession="MS:1000004" name="sample mass" value="0" unitAccession="UO:0000021" unitName="gram" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000005" name="sample volume" value="0" unitAccession="UO:0000098" unitName="milliliter" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000006" name="sample concentration" value="0" unitAccession="UO:0000175" unitName="gram per liter" unitCvRef="UO" />
+		</sample>
+	</sampleList>
+	<softwareList count="5">
+		<software id="so_in_0" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_default" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_0" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_1" version="version_string" >
+			<cvParam cvRef="MS" accession="MS:1000756" name="FileConverter" />
+		</software>
+		<software id="so_dp_sp_0_pm_2" version="version_string" >
+			<cvParam cvRef="MS" accession="MS:1000756" name="FileConverter" />
+		</software>
+	</softwareList>
+	<instrumentConfigurationList count="1">
+		<instrumentConfiguration id="ic_0">
+			<cvParam cvRef="MS" accession="MS:1000031" name="instrument model" />
+			<componentList count="3">
+				<source order="0">
+					<cvParam cvRef="MS" accession="MS:1000008" name="ionization type" />
+				</source>
+				<analyzer order="0">
+					<cvParam cvRef="MS" accession="MS:1000014" name="accuracy" value="0" unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO" />
+					<cvParam cvRef="MS" accession="MS:1000022" name="TOF Total Path Length" value="0" unitAccession="UO:0000008" unitName="meter" unitCvRef="UO" />
+					<cvParam cvRef="MS" accession="MS:1000024" name="final MS exponent" value="0" />
+					<cvParam cvRef="MS" accession="MS:1000025" name="magnetic field strength" value="0" unitAccession="UO:0000228" unitName="tesla" unitCvRef="UO" />
+					<cvParam cvRef="MS" accession="MS:1000443" name="mass analyzer type" />
+				</analyzer>
+				<detector order="0">
+					<cvParam cvRef="MS" accession="MS:1000028" name="detector resolution" value="0" />
+					<cvParam cvRef="MS" accession="MS:1000029" name="sampling frequency" value="0" unitAccession="UO:0000106" unitName="hertz" unitCvRef="UO" />
+					<cvParam cvRef="MS" accession="MS:1000026" name="detector type" />
+				</detector>
+			</componentList>
+			<softwareRef ref="so_in_0" />
+		</instrumentConfiguration>
+	</instrumentConfigurationList>
+	<dataProcessingList count="1">
+		<dataProcessing id="dp_sp_0">
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_0">
+				<cvParam cvRef="MS" accession="MS:1000543" name="data processing action" />
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_1">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="1999-12-31+23:59" />
+				<userParam name="parameter: mode" type="xsd:string" value="test_mode"/>
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_2">
+				<cvParam cvRef="MS" accession="MS:1000544" name="Conversion to mzML" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="1999-12-31+23:59" />
+				<userParam name="parameter: mode" type="xsd:string" value="test_mode"/>
+			</processingMethod>
+		</dataProcessing>
+	</dataProcessingList>
+	<run id="ru_0" defaultInstrumentConfigurationRef="ic_0" sampleRef="sa_0">
+		<spectrumList count="10" defaultDataProcessingRef="dp_sp_0">
+			<spectrum id="spectrum=1" index="0" defaultArrayLength="787" dataProcessingRef="dp_sp_0">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="20.8713" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="3516">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QVBZdYAAAAAlb8R/iv7/f6VRAtJ370Mz9Zmg8mPrJGFjjAzL1SBT/2yaINmePJ8Iu7yIJ3biI00S6qM0TrJ6mzMTuajqOeIvwkKsJM/r2mrKA5SuK45II8Kym4PzMippg6mzi6MLG0MNGlM6d/qLVr0jsgA6kJZOMRVZKUYOGs11/jCmWLBFPLwgCqi2qeJKbYag0Q6TeD7M24Olp93j1ItTT7dzjB17vUabEajKMH6tIoVpKtpw7iGYvxqj0NwmCgor12vbHqqL5FOrtt5DRkabbiNbvMty4gSipASu5EbcvpauogA/4599UqUnUatYOesyCeIiaKGsItjqlt2OKw60KohYjjfJhrcfQibXbxz7g6Pj+OKzWGGikdviKfVDqkcI0jD0gbhGdzuwCqA+VcL6STI/2Qy9enOtUzXiH4/xuMfaLoPGGivCbrqjDbiFlLa1DS30chpB/64tFysqoa39Jl/FGgS9zj2LBzO5kzJEeDf2La3Z1+sWG9u5/KOJnSs5k0JVCxK7BzM5Wm+iPZHTJyjCChJRs/MDvhrQISbsE+0QajyDvSm6Kip/0v4ssKw61BraIQ1RG+WP6/eNMn06kq9l9ttp1dINa1E9VQmh4sXSnQ/ipuqk0pPXASZKiBrOEy6z7NoqSt8anwwutgpnKa3WKppFLrVeJCqLY3NNnmqSinuvjo7qP3K+IUzQGndrzrE2DiozVStj0BrrKl4qQtkTXlCC/EIRvEXiIQ8lOp9ku7CnVzsNzLSOdcJ4g/Jt64+DehtJ7iO97xqtH465AHsmy+sSMsNxona72hNw3j6Rez+7r7kdvrT/PbxZsihuvlqu+kumhyjjgfCLwZKLdAyjdwKKsK7eJWuIOu287j7sbq6nq+t8EupeZB4tC6crqVTCdZMTo7uF2myVLrzyHSbj/Rpi2U4z3ogtHuETIpArtagq9XpOJtkPE3AVcsdS0aLPt9uT31sIS7IbLEOrpYDCmb2krTv+szdGc7Ole6k/Kw5F4jYac6rJzMOISVNLmTOjwyKI5TK6Hb6p0ZbqWxL+LIFOGoUrrCXLThL/0OKvrd3LPwHbx/siRMlitvo5Ov95ousRwnvrVq6Vtuv9njp4uX6w4ZcpPXATXtVDzL86oKY9KN/7SqwcbDL0XaH3jest9MLZleK2V0WtOnrr/SBT2JySWNGTqI5lw0MEa/B4q+Z8q2An0oDnkq46DNIeNEGyzEyrJ3riw/ESrq4o6xdjYvj/ArEy2b/b2rcO1rlnOLIN1ikPhCKHVEKi/b/C382hoO3k67t3q16KYme0cTTB4raiqjRGDTNwlalUZ+q1Rn4zcoy5+i4sfMEzYeQ68QzNt/4LsRmgP3HFObhWr3Dd4td0MbHZg76txiY8xxuMfaOQLEPuxSJThYGoD9Xj+yPLk6S6hbnNts2uMn5IKiG2GqY/fir7sxJlR3GwLdK50QWvXj3ic7yCLQSgEmV9salrW7LHmAGlyz3Sf1Oipfss0rS3FKfl9ss71ZT7FSpsfCpHA+wq0Kg6vn0tJmNDGtE57SSAAyqOu/wogOsSsztyLaxeKoFaeyiYQiqpXkwuFhA607heoxSs48i2k6w2yyXA6hMs3jp0NS9OihvjwbpQFtwpwG86AU8uIgXJGrwZjrZsgrI6fSPmFyqnFW7LocJU4rKvubPaAC3uLtGcKz2T2ipg3S80tyoA0F01slIgBqpa7WAKKcnpGhOUriQS9Rultut1HTLRs3Gk1C3iEE/koN6ZkhEN8aYx1uJe18G0Et0x3jGsZE7SREuDokAQ4pzwUqTg9uqsen49dzfFPXsdt6IVjCKyl1mksRPi7KWCsxS4rp/54tGO4bdylD5cI6sfyOLCDmExb3yrGMHTuhIijZYjretC0j8/sc/iGhzhvi1A6FoN1Eu6lTCxxbMj7TEqeD8+PNI4LDKFKl1EDSJvZTpvLz0lC7Ea2Mf8Iy3MKwFyghULAbkx16U7GuMyrtNTQYTB/rZJhKYHMuKStoIvwAkSA4Yxo2aO6n4XzCfMWRoNTV444Y0rRT4TYN16DBW8T00zVDRivU/xsl17pgzH0uOHJaCaw8oXrv0vt1gr8eQL9OkTWcQrJ0Wy8nZCMy+PpRmJ6qA1XiIcpyolC70gt/cj7Dp6bl9sLhPqEhRVQbPVCTvV4irP+BrUX5wnPkVKgUnLL2MtGz6dikys/SgxHEraPgy98mMoVM4bxWCCKFvxpfhl0wp8Wt5o3i/F3jruS5w3UHIh+rc6nbQ8IqHqKkV4/bdoajqGKja4YSARrxo5JJ4jpqRKJzS8tY1DpYwQ64k7coprwqFXONL84eE71f6pNHbiHdThvrjcqfgr4nMSMiEMS0pGCdk2tbYjoI5qLJ9GPXZnu93cIh7YGhwvzjn4X7YUVjC8vKUVt+LqRYK58sWmxgrkklazb6spxfQ6W2/9Lz6MGjdU7aN94eLlcMEtwM0aubiuszmRKP1Suu+L5Dd9syK0whohVg46Wqqmnr7iI3rxNDKfL2LLKjuIPbXyM7TDsSHCcXpWR2cwm14msfAbnQ+SOekEoElfs8kxuzZEEkLtcr0F9br9dqTPfeu8FpsnmaK8EMKobZ3itRXxp0JlwnNHBaAu3KI8z6OqZWTTPXbihpkkopR62mMIzC419TIgt2GpdYrqXVLNMd1hKmDpikPjmLiUJSer2EpXhA4p0eEaFAlcJ3OBSodqui0kUIrS4sYtEt8aFC+tIEcoOmOj7SjxLjtyhhubZTOs2vpPoR4lFscaKvcOpCGd43NSM7bCEouR8qom5Nudd2JK7qeiYqDi5a8Rr//SsnBHp6tL63uLVIK8N4GgLzPSNpfkqzTIsr80lqI6RKtWyeJCOJKmeivTOvpDWMpiGz3yoIOyovnFA6dAQOIKBIqicXJypK2YrmbMato1/CP/lDNuUIIDtCOvhQqiEDBzoaIvwhDzFKIqrdLTUTgkjI2KbpySJFUYIlc9xqz+e3pum3gxIG8mDO6KsUdbreiLwmvmkkitSnfEHRXMbcGcU/FOLL4ZelGnJidTsyqFo761pmAh0RQbvFOylTD/p+I7iqJety8IFUov2LoiZNxKw+GMIa2Nqt5b5C1xrIKqqOKicZqK7eeerT1U0sztdSNFcWrPvSIi2KwRY4LgGnWEAbppEyNboUu8ZGLFu0qrvtoB0anqGXPXdeo3Kv46UfsnaB5ilBVOqFWfeljoJqwLfsNDIhM2EFJb2eWli77ib3axOBvvM62OLA9RGpp7bquC2LJwweesjiF66S49ODvrJVdV2vcdJ7l7aiSQKTJlvzEXAdnBk2s67RuhspSc972cl54qjikzwzIdxm6uiqwB3TZCGmmIMKdkMcsTsxKK8ZWpvP6qnyHOLXoKGyXXsbhRYDqxdJKpJ5eJG0of6iHtPi7dwKmXp53iVD3CEvOlc5585z6ofiJq2XUhKRGJK8VBGnD73BYbb6eX7MloLCgPkbGHyCkmSDPpUAYK4ZlyphE9iOFZPA8pkA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="2112">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QL5KAAAAAADI06Cx9pAY/J3f0sAGyfaZq8tO1ESyWpCBpx7cjb9EvQKtZcAm2C+xiq4tjVaf7cRyht281r9slv6zYsKmxP/uW+dzmsmOPaTxtLKrGcGdyXubIp0Ik8TQJr3kyxeYZ+j8/0jR9NTHxnPHMeDDxtPY39nJmC60Xr9dwjW1yKwQujDW67m8zAm5l6y0wTS8KMXo2D/TNe2V2US2M+gRxLHSR42ixYuwpKct0NbN2aXStEFiYK+joTy0mngrmuezUrSm0xqo/JA10U6wk71Imbd9Jahs9w7V6tNG0da6NbkPkOG1PL06zM/GjLYllVGwv7f0nIaqhpYmtPeo/5rHxlrFAbHzxjea8L3bkyS/u9SvoT+hq4AcvqukgJQdpRqJq4y8vHDElJrewGq+G8vmorSrOJubnPnPDYw1g+93MKrqkC9+LZtvqMqtSrfJ72CTM6OgruCyhpkTytW1aH0krdSOA8CR3NKlvLOjqzuyPs9FxuC4d4SBqL+KRpkovvGpHb8op/3CzbJZr9B9+8GOdyq7rrXZuWeoq9LOvTG/EJ9Tn/PDm5IzhIC5T8TPmsHGQKzamMeCSowws6G+QrfVvM6dHK2boH6kX6VnlRCaOIoHvL6WI6bCtsi0LYAexfqyw7HevJq6OLFWmC2ovroPw3C5g6SfgIzmLcqwvgm3Va4ur1mrP5vtiTyqsqFPkdqM5bV/u5y7aal5mOnA2ZXDzKWYeK5rq2O8WazFwaCCYMBjzOG7IJjjq1/Jj6USmeeYeobuhVmyRbh2ljixsbalpC+DFrJnnxPapqQQqBGb6Hmhke1/ssJ7mrzBR5z1rw69JK/1jEHIx5xek1mSEn4at/TKULrcwnKnL7EpkoN5N2ZfpraZS5FcsJqUE4+Ur5y9XKSTq6CMIIoWg2mperVwi7qw/JRCtmWg/Jqds0ixwpHraaGyJ3m5r7qxnpN8q6KHIqQthDe06qdXtY2z7qSetfK8FqrbsRmd44G/ohGbgMgUwimj1KL2cIWllsCZqFdWaogupK2wsMdhosext5abv8ycnL3mjIm6J72KnVmtqp+Ue6OS36qbh6SL/p90lPCvZaBIsGuvO4ePngS/X61Kr+ScE6ZRxa2+EtzbunTTQ6cSwpfFZbizpjSZf6WrbhnR1pnRxn6dPJ1Xm1zKArhosvumEMWgrO6WTMqKxbegfaXpeh2pLpWCpW/NdoFYpUSa0HiFt/WpeZm5t8eGc5yM0zB6kLMTjsq/iqrsujjJmq5uljl2daAzbs6geKLMZpqCbYNHmqNyKKaGuRl8W8SFcpzGJ64YlUuc5qzCnoWjIoYTxn+9xq8envZ6X54joQJ+DHafutnISqhLsNeHbIw+f521Eng5jjqw9cDeheWSl3qyuDuxPKkQgJC7MIydgkmDDXREmUivKZJCvUW4XokmstS7t4lQnUCVGJMIg7asVaMKo9ZwjrGQhm58JYuDr4GvxqXlkwB0x4IhpQyPS3QTfQCiBI2BWAKNvZ/gbGqplM+SqIGeM6HQonFvT8X0wryumLRVokyYDKMmja69Lp72pqla3nCMfFSKx5bxeN+a1rCEoueWbajQiqh7rKGpjUKcDHZ5eP5t56pYusmk35p3ex2zO5afqDOh3r0/qrKhfY42tjWl3KdDwQWWP5kDkRufmWkTfceugbnznI2g2qSRfftmO651rFmFUZZgsxeSk4cJfBBrS5GEq/y04Zdfc5+l4GzHdAezRroPmQx2A7PTemOuA3R/bIK2qqZ0qe6WznFZkiqawZxPmWmel5UMXX6dR5rVlB6xHWuLlNKNDIF6mlOlZ8QcX5xuxYnnkg9rdquhmxujDpYhYcKCaGzBbUqDk6FXglVwF5KLxyeBLWrgZQKrqb98jhCAzqIXkoqE91z7c8OsZ2UUmi15EI1licaM9o1iheSNJYubfpGOgqsOg7tkbmYSalqFu4praO5tKH3mgQWJCnK2u/hrCnFek1iFO5YWkvOT+GuvloiAWHqtmh1hD2eydHarYJ5jiCqH+4EqndKNzHHjoBt+r5aFaaSPkJHGb16JG37penqQEIAofSKs9GqKY7eLDYT7aseCSXOrhYmbt4mxbg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=2" index="1" defaultArrayLength="683">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="22.4373" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="3072">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QVBXcIAAAADcmK9/Dv//f7XB0LbV+D4lJK6P1uKwu+Km9G6y3sTBKtnhExQVOicLzC0f0EqpASwlbssjuz2KX23sL4DoWrGnDLwYrMH9CkAZziJ4+Eroxq6neRnikNqBpIJB4ifM0atQd8LQhvEs56gas6N8LAOVI1Lymj/GrT8KeiWaGCoenZ0wn+02BF8u/KkqwpmNrkXE49/CM7m2Gq7XrjZGSC10thP3MlSlCrQKxKjdhuNFWcs3rpvkRZLRdEKnzcLjBcMzKPWjg+/jn78iDAfTprmduoUA3iAEcSPmyZp5yGzC/QJSseasAlCrYJdjPjOCSuIxqtBj4rVEIjlIZrQNYSzEKCoASRwrtRMqltMeL7XwGqxdnSJMJiraJ642udm5RDgvXZsqYXaeNB9lMxBUt3u5rkyM0+W4c41BQtKOYqwJcdL4J2WknE+SQGMztnCTO4Bbpxkn4ohCkbxPvrhW+KtVx+MlzDIcszSs3XfqcfAOoE+o4r7xhLs146U/U9pUve47gFsnXPcSid5Covq/6mZtXTdKwy8nxBPzkzJ7ZEOjfaaS+EqhLoBfGojpPSwDIhO2w5LrSxGqxCvS3hnxr5IE0+e64rR4RaKPx5IC0ESoSxnCqAcTryRf0oyXQ6TQm7ONUjunnsIiF5EoTGQafKhuLytAGgOHrbjQRiKaJyL0s3GtaCjq5PDOKpUPKrk/HSOJFSp9nH0icWFaO8BqIFQAK50Ba7VrkpxuEaPGB9N2kMI2aUOs2vfTCSCqbJR+PAGBKEHEOsUNfD1cBi7JlToZKds5JTNArXImyTWnB6yrSc/ideVRzNmSVRqkqxkY6qdTjCeA3RsHpZrNJOwk6hYjUkYzB+t60HV+u83GyqAClZLyoX7B4s8fIjtcpaV5dduJbDO3seqOi/41Gvuzjsg/Lryy3GkxGH2kacTiV54SML00qYqo04XnIgrjIS9rjhoMaJ6sUC7i8ZAip7gi0gm2IbYxpzMztylEYTqaOxwtrngqfNv8Nrj6LO2UKmKgnshOG1Lje27B4y0xSyY84v/mcq3ZLOrFK74mGHEro2Yqt/suLtXnErmI46JwjMRBPD+8iKHTisIi78G658EvUog6z2fbOW1XLxLHG3otutppXj6GxCSdJCJGMyGlSfrCHggTo5GC0zNiQrxcxKqrm8uNl+siOAq+z74qWUwTwJ2qTOsOPzb2KGoUSsTYS7PBQCZaTSJeHwOm53e6Dp7ONd7KPoVGss20LmlgI7wFYliWIazs1cP+U4LttgExV5kx43ciwUkqfcHqKujGEsh1YaVea9t1b4PjTYI8GWGmAczkMmwk5md6dqQXIDqeU18T6oKJ+StW3xpnWd6hYqzjFULbsRoTgYnkmyI0y8osTXcqA6CNLHg7SsBB6S/yLFoR5Zs5Wdi1tXsuc1461L46I+a3E80fikU0XSF/HSPUbJI4/9GvpBLCv1vRpNBC6xRQUgSmgrLOkyXJClqNZIylH5zCEHITr1f/s/cyUtdXgjPpEb2rQjDNlywCyTqkA9ktT2Uj4AA7IEi6NW9OLsijI3lfehhu7rdSras/5+KIT4EkXEoqiDEeq3304tUkUrsqba5T+ux/4CmfKUoCl/olrvYqZZkeuS15PpwxtDYRLXpyIk+4grpbg6jWu9Jwx8KnixTDIs+6BQSNIhrEQgICBKIftaNQ10pHyx0mAjUrpByyGehTrjfYsl9I0bAJhaQAetKxZbSnH/zCvXVBogY24n5Zkan8/uxxUSWI7EqYj0uiCXLin8rkrIkEssIf4iDBGSoBiD06kyu0oZyh1VvSJS5TuBiLtuVzoJoN60unUvKmEbOBdTLKWzC0vjow/KYfbMO27GLQy6ErW5Na589oJECFO256CuIxDi8qpCvRBTON67Kil0Ii/wAaX/EbKnvAKiUKjSCmyxopWtwtcV0qz7ndLZ5rSxlTOkd9TMKbgv8FtKPST9vjFZKmjwKp8ObSkGN0pr+5yuoynqch0OLv2bMpJUYaiG6cuZmQJJCzOttuXTM0NrSWAzMFDiuAbhoQHb60uZYwLPul5w3SSqwVr87y6mwB/T9JliihkBO0FvrOsd47DtSxlLQ8Gk271PEmOhMSbhZEqdcugr5O4qPeFONX0qucddItO3Gp/gbC6ikBOkLtIi/bG2jdqzDCKqftPiA9JDqgNVwzctO5BespHuoSy6sDybLKEaK6I2Izek5gi7zzaiqmEToue2vGryJwdSmz48Ssv4SrdO7rt7ejnnpK2i88KDV5EgzMsaUtRerSaf4v2iUqHsieMV0SMOA7rBeK4nIAJKz1tOsWUsNoSFtYzLMI8qqPDm0pcMBKb+dcsW2SIZbuMsRyhqNO19oQOckgn/aqijzkI/U8Gg8NTbi5hyFcuSrEw/4m8BlKjyh+pUQh0/hsQ+Rwko+29DoTQqC0EsrXRd0hDkJq3kwoJaudMoBRU6iApOT/66ewqMJYPMKqBBfSuQ8SpAd14nhu9CxTo4pQR5KzhOG2RHcpNgh6CsaMLUoLKjUK+SrZ9CpSj0wtnhUiQKh2qKywmwk9Ui5eRqdRDIIgJXOmELvMhj4k6wgyYqwipvPV6mYPzSGLZZqqkxgqzA4aHQHsIB3jU0Us+j89iSqSjxqriC0mWk0iuSBkr/vXuhpDXrdO7rLxaiT7RRJSuEOrPjySkDp/qozWEvSfXK4zmkrxqk0ndGUTcAgSzB0VI2BfSnVJ6ipBBZoocrErQTxSR2rlMpUHLQrJatiRgLTnQKj3seLajIYs2RXqUrAgqW94spOxxLIEi7kfcy55cNlabd/rbvWhC8ikGuWHgxier4Gom2S626oRov7a6lWhpS7cCULnr4SiCNB6ckmsJf4R0ZOlJSmDxS3a4zYRJ0ZbEbzr1ilcv7Lh+jkWKQl9F+I2Biaa6QB+HEJHYZPXCr6s5Cy64TqcLzNwM7HNoQzNoxkIP/vhxjKJOYpcR8GxDEgZvJf+4bAo4ylYZbLRnxcUGmsjl6OyTzG6BB8ZQF234qPiWSnLFUGXh4OJe7C5YvZu1RnIvMMdqGIBm83HHg==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="1832">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QLvYAAAAAAC4rsO/9/9C6uPOq7+w0VfMLr8c0ODUybTRqQ2KTMGzwGPVDrLok5udMNCKtSO5ocIclbLGc84P3ujaLNfXy5Cby8edqVjAFofzrk3bKZ8Zz0mOX8HzylWT7a8wtwK+SOdu467eqrn+mxDRQMwPupy93chrySK+d75MsY2jQcnRopep36VcmwqbeM23w1zeZOewkMvTmNgfxj+lDLo2rcq3971knRORhKXWfx/LB8dtg3KzCZB5weagNsVGxIjSIs31zAnmsd/R4EXcHM9+uSe76chkwBbdacu9sJfDdrgDeEilUMAC2JC9b8h4urTSgKJt2DjV09rN0nC7VISHimHNhZ9xwuqig7ZKy8SdR7eCvS+6nMU4tkrVKYD7w3euXchyw1y1XtFquGq9h7NrqcPAwafmqWmNqqVfsufE1ZkosWiZJ8R3zIm5d6cFte6Sw2cHn4+1jqg5xtOwGtLvtpaUhLGPcsuSVILRnryyaqRohNWmdsVGwE3Cw6jdsQKYv9oPwO+vL6CzwXakFoIFsj+ylIVpl6WulLGiuTSnv8EKwMqY/rmXseixu52AhpvEmHuQhy2njJeesHe0vLK0tRi16rY9pFKbPbDxl12jJeSGj2DB15nXqNXIYscyqvvFE4+oo5et8pLetIO+9Jl/uf+w0IRo2PvRI7ecyELDwaTWfiKQT+rMujioj5j8vYe+ArNDjw20L4iQhZ+onH7Bg3KjvKFkoe2QLcuEpVTJ3aM0iQ+K0qFfsGXIOsn4py2l8cDKn1imA7V7n/aAqqPHvnSVmG1RmJqGm669s1Cuiqeulva4FsQ/t/yXtraFlVSRgLOrne6K633IlOepiaLLk/yJA5XQxny0HZHl1R26pL6cfeqQ8JcGmXqF5M2LkRWpUnsypFR5trhHsiyLbIKUyhuw3357nXGkR3y7mm6Zjo47xSq0ebV2riXUh5fmwAGH58p1yEO1RJL7t26qcqbmybCyPrUCcSK0MZlBsiKlL8khrGXDxMJwsmujgcvypsKxm5sOev9u8Z9Px4Cek8fLs3q7c8IKn2pp3s4RjKOpGp9b1Y63jq/KioeTosC6b9bL9aNSqaegcrx0nzqo+qfCjU2pDbuUxhitm4KNi2ehzc1JypW8C7BrqtiTbIJ9rVmwRrb5pJ2Csqi9tQuU1556xo2YzbQyqkWl2KEWgy2bmJUFuI61I76WyROd8qqEtta03LL6o96k3Z/vi7WXCYedoWqbrbP/o42z+rsJlaGoEn/Rs3uaf76AxfaoMMQ0qSiR/H1BsgivK4PYuh+jM5Wad0KPyKp8nA2jaI7gd0B9ypx9lEWA6HKztdiCWKXfsjDEraNRrwiX2ZDolJW3LrsojwiuUpDDe9CfS6kukG2O8q63sBnAxYzZxxqgloiUjAK3PMCeqZGp8I39dy+7xqEFkQmWw6OonOmh96QZjfaA14qJmlytM5pYrkOWO6rkg+LH5J2cl3OKX320p/F4eZhenwmCQGn6uQuBVbkJi8e0hpGpnSehi57bonaIJamIsM6VOqZjxSOvQrahc3OduI8/mcWfcZvykrG1L75GeRei9pybktmznbENe6WXpbEOiuiURJ0LnZKS04QlnF2H45TogFO2NaI4juuwOoUapJuWLqxpcih1YaFXmfR6VKBZwGt+fZ6Gb2GBQYCNn9yY+ZpWwUmS3nqVs4OJEabSeNd0+7jniKZ9KIAHkC6kJJc/eEG8kH6YlfRuh39xfFGgY3j9nf1z2MMwfFWJFYkQgZ2t7pX9c4B6v6SZhVqLo3QwfMS0loiAqqilwo2ypq2Qc6OUj+V8w3HCj1qz</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=3" index="2" defaultArrayLength="3">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="30.2243" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QUz+vQAAAAC+qZp8yv3/fyrysDA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMY/AAAAAADo38vK/P8=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=4" index="3" defaultArrayLength="5">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="27.8168" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="40">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QUWrKYAAAABFAtxXMv//fwyPW1jaeU5NF+9EMw==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="24">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMZeAAAAAABtj/3/gcBtj0+c</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=5" index="4" defaultArrayLength="8">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="25.3972" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="52">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QVBL/0AAAAD0Vb1/zv7/fyQMzDJcsrYQc4Cxp/WyoVH84TAP3Ekk</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="32">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMUdgAAAAAAp5U2g8Lah4fr/odMn5PrV</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=6" index="5" defaultArrayLength="885">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="31.2627" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="3924">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QVBYBUAAAABZ3Md/r///fzmrbrNPVTURd6hS1dOX/SIAnVOkFTnbCLWyVdmhoukN467R+mwU7TXxkSmuLRPF8XqhSD4zz/EsgPYaJn6uzqGSv3bBxcWaqyDeJ/taGmwYHqy3pOKyicK1tSgh4IAbkrjqiwetufFoJ+tcKkMu/rSpq6sa2uKR6CKzYzmrweHixGeSqRhr624g1O/YOFsStXVzMvx2vSYkvdJMKo9qKlMS3SsZ9xOgTrtR7rNYTBvdfjJnjuGpS7rSAWrhovmRwnF0g6p2puKgmmG5p8yuN0ji4UgCqq296iNHjitaTBvVFDMCjrqP7f0jhvMSMGZxqmk04jxzg6YwFMMG93stDFMSBPq6F/0lzSkjaFYTZeF6fiY+sUAYJVxBKjjorrbznayWn+L2c1IspvYa7/vMzIuCPFLCr3kZ0tYVQbB9NrfJxzveirSjl7t+QCga0Dp/Y221Cdw2w9Y+vDmgCSni/CxBoCSt4qzbwTKMtDo6Dc8FGojX7SdWFxo7A96xXNolDjQaXHy8KpXSK2Izu/+ystyyQjU5DaBiI9PAHmI7NSGoBRXiXM3yoo+zw7Rt8vnSM66SLtKrRSGne2TruLCbkw3TM53KHJROI4CJKp0a/r7A66GGjeKWvcGpnHbjxSXKGfG+JZinKzeye0niI7J7Y0Sdejfy/jhw2LfFeTNNfDMts73RrL4MTLF7oCoH7RMHfLpXXZ0nnkIbr2ALhkOSj7ihsHPTPqIMouOi4uJUEjMD66WqoetZd7LhMUGzXhor5QwbxVka0yKuqMC+4hiaISP49BpCOR40WK81M3+rlhnj06Pa0lPuMO9avt1xQ9ZSyHqhvhZZrkMb46No6qNDni5rthNUy2qHJ+676go+gpm4JAspA7Uqs46tKvZpKmteHT2xB7aSjbZ8oCU8VSobl54qBxEaicduIGjmG4NcujZkvj3QgzxNDTpTdb4KDatl5eIcSvOlJQTSHaGBpqes0s8QIbgRtCAunBv+wjoHta4r9+UbMhy7+5vSHeZhr6Uu0rtitK5bf6L/G4GojcTiD8mRvrzluOcrLsdfG2AbmtJMHrCjZyEMkSqiDv4xWmi4B/AlWEkqLCetNsUWJTn8KqhDLrwuwLivmbbSZSw9/jpoCTw6+5cyTFa3Q1cje+MqIbueubahLQTYOscyvSkcphpfCb6qOSfi1QkxOTWYrezf0vCqYaD2T+MCQXtvGOs59uLVS+GsosjSI7uBvidKtODAJbr1Mt/aMaERZ8v/Y9Pp91qV994277q2Jhq2Gf07+5cxD9Y6HIOqzf/iTnuhrUu36n8Z7S+QRSt4+gJCkPG+KLlJAMrog34th5o67yztoOWO61pL0yOdynwdfi1C1CptXw4hEHQSbzSko5Cn2u6BjCQD/jpaaG2hXa3if0gBs8LjO8rqP8u6tVTnqHHe4okVQqI3V+s9aDM3MnPMC4vj8It7IjLo5eG2cXu9UUM3c4c11TdbKKbkT+NqA8Oxb1rivL4wI/0lgxIqWVTNtqi1MAF8tL3EvbTCJSBMGqbJzS9GUyuaU3uoKcvRiYLlIZOjrlPbUoojcRLr6ANzB/Qj7ZnLTYwj9hYSk9iBvHpINiAprKQI0l+9Mb+jiLShiC2BhjqlqP6o4uniN8gyptNr0ojOEbGxeaJ/2OPlSbpouF4iONYjSGJzTp1jBHOKikp9L281GoHlzSqkhxt/r6vI7nNpkBIj4RHLPKKfSAG8gsyomZfiqHjUqdpvkr/TBKjLesyBZCpiszqMB4w+j1QjYHoauYrutYwYvVhwILcaI2flm4hKulng/TtBa65cqOLoriWtbn+iViuRIPsdIsfToqR/f6vVybueGdqIjW4hMVYb2J+bSqSzsQvrD03C0bvRqf7f2zqkszcZEvbKkq4mAeLf/iGkx+7TmdXK3SKeN+2rMb1huSQLtW8LO9MCPcMRupnqML23IpMDK0vwS8nRM0l26jEd3iBZZRqY+awm/ZkSWpmxsjMsv9iDO5iet1UOPA+Xrrvc0r+7oTdYM6ODiOrupt4rJCsbXEUzFetjsMuDsW9aU1zuvQ27v1igLcKUEyKtQi71caSw9sL2b4E0bHK4xNktaacbzpFDwLSaifJeLETAG+t/c0fq+1bmu7+8q4QP41TA2i16zrGLSCRvyhq+9b4+gkOywjovYOQbQawCSe0TKVurOpUbyrRwVaOZ4OLkBPGjOyziQzxRonyj4x2LUsrSQS0v1hqlI846/syqzz/rRZLDR17K0KY+u4GmITVhSho9rDhzMSRrwip7010qe+065mTMJ92tGkgd/CdodxMnFurma14lwEsaIHw+JD4OOmQi671BeC/VxBN682veZlKizHGmLNrrkcDTd/fzKv1bJPErbTWzV3LLQ+UbHFGT/W7Tja2yOnXBpD17wgqBIq9bX+Kj1FSiIwiiO1YRtFdAIMlKKo5zvSLQXyoVifwhgkIq209eq8GO4wo4olnU8aZSheNNxkoIRx4htxorywRK1tOeMoIvIwt4KmUWzq0X1ePZRzPtlGsJZ7IAIPEtNCYar/TOoxFk0imM0rnPhStmuyrj8lw4JuaxYfkkpdlKkxrZLSVkOnGiTjXXzKVyTuPDXIMjQStvKnJP1JWloQyqHJmuKi/8Gszs/jjNab+fgrVDfbLzFyJApCocBe6/QAlPdnMPOzKWmdGs1qrcZN075ZIjyGESMkFBrw54wr35Mq+Y3uoV2t4hotoiP2PBo4EDwv04Uaavz9JRNzOoI57ifT9BrYAkwibzQ6Yp2NOjxMJiBMG9BKKpvQLiDkOEprDz2u6SHixk3xsD53sMYyLtosIiyIQqt1raL31g2gR+tauM2+rVij4oULkT6AWiBUdxpA2B65iuIqwZEqdpasM6jYNBXFvbDKLE8sSsfY3aW/Z+Oq0nI8WyEkooE6+YdbrePp4q0PJiXFjxr8pryqrAuyze0BJkD3mp99+KvHCbKoaEG4pY24KFkj4/hKMO3cpXMR4pwCUUTWUponga9cIuKaesMvKeI6FipoLhhYejzc+C1nBSMY1UoZXr0swuoTFDk73LEVwoNTgXODPSKI/jIzFKyp2JmyuXyxr2iu0s4UpK4w99NqSKodvX0szewTG/Ta69+MKcv2E96RGsLDvr2nUCXK0BLAUCEoII9KB8TZognf4tUkwjc1aClIzkqDKjgiH3FkeHqqW0+qVwD+IoKYKv9LfSbMRlp/yQ6pAaPSQdlVrxneshiu4afTm9zZ3iSpFRpDM542qw4g+WQTA2ISVw3kqpiLcxcW47uzmkz97iwh+Gqr2oquajTjWjZCoMhRvd1xIqcyqg5Z7KuGXsKWehOhl4HE4nmltTjScnEzL5b1OrE4eCuhghMQsCKcDhSt1ferriPSexrKpnrhUqZ7ESxujsouWVOhNRji/ImDp4n/0g2w4SufAjozss44Es0sRqwS6H7UoY36assdDCgAk1oZQZ450COvHfnCzMGiIpoNKi3Jrqb1Y+utXKPsBiuhG0oYAj4pSVsSJqnDrM7P4mcUtSiuDSp4dkO/N2snCJNKUZDtvneZsjpZMKBVJhT/GjGOfTRWwygaUNraV+OtmFjhcFZzGaVJK+LESwMuNhv6pwE0pxCuy8lZykK27SxFyUJirH2XdMTeKVqL2lE22qGSk8ICskSo4rOi1KKxI5hnQtTvXC0mahmBLBzrXHiDM5hh9+3mKZkY/dI/3iGpXSuzizPCwA81oihJUWrRMRNThtqpYTQj7VTqsmitEuVKsZYuIj0qMhOhio+hKfr3FuF+imIZUC3a0e4WNhl29irhK5WMEsEuCJPWIc4eSIGBpZY/iaXP/tHjybYaR4+FsnqHsqklFcCOtJMfcD2W47RNJd2QMh3S1RkJuLaZVQvarM6DIgDAsw</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="2372">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QLm1AAAAAABCtmnSEfJj3urXd7ZrvuK3Fry7sgaXfNITutmUdLEOxVi7E5+Ox+PD0IsL1Pn/79uYuJSnDLTsilv1aM6s45fIl6JoxmfRQMVnjam4qMglzujYf8s3zvKqyKepv9GafbpJsNmoVZnDqZ/okdmG30LHnIUK36jUu9e8tzLXh7tFsuSS6qneqDmjHI5hv2TCOLGTqWaka4/4x5rGgNaku2bUCMV7sa+3eMwgwsnT1MojxpOyP5x2wQad5cXctBqteM63upWXu8BromSy/qwOxaOzesO8qAO7BPEo2sjPnMoFyUTDN8gI1svc7srtuFzO4L3Bc8yYPZDvh6+v/L7Bh2STmcDB4GS6WrhYwgHercYMytXf5L5GxFuy6poUoG+V66GehQjN0ck1u/OvJtN6rR6+DsCSWISeiL9bn0q50LQjogm/kbJdf1Gul5Ckv/jIW8/uqLHcc8jDsmC7fZULosqaO8SsxbzAfqhVufut3MErmG+Np6d0j6DOVKsgonzEpsd2renKeKmEv2+/XLVvqlfO4a+vrjKeO7BzvPO9Ha9/uVHJTbMTplqVtq7N1gOx0MI+u+fEW6qkxsHE86lJo0/CDK33s7TFG8BSi9vEkrmnqo+rBsOvsAKr5K/np/2sLbRtxiS4LLYEvdO5ycOpvLi+qZ0TuEqtI6o9mUq+Nak7sKuPxbm6mOmnUqM1yKOiW8UPrguZ+IsGo1faOrkrkrymyaWcubGjZJcVvpm2243Pm+fIdagTtFrLxKaCpDKdwpJEi3qUt7o7s++uU40FiUGARrM9tSiqJMoJyBOkZbP4njDAIoqtsnaDSbR8i5iRBcAvrFSy/qy2dsiwybaZliKOXq8H0Dm9q8OgnTe5Y7DDm0Sqk58vtj6ywLqcwMS2fJS7u9q4NbPtj/e836n4qZTAnpjPh0+xZb1SrlKOcZZzpuKsrbkJvNjAEaXZw6qQz8Lzpd2ggrBAtru5Na6CtzOlz4k9qk+1UrWxuwKfTqxHuNPBUr3No22Z+buZp1Wu07bOkeXAeq5UlGWc069zlZ67H7Yfs0i1ibT5wt+wBsCpsvWnmI49p9WsCsHxoQughKz+dNzSm6A9ljqee6/exy20WrWdpCWM1MSNxTqtFbW/tHOE/6llr+maWIs3rVKb1L3tvlK8J7bSs0/DnsMZiZN73ay8tkPNPJZPsWiczangpJ3OT5BcszmvdrNsrtq6lKhjqESZCscLpaGmZHQ4tHGe/qWs0EijA7wYn4aZDrALqfV3uML4e32gcrUjnJOFSMdFwu6Qy609tW20jabduimhU59Wm3Gpwa0Rp82WrKBRrKma5pUDtHWY76ivqqGvx55CnIxwpoVTyHu1F79krkPACJvSxrWnYq+JwEytkbcTqgqdOrJihGqnwL8Gr3WZM6kSuaXFibiDj2rENaw0syhsm2w/ue+M9H9goruqurSNtDidCJHllp2vpLXgq6qkoYxMnqyTxZyfg62LcLAPs2ajnq6HmQVuS6YMfy+qqKTMnE61vogsom+xfqe6s7ePzbGIuqipbZrWnamRL6lao52D75+9o1ePQpV+w4iodqp/qpJpHInbrVCYrIa8o/DAiZPmwd+ccHq2l2OUNquqm4qhIJEQpzt5fn+Fp9Oj/J1RiyCi56E4l8+bhI1bqg2c57OVqf+MVJfNelGOP5VGso6nfqmoh/Wyu6apqmSUsn9Kqe2H8IwTe8yGCK1ypaSg97ajjNS9R7sxo/yvd25VxZeYW4pZgq2LUJ0VgmO1Za5rrYDHMbDhe0OwKKWurYWU+cmsfcaPm4zGoF2ndIS9qASIwqNxpTWEGqGCoTWmfZ8ZmqahVJ6fgKFxGKW2q6iaCpAVege0mo/UeNiA03jnwdiRhoW7ebGRxaIdgOJ6jZz9cSibP5jUWiJy65AIfQC2cJh5hah6RY63dQWqgpbwfUJ8Gm7wovqcRrj+kymgnKj4jk+VrZP/pytyo6bHbLOHlqCrsP6WEo1cnYh6kqXksLSsO28Xiy56pJL9otOikqUFohJ917HGtI6IXbTidJqBQqQ1h6SMxJ5eimuO+YFKiEeASn0blvBsk4M8pGl4tIhjcLKZv6KVgv6eFJJnnP+Q/paEpI5fioW6hQWSUWmipIieLadbeqKkwnXPd+iZ95FuhKmMEJX3ja6HnoY9nG19UYiokwdw0nY3kOuEM4H0oxKMp6mYs+uClnTMeGqKmorscQ9wBIimlRSl2IDLblNraGuZf3CnToGeo0SSlpZIdhGcc3shmGWbzpCOgZ6VEnVYcb5/9IyJaO13P3P8j9p8tKJxelqSlYJOgd15bGutZRiROHWka0qsqXAbcVFqnoBMprhilXFjhBJq0Yo=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=7" index="6" defaultArrayLength="5">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="36.7164" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="40">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QVA6s8AAAAD5fPp+2/7/fxrQgLIXxJfqANH5zSA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="24">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMUDgAAAAADPlXzzzov9/xbU</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=8" index="7" defaultArrayLength="7">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="34.2968" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="52">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QU9Yu4AAAADw4nh6zf//f68h6THDeMUQUKTVQgSKOD/gUIvmfg==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="32">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QMNpAAAAAAD7/4rRTpsUtZ625IwGgA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=9" index="8" defaultArrayLength="3">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="2" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="39.1126" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="28">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QU2iGAAAAADmOz12iP7/f536Qwk=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="20">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QM8ggAAAAAD9/0b12e8=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+			<spectrum id="spectrum=10" index="9" defaultArrayLength="763">
+				<cvParam cvRef="MS" accession="MS:1000525" name="spectrum representation" />
+				<cvParam cvRef="MS" accession="MS:1000511" name="ms level" value="1" />
+				<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+				<cvParam cvRef="MS" accession="MS:1000130" name="positive scan" />
+				<scanList count="1">
+					<cvParam cvRef="MS" accession="MS:1000795" name="no combination" />
+					<scan >
+						<cvParam cvRef="MS" accession="MS:1000016" name="scan start time" value="39.9708" unitAccession="UO:0000010" unitName="second" unitCvRef="UO" />
+					</scan>
+				</scanList>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="3420">
+						<cvParam cvRef="MS" accession="MS:1000514" name="m/z array" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002312" name="MS-Numpress linear prediction compression" />
+						<binary>QVBdXAAAAAAkPeF/HP//fzXoUiWkATojvG6yqpwoPCway68eObN4vHDyKKQ4Ov8qHa+UZ+u4G+ILUAI5VNO/5imih4rsI1U19TunbX3iIkKhMZZYsJH8Nc85quOk4lszAqjpXOOsMZoHkw0pVj8q2VCuvxu2UyYhzGoSCnFBou+l6o7+Pi1ZNSJarPKmUmSiO77RMHB3oVRo46S8uzXLI38lMm7hcbj0QTpz4juuCcqEatvBfSmsQzomDH0938Yq6K4aoh4eP3T6JZsSKogfHioSMRuR5IJJGCGuJ7fSCYHCpu9GwhkaIq8Aa9K215EgYYcqWzM+srkLIrdEGrXw/q4YiOM3OdNWC8sJYZp0TM45uDy2eQUiXIgqfa7eKiAVGmVTHq9UWuKyzRK1/oow2U1A8LJECiGsIbnCqAmyp91ewtNNYaAufuKTKSK76kW0UoGyWn68cZU6ChxLFer8U94q+CY6GGkeOQ8BvGlRICCgKtQFnS5uWhLRsWGqHWbi+bxSp7mqy8DPEjO/oqUWaNIkrTE6f3iqWeHjhVBiT9RxMntqqz2/6ywroqstsTJZA6T7XOsgJcu69sOLgFLvorG1dk26rpK7BAatJcnixBwROn7toPAL0ufakbjZciaPUxwmTijEwxoaPj6ku0/ilinhs7rMvQCyOrA4NDTjOUbOqj1R4puHsb+TBElWk7nti3b9G0vaM90qYx4hw7MkuqzavTAu/KVR7uIFDTK/tMg4beOj6ETjtfViEyDhtypxqZWU4qREc6mvj8IfEROnuy/avxv+L5rjG95We37DQjUyE6JX4NQa/CLabRrKlW6+VQU9koE9/bs7Q+a/pVooIpkrscA6lWKuu7DgPh7FOK9VvMnuvBcetLrrP+/2JFDqGpnuPTkN0zQ/7jHuYjAfdjSfBqWzM+Inw0G4SSi7QKArU44qkRqduDfpKFS6Go5hbSf3RTpBbe4pD2Aqt1UtPgApvLRyPp+hIr/eOvxmjCGA3xpzBJ4nJGgSYoAirTUlw0poip1wbigdRCqYeo03EL068qkoQBgaZZ2uri/i4ud9ITqKba52qeM8Ret/uiIHonKmNUbjBCiaYcRtJz81G5agyzDqIsrFoqq1ltJughErZgASPScSre530hY+sqMrdtyoRqobOeLcOWG1/xW4iTW8i9ctcRQbHQnrsCwDpEaifn7Bq+zz0g1RobV4YjP5dilR8iKkpQGnIVzCLW2xpkxC0uhkES+I5CrH2N0nF0Ya8ogeMHTRJjZ5ikWSiK2os+LBIGOtcvjqbAdOLJfVGzrk0qV75aQseqp9lL47wEm1SpM3dqu2+LMhaAgrDmGE6PmtwjbiCodEpuIeujkp7iJiSSuLvMoq9560dOg+3kMtTY4aaQQeKnKXE2WVm+5vE2aMcw7e+5WsO96fgzWHihdS3qPZDeIRhzGzyqZGhENuxzoymI4r3C8bb5dbCtbCWI8RIemFGoH3TqUQCOLUT/G25Qo94HIzeSWkgo3jE1Z0GAeoeRzjQ2ESMzzxpkbC4sZ9kb/qgzmu6TYbQqHDBuIOYNIlAdU6jqqpI6IzWkL4my65wjqO9lwqZlcqvzrdPEJculFUKhpsGvFkPrgsDT1TLyg/VBqn+D25DAokyQE6DATuJ1ceelZ05SrLAkrfqvstygAj9B96R6MeIE6FKgmN/SIMh3q3cButhfjqYho+JoM0KtJWvSox/xsbzavWPoovEM4lxYYq+qN+Lsq1SuMXOyzS5RvfzZsQ9dtEyhL8O1EviuoajJo8Jxb6I9huJL76pqWG6zgq06jv45jscqEAQamTZ+LyiOGv6A/STk5iqx6pwvZHA6xq6+PciLrAc3wn4MorTixC1GTBppbA21aGkgB7gSreRBvWOxL+82GvRjfTYLaL3e5C5OdyoFED0jSvISU6Llrl20q6egUxpAW8SMMx6UYn98YSsrg3oWkimihrDrrceTdbpT637zVds6L4VeIk8QKr3obimu8RKHV/GhkjDqzmq+MS15MztdNfJrqBqP6qk57ihaQhLuSaKn5CjkbCKm6JrrAUe6KJz+PV91vUI8K3H0Gl+HTiESMzsIsFomT6wjvUIq9JfeKAVHKlG0XCWJ0yvlPXIwgYOiWh/SnlcBOD8VpJPp0uMzQanAk+u+HtIdbjKuWuHjPHFivbSkp8jhwyuTI6wDGmbHzSuLbhpCa44geV0apX6+P5fsIvjoSnBHOi8B8huPdILolIGl6pDiY40Fru74usuZ7i9S8ipyP/0wv+klPIUrfDur7obiuUHhJdAkGtLlujdF7Se7FBsvk3vTxcIxQBGpLY/rmN/aNMeuKNu0OgoPTq4HzNIzsbO5aTKkU6XSx7hCvdVWIt2EOi53rTsGqb4LvaFeWtOYIyIKyHKk1v3Tux+btYtSAKPjpoLWuxmxYmMlQitn4Sr2gIshhyZa7du8r6x84joasaNV0tIvyCWqfmKyKddzq2Hm2ySCgtqbE6PiRtqWE+4lhQMSGBHXrYwj6jVEubExzSyfASMhTZp+f34/WDMj4ndbuSO6rdv5I8eUIr7T5qbH43NcmZL3k3Gt0bzkpvOzkzEkB7RKARLdKxh+Ktf0O6a9ZOK47jSuSYiyBbpGoOmLkn5hMTlg+qOW+OKEbl2ntuhaKR3OJO7AGqe1Di5KuJqUmUk092i24O2tyjrq8zbtJHANGo0tHiwmCxsY+WP7tppLBE4hgrJK29esLfxYGkLRriLsdBvXj2KtPfIiYeU6QVX7oU5w6gJwXrz3hiTB8Wpr/yszSfEgYHtDr7b6NJdqsaYqKAezMjCTlafImqr2hHwqSHdq5y4Or12R0ovqu6OQajIt18KqchyyJjrBq7rx4ily9KLkzaMUWvrkcZ4gCeUSbwpCo/Mh4sxjxKpIZeqG6w0or6laIURqIewLMvGH0Sj1ADorqN6qFyyC6EJpqftwY7zWm0zbQm7n3qhhk5pwjC2h1/LKH2CeKXyeSh1Lniq1qxNlrjsdHxPVylo5aFkgvFkSPD4hJqvy05bQOuuTVSICIjrgQIooY0kqFukuIhrsUm3KEaAQF4rSzz4tty8aAf9+HAm2gZlQsM4gk3EaFoFrqiNe6on/zjD/9iHrZXrTYH2j7fnCB6ZjLj/JGqm3WjW1DyKdrjGUSyUZ+VKL4rhxwh4QVcGSLPOtKuNAUhddyKwjx8EE9QFJoDCPyliisSlCjpoKCjU5ciGuyuLS2uviquO864voQVsr5RrbRtqqstcqshGeIN9LGrq4Pq3phaGeIjISQJIVlZVNrh0KtNGSjQ8uHEsogZH1aH4bGMEjkdSTjCZ/iNrswo2vI/2yPzM2K5cSadBtKuLtKx+t3WiCMnE5F19qwZeu864rkrOZhw+F4uMPoxkSWQIRdGfCmmfdPRIvvoYA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="2048">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1002314" name="MS-Numpress short logged float compression" />
+						<binary>QLg4AAAAAAD9xd6ZxJMS6SXSu6kBwfGsRMcjrpPULct4izWvXsaZxdTFQLsTtV28v7/6/7rZNJBNwU7A9N1IzfTA7NtV0oGyT5mcu9Wqp77lxQy25826wxW6Z49CmzSKJa3ErUy9254qrvPeGtY01dbGfrpdj3em7shRr/SwIc1BuU+7wsRXhyGBL6BnvIK0f9FIuNPaLqpCr3mihqKmlse53d20sXbJyK1QyAyvVrncz2PKVsiar9+4oYqRiOvJRXIbveu1I7kEoGvDDr8hrRG4O5qjrMihdaBMw9C2asgp13q/l7Ojx926sLuBv++6v5hZwXeotKQttDi1q6XzvJO6Ca1lhwnUNshkrtvRcK03u3iozMRps6fC27zz1jOxMrlmrTGh+al5rQLEGb94tH+1UKbDvAjFQKXCio2eTZykxjy1qa9UxeO4CKnatdetq7SRx5TMLcmZv5GgQK0+lEuaR5ocnlS/qMFTuCe0CbHXwHivOqD1p7GhMZs7uv2lbbZteYWn9scSvSTI2aglsvy7asM0rWW/zofVkR63kaKgfPWSfKTwntC1fLcPqCibZ6YU0Ay5usKV2SbA1q0suCicdcoMlzykp6R6rJ6++YQjqpCiCn7Zp2XBa70mmInFabclwYZvZrrhqc+AeqwstxyiDaT8vq2LK7cvoROkc68mny2rG5EZrOmyCpJNi8K2ttVqs/SxCrMQtRqqn8PPqiy7/bX9mqK8p75hyjaqL8Q9vmamUKEyp16ehYten+jNqM4Rx6KgCKZ3pxm6osA4wUCnJJWVkv2nfLRVnj6fz6I4ma6t5I3Xp0G+nrEPvanLcLwEpwS2zLM+lcOthKu6qpm/EbV3na21yqGUxPOXtrYvseSYcIIooaS67Y4/rmfHGKZrszSClqbQjb3QF64XwDy8FbpkqU+iBahwx4yQQbM8m1Ok/pGIqWS8Cqx0pkq2MpUCjv65ibXNhQuow6BgmienWZ7Fo2KPOaRtpeq2pL/pwnmmss6Srhyi1at+fRugoKqTpWGr66a6kRe/lZYQil2ot6IKmZ2aGKmDiPiXsIg9wre4tJOomiuf+qOLjdi4XJ6adUyy76WSp7HCBbK+svecz6/ss++wWobwdJh1zpSouZ6g9pN5uJmZJpH5hU2QGaHCu4+mI7mor+Wa6J40qQig2Jf0o12Ebo1wnjyhGZc2mUOi/7Zlus+KgqRmt1a0qprEppqLobXJsfulhJ+uiQiUGYxnjGyaep/eonu1N5b1pGWk8YbQq8aLJIZhoUC1650kst2jhLhneR2fWo6Gc2d+ca1Wq5SuH6Y6gM+GOagHmc2o4aRQsdajwLHYlo6azaGGmKCAwn5/rb6OAXqEhHiXwcS+rXai9qwBp8KjupqPh0R3A4FJp/+ZZIjjtGV7sI5Ot3Ge0pLOvwp8SaLfsB62zrmwk5CjAKlCn6CvupySnF+4iZf9lnGh57N9qlKsgp50o9KWO4cwlLB6lsQlfd2tW6Ivdf60Pq2Bp+iaLaQ1pmCgDmPCdvWWAKdMnnCqLovGlHeCO4k7r/2qnHIIpuGuXKEdlQ6fyKI0r8mO+ZdBmoyYTqQtnZ6ovJlRuUSMP30Jov2KoHvbrPykAZxOgA2M0Kv/rPh5bZnOoLWAiJGAq250XazUj+iWCX+spmukN4Aepk6kd4u+gzSRF5dilj+RWY7lpZajuaOpec6nA4xSifGdfXXqrsqUrLZ+huBzAq7rdWiUm3pbgJeY1pSAmu6g/pRCoP2gU3paqp6fMKlar5p2VIZ1lih+MHOdm2Ru7XVmpMB16XmNgCiE1IiJhE1/9ZZMhmWdW4iDbM91WXkkj21qK4O4mb+Qo5GdfVymeno6cu6J8YBmbb2Jk6DVsyGEW6FreZ58mnnyksmk+paDpC6groxOjoNszqvOlauQnJNfkZ6J1HTtpL2LZo+RcmN7bWqalOeTkoGAokZ6a5cTnPmXVJvmgttzd4IjruOPCprhhOynv4CwhiCcL4sRvNCrSoVnkF2lHpWxaYOktYEJoI+HE407jEJ4iZSRdA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</spectrum>
+		</spectrumList>
+	</run>
+</mzML>
+<indexList count="1">
+	<index name="spectrum">
+		<offset idRef="spectrum=1">5379</offset>
+		<offset idRef="spectrum=2">12578</offset>
+		<offset idRef="spectrum=3">19025</offset>
+		<offset idRef="spectrum=4">20610</offset>
+		<offset idRef="spectrum=5">22211</offset>
+		<offset idRef="spectrum=6">23832</offset>
+		<offset idRef="spectrum=7">31671</offset>
+		<offset idRef="spectrum=8">33272</offset>
+		<offset idRef="spectrum=9">34893</offset>
+		<offset idRef="spectrum=10">36478</offset>
+	</index>
+</indexList>
+<indexListOffset>43520</indexListOffset>
+<fileChecksum>0</fileChecksum>
+</indexedmzML>

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -174,7 +174,7 @@ protected:
 
     registerFlag_("write_mzML_index", "Add an index to the file when writing mzML files (default: no index)");
     registerFlag_("lossy_compression", "Use numpress compression to achieve optimally small file size (attention: may cause small loss of precision; only for mzML data)");
-    registerDoubleOption_("lossy_mass_accuracy", "<error>", -1.0, "Desired (absolute) m/z accuracy for lossy compression (e.g. use 0.0001 for a mass accuracy of 0.2 ppm at 550 m/z, default uses -1.0 for maximal accuracy)", false);
+    registerDoubleOption_("lossy_mass_accuracy", "<error>", -1.0, "Desired (absolute) m/z accuracy for lossy compression (e.g. use 0.0001 for a mass accuracy of 0.2 ppm at 500 m/z, default uses -1.0 for maximal accuracy)", false);
 
     registerFlag_("process_lowmemory", "Whether to process the file on the fly without loading the whole file into memory first (only for conversions of mzXML/mzML to mzML).\nNote: this flag will prevent conversion from spectra to chromatograms.", true);
   }

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -174,6 +174,7 @@ protected:
 
     registerFlag_("write_mzML_index", "Add an index to the file when writing mzML files (default: no index)");
     registerFlag_("lossy_compression", "Use numpress compression to achieve optimally small file size (attention: may cause small loss of precision; only for mzML data)");
+    registerDoubleOption_("lossy_mass_accuracy", "<error>", -1.0, "Desired (absolute) m/z accuracy for lossy compression (e.g. use 0.0001 for a mass accuracy of 0.2 ppm at 550 m/z, default uses -1.0 for maximal accuracy)", false);
 
     registerFlag_("process_lowmemory", "Whether to process the file on the fly without loading the whole file into memory first (only for conversions of mzXML/mzML to mzML).\nNote: this flag will prevent conversion from spectra to chromatograms.", true);
   }
@@ -188,6 +189,7 @@ protected:
     String in = getStringOption_("in");
     bool write_mzML_index = getFlag_("write_mzML_index");
     bool lossy_compression = getFlag_("lossy_compression");
+    double mass_acc = getDoubleOption_("lossy_mass_accuracy");
 
     //input file type
     FileHandler fh;
@@ -202,6 +204,7 @@ protected:
     npconfig_int.numpressErrorTolerance = 0.5;
     npconfig_mz.setCompression("linear");
     npconfig_int.setCompression("slof");
+    npconfig_mz.linear_fp_mass_acc = mass_acc; // set the desired mass accuracy
 
     if (in_type == FileTypes::UNKNOWN)
     {

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -200,8 +200,8 @@ protected:
     MSNumpressCoder::NumpressConfig npconfig_int;
     npconfig_mz.estimate_fixed_point = true; // critical
     npconfig_int.estimate_fixed_point = true; // critical
-    npconfig_mz.numpressErrorTolerance = 0.0001;
-    npconfig_int.numpressErrorTolerance = 0.5;
+    npconfig_mz.numpressErrorTolerance = -1.0; // skip check, faster
+    npconfig_int.numpressErrorTolerance = -1.0; // skip check, faster
     npconfig_mz.setCompression("linear");
     npconfig_int.setCompression("slof");
     npconfig_mz.linear_fp_mass_acc = mass_acc; // set the desired mass accuracy

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -173,6 +173,7 @@ protected:
     registerFlag_("MGF_compact", "Use a more compact format when writing MGF (no zero-intensity peaks, limited number of decimal places)", true);
 
     registerFlag_("write_mzML_index", "Add an index to the file when writing mzML files (default: no index)");
+    registerFlag_("lossy_compression", "Use numpress compression to achieve optimally small file size (attention: may cause small loss of precision; only for mzML data)");
 
     registerFlag_("process_lowmemory", "Whether to process the file on the fly without loading the whole file into memory first (only for conversions of mzXML/mzML to mzML).\nNote: this flag will prevent conversion from spectra to chromatograms.", true);
   }
@@ -186,10 +187,21 @@ protected:
     //input file names
     String in = getStringOption_("in");
     bool write_mzML_index = getFlag_("write_mzML_index");
+    bool lossy_compression = getFlag_("lossy_compression");
 
     //input file type
     FileHandler fh;
     FileTypes::Type in_type = FileTypes::nameToType(getStringOption_("in_type"));
+
+    // prepare data structures for lossy compression
+    MSNumpressCoder::NumpressConfig npconfig_mz;
+    MSNumpressCoder::NumpressConfig npconfig_int;
+    npconfig_mz.estimate_fixed_point = true; // critical
+    npconfig_int.estimate_fixed_point = true; // critical
+    npconfig_mz.numpressErrorTolerance = 0.0001;
+    npconfig_int.numpressErrorTolerance = 0.5;
+    npconfig_mz.setCompression("linear");
+    npconfig_int.setCompression("slof");
 
     if (in_type == FileTypes::UNKNOWN)
     {
@@ -325,25 +337,37 @@ protected:
       // We can transform the complete experiment directly without first
       // loading the complete data into memory. PlainMSDataWritingConsumer will
       // write out mzML to disk as they are read from the input.
-      if (in_type == FileTypes::MZML && out_type == FileTypes::MZML)
+
+      if ((in_type == FileTypes::MZXML || in_type == FileTypes::MZML) && out_type == FileTypes::MZML)
       {
+        // Prepare the consumer
         PlainMSDataWritingConsumer consumer(out);
         consumer.getOptions().setWriteIndex(write_mzML_index);
+        bool skip_full_count = false;
+        // numpress compression
+        if (lossy_compression)
+        {
+          consumer.getOptions().setNumpressConfigurationMassTime(npconfig_mz);
+          consumer.getOptions().setNumpressConfigurationIntensity(npconfig_int);
+          // f.getOptions().setCompression(true); // maybe later.
+        }
         consumer.addDataProcessing(getProcessingInfo_(DataProcessing::CONVERSION_MZML));
-        MzMLFile mzmlfile; 
-        mzmlfile.setLogType(log_type_);
-        mzmlfile.transform(in, &consumer);
-        return EXECUTION_OK;
-      }
-      else if (in_type == FileTypes::MZXML && out_type == FileTypes::MZML)
-      {
-        PlainMSDataWritingConsumer consumer(out);
-        consumer.getOptions().setWriteIndex(write_mzML_index);
-        consumer.addDataProcessing(getProcessingInfo_(DataProcessing::CONVERSION_MZML));
-        MzXMLFile mzxmlfile;
-        mzxmlfile.setLogType(log_type_);
-        mzxmlfile.transform(in, &consumer);
-        return EXECUTION_OK;
+
+        // for different input file type
+        if (in_type == FileTypes::MZML)
+        {
+          MzMLFile mzmlfile;
+          mzmlfile.setLogType(log_type_);
+          mzmlfile.transform(in, &consumer, skip_full_count);
+          return EXECUTION_OK;
+        }
+        else if (in_type == FileTypes::MZXML)
+        {
+          MzXMLFile mzxmlfile;
+          mzxmlfile.setLogType(log_type_);
+          mzxmlfile.transform(in, &consumer, skip_full_count);
+          return EXECUTION_OK;
+        }
       }
       else if (in_type == FileTypes::MZML && out_type == FileTypes::CACHEDMZML)
       {
@@ -386,6 +410,14 @@ protected:
       MzMLFile f;
       f.setLogType(log_type_);
       f.getOptions().setWriteIndex(write_mzML_index);
+      // numpress compression
+      if (lossy_compression)
+      {
+        f.getOptions().setNumpressConfigurationMassTime(npconfig_mz);
+        f.getOptions().setNumpressConfigurationIntensity(npconfig_int);
+        // f.getOptions().setCompression(true); // maybe later.
+      }
+
       ChromatogramTools().convertSpectraToChromatograms(exp, true);
       f.store(out, exp);
     }

--- a/src/topp/FileFilter.cpp
+++ b/src/topp/FileFilter.cpp
@@ -285,10 +285,10 @@ protected:
     registerTOPPSubsection_("peak_options:numpress", "Numpress compression for peak data");
     registerStringOption_("peak_options:numpress:masstime", "<compression_scheme>", "none", "Apply MS Numpress compression algorithms in m/z or rt dimension (recommended: linear)", false);
     setValidStrings_("peak_options:numpress:masstime", MSNumpressCoder::NamesOfNumpressCompression, (int)MSNumpressCoder::SIZE_OF_NUMPRESSCOMPRESSION);
-    registerDoubleOption_("peak_options:numpress:masstime_error", "<error>", 0.0001, "Maximal allowable error in m/z or rt dimension (set to 0.5 for pic)", false);
+    registerDoubleOption_("peak_options:numpress:masstime_error", "<error>", 0.0001, "Maximal allowable error in m/z or rt dimension (default 10 ppm at 100 m/z; set to 0.5 for pic or negative to disable check and speed up conversion)", false);
     registerStringOption_("peak_options:numpress:intensity", "<compression_scheme>", "none", "Apply MS Numpress compression algorithms in intensity dimension (recommended: slof or pic)", false);
     setValidStrings_("peak_options:numpress:intensity", MSNumpressCoder::NamesOfNumpressCompression, (int)MSNumpressCoder::SIZE_OF_NUMPRESSCOMPRESSION);
-    registerDoubleOption_("peak_options:numpress:intensity_error", "<error>", 0.0001, "Maximal allowable error in intensity dimension (set to 0.5 for pic)", false);
+    registerDoubleOption_("peak_options:numpress:intensity_error", "<error>", 0.0001, "Maximal allowable error in intensity dimension (set to 0.5 for pic or negative to disable check and speed up conversion)", false);
 
     registerTOPPSubsection_("spectra", "Remove spectra or select spectra (removing all others) with certain properties");
     registerFlag_("spectra:remove_zoom", "Remove zoom (enhanced resolution) scans");


### PR DESCRIPTION
allow FileConverter to use numpress compression and create rather small profile-mode files. 

Adds functionality to numpress to choose mass accuracy. Instead of computing the maximal possible fixpoint, this computes the minimal fixpoint to achieve the desired mass accuracy. 

This results in substantially smaller file sizes. I observe 70% smaller files in some instances by simply changing this parameter from the maximal accuracy to ca 1 ppm accuracy @ 150 mass-to-charge (which is about 0.5 ppm accuracy at 300 m/z). This is more than sufficient for most TOF data and brings down the file sizes substantially:

As a test file I use the file `olgas_K121026_001_SW_Wayne_R1_d00.wiff` from the Schubert et al [1,2]:

```
-rw-rw-r-- 1 hr   hr   8.6M Dec  6  2015 olgas_K121026_001_SW_Wayne_R1_d00.wiff
-rw-rw-r-- 1 hr   hr   3.5G Dec  6  2015 olgas_K121026_001_SW_Wayne_R1_d00.wiff.scan
```

when using a regular converter to mzML, I end up with a file of about 15 GB size in profile mode (no numpress compression but `.gz` on the file). Applying the currently implemented conversion in proteowizard / OpenMS with the "maximal" fixed point results in a file of 5.6 GB size (using `.gz`) but when specifying 1ppm accuracy at either 150 m/z or 400 m/z, the file size goes down to 3.1 to 3.3 GB:

```
-rw-r--r-- 1 hr hr    15G Mar  3 22:28 olgas_K121026_001_SW_Wayne_R1_d00.wiff.profile.mzML.gz
-rw-rw-r-- 1 hr hr   5.6G Mar  7 18:37 olgas_K121026_001_SW_Wayne_R1_d00.wiff.profile.compress.mzML.gz
-rw-rw-r-- 1 hr hr   3.3G Mar  8 14:03 olgas_K121026_001_SW_Wayne_R1_d00.wiff.profile.lc_1ppm_150.mzML.gz
-rw-rw-r-- 1 hr hr   3.1G Mar  8 13:02 olgas_K121026_001_SW_Wayne_R1_d00.wiff.profile.lc_1ppm_400.mzML.gz
```

By exposing this API, we can minimize file size while at the same time preserving a desired accuracy.  Basically, this PR will allow users to reduce their file sizes by a large amount by choosing appropriate parameters. The resulting file sizes are as big as the original `.wiff` files or smaller (depending on desired accuracy).

Ref

1. http://www.biorxiv.org/content/early/2016/03/18/044552
2. http://www.peptideatlas.org/PASS/PASS00779
