### PR TITLE
Feature/rework ms experiment

### DIFF
--- a/doc/code_examples/Tutorial_ComparatorUtils.cpp
+++ b/doc/code_examples/Tutorial_ComparatorUtils.cpp
@@ -30,6 +30,9 @@
 
 #include <OpenMS/KERNEL/ComparatorUtils.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/CONCEPT/Types.h>
+
 using OpenMS::Int;
 using OpenMS::UInt;
 using OpenMS::Size;

--- a/doc/code_examples/Tutorial_MSExperiment.cpp
+++ b/doc/code_examples/Tutorial_MSExperiment.cpp
@@ -29,6 +29,8 @@
 //
 
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <iostream>
 
 using namespace OpenMS;

--- a/doc/code_examples/Tutorial_TheoreticalSpectrumGenerator.cpp
+++ b/doc/code_examples/Tutorial_TheoreticalSpectrumGenerator.cpp
@@ -30,6 +30,9 @@
 
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 #include <iostream>
 
 using namespace OpenMS;

--- a/src/openms/include/OpenMS/ANALYSIS/DENOVO/CompNovoIonScoringBase.h
+++ b/src/openms/include/OpenMS/ANALYSIS/DENOVO/CompNovoIonScoringBase.h
@@ -39,6 +39,7 @@
 // OpenMS includes
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 // stl includes
 #include <vector>

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -32,12 +32,16 @@
 // $Authors: David Wojnar, Timo Sachsenberg, Petra Gutenbrunner $
 // --------------------------------------------------------------------------
 
-#ifndef  OPENMS_ANALYSIS_ID_ASCORE_H
-#define  OPENMS_ANALYSIS_ID_ASCORE_H
+#ifndef OPENMS_ANALYSIS_ID_ASCORE_H
+#define OPENMS_ANALYSIS_ID_ASCORE_H
 
 #include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 #include <OpenMS/ANALYSIS/RNPXL/PScore.h>
+
 #include <limits>
 #include <vector>
 
@@ -185,3 +189,4 @@ class OPENMS_DLLAPI AScore
 } // namespace OpenMS
 
 #endif // OPENMS_ANALYSIS_ID_ASCORE_H
+

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
@@ -46,6 +46,7 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 
 #include <iosfwd>
 #include <vector>

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
@@ -36,7 +36,10 @@
 #define OPENMS_ANALYSIS_ID_PEPTIDEINDEXING_H
 
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideProteinResolution.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideProteinResolution.h
@@ -38,6 +38,8 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
 #include <vector>
 #include <set>
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ConfidenceScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ConfidenceScoring.h
@@ -47,6 +47,7 @@
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/FORMAT/TransformationXMLFile.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
 
 #include "OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/ALGO/Scoring.h"
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
@@ -222,7 +222,7 @@ namespace OpenMS
                            FeatureMap& out_featureFile, 
                            bool store_features, 
                            OpenSwathTSVWriter & tsv_writer,
-                           Interfaces::IMSDataConsumer<> * chromConsumer, 
+                           Interfaces::DefaultIMSDataConsumer * chromConsumer, 
                            int batchSize,
                            bool load_into_memory);
 
@@ -236,14 +236,14 @@ namespace OpenMS
                                     const FeatureMap & featureFile,
                                     FeatureMap& out_featureFile,
                                     bool store_features,
-                                    Interfaces::IMSDataConsumer<> * chromConsumer);
+                                    Interfaces::DefaultIMSDataConsumer * chromConsumer);
 
     /** @brief Perform MS1 extraction and store result in ms1_chromatograms
      *
     */
     void MS1Extraction_(const std::vector< OpenSwath::SwathMap > & swath_maps, 
                         std::map< std::string, OpenSwath::ChromatogramPtr >& ms1_chromatograms,
-                        Interfaces::IMSDataConsumer<> * chromConsumer, 
+                        Interfaces::DefaultIMSDataConsumer * chromConsumer, 
                         const ChromExtractParams & cp,
                         const OpenSwath::LightTargetedExperiment& transition_exp, 
                         const TransformationDescription& trafo_inverse,
@@ -410,7 +410,7 @@ namespace OpenMS
                                 FeatureMap& out_featureFile,
                                 bool store_features, 
                                 OpenSwathTSVWriter & tsv_writer,
-                                Interfaces::IMSDataConsumer<> * chromConsumer, 
+                                Interfaces::DefaultIMSDataConsumer * chromConsumer, 
                                 int batchSize,
                                 bool load_into_memory);
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
@@ -222,7 +222,7 @@ namespace OpenMS
                            FeatureMap& out_featureFile, 
                            bool store_features, 
                            OpenSwathTSVWriter & tsv_writer,
-                           Interfaces::DefaultIMSDataConsumer * chromConsumer, 
+                           Interfaces::IMSDataConsumer * chromConsumer, 
                            int batchSize,
                            bool load_into_memory);
 
@@ -236,14 +236,14 @@ namespace OpenMS
                                     const FeatureMap & featureFile,
                                     FeatureMap& out_featureFile,
                                     bool store_features,
-                                    Interfaces::DefaultIMSDataConsumer * chromConsumer);
+                                    Interfaces::IMSDataConsumer * chromConsumer);
 
     /** @brief Perform MS1 extraction and store result in ms1_chromatograms
      *
     */
     void MS1Extraction_(const std::vector< OpenSwath::SwathMap > & swath_maps, 
                         std::map< std::string, OpenSwath::ChromatogramPtr >& ms1_chromatograms,
-                        Interfaces::DefaultIMSDataConsumer * chromConsumer, 
+                        Interfaces::IMSDataConsumer * chromConsumer, 
                         const ChromExtractParams & cp,
                         const OpenSwath::LightTargetedExperiment& transition_exp, 
                         const TransformationDescription& trafo_inverse,
@@ -410,7 +410,7 @@ namespace OpenMS
                                 FeatureMap& out_featureFile,
                                 bool store_features, 
                                 OpenSwathTSVWriter & tsv_writer,
-                                Interfaces::DefaultIMSDataConsumer * chromConsumer, 
+                                Interfaces::IMSDataConsumer * chromConsumer, 
                                 int batchSize,
                                 bool load_into_memory);
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h
@@ -35,9 +35,10 @@
 #ifndef OPENMS_ANALYSIS_OPENSWATH_SWATHWINDOWLOADER_H
 #define OPENMS_ANALYSIS_OPENSWATH_SWATHWINDOWLOADER_H
 
-#include <vector>
 #include <OpenMS/config.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/SwathMap.h>
+
+#include <vector>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h
@@ -38,6 +38,7 @@
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h>
 
+#include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/KDTreeFeatureNode.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/KDTreeFeatureNode.h
@@ -36,7 +36,10 @@
 #define OPENMS_ANALYSIS_QUANTITATION_KDTREENODE_H
 
 #include <OpenMS/config.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
+
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/Macros.h>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/HyperScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/HyperScore.h
@@ -36,6 +36,8 @@
 #define OPENMS_ANALYSIS_RNPXL_HYPERSCORE_H
 
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CONCEPT/Macros.h>
 #include <vector>
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
@@ -35,10 +35,12 @@
 #ifndef OPENMS_ANALYSIS_RNPXL_MODIFIEDPEPTIDEGENERATOR_H
 #define OPENMS_ANALYSIS_RNPXL_MODIFIEDPEPTIDEGENERATOR_H
 
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CHEMISTRY/AASequence.h>
 #include <vector>
 #include <map>
 #include <set>
