### PR TITLE
Feature/sulfur specific averagine

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -141,6 +141,23 @@ public:
     bool estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P);
 
     /**
+      @brief Fills this EmpiricalFormula with an approximate elemental composition for a given average weight,
+      exact number of sulfurs, and approximate elemental stoichiometry
+
+      @param average_weight: Average weight to estimate an EmpiricalFormula for
+      @param S: The exact number of Sulfurs in this molecule
+      @param C: The approximate relative stoichiometry of Carbons to other elements (excluding Sulfur) in this molecule
+      @param H: The approximate relative stoichiometry of Hydrogens to other elements (excluding Sulfur) in this molecule
+      @param N: The approximate relative stoichiometry of Nitrogens to other elements (excluding Sulfur) in this molecule
+      @param O: The approximate relative stoichiometry of Oxygens to other elements (excluding Sulfur) in this molecule
+      @param P: The approximate relative stoichiometry of Phosphoruses to other elements (excluding Sulfur) in this molecule
+
+      @return bool flag for whether the approximation succeeded without requesting negative hydrogens. true = no problems, false = negative hydrogens requested.
+   */
+    bool estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P);
+
+
+    /**
       @brief returns the isotope distribution of the formula
       The details of the calculation of the isotope distribution
       are described in the doc to the IsotopeDistribution class.

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -135,13 +135,13 @@ public:
     void estimateFromPeptideWeight(double average_weight);
 
     /**
-      @brief Estimate peptide IsotopeDistribution from average weight and exact number of sulfurs
+        @brief Estimate peptide IsotopeDistribution from average weight and exact number of sulfurs
 
-      @param average_weight: Average weight to estimate an EmpiricalFormula for
-      @param S: The exact number of Sulfurs in this molecule
+        @param average_weight: Average weight to estimate an EmpiricalFormula for
+        @param S: The exact number of Sulfurs in this molecule
 
-      @pre S <= average_weight / average_weight(sulfur)
-      @pre average_weight >= 0
+        @pre S <= average_weight / average_weight(sulfur)
+        @pre average_weight >= 0
     */
     void estimateFromPeptideWeightAndS(double average_weight, UInt S);
 
@@ -168,18 +168,18 @@ public:
     void estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P);
 
     /**
-      @brief Estimate IsotopeDistribution from weight, exact number of sulfurs, and average remaining composition
+        @brief Estimate IsotopeDistribution from weight, exact number of sulfurs, and average remaining composition
 
-      @param average_weight: Average weight to estimate an IsotopeDistribution for
-      @param S: The exact numbers of Sulfurs in this molecule
-      @param C: The approximate relative stoichiometry of Carbons to other elements (excluding Sulfur) in this molecule
-      @param H: The approximate relative stoichiometry of Hydrogens to other elements (excluding Sulfur) in this molecule
-      @param N: The approximate relative stoichiometry of Nitrogens to other elements (excluding Sulfur) in this molecule
-      @param O: The approximate relative stoichiometry of Oxygens to other elements (excluding Sulfur) in this molecule
-      @param P: The approximate relative stoichiometry of Phosphoruses to other elements (excluding Sulfur) in this molecule
+        @param average_weight: Average weight to estimate an IsotopeDistribution for
+        @param S: The exact numbers of Sulfurs in this molecule
+        @param C: The approximate relative stoichiometry of Carbons to other elements (excluding Sulfur) in this molecule
+        @param H: The approximate relative stoichiometry of Hydrogens to other elements (excluding Sulfur) in this molecule
+        @param N: The approximate relative stoichiometry of Nitrogens to other elements (excluding Sulfur) in this molecule
+        @param O: The approximate relative stoichiometry of Oxygens to other elements (excluding Sulfur) in this molecule
+        @param P: The approximate relative stoichiometry of Phosphoruses to other elements (excluding Sulfur) in this molecule
 
-      @pre S, C, H, N, O, P >= 0
-      @pre average_weight >= 0
+        @pre S, C, H, N, O, P >= 0
+        @pre average_weight >= 0
     */
     void estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P);
 
