### PR TITLE
[OBO] update to psi-ms 4.0.10

### DIFF
--- a/share/OpenMS/CV/psi-ms.obo
+++ b/share/OpenMS/CV/psi-ms.obo
@@ -7112,7 +7112,7 @@ name: retention time(s)
 def: "OBSOLETE Retention time of the spectrum from the source file." [PSI:PI]
 comment: This term was made obsolete because scan start time (MS:1000016) should be used instead.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
@@ -7581,7 +7581,7 @@ name: p-value
 def: "OBSOLETE Quality estimation by p-value." [PSI:PI]
 comment: This term was made obsolete because now is split into peptide and protein terms.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001092 ! peptide identification confidence metric
+is_a: MS:1001092 ! peptide sequence-level identification statistic
 is_a: MS:1001198 ! protein identification confidence metric
 is_obsolete: true
 
@@ -7630,7 +7630,7 @@ is_a: MS:1001450 ! decoy DB details
 id: MS:1001198
 name: protein identification confidence metric
 def: "Identification confidence metric for a protein." [PSI:PI]
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001116 ! single protein identification statistic
 
 [Term]
 id: MS:1001199
@@ -12074,7 +12074,7 @@ name: FDRScore
 def: "OBSOLETE A smoothing of the distribution of q-values calculated for PSMs from individual search engines, such that ordering of result quality is maintained and all FDRScore values are guaranteed to have a value > 0." [PMID:19253293]
 comment: This term was made obsolete because it was split into the more specific terms for PSM-level FDRScore (1002355), distinct peptide-level FDRScore (MS:1002360), protein-level FDRScore (MS:1002365) and protein group-level FDRScore (MS:1002374).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 is_obsolete: true
 
@@ -14703,7 +14703,7 @@ id: MS:1002268
 name: Byonic:Best LogProb
 def: "Best (most negative) log p-value of an individual PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001116 ! single protein identification statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002109 ! lower score better
 
@@ -15665,7 +15665,7 @@ id: MS:1002408
 name: number of distinct protein sequences
 def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:1002405 ! protein cluster details
+is_a: MS:1002405 ! protein group-level result list attribute
 
 [Term]
 id: MS:1002409
@@ -16275,7 +16275,7 @@ id: MS:1002499
 name: peptide level score
 def: "OBSOLETE Peptide level score." [PSI:PI]
 comment: This term was obsoleted because it was never intended to go in the CV.
-is_a: MS:1002358 ! search engine specific score for distinct peptides
+is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 is_obsolete: true
 
 [Term]
@@ -17485,7 +17485,7 @@ id: MS:1002681
 name: OpenXQuest:combined score
 def: "OpenXQuest's combined score for a cross-link spectrum match." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 
@@ -17494,7 +17494,7 @@ id: MS:1002682
 name: OpenXQuest:xcorr xlink
 def: "OpenXQuest's cross-correlation of cross-linked ions subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 
@@ -17503,7 +17503,7 @@ id: MS:1002683
 name: OpenXQuest:xcorr common
 def: "OpenXQuest's cross-correlation of unlinked ions subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 
@@ -17512,7 +17512,7 @@ id: MS:1002684
 name: OpenXQuest:match-odds
 def: "OpenXQuest's match-odds subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002306 ! value greater than zero
@@ -17522,7 +17522,7 @@ id: MS:1002685
 name: OpenXQuest:intsum
 def: "OpenXQuest's sum of matched peak intensity subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002306 ! value greater than zero
@@ -17532,7 +17532,7 @@ id: MS:1002686
 name: OpenXQuest:wTIC
 def: "OpenXQuest's weighted percent of total ion current subscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
@@ -17876,7 +17876,7 @@ is_a: MS:1001347 ! database file formats
 id: MS:1002752
 name: database type spectral library
 def: "Database containing spectra." [PSI:PI]
-is_a: MS:1001073 ! database type
+is_a: MS:1001073 ! database type amino acid
 
 [Term]
 id: MS:1002753

--- a/share/OpenMS/CV/psi-ms.obo
+++ b/share/OpenMS/CV/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.0.10_rc1
-date: 29:03:2017 12:18
+data-version: 4.0.10
+date: 31:03:2017 10:14
 saved-by: Gerhard Mayer
 auto-generated-by: OBO-Edit 2.3.1
 import: http://ontologies.berkeleybop.org/pato.obo

--- a/share/OpenMS/CV/psi-ms.obo
+++ b/share/OpenMS/CV/psi-ms.obo
@@ -1,15 +1,13 @@
 format-version: 1.2
-data-version: 3.70.1
-date: 03:11:2014 14:22
+data-version: 4.0.9
+date: 28:03:2017 09:20
 saved-by: Gerhard Mayer
-auto-generated-by: OBO-Edit 2.3
-import: http://pato.googlecode.com/svn/trunk/quality.obo
-import: http://unit-ontology.googlecode.com/svn/trunk/unit.obo
+auto-generated-by: OBO-Edit 2.3.1
+import: http://ontologies.berkeleybop.org/pato.obo
+import: http://ontologies.berkeleybop.org/uo.obo
 default-namespace: MS
 namespace-id-rule: * MS:$sequence(7,0,9999999)$
 remark: namespace: MS
-remark: version: 3.70.1
-remark: release date: 2014-11-03
 remark: coverage: Mass spectrometer output files and spectra interpretation
 remark: creator: Matt Chambers <matt.chambers <-at-> vanderbilt.edu>
 remark: creator: Andreas Bertsch <bertsch <-at-> informatik.uni-tuebingen.de>
@@ -20,10 +18,11 @@ remark: creator: Pierre-Alain Binz <pierre-alain.binz <-at-> chuv.ch>
 remark: creator: Gerhard Mayer <mayerg97 <-at-> rub.de>
 remark: publisher: HUPO Proteomics Standards Initiative Mass Spectrometry Standards Working Group and HUPO Proteomics Standards Initiative Proteomics Informatics Working Group
 remark: When appropriate the definition and synonyms of a term are reported exactly as in the chapter 12 of IUPAC orange book. See http://www.iupac.org/projects/2003/2003-056-2-500.html and http://mass-spec.lsu.edu/msterms/index.php/Main_Page
+remark: For any queries contact psidev-ms-vocab@lists.sourceforge.net
+remark: URL: https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo
 remark: This work is licensed under the Creative Commons Attribution 3.0 Unported License.
 remark: To view a copy of this license, visit http://creativecommons.org/licenses/by/3.0/ or send a letter to Creative Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.
-ontology: pato
-ontology: uo
+ontology: ms
 
 [Typedef]
 id: has_regexp
@@ -164,8 +163,7 @@ name: scan start time
 def: "The time that an analyzer started a scan, relative to the start of the MS run." [PSI:MS]
 xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1000503 ! scan attribute
-is_a: MS:1001105 ! peptide result details
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1002345 ! PSM-level attribute
 relationship: has_units UO:0000010 ! second
 relationship: has_units UO:0000031 ! minute
 
@@ -370,7 +368,6 @@ is_a: UO:0000000 ! unit
 id: MS:1000044
 name: dissociation method
 def: "Fragmentation method used for dissociation or fragmentation." [PSI:MS]
-#xref: value-type:xsd\:string "The allowed value-type for this CV term."
 synonym: "Activation Method" RELATED []
 relationship: part_of MS:1000456 ! precursor activation
 
@@ -931,15 +928,15 @@ is_a: MS:1000525 ! spectrum representation
 id: MS:1000129
 name: negative scan
 def: "Polarity of the scan is negative." [PSI:MS]
-is_a: PATO:0002186 ! polarity
 is_a: MS:1000465 ! scan polarity
+is_a: MS:1000808 ! chromatogram attribute
 
 [Term]
 id: MS:1000130
 name: positive scan
 def: "Polarity of the scan is positive." [PSI:MS]
-is_a: PATO:0002186 ! polarity
 is_a: MS:1000465 ! scan polarity
+is_a: MS:1000808 ! chromatogram attribute
 
 [Term]
 id: MS:1000131
@@ -1069,7 +1066,7 @@ is_a: MS:1001534 ! Bruker Daltonics flex series
 [Term]
 id: MS:1000150
 name: Auto Spec Ultima NT
-def: "Waters AutoSpec Ultima NT MS." [PSI:MS]
+def: "Waters magnetic sector based AutoSpec Ultima NT MS." [PSI:MS]
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -1303,7 +1300,7 @@ is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000189
-name: Q-Tof ultima
+name: Q-Tof Ultima
 def: "Waters oa-ToF based Q-Tof Ultima." [PSI:MS]
 is_a: MS:1000126 ! Waters instrument model
 
@@ -1316,13 +1313,13 @@ is_a: MS:1000121 ! SCIEX instrument model
 [Term]
 id: MS:1000191
 name: quattro micro
-def: "Waters oa-ToF based micro." [PSI:MS]
+def: "Waters (triple) quadrupole based micro." [PSI:MS]
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1000192
-name: Quattro UItima
-def: "Waters oa-ToF based Ultima." [PSI:MS]
+name: Quattro Ultima
+def: "Waters (triple) quadrupole based Ultima." [PSI:MS]
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -1453,7 +1450,7 @@ is_a: MS:1000231 ! peak
 [Term]
 id: MS:1000211
 name: OBSOLETE charge number
-def: "OBSOLETE. The total charge on an ion divided by the electron charge e. OBSOLETED 2009-10-27 since this was viewed as a duplication of 00041 charge state." [PSI:MS]
+def: "OBSOLETE The total charge on an ion divided by the electron charge e. OBSOLETED 2009-10-27 since this was viewed as a duplication of 00041 charge state." [PSI:MS]
 synonym: "z" EXACT []
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_obsolete: true
@@ -1873,7 +1870,7 @@ is_obsolete: true
 [Term]
 id: MS:1000266
 name: Laser Desorption
-alt_id: MS:1000394
+alt_id: MS:1000393
 def: "OBSOLETE The formation of ions through the interaction of a laser with a material or with gas-phase ions or molecules." [PSI:MS]
 comment: This term was made obsolete because it was replaced by laser desorption ionization (MS:1000393).
 synonym: "Laser Ionization MERGE" EXACT []
@@ -2373,7 +2370,8 @@ is_obsolete: true
 [Term]
 id: MS:1000336
 name: neutral loss
-def: "The loss of an uncharged species during a rearrangement process." [PSI:MS]
+def: "The loss of an uncharged species during a rearrangement process. The value slot holds the molecular formula in Hill notation of the neutral loss molecule, see PMID: 21182243. This term must be used in conjunction with a child of the term MS:1002307 (fragmentation ion type)." [PSI:MS]
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
 
 [Term]
@@ -3837,8 +3835,8 @@ is_obsolete: true
 [Term]
 id: MS:1000551
 name: Analyst
-def: "AB SCIEX or Applied Biosystems|MDS SCIEX software for data acquisition." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+def: "SCIEX or Applied Biosystems|MDS SCIEX software for data acquisition." [PSI:MS]
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001455 ! acquisition software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
@@ -4514,31 +4512,31 @@ is_a: MS:1001457 ! data processing software
 [Term]
 id: MS:1000651
 name: 3200 QTRAP
-def: "AB SCIEX or Applied Biosystems|MDS SCIEX QTRAP 3200." [PSI:MS]
+def: "SCIEX or Applied Biosystems|MDS SCIEX QTRAP 3200." [PSI:MS]
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000652
 name: 4800 Plus MALDI TOF/TOF
-def: "AB SCIEX or Applied Biosystems|MDS SCIEX 4800 Plus MALDI TOF-TOF Analyzer." [PSI:MS]
+def: "SCIEX or Applied Biosystems|MDS SCIEX 4800 Plus MALDI TOF-TOF Analyzer." [PSI:MS]
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000653
 name: API 3200
-def: "AB SCIEX or Applied Biosystems|MDS SCIEX API 3200 MS." [PSI:MS]
+def: "SCIEX or Applied Biosystems|MDS SCIEX API 3200 MS." [PSI:MS]
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000654
 name: API 5000
-def: "AB SCIEX or Applied Biosystems|MDS SCIEX API 5000 MS." [PSI:MS]
+def: "SCIEX or Applied Biosystems|MDS SCIEX API 5000 MS." [PSI:MS]
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1000655
 name: QSTAR Elite
-def: "AB SCIEX or Applied Biosystems|MDS SCIEX QSTAR Elite." [PSI:MS]
+def: "SCIEX or Applied Biosystems|MDS SCIEX QSTAR Elite." [PSI:MS]
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -4562,8 +4560,8 @@ is_a: MS:1000495 ! Applied Biosystems instrument model
 [Term]
 id: MS:1000659
 name: 4000 Series Explorer Software
-def: "AB SCIEX or Applied Biosystems software for data acquisition and analysis." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+def: "SCIEX or Applied Biosystems software for data acquisition and analysis." [PSI:MS]
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001455 ! acquisition software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
@@ -4571,8 +4569,8 @@ is_a: MS:1001457 ! data processing software
 [Term]
 id: MS:1000661
 name: GPS Explorer
-def: "AB SCIEX or Applied Biosystems software for data acquisition and analysis." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+def: "SCIEX or Applied Biosystems software for data acquisition and analysis." [PSI:MS]
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001455 ! acquisition software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
@@ -4580,16 +4578,16 @@ is_a: MS:1001457 ! data processing software
 [Term]
 id: MS:1000662
 name: LightSight Software
-def: "AB SCIEX or Applied Biosystems|MDS SCIEX software metabolite identification." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+def: "SCIEX or Applied Biosystems|MDS SCIEX software metabolite identification." [PSI:MS]
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
 [Term]
 id: MS:1000663
 name: ProteinPilot Software
-def: "AB SCIEX or Applied Biosystems|MDS SCIEX software for protein ID and quant." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+def: "SCIEX or Applied Biosystems|MDS SCIEX software for protein ID and quant." [PSI:MS]
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4597,7 +4595,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000664
 name: TissueView Software
 def: "Applied Biosystems|MDS SCIEX software for tissue imaging." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4605,7 +4603,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000665
 name: MarkerView Software
 def: "Applied Biosystems|MDS SCIEX software for metabolomics and biomarker profiling." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4613,7 +4611,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000666
 name: MRMPilot Software
 def: "Applied Biosystems|MDS SCIEX software for MRM assay development." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4621,7 +4619,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000667
 name: BioAnalyst
 def: "Applied Biosystems|MDS SCIEX software for bio-related data exploration." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4629,7 +4627,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000668
 name: Pro ID
 def: "Applied Biosystems|MDS SCIEX software for protein identification." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4637,7 +4635,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000669
 name: Pro ICAT
 def: "Applied Biosystems|MDS SCIEX software for protein ID and quant by ICAT." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4645,7 +4643,7 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000670
 name: Pro Quant
 def: "Applied Biosystems|MDS SCIEX software for protein ID and quant by iTRAQ." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4653,27 +4651,27 @@ is_a: MS:1001457 ! data processing software
 id: MS:1000671
 name: Pro BLAST
 def: "Applied Biosystems|MDS SCIEX software for MS-BLAST identification." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
 [Term]
 id: MS:1000672
 name: Cliquid
-def: "AB SCIEX Cliquid software for data analysis and quantitation." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+def: "SCIEX Cliquid software for data analysis and quantitation." [PSI:MS]
+is_a: MS:1000690 ! SCIEX software
 
 [Term]
 id: MS:1000673
 name: MIDAS Workflow Designer
 def: "Applied Biosystems|MDS SCIEX software for MRM assay development." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 
 [Term]
 id: MS:1000674
 name: MultiQuant
 def: "Applied Biosystems|MDS SCIEX software for MRM-based quantitation." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
 
@@ -4790,8 +4788,8 @@ is_a: MS:1000531 ! software
 
 [Term]
 id: MS:1000690
-name: AB SCIEX software
-def: "AB SCIEX or Applied Biosystems software for data acquisition and analysis." [PSI:MS]
+name: SCIEX software
+def: "SCIEX or Applied Biosystems software for data acquisition and analysis." [PSI:MS]
 is_a: MS:1000531 ! software
 
 [Term]
@@ -5250,7 +5248,7 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1000760
 name: MapAligner
 def: "OBSOLETE Corrects retention time distortions between maps." [PSI:MS]
-comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP MapAligner' (MS:1002147) branch.
+comment: This term was made obsolete, because it is replaced by the terms under the 'TOPP map aligner' (MS:1002147) branch.
 is_a: MS:1000752 ! TOPP software
 is_obsolete: true
 
@@ -5835,7 +5833,7 @@ relationship: part_of MS:1000840 ! laser
 [Term]
 id: MS:1000842
 name: laser type
-def: "Type of laser used used for desorption purpose." [PSI:MS]
+def: "Type of laser used for desorption purpose." [PSI:MS]
 relationship: part_of MS:1000840 ! laser
 
 [Term]
@@ -6030,7 +6028,7 @@ relationship: has_units UO:0000110 ! pascal
 [Term]
 id: MS:1000870
 name: 4000 QTRAP
-def: "OBSOLETE AB SCIEX or Applied Biosystems|MDS SCIEX QTRAP 4000." [PSI:MS]
+def: "OBSOLETE SCIEX or Applied Biosystems|MDS SCIEX QTRAP 4000." [PSI:MS]
 comment: This term was obsoleted because was redundant to MS:1000139.
 is_a: MS:1000121 ! SCIEX instrument model
 is_obsolete: true
@@ -6262,14 +6260,13 @@ id: MS:1000903
 name: product ion series ordinal
 def: "The ordinal of the fragment within a specified ion series. (e.g. 8 for a y8 ion)." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 
 [Term]
 id: MS:1000904
 name: product ion m/z delta
 def: "The difference in m/z of the predicted m/z based on the assigned product ion minus the actual observed peak m/z." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 relationship: has_units MS:1000040 ! m/z
 
 [Term]
@@ -6419,7 +6416,7 @@ id: MS:1000926
 name: product interpretation rank
 def: "The integer rank given an interpretation of an observed product ion. For example, if y8 is selected as the most likely interpretation of a peak, then it is assigned a rank of 1." [PSI:MS]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 
 [Term]
 id: MS:1000927
@@ -6456,7 +6453,7 @@ is_a: MS:1000121 ! SCIEX instrument model
 [Term]
 id: MS:1000932
 name: TripleTOF 5600
-def: "AB SCIEX TripleTOF 5600, a quadrupole - quadrupole - time-of-flight mass spectrometer." [PSI:MS]
+def: "SCIEX TripleTOF 5600, a quadrupole - quadrupole - time-of-flight mass spectrometer." [PSI:MS]
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -6914,9 +6911,9 @@ is_a: MS:1001013 ! database name
 
 [Term]
 id: MS:1001085
-name: protein result details
+name: protein-level identification attribute
 def: "Protein level information." [PSI:PI]
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1002694 ! single identification result attribute
 
 [Term]
 id: MS:1001086
@@ -6936,7 +6933,7 @@ id: MS:1001088
 name: protein description
 def: "The protein description line from the sequence entry in the source database FASTA file." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 
 [Term]
@@ -6944,7 +6941,7 @@ id: MS:1001089
 name: molecule taxonomy
 def: "The taxonomy of the resultant molecule from the search." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001085 ! protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001342 ! database sequence details
 is_a: MS:1001512 ! Sequence database filters
 
@@ -6968,16 +6965,16 @@ is_obsolete: true
 
 [Term]
 id: MS:1001092
-name: peptide identification confidence metric
+name: peptide sequence-level identification statistic
 def: "Identification confidence metric for a peptide." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001093
 name: sequence coverage
 def: "The percent coverage for the protein based upon the matched peptide sequences (can be calculated)." [PSI:PI]
 xref: value-type:xsd\:decimal "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001094
@@ -7004,34 +7001,34 @@ id: MS:1001097
 name: distinct peptide sequences
 def: "This counts distinct sequences hitting the protein without regard to a minimal confidence threshold." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001098
 name: confident distinct peptide sequences
 def: "This counts the number of distinct peptide sequences. Multiple charge states and multiple modification states do NOT count as multiple sequences. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001099
 name: confident peptide qualification
 def: "The point of this entry is to define what is meant by confident for the term Confident distinct peptide sequence and/or Confident peptides. Example 1 - metric=Paragon:Confidence value=95 sense=greater than Example 2 - metric=Mascot:Eval value=0.05 sense=less than." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001100
 name: confident peptide sequence number
 def: "This counts the number of peptide sequences without regard to whether they are distinct. Multiple charges states and multiple modification states DO count as multiple peptides. The definition of 'confident' must be qualified elsewhere." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001101
 name: protein group or subset relationship
 def: "Protein group or subset relationships." [PSI:PI]
-is_a: MS:1001085 ! protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001102
@@ -7053,9 +7050,9 @@ is_a: MS:1002126 ! database UniProtKB
 
 [Term]
 id: MS:1001105
-name: peptide result details
+name: peptide sequence-level identification attribute
 def: "Peptide level information." [PSI:PI]
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1002694 ! single identification result attribute
 
 [Term]
 id: MS:1001106
@@ -7100,14 +7097,14 @@ id: MS:1001112
 name: n-terminal flanking residue
 def: "The residue preceding the first amino acid in the peptide sequence as it occurs in the protein. Use 'N-term' to denote if the peptide starts at the N terminus of the protein." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001113
 name: c-terminal flanking residue
 def: "The residue following the last amino acid in the peptide sequence as it occurs in the protein. Use 'C-term' to denote if the peptide ends at the C terminus of the protein." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001114
@@ -7130,16 +7127,16 @@ is_obsolete: true
 
 [Term]
 id: MS:1001116
-name: single protein result details
+name: single protein identification statistic
 def: "Results specific for one protein as part of a protein ambiguity group (a result not valid for all the other proteins in the protein ambiguity group)." [PSI:PI]
-is_a: MS:1001085 ! protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001117
 name: theoretical mass
 def: "The theoretical mass of the molecule (e.g. the peptide sequence and its modifications)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 relationship: has_units UO:0000221 ! dalton
 
 [Term]
@@ -7165,35 +7162,35 @@ id: MS:1001121
 name: number of matched peaks
 def: "The number of peaks that were matched as qualified by the ion series considered field. If a peak matches multiple ions then only 1 would be added the count." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001122
 name: ions series considered
 def: "The ion series that were used during the calculation of the count (e.g. a, b, c, d, v, w, x, y, z, a-H2O, a-NH3, b-H2O, b-NH3, y-H2O, y-NH3, b-H20, b+, z-, z+1, z+2, b-H3PO4, y-H3PO4, immonium, internal ya, internal yb)." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001123
 name: number of peaks used
 def: "The number of peaks from the original peak list that are used to calculate the scores for a particular search engine. All ions that have the opportunity to match or be counted even if they don't." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001124
 name: number of peaks submitted
 def: "The number of peaks from the original peaks listed that were submitted to the search engine." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001125
 name: manual validation
 def: "Result of quality estimation: decision of a manual validation." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001092 ! peptide identification confidence metric
-is_a: MS:1001198 ! protein identification confidence metric
+is_a: MS:1001092 ! peptide sequence-level identification statistic
+is_a: MS:1001116 ! single protein identification statistic
 
 [Term]
 id: MS:1001126
@@ -7205,7 +7202,7 @@ is_a: MS:1001110 ! SEQUEST:modeCV
 id: MS:1001127
 name: peptide sharing details
 def: "Accessions Containing Sequence - Accessions for each protein containing this peptide." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001128
@@ -7225,7 +7222,7 @@ name: peptide raw area
 def: "OBSOLETE Peptide raw area." [PSI:PI]
 comment: This term was made obsolete because it is replaced by 'MS1 feature area' (MS:1001844).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 is_obsolete: true
 
 [Term]
@@ -7233,35 +7230,35 @@ id: MS:1001131
 name: error on peptide area
 def: "Error on peptide area." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001132
 name: peptide ratio
 def: "Peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001133
 name: error on peptide ratio
 def: "Error on peptide ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001134
 name: protein ratio
 def: "Protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001135
 name: error on protein ratio
 def: "Error on protein ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001136
@@ -7269,7 +7266,7 @@ name: p-value (protein diff from 1 randomly)
 def: "OBSOLETE P-value (protein diff from 1 randomly)." [PSI:PI]
 comment: This term was made obsolete because it is replaced by 't-test p-value' (MS:1001855).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 is_obsolete: true
 
 [Term]
@@ -7316,9 +7313,9 @@ is_a: MS:1001013 ! database name
 
 [Term]
 id: MS:1001143
-name: search engine specific score for PSMs
+name: PSM-level search engine specific statistic
 def: "Search engine specific peptide spectrum match scores." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1002347 ! PSM-level identification statistic
 
 [Term]
 id: MS:1001144
@@ -7340,7 +7337,7 @@ is_a: MS:1001066 ! ions series considered in search
 [Term]
 id: MS:1001147
 name: protein ambiguity group result details
-is_a: MS:1001085 ! protein result details
+is_a: MS:1001085 ! protein-level identification attribute
 is_a: MS:1001153 ! search engine specific score
 
 [Term]
@@ -7377,23 +7374,21 @@ is_a: MS:1001066 ! ions series considered in search
 id: MS:1001153
 name: search engine specific score
 def: "Search engine specific scores." [PSI:PI]
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1002694 ! single identification result attribute
 
 [Term]
 id: MS:1001154
 name: SEQUEST:probability
 def: "The SEQUEST result 'Probability'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001155
 name: SEQUEST:xcorr
 def: "The SEQUEST result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -7401,23 +7396,20 @@ id: MS:1001156
 name: SEQUEST:deltacn
 def: "The SEQUEST result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001157
 name: SEQUEST:sp
 def: "The SEQUEST result 'Sp' (protein)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001158
 name: SEQUEST:Uniq
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001159
@@ -7431,24 +7423,21 @@ id: MS:1001160
 name: SEQUEST:sf
 def: "The SEQUEST result 'Sf'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001161
 name: SEQUEST:matched ions
 def: "The SEQUEST result 'Matched Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001162
 name: SEQUEST:total ions
 def: "The SEQUEST result 'Total Ions'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001163
@@ -7462,86 +7451,79 @@ id: MS:1001164
 name: Paragon:unused protscore
 def: "The Paragon result 'Unused ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001147 ! protein ambiguity group result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
+is_a: MS:1002368 ! search engine specific score for protein groups
 
 [Term]
 id: MS:1001165
 name: Paragon:total protscore
 def: "The Paragon result 'Total ProtScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001147 ! protein ambiguity group result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
+is_a: MS:1002368 ! search engine specific score for protein groups
 
 [Term]
 id: MS:1001166
 name: Paragon:score
 def: "The Paragon result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001167
 name: Paragon:confidence
 def: "The Paragon result 'Confidence'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001168
 name: Paragon:expression error factor
 def: "The Paragon result 'Expression Error Factor'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001169
 name: Paragon:expression change p-value
 def: "The Paragon result 'Expression change P-value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001871 ! protein-level p-value
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001170
 name: Paragon:contrib
 def: "The Paragon result 'Contrib'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001171
 name: Mascot:score
 def: "The Mascot result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001172
 name: Mascot:expectation value
 def: "The Mascot result 'expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001173
 name: Mascot:matched ions
 def: "The Mascot result 'Matched ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001174
 name: Mascot:total ions
 def: "The Mascot result 'Total ions'." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001175
@@ -7552,7 +7534,7 @@ is_a: MS:1001127 ! peptide sharing details
 [Term]
 id: MS:1001176
 name: (?<=[KR])(?\!P)
-def:"Regular expression for Trypsin." [PSI:PI]
+def: "Regular expression for Trypsin." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
@@ -7608,16 +7590,16 @@ id: MS:1001192
 name: Expect value
 def: "Result of quality estimation: Expect value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001092 ! peptide identification confidence metric
-is_a: MS:1001198 ! protein identification confidence metric
+is_a: MS:1001092 ! peptide sequence-level identification statistic
+is_a: MS:1001116 ! single protein identification statistic
 
 [Term]
 id: MS:1001193
 name: confidence score
 def: "Result of quality estimation: confidence score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001092 ! peptide identification confidence metric
-is_a: MS:1001198 ! protein identification confidence metric
+is_a: MS:1001092 ! peptide sequence-level identification statistic
+is_a: MS:1001116 ! single protein identification statistic
 
 [Term]
 id: MS:1001194
@@ -7742,7 +7724,7 @@ id: MS:1001214
 name: protein-level global FDR
 def: "Estimation of the global false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1002705 ! protein-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -7750,32 +7732,28 @@ id: MS:1001215
 name: SEQUEST:PeptideSp
 def: "The SEQUEST result 'Sp' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001217
 name: SEQUEST:PeptideRankSp
 def: "The SEQUEST result 'Sp' of 'Rank/Sp' in out file (peptide). Also called 'rsp'." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001218
 name: SEQUEST:PeptideNumber
 def: "The SEQUEST result '#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001219
 name: SEQUEST:PeptideIdnumber
 def: "The SEQUEST result 'Id#' in out file (peptide)." [PSI:PI]
 xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001220
@@ -7785,9 +7763,9 @@ is_a: MS:1002307 ! fragmentation ion type
 
 [Term]
 id: MS:1001221
-name: fragmentation information
+name: product ion attribute
 def: "Fragmentation information like ion types." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1002694 ! single identification result attribute
 
 [Term]
 id: MS:1001222
@@ -7812,16 +7790,15 @@ id: MS:1001225
 name: product ion m/z
 def: "The m/z of the product ion." [PSI:PI]
 synonym: "fragment ion m/z" EXACT []
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 relationship: has_units MS:1000040 ! m/z
 
 [Term]
 id: MS:1001226
 name: product ion intensity
 def: "The intensity of a single product ion." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 synonym: "fragment ion intensity" EXACT []
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 relationship: has_units MS:1000131 ! number of detector counts
 relationship: has_units MS:1000132 ! percent of base peak
 relationship: has_units MS:1000814 ! counts per second
@@ -7831,7 +7808,7 @@ relationship: has_units MS:1000905 ! percent of base peak times 100
 id: MS:1001227
 name: product ion m/z error
 def: "The product ion m/z error." [PSI:PI]
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 relationship: has_units MS:1000040 ! m/z
 relationship: has_units UO:0000166 ! parts per notation unit
 
@@ -7911,13 +7888,13 @@ is_a: MS:1002307 ! fragmentation ion type
 id: MS:1001240
 name: non-identified ion
 def: "Non-identified ion." [PSI:PI]
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 
 [Term]
 id: MS:1001241
 name: co-eluting ion
 def: "Co-eluting ion." [PSI:PI]
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 
 [Term]
 id: MS:1001242
@@ -7939,8 +7916,8 @@ is_a: MS:1000560 ! mass spectrometer file format
 
 [Term]
 id: MS:1001246