-#include <OpenMS/KERNEL/StandardTypes.h>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/PScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/PScore.h
@@ -37,6 +37,10 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 
+#include <OpenMS/CONCEPT/Types.h>
+#include <vector>
+#include <map>
+
 namespace OpenMS
 {
   /**

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/RNPxlModificationsGenerator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/RNPxlModificationsGenerator.h
@@ -35,10 +35,13 @@
 #ifndef OPENMS_ANALYSIS_RNPXL_RNPXLMODIFICATIONSGENERATOR_H
 #define OPENMS_ANALYSIS_RNPXL_RNPXLMODIFICATIONSGENERATOR_H
 
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <vector>
 #include <map>
 #include <set>
-#include <OpenMS/KERNEL/StandardTypes.h>
+#include <iostream>
 
 namespace OpenMS
 {  

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/RNPxlReport.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/RNPxlReport.h
@@ -39,6 +39,12 @@
 #include <OpenMS/ANALYSIS/RNPXL/RNPxlMarkerIonExtractor.h>
 #include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>
 
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+#include <OpenMS/CONCEPT/Constants.h>
+
 namespace OpenMS
 {
 

--- a/src/openms/include/OpenMS/ANALYSIS/TARGETED/InclusionExclusionList.h
+++ b/src/openms/include/OpenMS/ANALYSIS/TARGETED/InclusionExclusionList.h
@@ -38,6 +38,7 @@
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h
+++ b/src/openms/include/OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h
@@ -41,6 +41,7 @@
 #include <OpenMS/METADATA/CVTerm.h>
 #include <OpenMS/METADATA/CVTermList.h>
 #include <OpenMS/METADATA/Software.h>
+#include <OpenMS/METADATA/SourceFile.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>
 
 #include <vector>

--- a/src/openms/include/OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h
@@ -36,6 +36,13 @@
 #define OPENMS_ANALYSIS_TARGETED_TARGETEDEXPERIMENTHELPER_H
 
 #include <OpenMS/KERNEL/StandardTypes.h>
+
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/Macros.h>
+
+#include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/METADATA/CVTerm.h>
 #include <OpenMS/METADATA/CVTermList.h>
 #include <OpenMS/METADATA/CVTermListInterface.h>

--- a/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGenerator.h
@@ -38,8 +38,13 @@
 
 #include <OpenMS/config.h>
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
-#include <OpenMS/SIMULATION/SimTypes.h>
 #include <OpenMS/ANALYSIS/SVM/SVMWrapper.h>
+
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 
 #include <boost/random/mersenne_twister.hpp>
 

--- a/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.h
@@ -36,7 +36,12 @@
 #ifndef OPENMS_CHEMISTRY_SVMTHEORETICALSPECTRUMGENERATORSET_H
 #define OPENMS_CHEMISTRY_SVMTHEORETICALSPECTRUMGENERATORSET_H
 
-#include <OpenMS/SIMULATION/SimTypes.h>
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGenerator.h>
 

--- a/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorTrainer.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorTrainer.h
@@ -35,9 +35,14 @@
 #ifndef OPENMS_CHEMISTRY_SVMTHEORETICALSPECTRUMGENERATORTRAINER_H
 #define OPENMS_CHEMISTRY_SVMTHEORETICALSPECTRUMGENERATORTRAINER_H
 
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGenerator.h>
-#include <OpenMS/SIMULATION/SimTypes.h>
 #include <OpenMS/FORMAT/TextFile.h>
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/COMPARISON/CLUSTERING/ClusteringGrid.h
+++ b/src/openms/include/OpenMS/COMPARISON/CLUSTERING/ClusteringGrid.h
@@ -31,14 +31,20 @@
 // $Maintainer: Lars Nilse $
 // $Authors: Lars Nilse $
 // --------------------------------------------------------------------------
+#ifndef OPENMS_COMPARISON_CLUSTERING_CLUSTERINGGRID_H
+#define OPENMS_COMPARISON_CLUSTERING_CLUSTERINGGRID_H
+
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/DATASTRUCTURES/DPosition.h>
+
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/Macros.h>
 
 #include <map>
 #include <vector>
-
-#include <OpenMS/KERNEL/StandardTypes.h>
-
-#ifndef OPENMS_COMPARISON_CLUSTERING_CLUSTERINGGRID_H
-#define OPENMS_COMPARISON_CLUSTERING_CLUSTERINGGRID_H
+#include <list>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h
+++ b/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumAlignment.h
@@ -37,6 +37,9 @@
 
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 #include <vector>
 #include <map>
 #include <utility>

--- a/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumCheapDPCorr.h
+++ b/src/openms/include/OpenMS/COMPARISON/SPECTRA/SpectrumCheapDPCorr.h
@@ -39,6 +39,9 @@
 #include <OpenMS/COMPARISON/SPECTRA/PeakSpectrumCompareFunctor.h>
 #include <OpenMS/DATASTRUCTURES/Map.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 namespace OpenMS
 {
 

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/MarkerMower.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/MarkerMower.h
@@ -39,6 +39,9 @@
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/FILTERING/TRANSFORMERS/PeakMarker.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 #include <vector>
 #include <map>
 

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/NLargest.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/NLargest.h
@@ -39,6 +39,9 @@
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 namespace OpenMS
 {
 

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/Normalizer.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/Normalizer.h
@@ -39,6 +39,9 @@
 
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 #include <vector>
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/ParentPeakMower.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/ParentPeakMower.h
@@ -37,6 +37,8 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <vector>
 

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/Scaler.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/Scaler.h
@@ -37,6 +37,8 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <map>
 

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/SqrtMower.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/SqrtMower.h
@@ -37,6 +37,8 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <cmath>
 

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/ThresholdMower.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/ThresholdMower.h
@@ -37,6 +37,8 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/WindowMower.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/WindowMower.h
@@ -37,6 +37,8 @@
 
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <set>
 

--- a/src/openms/include/OpenMS/FORMAT/CachedMzML.h
+++ b/src/openms/include/OpenMS/FORMAT/CachedMzML.h
@@ -37,12 +37,13 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/ISpectrumAccess.h>
 
+#include <OpenMS/KERNEL/StandardDeclarations.h>
 #include <OpenMS/CONCEPT/Types.h>
-#include <OpenMS/CONCEPT/ProgressLogger.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/Macros.h>
 
 #include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
-#include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/CONCEPT/ProgressLogger.h>
 
 #include <fstream>
 

--- a/src/openms/include/OpenMS/FORMAT/ConsensusXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ConsensusXMLFile.h
@@ -150,4 +150,5 @@ protected:
   };
 } // namespace OpenMS
 
-#endif // OPENMS_FOMAT_CONSENSUSXMLFILE_H
+#endif // OPENMS_FORMAT_CONSENSUSXMLFILE_H
+

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -35,6 +35,7 @@
 #ifndef OPENMS_FORMAT_CONTROLLEDVOCABULARY_H
 #define OPENMS_FORMAT_CONTROLLEDVOCABULARY_H
 
+#include <OpenMS/DATASTRUCTURES/ListUtils.h> // StringList
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 #include <OpenMS/DATASTRUCTURES/Map.h>
 #include <OpenMS/CONCEPT/Exception.h>

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataAggregatingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataAggregatingConsumer.h
@@ -60,9 +60,6 @@ namespace OpenMS
       std::vector<SpectrumType> s_list;
 
     public:
-      typedef PeakMap MapType;
-      typedef MapType::SpectrumType SpectrumType;
-      typedef MapType::ChromatogramType ChromatogramType;
 
       /**
         @brief Constructor

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataAggregatingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataAggregatingConsumer.h
@@ -45,10 +45,10 @@ namespace OpenMS
 
     */
     class OPENMS_DLLAPI MSDataAggregatingConsumer :
-      public Interfaces::IMSDataConsumer<>
+      public Interfaces::DefaultIMSDataConsumer
     {
 
-      Interfaces::IMSDataConsumer<>* next_consumer_;
+      Interfaces::DefaultIMSDataConsumer* next_consumer_;
       double previous_rt_;
       bool rt_initialized_;
       SpectrumType s_tmp;
@@ -64,7 +64,7 @@ namespace OpenMS
 
         @note This does not transfer ownership of the consumer
       */
-      MSDataAggregatingConsumer(Interfaces::IMSDataConsumer<>* next_consumer) :
+      MSDataAggregatingConsumer(Interfaces::DefaultIMSDataConsumer* next_consumer) :
         next_consumer_(next_consumer),
         previous_rt_(0.0),
         rt_initialized_(false)

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataAggregatingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataAggregatingConsumer.h
@@ -37,6 +37,11 @@
 
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
+#include <OpenMS/KERNEL/StandardTypes.h>
+
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+
 namespace OpenMS
 {
 
@@ -45,10 +50,10 @@ namespace OpenMS
 
     */
     class OPENMS_DLLAPI MSDataAggregatingConsumer :
-      public Interfaces::DefaultIMSDataConsumer
+      public Interfaces::IMSDataConsumer
     {
 
-      Interfaces::DefaultIMSDataConsumer* next_consumer_;
+      Interfaces::IMSDataConsumer* next_consumer_;
       double previous_rt_;
       bool rt_initialized_;
       SpectrumType s_tmp;
@@ -64,7 +69,7 @@ namespace OpenMS
 
         @note This does not transfer ownership of the consumer
       */
-      MSDataAggregatingConsumer(Interfaces::DefaultIMSDataConsumer* next_consumer) :
+      MSDataAggregatingConsumer(Interfaces::IMSDataConsumer* next_consumer) :
         next_consumer_(next_consumer),
         previous_rt_(0.0),
         rt_initialized_(false)

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataCachedConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataCachedConsumer.h
@@ -50,7 +50,7 @@ namespace OpenMS
     */
     class OPENMS_DLLAPI MSDataCachedConsumer :
       public CachedmzML,
-      public Interfaces::IMSDataConsumer<>
+      public Interfaces::DefaultIMSDataConsumer
     {
       typedef PeakMap MapType;
       typedef MapType::SpectrumType SpectrumType;

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataCachedConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataCachedConsumer.h
@@ -56,9 +56,8 @@ namespace OpenMS
       public CachedmzML,
       public Interfaces::IMSDataConsumer
     {
-      typedef PeakMap MapType;
-      typedef MapType::SpectrumType SpectrumType;
-      typedef MapType::ChromatogramType ChromatogramType;
+      typedef MSSpectrum<> SpectrumType;
+      typedef MSChromatogram<> ChromatogramType;
 
     public:
 

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataCachedConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataCachedConsumer.h
@@ -37,6 +37,10 @@
 
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+
 #include <OpenMS/FORMAT/CachedMzML.h>
 
 namespace OpenMS
@@ -50,7 +54,7 @@ namespace OpenMS
     */
     class OPENMS_DLLAPI MSDataCachedConsumer :
       public CachedmzML,
-      public Interfaces::DefaultIMSDataConsumer
+      public Interfaces::IMSDataConsumer
     {
       typedef PeakMap MapType;
       typedef MapType::SpectrumType SpectrumType;

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataChainingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataChainingConsumer.h
@@ -57,7 +57,7 @@ namespace OpenMS
     MSDataTransformingConsumer * transforming_consumer_second = new MSDataTransformingConsumer(); // apply second transformation
     MSDataWritingConsumer * writing_consumer = new MSDataWritingConsumer(outfile); // writing to disk
 
-    std::vector<Interfaces::IMSDataConsumer<> *> consumer_list;
+    std::vector<Interfaces::DefaultIMSDataConsumer *> consumer_list;
     consumer_list.push_back(transforming_consumer_first);
     consumer_list.push_back(transforming_consumer_second);
     consumer_list.push_back(writing_consumer);
@@ -68,9 +68,9 @@ namespace OpenMS
 
   */
   class OPENMS_DLLAPI MSDataChainingConsumer :
-    public Interfaces::IMSDataConsumer< PeakMap >
+    public Interfaces::DefaultIMSDataConsumer
   {
-    std::vector<Interfaces::IMSDataConsumer<> *> consumers_;
+    std::vector<Interfaces::DefaultIMSDataConsumer *> consumers_;
 
   public:
 
@@ -89,7 +89,7 @@ namespace OpenMS
      * responsibility to delete the pointer to consumer afterwards.
      *
      */
-    MSDataChainingConsumer(std::vector<Interfaces::IMSDataConsumer<> *> consumers);
+    MSDataChainingConsumer(std::vector<Interfaces::DefaultIMSDataConsumer *> consumers);
 
     /**
      * @brief Destructor
@@ -107,7 +107,7 @@ namespace OpenMS
      * responsibility to delete the pointer to consumer afterwards.
      *
      */
-    void appendConsumer(Interfaces::IMSDataConsumer<> * consumer);
+    void appendConsumer(Interfaces::DefaultIMSDataConsumer * consumer);
 
     /**
      * @brief Set experimental settings for all consumers

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataChainingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataChainingConsumer.h
@@ -37,6 +37,8 @@
 
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
+#include <vector>
+
 namespace OpenMS
 {
 
@@ -57,7 +59,7 @@ namespace OpenMS
     MSDataTransformingConsumer * transforming_consumer_second = new MSDataTransformingConsumer(); // apply second transformation
     MSDataWritingConsumer * writing_consumer = new MSDataWritingConsumer(outfile); // writing to disk
 
-    std::vector<Interfaces::DefaultIMSDataConsumer *> consumer_list;
+    std::vector<Interfaces::IMSDataConsumer *> consumer_list;
     consumer_list.push_back(transforming_consumer_first);
     consumer_list.push_back(transforming_consumer_second);
     consumer_list.push_back(writing_consumer);
@@ -68,9 +70,9 @@ namespace OpenMS
 
   */
   class OPENMS_DLLAPI MSDataChainingConsumer :
-    public Interfaces::DefaultIMSDataConsumer
+    public Interfaces::IMSDataConsumer
   {
-    std::vector<Interfaces::DefaultIMSDataConsumer *> consumers_;
+    std::vector<Interfaces::IMSDataConsumer *> consumers_;
 
   public:
 
@@ -89,7 +91,7 @@ namespace OpenMS
      * responsibility to delete the pointer to consumer afterwards.
      *
      */
-    MSDataChainingConsumer(std::vector<Interfaces::DefaultIMSDataConsumer *> consumers);
+    MSDataChainingConsumer(std::vector<Interfaces::IMSDataConsumer *> consumers);
 
     /**
      * @brief Destructor
@@ -107,7 +109,7 @@ namespace OpenMS
      * responsibility to delete the pointer to consumer afterwards.
      *
      */
-    void appendConsumer(Interfaces::DefaultIMSDataConsumer * consumer);
+    void appendConsumer(Interfaces::IMSDataConsumer * consumer);
 
     /**
      * @brief Set experimental settings for all consumers

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataStoringConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataStoringConsumer.h
@@ -40,6 +40,7 @@
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/KERNEL/MSChromatogram.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataStoringConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataStoringConsumer.h
@@ -36,7 +36,10 @@
 #define OPENMS_FORMAT_DATAACCESS_MSDATASTORINGCONSUMER_H
 
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
+
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
 
 namespace OpenMS
 {
@@ -49,7 +52,7 @@ namespace OpenMS
 
   */
   class OPENMS_DLLAPI MSDataStoringConsumer :
-    public Interfaces::DefaultIMSDataConsumer
+    public Interfaces::IMSDataConsumer
   {
   private:
     PeakMap exp_;

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataStoringConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataStoringConsumer.h
@@ -49,7 +49,7 @@ namespace OpenMS
 
   */
   class OPENMS_DLLAPI MSDataStoringConsumer :
-    public Interfaces::IMSDataConsumer< PeakMap >
+    public Interfaces::DefaultIMSDataConsumer
   {
   private:
     PeakMap exp_;

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h
@@ -38,6 +38,10 @@
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+#include <OpenMS/KERNEL/Peak1D.h>
+#include <OpenMS/KERNEL/ChromatogramPeak.h>
 
 namespace OpenMS
 {
@@ -65,9 +69,6 @@ namespace OpenMS
     {
 
     public:
-      typedef PeakMap MapType;
-      typedef MapType::SpectrumType SpectrumType;
-      typedef MapType::ChromatogramType ChromatogramType;
 
       /**
         @brief Constructor

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h
@@ -59,7 +59,7 @@ namespace OpenMS
       Note that the spectrum gets transformed in-place.
     */
     class OPENMS_DLLAPI MSDataTransformingConsumer :
-      public Interfaces::IMSDataConsumer<>
+      public Interfaces::DefaultIMSDataConsumer
     {
 
     public:

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h
@@ -37,6 +37,8 @@
 
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
+#include <OpenMS/KERNEL/StandardTypes.h>
+
 namespace OpenMS
 {
 
@@ -59,7 +61,7 @@ namespace OpenMS
       Note that the spectrum gets transformed in-place.
     */
     class OPENMS_DLLAPI MSDataTransformingConsumer :
-      public Interfaces::DefaultIMSDataConsumer
+      public Interfaces::IMSDataConsumer
     {
 
     public:

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h
@@ -88,7 +88,7 @@ namespace OpenMS
     */
     class OPENMS_DLLAPI MSDataWritingConsumer : 
       public Internal::MzMLHandler,
-      public Interfaces::DefaultIMSDataConsumer
+      public Interfaces::IMSDataConsumer
     {
 
     public:

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h
@@ -88,7 +88,7 @@ namespace OpenMS
     */
     class OPENMS_DLLAPI MSDataWritingConsumer : 
       public Internal::MzMLHandler,
-      public Interfaces::IMSDataConsumer< PeakMap >
+      public Interfaces::DefaultIMSDataConsumer
     {
 
     public:

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h
@@ -101,29 +101,10 @@ namespace OpenMS
 
         @param filename Filename for the output mzML
       */
-      explicit MSDataWritingConsumer(String filename) :
-        Internal::MzMLHandler(MapType(), filename, MzMLFile().getVersion(), ProgressLogger()),
-        started_writing_(false),
-        writing_spectra_(false),
-        writing_chromatograms_(false),
-        spectra_written_(0),
-        chromatograms_written_(0),
-        spectra_expected_(0),
-        chromatograms_expected_(0),
-        add_dataprocessing_(false)
-      {
-        validator_ = new Internal::MzMLValidator(this->mapping_, this->cv_);
-
-        // open file in binary mode to avoid any line ending conversions
-        ofs_.open(filename.c_str(), std::ios::out | std::ios::binary);
-        ofs_.precision(writtenDigits(double()));
-      }
+      explicit MSDataWritingConsumer(String filename);
 
       /// Destructor
-      virtual ~MSDataWritingConsumer()
-      {
-        doCleanup_();
-      }
+      virtual ~MSDataWritingConsumer();
 
       /// @name IMSDataConsumer interface
       //@{
@@ -134,10 +115,7 @@ namespace OpenMS
           and the first spectrum/chromatogram, the class will deduce most of
           the header of the mzML file)
       */
-      virtual void setExperimentalSettings(const ExperimentalSettings& exp)
-      {
-        settings_ = exp;
-      }
+      virtual void setExperimentalSettings(const ExperimentalSettings& exp);
 
       /**
         @brief Set expected size of spectra and chromatograms to be written.
@@ -149,11 +127,7 @@ namespace OpenMS
         @param expectedSpectra Number of spectra expected
         @param expectedChromatograms Number of chromatograms expected
       */
-      virtual void setExpectedSize(Size expectedSpectra, Size expectedChromatograms)
-      {
-        spectra_expected_ = expectedSpectra;
-        chromatograms_expected_ = expectedChromatograms;
-      }
+      virtual void setExpectedSize(Size expectedSpectra, Size expectedChromatograms);
 
       /**
         @brief Consume a spectrum
@@ -163,51 +137,7 @@ namespace OpenMS
 
         @param s The spectrum to be written to mzML
       */
-      virtual void consumeSpectrum(SpectrumType & s)
-      {
-        if (writing_chromatograms_)
-        {
-          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-              "Cannot write spectra after writing chromatograms.");
-        }
-
-        // Process the spectrum 
-        SpectrumType scpy = s;
-        processSpectrum_(scpy);
-
-        // Add dataprocessing if required
-        if (add_dataprocessing_)
-        {
-          scpy.getDataProcessing().push_back(additional_dataprocessing_);
-        }
-
-        if (!started_writing_)
-        {
-          // This is the first data to be written -> start writing the header
-          // We also need to modify the map and add this dummy spectrum in
-          // order to write the header correctly
-          MapType dummy;
-          dummy = settings_;
-          dummy.addSpectrum(scpy);
-
-          //--------------------------------------------------------------------
-          //header
-          //--------------------------------------------------------------------
-          Internal::MzMLHandler::writeHeader_(ofs_, dummy, dps_, *validator_);
-          started_writing_ = true;
-        }
-        if (!writing_spectra_)
-        {
-          // This is the first spectrum, thus write the spectrumList header
-          ofs_ << "\t\t<spectrumList count=\"" << spectra_expected_ << "\" defaultDataProcessingRef=\"dp_sp_0\">\n";
-          writing_spectra_ = true;
-        }
-        bool renew_native_ids = false;
-        // TODO writeSpectrum assumes that dps_ has at least one value -> assert
-        // this here ...
-        Internal::MzMLHandler::writeSpectrum_(ofs_, scpy,
-                spectra_written_++, *validator_, renew_native_ids, dps_);
-      }
+      virtual void consumeSpectrum(SpectrumType & s);
 
       /**
         @brief Consume a chromatogram
@@ -217,47 +147,7 @@ namespace OpenMS
 
         @param c The chromatogram to be written to mzML
       */
-      virtual void consumeChromatogram(ChromatogramType & c)
-      {
-        // make sure to close an open List tag
-        if (writing_spectra_)
-        {
-          ofs_ << "\t\t</spectrumList>\n";
-        }
-
-        // Create copy and add dataprocessing if required
-        ChromatogramType ccpy = c;
-        processChromatogram_(ccpy);
-
-        if (add_dataprocessing_)
-        {
-          ccpy.getDataProcessing().push_back(additional_dataprocessing_);
-        }
-
-        if (!started_writing_)
-        {
-          // this is the first data to be written -> start writing the header
-          // We also need to modify the map and add this dummy chromatogram in
-          // order to write the header correctly
-          MapType dummy;
-          dummy = settings_;
-          dummy.addChromatogram(ccpy);
-
-          //--------------------------------------------------------------------
-          //header (fill also dps_ variable)
-          //--------------------------------------------------------------------
-          Internal::MzMLHandler::writeHeader_(ofs_, dummy, dps_, *validator_);
-          started_writing_ = true;
-        }
-        if (!writing_chromatograms_)
-        {
-          ofs_ << "\t\t<chromatogramList count=\"" << chromatograms_expected_ << "\" defaultDataProcessingRef=\"dp_sp_0\">\n";
-          writing_chromatograms_ = true;
-          writing_spectra_ = false;
-        }
-        Internal::MzMLHandler::writeChromatogram_(ofs_, ccpy,
-                chromatograms_written_++, *validator_);
-      }
+      virtual void consumeChromatogram(ChromatogramType & c);
       //@}
 
       /**
@@ -268,20 +158,17 @@ namespace OpenMS
 
         @param d The DataProcessing object to be added
       */
-      virtual void addDataProcessing(DataProcessing d)
-      {
-        additional_dataprocessing_ = DataProcessingPtr( new DataProcessing(d) );
-        add_dataprocessing_ = true;
-      }
+      virtual void addDataProcessing(DataProcessing d);
 
       /**
         @brief Return the number of spectra written.
       */
-      virtual Size getNrSpectraWritten() {return spectra_written_;}
+      virtual Size getNrSpectraWritten();
+
       /**
         @brief Return the number of chromatograms written.
       */
-      virtual Size getNrChromatogramsWritten() {return chromatograms_written_;}
+      virtual Size getNrChromatogramsWritten();
 
     private:
 
@@ -307,28 +194,7 @@ namespace OpenMS
 
         Will write the last tags to the file and close the file stream.
       */
-      virtual void doCleanup_()
-      {
-        //--------------------------------------------------------------------------------------------
-        //cleanup
-        //--------------------------------------------------------------------------------------------
-        // make sure to close an open List tag
-        if (writing_spectra_)
-        {
-          ofs_ << "\t\t</spectrumList>\n";
-        }
-        else if (writing_chromatograms_)
-        {
-          ofs_ << "\t\t</chromatogramList>\n";
-        }
-
-        // Only write the footer if we actually did start writing ... 
-        if (started_writing_) 
-          Internal::MzMLHandlerHelper::writeFooter_(ofs_, options_, spectra_offsets, chromatograms_offsets);
-
-        delete validator_;
-        ofs_.close();
-      }
+      virtual void doCleanup_();
 
     protected:
 
@@ -410,4 +276,5 @@ namespace OpenMS
 
 } //end namespace OpenMS
 
-#endif
+#endif // OPENMS_FORMAT_DATAACCESS_MSDATAWRITINGCONSUMER_H
+

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/NoopMSDataConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/NoopMSDataConsumer.h
@@ -44,12 +44,12 @@ namespace OpenMS
     @brief Consumer class that performs no operation.
 
     This is sometimes necessary to fulfill the requirement of passing an
-    valid Interfaces::IMSDataConsumer<> object or pointer but no operation is
+    valid Interfaces::DefaultIMSDataConsumer object or pointer but no operation is
     required.
 
   */
   class OPENMS_DLLAPI NoopMSDataConsumer :
-    public Interfaces::IMSDataConsumer< PeakMap >
+    public Interfaces::DefaultIMSDataConsumer
   {
   public:
 

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/NoopMSDataConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/NoopMSDataConsumer.h
@@ -44,12 +44,12 @@ namespace OpenMS
     @brief Consumer class that performs no operation.
 
     This is sometimes necessary to fulfill the requirement of passing an
-    valid Interfaces::DefaultIMSDataConsumer object or pointer but no operation is
+    valid Interfaces::IMSDataConsumer object or pointer but no operation is
     required.
 
   */
   class OPENMS_DLLAPI NoopMSDataConsumer :
-    public Interfaces::DefaultIMSDataConsumer
+    public Interfaces::IMSDataConsumer
   {
   public:
 

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
@@ -99,7 +99,7 @@ namespace OpenMS
    *
    */
   class OPENMS_DLLAPI FullSwathFileConsumer :
-    public Interfaces::IMSDataConsumer<>
+    public Interfaces::DefaultIMSDataConsumer
   {
 
 public:

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
@@ -99,7 +99,7 @@ namespace OpenMS
    *
    */
   class OPENMS_DLLAPI FullSwathFileConsumer :
-    public Interfaces::DefaultIMSDataConsumer
+    public Interfaces::IMSDataConsumer
   {
 
 public:

--- a/src/openms/include/OpenMS/FORMAT/FeatureXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/FeatureXMLFile.h
@@ -35,7 +35,6 @@
 #ifndef OPENMS_FORMAT_FEATUREXMLFILE_H
 #define OPENMS_FORMAT_FEATUREXMLFILE_H
 
-#include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/FORMAT/OPTIONS/FeatureFileOptions.h>
 #include <OpenMS/FORMAT/XMLFile.h>
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>

--- a/src/openms/include/OpenMS/FORMAT/FeatureXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/FeatureXMLFile.h
@@ -41,22 +41,31 @@
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/DATASTRUCTURES/ConvexHull2D.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>
+#include <OpenMS/DATASTRUCTURES/Map.h>
 
 #include <iosfwd>
 
 namespace OpenMS
 {
+  class Feature;
+  class FeatureMap;
+
   /**
-  @brief This class provides Input/Output functionality for feature maps
+    @brief This class provides Input/Output functionality for feature maps
 
-      A documented schema for this format can be found at http://open-ms.sourceforge.net/schemas/.
+    A documented schema for this format can be found at http://open-ms.sourceforge.net/schemas/.
 
-  @todo Take care that unique ids are assigned properly by TOPP tools before calling FeatureXMLFile::store().  There will be a message on LOG_INFO but we will make no attempt to fix the problem in this class.  (all developers)
+    @todo Take care that unique ids are assigned properly by TOPP tools before
+    calling FeatureXMLFile::store().  There will be a message on LOG_INFO but
+    we will make no attempt to fix the problem in this class.  (all developers)
 
-  @note This format will eventually be replaced by the HUPO-PSI AnalysisXML (mzIdentML and mzQuantML) formats!
+    @note This format will eventually be replaced by the HUPO-PSI AnalysisXML
+    (mzIdentML and mzQuantML) formats!
 
-  @ingroup FileIO
-*/
+    @ingroup FileIO
+  */
   class OPENMS_DLLAPI FeatureXMLFile :
     protected Internal::XMLHandler,
     public Internal::XMLFile,

--- a/src/openms/include/OpenMS/FORMAT/FileHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/FileHandler.h
@@ -37,26 +37,15 @@
 
 #include <OpenMS/config.h>
 #include <OpenMS/FORMAT/FileTypes.h>
-
-#include <OpenMS/FORMAT/DTAFile.h>
-#include <OpenMS/FORMAT/DTA2DFile.h>
-#include <OpenMS/FORMAT/MzXMLFile.h>
-#include <OpenMS/FORMAT/MzMLFile.h>
-#include <OpenMS/FORMAT/FeatureXMLFile.h>
-#include <OpenMS/FORMAT/MzDataFile.h>
-#include <OpenMS/FORMAT/MascotGenericFile.h>
-#include <OpenMS/FORMAT/MS2File.h>
-#include <OpenMS/FORMAT/XMassFile.h>
-
-#include <OpenMS/FORMAT/MsInspectFile.h>
-#include <OpenMS/FORMAT/SpecArrayFile.h>
-#include <OpenMS/FORMAT/KroenikFile.h>
-
-#include <OpenMS/KERNEL/ChromatogramTools.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
+#include <OpenMS/FORMAT/OPTIONS/PeakFileOptions.h>
 
 namespace OpenMS
 {
+  class PeakFileOptions;
+  class MSExperiment;
+  class FeatureMap;
+
   /**
     @brief Facilitates file handling by file type recognition.
 
@@ -121,133 +110,7 @@ public:
       @exception Exception::FileNotFound is thrown if the file could not be opened
       @exception Exception::ParseError is thrown if an error occurs during parsing
     */
-    bool loadExperiment(const String& filename, PeakMap& exp, FileTypes::Type force_type = FileTypes::UNKNOWN, ProgressLogger::LogType log = ProgressLogger::NONE, const bool rewrite_source_file = true, const bool compute_hash = true)
-    {
-      // setting the flag for hash recomputation only works if source file entries are rewritten 
-      OPENMS_PRECONDITION(rewrite_source_file || !compute_hash, "Can't compute hash if no SourceFile written");
-
-      //determine file type
-      FileTypes::Type type;
-      if (force_type != FileTypes::UNKNOWN)
-      {
-        type = force_type;
-      }
-      else
-      {
-        try
-        {
-          type = getType(filename);
-        }
-        catch (Exception::FileNotFound)
-        {
-          return false;
-        }
-      }
-
-      //load right file
-      switch (type)
-      {
-      case FileTypes::DTA:
-        exp.reset();
-        exp.resize(1);
-        DTAFile().load(filename, exp[0]);
-        break;
-
-      case FileTypes::DTA2D:
-      {
-        DTA2DFile f;
-        f.getOptions() = options_;
-        f.setLogType(log);
-        f.load(filename, exp);
-      }
-
-      break;
-
-      case FileTypes::MZXML:
-      {
-        MzXMLFile f;
-        f.getOptions() = options_;
-        f.setLogType(log);
-        f.load(filename, exp);
-      }
-
-      break;
-
-      case FileTypes::MZDATA:
-      {
-        MzDataFile f;
-        f.getOptions() = options_;
-        f.setLogType(log);
-        f.load(filename, exp);
-      }
-      break;
-
-      case FileTypes::MZML:
-      {
-        MzMLFile f;
-        f.getOptions() = options_;
-        f.setLogType(log);
-        f.load(filename, exp);
-        ChromatogramTools().convertSpectraToChromatograms<PeakMap >(exp, true);
-      }
-      break;
-
-      case FileTypes::MGF:
-      {
-        MascotGenericFile f;
-        f.setLogType(log);
-        f.load(filename, exp);
-      }
-
-      break;
-
-      case FileTypes::MS2:
-      {
-        MS2File f;
-        f.setLogType(log);
-        f.load(filename, exp);
-      }
-
-      break;
-
-      case FileTypes::XMASS:
-        exp.reset();
-        exp.resize(1);
-        XMassFile().load(filename, exp[0]);
-        XMassFile().importExperimentalSettings(filename, exp);
-
-        break;
-
-      default:
-        return false;
-
-        break;
-      }
-
-      if (rewrite_source_file)
-      {
-        SourceFile src_file;
-        src_file.setNameOfFile(File::basename(filename));
-        String path_to_file = File::path(File::absolutePath(filename)); //convert to absolute path and strip file name
-        
-        // make sure we end up with at most 3 forward slashes       
-        String uri = path_to_file.hasPrefix("/") ? String("file://") + path_to_file : String("file:///") + path_to_file;
-        src_file.setPathToFile(uri);
-        // this is more complicated since the data formats allowed by mzML are very verbose.
-        // this is prone to changing CV's... our writer will fall back to a default if the name given here is invalid.
-        src_file.setFileType(FileTypes::typeToMZML(type));
-
-        if (compute_hash)
-        {
-          src_file.setChecksum(computeFileHash(filename), SourceFile::SHA1);
-        }
-
-        exp.getSourceFiles().clear();
-        exp.getSourceFiles().push_back(src_file);
-      }
-
-      return true;
-    }
+    bool loadExperiment(const String& filename, MSExperiment& exp, FileTypes::Type force_type = FileTypes::UNKNOWN, ProgressLogger::LogType log = ProgressLogger::NONE, const bool rewrite_source_file = true, const bool compute_hash = true);
 
     /**
       @brief Stores an MSExperiment to a file
@@ -260,66 +123,7 @@ public:
 
       @exception Exception::UnableToCreateFile is thrown if the file could not be written
     */
-    void storeExperiment(const String& filename, const PeakMap& exp, ProgressLogger::LogType log = ProgressLogger::NONE)
-    {
-      //load right file
-      switch (getTypeByFileName(filename))
-      {
-      case FileTypes::DTA2D:
-      {
-        DTA2DFile f;
-        f.getOptions() = options_;
-        f.setLogType(log);
-        f.store(filename, exp);
-      }
-      break;
-
-      case FileTypes::MZXML:
-      {
-        MzXMLFile f;
-        f.getOptions() = options_;
-        f.setLogType(log);
-        if (!exp.getChromatograms().empty())
-        {
-          PeakMap exp2 = exp;
-          ChromatogramTools().convertChromatogramsToSpectra<PeakMap >(exp2);
-          f.store(filename, exp2);
-        }
-        else
-        {
-          f.store(filename, exp);
-        }
-      }
-      break;
-
-      case FileTypes::MZDATA:
-      {
-        MzDataFile f;
-        f.getOptions() = options_;
-        f.setLogType(log);
-        if (!exp.getChromatograms().empty())
-        {
-          PeakMap exp2 = exp;
-          ChromatogramTools().convertChromatogramsToSpectra<PeakMap >(exp2);
-          f.store(filename, exp2);
-        }
-        else
-        {
-          f.store(filename, exp);
-        }
-      }
-      break;
-
-      default:
-      {
-        MzMLFile f;
-        f.getOptions() = options_;
-        f.setLogType(log);
-        f.store(filename, exp);
-      }
-      break;
-      }
-    }
+    void storeExperiment(const String& filename, const MSExperiment& exp, ProgressLogger::LogType log = ProgressLogger::NONE);
 
     /**
       @brief Loads a file into a FeatureMap

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzIdentMLDOMHandler.h
@@ -44,6 +44,7 @@
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/METADATA/CVTermList.h>
 
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/dom/DOMDocument.hpp>

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -52,9 +52,8 @@
 #include <OpenMS/FORMAT/OPTIONS/PeakFileOptions.h>
 #include <OpenMS/FORMAT/Base64.h>
 #include <OpenMS/FORMAT/MSNumpressCoder.h>
-#include <OpenMS/FORMAT/VALIDATORS/SemanticValidator.h>
-#include <OpenMS/FORMAT/CVMappingFile.h>
 #include <OpenMS/FORMAT/ControlledVocabulary.h>
+#include <OpenMS/FORMAT/VALIDATORS/SemanticValidator.h>
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 #include <OpenMS/CONCEPT/Helpers.h>
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -180,7 +180,7 @@ public:
       }
 
       /// Set the IMSDataConsumer consumer which will consume the read data
-      void setMSDataConsumer(Interfaces::IMSDataConsumer<MapType>* consumer)
+      void setMSDataConsumer(Interfaces::DefaultIMSDataConsumer* consumer)
       {
         consumer_ = consumer;
       }
@@ -342,7 +342,7 @@ protected:
       const ProgressLogger& logger_;
 
       /// Consumer class to work on spectra
-      Interfaces::IMSDataConsumer<MapType>* consumer_;
+      Interfaces::DefaultIMSDataConsumer* consumer_;
 
       /// Counting spectra and chromatograms
       UInt scan_count;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -180,7 +180,7 @@ public:
       }
 
       /// Set the IMSDataConsumer consumer which will consume the read data
-      void setMSDataConsumer(Interfaces::DefaultIMSDataConsumer* consumer)
+      void setMSDataConsumer(Interfaces::IMSDataConsumer* consumer)
       {
         consumer_ = consumer;
       }
@@ -342,7 +342,7 @@ protected:
       const ProgressLogger& logger_;
 
       /// Consumer class to work on spectra
-      Interfaces::DefaultIMSDataConsumer* consumer_;
+      Interfaces::IMSDataConsumer* consumer_;
 
       /// Counting spectra and chromatograms
       UInt scan_count;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
@@ -104,7 +104,7 @@ public:
       }
 
       /// Set the IMSDataConsumer consumer which will consume the read data
-      void setMSDataConsumer(Interfaces::DefaultIMSDataConsumer * consumer)
+      void setMSDataConsumer(Interfaces::IMSDataConsumer * consumer)
       {
         consumer_ = consumer;
       }
@@ -162,7 +162,7 @@ protected:
       UInt spec_write_counter_;
 
       /// Consumer class to work on spectra
-      Interfaces::DefaultIMSDataConsumer* consumer_;
+      Interfaces::IMSDataConsumer* consumer_;
 
       /// Consumer class to work on spectra
       UInt scan_count_;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
@@ -104,7 +104,7 @@ public:
       }
 
       /// Set the IMSDataConsumer consumer which will consume the read data
-      void setMSDataConsumer(Interfaces::IMSDataConsumer<MapType> * consumer)
+      void setMSDataConsumer(Interfaces::DefaultIMSDataConsumer * consumer)
       {
         consumer_ = consumer;
       }
@@ -162,7 +162,7 @@ protected:
       UInt spec_write_counter_;
 
       /// Consumer class to work on spectra
-      Interfaces::IMSDataConsumer<MapType>* consumer_;
+      Interfaces::DefaultIMSDataConsumer* consumer_;
 
       /// Consumer class to work on spectra
       UInt scan_count_;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/TraMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/TraMLHandler.h
@@ -38,6 +38,7 @@
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
 #include <OpenMS/FORMAT/ControlledVocabulary.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
+#include <OpenMS/METADATA/SourceFile.h>
 #include <OpenMS/METADATA/CVTermList.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -40,6 +40,7 @@
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/CONCEPT/Macros.h>
 
+#include <OpenMS/DATASTRUCTURES/ListUtils.h> // StringList
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>

--- a/src/openms/include/OpenMS/FORMAT/InspectOutfile.h
+++ b/src/openms/include/OpenMS/FORMAT/InspectOutfile.h
@@ -38,6 +38,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>

--- a/src/openms/include/OpenMS/FORMAT/MascotXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MascotXMLFile.h
@@ -39,6 +39,7 @@
 #include <OpenMS/FORMAT/XMLFile.h>
 #include <OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 
 

--- a/src/openms/include/OpenMS/FORMAT/MzDataFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzDataFile.h
@@ -111,4 +111,5 @@ private:
 
 } // namespace OpenMS
 
-#endif // OPENMS_FOMAT_MZXMLFILE_H
+#endif // OPENMS_FORMAT_MZXMLFILE_H
+

--- a/src/openms/include/OpenMS/FORMAT/MzMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzMLFile.h
@@ -35,14 +35,12 @@
 #ifndef OPENMS_FORMAT_MZMLFILE_H
 #define OPENMS_FORMAT_MZMLFILE_H
 
+#include <OpenMS/INTERFACES/IMSDataConsumer.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/XMLFile.h>
-#include <OpenMS/FORMAT/HANDLERS/MzMLHandler.h>
 #include <OpenMS/FORMAT/OPTIONS/PeakFileOptions.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/CONCEPT/Exception.h>
-#include <OpenMS/METADATA/DocumentIdentifier.h>
-#include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
 namespace OpenMS
 {
@@ -95,13 +93,7 @@ public:
 
       @exception Exception::UnableToCreateFile is thrown if the file could not be created
     */
-    template <typename MapType>
-    void store(const String& filename, const MapType& map) const
-    {
-      Internal::MzMLHandler handler(map, filename, getVersion(), *this);
-      handler.setOptions(options_);
-      save_(filename, &handler);
-    }
+    void store(const String& filename, const PeakMap& map) const;
 
     /**
       @brief Transforms a map while loading using the supplied MSDataConsumer.
@@ -121,21 +113,7 @@ public:
       @param consumer Consumer class to operate on the input filename (implementing a transformation)
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file
     */
-    template <typename MapType>
-    void transform(const String& filename_in, Interfaces::IMSDataConsumer<MapType> * consumer, bool skip_full_count = false, bool skip_first_pass = false)
-    {
-      // First pass through the file -> get the meta-data and hand it to the consumer
-      if (!skip_first_pass) transformFirstPass_(filename_in, consumer, skip_full_count);
-
-      // Second pass through the data, now read the spectra!
-      {
-        MapType dummy;
-        Internal::MzMLHandler handler(dummy, filename_in, getVersion(), *this);
-        handler.setOptions(options_);
-        handler.setMSDataConsumer(consumer);
-        safeParse_(filename_in, &handler);
-      }
-    }
+    void transform(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, bool skip_full_count = false, bool skip_first_pass = false);
 
     /**
       @brief Transforms a map while loading using the supplied MSDataConsumer
@@ -151,23 +129,7 @@ public:
       @param map Map to store the resulting spectra and chromatograms
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file
     */
-    template <typename MapType>
-    void transform(const String& filename_in, Interfaces::IMSDataConsumer<MapType> * consumer, MapType& map, bool skip_full_count = false, bool skip_first_pass = false)
-    {
-      // First pass through the file -> get the meta-data and hand it to the consumer
-      if (!skip_first_pass) transformFirstPass_(filename_in, consumer, skip_full_count);
-
-      // Second pass through the data, now read the spectra!
-      {
-        PeakFileOptions tmp_options(options_);
-        Internal::MzMLHandler handler(map, filename_in, getVersion(), *this);
-        tmp_options.setAlwaysAppendData(true);
-        handler.setOptions(tmp_options);
-        handler.setMSDataConsumer(consumer);
-
-        safeParse_(filename_in, &handler);
-      }
-    }
+    void transform(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, PeakMap& map, bool skip_full_count = false, bool skip_first_pass = false);
 
     /**
       @brief Checks if a file validates against the XML schema.
@@ -189,29 +151,8 @@ public:
 
 protected:
 
-
     /// Perform first pass through the file and retrieve the meta-data to initialize the consumer
-    template <typename MapType>
-    void transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer<MapType> * consumer, bool skip_full_count)
-    {
-      // Create temporary objects and counters
-      PeakFileOptions tmp_options(options_);
-      Size scount = 0, ccount = 0;
-      MapType experimental_settings;
-      Internal::MzMLHandler handler(experimental_settings, filename_in, getVersion(), *this);
-
-      // set temporary options for handler
-      tmp_options.setSizeOnly(true);
-      tmp_options.setMetadataOnly( skip_full_count );
-      handler.setOptions(tmp_options);
-
-      safeParse_(filename_in, &handler);
-
-      // After parsing, collect information
-      handler.getCounts(scount, ccount);
-      consumer->setExpectedSize(scount, ccount);
-      consumer->setExperimentalSettings(experimental_settings);
-    }
+    void transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, bool skip_full_count);
 
     /// Safe parse that catches exceptions and handles them accordingly
     void safeParse_(const String & filename, Internal::XMLHandler * handler);

--- a/src/openms/include/OpenMS/FORMAT/MzMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzMLFile.h
@@ -41,11 +41,11 @@
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/CONCEPT/Exception.h>
 
+#include <OpenMS/DATASTRUCTURES/ListUtils.h> // StringList
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
 namespace OpenMS
 {
-
   /**
     @brief File adapter for MzML files
 

--- a/src/openms/include/OpenMS/FORMAT/MzMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzMLFile.h
@@ -115,7 +115,7 @@ public:
       @param consumer Consumer class to operate on the input filename (implementing a transformation)
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file
     */
-    void transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, bool skip_full_count = false, bool skip_first_pass = false);
+    void transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count = false, bool skip_first_pass = false);
 
     /**
       @brief Transforms a map while loading using the supplied MSDataConsumer
@@ -131,7 +131,7 @@ public:
       @param map Map to store the resulting spectra and chromatograms
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file
     */
-    void transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, PeakMap& map, bool skip_full_count = false, bool skip_first_pass = false);
+    void transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, PeakMap& map, bool skip_full_count = false, bool skip_first_pass = false);
 
     /**
       @brief Checks if a file validates against the XML schema.
@@ -154,7 +154,7 @@ public:
 protected:
 
     /// Perform first pass through the file and retrieve the meta-data to initialize the consumer
-    void transformFirstPass_(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, bool skip_full_count);
+    void transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count);
 
     /// Safe parse that catches exceptions and handles them accordingly
     void safeParse_(const String & filename, Internal::XMLHandler * handler);

--- a/src/openms/include/OpenMS/FORMAT/MzMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzMLFile.h
@@ -35,15 +35,17 @@
 #ifndef OPENMS_FORMAT_MZMLFILE_H
 #define OPENMS_FORMAT_MZMLFILE_H
 
-#include <OpenMS/INTERFACES/IMSDataConsumer.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/XMLFile.h>
 #include <OpenMS/FORMAT/OPTIONS/PeakFileOptions.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/CONCEPT/Exception.h>
 
+#include <OpenMS/INTERFACES/IMSDataConsumer.h>
+
 namespace OpenMS
 {
+
   /**
     @brief File adapter for MzML files
 
@@ -113,7 +115,7 @@ public:
       @param consumer Consumer class to operate on the input filename (implementing a transformation)
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file
     */
-    void transform(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, bool skip_full_count = false, bool skip_first_pass = false);
+    void transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, bool skip_full_count = false, bool skip_first_pass = false);
 
     /**
       @brief Transforms a map while loading using the supplied MSDataConsumer
@@ -129,7 +131,7 @@ public:
       @param map Map to store the resulting spectra and chromatograms
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file
     */
-    void transform(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, PeakMap& map, bool skip_full_count = false, bool skip_first_pass = false);
+    void transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, PeakMap& map, bool skip_full_count = false, bool skip_first_pass = false);
 
     /**
       @brief Checks if a file validates against the XML schema.
@@ -152,7 +154,7 @@ public:
 protected:
 
     /// Perform first pass through the file and retrieve the meta-data to initialize the consumer
-    void transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, bool skip_full_count);
+    void transformFirstPass_(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, bool skip_full_count);
 
     /// Safe parse that catches exceptions and handles them accordingly
     void safeParse_(const String & filename, Internal::XMLHandler * handler);

--- a/src/openms/include/OpenMS/FORMAT/MzTabFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTabFile.h
@@ -37,6 +37,11 @@
 
 #include <OpenMS/FORMAT/MzTab.h>
 
+#include <OpenMS/METADATA/PeptideHit.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+
 #include <boost/math/special_functions/fpclassify.hpp>
 
 #include <vector>

--- a/src/openms/include/OpenMS/FORMAT/MzXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzXMLFile.h
@@ -137,4 +137,4 @@ private:
   };
 } // namespace OpenMS
 
-#endif // OPENMS_FOMAT_MZXMLFILE_H
+#endif // OPENMS_FORMAT_MZXMLFILE_H

--- a/src/openms/include/OpenMS/FORMAT/MzXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzXMLFile.h
@@ -37,11 +37,8 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/XMLFile.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
-#include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/FORMAT/OPTIONS/PeakFileOptions.h>
-#include <OpenMS/FORMAT/HANDLERS/MzXMLHandler.h>
 #include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
 namespace OpenMS
@@ -91,11 +88,7 @@ public:
 
         @exception Exception::UnableToCreateFile is thrown if the file could not be created
     */
-    void store(const String & filename, const MapType & map) const
-    {
-      Internal::MzXMLHandler handler(map, filename, schema_version_, *this);
-      save_(filename, &handler);
-    }
+    void store(const String & filename, const MapType & map) const;
 
     /**
       @brief Transforms a map while loading using the supplied MSDataConsumer.
@@ -115,20 +108,7 @@ public:
       @param consumer Consumer class to operate on the input filename (implementing a transformation)
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file 
     */
-    void transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count = false)
-    {
-      // First pass through the file -> get the meta-data and hand it to the consumer
-      transformFirstPass_(filename_in, consumer, skip_full_count);
-      
-      // Second pass through the data, now read the spectra!
-      {
-        MapType dummy;
-        Internal::MzXMLHandler handler(dummy, filename_in, getVersion(), *this);
-        handler.setOptions(options_);
-        handler.setMSDataConsumer(consumer);
-        parse_(filename_in, &handler);
-      }
-    }
+    void transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count = false);
 
     /**
       @brief Transforms a map while loading using the supplied MSDataConsumer
@@ -144,46 +124,12 @@ public:
       @param map Map to store the resulting spectra and chromatograms
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file 
     */
-    void transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, MapType& map, bool skip_full_count = false)
-    {
-      // First pass through the file -> get the meta-data and hand it to the consumer
-      transformFirstPass_(filename_in, consumer, skip_full_count);
-
-      // Second pass through the data, now read the spectra!
-      {
-        PeakFileOptions tmp_options(options_);
-        Internal::MzXMLHandler handler(map, filename_in, getVersion(), *this);
-        tmp_options.setAlwaysAppendData(true);
-        handler.setOptions(tmp_options);
-        handler.setMSDataConsumer(consumer);
-
-        parse_(filename_in, &handler);
-      }
-    }
+    void transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, MapType& map, bool skip_full_count = false);
 
 protected:
 
     /// Perform first pass through the file and retrieve the meta-data to initialize the consumer
-    void transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count)
-    {
-      // Create temporary objects and counters
-      PeakFileOptions tmp_options(options_);
-      Size scount = 0, ccount = 0;
-      MapType experimental_settings;
-      Internal::MzXMLHandler handler(experimental_settings, filename_in, getVersion(), *this);
-
-      // set temporary options for handler
-      tmp_options.setSizeOnly(true);
-      tmp_options.setMetadataOnly( skip_full_count );
-      handler.setOptions(tmp_options);
-
-      parse_(filename_in, &handler);
-
-      // After parsing, collect information
-      scount = handler.getScanCount();
-      consumer->setExpectedSize(scount, ccount);
-      consumer->setExperimentalSettings(experimental_settings);
-    }
+    void transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count);
 
 private:
 

--- a/src/openms/include/OpenMS/FORMAT/MzXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzXMLFile.h
@@ -115,7 +115,7 @@ public:
       @param consumer Consumer class to operate on the input filename (implementing a transformation)
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file 
     */
-    void transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, bool skip_full_count = false)
+    void transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count = false)
     {
       // First pass through the file -> get the meta-data and hand it to the consumer
       transformFirstPass_(filename_in, consumer, skip_full_count);
@@ -144,7 +144,7 @@ public:
       @param map Map to store the resulting spectra and chromatograms
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file 
     */
-    void transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, MapType& map, bool skip_full_count = false)
+    void transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, MapType& map, bool skip_full_count = false)
     {
       // First pass through the file -> get the meta-data and hand it to the consumer
       transformFirstPass_(filename_in, consumer, skip_full_count);
@@ -164,7 +164,7 @@ public:
 protected:
 
     /// Perform first pass through the file and retrieve the meta-data to initialize the consumer
-    void transformFirstPass_(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, bool skip_full_count)
+    void transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count)
     {
       // Create temporary objects and counters
       PeakFileOptions tmp_options(options_);

--- a/src/openms/include/OpenMS/FORMAT/MzXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MzXMLFile.h
@@ -115,8 +115,7 @@ public:
       @param consumer Consumer class to operate on the input filename (implementing a transformation)
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file 
     */
-    template <typename MapType>
-    void transform(const String& filename_in, Interfaces::IMSDataConsumer<MapType> * consumer, bool skip_full_count = false)
+    void transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, bool skip_full_count = false)
     {
       // First pass through the file -> get the meta-data and hand it to the consumer
       transformFirstPass_(filename_in, consumer, skip_full_count);
@@ -145,8 +144,7 @@ public:
       @param map Map to store the resulting spectra and chromatograms
       @param skip_full_count Whether to skip computing the correct number of spectra and chromatograms in the input file 
     */
-    template <typename MapType>
-    void transform(const String& filename_in, Interfaces::IMSDataConsumer<MapType> * consumer, MapType& map, bool skip_full_count = false)
+    void transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, MapType& map, bool skip_full_count = false)
     {
       // First pass through the file -> get the meta-data and hand it to the consumer
       transformFirstPass_(filename_in, consumer, skip_full_count);
@@ -166,8 +164,7 @@ public:
 protected:
 
     /// Perform first pass through the file and retrieve the meta-data to initialize the consumer
-    template <typename MapType>
-    void transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer<MapType> * consumer, bool skip_full_count)
+    void transformFirstPass_(const String& filename_in, Interfaces::DefaultIMSDataConsumer * consumer, bool skip_full_count)
     {
       // Create temporary objects and counters
       PeakFileOptions tmp_options(options_);

--- a/src/openms/include/OpenMS/FORMAT/SwathFile.h
+++ b/src/openms/include/OpenMS/FORMAT/SwathFile.h
@@ -36,11 +36,13 @@
 #define OPENMS_FORMAT_SWATHFILE_H
 
 // Datastructures
+#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/DataStructures.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/SwathMap.h>
 
-#include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/METADATA/ExperimentalSettings.h>
+
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/MzXMLFile.h>
 #ifdef OPENMS_FORMAT_SWATHFILE_MZXMLSUPPORT

--- a/src/openms/include/OpenMS/FORMAT/TraMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/TraMLFile.h
@@ -37,11 +37,12 @@
 
 #include <OpenMS/FORMAT/XMLFile.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
-#include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
 
 namespace OpenMS
 {
   class Identification;
+  class TargetedExperiment;
 
   /**
       @brief File adapter for HUPO PSI TraML files

--- a/src/openms/include/OpenMS/FORMAT/TraMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/TraMLFile.h
@@ -90,5 +90,5 @@ private:
 
 } // namespace OpenMS
 
-#endif // OPENMS_FOMAT_TRAMLFILE_H
+#endif // OPENMS_FORMAT_TRAMLFILE_H
 

--- a/src/openms/include/OpenMS/FORMAT/TransformationXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/TransformationXMLFile.h
@@ -35,7 +35,6 @@
 #ifndef OPENMS_FORMAT_TRANSFORMATIONXMLFILE_H
 #define OPENMS_FORMAT_TRANSFORMATIONXMLFILE_H
 
-
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
 #include <OpenMS/FORMAT/XMLFile.h>

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzDataValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzDataValidator.h
@@ -35,10 +35,7 @@
 #ifndef OPENMS_FORMAT_VALIDATORS_MZDATAVALIDATOR_H
 #define OPENMS_FORMAT_VALIDATORS_MZDATAVALIDATOR_H
 
-
 #include <OpenMS/FORMAT/VALIDATORS/SemanticValidator.h>
-#include <OpenMS/FORMAT/ControlledVocabulary.h>
-
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzIdentMLValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzIdentMLValidator.h
@@ -35,10 +35,7 @@
 #ifndef OPENMS_FORMAT_VALIDATORS_MZIDENTMLVALIDATOR_H
 #define OPENMS_FORMAT_VALIDATORS_MZIDENTMLVALIDATOR_H
 
-
 #include <OpenMS/FORMAT/VALIDATORS/SemanticValidator.h>
-#include <OpenMS/FORMAT/ControlledVocabulary.h>
-
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzMLValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/MzMLValidator.h
@@ -35,10 +35,7 @@
 #ifndef OPENMS_FORMAT_VALIDATORS_MZMLVALIDATOR_H
 #define OPENMS_FORMAT_VALIDATORS_MZMLVALIDATOR_H
 
-
 #include <OpenMS/FORMAT/VALIDATORS/SemanticValidator.h>
-#include <OpenMS/FORMAT/ControlledVocabulary.h>
-
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/VALIDATORS/TraMLValidator.h
+++ b/src/openms/include/OpenMS/FORMAT/VALIDATORS/TraMLValidator.h
@@ -35,10 +35,7 @@
 #ifndef OPENMS_FORMAT_VALIDATORS_TRAMLVALIDATOR_H
 #define OPENMS_FORMAT_VALIDATORS_TRAMLVALIDATOR_H
 
-
 #include <OpenMS/FORMAT/VALIDATORS/SemanticValidator.h>
-#include <OpenMS/FORMAT/ControlledVocabulary.h>
-
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/XMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/XMLFile.h
@@ -36,12 +36,8 @@
 #define OPENMS_FORMAT_XMLFILE_H
 
 // OpenMS includes
-#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
-
-#include <xercesc/framework/XMLFormatter.hpp>
-
-#include <iosfwd>
 
 namespace OpenMS
 {
@@ -116,4 +112,5 @@ protected:
   }   // namespace Internal
 } // namespace OpenMS
 
-#endif // OPENMS_FOMAT_XMLFILE_H
+#endif // OPENMS_FORMAT_XMLFILE_H
+

--- a/src/openms/include/OpenMS/INTERFACES/IMSDataConsumer.h
+++ b/src/openms/include/OpenMS/INTERFACES/IMSDataConsumer.h
@@ -124,6 +124,8 @@ namespace Interfaces
       virtual void setExperimentalSettings(const ExperimentalSettings& exp) = 0;
     };
 
+    typedef IMSDataConsumer<MSExperiment> DefaultIMSDataConsumer;
+
 } //end namespace Interfaces
 } //end namespace OpenMS
 

--- a/src/openms/include/OpenMS/INTERFACES/IMSDataConsumer.h
+++ b/src/openms/include/OpenMS/INTERFACES/IMSDataConsumer.h
@@ -35,13 +35,13 @@
 #ifndef OPENMS_INTERFACES_IMSDATACONSUMER_H
 #define OPENMS_INTERFACES_IMSDATACONSUMER_H
 
-#include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
-#include <OpenMS/KERNEL/MSSpectrum.h>
-#include <OpenMS/KERNEL/MSChromatogram.h>
+#include <OpenMS/config.h>
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/CONCEPT/Types.h>
 
 namespace OpenMS
 {
+
 namespace Interfaces
 {
 
@@ -65,12 +65,11 @@ namespace Interfaces
       are expected to be called before consuming starts.
 
     */
-    template <typename MapType = PeakMap >
     class OPENMS_DLLAPI IMSDataConsumer
     {
     public:
-      typedef typename MapType::SpectrumType SpectrumType;
-      typedef typename MapType::ChromatogramType ChromatogramType;
+      typedef MSSpectrum<> SpectrumType;
+      typedef MSChromatogram<> ChromatogramType;
 
       virtual ~IMSDataConsumer() {}
 
@@ -108,7 +107,7 @@ namespace Interfaces
         @param expectedSpectra Number of spectra expected
         @param expectedChromatograms Number of chromatograms expected
       */
-      virtual void setExpectedSize(Size expectedSpectra, Size expectedChromatograms) = 0;
+      virtual void setExpectedSize(size_t expectedSpectra, size_t expectedChromatograms) = 0;
 
       /**
         @brief Set experimental settings (meta-data) of the data to be consumed
@@ -124,7 +123,7 @@ namespace Interfaces
       virtual void setExperimentalSettings(const ExperimentalSettings& exp) = 0;
     };
 
-    typedef IMSDataConsumer<MSExperiment> DefaultIMSDataConsumer;
+    typedef IMSDataConsumer IMSDataConsumer;
 
 } //end namespace Interfaces
 } //end namespace OpenMS

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -35,6 +35,7 @@
 #ifndef OPENMS_KERNEL_MSCHROMATOGRAM_H
 #define OPENMS_KERNEL_MSCHROMATOGRAM_H
 
+#include <OpenMS/KERNEL/StandardDeclarations.h>
 #include <OpenMS/METADATA/ChromatogramSettings.h>
 #include <OpenMS/METADATA/MetaInfoDescription.h>
 #include <OpenMS/KERNEL/RangeManager.h>
@@ -44,11 +45,13 @@
 
 namespace OpenMS
 {
+  class ChromatogramPeak;
+
   /**
     @brief The representation of a chromatogram.
     @ingroup Kernel
   */
-  template <typename PeakT = ChromatogramPeak>
+  template <typename PeakT>
   class MSChromatogram :
     private std::vector<PeakT>,
     public RangeManager<1>,

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -35,12 +35,15 @@
 #ifndef OPENMS_KERNEL_MSEXPERIMENT_H
 #define OPENMS_KERNEL_MSEXPERIMENT_H
 
+#include <OpenMS/KERNEL/StandardDeclarations.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/DRange.h>
 #include <OpenMS/KERNEL/AreaIterator.h>
 #include <OpenMS/KERNEL/MSChromatogram.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/Peak1D.h>
+#include <OpenMS/KERNEL/ChromatogramPeak.h>
 #include <OpenMS/METADATA/ExperimentalSettings.h>
 #include <OpenMS/SYSTEM/File.h>
 
@@ -1080,7 +1083,7 @@ private:
 
 } // namespace OpenMS
 
+#include <OpenMS/KERNEL/StandardTypes.h>
+
 #endif // OPENMS_KERNEL_MSEXPERIMENT_H
 
-
-#include <OpenMS/KERNEL/StandardTypes.h>

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -1082,3 +1082,5 @@ private:
 
 #endif // OPENMS_KERNEL_MSEXPERIMENT_H
 
+
+#include <OpenMS/KERNEL/StandardTypes.h>

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -35,6 +35,7 @@
 #ifndef OPENMS_KERNEL_MSSPECTRUM_H
 #define OPENMS_KERNEL_MSSPECTRUM_H
 
+#include <OpenMS/KERNEL/StandardDeclarations.h>
 #include <OpenMS/METADATA/SpectrumSettings.h>
 #include <OpenMS/METADATA/MetaInfoDescription.h>
 #include <OpenMS/KERNEL/RangeManager.h>
@@ -63,7 +64,7 @@ namespace OpenMS
 
     @ingroup Kernel
   */
-  template <typename PeakT = Peak1D>
+  template <typename PeakT>
   class MSSpectrum :
     private std::vector<PeakT>,
     public RangeManager<1>,

--- a/src/openms/include/OpenMS/KERNEL/StandardDeclarations.h
+++ b/src/openms/include/OpenMS/KERNEL/StandardDeclarations.h
@@ -1,0 +1,54 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2016.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Timo Sachsenberg $
+// $Authors: Andreas Bertsch $
+// --------------------------------------------------------------------------
+
+#ifndef OPENMS_KERNEL_FORWARD_H
+#define OPENMS_KERNEL_FORWARD_H
+
+// Forward declarations
+namespace OpenMS
+{
+  class Peak1D;
+  class RichPeak1D;
+  class ChromatogramPeak;
+
+  template <typename PeakT = Peak1D>
+  class MSSpectrum;
+
+  template <typename PeakT = ChromatogramPeak>
+  class MSChromatogram;
+
+  class MSExperiment;
+  class ExperimentalSettings;
+}
+#endif // OPENMS_KERNEL_FORWARD_H

--- a/src/openms/include/OpenMS/KERNEL/StandardTypes.h
+++ b/src/openms/include/OpenMS/KERNEL/StandardTypes.h
@@ -36,9 +36,7 @@
 #define OPENMS_KERNEL_STANDARDTYPES_H
 
 #include <OpenMS/config.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/KERNEL/RichPeak1D.h>
-#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/StandardDeclarations.h>
 
 namespace OpenMS
 {
@@ -76,3 +74,4 @@ namespace OpenMS
 }
 
 #endif // OPENMS_KERNEL_STANDARDTYPES_H
+

--- a/src/openms/include/OpenMS/MATH/MISC/BSpline2d.h
+++ b/src/openms/include/OpenMS/MATH/MISC/BSpline2d.h
@@ -38,7 +38,10 @@
 #include <vector>
 
 #include <OpenMS/config.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/Macros.h>
 
 // forward declaration of impl class BSpline
 namespace eol_bspline

--- a/src/openms/include/OpenMS/MATH/MISC/CubicSpline2d.h
+++ b/src/openms/include/OpenMS/MATH/MISC/CubicSpline2d.h
@@ -36,8 +36,13 @@
 #define OPENMS_MATH_MISC_CUBICSPLINE2D_H
 
 #include <OpenMS/config.h>
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/Macros.h>
 
 #include <vector>
+#include <algorithm>
 #include <map>
 
 namespace OpenMS

--- a/src/openms/include/OpenMS/METADATA/CVTermList.h
+++ b/src/openms/include/OpenMS/METADATA/CVTermList.h
@@ -37,8 +37,7 @@
 
 #include <OpenMS/METADATA/CVTerm.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
-#include <OpenMS/DATASTRUCTURES/CVMappingRule.h>
-#include <OpenMS/FORMAT/ControlledVocabulary.h>
+#include <OpenMS/DATASTRUCTURES/Map.h>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -44,6 +44,7 @@
 namespace OpenMS
 {
   class PeptideIdentification;
+
   /**
     @brief Representation of a protein identification run
 

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h
@@ -36,8 +36,11 @@
 #define OPENMS_TRANSFORMATIONS_FEATUREFINDER_MULTIPLEXDELTAMASSES_H
 
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <vector>
+#include <set>
 #include <algorithm>
 #include <iostream>
 

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -33,6 +33,9 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/ID/PeptideIndexing.h>
+
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/CONCEPT/Macros.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
 #include <OpenMS/DATASTRUCTURES/SeqanIncludeWrapper.h>

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmKD.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmKD.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmKD.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <queue>
 
 using namespace std;

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmSpectrumAlignment.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmSpectrumAlignment.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmSpectrumAlignment.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <OpenMS/CONCEPT/Factory.h>
 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationDescription.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationDescription.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
 #include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
 
+#include <iomanip>
+
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/ANALYSIS/MRM/MRMFragmentSelection.cpp
+++ b/src/openms/source/ANALYSIS/MRM/MRMFragmentSelection.cpp
@@ -35,6 +35,8 @@
 #include <OpenMS/ANALYSIS/MRM/MRMFragmentSelection.h>
 
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
 
 #include <algorithm>
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.cpp
@@ -36,6 +36,7 @@
 
 #include <OpenMS/KERNEL/Peak1D.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
 #include <OpenMS/ANALYSIS/MRM/ReactionMonitoringTransition.h>
 
 namespace OpenMS

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSCached.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSCached.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/SpectrumAccessOpenMSCached.h>
 
+#include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/CachedMzML.h>
 
 namespace OpenMS

--- a/src/openms/source/ANALYSIS/OPENSWATH/DIAHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DIAHelper.cpp
@@ -33,12 +33,18 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/OPENSWATH/DIAHelper.h>
-#include <utility>
-#include <boost/bind.hpp>
+
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/CHEMISTRY/IsotopeDistribution.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPickedHelperStructs.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithm.h>
+
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
+#include <utility>
+#include <boost/bind.hpp>
 
 namespace OpenMS
 {

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -35,6 +35,8 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 
+#include <OpenMS/CONCEPT/LogStream.h>
+
 #include <map>
 #include <utility> //for pair
 #include <string>

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -390,7 +390,7 @@ namespace OpenMS
     FeatureMap& out_featureFile,
     bool store_features,
     OpenSwathTSVWriter & tsv_writer,
-    Interfaces::IMSDataConsumer<> * chromConsumer,
+    Interfaces::DefaultIMSDataConsumer * chromConsumer,
     int batchSize,
     bool load_into_memory)
   {
@@ -513,7 +513,7 @@ namespace OpenMS
     const FeatureMap & featureFile,
     FeatureMap& out_featureFile,
     bool store_features,
-    Interfaces::IMSDataConsumer<> * chromConsumer)
+    Interfaces::DefaultIMSDataConsumer * chromConsumer)
   {
     // write chromatograms to output if so desired
     for (Size chrom_idx = 0; chrom_idx < chromatograms.size(); ++chrom_idx)
@@ -541,7 +541,7 @@ namespace OpenMS
 
   void OpenSwathWorkflow::MS1Extraction_(const std::vector< OpenSwath::SwathMap > & swath_maps,
                                          std::map< std::string, OpenSwath::ChromatogramPtr >& ms1_chromatograms,
-                                         Interfaces::IMSDataConsumer<> * chromConsumer,
+                                         Interfaces::DefaultIMSDataConsumer * chromConsumer,
                                          const ChromExtractParams & cp,
                                          const OpenSwath::LightTargetedExperiment& transition_exp,
                                          const TransformationDescription& trafo_inverse,
@@ -879,7 +879,7 @@ namespace OpenMS
            FeatureMap& out_featureFile,
            bool store_features,
            OpenSwathTSVWriter & tsv_writer,
-           Interfaces::IMSDataConsumer<> * chromConsumer,
+           Interfaces::DefaultIMSDataConsumer * chromConsumer,
            int batchSize,
            bool load_into_memory)
     {

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -390,7 +390,7 @@ namespace OpenMS
     FeatureMap& out_featureFile,
     bool store_features,
     OpenSwathTSVWriter & tsv_writer,
-    Interfaces::DefaultIMSDataConsumer * chromConsumer,
+    Interfaces::IMSDataConsumer * chromConsumer,
     int batchSize,
     bool load_into_memory)
   {
@@ -513,7 +513,7 @@ namespace OpenMS
     const FeatureMap & featureFile,
     FeatureMap& out_featureFile,
     bool store_features,
-    Interfaces::DefaultIMSDataConsumer * chromConsumer)
+    Interfaces::IMSDataConsumer * chromConsumer)
   {
     // write chromatograms to output if so desired
     for (Size chrom_idx = 0; chrom_idx < chromatograms.size(); ++chrom_idx)
@@ -541,7 +541,7 @@ namespace OpenMS
 
   void OpenSwathWorkflow::MS1Extraction_(const std::vector< OpenSwath::SwathMap > & swath_maps,
                                          std::map< std::string, OpenSwath::ChromatogramPtr >& ms1_chromatograms,
-                                         Interfaces::DefaultIMSDataConsumer * chromConsumer,
+                                         Interfaces::IMSDataConsumer * chromConsumer,
                                          const ChromExtractParams & cp,
                                          const OpenSwath::LightTargetedExperiment& transition_exp,
                                          const TransformationDescription& trafo_inverse,
@@ -879,7 +879,7 @@ namespace OpenMS
            FeatureMap& out_featureFile,
            bool store_features,
            OpenSwathTSVWriter & tsv_writer,
-           Interfaces::DefaultIMSDataConsumer * chromConsumer,
+           Interfaces::IMSDataConsumer * chromConsumer,
            int batchSize,
            bool load_into_memory)
     {

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
 
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
+#include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ResidueDB.h>

--- a/src/openms/source/ANALYSIS/QUANTITATION/QuantitativeExperimentalDesign.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/QuantitativeExperimentalDesign.cpp
@@ -33,6 +33,8 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/QUANTITATION/QuantitativeExperimentalDesign.h>
+
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>

--- a/src/openms/source/ANALYSIS/RNPXL/HyperScore.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/HyperScore.cpp
@@ -32,11 +32,16 @@
 // $Authors: Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/ANALYSIS/RNPXL/HyperScore.h>
+
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 
 #include <vector>
 #include <map>
+#include <cmath>
+#include <iostream>
 
 using std::vector;
 

--- a/src/openms/source/ANALYSIS/RNPXL/PScore.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/PScore.cpp
@@ -36,6 +36,9 @@
 #include <OpenMS/ANALYSIS/RNPXL/PScore.h>
 #include <OpenMS/ANALYSIS/ID/AScore.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 #include <vector>
 #include <map>
 

--- a/src/openms/source/ANALYSIS/RNPXL/RNPxlMarkerIonExtractor.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/RNPxlMarkerIonExtractor.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/ANALYSIS/RNPXL/RNPxlMarkerIonExtractor.h>
 #include <OpenMS/FILTERING/TRANSFORMERS/Normalizer.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace std;
 

--- a/src/openms/source/ANALYSIS/TARGETED/TargetedExperiment.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/TargetedExperiment.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <algorithm>
 

--- a/src/openms/source/ANALYSIS/TARGETED/TargetedExperimentHelper.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/TargetedExperimentHelper.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <iostream>
 
 namespace OpenMS
 {

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
+
 #include <OpenMS/DATASTRUCTURES/Map.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/CHEMISTRY/IsotopeDistribution.h>
@@ -41,6 +42,11 @@
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/ResidueDB.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
+
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+#include <OpenMS/KERNEL/Peak1D.h>
 
 using namespace std;
 

--- a/src/openms/source/COMPARISON/CLUSTERING/ClusteringGrid.cpp
+++ b/src/openms/source/COMPARISON/CLUSTERING/ClusteringGrid.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
+#include <sstream>
 
 namespace OpenMS
 {

--- a/src/openms/source/COMPARISON/SPECTRA/PeakAlignment.cpp
+++ b/src/openms/source/COMPARISON/SPECTRA/PeakAlignment.cpp
@@ -37,6 +37,9 @@
 #include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/DATASTRUCTURES/Matrix.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/COMPARISON/SPECTRA/SpectrumPrecursorComparator.cpp
+++ b/src/openms/source/COMPARISON/SPECTRA/SpectrumPrecursorComparator.cpp
@@ -34,6 +34,8 @@
 //
 
 #include <OpenMS/COMPARISON/SPECTRA/SpectrumPrecursorComparator.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <cmath>
 
 using namespace std;

--- a/src/openms/source/COMPARISON/SPECTRA/SteinScottImproveScore.cpp
+++ b/src/openms/source/COMPARISON/SPECTRA/SteinScottImproveScore.cpp
@@ -34,6 +34,8 @@
 //
 #include <OpenMS/COMPARISON/SPECTRA/SteinScottImproveScore.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 namespace OpenMS
 {

--- a/src/openms/source/COMPARISON/SPECTRA/ZhangSimilarityScore.cpp
+++ b/src/openms/source/COMPARISON/SPECTRA/ZhangSimilarityScore.cpp
@@ -34,8 +34,11 @@
 
 #include <OpenMS/COMPARISON/SPECTRA/ZhangSimilarityScore.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
-#include <boost/math/special_functions/erf.hpp>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
+#include <boost/math/special_functions/erf.hpp>
 #include <cmath>
 
 using namespace std;

--- a/src/openms/source/CONCEPT/ClassTest.cpp
+++ b/src/openms/source/CONCEPT/ClassTest.cpp
@@ -43,6 +43,7 @@
 #include <OpenMS/FORMAT/MzDataFile.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/MzXMLFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/TransformationXMLFile.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 

--- a/src/openms/source/FILTERING/DATAREDUCTION/IsotopeDistributionCache.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/IsotopeDistributionCache.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/FILTERING/DATAREDUCTION/IsotopeDistributionCache.h>
 
 #include <OpenMS/CHEMISTRY/IsotopeDistribution.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
 
 namespace OpenMS
 {

--- a/src/openms/source/FILTERING/DATAREDUCTION/SplineSpectrum.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/SplineSpectrum.cpp
@@ -36,6 +36,8 @@
 #include <OpenMS/FILTERING/DATAREDUCTION/SplinePackage.h>
 #include <OpenMS/FILTERING/DATAREDUCTION/SplineSpectrum.h>
 #include <OpenMS/MATH/MISC/Spline2d.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <vector>
 #include <algorithm>

--- a/src/openms/source/FILTERING/TRANSFORMERS/BernNorm.cpp
+++ b/src/openms/source/FILTERING/TRANSFORMERS/BernNorm.cpp
@@ -34,7 +34,10 @@
 //
 
 #include <OpenMS/FILTERING/TRANSFORMERS/BernNorm.h>
+
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace std;
 

--- a/src/openms/source/FORMAT/CachedMzML.cpp
+++ b/src/openms/source/FORMAT/CachedMzML.cpp
@@ -34,6 +34,9 @@
 
 #include <OpenMS/FORMAT/CachedMzML.h>
 
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
+
 namespace OpenMS
 {
 

--- a/src/openms/source/FORMAT/DATAACCESS/MSDataChainingConsumer.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/MSDataChainingConsumer.cpp
@@ -39,13 +39,13 @@ namespace OpenMS
 
   MSDataChainingConsumer::MSDataChainingConsumer() {}
 
-  MSDataChainingConsumer::MSDataChainingConsumer(std::vector<Interfaces::DefaultIMSDataConsumer *> consumers) :
+  MSDataChainingConsumer::MSDataChainingConsumer(std::vector<Interfaces::IMSDataConsumer *> consumers) :
     consumers_(consumers)
   {}
 
   MSDataChainingConsumer::~MSDataChainingConsumer() {}
 
-  void MSDataChainingConsumer::appendConsumer(Interfaces::DefaultIMSDataConsumer * consumer)
+  void MSDataChainingConsumer::appendConsumer(Interfaces::IMSDataConsumer * consumer)
   {
     consumers_.push_back(consumer);
   }

--- a/src/openms/source/FORMAT/DATAACCESS/MSDataChainingConsumer.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/MSDataChainingConsumer.cpp
@@ -39,13 +39,13 @@ namespace OpenMS
 
   MSDataChainingConsumer::MSDataChainingConsumer() {}
 
-  MSDataChainingConsumer::MSDataChainingConsumer(std::vector<Interfaces::IMSDataConsumer<> *> consumers) :
+  MSDataChainingConsumer::MSDataChainingConsumer(std::vector<Interfaces::DefaultIMSDataConsumer *> consumers) :
     consumers_(consumers)
   {}
 
   MSDataChainingConsumer::~MSDataChainingConsumer() {}
 
-  void MSDataChainingConsumer::appendConsumer(Interfaces::IMSDataConsumer<> * consumer)
+  void MSDataChainingConsumer::appendConsumer(Interfaces::DefaultIMSDataConsumer * consumer)
   {
     consumers_.push_back(consumer);
   }

--- a/src/openms/source/FORMAT/DATAACCESS/MSDataWritingConsumer.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/MSDataWritingConsumer.cpp
@@ -37,4 +37,159 @@
 namespace OpenMS
 {
 
+  MSDataWritingConsumer::MSDataWritingConsumer(String filename) :
+    Internal::MzMLHandler(MapType(), filename, MzMLFile().getVersion(), ProgressLogger()),
+    started_writing_(false),
+    writing_spectra_(false),
+    writing_chromatograms_(false),
+    spectra_written_(0),
+    chromatograms_written_(0),
+    spectra_expected_(0),
+    chromatograms_expected_(0),
+    add_dataprocessing_(false)
+  {
+    validator_ = new Internal::MzMLValidator(this->mapping_, this->cv_);
+
+    // open file in binary mode to avoid any line ending conversions
+    ofs_.open(filename.c_str(), std::ios::out | std::ios::binary);
+    ofs_.precision(writtenDigits(double()));
+  }
+
+   MSDataWritingConsumer::~MSDataWritingConsumer()
+  {
+    doCleanup_();
+  }
+
+   void MSDataWritingConsumer::setExperimentalSettings(const ExperimentalSettings& exp)
+  {
+    settings_ = exp;
+  }
+
+   void MSDataWritingConsumer::setExpectedSize(Size expectedSpectra, Size expectedChromatograms)
+  {
+    spectra_expected_ = expectedSpectra;
+    chromatograms_expected_ = expectedChromatograms;
+  }
+
+   void MSDataWritingConsumer::consumeSpectrum(SpectrumType & s)
+  {
+    if (writing_chromatograms_)
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "Cannot write spectra after writing chromatograms.");
+    }
+
+    // Process the spectrum 
+    SpectrumType scpy = s;
+    processSpectrum_(scpy);
+
+    // Add dataprocessing if required
+    if (add_dataprocessing_)
+    {
+      scpy.getDataProcessing().push_back(additional_dataprocessing_);
+    }
+
+    if (!started_writing_)
+    {
+      // This is the first data to be written -> start writing the header
+      // We also need to modify the map and add this dummy spectrum in
+      // order to write the header correctly
+      MapType dummy;
+      dummy = settings_;
+      dummy.addSpectrum(scpy);
+
+      //--------------------------------------------------------------------
+      //header
+      //--------------------------------------------------------------------
+      Internal::MzMLHandler::writeHeader_(ofs_, dummy, dps_, *validator_);
+      started_writing_ = true;
+    }
+    if (!writing_spectra_)
+    {
+      // This is the first spectrum, thus write the spectrumList header
+      ofs_ << "\t\t<spectrumList count=\"" << spectra_expected_ << "\" defaultDataProcessingRef=\"dp_sp_0\">\n";
+      writing_spectra_ = true;
+    }
+    bool renew_native_ids = false;
+    // TODO writeSpectrum assumes that dps_ has at least one value -> assert
+    // this here ...
+    Internal::MzMLHandler::writeSpectrum_(ofs_, scpy,
+            spectra_written_++, *validator_, renew_native_ids, dps_);
+  }
+
+   void MSDataWritingConsumer::consumeChromatogram(ChromatogramType & c)
+  {
+    // make sure to close an open List tag
+    if (writing_spectra_)
+    {
+      ofs_ << "\t\t</spectrumList>\n";
+    }
+
+    // Create copy and add dataprocessing if required
+    ChromatogramType ccpy = c;
+    processChromatogram_(ccpy);
+
+    if (add_dataprocessing_)
+    {
+      ccpy.getDataProcessing().push_back(additional_dataprocessing_);
+    }
+
+    if (!started_writing_)
+    {
+      // this is the first data to be written -> start writing the header
+      // We also need to modify the map and add this dummy chromatogram in
+      // order to write the header correctly
+      MapType dummy;
+      dummy = settings_;
+      dummy.addChromatogram(ccpy);
+
+      //--------------------------------------------------------------------
+      //header (fill also dps_ variable)
+      //--------------------------------------------------------------------
+      Internal::MzMLHandler::writeHeader_(ofs_, dummy, dps_, *validator_);
+      started_writing_ = true;
+    }
+    if (!writing_chromatograms_)
+    {
+      ofs_ << "\t\t<chromatogramList count=\"" << chromatograms_expected_ << "\" defaultDataProcessingRef=\"dp_sp_0\">\n";
+      writing_chromatograms_ = true;
+      writing_spectra_ = false;
+    }
+    Internal::MzMLHandler::writeChromatogram_(ofs_, ccpy,
+            chromatograms_written_++, *validator_);
+  }
+
+   void MSDataWritingConsumer::addDataProcessing(DataProcessing d)
+  {
+    additional_dataprocessing_ = DataProcessingPtr( new DataProcessing(d) );
+    add_dataprocessing_ = true;
+  }
+
+   Size MSDataWritingConsumer::getNrSpectraWritten() {return spectra_written_;}
+
+   Size MSDataWritingConsumer::getNrChromatogramsWritten() {return chromatograms_written_;}
+
+   void MSDataWritingConsumer::doCleanup_()
+  {
+    //--------------------------------------------------------------------------------------------
+    //cleanup
+    //--------------------------------------------------------------------------------------------
+    // make sure to close an open List tag
+    if (writing_spectra_)
+    {
+      ofs_ << "\t\t</spectrumList>\n";
+    }
+    else if (writing_chromatograms_)
+    {
+      ofs_ << "\t\t</chromatogramList>\n";
+    }
+
+    // Only write the footer if we actually did start writing ... 
+    if (started_writing_) 
+      Internal::MzMLHandlerHelper::writeFooter_(ofs_, options_, spectra_offsets, chromatograms_offsets);
+
+    delete validator_;
+    ofs_.close();
+  }
+
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/FeatureXMLFile.cpp
+++ b/src/openms/source/FORMAT/FeatureXMLFile.cpp
@@ -33,6 +33,8 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
+
+#include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/PrecisionWrapper.h>

--- a/src/openms/source/FORMAT/FileHandler.cpp
+++ b/src/openms/source/FORMAT/FileHandler.cpp
@@ -33,6 +33,23 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/FileHandler.h>
+
+#include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/FORMAT/DTA2DFile.h>
+#include <OpenMS/FORMAT/MzXMLFile.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
+#include <OpenMS/FORMAT/MzDataFile.h>
+#include <OpenMS/FORMAT/MascotGenericFile.h>
+#include <OpenMS/FORMAT/MS2File.h>
+#include <OpenMS/FORMAT/XMassFile.h>
+
+#include <OpenMS/FORMAT/MsInspectFile.h>
+#include <OpenMS/FORMAT/SpecArrayFile.h>
+#include <OpenMS/FORMAT/KroenikFile.h>
+
+#include <OpenMS/KERNEL/ChromatogramTools.h>
+
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/FORMAT/GzipIfstream.h>
 #include <OpenMS/FORMAT/Bzip2Ifstream.h>
@@ -498,6 +515,195 @@ if (first_line.hasSubstring("File	First Scan	Last Scan	Num of Scans	Charge	Monoi
     }
 
     return true;
+  }
+
+  bool FileHandler::loadExperiment(const String& filename, PeakMap& exp, FileTypes::Type force_type, ProgressLogger::LogType log, const bool rewrite_source_file, const bool compute_hash)
+  {
+    // setting the flag for hash recomputation only works if source file entries are rewritten 
+    OPENMS_PRECONDITION(rewrite_source_file || !compute_hash, "Can't compute hash if no SourceFile written");
+
+    //determine file type
+    FileTypes::Type type;
+    if (force_type != FileTypes::UNKNOWN)
+    {
+      type = force_type;
+    }
+    else
+    {
+      try
+      {
+        type = getType(filename);
+      }
+      catch (Exception::FileNotFound)
+      {
+        return false;
+      }
+    }
+
+    //load right file
+    switch (type)
+    {
+    case FileTypes::DTA:
+      exp.reset();
+      exp.resize(1);
+      DTAFile().load(filename, exp[0]);
+      break;
+
+    case FileTypes::DTA2D:
+    {
+      DTA2DFile f;
+      f.getOptions() = options_;
+      f.setLogType(log);
+      f.load(filename, exp);
+    }
+
+    break;
+
+    case FileTypes::MZXML:
+    {
+      MzXMLFile f;
+      f.getOptions() = options_;
+      f.setLogType(log);
+      f.load(filename, exp);
+    }
+
+    break;
+
+    case FileTypes::MZDATA:
+    {
+      MzDataFile f;
+      f.getOptions() = options_;
+      f.setLogType(log);
+      f.load(filename, exp);
+    }
+    break;
+
+    case FileTypes::MZML:
+    {
+      MzMLFile f;
+      f.getOptions() = options_;
+      f.setLogType(log);
+      f.load(filename, exp);
+      ChromatogramTools().convertSpectraToChromatograms<PeakMap >(exp, true);
+    }
+    break;
+
+    case FileTypes::MGF:
+    {
+      MascotGenericFile f;
+      f.setLogType(log);
+      f.load(filename, exp);
+    }
+
+    break;
+
+    case FileTypes::MS2:
+    {
+      MS2File f;
+      f.setLogType(log);
+      f.load(filename, exp);
+    }
+
+    break;
+
+    case FileTypes::XMASS:
+      exp.reset();
+      exp.resize(1);
+      XMassFile().load(filename, exp[0]);
+      XMassFile().importExperimentalSettings(filename, exp);
+
+      break;
+
+    default:
+      return false;
+
+      break;
+    }
+
+    if (rewrite_source_file)
+    {
+      SourceFile src_file;
+      src_file.setNameOfFile(File::basename(filename));
+      String path_to_file = File::path(File::absolutePath(filename)); //convert to absolute path and strip file name
+      
+      // make sure we end up with at most 3 forward slashes       
+      String uri = path_to_file.hasPrefix("/") ? String("file://") + path_to_file : String("file:///") + path_to_file;
+      src_file.setPathToFile(uri);
+      // this is more complicated since the data formats allowed by mzML are very verbose.
+      // this is prone to changing CV's... our writer will fall back to a default if the name given here is invalid.
+      src_file.setFileType(FileTypes::typeToMZML(type));
+
+      if (compute_hash)
+      {
+        src_file.setChecksum(computeFileHash(filename), SourceFile::SHA1);
+      }
+
+      exp.getSourceFiles().clear();
+      exp.getSourceFiles().push_back(src_file);
+    }
+
+    return true;
+  }
+
+  void FileHandler::storeExperiment(const String& filename, const PeakMap& exp, ProgressLogger::LogType log)
+  {
+    //load right file
+    switch (getTypeByFileName(filename))
+    {
+    case FileTypes::DTA2D:
+    {
+      DTA2DFile f;
+      f.getOptions() = options_;
+      f.setLogType(log);
+      f.store(filename, exp);
+    }
+    break;
+
+    case FileTypes::MZXML:
+    {
+      MzXMLFile f;
+      f.getOptions() = options_;
+      f.setLogType(log);
+      if (!exp.getChromatograms().empty())
+      {
+        PeakMap exp2 = exp;
+        ChromatogramTools().convertChromatogramsToSpectra<PeakMap >(exp2);
+        f.store(filename, exp2);
+      }
+      else
+      {
+        f.store(filename, exp);
+      }
+    }
+    break;
+
+    case FileTypes::MZDATA:
+    {
+      MzDataFile f;
+      f.getOptions() = options_;
+      f.setLogType(log);
+      if (!exp.getChromatograms().empty())
+      {
+        PeakMap exp2 = exp;
+        ChromatogramTools().convertChromatogramsToSpectra<PeakMap >(exp2);
+        f.store(filename, exp2);
+      }
+      else
+      {
+        f.store(filename, exp);
+      }
+    }
+    break;
+
+    default:
+    {
+      MzMLFile f;
+      f.getOptions() = options_;
+      f.setLogType(log);
+      f.store(filename, exp);
+    }
+    break;
+    }
   }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MascotXMLHandler.cpp
@@ -34,6 +34,9 @@
 
 #include <OpenMS/FORMAT/HANDLERS/MascotXMLHandler.h>
 #include <OpenMS/CHEMISTRY/EnzymesDB.h>
+
+#include <xercesc/sax2/DefaultHandler.hpp>
+#include <xercesc/sax/Locator.hpp>
 #include <xercesc/sax2/Attributes.hpp>
 
 using namespace std;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -32,8 +32,10 @@
 // $Authors: Mathias Walzer, Andreas Bertsch $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/HANDLERS/MzIdentMLHandler.h>
+
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/CHEMISTRY/Residue.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -34,6 +34,9 @@
 
 #include <OpenMS/FORMAT/HANDLERS/MzMLHandler.h>
 
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
+#include <OpenMS/FORMAT/CVMappingFile.h>
+
 namespace OpenMS
 {
   namespace Internal

--- a/src/openms/source/FORMAT/InspectOutfile.cpp
+++ b/src/openms/source/FORMAT/InspectOutfile.cpp
@@ -39,9 +39,11 @@
 #endif
 
 #include <OpenMS/FORMAT/InspectOutfile.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
 #include <QRegExp>
 
 #include <set>
+#include <fstream>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunreachable-code"

--- a/src/openms/source/FORMAT/InspectOutfile.cpp
+++ b/src/openms/source/FORMAT/InspectOutfile.cpp
@@ -39,6 +39,7 @@
 #endif
 
 #include <OpenMS/FORMAT/InspectOutfile.h>
+#include <QRegExp>
 
 #include <set>
 

--- a/src/openms/source/FORMAT/MSPFile.cpp
+++ b/src/openms/source/FORMAT/MSPFile.cpp
@@ -33,6 +33,11 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/MSPFile.h>
+
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/KERNEL/RichPeak1D.h>
 #include <OpenMS/CONCEPT/Constants.h>

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -33,6 +33,12 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/MascotGenericFile.h>
+
+#include <OpenMS/METADATA/Precursor.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 

--- a/src/openms/source/FORMAT/MzDataFile.cpp
+++ b/src/openms/source/FORMAT/MzDataFile.cpp
@@ -36,6 +36,7 @@
 #include <OpenMS/FORMAT/MzDataFile.h>
 #include <OpenMS/FORMAT/VALIDATORS/MzDataValidator.h>
 #include <OpenMS/FORMAT/CVMappingFile.h>
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
 
 namespace OpenMS
 {
@@ -81,7 +82,7 @@ namespace OpenMS
     return result;
   }
 
-  void MzDataFile::load(const String & filename, MapType & map)
+  void MzDataFile::load(const String & filename, PeakMap & map)
   {
     map.reset();
 
@@ -94,7 +95,7 @@ namespace OpenMS
     parse_(filename, &handler);
   }
 
-  void MzDataFile::store(const String & filename, const MapType & map) const
+  void MzDataFile::store(const String & filename, const PeakMap & map) const
   {
     Internal::MzDataHandler handler(map, filename, schema_version_, *this);
     handler.setOptions(options_);

--- a/src/openms/source/FORMAT/MzMLFile.cpp
+++ b/src/openms/source/FORMAT/MzMLFile.cpp
@@ -174,7 +174,7 @@ namespace OpenMS
     save_(filename, &handler);
   }
 
-  void MzMLFile::transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer* consumer, bool skip_full_count, bool skip_first_pass)
+  void MzMLFile::transform(const String& filename_in, Interfaces::IMSDataConsumer* consumer, bool skip_full_count, bool skip_first_pass)
   {
     // First pass through the file -> get the meta-data and hand it to the consumer
     if (!skip_first_pass) transformFirstPass_(filename_in, consumer, skip_full_count);
@@ -189,7 +189,7 @@ namespace OpenMS
     }
   }
 
-  void MzMLFile::transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer* consumer, PeakMap& map, bool skip_full_count, bool skip_first_pass)
+  void MzMLFile::transform(const String& filename_in, Interfaces::IMSDataConsumer* consumer, PeakMap& map, bool skip_full_count, bool skip_first_pass)
   {
     // First pass through the file -> get the meta-data and hand it to the consumer
     if (!skip_first_pass) transformFirstPass_(filename_in, consumer, skip_full_count);
@@ -206,7 +206,7 @@ namespace OpenMS
     }
   }
 
-  void MzMLFile::transformFirstPass_(const String& filename_in, Interfaces::DefaultIMSDataConsumer* consumer, bool skip_full_count)
+  void MzMLFile::transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer* consumer, bool skip_full_count)
   {
     // Create temporary objects and counters
     PeakFileOptions tmp_options(options_);

--- a/src/openms/source/FORMAT/MzMLFile.cpp
+++ b/src/openms/source/FORMAT/MzMLFile.cpp
@@ -33,10 +33,14 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/MzMLFile.h>
+
+#include <OpenMS/FORMAT/HANDLERS/MzMLHandler.h>
 #include <OpenMS/FORMAT/VALIDATORS/MzMLValidator.h>
 #include <OpenMS/FORMAT/CVMappingFile.h>
 #include <OpenMS/FORMAT/VALIDATORS/XMLValidator.h>
 #include <OpenMS/FORMAT/TextFile.h>
+#include <OpenMS/METADATA/DocumentIdentifier.h>
+#include <OpenMS/INTERFACES/IMSDataConsumer.h>
 
 namespace OpenMS
 {
@@ -115,9 +119,7 @@ namespace OpenMS
 
   void MzMLFile::loadSize(const String& filename, Size& scount, Size& ccount)
   {
-    typedef PeakMap MapType;
-
-    MapType dummy;
+    PeakMap dummy;
     bool size_only_before_ = options_.getSizeOnly();
     options_.setSizeOnly(true);
     Internal::MzMLHandler handler(dummy, filename, getVersion(), *this);
@@ -163,6 +165,66 @@ namespace OpenMS
     Internal::MzMLHandler handler(map, filename, getVersion(), *this);
     handler.setOptions(options_);
     safeParse_(filename, &handler);
+  }
+
+  void MzMLFile::store(const String& filename, const PeakMap& map) const
+  {
+    Internal::MzMLHandler handler(map, filename, getVersion(), *this);
+    handler.setOptions(options_);
+    save_(filename, &handler);
+  }
+
+  void MzMLFile::transform(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, bool skip_full_count, bool skip_first_pass)
+  {
+    // First pass through the file -> get the meta-data and hand it to the consumer
+    if (!skip_first_pass) transformFirstPass_(filename_in, consumer, skip_full_count);
+
+    // Second pass through the data, now read the spectra!
+    {
+      PeakMap dummy;
+      Internal::MzMLHandler handler(dummy, filename_in, getVersion(), *this);
+      handler.setOptions(options_);
+      handler.setMSDataConsumer(consumer);
+      safeParse_(filename_in, &handler);
+    }
+  }
+
+  void MzMLFile::transform(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, PeakMap& map, bool skip_full_count, bool skip_first_pass)
+  {
+    // First pass through the file -> get the meta-data and hand it to the consumer
+    if (!skip_first_pass) transformFirstPass_(filename_in, consumer, skip_full_count);
+
+    // Second pass through the data, now read the spectra!
+    {
+      PeakFileOptions tmp_options(options_);
+      Internal::MzMLHandler handler(map, filename_in, getVersion(), *this);
+      tmp_options.setAlwaysAppendData(true);
+      handler.setOptions(tmp_options);
+      handler.setMSDataConsumer(consumer);
+
+      safeParse_(filename_in, &handler);
+    }
+  }
+
+  void MzMLFile::transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, bool skip_full_count)
+  {
+    // Create temporary objects and counters
+    PeakFileOptions tmp_options(options_);
+    Size scount = 0, ccount = 0;
+    PeakMap experimental_settings;
+    Internal::MzMLHandler handler(experimental_settings, filename_in, getVersion(), *this);
+
+    // set temporary options for handler
+    tmp_options.setSizeOnly(true);
+    tmp_options.setMetadataOnly( skip_full_count );
+    handler.setOptions(tmp_options);
+
+    safeParse_(filename_in, &handler);
+
+    // After parsing, collect information
+    handler.getCounts(scount, ccount);
+    consumer->setExpectedSize(scount, ccount);
+    consumer->setExperimentalSettings(experimental_settings);
   }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/MzMLFile.cpp
+++ b/src/openms/source/FORMAT/MzMLFile.cpp
@@ -174,7 +174,7 @@ namespace OpenMS
     save_(filename, &handler);
   }
 
-  void MzMLFile::transform(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, bool skip_full_count, bool skip_first_pass)
+  void MzMLFile::transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer* consumer, bool skip_full_count, bool skip_first_pass)
   {
     // First pass through the file -> get the meta-data and hand it to the consumer
     if (!skip_first_pass) transformFirstPass_(filename_in, consumer, skip_full_count);
@@ -189,7 +189,7 @@ namespace OpenMS
     }
   }
 
-  void MzMLFile::transform(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, PeakMap& map, bool skip_full_count, bool skip_first_pass)
+  void MzMLFile::transform(const String& filename_in, Interfaces::DefaultIMSDataConsumer* consumer, PeakMap& map, bool skip_full_count, bool skip_first_pass)
   {
     // First pass through the file -> get the meta-data and hand it to the consumer
     if (!skip_first_pass) transformFirstPass_(filename_in, consumer, skip_full_count);
@@ -206,7 +206,7 @@ namespace OpenMS
     }
   }
 
-  void MzMLFile::transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer<PeakMap> * consumer, bool skip_full_count)
+  void MzMLFile::transformFirstPass_(const String& filename_in, Interfaces::DefaultIMSDataConsumer* consumer, bool skip_full_count)
   {
     // Create temporary objects and counters
     PeakFileOptions tmp_options(options_);

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/FORMAT/MzTab.h>
 
+#include <OpenMS/DATASTRUCTURES/ListUtils.h>
+
 namespace OpenMS
 {
 

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -32,11 +32,15 @@
 // $Authors: Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/FORMAT/MzTab.h>
 #include <OpenMS/FORMAT/MzTabFile.h>
+
+#include <OpenMS/FORMAT/MzTab.h>
 #include <OpenMS/FORMAT/TextFile.h>
+
+#include <QString>
 #include <boost/regex.hpp>
 #include <fstream>
+#include <iostream>
 
 using namespace std;
 

--- a/src/openms/source/FORMAT/MzXMLFile.cpp
+++ b/src/openms/source/FORMAT/MzXMLFile.cpp
@@ -34,6 +34,10 @@
 
 #include <OpenMS/FORMAT/MzXMLFile.h>
 
+#include <OpenMS/FORMAT/HANDLERS/MzXMLHandler.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/Peak1D.h>
+
 #include <fstream>
 
 using namespace std;
@@ -75,6 +79,65 @@ namespace OpenMS
     Internal::MzXMLHandler handler(map, filename, schema_version_, *this);
     handler.setOptions(options_);
     parse_(filename, &handler);
+  }
+
+  void MzXMLFile::store(const String & filename, const MapType & map) const
+  {
+    Internal::MzXMLHandler handler(map, filename, schema_version_, *this);
+    save_(filename, &handler);
+  }
+
+  void MzXMLFile::transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count)
+  {
+    // First pass through the file -> get the meta-data and hand it to the consumer
+    transformFirstPass_(filename_in, consumer, skip_full_count);
+    
+    // Second pass through the data, now read the spectra!
+    {
+      MapType dummy;
+      Internal::MzXMLHandler handler(dummy, filename_in, getVersion(), *this);
+      handler.setOptions(options_);
+      handler.setMSDataConsumer(consumer);
+      parse_(filename_in, &handler);
+    }
+  }
+
+  void MzXMLFile::transform(const String& filename_in, Interfaces::IMSDataConsumer * consumer, MapType& map, bool skip_full_count)
+  {
+    // First pass through the file -> get the meta-data and hand it to the consumer
+    transformFirstPass_(filename_in, consumer, skip_full_count);
+
+    // Second pass through the data, now read the spectra!
+    {
+      PeakFileOptions tmp_options(options_);
+      Internal::MzXMLHandler handler(map, filename_in, getVersion(), *this);
+      tmp_options.setAlwaysAppendData(true);
+      handler.setOptions(tmp_options);
+      handler.setMSDataConsumer(consumer);
+
+      parse_(filename_in, &handler);
+    }
+  }
+
+  void MzXMLFile::transformFirstPass_(const String& filename_in, Interfaces::IMSDataConsumer * consumer, bool skip_full_count)
+  {
+    // Create temporary objects and counters
+    PeakFileOptions tmp_options(options_);
+    Size scount = 0, ccount = 0;
+    MapType experimental_settings;
+    Internal::MzXMLHandler handler(experimental_settings, filename_in, getVersion(), *this);
+
+    // set temporary options for handler
+    tmp_options.setSizeOnly(true);
+    tmp_options.setMetadataOnly( skip_full_count );
+    handler.setOptions(tmp_options);
+
+    parse_(filename_in, &handler);
+
+    // After parsing, collect information
+    scount = handler.getScanCount();
+    consumer->setExpectedSize(scount, ccount);
+    consumer->setExperimentalSettings(experimental_settings);
   }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -45,6 +45,7 @@
 #include <OpenMS/FORMAT/PepXMLFile.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
 #include <fstream>
 #include <iostream>
 #include <boost/regex.hpp>

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -46,6 +46,8 @@
 #include <OpenMS/MATH/MISC/MathFunctions.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 #include <fstream>
 #include <iostream>
 #include <boost/regex.hpp>

--- a/src/openms/source/FORMAT/TraMLFile.cpp
+++ b/src/openms/source/FORMAT/TraMLFile.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/FORMAT/TraMLFile.h>
 
+#include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/FORMAT/VALIDATORS/TraMLValidator.h>
 #include <OpenMS/FORMAT/CVMappingFile.h>
 #include <OpenMS/FORMAT/VALIDATORS/XMLValidator.h>

--- a/src/openms/source/FORMAT/TraMLFile.cpp
+++ b/src/openms/source/FORMAT/TraMLFile.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/TraMLFile.h>
+
 #include <OpenMS/FORMAT/VALIDATORS/TraMLValidator.h>
 #include <OpenMS/FORMAT/CVMappingFile.h>
 #include <OpenMS/FORMAT/VALIDATORS/XMLValidator.h>

--- a/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
@@ -36,6 +36,8 @@
 #include <OpenMS/DATASTRUCTURES/CVMappingTerm.h>
 #include <OpenMS/DATASTRUCTURES/CVMappingRule.h>
 
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
+
 using namespace xercesc;
 using namespace std;
 

--- a/src/openms/source/FORMAT/VALIDATORS/MzIdentMLValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzIdentMLValidator.cpp
@@ -34,6 +34,8 @@
 
 #include <OpenMS/FORMAT/VALIDATORS/MzIdentMLValidator.h>
 
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
+
 using namespace xercesc;
 using namespace std;
 

--- a/src/openms/source/FORMAT/VALIDATORS/MzMLValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzMLValidator.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/VALIDATORS/MzMLValidator.h>
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
 
 using namespace xercesc;
 using namespace std;

--- a/src/openms/source/FORMAT/XMLFile.cpp
+++ b/src/openms/source/FORMAT/XMLFile.cpp
@@ -33,17 +33,24 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/XMLFile.h>
+
+#include <OpenMS/CONCEPT/Macros.h>
+#include <OpenMS/CONCEPT/Exception.h>
+
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/VALIDATORS/XMLValidator.h>
 
 #include <OpenMS/FORMAT/CompressedInputSource.h>
 
+#include <xercesc/framework/XMLFormatter.hpp>
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/framework/LocalFileInputSource.hpp>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
+
 #include <fstream>
 #include <iomanip> // setprecision etc.
+#include <iosfwd>
 
 #include <boost/shared_ptr.hpp>
 

--- a/src/openms/source/FORMAT/XTandemInfile.cpp
+++ b/src/openms/source/FORMAT/XTandemInfile.cpp
@@ -42,7 +42,6 @@
 #include <map>
 #include <fstream>
 
-using namespace xercesc;
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/MATH/MISC/BSpline2d.cpp
+++ b/src/openms/source/MATH/MISC/BSpline2d.cpp
@@ -37,6 +37,7 @@
 #include <BSpline/BSplineBase.cpp>
 #include <BSpline/BSpline.cpp>
 
+
 namespace OpenMS
 {
 

--- a/src/openms/source/METADATA/CVTermList.cpp
+++ b/src/openms/source/METADATA/CVTermList.cpp
@@ -34,6 +34,9 @@
 
 #include <OpenMS/METADATA/CVTermList.h>
 
+#include <OpenMS/DATASTRUCTURES/CVMappingRule.h>
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
+
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/METADATA/DocumentIdentifier.cpp
+++ b/src/openms/source/METADATA/DocumentIdentifier.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/METADATA/DocumentIdentifier.h>
+#include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 
 #include <QDir>

--- a/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
@@ -37,6 +37,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace std;
 

--- a/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
@@ -36,6 +36,7 @@
 
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/KERNEL/StandardTypes.h>
 
 using namespace std;
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.cpp
@@ -33,6 +33,10 @@
 
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/ProductModel.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/EmgFitter1D.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/EmgModel.h>

--- a/src/openms_gui/include/OpenMS/VISUAL/EnhancedTabBarWidgetInterface.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/EnhancedTabBarWidgetInterface.h
@@ -37,6 +37,11 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 
+#include <OpenMS/KERNEL/StandardDeclarations.h>
+#include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/CONCEPT/Exception.h>
+#include <OpenMS/CONCEPT/Macros.h>
+
 namespace OpenMS
 {
   /**

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -34,6 +34,9 @@
 
 #include <OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 #include <OpenMS/ANALYSIS/ID/IDMapper.h>
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
@@ -50,6 +53,7 @@
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/METADATA/Precursor.h>
 #include <OpenMS/SYSTEM/FileWatcher.h>

--- a/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/KERNEL/Feature.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/VISUAL/DIALOGS/Spectrum2DPrefDialog.h>

--- a/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/VISUAL/TOPPASOutputFileListVertex.h>
 
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/SYSTEM/File.h>

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -34,6 +34,10 @@
 
 #include <OpenMS/CHEMISTRY/IsotopeDistribution.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 #include <OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h>
 #include <OpenMS/VISUAL/Spectrum1DWidget.h>
 #include <OpenMS/VISUAL/TOPPViewIdentificationViewBehavior.h>

--- a/src/pyOpenMS/tests/unittests/test_FileIO.py
+++ b/src/pyOpenMS/tests/unittests/test_FileIO.py
@@ -26,7 +26,7 @@ class TestPepXML(unittest.TestCase):
         self.assertEqual( len(prots),  3)
         self.assertEqual( len(peps),  19)
 
-        self.assertEqual( peps[0].getHits()[0].getSequence().toString(), b'(Glu->pyro-Glu)ELNKEMAAEKAKAAAG')
+        self.assertEqual( peps[0].getHits()[0].getSequence().toString(), b'.(Glu->pyro-Glu)ELNKEMAAEKAKAAAG')
 
 class TestIdXML(unittest.TestCase):
 

--- a/src/tests/class_tests/openms/source/AccurateMassSearchEngine_test.cpp
+++ b/src/tests/class_tests/openms/source/AccurateMassSearchEngine_test.cpp
@@ -38,6 +38,7 @@
 ///////////////////////////
 #include <OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h>
 #include <OpenMS/CONCEPT/FuzzyStringComparator.h>
+#include <OpenMS/CONCEPT/Constants.h>
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/MzTab.h>
@@ -47,6 +48,9 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 
 ///////////////////////////
 

--- a/src/tests/class_tests/openms/source/BernNorm_test.cpp
+++ b/src/tests/class_tests/openms/source/BernNorm_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FILTERING/TRANSFORMERS/BernNorm.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/CachedMzML_test.cpp
+++ b/src/tests/class_tests/openms/source/CachedMzML_test.cpp
@@ -39,6 +39,10 @@
 #include <OpenMS/FORMAT/CachedMzML.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"
 

--- a/src/tests/class_tests/openms/source/CompNovoIdentificationCID_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIdentificationCID_test.cpp
@@ -41,6 +41,10 @@
 #include <OpenMS/CONCEPT/Constants.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/CompNovoIdentification_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIdentification_test.cpp
@@ -41,6 +41,10 @@
 #include <OpenMS/CONCEPT/Constants.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/CompNovoIonScoringCID_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIonScoringCID_test.cpp
@@ -40,6 +40,10 @@
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/CompNovoIonScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIonScoring_test.cpp
@@ -41,6 +41,10 @@
 #include <OpenMS/CONCEPT/Constants.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/ComplementFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/ComplementFilter_test.cpp
@@ -37,15 +37,17 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <OpenMS/FILTERING/TRANSFORMERS/ComplementFilter.h>
+///////////////////////////
+
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/FORMAT/DTAFile.h>
 
 using namespace OpenMS;
 using namespace std;
 
-///////////////////////////
 
 START_TEST(ComplementFilter, "$Id$")
 

--- a/src/tests/class_tests/openms/source/ComplementMarker_test.cpp
+++ b/src/tests/class_tests/openms/source/ComplementMarker_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FILTERING/TRANSFORMERS/ComplementMarker.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <map>
 

--- a/src/tests/class_tests/openms/source/ConsensusMap_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusMap_test.cpp
@@ -41,6 +41,10 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 ///////////////////////////
 
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/METADATA/DataProcessing.h>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/ConsensusXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ConsensusXMLFile_test.cpp
@@ -34,12 +34,14 @@
 
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/FORMAT/FileHandler.h>
 
 ///////////////////////////
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 ///////////////////////////
+
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 

--- a/src/tests/class_tests/openms/source/ConstRefVector_test.cpp
+++ b/src/tests/class_tests/openms/source/ConstRefVector_test.cpp
@@ -41,6 +41,10 @@
 #include <OpenMS/DATASTRUCTURES/ConstRefVector.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"
 

--- a/src/tests/class_tests/openms/source/EDTAFile_test.cpp
+++ b/src/tests/class_tests/openms/source/EDTAFile_test.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/FORMAT/EDTAFile.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>

--- a/src/tests/class_tests/openms/source/FeatureXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureXMLFile_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FORMAT/OPTIONS/FeatureFileOptions.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/FileHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/FileHandler_test.cpp
@@ -36,11 +36,14 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
-
 ///////////////////////////
+
+#include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 
 START_TEST(FileHandler, "$Id$")
 

--- a/src/tests/class_tests/openms/source/GoodDiffFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/GoodDiffFilter_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FILTERING/TRANSFORMERS/GoodDiffFilter.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/HyperScore_test.cpp
+++ b/src/tests/class_tests/openms/source/HyperScore_test.cpp
@@ -38,6 +38,10 @@
 #include <OpenMS/ANALYSIS/RNPXL/HyperScore.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/InclusionExclusionList_test.cpp
+++ b/src/tests/class_tests/openms/source/InclusionExclusionList_test.cpp
@@ -41,6 +41,9 @@
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/FORMAT/TextFile.h>
 ///////////////////////////
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/FeatureMap.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/IntensityBalanceFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/IntensityBalanceFilter_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FILTERING/TRANSFORMERS/IntensityBalanceFilter.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/InternalCalibration_test.cpp
+++ b/src/tests/class_tests/openms/source/InternalCalibration_test.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/FILTERING/CALIBRATION/InternalCalibration.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>

--- a/src/tests/class_tests/openms/source/IsotopeDiffFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDiffFilter_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FILTERING/TRANSFORMERS/IsotopeDiffFilter.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/IsotopeMarker_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeMarker_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FILTERING/TRANSFORMERS/IsotopeMarker.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <map>
 

--- a/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
@@ -32,17 +32,19 @@
 // $Authors: George Rosenberger, Hannes Roest, Witold Wolski $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
-#include <OpenMS/FORMAT/TraMLFile.h>
-
-#include <boost/assign/std/vector.hpp>
-#include <boost/assign/list_of.hpp>
+#include <OpenMS/CONCEPT/ClassTest.h>
 
 ///////////////////////////
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h>
-#include <OpenMS/CHEMISTRY/ModificationsDB.h>
 ///////////////////////////
+
+#include <OpenMS/FORMAT/TraMLFile.h>
+#include <OpenMS/FORMAT/TraMLFile.h>
+#include <OpenMS/CHEMISTRY/ModificationsDB.h>
+
+#include <boost/assign/std/vector.hpp>
+#include <boost/assign/list_of.hpp>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wshadow"

--- a/src/tests/class_tests/openms/source/MRMFragmentSelection_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFragmentSelection_test.cpp
@@ -37,10 +37,13 @@
 
 ///////////////////////////
 #include <OpenMS/ANALYSIS/MRM/MRMFragmentSelection.h>
-#include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 ///////////////////////////
 
+#include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
@@ -32,14 +32,20 @@
 // $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/test_config.h>
+#include <OpenMS/CONCEPT/ClassTest.h>
+
+///////////////////////////
+#include <OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h>
+///////////////////////////
+
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
+#include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 
 #include <boost/assign/std/vector.hpp>
-
-#include <OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/MRMTransitionGroup_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMTransitionGroup_test.cpp
@@ -40,12 +40,14 @@
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/KERNEL/MRMTransitionGroup.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 using namespace OpenMS;
 using namespace std;
 
-typedef MSSpectrum<ChromatogramPeak> RichPeakChromatogram;
 typedef OpenMS::ReactionMonitoringTransition TransitionType;
-typedef MRMTransitionGroup<RichPeakChromatogram, TransitionType> MRMTransitionGroupType;
+typedef MRMTransitionGroup<MSChromatogram<>, TransitionType> MRMTransitionGroupType;
 
 ///////////////////////////
 
@@ -70,8 +72,8 @@ START_SECTION(~MRMTransitionGroup())
 END_SECTION
 
 
-RichPeakChromatogram chrom1;
-RichPeakChromatogram chrom2;
+MSChromatogram<> chrom1;
+MSChromatogram<> chrom2;
 TransitionType trans1;
 TransitionType trans2;
 MRMFeature feature1;

--- a/src/tests/class_tests/openms/source/MSDataChainingConsumer_test.cpp
+++ b/src/tests/class_tests/openms/source/MSDataChainingConsumer_test.cpp
@@ -44,6 +44,9 @@
 
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 #include <OpenMS/FORMAT/MzMLFile.h>
 
 void FunctionChangeSpectrum (OpenMS::MSSpectrum<OpenMS::Peak1D> & s)
@@ -77,7 +80,7 @@ START_SECTION((~MSDataChainingConsumer()))
 END_SECTION
 
 START_SECTION(( MSDataChainingConsumer(std::vector<IMSDataConsumer*> consumers) ))
-  std::vector<Interfaces::IMSDataConsumer<> *> consumer_list;
+  std::vector<Interfaces::IMSDataConsumer *> consumer_list;
   chaining_consumer_ptr = new MSDataChainingConsumer(consumer_list);
   TEST_NOT_EQUAL(chaining_consumer_ptr, chaining_consumer_nullPointer)
   delete chaining_consumer_ptr;
@@ -85,7 +88,7 @@ END_SECTION
 
 START_SECTION((void consumeSpectrum(SpectrumType & s)))
 {
-  std::vector<Interfaces::IMSDataConsumer<> *> consumer_list;
+  std::vector<Interfaces::IMSDataConsumer *> consumer_list;
   consumer_list.push_back(new NoopMSDataConsumer());
   consumer_list.push_back(new NoopMSDataConsumer());
   consumer_list.push_back(new NoopMSDataConsumer());
@@ -111,7 +114,7 @@ START_SECTION(([EXTRA] void consumeSpectrum(SpectrumType & s)))
   transforming_consumer->setExpectedSize(2,0);
   transforming_consumer->setSpectraProcessingPtr(FunctionChangeSpectrum);
 
-  std::vector<Interfaces::IMSDataConsumer<> *> consumer_list;
+  std::vector<Interfaces::IMSDataConsumer *> consumer_list;
   consumer_list.push_back(new NoopMSDataConsumer());
   consumer_list.push_back(transforming_consumer);
   consumer_list.push_back(new NoopMSDataConsumer());
@@ -144,7 +147,7 @@ END_SECTION
 
 START_SECTION((void consumeChromatogram(ChromatogramType & c)))
 {
-  std::vector<Interfaces::IMSDataConsumer<> *> consumer_list;
+  std::vector<Interfaces::IMSDataConsumer *> consumer_list;
   consumer_list.push_back(new NoopMSDataConsumer());
   consumer_list.push_back(new NoopMSDataConsumer());
   consumer_list.push_back(new NoopMSDataConsumer());
@@ -170,7 +173,7 @@ START_SECTION(([EXTRA]void consumeChromatogram(ChromatogramType & c)))
   transforming_consumer->setExpectedSize(2,0);
   transforming_consumer->setChromatogramProcessingPtr(FunctionChangeChromatogram);
 
-  std::vector<Interfaces::IMSDataConsumer<> *> consumer_list;
+  std::vector<Interfaces::IMSDataConsumer *> consumer_list;
   consumer_list.push_back(new NoopMSDataConsumer());
   consumer_list.push_back(transforming_consumer);
   consumer_list.push_back(new NoopMSDataConsumer());
@@ -209,13 +212,13 @@ START_SECTION((void setExperimentalSettings(const ExperimentalSettings&)))
 }
 END_SECTION
 
-START_SECTION(( void appendConsumer(IMSDataConsumer<> * consumer) ))
+START_SECTION(( void appendConsumer(IMSDataConsumer * consumer) ))
 {
   MSDataTransformingConsumer * transforming_consumer = new MSDataTransformingConsumer();
   transforming_consumer->setExpectedSize(2,0);
   transforming_consumer->setSpectraProcessingPtr(FunctionChangeSpectrum);
 
-  std::vector<Interfaces::IMSDataConsumer<> *> consumer_list;
+  std::vector<Interfaces::IMSDataConsumer *> consumer_list;
   consumer_list.push_back(new NoopMSDataConsumer());
   consumer_list.push_back(new NoopMSDataConsumer());
   MSDataChainingConsumer * chaining_consumer = new MSDataChainingConsumer(consumer_list);

--- a/src/tests/class_tests/openms/source/MSDataTransformingConsumer_test.cpp
+++ b/src/tests/class_tests/openms/source/MSDataTransformingConsumer_test.cpp
@@ -36,11 +36,11 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <OpenMS/FORMAT/DATAACCESS/MSDataTransformingConsumer.h>
-
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 
 void FunctionChangeSpectrum (OpenMS::MSSpectrum<OpenMS::Peak1D> & s)

--- a/src/tests/class_tests/openms/source/MSPFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MSPFile_test.cpp
@@ -39,6 +39,8 @@
 #include <OpenMS/FORMAT/MSPFile.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -37,8 +37,12 @@
 
 ///////////////////////////
 #include <OpenMS/KERNEL/MSSpectrum.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
 ///////////////////////////
+
+#include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MascotGenericFile_test.cpp
@@ -40,6 +40,9 @@
 #include <sstream>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 using namespace OpenMS;
 using namespace std;
 

--- a/src/tests/class_tests/openms/source/MzDataValidator_test.cpp
+++ b/src/tests/class_tests/openms/source/MzDataValidator_test.cpp
@@ -39,6 +39,8 @@
 #include <OpenMS/FORMAT/VALIDATORS/MzDataValidator.h>
 ///////////////////////////
 
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
+
 using namespace OpenMS;
 using namespace OpenMS::Internal;
 using namespace std;

--- a/src/tests/class_tests/openms/source/MzMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzMLFile_test.cpp
@@ -36,8 +36,9 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <OpenMS/FORMAT/MzMLFile.h>
+///////////////////////////
+
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 

--- a/src/tests/class_tests/openms/source/NeutralLossDiffFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/NeutralLossDiffFilter_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FILTERING/TRANSFORMERS/NeutralLossDiffFilter.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/NeutralLossMarker_test.cpp
+++ b/src/tests/class_tests/openms/source/NeutralLossMarker_test.cpp
@@ -42,6 +42,9 @@
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 #include <map>
 
 using namespace OpenMS;

--- a/src/tests/class_tests/openms/source/OpenSwathMRMFeatureAccessOpenMS_test.cpp
+++ b/src/tests/class_tests/openms/source/OpenSwathMRMFeatureAccessOpenMS_test.cpp
@@ -40,9 +40,12 @@
 
 ///////////////////////////
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h>
+///////////////////////////
 
 #include <OpenMS/ANALYSIS/MRM/ReactionMonitoringTransition.h>
-///////////////////////////
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/PScore_test.cpp
+++ b/src/tests/class_tests/openms/source/PScore_test.cpp
@@ -39,6 +39,9 @@
 ///////////////////////////
 #include <OpenMS/ANALYSIS/RNPXL/PScore.h>
 ///////////////////////////
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/PeakAlignment_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakAlignment_test.cpp
@@ -38,6 +38,8 @@
 ///////////////////////////
 #include <OpenMS/COMPARISON/SPECTRA/PeakAlignment.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <vector>
 ///////////////////////////
 

--- a/src/tests/class_tests/openms/source/PeakPickerMaxima_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakPickerMaxima_test.cpp
@@ -39,6 +39,8 @@
 #include <OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerMaxima.h>
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <cmath>
 #define PI 3.141592653589793

--- a/src/tests/class_tests/openms/source/PepXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/PepXMLFile_test.cpp
@@ -39,6 +39,9 @@
 #include <OpenMS/FORMAT/PepXMLFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h> //ONLY used for checking if pepxml transformation produced a reusable id file
 ///////////////////////////
+
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/CONCEPT/FuzzyStringComparator.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>

--- a/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
+++ b/src/tests/class_tests/openms/source/QTClusterFinder_test.cpp
@@ -43,6 +43,8 @@
 
 #include <OpenMS/KERNEL/Feature.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
+#include <OpenMS/METADATA/PeptideHit.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/SpectrumPrecursorComparator_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumPrecursorComparator_test.cpp
@@ -36,15 +36,17 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <OpenMS/COMPARISON/SPECTRA/SpectrumPrecursorComparator.h>
+///////////////////////////
+
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
 
 using namespace OpenMS;
 using namespace std;
 
-///////////////////////////
 
 START_TEST(SpectrumPrecursorComparator, "$Id$")
 

--- a/src/tests/class_tests/openms/source/StandardTypes_test.cpp
+++ b/src/tests/class_tests/openms/source/StandardTypes_test.cpp
@@ -36,10 +36,11 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <OpenMS/KERNEL/StandardTypes.h>
-
 ///////////////////////////
+
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 START_TEST(StandardTypes, "$Id$")
 

--- a/src/tests/class_tests/openms/source/SysInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/SysInfo_test.cpp
@@ -43,6 +43,9 @@
 
 ///////////////////////////
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+
 using namespace OpenMS;
 
 START_TEST(SysInfo, "$Id$")

--- a/src/tests/class_tests/openms/source/TICFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/TICFilter_test.cpp
@@ -41,6 +41,8 @@
 #include <OpenMS/FILTERING/TRANSFORMERS/TICFilter.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/FORMAT/DTAFile.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -41,6 +41,10 @@
 
 #include <OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+#include <OpenMS/CONCEPT/Constants.h>
 
 ///////////////////////////
 

--- a/src/tests/class_tests/openms/source/TraMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/TraMLFile_test.cpp
@@ -36,9 +36,10 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <OpenMS/FORMAT/TraMLFile.h>
-#include <OpenMS/FORMAT/FileHandler.h>
+///////////////////////////
+
+#include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/TraMLValidator_test.cpp
+++ b/src/tests/class_tests/openms/source/TraMLValidator_test.cpp
@@ -38,6 +38,7 @@
 ///////////////////////////
 #include <OpenMS/FORMAT/VALIDATORS/TraMLValidator.h>
 ///////////////////////////
+#include <OpenMS/FORMAT/ControlledVocabulary.h>
 
 using namespace OpenMS;
 using namespace OpenMS::Internal;

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -41,11 +41,16 @@
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/MzXMLFile.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/FORMAT/MzDataFile.h>
+#include <OpenMS/FORMAT/TextFile.h>
+#include <OpenMS/FORMAT/MascotGenericFile.h>
+#include <OpenMS/FORMAT/DTA2DFile.h>
 #include <OpenMS/FORMAT/IBSpectraFile.h>
 #include <OpenMS/FORMAT/CachedMzML.h>
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/KERNEL/ConversionHelper.h>
+#include <OpenMS/KERNEL/ChromatogramTools.h>
 
 #include <OpenMS/FORMAT/DATAACCESS/MSDataWritingConsumer.h>
 #include <OpenMS/FORMAT/DATAACCESS/MSDataCachedConsumer.h>

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -41,10 +41,12 @@
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
+#include <OpenMS/FORMAT/MzDataFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/FORMAT/IndexedMzMLFile.h>
 #include <OpenMS/FORMAT/MzIdentMLFile.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/FORMAT/MzXMLFile.h>
 #include <OpenMS/FORMAT/PepXMLFile.h>
 #include <OpenMS/FORMAT/TransformationXMLFile.h>
 #include <OpenMS/FORMAT/PeakTypeEstimator.h>

--- a/src/topp/FileMerger.cpp
+++ b/src/topp/FileMerger.cpp
@@ -42,6 +42,7 @@
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
+#include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/FORMAT/TransformationXMLFile.h>
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>

--- a/src/topp/IDFileConverter.cpp
+++ b/src/topp/IDFileConverter.cpp
@@ -44,6 +44,7 @@
 #include <OpenMS/FORMAT/ProtXMLFile.h>
 #include <OpenMS/FORMAT/SequestOutfile.h>
 #include <OpenMS/FORMAT/XTandemXMLFile.h>
+#include <OpenMS/FORMAT/TextFile.h>
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 

--- a/src/topp/InclusionExclusionListCreator.cpp
+++ b/src/topp/InclusionExclusionListCreator.cpp
@@ -34,7 +34,9 @@
 
 //#include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/KERNEL/RangeUtils.h>
 #include <OpenMS/ANALYSIS/TARGETED/InclusionExclusionList.h>
 #include <OpenMS/ANALYSIS/TARGETED/OfflinePrecursorIonSelection.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>

--- a/src/topp/InternalCalibration.cpp
+++ b/src/topp/InternalCalibration.cpp
@@ -40,6 +40,7 @@
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/FORMAT/TransformationXMLFile.h>

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -42,6 +42,7 @@
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/FORMAT/PepXMLFile.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/SYSTEM/JavaInfo.h>

--- a/src/topp/MzTabExporter.cpp
+++ b/src/topp/MzTabExporter.cpp
@@ -36,10 +36,11 @@
 
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 #include <OpenMS/MATH/MISC/MathFunctions.h>
+#include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
-#include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/METADATA/MetaInfoInterfaceUtils.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/ProteinHit.h>

--- a/src/topp/OpenSwathFeatureXMLToTSV.cpp
+++ b/src/topp/OpenSwathFeatureXMLToTSV.cpp
@@ -35,6 +35,7 @@
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
+#include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <fstream>
 
 using namespace OpenMS;

--- a/src/topp/PepNovoAdapter.cpp
+++ b/src/topp/PepNovoAdapter.cpp
@@ -42,6 +42,7 @@
 #include <OpenMS/FORMAT/MzXMLFile.h>
 #include <OpenMS/FORMAT/PepNovoInfile.h>
 #include <OpenMS/FORMAT/PepNovoOutfile.h>
+#include <OpenMS/FORMAT/MascotGenericFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/METADATA/ContactPerson.h>
 #include <OpenMS/SYSTEM/File.h>

--- a/src/topp/PrecursorMassCorrector.cpp
+++ b/src/topp/PrecursorMassCorrector.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmIsotopeWavelet.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>

--- a/src/topp/SeedListGenerator.cpp
+++ b/src/topp/SeedListGenerator.cpp
@@ -36,6 +36,7 @@
 
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>

--- a/src/utils/IDMassAccuracy.cpp
+++ b/src/utils/IDMassAccuracy.cpp
@@ -45,6 +45,10 @@
 #include <OpenMS/MATH/STATISTICS/GaussFitter.h>
 #include <OpenMS/FILTERING/TRANSFORMERS/Normalizer.h>
 
+#include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
+#include <OpenMS/KERNEL/RichPeak1D.h>
+
 #include <OpenMS/MATH/STATISTICS/StatisticFunctions.h>
 
 using namespace OpenMS;

--- a/src/utils/SpecLibCreator.cpp
+++ b/src/utils/SpecLibCreator.cpp
@@ -33,10 +33,13 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/KERNEL/MSExperiment.h>
-#include <OpenMS/FORMAT/CsvFile.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
+#include <OpenMS/FORMAT/CsvFile.h>
 #include <OpenMS/FORMAT/FileTypes.h>
 #include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/FORMAT/MzXMLFile.h>
+#include <OpenMS/FORMAT/MzDataFile.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/FORMAT/MSPFile.h>
 #include <OpenMS/KERNEL/RichPeak1D.h>

--- a/src/utils/TICCalculator.cpp
+++ b/src/utils/TICCalculator.cpp
@@ -81,7 +81,7 @@ using namespace OpenSwath;
 
 
 class TICConsumer : 
-    public Interfaces::IMSDataConsumer< PeakMap >
+    public Interfaces::IMSDataConsumer
 {
 
     typedef PeakMap MapType;

--- a/src/utils/XMLValidator.cpp
+++ b/src/utils/XMLValidator.cpp
@@ -42,6 +42,9 @@
 #include <OpenMS/FORMAT/MzIdentMLFile.h>
 #include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/ParamXMLFile.h>
+#include <OpenMS/FORMAT/MzDataFile.h>
+#include <OpenMS/FORMAT/MzXMLFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 


### PR DESCRIPTION
- move code to cpp files
- remove template from `IMSDataConsumer`
- introduces the file `OpenMS/KERNEL/StandardDeclarations.h` which contains forward declarations for all the important stuff, e.g. `MSSpectrum` and `MSChromatogram` and `MSExperiment`
- generally reduces header mess a bit and makes includes more on a "per-need" basis