@@ -200,23 +200,23 @@ public:
     void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes);
 
     /**
-      @brief Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
-      number of sulfurs in the precursor, fragment's average weight, number of sulfurs in the fragment,
-      and a list of isolated precursor isotopes.
+        @brief Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
+        number of sulfurs in the precursor, fragment's average weight, number of sulfurs in the fragment,
+        and a list of isolated precursor isotopes.
 
-      The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
-      @param average_weight_precursor: average weight of the precursor peptide
-      @param S_precursor: The exact number of Sulfurs in the precursor peptide
-      @param average_weight_fragment: average weight of the fragment
-      @param S_fragment: The exact number of Sulfurs in the fragment
-      @param precursor_isotopes: the precursor isotopes that were isolated
+        The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
+        @param average_weight_precursor: average weight of the precursor peptide
+        @param S_precursor: The exact number of Sulfurs in the precursor peptide
+        @param average_weight_fragment: average weight of the fragment
+        @param S_fragment: The exact number of Sulfurs in the fragment
+        @param precursor_isotopes: the precursor isotopes that were isolated
 
-      @pre S_fragment <= average_weight_fragment / average_weight(sulfur)
-      @pre S_precursor - S_fragment <= (average_weight_precursor - average_weight_fragment) / average_weight(sulfur)
-      @pre average_weight_precursor >= average_weight_fragment
-      @pre average_weight_precursor > 0
-      @pre average_weight_fragment > 0
-      @pre precursor_isotopes.size() > 0
+        @pre S_fragment <= average_weight_fragment / average_weight(sulfur)
+        @pre S_precursor - S_fragment <= (average_weight_precursor - average_weight_fragment) / average_weight(sulfur)
+        @pre average_weight_precursor >= average_weight_fragment
+        @pre average_weight_precursor > 0
+        @pre average_weight_fragment > 0
+        @pre precursor_isotopes.size() > 0
     */
     void estimateForFragmentFromPeptideWeightAndS(double average_weight_precursor, UInt S_precursor, double average_weight_fragment, UInt S_fragment, const std::set<UInt>& precursor_isotopes);
 

--- a/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/IsotopeDistribution.h
@@ -135,6 +135,17 @@ public:
     void estimateFromPeptideWeight(double average_weight);
 
     /**
+      @brief Estimate peptide IsotopeDistribution from average weight and exact number of sulfurs
+
+      @param average_weight: Average weight to estimate an EmpiricalFormula for
+      @param S: The exact number of Sulfurs in this molecule
+
+      @pre S <= average_weight / average_weight(sulfur)
+      @pre average_weight >= 0
+    */
+    void estimateFromPeptideWeightAndS(double average_weight, UInt S);
+
+    /**
         @brief Estimate Nucleotide Isotopedistribution from weight and number of isotopes that should be reported
 
         averagine model from Zubarev, R. A.; Demirev, P. A. in
@@ -156,6 +167,21 @@ public:
     */
     void estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P);
 
+    /**
+      @brief Estimate IsotopeDistribution from weight, exact number of sulfurs, and average remaining composition
+
+      @param average_weight: Average weight to estimate an IsotopeDistribution for
+      @param S: The exact numbers of Sulfurs in this molecule
+      @param C: The approximate relative stoichiometry of Carbons to other elements (excluding Sulfur) in this molecule
+      @param H: The approximate relative stoichiometry of Hydrogens to other elements (excluding Sulfur) in this molecule
+      @param N: The approximate relative stoichiometry of Nitrogens to other elements (excluding Sulfur) in this molecule
+      @param O: The approximate relative stoichiometry of Oxygens to other elements (excluding Sulfur) in this molecule
+      @param P: The approximate relative stoichiometry of Phosphoruses to other elements (excluding Sulfur) in this molecule
+
+      @pre S, C, H, N, O, P >= 0
+      @pre average_weight >= 0
+    */
+    void estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P);
 
     /**
         @brief Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
@@ -172,6 +198,27 @@ public:
         @pre precursor_isotopes.size() > 0
     */
     void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes);