-name: Sciex API III format
-def: "PE Sciex peak list file format." [http://www.matrixscience.com/help/data_file_help.html#API]
+name: SCIEX API III format
+def: "PE SCIEX peak list file format." [http://www.matrixscience.com/help/data_file_help.html#API]
 is_a: MS:1000560 ! mass spectrometer file format
 
 [Term]
@@ -7960,10 +7937,8 @@ id: MS:1001250
 name: local FDR
 def: "Result of quality estimation: the local FDR at the current position of a sorted list." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001092 ! peptide identification confidence metric
-is_a: MS:1001198 ! protein identification confidence metric
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000187 ! percent
+is_a: MS:1001092 ! peptide sequence-level identification statistic
+is_a: MS:1001116 ! single protein identification statistic
 
 [Term]
 id: MS:1001251
@@ -8086,19 +8061,19 @@ is_a: MS:1001266 ! role type
 [Term]
 id: MS:1001272
 name: (?<=R)(?\!P)
-def:"Regular expression for Arg-C." [PSI:PI]
+def: "Regular expression for Arg-C." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001273
 name: (?=[BD])
-def:"Regular expression for Asp-N." [PSI:PI]
+def: "Regular expression for Asp-N." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001274
 name: (?=[DE])
-def:"Regular expression for Asp-N-ambic." [PSI:PI]
+def: "Regular expression for Asp-N-ambic." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
@@ -8238,8 +8213,8 @@ is_obsolete: true
 id: MS:1001301
 name: protein rank
 def: "The rank of the protein in a list sorted by the search engine." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001147 ! protein ambiguity group result details
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1001085 ! protein-level identification attribute
 
 [Term]
 id: MS:1001302
@@ -8421,94 +8396,87 @@ id: MS:1001328
 name: OMSSA:evalue
 def: "OMSSA E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001872 ! distinct peptide-level e-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001329
 name: OMSSA:pvalue
 def: "OMSSA p-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001870 ! distinct peptide-level p-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001330
 name: X\!Tandem:expect
 def: "The X!Tandem expectation value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001872 ! distinct peptide-level e-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001331
 name: X\!Tandem:hyperscore
 def: "The X!Tandem hyperscore." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001332
 name: (?<=[FYWL])(?\!P)
-def:"Regular expression for Chymotrypsin." [PSI:PI]
+def: "Regular expression for Chymotrypsin." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001333
 name: (?<=M)
-def:"Regular expression for CNBr." [PSI:PI]
+def: "Regular expression for CNBr." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001334
 name: ((?<=D))|((?=D))
-def:"Regular expression for formic acid." [PSI:PI]
+def: "Regular expression for formic acid." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001335
 name: (?<=K)(?\!P)
-def:"Regular expression for Lys-C." [PSI:PI]
+def: "Regular expression for Lys-C." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001336
 name: (?<=K)
-def:"Regular expression for Lys-C/P." [PSI:PI]
+def: "Regular expression for Lys-C/P." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001337
 name: (?<=[FL])
-def:"Regular expression for PepsinA." [PSI:PI]
+def: "Regular expression for PepsinA." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001338
 name: (?<=[FYWLKR])(?\!P)
-def:"Regular expression for TrypChymo." [PSI:PI]
+def: "Regular expression for TrypChymo." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001339
 name: (?<=[KR])
-def:"Regular expression for Trypsin/P." [PSI:PI]
+def: "Regular expression for Trypsin/P." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001340
 name: (?<=[BDEZ])(?\!P)
-def:"Regular expression for V8-DE." [PSI:PI]
+def: "Regular expression for V8-DE." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001341
 name: (?<=[EZ])(?\!P)
-def:"Regular expression for V8-E." [PSI:PI]
+def: "Regular expression for V8-E." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
@@ -8593,7 +8561,7 @@ relationship: part_of MS:1001000 ! spectrum interpretation
 id: MS:1001355
 name: peptide descriptions
 def: "Descriptions of peptides." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1001356
@@ -8640,8 +8608,7 @@ id: MS:1001362
 name: number of unmatched peaks
 def: "The number of unmatched peaks." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1002345 ! PSM-level attribute
 
 [Term]
 id: MS:1001363
@@ -8651,11 +8618,10 @@ is_a: MS:1001127 ! peptide sharing details
 
 [Term]
 id: MS:1001364
-name: distinct peptide-level global FDR
+name: peptide sequence-level global FDR
 def: "Estimation of the global false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
-is_a: MS:1002484 ! peptide-level statistical threshold
+is_a: MS:1002703 ! peptide sequence-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -8693,41 +8659,33 @@ id: MS:1001370
 name: Mascot:homology threshold
 def: "The Mascot result 'homology threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001371
 name: Mascot:identity threshold
 def: "The Mascot result 'identity threshold'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001372
 name: SEQUEST:Sequences
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001373
 name: SEQUEST:TIC
 def: "SEQUEST total ion current." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001374
 name: SEQUEST:Sum
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001375
@@ -8825,89 +8783,80 @@ id: MS:1001388
 name: Phenyx:AC
 def: "The primary sequence database identifier of a protein in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001389
 name: Phenyx:ID
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 def: "A secondary sequence database identifier of a protein in Phenyx." [PSI:PI]
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001390
 name: Phenyx:Score
 def: "The protein score of a protein match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001391
 name: Phenyx:Peptides1
 def: "First number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001392
 name: Phenyx:Peptides2
 def: "Second number of phenyx result \"#Peptides\"." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001393
 name: Phenyx:Auto
 def: "The value of the automatic peptide acceptance filter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001394
 name: Phenyx:User
 def: "The value of the user-defined peptide acceptance filter in Phenyx." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001395
 name: Phenyx:Pepzscore
 def: "The z-score value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001396
 name: Phenyx:PepPvalue
 def: "The p-value of a peptide sequence match in Phenyx." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001870 ! p-value for peptides
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 
 [Term]
 id: MS:1001397
 name: Phenyx:NumberOfMC
 def: "The number of missed cleavages of a peptide sequence in Phenyx." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001398
 name: Phenyx:Modif
 def: "The expression of the nature and position(s) of modified residue(s) on a matched peptide sequence in Phenyx." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001399
@@ -8976,6 +8925,7 @@ name: search tolerance plus value
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001411 ! search tolerance specification
 relationship: has_units UO:0000166 ! parts per notation unit
+relationship: has_units UO:0000169 ! parts per million
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
 
@@ -8985,6 +8935,7 @@ name: search tolerance minus value
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001411 ! search tolerance specification
 relationship: has_units UO:0000166 ! parts per notation unit
+relationship: has_units UO:0000169 ! parts per million
 relationship: has_units UO:0000187 ! percent
 relationship: has_units UO:0000221 ! dalton
 
@@ -9020,32 +8971,28 @@ id: MS:1001417
 name: SpectraST:dot
 def: "SpectraST dot product of two spectra, measuring spectral similarity." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001418
 name: SpectraST:dot_bias
 def: "SpectraST measure of how much of the dot product is dominated by a few peaks." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001419
 name: SpectraST:discriminant score F
 def: "SpectraST spectrum score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001420
 name: SpectraST:delta
 def: "SpectraST normalised difference between dot product of top hit and runner-up." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001421
@@ -9312,7 +9259,6 @@ relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrom
 id: MS:1001460
 name: unknown modification
 def: "This term should be given if the modification was unknown." [PSI:PI]
-xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001471 ! peptide modification details
 
 [Term]
@@ -9344,7 +9290,7 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1001466
 name: MS2 format
 def: "MS2 file format for MS2 spectral data." [PMID:15317041, DOI:10.1002/rcm.1603, http://fields.scripps.edu/sequest/SQTFormat.html]
-is_a: MS:1001040 ! intermediate analysis format
+is_a: MS:1000560 ! mass spectrometer file format
 
 [Term]
 id: MS:1001467
@@ -9438,27 +9384,27 @@ is_a: MS:1000518 ! binary data type
 
 [Term]
 id: MS:1001480
-name: AB SCIEX TOF/TOF nativeID format
+name: SCIEX TOF/TOF nativeID format
 def: "Native format defined by jobRun=xsd:nonNegativeInteger spotLabel=xsd:string spectrum=xsd:nonNegativeInteger." [PSI:MS]
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1001481
-name: AB SCIEX TOF/TOF database
+name: SCIEX TOF/TOF database
 def: "Applied Biosystems/MDS Analytical Technologies TOF/TOF instrument database." [PSI:MS]
 is_a: MS:1000560 ! mass spectrometer file format
 
 [Term]
 id: MS:1001482
-name: TOF/TOF 5800
-def: "AB SCIEX or Applied Biosystems|MDS Analytical Technologies AB SCIEX TOF/TOF 5800 Analyzer." [PSI:MS]
+name: 5800 TOF/TOF
+def: "SCIEX 5800 TOF-TOF Analyzer." [PSI:MS]
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
 id: MS:1001483
-name: AB SCIEX TOF/TOF Series Explorer Software
-def: "AB SCIEX or Applied Biosystems software for TOF/TOF data acquisition and analysis." [PSI:MS]
-is_a: MS:1000690 ! AB SCIEX software
+name: SCIEX TOF/TOF Series Explorer Software
+def: "SCIEX or Applied Biosystems software for TOF/TOF data acquisition and analysis." [PSI:MS]
+is_a: MS:1000690 ! SCIEX software
 is_a: MS:1001455 ! acquisition software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
@@ -9512,135 +9458,118 @@ id: MS:1001491
 name: percolator:Q value
 def: "Percolator:Q value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001868 ! distinct peptide-level q-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001492
 name: percolator:score
 def: "Percolator:score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001493
 name: percolator:PEP
 def: "Posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001494
 name: no threshold
 def: "In case no threshold was used." [PSI:PI]
-is_a: MS:1001060 ! quality estimation method details
+is_a: MS:1002482 ! statistical threshold
 
 [Term]
 id: MS:1001495
 name: ProteinScape:SearchResultId
 def: "The SearchResultId of this peptide as SearchResult in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001496
 name: ProteinScape:SearchEventId
 def: "The SearchEventId of the SearchEvent in the ProteinScape database." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001497
 name: ProteinScape:ProfoundProbability
 def: "The Profound probability score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001498
 name: Profound:z value
 def: "The Profound z value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001499
 name: Profound:Cluster
 def: "The Profound cluster score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001500
 name: Profound:ClusterRank
 def: "The Profound cluster rank." [PSI:PI]
 xref: value-type:xsd\:positiveInteger "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001501
 name: MSFit:Mowse score
 def: "The MSFit Mowse score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001502
 name: Sonar:Score
 def: "The Sonar score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001503
 name: ProteinScape:PFFSolverExp
 def: "The ProteinSolver exp value stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001504
 name: ProteinScape:PFFSolverScore
 def: "The ProteinSolver score stored by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001505
 name: ProteinScape:IntensityCoverage
 def: "The intensity coverage of the identified peaks in the spectrum calculated by ProteinScape." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001506
 name: ProteinScape:SequestMetaScore
 def: "The SEQUEST meta score calculated by ProteinScape from the original SEQUEST scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001507
 name: ProteinExtractor:Score
 def: "The score calculated by ProteinExtractor." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001508
@@ -9955,13 +9884,13 @@ is_a: MS:1001557 ! Shimadzu Corporation software
 
 [Term]
 id: MS:1001559
-name: AB SCIEX TOF/TOF T2D nativeID format
+name: SCIEX TOF/TOF T2D nativeID format
 def: "Native format defined by file=xsd:IDREF." [PSI:MS]
 is_a: MS:1000767 ! native spectrum identifier format
 
 [Term]
 id: MS:1001560
-name: AB SCIEX TOF/TOF T2D format
+name: SCIEX TOF/TOF T2D format
 def: "Applied Biosystems/MDS Analytical Technologies TOF/TOF instrument export format." [PSI:MS]
 is_a: MS:1000560 ! mass spectrometer file format
 
@@ -10012,48 +9941,42 @@ id: MS:1001568
 name: Scaffold:Peptide Probability
 def: "Scaffold peptide probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001569
 name: IdentityE Score
 def: "Waters IdentityE peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001570
 name: ProteinLynx:Log Likelihood
 def: "ProteinLynx log likelihood score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001571
 name: ProteinLynx:Ladder Score
 def: "Waters ProteinLynx Ladder score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001572
 name: SpectrumMill:Score
 def: "Spectrum mill peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001573
 name: SpectrumMill:SPI
 def: "SpectrumMill SPI score (%)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001574
@@ -10094,16 +10017,14 @@ id: MS:1001579
 name: Scaffold:Protein Probability
 def: "Scaffold protein probability score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001580
 name: SpectrumMill:Discriminant Score
 def: "Discriminant score from Agilent SpectrumMill software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001581
@@ -10162,8 +10083,7 @@ name: MyriMatch:MVH
 def: "Using the multivariate hypergeometric distribution and a peak list divided into several intensity classes, this score is the negative natural log probability that the predicted peaks matched to experimental peaks by random chance." [PSI:MS]
 synonym: "Pepitome:MVH" EXACT []
 synonym: "TagRecon:MVH" EXACT []
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001590
@@ -10171,8 +10091,7 @@ name: MyriMatch:mzFidelity
 def: "The negative natural log probability that predicted peaks match to experimental peaks by random chance by scoring the m/z delta of the matches in a multinomial distribution." [PSI:MS]
 synonym: "Pepitome:mzFidelity" EXACT []
 synonym: "TagRecon:mzFidelity" EXACT []
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001591
@@ -10568,14 +10487,14 @@ is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 
 [Term]
 id: MS:1001644
-name: ProteomeDiscoverer:Dynamic Modifications
+name: ProteomeDiscoverer:Dynamic Modification
 def: "Determine dynamic post-translational modifications (PTMs)." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 
 [Term]
 id: MS:1001645
-name: ProteomeDiscoverer:Static Modifications
+name: ProteomeDiscoverer:Static Modification
 def: "Static Modification to all occurrences of a named amino acid." [PSI:MS]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
@@ -11123,30 +11042,38 @@ is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 [Term]
 id: MS:1001720
 name: ProteomeDiscoverer:1. Dynamic Modification
-def: "Determine 1st dynamic post-translational modifications (PTMs)." [PSI:MS]
+def: "OBSOLETE ProteomeDiscoverer's 1st dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+is_obsolete: true
 
 [Term]
 id: MS:1001721
 name: ProteomeDiscoverer:2. Dynamic Modification
-def: "Determine 2nd dynamic post-translational modifications (PTMs)." [PSI:MS]
+def: "OBSOLETE ProteomeDiscoverer's 2nd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+is_obsolete: true
 
 [Term]
 id: MS:1001722
 name: ProteomeDiscoverer:3. Dynamic Modification
-def: "Determine 3rd dynamic post-translational modifications (PTMs)." [PSI:MS]
+def: "OBSOLETE ProteomeDiscoverer's 3rd dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+is_obsolete: true
 
 [Term]
 id: MS:1001723
 name: ProteomeDiscoverer:4. Dynamic Modification
-def: "Determine 4th dynamic post-translational modifications (PTMs)." [PSI:MS]
+def: "OBSOLETE ProteomeDiscoverer's 4th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+is_obsolete: true
 
 [Term]
 id: MS:1001724
@@ -11454,8 +11381,8 @@ is_a: MS:1000126 ! Waters instrument model
 
 [Term]
 id: MS:1001767
-name: nanoACQUITY UPLC System with Technology
-def: "Waters LC-system nanoACQUITY UPLC System with Technology." [PSI:MS]
+name: nanoACQUITY UPLC System with 1D Technology
+def: "Waters LC-system nanoACQUITY UPLC System with 1D Technology." [PSI:MS]
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -11587,7 +11514,7 @@ is_a: MS:1000126 ! Waters instrument model
 [Term]
 id: MS:1001789
 name: Quattro micro GC
-def: "Waters quadrupole based Quattro micro GC." [PSI:MS]
+def: "Waters (triple) quadrupole based Quattro micro GC." [PSI:MS]
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -11625,8 +11552,8 @@ is_a: MS:1001457 ! data processing software
 
 [Term]
 id: MS:1001796
-name: Unify
-def: "Waters Unify software for liquid chromatography and mass spectrometry acquisition." [PSI:MS]
+name: UNIFY
+def: "Waters UNIFY software for liquid chromatography and mass spectrometry acquisition." [PSI:MS]
 is_a: MS:1000694 ! Waters software
 is_a: MS:1001456 ! analysis software
 is_a: MS:1001457 ! data processing software
@@ -11687,7 +11614,7 @@ is_a: MS:1001800 ! LECO instrument model
 [Term]
 id: MS:1001805
 name: quantification datatype
-def: "The data type of the value reported in a QuantLayer for a feature, peptide, protein, protein group." [PSI:MS]
+def: "The data type of the value reported in a QuantLayer." [PSI:MS]
 is_a: MS:1001129 ! quantification information
 
 [Term]
@@ -11886,7 +11813,7 @@ is_a: MS:1001833 ! quantitation analysis summary
 [Term]
 id: MS:1001837
 name: iTRAQ quantitation analysis
-def: "Quantification analysis using the AB SCIEX iTRAQ isobaric labelling workflow, wherein 2-8 reporter ions are measured in MS2 spectra near 114 m/z." [PSI:PI]
+def: "Quantification analysis using the SCIEX iTRAQ isobaric labelling workflow, wherein 2-8 reporter ions are measured in MS2 spectra near 114 m/z." [PSI:PI]
 is_a: MS:1002009 ! isobaric label quantitation analysis
 
 [Term]
@@ -11906,35 +11833,35 @@ id: MS:1001840
 name: LC-MS feature intensity
 def: "Maximum peak intensity of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002735 ! feature-level quantification datatype
 
 [Term]
 id: MS:1001841
 name: LC-MS feature volume
 def: "Real (intensity times area) volume of the LC-MS feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002735 ! feature-level quantification datatype
 
 [Term]
 id: MS:1001842
-name: peptide PSM count
-def: "The number of MS2 spectra identified for this peptide in spectral counting." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+name: sequence-level spectral count
+def: "The number of MS2 spectra identified for a raw peptide sequence without PTMs and charge state in spectral counting." [PSI:PI]
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001843
 name: MS1 feature maximum intensity
 def: "Maximum intensity of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002735 ! feature-level quantification datatype
 
 [Term]
 id: MS:1001844
 name: MS1 feature area
 def: "Area of MS1 feature." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002735 ! feature-level quantification datatype
 
 [Term]
 id: MS:1001845
@@ -11971,7 +11898,7 @@ name: sum of MatchedFeature values
 def: "OBSOLETE Peptide quantification value calculated as sum of MatchedFeature quantification values." [PSI:PI]
 comment: This term was made obsolete because the concept MatchedFeature was dropped.
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002735 ! feature-level quantification datatype
 is_obsolete: true
 
 [Term]
@@ -11979,21 +11906,21 @@ id: MS:1001850
 name: normalized peptide value
 def: "Normalized peptide value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001851
 name: protein value: sum of peptide values
 def: "Protein quantification value calculated as sum of peptide values." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001852
 name: normalized protein value
 def: "Normalized protein value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001853
@@ -12049,7 +11976,7 @@ id: MS:1001860
 name: protein value: mean of peptide ratios
 def: "Protein quantification value calculated as mean of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001861
@@ -12096,11 +12023,9 @@ is_a: MS:1001861 ! quantification data processing
 [Term]
 id: MS:1001868
 name: distinct peptide-level q-value
-def: "Estimation of the q-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
+def: "Estimation of the q-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs, possibly with different mass modifications, mapping to the same sequence have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002347 ! PSM-level identification confidence metric
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000187 ! percent
+is_a: MS:1002484 ! peptide-level statistical threshold
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -12108,17 +12033,15 @@ id: MS:1001869
 name: protein-level q-value
 def: "Estimation of the q-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001198 ! protein identification confidence metric
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000187 ! percent
+is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1001870
-name: distinct peptide-level p-value
+name: peptide sequence-level p-value
 def: "Estimation of the p-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002347 ! PSM-level identification confidence metric
+is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -12126,15 +12049,15 @@ id: MS:1001871
 name: protein-level p-value
 def: "Estimation of the p-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001198 ! protein identification confidence metric
+is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1001872
-name: distinct peptide-level e-value
+name: peptide sequence-level e-value
 def: "Estimation of the e-value for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002347 ! PSM-level identification confidence metric
+is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
 
 [Term]
@@ -12142,7 +12065,7 @@ id: MS:1001873
 name: protein-level e-value
 def: "Estimation of the e-value for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001198 ! protein identification confidence metric
+is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
 
 [Term]
@@ -12244,50 +12167,47 @@ is_a: MS:1001457 ! data processing software
 id: MS:1001887
 name: SQID:score
 def: "The SQID result 'Score'." [PSI:PI]
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001888
 name: SQID:deltaScore
 def: "The SQID result 'deltaScore'." [PSI:PI]
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001889
 name: SQID:protein score
 def: "The SQID result 'protein score'." [PSI:PI]
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001890
 name: Progenesis:protein normalised abundance
 def: "The data type normalised abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001891
 name: Progenesis:peptide normalised abundance
 def: "The data type normalised abundance for peptides produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001892
 name: Progenesis:protein raw abundance
 def: "The data type raw abundance for proteins produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001893
 name: Progenesis:peptide raw abundance
 def: "The data type raw abundance for peptide produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001894
@@ -12300,43 +12220,43 @@ is_a: MS:1001805 ! quantification datatype
 id: MS:1001895
 name: Progenesis:peptide count
 def: "The data type peptide count produced by Progenesis LC-MS." [PSI:MS]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001896
 name: Progenesis:feature intensity
 def: "The data type feature intensity produced by Progenesis LC-MS." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002735 ! feature-level quantification datatype
 
 [Term]
 id: MS:1001897
 name: MaxQuant:peptide counts (unique)
 def: "The data type peptide counts (unique) produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001898
 name: MaxQuant:peptide counts (all)
 def: "The data type peptide counts (all) produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001899
 name: MaxQuant:peptide counts (razor+unique)
 def: "The data type peptide counts (razor+unique) produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001900
 name: MaxQuant:sequence length
 def: "The data type sequence length produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1001901
@@ -12357,13 +12277,13 @@ id: MS:1001903
 name: MaxQuant:feature intensity
 def: "The data type feature intensity produced by MaxQuant." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002735 ! feature-level quantification datatype
 
 [Term]
 id: MS:1001904
 name: MaxQuant:MS/MS count
 def: "The data type MS2 count produced by MaxQuant." [PSI:MS]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001805 ! quantification datatype
 
 [Term]
@@ -12371,14 +12291,14 @@ id: MS:1001905
 name: emPAI value
 def: "The emPAI value of protein abundance, produced from the emPAI algorithm." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001906
 name: APEX value
 def: "The APEX value of protein abundance, produced from the APEX software." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1001907
@@ -12483,6 +12403,7 @@ is_a: MS:1000878 ! external reference identifier
 id: MS:1001922
 name: Digital Object Identifier (DOI)
 def: "DOI unique identifier of a publication." [PSI:PI, http://dx.doi.org]
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 synonym: "doi" EXACT []
 is_a: MS:1000878 ! external reference identifier
 relationship: has_regexp MS:1002480 ! (10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)
@@ -12675,24 +12596,21 @@ id: MS:1001950
 name: PEAKS:peptideScore
 def: "The PEAKS peptide '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001951
 name: PEAKS:proteinScore
 def: "The PEAKS protein '-10lgP Score'." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1001952
 name: ZCore:probScore
 def: "The ZCore probability score." [PSI:MS]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1001953
@@ -12723,25 +12641,25 @@ is_a: MS:1001045 ! cleavage agent name
 [Term]
 id: MS:1001957
 name: (?<=[ALIV])(?!P)
-def:"Regular expression for leukocyte elastase." [PSI:PI]
+def: "Regular expression for leukocyte elastase." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001958
 name: (?<=[HKR]P)(?!P)
-def:"Regular expression for proline endopeptidase." [PSI:PI]
+def: "Regular expression for proline endopeptidase." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001959
 name: (?<=[^E]E)
-def:"Regular expression for glutamyl endopeptidase." [PSI:PI]
+def: "Regular expression for glutamyl endopeptidase." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
 id: MS:1001960
 name: (?<=W)
-def:"Regular expression for 2-iodobenzoate." [PSI:PI]
+def: "Regular expression for 2-iodobenzoate." [PSI:PI]
 is_a: MS:1001180 ! Cleavage agent regular expression
 
 [Term]
@@ -12783,7 +12701,7 @@ is_a: MS:1002100 ! ProteinScape input parameter
 id: MS:1001966
 name: product ion mobility
 def: "The mobility of an MS2 product ion, as measured by ion mobility mass spectrometry." [PSI:MS]
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 
 [Term]
 id: MS:1001967
@@ -12797,27 +12715,33 @@ is_obsolete: true
 
 [Term]
 id: MS:1001968
-name: PTM localization score
-def: "A score that assign confidence to the localization of an amino acid modification on a peptide sequence." [PSI:MS]
-is_a: MS:1001405 ! spectrum identification result details
+name: PTM localization PSM-level statistic
+def: "Statistic to convey the confidence of the localization of an amino acid modification on a peptide sequence at the PSM-level." [PSI:MS]
+is_a: MS:1002689 ! PTM localization single result statistic
 
 [Term]
 id: MS:1001969
 name: phosphoRS score
-def: "Peptide score based on the cumulative binomial probability that the observed match is a random event." [DOI:10.1021/pr200611n, PMID:22073976]
-is_a: MS:1001968 ! PTM localization score
+def: "phosphoRS score for PTM site location at the PSM-level." [DOI:10.1021/pr200611n, PMID:22073976]
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001970
 name: phosphoRS sequence probability
 def: "Probability that the respective isoform is correct." [DOI:10.1021/pr200611n, PMID:22073976]
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001971
 name: phosphoRS site probability
 def: "Estimate of the probability that the respective site is truly phosphorylated." [DOI:10.1021/pr200611n, PMID:22073976]
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001972
@@ -12836,15 +12760,17 @@ is_a: MS:1001456 ! analysis software
 id: MS:1001974
 name: DeBunker:score
 def: "Score specific to DeBunker." [PSI:MS]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001975
 name: delta m/z
 def: "The difference between a theoretically calculated m/z and the corresponding experimentally measured m/z. It can be expressed as absolute or relative value." [PSI:MS]
 synonym: "m/z difference" EXACT []
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
@@ -12855,6 +12781,7 @@ id: MS:1001976
 name: delta M
 def: "The difference between a theoretically calculated molecular mass M and the corresponding experimentally measured M. It can be expressed as absolute or relative value." [PSI:MS]
 synonym: "mass difference" EXACT []
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1001405 ! spectrum identification result details
 relationship: has_units UO:0000166 ! parts per notation unit
 relationship: has_units UO:0000187 ! percent
@@ -12870,72 +12797,70 @@ is_a: MS:1001456 ! analysis software
 id: MS:1001978
 name: MSQuant:PTM-score
 def: "The PTM score from MSQuant software." [DOI:10.1021/pr900721e, PMID:19888749]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001979
 name: MaxQuant:PTM Score
 def: "The PTM score from MaxQuant software." [PSI:MS]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001980
 name: MaxQuant:Phospho (STY) Probabilities
 def: "The Phospho (STY) Probabilities from MaxQuant software." [PSI:MS]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001405 ! spectrum identification result details
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001981
 name: MaxQuant:Phospho (STY) Score Diffs
 def: "The Phospho (STY) Score Diffs from MaxQuant software." [PSI:MS]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001405 ! spectrum identification result details
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
 
 [Term]
 id: MS:1001982
 name: MaxQuant:P-site localization probability
 def: "The P-site localization probability value from MaxQuant software." [PSI:MS]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001405 ! spectrum identification result details
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001983
 name: MaxQuant:PTM Delta Score
 def: "The PTM Delta Score value from MaxQuant software (Difference between highest scoring site and second highest)." [PSI:MS]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001984
-name: Ascore
+name: Ascore software
 def: "Ascore software." [PSI:MS]
 is_a: MS:1001456 ! analysis software
 
 [Term]
 id: MS:1001985
-name: Ascore:Ascore
-def: "The Ascore score value from Ascore software." [DOI:10.1038/nbt1240, PMID:16964243]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001968 ! PTM localization score
+name: Ascore
+def: "A-score for PTM site location at the PSM-level." [DOI:10.1038/nbt1240, PMID:16964243]
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001986
 name: H-Score
 def: "H-Score for peptide phosphorylation site location." [DOI:10.1021/pr1006813, PMID:20836569]
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
+relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1001987
@@ -13101,11 +13026,8 @@ is_a: MS:1000240 ! atmospheric pressure ionization
 id: MS:1002012
 name: Mascot:PTM site assignment confidence
 def: "Relative probability that PTM site assignment is correct, derived from the Mascot score difference between matches to the same spectrum (Mascot Delta Score)." [http://www.matrixscience.com/help/pt_mods_help.html#SITE]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001405 ! spectrum identification result details
-is_a: MS:1001968 ! PTM localization score
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
+is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_units UO:0000187 ! percent
 
 [Term]
@@ -13331,16 +13253,14 @@ id: MS:1002044
 name: ProteinProspector:score
 def: "The ProteinProspector result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002045
 name: ProteinProspector:expectation value
 def: "The ProteinProspector result 'Expectation value'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002046
@@ -13367,32 +13287,29 @@ id: MS:1002049
 name: MS-GF:RawScore
 def: "MS-GF raw score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002050
 name: MS-GF:DeNovoScore
 def: "MS-GF de novo score." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1002051
 name: MS-GF:Energy
 def: "MS-GF energy score." [PSI:PI]
 xref: value-type:xsd\:nonNegativeInteger "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002052
 name: MS-GF:SpecEValue
 def: "MS-GF spectral E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
 is_a: MS:1002353 ! PSM-level e-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
 
 [Term]
@@ -13400,9 +13317,8 @@ id: MS:1002053
 name: MS-GF:EValue
 def: "MS-GF E-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
 is_a: MS:1002353 ! PSM-level e-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
 
 [Term]
@@ -13410,26 +13326,22 @@ id: MS:1002054
 name: MS-GF:QValue
 def: "MS-GF Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
 is_a: MS:1002354 ! PSM-level q-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002055
 name: MS-GF:PepQValue
 def: "MS-GF peptide-level Q-value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001868 ! distinct peptide-level q-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002056
 name: MS-GF:PEP
 def: "MS-GF posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002057
@@ -13479,14 +13391,14 @@ id: MS:1002064
 name: peptide consensus RT
 def: "Peptide consensus retention time." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1002065
 name: peptide consensus m/z
 def: "Peptide consensus mass/charge ratio." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1002066
@@ -13500,7 +13412,7 @@ id: MS:1002067
 name: protein value: median of peptide ratios
 def: "Protein quantification value calculated as median of peptide ratios." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1002068
@@ -13510,7 +13422,7 @@ is_a: MS:1001055 ! modification parameters
 
 [Term]
 id: MS:1002069
-name: metabolic labelling: labelling purity
+name: metabolic labelling purity
 def: "Metabolic labelling: Description of labelling purity. Usually the purity of feeding material (e.g. 95%), or the inclusion rate derived from isotopic peak pattern shape." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
@@ -13570,16 +13482,20 @@ is_a: MS:1001536 ! Bruker Daltonics micrOTOF series
 [Term]
 id: MS:1002078
 name: ProteomeDiscoverer:1. Static Modification
-def: "Determine 1st static post-translational modifications (PTMs)." [PSI:MS]
+def: "OBSOLETE ProteomeDiscoverer's 1st static post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+is_obsolete: true
 
 [Term]
 id: MS:1002079
 name: ProteomeDiscoverer:2. Static Modification
-def: "Determine 2nd static post-translational modifications (PTMs)." [PSI:MS]
+def: "OBSOLETE ProteomeDiscoverer's 2nd static post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+is_obsolete: true
 
 [Term]
 id: MS:1002080
@@ -13850,7 +13766,7 @@ is_a: MS:1001825 ! feature list attribute
 [Term]
 id: MS:1002123
 name: x-Tracker
-def: "x-Tracker generic tool for quantitative proteomics." [http://www.x-tracker.info/]
+def: "X-Tracker generic tool for quantitative proteomics." [https://bessantlab.org/software/x-tracker/]
 is_a: MS:1001139 ! quantitation software name
 
 [Term]
@@ -13865,7 +13781,7 @@ name: combined FDRScore
 def: "OBSOLETE FDRScore values specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
 comment: This term was made obsolete because it was split into the more specific terms for PSM-level combined FDRScore (MS:1002356), distinct peptide-level combined FDRScore (MS:1002361), protein-level combined FDRScore (MS:1002366) and protein group-level combined FDRScore (MS:1002375).
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 is_a: MS:1001153 ! search engine specific score
 is_obsolete: true
 
@@ -13998,7 +13914,7 @@ is_a: MS:1002137 ! TOPP spectra filter
 
 [Term]
 id: MS:1002147
-name: TOPP MapAligner
+name: TOPP map aligner
 def: "Map aligner component of the TOPP software." [PSI:PI]
 is_a: MS:1000752 ! TOPP software
 
@@ -14006,19 +13922,19 @@ is_a: MS:1000752 ! TOPP software
 id: MS:1002148
 name: TOPP MapAlignerIdentification
 def: "Corrects retention time distortions between maps based on common peptide identifications." [PSI:PI]
-is_a: MS:1002147 ! TOPP MapAligner
+is_a: MS:1002147 ! TOPP map aligner
 
 [Term]
 id: MS:1002149
 name: TOPP MapAlignerPoseClustering
 def: "Corrects retention time distortions between maps using a pose clustering approach." [PSI:PI]
-is_a: MS:1002147 ! TOPP MapAligner
+is_a: MS:1002147 ! TOPP map aligner
 
 [Term]
 id: MS:1002150
 name: TOPP MapAlignerSpectrum
 def: "Corrects retention time distortions between maps by spectrum alignment." [PSI:PI]
-is_a: MS:1002147 ! TOPP MapAligner
+is_a: MS:1002147 ! TOPP map aligner
 
 [Term]
 id: MS:1002151
@@ -14037,7 +13953,7 @@ id: MS:1002153
 name: protein level PSM counts
 def: "The number of spectra identified for this protein in spectral counting." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002738 ! protein-level quantification datatype
 
 [Term]
 id: MS:1002154
@@ -14427,7 +14343,7 @@ id: MS:1002217
 name: decoy peptide
 def: "A putative identified peptide issued from a decoy sequence database." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1002218
@@ -14455,8 +14371,8 @@ is_a: MS:1000871 ! SRM software
 id: MS:1002221
 name: MRMaid:peptide score
 def: "Score in MRMaid to indicate the expected performance of the peptide in SRM." [PSI:PI]
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001105 ! peptide sequence-level identification attribute
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1002222
@@ -14483,15 +14399,21 @@ is_a: MS:1002222 ! SRM transition attribute
 id: MS:1002225
 name: average product ion intensity
 def: "Average value of product ion intensity in a collection of identified spectra." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001226 ! product ion intensity
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
 
 [Term]
 id: MS:1002226
 name: product ion intensity standard deviation
 def: "Standard deviation of product ion intensity in a collection of identified spectra." [PSI:PI]
-xref: value-type:xsd\:float "The allowed value-type for this CV term."
 is_a: MS:1001226 ! product ion intensity
+relationship: has_units MS:1000131 ! number of detector counts
+relationship: has_units MS:1000132 ! percent of base peak
+relationship: has_units MS:1000814 ! counts per second
+relationship: has_units MS:1000905 ! percent of base peak times 100
 
 [Term]
 id: MS:1002227
@@ -14555,14 +14477,14 @@ id: MS:1002235
 name: ProteoGrouper:PDH score
 def: "A score assigned to a single protein accession (modelled as ProteinDetectionHypothesis in mzIdentML), based on summed peptide level scores." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1002236
 name: ProteoGrouper:PAG score
 def: "A score assigned to a protein group (modelled as ProteinAmbiguityGroup in mzIdentML), based on all summed peptide level scores that have been assigned to the group as unique or razor peptides." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001147 ! protein ambiguity group result details
+is_a: MS:1002368 ! search engine specific score for protein groups
 
 [Term]
 id: MS:1002237
@@ -14635,24 +14557,21 @@ id: MS:1002248
 name: SEQUEST:spscore
 def: "The SEQUEST result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002249
 name: SEQUEST:sprank
 def: "The SEQUEST result 'SpRank'." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002250
 name: SEQUEST:deltacnstar
 def: "The SEQUEST result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002251
@@ -14665,8 +14584,7 @@ id: MS:1002252
 name: Comet:xcorr
 def: "The Comet result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -14674,32 +14592,28 @@ id: MS:1002253
 name: Comet:deltacn
 def: "The Comet result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002254
 name: Comet:deltacnstar
 def: "The Comet result 'DeltaCnStar'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002255
 name: Comet:spscore
 def: "The Comet result 'SpScore'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002256
 name: Comet:sprank
 def: "The Comet result 'SpRank'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002257
@@ -14712,17 +14626,15 @@ is_a: MS:1001153 ! search engine specific score
 id: MS:1002258
 name: Comet:matched ions
 def: "The Comet result 'Matched Ions'." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002259
 name: Comet:total ions
 def: "The Comet result 'Total Ions'." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002260
@@ -14742,8 +14654,7 @@ id: MS:1002262
 name: Byonic:Score
 def: "The Byonic score is the primary indicator of PSM correctness. The Byonic score reflects the absolute quality of the peptide-spectrum match, not the relative quality compared to other candidate peptides. Byonic scores range from 0 to about 1000, with 300 a good score, 400 a very good score, and PSMs with scores over 500 almost sure to be correct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -14751,8 +14662,7 @@ id: MS:1002263
 name: Byonic:Delta Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide with distinct sequence. In this computation, the same peptide with different modifications is not considered distinct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -14760,8 +14670,7 @@ id: MS:1002264
 name: Byonic:DeltaMod Score
 def: "The drop in Byonic score from the top-scoring peptide to the next peptide different in any way, including placement of modifications. DeltaMod gives an indication of whether modifications are confidently localized; DeltaMod over 10.0 means that there is high likelihood that all modification placements are correct." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -14769,17 +14678,15 @@ id: MS:1002265
 name: Byonic:PEP
 def: "Byonic posterior error probability." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
 
 [Term]
 id: MS:1002266
 name: Byonic:Peptide LogProb
-def: "The log p-value of the PSM. This is the log of the probability that the PSM with such a score and delta would arise by chance in a search of this size (size of the protein database, as expanded by the modification rules). A log p-value of -3.0 should happen by chance on only one of a thousand spectra. Caveat: it is very hard to compute a p-value that works for all searches and all spectra, so read Byonic p-values with a certain amount of skepticism." [PSI:PI]
+def: "The log p-value of the PSM. This is the log of the probability that the PSM with such a score and delta would arise by chance in a search of this size (the size of the protein database, as expanded by the modification rules). A log p-value of -3.0 should happen by chance on only one of a thousand spectra. Caveat: it is very hard to compute a p-value that works for all searches and all spectra, so read Byonic p-values with a certain amount of skepticism." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002109 ! lower score better
 
 [Term]
@@ -14787,8 +14694,8 @@ id: MS:1002267
 name: Byonic:Protein LogProb
 def: "The log p-value of the protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002109 ! lower score better
 
 [Term]
@@ -14805,8 +14712,7 @@ id: MS:1002269
 name: Byonic:Best Score
 def: "Best (largest) Byonic score of a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -14856,7 +14762,7 @@ is_a: MS:1000126 ! Waters instrument model
 [Term]
 id: MS:1002277
 name: AutoSpec Premier
-def: "Waters AutoSpec Premier." [PSI:MS]
+def: "Waters AutoSpec Premier magnetic sector instrument." [PSI:MS]
 is_a: MS:1000126 ! Waters instrument model
 
 [Term]
@@ -14931,12 +14837,6 @@ is_a: MS:1002286 ! Trans-Proteomic Pipeline software
 id: MS:1002289
 name: ProteinProphet
 def: "A program in the TPP that calculates protein-level probabilities based on input PSM or peptide-level probabilities from PeptideProphet or iProphet. The output is written in the protXML format." [PMID:14632076]
-is_a: MS:1002286 ! Trans-Proteomic Pipeline software
-
-[Term]
-id: MS:1002289
-name: ASAPRatio
-def: "A program in the TPP that calculates PSM, peptide, and protein-level abundances based on 2-channel isotope-labelled data such as ICAT, SILAC, etc." [PSI:PI]
 is_a: MS:1002286 ! Trans-Proteomic Pipeline software
 
 [Term]
@@ -15046,7 +14946,7 @@ is_a: MS:1002304 ! domain range
 id: MS:1002307
 name: fragmentation ion type
 def: "Type of fragment ion based on where the backbone breaks, such as a y ion or a c ion." [PSI:PI]
-is_a: MS:1001221 ! fragmentation information
+is_a: MS:1001221 ! product ion attribute
 
 [Term]
 id: MS:1002308
@@ -15059,8 +14959,7 @@ id: MS:1002309
 name: Byonic: Peptide AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -15068,8 +14967,7 @@ id: MS:1002310
 name: Byonic: Protein AbsLogProb
 def: "The absolute value of the log-base10 of the Byonic posterior error probability (PEP) of the protein." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -15077,26 +14975,25 @@ id: MS:1002311
 name: Byonic: Peptide AbsLogProb2D
 def: "The absolute value of the log-base10 Byonic two-dimensional posterior error probability (PEP) of the PSM. The two-dimensional PEP takes into account protein ranking information as well as PSM information." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
 id: MS:1002312
 name: MS-Numpress linear prediction compression
-def: "Compression using MS-Numpress linear prediction compression." [https://github.com/fickludd/ms-numpress]
+def: "Compression using MS-Numpress linear prediction compression." [https://github.com/ms-numpress/ms-numpress]
 is_a: MS:1000572 ! binary data compression type
 
 [Term]
 id: MS:1002313
 name: MS-Numpress positive integer compression
-def: "Compression using MS-Numpress positive integer compression." [https://github.com/fickludd/ms-numpress]
+def: "Compression using MS-Numpress positive integer compression." [https://github.com/ms-numpress/ms-numpress]
 is_a: MS:1000572 ! binary data compression type
 
 [Term]
 id: MS:1002314
 name: MS-Numpress short logged float compression
-def: "Compression using MS-Numpress short logged float compression." [https://github.com/fickludd/ms-numpress]
+def: "Compression using MS-Numpress short logged float compression." [https://github.com/ms-numpress/ms-numpress]
 is_a: MS:1000572 ! binary data compression type
 
 [Term]
@@ -15131,8 +15028,7 @@ id: MS:1002319
 name: Amanda:AmandaScore
 def: "The Amanda score of the scoring function for a PSM." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002320
@@ -15207,16 +15103,20 @@ is_a: MS:1002101 ! ProteomeDiscoverer input parameter
 [Term]
 id: MS:1002330
 name: ProteomeDiscoverer:3. Static Modification
-def: "Determine 3rd static (fixed) post-translational modifications (PTMs)." [PSI:PI]
+def: "OBSOLETE ProteomeDiscoverer's 3rd static post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Static Modification (MS:1001645) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+is_obsolete: true
 
 [Term]
 id: MS:1002331
 name: ProteomeDiscoverer:5. Dynamic Modification
-def: "Determine 5th dynamic (variable) post-translational modifications (PTMs)." [PSI:PI]
+def: "OBSOLETE ProteomeDiscoverer's 5th dynamic post-translational modification (PTM) input parameter." [PSI:PI]
+comment: This term was made obsolete because it's recommended to use ProteomeDiscoverer:Dynamic Modification (MS:1001644) instead.
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002101 ! ProteomeDiscoverer input parameter
+is_obsolete: true
 
 [Term]
 id: MS:1002332
@@ -15261,8 +15161,7 @@ id: MS:1002338
 name: Andromeda:score
 def: "The probability based score of the Andromeda search engine." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -15284,7 +15183,7 @@ id: MS:1002341
 name: second-pass peptide identification
 def: "A putative identified peptide found in a second-pass search of protein sequences selected from a first-pass search." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1002342
@@ -15309,27 +15208,27 @@ is_a: MS:1001457 ! data processing software
 
 [Term]
 id: MS:1002345
-name: PSM-level result details
-def: "Peptide spectrum match level information." [PSI:PI]
-is_a: MS:1001405 ! spectrum identification result details
+name: PSM-level attribute
+def: "Attribute of a single peptide-spectrum match." [PSI:PI]
+is_a: MS:1002694 ! single identification result attribute
 
 [Term]
 id: MS:1002346
-name: protein group-level result details
+name: protein group-level identification attribute
 def: "Protein group level information." [PSI:PI]
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1002694 ! single identification result attribute
 
 [Term]
 id: MS:1002347
-name: PSM-level identification confidence metric
+name: PSM-level identification statistic
 def: "Identification confidence metric for a peptide spectrum match." [PSI:PI]
-is_a: MS:1002345 ! PSM-level result details
+is_a: MS:1002345 ! PSM-level attribute
 
 [Term]
 id: MS:1002348
-name: protein group-level identification confidence metric
+name: protein group-level identification statistic
 def: "Identification confidence metric for a protein group." [PSI:PI]
-is_a: MS:1002346 ! protein group-level result details
+is_a: MS:1002346 ! protein group-level identification attribute
 
 [Term]
 id: MS:1002349
@@ -15342,8 +15241,7 @@ id: MS:1002350
 name: PSM-level global FDR
 def: "Estimation of the global false discovery rate of peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002345 ! PSM-level result details
-is_a: MS:1002483 ! PSM-level statistical threshold
+is_a: MS:1002701 ! PSM-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -15351,8 +15249,7 @@ id: MS:1002351
 name: PSM-level local FDR
 def: "Estimation of the local false discovery rate of peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002345 ! PSM-level result details
-is_a: MS:1002483 ! PSM-level statistical threshold
+is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -15360,7 +15257,7 @@ id: MS:1002352
 name: PSM-level p-value
 def: "Estimation of the p-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002347 ! PSM-level identification confidence metric
+is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -15368,7 +15265,7 @@ id: MS:1002353
 name: PSM-level e-value
 def: "Estimation of the e-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002347 ! PSM-level identification confidence metric
+is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
 
 [Term]
@@ -15376,27 +15273,25 @@ id: MS:1002354
 name: PSM-level q-value
 def: "Estimation of the q-value for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002347 ! PSM-level identification confidence metric
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000187 ! percent
+is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002355
 name: PSM-level FDRScore
-def: "FDRScore for peptide spectrum matches." [PSI:PI]
+def: "mzidLibrary FDRScore for peptide spectrum matches." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
 
 [Term]
 id: MS:1002356
 name: PSM-level combined FDRScore
-def: "Combined FDRScore for peptide spectrum matches specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
+def: "mzidLibrary Combined FDRScore for peptide spectrum matches specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to 1
 
 [Term]
@@ -15404,79 +15299,76 @@ id: MS:1002357
 name: PSM-level probability
 def: "Probability that the reported peptide ion is truly responsible for some or all of the components of the specified mass spectrum." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002347 ! PSM-level identification confidence metric
+is_a: MS:1002347 ! PSM-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002358
-name: search engine specific score for distinct peptides
+name: search engine specific peptide sequence-level identification statistic
 def: "Search engine specific distinct peptide score." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001092 ! peptide sequence-level identification statistic
 
 [Term]
 id: MS:1002359
-name: distinct peptide-level local FDR
+name: peptide sequence-level local FDR
 def: "Estimation of the local false discovery rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
-is_a: MS:1002484 ! peptide-level statistical threshold
+is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002360
 name: distinct peptide-level FDRScore
-def: "FDRScore for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
+def: "mzidLibrary FDRScore for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002358 ! search engine specific score for distinct peptides
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 
 [Term]
 id: MS:1002361
 name: distinct peptide-level combined FDRScore
-def: "Combined FDRScore for peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry) specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given peptide, used for integrating results from these distinct pools." [PMID:19253293]
+def: "Combined FDRScore for peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry) specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given peptide, used for integrating results from these distinct pools." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002358 ! search engine specific score for distinct peptides
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 
 [Term]
 id: MS:1002362
-name: distinct peptide-level probability
+name: peptide sequence-level probability
 def: "Probability that the reported distinct peptide sequence (irrespective of mass modifications) has been correctly identified via the referenced PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001092 ! peptide identification confidence metric
+is_a: MS:1001092 ! peptide sequence-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002363
 name: search engine specific score for proteins
 def: "Search engine specific protein scores." [PSI:PI]
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001116 ! single protein identification statistic
 
 [Term]
 id: MS:1002364
 name: protein-level local FDR
 def: "Estimation of the local false discovery rate of proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1001116 ! single protein identification statistic
 
 [Term]
 id: MS:1002365
 name: FDRScore for proteins
-def: "FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
+def: "mzidLibrary FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-is_a: MS:1001153 ! search engine specific score
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 
 [Term]
 id: MS:1002366
 name: combined FDRScore for proteins
-def: "Combined FDRScore for proteins." [PSI:PI]
+def: "mzidLibrary Combined FDRScore for proteins." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002363 ! search engine specific score for proteins
-is_a: MS:1001153 ! search engine specific score
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 
 [Term]
@@ -15484,37 +15376,35 @@ id: MS:1002367
 name: probability for proteins
 def: "Probability that a specific protein sequence has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001198 ! protein identification confidence metric 
+is_a: MS:1001116 ! single protein identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002368
 name: search engine specific score for protein groups
 def: "Search engine specific protein group scores." [PSI:PI]
-is_a: MS:1002346 ! protein group-level result details
+is_a: MS:1002348 ! protein group-level identification statistic
 
 [Term]
 id: MS:1002369
 name: protein group-level global FDR
 def: "Estimation of the global false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002346 ! protein group-level result details
-is_a: MS:1002486 ! protein group-level statistical threshold
+is_a: MS:1002706 ! protein group-level result list statistic
 
 [Term]
 id: MS:1002370
 name: protein group-level local FDR
 def: "Estimation of the local false discovery rate of protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002346 ! protein group-level result details
-is_a: MS:1002486 ! protein group-level statistical threshold
+is_a: MS:1002348 ! protein group-level identification statistic
 
 [Term]
 id: MS:1002371
 name: protein group-level p-value
 def: "Estimation of the p-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002348 ! protein group-level identification confidence metric
+is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -15522,7 +15412,7 @@ id: MS:1002372
 name: protein group-level e-value
 def: "Estimation of the e-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002348 ! protein group-level identification confidence metric
+is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002306 ! value greater than zero
 
 [Term]
@@ -15530,27 +15420,23 @@ id: MS:1002373
 name: protein group-level q-value
 def: "Estimation of the q-value for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002348 ! protein group-level identification confidence metric
-relationship: has_units UO:0000166 ! parts per notation unit
-relationship: has_units UO:0000187 ! percent
+is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002374
 name: protein group-level FDRScore
-def: "FDRScore for protein groups." [PSI:PI]
+def: "mzidLibrary FDRScore for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-is_a: MS:1001153 ! search engine specific score
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 
 [Term]
 id: MS:1002375
 name: protein group-level combined FDRScore
-def: "Combined FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
+def: "mzidLibrary Combined FDRScore for proteins specifically obtained for distinct combinations of single, pairs or triplets of search engines making a given PSM, used for integrating results from these distinct pools." [PMID:19253293]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-is_a: MS:1001153 ! search engine specific score
 relationship: has_domain MS:1002349 ! value greater than zero but less than or equal to one
 
 [Term]
@@ -15558,7 +15444,7 @@ id: MS:1002376
 name: protein group-level probability
 def: "Probability that at least one of the members of a group of protein sequences has been correctly identified from the PSM and distinct peptide evidence, and based on the available protein sequences presented to the analysis software." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1002368 ! search engine specific score for protein groups
+is_a: MS:1002348 ! protein group-level identification statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
@@ -15649,6 +15535,7 @@ id: MS:1002389
 name: PIA workflow parameter
 def: "A parameter set for a single PIA analysis." [PSI:PI]
 is_a: MS:1002105 ! software specific input parameter
+is_a: MS:1001302 ! search engine specific input parameter
 
 [Term]
 id: MS:1002390
@@ -15683,7 +15570,7 @@ id: MS:1002394
 name: PIA:protein score
 def: "The score given to a protein by any protein inference." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -15751,27 +15638,27 @@ id: MS:1002404
 name: count of identified proteins
 def: "The number of proteins that have been identified, which must match the number of groups that pass the threshold in the file." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:1001085 ! protein result details
+is_a: MS:1002704 ! protein-level result list attribute
 
 [Term]
 id: MS:1002405
-name: protein cluster details
+name: protein group-level result list attribute
 def: "Details describing a protein cluster." [PSI:PI]
-is_a: MS:1001085 ! protein result details
+is_a: MS:1002699 ! result list attribute
 
 [Term]
 id: MS:1002406
 name: count of identified clusters
-def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [PSI:PI]
+def: "The number of protein clusters that have been identified, which must match the number of clusters that pass the threshold in the file." [DOI:10.1002/pmic.201400080, PMID:25092112]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:1002405 ! protein cluster details
+is_a: MS:1002405 ! protein group-level result list attribute
 
 [Term]
 id: MS:1002407
 name: cluster identifier
 def: "An identifier applied to protein groups to indicate that they are linked by shared peptides." [PSI:PI]
 xref: value-type:xsd\:int "The allowed value-type for this CV term."
-is_a: MS:1001147 ! protein ambiguity group result details
+is_a: MS:1002698 ! protein cluster identification attribute
 
 [Term]
 id: MS:1002408
@@ -15804,7 +15691,7 @@ id: MS:1002412
 name: total XIC area
 def: "Summed area of all the extracted ion chromatogram for the peptide (e.g. of all the transitions in SRM)." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002737 ! peptide-level quantification datatype
 
 [Term]
 id: MS:1002413
@@ -15824,7 +15711,7 @@ id: MS:1002415
 name: protein group passes threshold
 def: "A Boolean attribute to determine whether the protein group has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
-is_a: MS:1001147 ! protein ambiguity group result details
+is_a: MS:1002346 ! protein group-level identification attribute
 
 [Term]
 id: MS:1002416
@@ -15982,13 +15869,13 @@ relationship: part_of MS:1001000 ! spectrum interpretation
 
 [Term]
 id: MS:1002439
-name: final PSM list UNDER DISCUSSION
+name: final PSM list
 def: "A flag on a list of PSMs (SpectrumIdentificationList) to indicate that this is the final set of identifications to be interpreted by consuming software. Amongst the set of SpectrumIdentificationList(s) that are flagged with the term, each spectrum must not be referenced from more than one SpectrumIdentificationResult." [PSI:PI]
 is_a: MS:1002438 ! spectrum identification list result details
 
 [Term]
 id: MS:1002440
-name: intermediate PSM list UNDER DISCUSSION
+name: intermediate PSM list
 def: "A flag on a list of PSMs (SpectrumIdentificationList) to indicate that this is not the final set of identifications to be interpreted by consuming software. This term should be used when results are provided from multiple search engines for the results from each search engine before they are combined to give consensus identifications. Amongst the set of SpectrumIdentificationList(s) that are flagged with the term, each spectrum may be referenced from more than one SpectrumIdentificationResult." [PSI:PI]
 is_a: MS:1002438 ! spectrum identification list result details
 
@@ -16040,16 +15927,14 @@ id: MS:1002448
 name: PEAKS:inChorusPeptideScore
 def: "The PEAKS inChorus peptide score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002449
 name: PEAKS:inChorusProteinScore
 def: "The PEAKS inChorus protein score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001116 ! single protein result details
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1002450
@@ -16085,23 +15970,29 @@ is_a: MS:1002094 ! common search engine input parameter
 [Term]
 id: MS:1002455
 name: H2O neutral loss
-def: "Neutral loss of water." [PSI:PI]
+def: "OBSOLETE Neutral loss of water." [PSI:PI]
+comment: This term was obsoleted because it should be replaced by MS:1000336 with value H2O.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
+is_obsolete: true
 
 [Term]
 id: MS:1002456
 name: NH3 neutral loss
-def: "Neutral loss of ammonia." [PSI:PI]
+def: "OBSOLETE Neutral loss of ammonia." [PSI:PI]
+comment: This term was obsoleted because it should be replaced by MS:1000336 with value NH3.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
+is_obsolete: true
 
 [Term]
 id: MS:1002457
 name: H3PO4 neutral loss
-def: "Neutral loss of phosphoric acid." [PSI:PI]
+def: "OBSOLETE Neutral loss of phosphoric acid." [PSI:PI]
+comment: This term was obsoleted because it should be replaced by MS:1000336 with value H3PO4.
 is_a: MS:1000336 ! neutral loss
 is_a: MS:1002473 ! ion series considered in search
+is_obsolete: true
 
 [Term]
 id: MS:1002458
@@ -16119,86 +16010,89 @@ is_a: MS:1001040 ! intermediate analysis format
 id: MS:1002460
 name: protein group-level global FNR
 def: "Estimation of the global false negative rate of protein groups." [PSI:PI]
-is_a: MS:1002346 ! protein group-level result details
+is_a: MS:1002706 ! protein group-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
-is_a: MS:1002486 ! protein group-level statistical threshold
 
 [Term]
 id: MS:1002461
 name: protein group-level confidence
 def: "Estimation of the global confidence of protein groups." [PSI:PI]
-is_a: MS:1002346 ! protein group-level result details
+is_a: MS:1002348 ! protein group-level identification statistic
 
 [Term]
 id: MS:1002462
-name: distinct peptide-level global FNR
+name: peptide sequence-level global FNR
 def: "Estimation of the global false negative rate for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
-is_a: MS:1002484 ! peptide-level statistical threshold
+is_a: MS:1002703 ! peptide sequence-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002463
-name: distinct peptide-level global confidence
+name: peptide sequence-level global confidence
 def: "Estimation of the global confidence for distinct peptides once redundant identifications of the same peptide have been removed (id est multiple PSMs have been collapsed to one entry)." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1002703 ! peptide sequence-level result list statistic
 
 [Term]
 id: MS:1002464
 name: PSM-level global FNR
 def: "Estimation of the global false negative rate of peptide spectrum matches." [PSI:PI]
-is_a: MS:1002345 ! PSM-level result details
-is_a: MS:1002483 ! PSM-level statistical threshold
+is_a: MS:1002701 ! PSM-level result list statistic
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
 
 [Term]
 id: MS:1002465
 name: PSM-level global confidence
 def: "Estimation of the global confidence of peptide spectrum matches." [PSI:PI]
-is_a: MS:1002345 ! PSM-level result details
+is_a: MS:1002701 ! PSM-level result list statistic
 
 [Term]
 id: MS:1002466
 name: PeptideShaker PSM score
 def: "The probability based PeptideShaker PSM score." [PSI:PI]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
+xref: value-type:xsd\:float "The allowed value-type for this CV term."
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
 id: MS:1002467
 name: PeptideShaker PSM confidence
 def: "The probability based PeptideShaker PSM confidence." [PSI:PI]
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001143 ! search engine specific score for PSMs
+xref: value-type:xsd\:float "The allowed value-type for this CV term."
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
 id: MS:1002468
 name: PeptideShaker peptide score
 def: "The probability based PeptideShaker peptide score." [PSI:PI]
-is_a: MS:1001153 ! search engine specific score
+xref: value-type:xsd\:float "The allowed value-type for this CV term."
+is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
 id: MS:1002469
 name: PeptideShaker peptide confidence
 def: "The probability based PeptideShaker peptide confidence." [PSI:PI]
-is_a: MS:1001153 ! search engine specific score
+xref: value-type:xsd\:float "The allowed value-type for this CV term."
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
 id: MS:1002470
 name: PeptideShaker protein group score
 def: "The probability based PeptideShaker protein group score." [PSI:PI]
-is_a: MS:1001153 ! search engine specific score
+xref: value-type:xsd\:float "The allowed value-type for this CV term."
+is_a: MS:1002363 ! search engine specific score for proteins
+is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
 id: MS:1002471
 name: PeptideShaker protein group confidence
 def: "The probability based PeptideShaker protein group confidence." [PSI:PI]
-is_a: MS:1001153 ! search engine specific score
+xref: value-type:xsd\:float "The allowed value-type for this CV term."
+is_a: MS:1002363 ! search engine specific score for proteins
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -16218,15 +16112,15 @@ id: MS:1002474
 name: ProteoAnnotator:non-canonical gene model score
 def: "The sum of peptide-level scores for peptides mapped only to non-canonical gene models within the group." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001147 ! protein ambiguity group result details
+is_a: MS:1002368 ! search engine specific score for protein groups
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
 id: MS:1002475
 name: ProteoAnnotator:count alternative peptides
 def: "The count of the number of peptide sequences mapped to non-canonical gene models only within the group." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
-is_a: MS:1001147 ! protein ambiguity group result details
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002368 ! search engine specific score for protein groups
 
 [Term]
 id: MS:1002476
@@ -16262,7 +16156,7 @@ relationship: part_of MS:0000000 ! Proteomics Standards Initiative Mass Spectrom
 [Term]
 id: MS:1002480
 name: regular expression for a digital object identifier (DOI)
-def: "(10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)." [PSI:PI, http://dx.doi.org/]
+def: "(10[.][0-9]\{4,\}(?:[.][0-9]+)*/(?:(?![\"&\'<>])[^ \t\\r\n\\v\\f])+)" [PSI:PI, http://dx.doi.org/]
 is_a: MS:1002479 ! regular expression
 
 [Term]
@@ -16281,30 +16175,31 @@ is_a: MS:1001060 ! quality estimation method details
 id: MS:1002483
 name: PSM-level statistical threshold
 def: "Estimated statistical threshold at PSM-level." [PSI:MS]
-is_a: MS:1002482 ! statistical threshold
+is_a: MS:1002573 ! spectrum identification statistical threshold
 
 [Term]
 id: MS:1002484
 name: peptide-level statistical threshold
 def: "Estimated statistical threshold at peptide-level." [PSI:MS]
-is_a: MS:1002482 ! statistical threshold
+is_a: MS:1002573 ! spectrum identification statistical threshold
 
 [Term]
 id: MS:1002485
 name: protein-level statistical threshold
 def: "Estimated statistical threshold at protein-level." [PSI:MS]
-is_a: MS:1002482 ! statistical threshold
+is_a: MS:1002572 ! protein detection statistical threshold
 
 [Term]
 id: MS:1002486
 name: protein group-level statistical threshold
 def: "Estimated statistical threshold at protein group-level." [PSI:PI]
-is_a: MS:1002482 ! statistical threshold
+is_a: MS:1002572 ! protein detection statistical threshold
 
 [Term]
 id: MS:1002487
 name: MassIVE dataset identifier
 def: "Dataset identifier issued by the MassIVE repository. A dataset can refer to either a single sample as part of a study, or all samples that are part of the study corresponding to a publication." [PSI:PI]
+xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1000878 ! external reference identifier
 
 [Term]
@@ -16361,62 +16256,64 @@ is_a: MS:1002489 ! special processing
 id: MS:1002496
 name: group PSMs by sequence
 def: "Group PSMs by distinct peptide sequence ignoring modifications." [PSI:PI]
-is_a: MS:1002345 ! PSM-level result details
+is_a: MS:1002658 ! identification parameter
 
 [Term]
 id: MS:1002497
 name: group PSMs by sequence with modifications
 def: "Group PSMs by distinct peptide sequence with taking modifications into account." [PSI:PI]
-is_a: MS:1002345 ! PSM-level result details
+is_a: MS:1002658 ! identification parameter
 
 [Term]
 id: MS:1002498
 name: group PSMs by sequence with modifications and charge
 def: "Group PSMs by distinct peptide sequence with taking modifications and charge into account." [PSI:PI]
-is_a: MS:1002345 ! PSM-level result details
+is_a: MS:1002658 ! identification parameter
 
 [Term]
 id: MS:1002499
 name: peptide level score
-def: "Peptide level score." [PSI:PI]
+def: "OBSOLETE Peptide level score." [PSI:PI]
+comment: This term was obsoleted because it was never intended to go in the CV.
 is_a: MS:1002358 ! search engine specific score for distinct peptides
+is_obsolete: true
 
 [Term]
 id: MS:1002500
 name: peptide passes threshold
 def: "A Boolean attribute to determine whether the peptide has passed the threshold indicated in the file." [PSI:PI]
 xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1002501
 name: no PSM threshold
 def: "Indicating that no PSM threshold was used." [PSI:PI]
-is_a: MS:1002345 ! PSM-level result details
+is_a: MS:1002701 ! PSM-level result list statistic
 
 [Term]
 id: MS:1002502
 name: no peptide-level threshold
 def: "Indicating that no peptide-level threshold was used." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1002503
 name: PSM is used for peptide-level scoring
 def: "Flags a PSM that it is used for peptide-level scoring." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1002504
-name: order
+name: modification index
 def: "The order of modifications to be referenced elsewhere in the document." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1001055 ! modification parameters
 
 [Term]
 id: MS:1002505
 name: regular expression for modification localization scoring
-def: "([:digit:]+:[0|1]\{1\}.[:digit:]+:[:digit:]+[|]\{1\}[:digit:]+:(true|false)\{1\})" [PSI:PI]
+def: "([:digit:]+:[0|1]\{1\}.[:digit:]+[Ee]{0,1}[+-]{0,1}[:digit:]*:[:digit:]+[|]\{1\}[:digit:]+:(true|false)\{1\})" [PSI:PI]
 is_a: MS:1002479 ! regular expression
 
 [Term]
@@ -16437,7 +16334,7 @@ relationship: has_regexp MS:1002505 ! regular expression for modification locali
 id: MS:1002508
 name: cross-linking attribute
 def: "Cross-linking attribute." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1002694 ! single identification result attribute
 
 [Term]
 id: MS:1002509
@@ -16448,8 +16345,8 @@ is_a: MS:1002508 ! cross-linking attribute
 
 [Term]
 id: MS:1002510
-name: cross-link receiver
-def: "Cross-linking receiver, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
+name: cross-link acceptor
+def: "Cross-linking acceptor, assigned according to the following rules: the export software SHOULD use the following rules to choose the cross-link donor as the: longer peptide, then higher peptide neutral mass, then alphabetical order." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
 
@@ -16457,7 +16354,7 @@ is_a: MS:1002508 ! cross-linking attribute
 id: MS:1002511
 name: cross-link spectrum identification item
 def: "Cross-linked spectrum identification item." [PSI:PI]
-xref: value-type:xsd\:integer "The allowed value-type for this CV term."
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
 is_a: MS:1002508 ! cross-linking attribute
 
 [Term]
@@ -16465,7 +16362,7 @@ id: MS:1002512
 name: cross-linking score
 def: "Cross-linking scoring value." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1002363 ! search engine specific score for proteins
 
 [Term]
 id: MS:1002513
@@ -16506,21 +16403,21 @@ id: MS:1002518
 name: Progenesis:protein group normalised abundance
 def: "The data type normalised abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002739 ! protein group-level quantification datatype
 
 [Term]
 id: MS:1002519
 name: Progenesis:protein group raw abundance
 def: "The data type raw abundance for protein groups produced by Progenesis LC-MS." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001805 ! quantification datatype
+is_a: MS:1002739 ! protein group-level quantification datatype
 
 [Term]
 id: MS:1002520
 name: peptide group ID
 def: "Peptide group identifier for peptide-level stats." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1002521
@@ -16603,7 +16500,7 @@ is_a: MS:1000767 ! native spectrum identifier format
 [Term]
 id: MS:1002533
 name: TripleTOF 6600
-def: "AB SCIEX TripleTOF 6600, a quadrupole - quadrupole - time-of-flight mass spectrometer." [PSI:MS]
+def: "SCIEX TripleTOF 6600, a quadrupole - quadrupole - time-of-flight mass spectrometer." [PSI:MS]
 is_a: MS:1000121 ! SCIEX instrument model
 
 [Term]
@@ -16611,8 +16508,7 @@ id: MS:1002534
 name: ProLuCID:xcorr
 def: "The ProLuCID result 'XCorr'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -16620,23 +16516,22 @@ id: MS:1002535
 name: ProLuCID:deltacn
 def: "The ProLuCID result 'DeltaCn'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 
 [Term]
 id: MS:1002536
 name: D-Score
 def: "D-Score for PTM site location at the PSM-level." [DOI:10.1002/pmic.201200408, PMID:23307401]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001968 ! PTM localization score
+is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
 id: MS:1002537
 name: MD-Score
-def: "MD-Score for PTM site location at the PSM-level." [DOI:10.1074/mcp.M110.003830-1, PMID:21057138]
+def: "MD-Score for PTM site location at the PSM-level." [DOI:10.1074/mcp.M110.003830–1, PMID:21057138]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001968 ! PTM localization score
+is_a: MS:1001968 ! PTM localization PSM-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
@@ -16658,21 +16553,21 @@ id: MS:1002540
 name: PeptideShaker PSM confidence type
 def: "PeptideShaker quality criteria for the confidence of PSM's." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1002347 ! PSM-level identification confidence metric
+is_a: MS:1002347 ! PSM-level identification statistic
 
 [Term]
 id: MS:1002541
 name: PeptideShaker peptide confidence type
 def: "PeptideShaker quality criteria for the confidence of peptide identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001092 ! peptide identification confidence metric
+is_a: MS:1002358 ! search engine specific peptide sequence-level identification statistic
 
 [Term]
 id: MS:1002542
 name: PeptideShaker protein confidence type
 def: "PeptideShaker quality criteria for the confidence of protein identifications." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1001198 ! protein identification confidence metric
+is_a: MS:1001116 ! single protein identification statistic
 
 [Term]
 id: MS:1002543
@@ -16691,8 +16586,7 @@ id: MS:1002545
 name: xi:score
 def: "The xi result 'Score'." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -16711,21 +16605,21 @@ is_a: MS:1001805 ! quantification datatype
 [Term]
 id: MS:1002548
 name: distributed normalized spectral abundance factor
-def: "A distributed normalized spectral abundance factor (dNSAF." [DOI:10.1021/ac9023999, PMID:20166708] 
+def: "A distributed normalized spectral abundance factor (dNSAF)." [DOI:10.1021/ac9023999, PMID:20166708] 
 is_a: MS:1001805 ! quantification datatype
 
 [Term]
 id: MS:1002549
-name: peptide-level PTM localization score
-def: "A score that assign confidence to the localization of an amino acid modification on a peptide sequence at the peptide-level." [PSI:PI]
-is_a: MS:1001405 ! spectrum identification result details
+name: PTM localization distinct peptide-level statistic
+def: "Statistic to convey the confidence of the localization of an amino acid modification on a peptide sequence." [PSI:PI]
+is_a: MS:1002689 ! PTM localization single result statistic
 
 [Term]
 id: MS:1002550
 name: peptide:phosphoRS score
 def: "phosphoRS score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1002549 ! peptide-level PTM localization score
+is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
@@ -16733,7 +16627,7 @@ id: MS:1002551
 name: peptide:Ascore
 def: "A-score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1002549 ! peptide-level PTM localization score
+is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
@@ -16741,7 +16635,7 @@ id: MS:1002552
 name: peptide:H-Score
 def: "H-Score for peptide phosphorylation site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1002549 ! peptide-level PTM localization score
+is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
@@ -16749,7 +16643,7 @@ id: MS:1002553
 name: peptide:D-Score
 def: "D-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1002549 ! peptide-level PTM localization score
+is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
@@ -16757,7 +16651,7 @@ id: MS:1002554
 name: peptide:MD-Score
 def: "MD-Score for PTM site location at the peptide-level." [PSI:PI]
 xref: value-type:xsd\:string "The allowed value-type for this CV term."
-is_a: MS:1002549 ! peptide-level PTM localization score
+is_a: MS:1002549 ! PTM localization distinct peptide-level statistic
 relationship: has_regexp MS:1002505 ! regular expression for modification localization scoring
 
 [Term]
@@ -16795,7 +16689,7 @@ xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002555 ! PTM localization score threshold
 
 [Term]
-id: MS:10025560
+id: MS:1002560
 name: DeBunker:score threshold
 def: "Threshold for DeBunker PTM site location score." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
@@ -17272,7 +17166,7 @@ is_a: MS:1002489 ! special processing
 id: MS:1002636
 name: proteogenomics attribute
 def: "Proteogenomics attribute." [PSI:PI]
-is_a: MS:1001105 ! peptide result details
+is_a: MS:1001105 ! peptide sequence-level identification attribute
 
 [Term]
 id: MS:1002637
@@ -17459,9 +17353,7 @@ id: MS:1002662
 name: Morpheus:Morpheus score
 def: "Morpheus score for PSMs." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
-is_a: MS:1001143 ! search engine specific score for PSMs
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001405 ! spectrum identification result details
+is_a: MS:1001143 ! PSM-level search engine specific statistic
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -17470,8 +17362,6 @@ name: Morpheus:summed Morpheus score
 def: "Summed Morpheus score for protein groups." [PSI:PI]
 xref: value-type:xsd\:double "The allowed value-type for this CV term."
 is_a: MS:1002368 ! search engine specific score for protein groups
-is_a: MS:1001153 ! search engine specific score
-is_a: MS:1001147 ! protein ambiguity group result details
 relationship: has_order MS:1002108 ! higher score better
 
 [Term]
@@ -17572,15 +17462,15 @@ relationship: has_regexp MS:1002665 ! ([:digit:]+[.][a|b]:[:digit:]+:[:digit:]+[
 
 [Term]
 id: MS:1002678
-name: supplemental higher energy beam-type collision-induced dissociation
-def: "A supplemental collision-induced dissociation process wherein the projectile ion has the translational energy higher than approximately 1000 eV." [PSI:MS]
+name: supplemental beam-type collision-induced dissociation
+def: "A supplemental collision-induced dissociation process that occurs in a beam-type collision cell in addition to another primary type of dissociation." [PSI:MS]
 is_a: MS:1000422 ! beam-type collision-induced dissociation
 
 [Term]
 id: MS:1002679
 name: supplemental collision-induced dissociation
 def: "The dissociation of an ion after supplemental collisional excitation." [PSI:MS]
-is_a: MS:1000044 ! dissociation method
+is_a: MS:1000133 ! collision-induced dissociation
 
 [Term]
 id: MS:1002680
@@ -17646,3 +17536,364 @@ is_a: MS:1001143 ! search engine specific score for PSMs
 is_a: MS:1001153 ! search engine specific score
 relationship: has_order MS:1002108 ! higher score better
 relationship: has_domain MS:1002305 ! value between 0 and 1 inclusive
+
+[Term]
+id: MS:1002687
+name: analysis attribute
+def: "Attribute of an item in the result of mass spectrometry proteomics data analysis." [PSI:PI]
+is_a: MS:1001405 ! spectrum identification result details
+
+[Term]
+id: MS:1002688
+name: PTM localization attribute
+def: "Statistic derived from a post-translational modification localization analysis." [PSI:PI]
+is_a: MS:1002687 ! analysis attribute
+
+[Term]
+id: MS:1002689
+name: PTM localization single result statistic
+def: "Statistic for a single item derived from a post-translational modification localization analysis." [PSI:PI]
+is_a: MS:1002688 ! PTM localization attribute
+
+[Term]
+id: MS:1002690
+name: PTM localization result list statistic
+def: "Statistic for all items derived from a post-translational modification localization analysis." [PSI:PI]
+is_a: MS:1002688 ! PTM localization attribute
+
+[Term]
+id: MS:1002691
+name: global FLR
+def: "Global false localization rate for all localizations in a dataset." [PSI:PI]
+is_a: MS:1002690 ! PTM localization result list statistic
+
+[Term]
+id: MS:1002692
+name: local FLR at threshold
+def: "Local false localization rate for the bottom item in list of localizations sorted from most to least confident." [PSI:PI]
+is_a: MS:1002690 ! PTM localization result list statistic
+
+[Term]
+id: MS:1002693
+name: identification attribute
+def: "Attribute of an identification item in the result of mass spectrometry proteomics data analysis." [PSI:PI]
+is_a: MS:1002687 ! analysis attribute
+
+[Term]
+id: MS:1002694
+name: single identification result attribute
+def: "Attribute of a single identification item (as opposed to a list) in the result of mass spectrometry proteomics data analysis." [PSI:PI]
+is_a: MS:1002693 ! identification attribute
+
+[Term]
+id: MS:1002695
+name: frag: isobaric label ion
+def: "Fragment ion corresponding to an isobaric label artifact." [PSI:PI]
+is_a: MS:1002307 ! fragmentation ion type
+
+[Term]
+id: MS:1002697
+name: secondary isotope peak
+def: "Fragment ion is an isotopic peak other than that monoisotopic peak. This is used in conjuction with another ion type, such as frag: y ion." [PSI:PI]
+is_a: MS:1002307 ! fragmentation ion type
+
+[Term]
+id: MS:1002698
+name: protein cluster identification attribute
+def: "An attribute of the protein cluster concept as used in mzIdentML." [PSI:PI]
+is_a: MS:1002694 ! single identification result attribute
+
+[Term]
+id: MS:1002699
+name: result list attribute
+def: "General property of an entire result list." [PSI:PI]
+is_a: MS:1002693 ! identification attribute
+
+[Term]
+id: MS:1002700
+name: PSM-level result list attribute
+def: "General property of the list of all PSMs." [PSI:PI]
+is_a: MS:1002699 ! result list attribute
+
+[Term]
+id: MS:1002701
+name: PSM-level result list statistic
+def: "Statistic pertaining to the full list of all PSMs." [PSI:PI]
+is_a: MS:1002700 ! PSM-level result list attribute
+
+[Term]
+id: MS:1002702
+name: peptide sequence-level result list attribute
+def: "General property of all peptide sequences in the list." [PSI:PI]
+is_a: MS:1002699 ! result list attribute
+
+[Term]
+id: MS:1002703
+name: peptide sequence-level result list statistic
+def: "Statistic pertaining to all peptide sequences in the list." [PSI:PI]
+is_a: MS:1002702 ! peptide sequence-level result list attribute
+
+[Term]
+id: MS:1002704
+name: protein-level result list attribute
+def: "Attribute of an entire protein list." [PSI:PI]
+is_a: MS:1002699 ! result list attribute
+
+[Term]
+id: MS:1002705
+name: protein-level result list statistic
+def: "A statistical metric of an entire protein list." [PSI:PI]
+is_a: MS:1002704 ! protein-level result list attribute
+
+[Term]
+id: MS:1002706
+name: protein group-level result list statistic
+def: "Attrbiute of an entire list of protein groups." [PSI:PI]
+is_a: MS:1002405 ! protein group-level result list attribute
+
+[Term]
+id: MS:1002719
+name: Pegasus BT
+def: "LECO bench-top GC time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1001800 ! LECO instrument model
+
+[Term]
+id: MS:1002720
+name: MSPathFinder
+def: "PNNL top-down/bottom-up analysis software for identifying peptides and proteoforms in fragmentation mass spectra." [PSI:PI]
+is_a: MS:1001456 ! analysis software
+
+[Term]
+id: MS:1002721
+name: MSPathFinder:SpecEValue
+def: "MSPathFinder spectral E-value." [PSI:PI]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
+is_a: MS:1002353 ! PSM-level e-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_order MS:1002109 ! lower score better
+
+[Term]
+id: MS:1002722
+name: MSPathFinder:EValue
+def: "MSPathFinder E-value." [PSI:PI]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
+is_a: MS:1002353 ! PSM-level e-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_order MS:1002109 ! lower score better
+
+[Term]
+id: MS:1002723
+name: MSPathFinder:QValue
+def: "MSPathFinder Q-value." [PSI:PI]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
+is_a: MS:1002354 ! PSM-level q-value
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+
+[Term]
+id: MS:1002724
+name: MSPathFinder:PepQValue
+def: "MSPathFinder peptide-level Q-value." [PSI:PI]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+
+[Term]
+id: MS:1002725
+name: MSPathFinder:RawScore
+def: "MSPathFinder raw score." [PSI:PI]
+xref: value-type:xsd\:double "The allowed value-type for this CV term."
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+
+[Term]
+id: MS:1002726
+name: SYNAPT G2-Si
+def: "Waters Corporation SYNAPT G2-Si orthogonal acceleration time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1000126 ! Waters instrument model
+
+[Term]
+id: MS:1002727
+name: MALDI SYNAPT G2-Si
+def: "Waters Corporation MALDI SYNAPT G2-Si orthogonal acceleration time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1000126 ! Waters instrument model
+
+[Term]
+id: MS:1002728
+name: Vion IMS QTof
+def: "Waters Corporation Vion IMS QTof orthogonal acceleration time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1000126 ! Waters instrument model
+
+[Term]
+id: MS:1002729
+name: Xevo G2 XS Tof
+def: "Waters Corporation Xevo G2 XS Tof orthogonal acceleration time-of-flight mass spectrometer." [PSI:PI]
+is_a: MS:1000126 ! Waters instrument model
+
+[Term]
+id: MS:1002730
+name: Xevo TQ-XS
+def: "Waters Corporation Xevo TQ-XS triple quadrupole mass spectrometer." [PSI:PI]
+is_a: MS:1000126 ! Waters instrument model
+
+[Term]
+id: MS:1002731
+name: Xevo TQ-S micro
+def: "Waters Corporation Xevo TQ-S micro triple quadrupole mass spectrometer." [PSI:PI]
+is_a: MS:1000126 ! Waters instrument model
+
+[Term]
+id: MS:1002732
+name: Orbitrap Fusion Lumos
+def: "Thermo Scientific Orbitrap Fusion Lumos mass spectrometer with Tribrid architecture consisting of quadrupole mass filter, linear ion trap and Orbitrap mass analyzers." [PSI:PI]
+is_a: MS:1000494 ! Thermo Scientific instrument model
+
+[Term]
+id: MS:1002733
+name: peptide-level spectral count
+def: "The number of MS2 spectra identified for a peptide sequence specified by the amino acid one-letter codes plus optional PTMs in spectral counting." [PSI:PI]
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002737 ! peptide-level quantification datatype
+
+[Term]
+id: MS:1002734
+name: peptide ion-level spectral count
+def: "The number of MS2 spectra identified for a molecular ion defined by the peptide sequence represented by the amino acid one-letter codes, plus optional PTMs plus optional charged aducts plus the charge state, in spectral counting." [PSI:PI]
+xref: value-type:xsd\:int "The allowed value-type for this CV term."
+is_a: MS:1002737 ! peptide-level quantification datatype
+
+[Term]
+id: MS:1002735
+name: feature-level quantification datatype
+def: "The data type of the value reported in a QuantLayer for a feature." [PSI:PI]
+is_a: MS:1001805 ! quantification datatype
+
+[Term]
+id: MS:1002736
+name: PSM-level quantification datatype
+def: "The data type of the value reported in a QuantLayer for a PSM." [PSI:PI]
+is_a: MS:1001805 ! quantification datatype
+
+[Term]
+id: MS:1002737
+name: peptide-level quantification datatype
+def: "The data type of the value reported in a QuantLayer for a peptide." [PSI:PI]
+is_a: MS:1001805 ! quantification datatype
+
+[Term]
+id: MS:1002738
+name: protein-level quantification datatype
+def: "The data type of the value reported in a QuantLayer for a protein." [PSI:PI]
+is_a: MS:1001805 ! quantification datatype
+
+[Term]
+id: MS:1002739
+name: protein group-level quantification datatype
+def: "The data type of the value reported in a QuantLayer for a protein group." [PSI:PI]
+is_a: MS:1001805 ! quantification datatype
+
+[Term]
+id: MS:1002740
+name: unmapped peptide
+def: "Within the context of a proteogenomics approach, a peptide sequence that has not been mapped to a genomic location." [PSI:PI]
+is_a: MS:1002636 ! proteogenomics attribute
+
+[Term]
+id: MS:1002741
+name: unmapped protein
+def: "Within the context of a proteogenomics approach, a protein sequence that has not been mapped to a genomic location." [PSI:PI]
+is_a: MS:1002636 ! proteogenomics attribute
+
+[Term]
+id: MS:1002742
+name: noise array
+def: "A data array of noise values." [PSI:MS]
+xref: binary-data-type:MS\:1000521 "32-bit float"
+xref: binary-data-type:MS\:1000523 "64-bit float"
+is_a: MS:1000513 ! binary data array
+
+[Term]
+id: MS:1002743
+name: sampled noise m/z array
+def: "A data array of parallel, independent m/z values for a sampling of noise across a spectrum (typically much smaller than MS:1000514, the m/z array)." [PSI:MS]
+xref: binary-data-type:MS\:1000521 "32-bit float"
+xref: binary-data-type:MS\:1000523 "64-bit float"
+is_a: MS:1000513 ! binary data array
+relationship: has_units MS:1000040 ! m/z 
+
+[Term]
+id: MS:1002744
+name: sampled noise intensity array
+def: "A data array of intensity values for the amplitude of noise variation superposed on the baseline (MS:1002745) across a spectrum (for use with MS:1002743, sampled noise m/z array)." [PSI:MS]
+xref: binary-data-type:MS\:1000521 "32-bit float"
+xref: binary-data-type:MS\:1000523 "64-bit float"
+is_a: MS:1000513 ! binary data array
+relationship: has_units MS:1000131 ! number of detector counts
+
+[Term]
+id: MS:1002745
+name: sampled noise baseline array
+def: "A data array of baseline intensity values (the intensity in the absence of analytes) for a sampling of noise across a spectrum (for use with MS:1002743, sampled noise m/z array)." [PSI:MS]
+xref: binary-data-type:MS\:1000521 "32-bit float"
+xref: binary-data-type:MS\:1000523 "64-bit float"
+is_a: MS:1000513 ! binary data array
+
+[Term]
+id: MS:1002746
+name: MS-Numpress linear prediction compression followed by zlib compression
+def: "Compression using MS-Numpress linear prediction compression and zlib." [https://github.com/ms-numpress/ms-numpress]
+is_a: MS:1000572 ! binary data compression type
+
+[Term]
+id: MS:1002747
+name: MS-Numpress positive integer compression followed by zlib compression
+def: "Compression using MS-Numpress positive integer compression and zlib." [https://github.com/ms-numpress/ms-numpress]
+is_a: MS:1000572 ! binary data compression type
+
+[Term]
+id: MS:1002748
+name: MS-Numpress short logged float compression followed by zlib compression
+def: "Compression using MS-Numpress short logged float compression and zlib." [https://github.com/ms-numpress/ms-numpress]
+is_a: MS:1000572 ! binary data compression type
+
+[Term]
+id: MS:1002749
+name: Mascot:IntegratedSpectralLibrarySearch
+def: "Means that Mascot has integrated the search results of database and spectral library search into a single data set." [PSI:PI]
+xref: value-type:xsd\:boolean "The allowed value-type for this CV term."
+is_a: MS:1002095 ! Mascot input parameter
+
+[Term]
+id: MS:1002750
+name: NIST MSPepSearch
+def: "Search tool of the NIST (National Institute of Standrads and Technology) for spectral library searches." [PSI:PI]
+is_a: MS:1001456 ! analysis software
+
+[Term]
+id: MS:1002751
+name: NIST MSP format
+def: "MSP text format defined by the NIST." [PSI:PI]
+is_a: MS:1001347 ! database file formats
+
+[Term]
+id: MS:1002752
+name: database type spectral library
+def: "Database containing spectra." [PSI:PI]
+is_a: MS:1001073 ! database type
+
+[Term]
+id: MS:1002753
+name: value between 0 and 1000 inclusive
+def: "Value range for scores." [PSI:PI]
+is_a: MS:1002304 ! domain range
+
+[Term]
+id: MS:1002754
+name: MSPepSearch:score
+def: "MSPepSearch score (0 for entirely dissimilar and 1000 for identical observed spectrum and library spectrum." [PSI:PI]
+is_a: MS:1001143 ! PSM-level search engine specific statistic
+relationship: has_order MS:1002108 ! higher score better
+relationship: has_domain MS:1002753 ! value between 0 and 1000 inclusive
+
+[Term]
+id: MS:1002755
+name: combined ms-ms + spectral library search
+def: "A combined MS2 (with fragment ions) and spectral library search." [PSI:PI]
+is_a: MS:1001080 ! search type

--- a/share/OpenMS/CV/psi-ms.obo
+++ b/share/OpenMS/CV/psi-ms.obo
@@ -1,6 +1,6 @@
 format-version: 1.2
-data-version: 4.0.9
-date: 28:03:2017 09:20
+data-version: 4.0.10_rc1
+date: 29:03:2017 12:18
 saved-by: Gerhard Mayer
 auto-generated-by: OBO-Edit 2.3.1
 import: http://ontologies.berkeleybop.org/pato.obo

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -1219,11 +1219,11 @@ namespace OpenMS
           }
           else
           {
-            String score_name_placeholder = st.empty()?"search engine specific score for PSMs":st;
-            sii_tmp += String(5, '\t') + cv_.getTermByName("search engine specific score for PSMs").toXMLString(cv_ns);
+            String score_name_placeholder = st.empty()?"PSM-level search engine specific statistic":st;
+            sii_tmp += String(5, '\t') + cv_.getTermByName("PSM-level search engine specific statistic").toXMLString(cv_ns);
             sii_tmp += "\n" + String(5, '\t') + "<userParam name=\"" + score_name_placeholder
                          + "\" unitName=\"" + "xsd:double" + "\" value=\"" + sc + "\"/>";
-            LOG_WARN << "Converting unknown score type to search engine specific score from PSI controlled vocabulary." << std::endl;
+            LOG_WARN << "Converting unknown score type to PSM-level search engine specific statistic from PSI controlled vocabulary." << std::endl;
           }
           sii_tmp += "\n";
 

--- a/src/tests/topp/IDFileConverter_9_output.mzid
+++ b/src/tests/topp/IDFileConverter_9_output.mzid
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MzIdentML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://psi-pi.googlecode.com/svn/trunk/schema/mzIdentML1.1.0.xsd"
+	xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/schema/mzIdentML1.1.0.xsd"
 	xmlns="http://psidev.info/psi/pi/mzIdentML/1.1"
 	version="1.1.0"
-	id="OpenMS_7276556891837796968"
-	creationDate="2016-08-03T13:41:07">
+	id="OpenMS_14509930621887606273"
+	creationDate="2017-03-28T21:46:58">
 <cvList>
-	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies"  uri="http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="3.15.0"></cv>
-	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv>
-	<cv id="UO" fullName="UNIT-ONTOLOGY" uri="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/unit.obo"></cv>
+	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv> 
+ 	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv> 
+	<cv id="UO"     fullName="UNIT-ONTOLOGY" uri="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"></cv>
 </cvList>
 <AnalysisSoftwareList>
 	<AnalysisSoftware version="2.1.0" name="Mascot" id="SOF_5233264595117471314">
@@ -16,7 +16,7 @@
 			<cvParam accession="MS:1001207" cvRef="PSI-MS" name="Mascot"/>
 		</SoftwareName>
 	</AnalysisSoftware>
-	<AnalysisSoftware version="OpenMS TOPP v2.0.1" name="TOPP software" id="SOF_1147219038608936718">
+	<AnalysisSoftware version="OpenMS TOPP v2.1.0" name="TOPP software" id="SOF_13424404046998308790">
 		<SoftwareName>
 			<cvParam accession="MS:1000752" cvRef="PSI-MS" name="TOPP software"/>
 		</SoftwareName>
@@ -34,24 +34,24 @@
 	<DBSequence accession="PROT3" searchDatabase_ref="SDB_3332699010107892018" id="PROT_12999979801269632061">
 		<cvParam accession="MS:1001088" cvRef="PSI-MS" name="protein description" value="PROT3"/>
 	</DBSequence>
-	<Peptide id="PEP_1755235105885170967">
+	<Peptide id="PEP_14811341817612382122">
 		<PeptideSequence>PEPTIDERR</PeptideSequence>
-	</Peptide>
- 	<Peptide id="PEP_17716858074023296841">
-		<PeptideSequence>PEPTIDERRRRR</PeptideSequence>
-	</Peptide>
- 	<Peptide id="PEP_2927519776102075938">
-		<PeptideSequence>PEPTIDER</PeptideSequence>
-	</Peptide>
- 	<Peptide id="PEP_3023658190814908261">
+	</Peptide> 
+ 	<Peptide id="PEP_15050004366391181853">
 		<PeptideSequence>PEPTIDERRRR</PeptideSequence>
-	</Peptide>
- 	<Peptide id="PEP_8119044117483804262">
+	</Peptide> 
+ 	<Peptide id="PEP_16907355690727166316">
+		<PeptideSequence>PEPTIDER</PeptideSequence>
+	</Peptide> 
+ 	<Peptide id="PEP_3023658190814908261">
 		<PeptideSequence>PEPTIDERRR</PeptideSequence>
-	</Peptide>
- 	<PeptideEvidence id="PEV_10306100746905639127" peptide_ref="PEP_2927519776102075938" dBSequence_ref="PROT_15916652588957785155"/>
-	<PeptideEvidence id="PEV_16250062551099875712" peptide_ref="PEP_17716858074023296841" dBSequence_ref="PROT_12999979801269632061"/>
-	<PeptideEvidence id="PEV_16907355690727166316" peptide_ref="PEP_2927519776102075938" dBSequence_ref="PROT_13440783915218733453" post="B" pre="A"/>
+	</Peptide> 
+ 	<Peptide id="PEP_7276556891837796968">
+		<PeptideSequence>PEPTIDERRRRR</PeptideSequence>
+	</Peptide> 
+ 	<PeptideEvidence id="PEV_10306100746905639127" peptide_ref="PEP_16907355690727166316" dBSequence_ref="PROT_13440783915218733453" post="B" pre="A"/>
+	<PeptideEvidence id="PEV_1147219038608936718" peptide_ref="PEP_7276556891837796968" dBSequence_ref="PROT_12999979801269632061"/>
+	<PeptideEvidence id="PEV_12524258085768770586" peptide_ref="PEP_16907355690727166316" dBSequence_ref="PROT_15916652588957785155"/>
 </SequenceCollection>
 <AnalysisCollection>
 	<SpectrumIdentification id="SI_Mascot_2006-01-12T12:13:14" spectrumIdentificationProtocol_ref="SIP_17749660155506638460" spectrumIdentificationList_ref="SIL_4835329514588776807" activityDate="2006-01-12T12:13:14">
@@ -165,10 +165,10 @@
 					<cvParam cvRef="PSI-MS" accession="MS:1001227" name="product ion m/z error" unitAccession="MS:1000040" unitCvRef="PSI-MS" unitName="m/z"/>
 				</Measure>
 			</FragmentationTable>
-			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:nan@RT:nan" id="SIR_15050004366391181853">
-				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_17716858074023296841" calculatedMassToCharge="1580.87280307147" experimentalMassToCharge="nan" chargeState="1" id="SII_16177748921272733768">
-					<PeptideEvidenceRef peptideEvidence_ref="PEV_16250062551099875712"/>
-					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="search engine specific score for PSMs"/>
+			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:nan@RT:nan" id="SIR_16250062551099875712">
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_7276556891837796968" calculatedMassToCharge="1580.87280307147" experimentalMassToCharge="nan" chargeState="1" id="SII_11115414975438642789">
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_1147219038608936718"/> 
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="1.4"/>
 				</SpectrumIdentificationItem>
 			</SpectrumIdentificationResult>
@@ -186,26 +186,26 @@
 				</Measure>
 			</FragmentationTable>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="17" id="SIR_17413765565443951891">
-				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_2927519776102075938" calculatedMassToCharge="956.468357540271" experimentalMassToCharge="675.9" chargeState="1" id="SII_12524258085768770586">
-					<PeptideEvidenceRef peptideEvidence_ref="PEV_16907355690727166316"/>
-					<PeptideEvidenceRef peptideEvidence_ref="PEV_10306100746905639127"/>
-					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="search engine specific score for PSMs"/>
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_16907355690727166316" calculatedMassToCharge="956.468357540271" experimentalMassToCharge="675.9" chargeState="1" id="SII_1755235105885170967">
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_10306100746905639127"/> 
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_12524258085768770586"/> 
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="0.9"/>
 					<userParam name="name" unitName="xsd:string" value="PeptideHit"/>
 				</SpectrumIdentificationItem>
-				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_1755235105885170967" calculatedMassToCharge="1112.56946892307" experimentalMassToCharge="675.9" chargeState="1" id="SII_14811341817612382122">
-					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="search engine specific score for PSMs"/>
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_14811341817612382122" calculatedMassToCharge="1112.56946892307" experimentalMassToCharge="675.9" chargeState="1" id="SII_2684106197423007927">
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="1.4"/>
 				</SpectrumIdentificationItem>
 				<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="1234.5" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 			</SpectrumIdentificationResult>
-			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:nan@RT:nan" id="SIR_2684106197423007927">
-				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_8119044117483804262" calculatedMassToCharge="634.838928386321" experimentalMassToCharge="nan" chargeState="2" id="SII_17314619952666245179">
-					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="search engine specific score for PSMs"/>
+			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:nan@RT:nan" id="SIR_8119044117483804262">
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_3023658190814908261" calculatedMassToCharge="634.838928386321" experimentalMassToCharge="nan" chargeState="2" id="SII_7898004582401008768">
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="44.4"/>
 				</SpectrumIdentificationItem>
-				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_3023658190814908261" calculatedMassToCharge="712.889484077721" experimentalMassToCharge="nan" chargeState="2" id="SII_7898004582401008768">
-					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="search engine specific score for PSMs"/>
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_15050004366391181853" calculatedMassToCharge="712.889484077721" experimentalMassToCharge="nan" chargeState="2" id="SII_17716858074023296841">
+					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="33.3"/>
 				</SpectrumIdentificationItem>
 			</SpectrumIdentificationResult>


### PR DESCRIPTION
has quite a selection of goodies, including some that we need

```
+[Term]
+id: MS:1002746
+name: MS-Numpress linear prediction compression followed by zlib compression
```

this will allow us to write substantially smaller mzML files. We have to check whether this breaks things, maybe @mwalzer can comment. If any of the names of the CV terms has changed, we may get warnings in our tests ... 