+
+    /**
+      @brief Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
+      number of sulfurs in the precursor, fragment's average weight, number of sulfurs in the fragment,
+      and a list of isolated precursor isotopes.
+
+      The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
+      @param average_weight_precursor: average weight of the precursor peptide
+      @param S_precursor: The exact number of Sulfurs in the precursor peptide
+      @param average_weight_fragment: average weight of the fragment
+      @param S_fragment: The exact number of Sulfurs in the fragment
+      @param precursor_isotopes: the precursor isotopes that were isolated
+
+      @pre S_fragment <= average_weight_fragment / average_weight(sulfur)
+      @pre S_precursor - S_fragment <= (average_weight_precursor - average_weight_fragment) / average_weight(sulfur)
+      @pre average_weight_precursor >= average_weight_fragment
+      @pre average_weight_precursor > 0
+      @pre average_weight_fragment > 0
+      @pre precursor_isotopes.size() > 0
+    */
+    void estimateForFragmentFromPeptideWeightAndS(double average_weight_precursor, UInt S_precursor, double average_weight_fragment, UInt S_fragment, const std::set<UInt>& precursor_isotopes);
 
     /**
         @brief Estimate RNA fragment IsotopeDistribution from the precursor's average weight,

--- a/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
+++ b/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
@@ -101,6 +101,22 @@ namespace OpenMS
     return weight;
   }
 
+  bool EmpiricalFormula::estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P)
+  {
+    const ElementDB* db = ElementDB::getInstance();
+
+    double remaining_weight = average_weight - S * db->getElement("S")->getAverageWeight();
+
+    // The number of sulfurs is set to 0 because we're explicitly specifying their count.
+    // We propagate the return value to let the programmer know if the approximation succeeded
+    // without requesting a negative number of hydrogens.
+    bool ret = estimateFromWeightAndComp(remaining_weight, C, H, N, O, 0.0, P);
+
+    formula_.at(db->getElement("S")) = S;
+
+    return ret;
+  }
+
   bool EmpiricalFormula::estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P)
   {
     const ElementDB* db = ElementDB::getInstance();

--- a/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/IsotopeDistribution.cpp
@@ -168,12 +168,16 @@ namespace OpenMS
     estimateFromWeightAndComp(average_weight, 4.9384, 7.7583, 1.3577, 1.4773, 0.0417, 0);
   }
 
+  void IsotopeDistribution::estimateFromPeptideWeightAndS(double average_weight, UInt S)
+  {
+    // Element counts are from Senko's Averagine model, excluding sulfur.
+    estimateFromWeightAndCompAndS(average_weight, S, 4.9384, 7.7583, 1.3577, 1.4773, 0);
+  }
 
   void IsotopeDistribution::estimateFromRNAWeight(double average_weight)
   {
     estimateFromWeightAndComp(average_weight, 9.75, 12.25, 3.75, 7, 0, 1);
   }
-
 
   void IsotopeDistribution::estimateFromDNAWeight(double average_weight)
   {
@@ -187,10 +191,32 @@ namespace OpenMS
       distribution_ = ef.getIsotopeDistribution(max_isotope_).getContainer();
   }
 
+  void IsotopeDistribution::estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P)
+  {
+    EmpiricalFormula ef;
+    ef.estimateFromWeightAndCompAndS(average_weight, S, C, H, N, O, P);
+    distribution_ = ef.getIsotopeDistribution(max_isotope_).getContainer();
+  }
+
   void IsotopeDistribution::estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes)
   {
     // Element counts are from Senko's Averagine model
     estimateForFragmentFromWeightAndComp(average_weight_precursor, average_weight_fragment, precursor_isotopes, 4.9384, 7.7583, 1.3577, 1.4773, 0.0417, 0);
+  }
+
+  void IsotopeDistribution::estimateForFragmentFromPeptideWeightAndS(double average_weight_precursor, UInt S_precursor, double average_weight_fragment, UInt S_fragment, const std::set<UInt>& precursor_isotopes)
+  {
+    UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end())+1;
+
+    double average_weight_comp_fragment = average_weight_precursor - average_weight_fragment;
+    double S_comp_fragment = S_precursor - S_fragment;
+
+    IsotopeDistribution id_comp_fragment(max_depth), id_fragment(max_depth);
+
+    id_fragment.estimateFromPeptideWeightAndS(average_weight_fragment, S_fragment);
+    id_comp_fragment.estimateFromPeptideWeightAndS(average_weight_comp_fragment, S_comp_fragment);
+
+    calcFragmentIsotopeDist(id_fragment, id_comp_fragment, precursor_isotopes);
   }
 
   void IsotopeDistribution::estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes)

--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -26,6 +26,10 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
         # Fills this EmpiricalFormula with an approximate elemental composition for a given average weight and approximate elemental stoichiometry
         bool estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P) nogil except +
 
+        # Fills this EmpiricalFormula with an approximate elemental composition for a given average weight,
+        # exact number of sulfurs, and approximate elemental stoichiometry
+        bool estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P) nogil except +
+
         # @brief returns the isotope distribution of the formula
         #   *	The details of the calculation of the isotope distribution
         #   * are described in the doc to the IsotopeDistribution class.

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -38,6 +38,9 @@ cdef extern from "<OpenMS/CHEMISTRY/IsotopeDistribution.h>" namespace "OpenMS":
         #   "Determination of Monoisotopic Masses and Ion Populations for Large Biomolecules from Resolved Isotopic Distributions"
         void estimateFromPeptideWeight(double average_weight) nogil except +
 
+        # Estimate peptide IsotopeDistribution from average weight and exact number of sulfurs
+        void estimateFromPeptideWeightAndS(double average_weight, UInt S);
+
         # Estimate Nucleotide Isotopedistribution from weight
         void estimateFromRNAWeight(double average_weight) nogil except +
 
@@ -49,9 +52,17 @@ cdef extern from "<OpenMS/CHEMISTRY/IsotopeDistribution.h>" namespace "OpenMS":
 
         void estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P) nogil except +
 
+        # Estimate IsotopeDistribution from weight, exact number of sulfurs, and average remaining composition
+        void estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P);
+
         # Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
         # fragment's average weight, and a set of isolated precursor isotopes.
         void estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
+
+        # Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
+        # number of sulfurs in the precursor, fragment's average weight, number of sulfurs in the fragment,
+        # and a set of isolated precursor isotopes.
+        void estimateForFragmentFromPeptideWeightAndS(double average_weight_precursor, UInt S_precursor, double average_weight_fragment, UInt S_fragment, libcpp_set[ unsigned int ]& precursor_isotopes);
 
         # Estimate RNA fragment IsotopeDistribution from the precursor's average weight,
         # fragment's average weight, and a set of isolated precursor isotopes.

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -265,6 +265,31 @@ START_SECTION(Int estimateFromWeightAndComp(double average_weight, double C, dou
 
 END_SECTION
 
+START_SECTION(bool estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P))
+    EmpiricalFormula ef("C494H776N136O148S4");
+    EmpiricalFormula ef_approx;
+    EmpiricalFormula ef_approx_S;
+    bool return_flag;
+    // Using averagine stoichiometry, excluding sulfur.
+    return_flag = ef_approx_S.estimateFromWeightAndCompAndS(ef.getAverageWeight(), 4, 4.9384, 7.7583, 1.3577, 1.4773, 0);
+    TEST_EQUAL(4, ef_approx_S.getNumberOf(db->getElement("S")));
+
+    // Formula of methionine.
+    EmpiricalFormula ef2("C5H9N1O1S1");
+    // Using averagine stoichiometry, excluding sulfur.
+    return_flag = ef_approx_S.estimateFromWeightAndCompAndS(ef2.getAverageWeight(), 1, 4.9384, 7.7583, 1.3577, 1.4773, 0);
+    // Shouldn't need negative hydrogens for this approximation.
+    TEST_EQUAL(return_flag, true);
+    ef_approx.estimateFromWeightAndComp(ef2.getAverageWeight(), 4.9384, 7.7583, 1.3577, 1.4773, 0.0417, 0);
+    // The averagine approximation should result in 0 sulfurs.
+    TEST_EQUAL(0, ef_approx.getNumberOf(db->getElement("S")));
+    // But with the sulfur-specified averagine version, we forced it be 1
+    TEST_EQUAL(1, ef_approx_S.getNumberOf(db->getElement("S")));
+    TOLERANCE_ABSOLUTE(1);
+    TEST_REAL_SIMILAR(ef_approx.getAverageWeight(), ef_approx_S.getAverageWeight());
+
+END_SECTION
+
 START_SECTION(double getMonoWeight() const)
   EmpiricalFormula ef("C2");
   const Element* e = db->getElement("C");


### PR DESCRIPTION
Added functionality to estimate isotopic distributions for a peptides and peptide fragments given their mass **and** the exact number of sulfurs in the molecule (instead of just the masses). Let's call them sulfur-specific averagine models. For peptides of similar mass, the number of sulfurs causes a large difference between their isotopic distributions. For example Dirk Valkenborg created separate models to compute isotopic distributions for each case of # sulfurs in the peptide (i.e. 0, 1, 2, etc.) http://www.sciencedirect.com/science/article/pii/S1044030508000597 and http://proteinspector.com/pdf/ghavidel2014a.pdf

The difference is larger for smaller peptides, and since I'm personally working on fragments this was important for me. Typically you wouldn't know how many sulfurs are in the peptide _a priori_ and would have to try a range of values, but I think there are still some uses cases for it. With my current evaluation procedure it appears to make a bigger difference on theoretical data than with experimental data though. On experimental data there appears to be a bias towards larger isotopes that I haven't been able to figure out yet.

**Comparisons on theoretical data:**

I generated the theoretical isotopic distributions of all peptides and all their b/y fragments and checked how well they matched with the averagine method vs sulfur-specific averagine. Note that the x and y-axes aren't synced - they're scaled for each subplot, but have the same binsize when comparing averagine vs sulfur-specific averagine.

![precursor_residuals](https://cloud.githubusercontent.com/assets/8868522/23804201/13841786-0587-11e7-908e-1d52b09099e4.png)

![precursor_chisquared](https://cloud.githubusercontent.com/assets/8868522/23804208/1bf81b24-0587-11e7-9a1c-497c4178a9ee.png)

The headers here (e.g. "0-4") specify which precursor isotopes were theoretically isolated.

![fragment_residuals](https://cloud.githubusercontent.com/assets/8868522/23804210/201425ae-0587-11e7-9f16-98f8f0a6b721.png)

![fragment_chisquared](https://cloud.githubusercontent.com/assets/8868522/23804214/232ec06e-0587-11e7-9c6d-0371a4d4a145.png)

**Comparisons on low-throughput experimental MS2 data:**

The method compared are the averagine approach for fragment isotopes, sulfur-specific averagine, and exact fragment method. These are for two fragments of Neurotensin which had various precursor isotopes isolated (the isolated isotope is labeled on the right). Averagine and the sulfur-specific Averagine (setting the number of sulfurs to 0 because we know the sequence of the fragment and peptide) were the same for Y7++ because at that particular mass the Averagine method would round to 0 sulfurs.
![low_throughput](https://cloud.githubusercontent.com/assets/8868522/23716482/70739a5a-03fe-11e7-8d03-373e5546a506.png)

**Comparisons on high-throughput experimental MS2 data:**

This was a HeLa whole cell lysate performed on an orbitrap lumos with an isolation width of 1.6. I performed a database search and then for each peptide at a 1%FDR I tried to match theoretical fragments to the observed spectra and compared the observed isotopic distribution to the computed ones. Here I only kept fragments where all the expected isotopes were observed. I split the plots based on how many isotopes were observed.


![chi-squared_complete_2](https://cloud.githubusercontent.com/assets/8868522/23720876/0fddbfee-040e-11e7-822c-a9f1e7625721.png)

| method | median | min | max | count
| ------------- | ------------- | ------------- | ------------- | ------------- |
| ApproxFragment  | 0.004739345  | 1.07001e-11 | 10.2918 | 128484
| ApproxFragmentSulf  | 0.004720605  | 4.21937e-13 | 10.2569 | 128484
| ExactFragment | 0.00439491 | 6.82101e-14 | 11.4251 | 128484

![chi-squared_complete_3](https://cloud.githubusercontent.com/assets/8868522/23720882/1518d8ea-040e-11e7-9340-f02b8dc00336.png)

| method | median | min | max | count
| ------------- | ------------- | ------------- | ------------- | ------------- |
| ApproxFragment  | 0.0226028  | 9.59216e-07 | 29.912 | 23592
| ApproxFragmentSulf  | 0.0198111  | 7.85389e-09 | 29.9408 | 23592
| ExactFragment | 0.0206527 | 1.02522e-06 | 28.5052 | 23592

![chi-squared_complete_4](https://cloud.githubusercontent.com/assets/8868522/23720895/1a145ae0-040e-11e7-9f64-1b4f7c8611a0.png)

| method | median | min | max | count
| ------------- | ------------- | ------------- | ------------- | ------------- |
| ApproxFragment  | 0.0401082  | 0.000226775 | 34.5792 | 1148
| ApproxFragmentSulf  | 0.0380023  | 0.000196022 | 33.6667 | 1148
| ExactFragment | 0.0391561 | 1.37692e-05 | 34.8144 | 1148

I appreciate any thoughts and input. Thanks!
