### PR TITLE
FeatureFinderIdentification runtime optimization

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
@@ -191,12 +191,11 @@ public:
      *   appropriate extraction coordinates in m/z and rt and sorted by m/z (to
      *   be used as input to extractChromatograms)
      * @param transition_exp The transition experiment used as input (is constant)
-     * @param rt_extraction_window If larger than zero, full RT extraction
-     *   window, centered on the first RT value (@p rt_end - @p rt_start will
-     *   equal this window size). If less than zero, @p rt_end will be set to -1
-     *   and @p rt_start to 0 (i.e. full RT range). If exactly zero, exactly two
-     *   RT entries are expected - the first is used as @p rt_start and the
-     *   second as @p rt_end.
+     * @param rt_extraction_window If non-negative, full RT extraction window,
+     *   centered on the first RT value (@p rt_end - @p rt_start will equal this
+     *   window size). If negative, @p rt_end will be set to -1 and @p rt_start
+     *   to 0 (i.e. full RT range). If NaN, exactly two RT entries are expected
+     *   - the first is used as @p rt_start and the second as @p rt_end.
      * @param ms1 Whether to extract for MS1 (peptide level) or MS2 (transition level)
      *
      * @throw Exception::IllegalArgument if RT values are expected (depending on @p rt_extraction_window) but not provided

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractor.h
@@ -180,7 +180,7 @@ public:
 public:
 
     /**
-     * @brief Prepare the extraction coordinates from a TargetedExperiment 
+     * @brief Prepare the extraction coordinates from a TargetedExperiment
      *
      * Will fill the coordinates vector with the appropriate extraction
      * coordinates (transitions for MS2 extraction, peptide m/z for MS1
@@ -191,12 +191,15 @@ public:
      *   appropriate extraction coordinates in m/z and rt and sorted by m/z (to
      *   be used as input to extractChromatograms)
      * @param transition_exp The transition experiment used as input (is constant)
-     * @param rt_extraction_window Full RT extraction window (rt_end - rt_start
-     *   will equal this window size). Enforces the presence of retention times
-     *   if larger than zero (throws an exception), if less than zero, rt_end
-     *   will be set to -1 and rt_start to 0.
+     * @param rt_extraction_window If larger than zero, full RT extraction
+     *   window, centered on the first RT value (@p rt_end - @p rt_start will
+     *   equal this window size). If less than zero, @p rt_end will be set to -1
+     *   and @p rt_start to 0 (i.e. full RT range). If exactly zero, exactly two
+     *   RT entries are expected - the first is used as @p rt_start and the
+     *   second as @p rt_end.
      * @param ms1 Whether to extract for MS1 (peptide level) or MS2 (transition level)
      *
+     * @throw Exception::IllegalArgument if RT values are expected (depending on @p rt_extraction_window) but not provided
     */
     void prepare_coordinates(std::vector< OpenSwath::ChromatogramPtr > & output_chromatograms,
       std::vector< ExtractionCoordinates > & coordinates,

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractorAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ChromatogramExtractorAlgorithm.h
@@ -64,11 +64,11 @@ public:
 
     struct ExtractionCoordinates
     {
-      double mz; /// m/z value around which should be extracted
-      double mz_precursor; /// precursor m/z value (is currently ignored by the algorithm)
-      double rt_start; /// rt start of extraction (in seconds)
-      double rt_end; /// rt end of extraction (in seconds)
-      std::string id; /// identifier
+      double mz; ///< m/z value around which should be extracted
+      double mz_precursor; ///< precursor m/z value (is currently ignored by the algorithm)
+      double rt_start; ///< rt start of extraction (in seconds)
+      double rt_end; ///< rt end of extraction (in seconds)
+      std::string id; ///< identifier
 
       static bool SortExtractionCoordinatesByMZ(
           const ChromatogramExtractorAlgorithm::ExtractionCoordinates& left,

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -79,7 +79,6 @@ namespace OpenMS
         coord.id = transition.getNativeID();
       }
 
-      std::cout << "RT window: " << rt_extraction_window << std::endl;
       if (rt_extraction_window < 0)
       {
         coord.rt_end = -1;

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -79,6 +79,7 @@ namespace OpenMS
         coord.id = transition.getNativeID();
       }
 
+      std::cout << "RT window: " << rt_extraction_window << std::endl;
       if (rt_extraction_window < 0)
       {
         coord.rt_end = -1;
@@ -91,7 +92,7 @@ namespace OpenMS
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                          "Error: Peptide " + pep.id + " does not have normalized retention times (term 1000896) which are necessary to perform an RT-limited extraction");
       }
-      else if (rt_extraction_window == 0)
+      else if (boost::math::isnan(rt_extraction_window))
       {
         if (pep.rts.size() != 2)
         {
@@ -100,7 +101,7 @@ namespace OpenMS
         coord.rt_start = pep.rts[0].getCVTerms()["MS:1000896"][0].getValue().toString().toDouble();
         coord.rt_end = pep.rts[1].getCVTerms()["MS:1000896"][0].getValue().toString().toDouble();
       }
-      else
+      else // if 'rt_extraction_window' is zero, just write the (first) RT value for later processing
       {
         double rt = pep.rts[0].getCVTerms()["MS:1000896"][0].getValue().toString().toDouble();
         coord.rt_start = rt - rt_extraction_window / 2.0;

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -79,17 +79,26 @@ namespace OpenMS
         coord.id = transition.getNativeID();
       }
 
-      if (pep.rts.empty() || pep.rts[0].getCVTerms()["MS:1000896"].empty())
+      if (rt_extraction_window < 0)
+      {
+        coord.rt_end = -1;
+        coord.rt_start = 0;
+      }
+      else if (pep.rts.empty() || pep.rts[0].getCVTerms()["MS:1000896"].empty())
       {
         // we don't have retention times -> this is only a problem if we actually
         // wanted to use the RT limit feature.
-        if (rt_extraction_window < 0)
+        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                         "Error: Peptide " + pep.id + " does not have normalized retention times (term 1000896) which are necessary to perform an RT-limited extraction");
+      }
+      else if (rt_extraction_window == 0)
+      {
+        if (pep.rts.size() != 2)
         {
-          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-            "Error: Peptide " + pep.id + " does not have normalized retention times (term 1000896) which are necessary to perform an RT-limited extraction");
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Error: Expected exactly two retention time entries for peptide '" + pep.id + "', found " + String(pep.rts.size()));
         }
-        coord.rt_end = -1;
-        coord.rt_start = 0;
+        coord.rt_start = pep.rts[0].getCVTerms()["MS:1000896"][0].getValue().toString().toDouble();
+        coord.rt_end = pep.rts[1].getCVTerms()["MS:1000896"][0].getValue().toString().toDouble();
       }
       else
       {

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -280,15 +280,16 @@ set_tests_properties("TOPP_FeatureFinderCentroided_1_out1" PROPERTIES DEPENDS "T
 # FeatureFinderIdentification test
 ## internal IDs only:
 add_test("TOPP_FeatureFinderIdentification_1" ${TOPP_BIN_PATH}/FeatureFinderIdentification -test -in ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.mzML -id ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.idXML -out FeatureFinderIdentification_1.tmp -extract:mz_window 0.1 -detect:peak_width 60 -model:type none)
-add_test("TOPP_FeatureFinderIdentification_1_out1" ${DIFF} -whitelist "id=" -in1 FeatureFinderIdentification_1.tmp -in2 ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_output.featureXML)
+add_test("TOPP_FeatureFinderIdentification_1_out1" ${DIFF} -whitelist -in1 FeatureFinderIdentification_1.tmp -in2 ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_output.featureXML)
 set_tests_properties("TOPP_FeatureFinderIdentification_1_out1" PROPERTIES DEPENDS "TOPP_FeatureFinderIdentification_1")
 ## with (faked) external IDs; fix SVM parameters to avoid randomness:
 add_test("TOPP_FeatureFinderIdentification_2" ${TOPP_BIN_PATH}/FeatureFinderIdentification -test -in ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.mzML -id ${DATA_DIR_TOPP}/FeatureFinderIdentification_2_input.idXML -id_ext ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.idXML -out FeatureFinderIdentification_2.tmp -extract:mz_window 0.1 -detect:peak_width 60 -svm:no_selection -svm:log2_C 1 -svm:log2_gamma 1 -model:type none)
-add_test("TOPP_FeatureFinderIdentification_2_out1" ${DIFF} -whitelist "id=" -in1 FeatureFinderIdentification_2.tmp -in2 ${DATA_DIR_TOPP}/FeatureFinderIdentification_2_output.featureXML)
+## results are somewhat random, so don't be too strict when comparing:
+add_test("TOPP_FeatureFinderIdentification_2_out1" ${DIFF} -whitelist "FDR_probabilities" "FFId_category" -ratio 1.1 -absdiff 0.03 -in1 FeatureFinderIdentification_2.tmp -in2 ${DATA_DIR_TOPP}/FeatureFinderIdentification_2_output.featureXML)
 set_tests_properties("TOPP_FeatureFinderIdentification_2_out1" PROPERTIES DEPENDS "TOPP_FeatureFinderIdentification_2")
 ## with elution model fitting:
 add_test("TOPP_FeatureFinderIdentification_3" ${TOPP_BIN_PATH}/FeatureFinderIdentification -test -in ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.mzML -id ${DATA_DIR_TOPP}/FeatureFinderIdentification_1_input.idXML -out FeatureFinderIdentification_3.tmp -extract:mz_window 0.1 -detect:peak_width 60 -model:type symmetric)
-add_test("TOPP_FeatureFinderIdentification_3_out1" ${DIFF} -whitelist "id=" -in1 FeatureFinderIdentification_3.tmp -in2 ${DATA_DIR_TOPP}/FeatureFinderIdentification_3_output.featureXML)
+add_test("TOPP_FeatureFinderIdentification_3_out1" ${DIFF} -whitelist -in1 FeatureFinderIdentification_3.tmp -in2 ${DATA_DIR_TOPP}/FeatureFinderIdentification_3_output.featureXML)
 set_tests_properties("TOPP_FeatureFinderIdentification_3_out1" PROPERTIES DEPENDS "TOPP_FeatureFinderIdentification_3")
 
 #------------------------------------------------------------------------------

--- a/src/tests/topp/FeatureFinderIdentification_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderIdentification_1_output.featureXML
@@ -58,13 +58,6 @@
 			</ProteinHit>
 		</ProteinIdentification>
 	</IdentificationRun>
-	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
-		<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_14">
-			<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="internal"/>
-	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="653.361755371094" RT="2490.31689453125" >
 		<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_14">
 			<UserParam type="float" name="OMSSA_score" value="0.0117575719819199"/>
@@ -75,6 +68,20 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.910125732422" RT="2488.0380859375" >
 		<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_14">
 			<UserParam type="float" name="OMSSA_score" value="3.09620313351901e-07"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="internal"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
+		<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_14">
+			<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="internal"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="526.261108398438" RT="2495.662109375" >
+		<PeptideHit score="0" sequence="LKPDPNTLC(Carbamidomethyl)DEFK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_14">
+			<UserParam type="float" name="OMSSA_score" value="0.00026056879779557"/>
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
@@ -93,15 +100,987 @@
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
 	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="526.261108398438" RT="2495.662109375" >
-		<PeptideHit score="0" sequence="LKPDPNTLC(Carbamidomethyl)DEFK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_14">
-			<UserParam type="float" name="OMSSA_score" value="0.00026056879779557"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="internal"/>
-	</UnassignedPeptideIdentification>
 	<featureList count="25">
 		<feature id="f_5233264595117471314">
+			<position dim="0">2024.60123336381</position>
+			<position dim="1">461.747653035421</position>
+			<intensity>7.80702e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.74809</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1998.99108886719" y="461.697653035421" />
+				<pt x="2087.48876953125" y="461.697653035421" />
+				<pt x="2087.48876953125" y="461.797653035421" />
+				<pt x="1998.99108886719" y="461.797653035421" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1998.99108886719" y="462.199330454321" />
+				<pt x="2087.48876953125" y="462.199330454321" />
+				<pt x="2087.48876953125" y="462.299330454321" />
+				<pt x="1998.99108886719" y="462.299330454321" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_5233264595117471314_4835329514588776807">
+					<position dim="0">2024.60123336381</position>
+					<position dim="1">461.747653035421</position>
+					<intensity>5.1932e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="461.747653035421"/>
+					<UserParam type="string" name="native_id" value="AEFVEVTK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="7271544.12011719"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.66642596900412"/>
+				</feature>
+				<feature id="f_5233264595117471314_17749660155506638460">
+					<position dim="0">2024.60123336381</position>
+					<position dim="1">462.249330454321</position>
+					<intensity>2.61382e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="462.249330454321"/>
+					<UserParam type="string" name="native_id" value="AEFVEVTK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="3647712.47851562"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.33357403099588"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="461.747497558594" RT="2015.59265136719" >
+				<PeptideHit score="0" sequence="AEFVEVTK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.000296258184030238"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="461.74755859375" RT="2038.95886230469" >
+				<PeptideHit score="0" sequence="AEFVEVTK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.00012753925040404"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="AEFVEVTK/2"/>
+			<UserParam type="float" name="leftWidth" value="1998.99108886719"/>
+			<UserParam type="float" name="rightWidth" value="2087.48876953125"/>
+			<UserParam type="float" name="total_xic" value="78856149.1257324"/>
+			<UserParam type="float" name="peak_apices_sum" value="10919256.5986328"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999964845503361"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999953110426825"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00123025228850404"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00221672421707534"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00123025228850404"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00134201647916671"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999149732785"/>
+			<UserParam type="float" name="var_intensity_score" value="0.990032925340049"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="99.118612261271"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.59631723663037"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.99825581908226"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.53469293463408"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.990778825707125"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.33480429649353"/>
+			<UserParam type="float" name="var_massdev_score" value="1.5081557298974"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.29524029783514"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="1"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.764252063684777"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.860376056103047"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.74808804926625"/>
+			<UserParam type="float" name="PrecursorMZ" value="461.747653035421"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_7804704400743266335">
+			<position dim="0">2072.67445045983</position>
+			<position dim="1">395.726522907821</position>
+			<intensity>2.40993e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>2.90616</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2045.21923828125" y="395.676522907821" />
+				<pt x="2151.267578125" y="395.676522907821" />
+				<pt x="2151.267578125" y="395.776522907821" />
+				<pt x="2045.21923828125" y="395.776522907821" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2045.21923828125" y="396.178200326721" />
+				<pt x="2151.267578125" y="396.178200326721" />
+				<pt x="2151.267578125" y="396.278200326721" />
+				<pt x="2045.21923828125" y="396.278200326721" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_7804704400743266335_15004869347769368353">
+					<position dim="0">2072.67445045983</position>
+					<position dim="1">395.726522907821</position>
+					<intensity>1.72337e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="395.726522907821"/>
+					<UserParam type="string" name="native_id" value="AGAFSLPK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="1920706.55371094"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.692511512336989"/>
+				</feature>
+				<feature id="f_7804704400743266335_3332699010107892018">
+					<position dim="0">2072.67445045983</position>
+					<position dim="1">396.228200326721</position>
+					<intensity>6.86563e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="396.228200326721"/>
+					<UserParam type="string" name="native_id" value="AGAFSLPK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="787648.461669922"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.307488487663011"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.700897216797" RT="2085.73901367188" >
+				<PeptideHit score="0.0454545454545455" sequence="AGAFSLPK" charge="2" aa_before="R" aa_after="D" protein_refs="PH_1">
+					<UserParam type="float" name="OMSSA_score" value="0.0631960134592704"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="AGAFSLPK/2"/>
+			<UserParam type="float" name="leftWidth" value="2045.21923828125"/>
+			<UserParam type="float" name="rightWidth" value="2151.267578125"/>
+			<UserParam type="float" name="total_xic" value="25676793.1026611"/>
+			<UserParam type="float" name="peak_apices_sum" value="2708355.01538086"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999783302096998"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999723138978434"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0225991493463209"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0387559354182129"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0225991493463209"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0258785056107158"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999693670468852"/>
+			<UserParam type="float" name="var_intensity_score" value="0.93856284558769"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="90.1918622910647"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.50193920449604"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.994698405265808"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.40764334991993"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.819453547569494"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.284889370203018"/>
+			<UserParam type="float" name="var_massdev_score" value="17.9434489619426"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="15.8733115429516"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.629640200535799"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.22548465137465"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.90615800346689"/>
+			<UserParam type="float" name="PrecursorMZ" value="395.726522907821"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_13440783915218733453">
+			<position dim="0">2123.35043908495</position>
+			<position dim="1">455.755280535421</position>
+			<intensity>5.95285e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>2.1168</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2094.08325195312" y="455.705280535421" />
+				<pt x="2197.34326171875" y="455.705280535421" />
+				<pt x="2197.34326171875" y="455.805280535421" />
+				<pt x="2094.08325195312" y="455.805280535421" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2094.08325195312" y="456.206957954321" />
+				<pt x="2197.34326171875" y="456.206957954321" />
+				<pt x="2197.34326171875" y="456.306957954321" />
+				<pt x="2094.08325195312" y="456.306957954321" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_13440783915218733453_15916652588957785155">
+					<position dim="0">2123.35043908495</position>
+					<position dim="1">455.755280535421</position>
+					<intensity>4.14411e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="455.755280535421"/>
+					<UserParam type="string" name="native_id" value="AGDLLFFK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="309924.96875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.652807062123664"/>
+				</feature>
+				<feature id="f_13440783915218733453_15157403601844400700">
+					<position dim="0">2123.35043908495</position>
+					<position dim="1">456.256957954321</position>
+					<intensity>1.80875e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="456.256957954321"/>
+					<UserParam type="string" name="native_id" value="AGDLLFFK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="157846.099365234"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.347192937876336"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="455.713287353516" RT="2155.63891601562" >
+				<PeptideHit score="0.0454545454545455" sequence="AGDLLFFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_0">
+					<UserParam type="float" name="OMSSA_score" value="0.0676769400449016"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="AGDLLFFK/2"/>
+			<UserParam type="float" name="leftWidth" value="2094.08325195312"/>
+			<UserParam type="float" name="rightWidth" value="2197.34326171875"/>
+			<UserParam type="float" name="total_xic" value="5997125.0446167"/>
+			<UserParam type="float" name="peak_apices_sum" value="467771.068115234"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.99795112736991"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997213738088641"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0433476733099384"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0772597046512218"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0433476733099384"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0477934471432182"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.9989293261486"/>
+			<UserParam type="float" name="var_intensity_score" value="0.992617455149373"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="83.2032969856814"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.42128697427377"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.995112538337708"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.27554241539011"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.0260724897716084"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="21.253494592472"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="14.7581264553983"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.411466872246703"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.5437174435549"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.11679838595154"/>
+			<UserParam type="float" name="PrecursorMZ" value="455.755280535421"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_6408859317243173796">
+			<position dim="0">1760.25657093773</position>
+			<position dim="1">569.752618393021</position>
+			<intensity>1.41459e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.74485</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1735.69311523438" y="569.702618393021" />
+				<pt x="1806.53210449219" y="569.702618393021" />
+				<pt x="1806.53210449219" y="569.802618393021" />
+				<pt x="1735.69311523438" y="569.802618393021" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1735.69311523438" y="570.204295811921" />
+				<pt x="1806.53210449219" y="570.204295811921" />
+				<pt x="1806.53210449219" y="570.304295811921" />
+				<pt x="1735.69311523438" y="570.304295811921" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_6408859317243173796_12999979801269632061">
+					<position dim="0">1760.25657093773</position>
+					<position dim="1">569.752618393021</position>
+					<intensity>9.09907e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="569.752618393021"/>
+					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="1354679.41699219"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.644498608917742"/>
+				</feature>
+				<feature id="f_6408859317243173796_17413765565443951891">
+					<position dim="0">1760.25657093773</position>
+					<position dim="1">570.254295811921</position>
+					<intensity>5.04683e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="570.254295811921"/>
+					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="754406.354980469"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.355501391082258"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
+				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
+				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2"/>
+			<UserParam type="float" name="leftWidth" value="1735.69311523438"/>
+			<UserParam type="float" name="rightWidth" value="1806.53210449219"/>
+			<UserParam type="float" name="total_xic" value="14486678.1954346"/>
+			<UserParam type="float" name="peak_apices_sum" value="2109085.77197266"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999786313233063"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999706240332848"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00126828605193474"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00234262974539749"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00126828605193474"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00135289409378492"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999123130552"/>
+			<UserParam type="float" name="var_intensity_score" value="0.976475891102353"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="117.627765815645"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.76752511147092"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.99731856584549"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.66028853965821"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.993260451842917"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.356769680976868"/>
+			<UserParam type="float" name="var_massdev_score" value="0.482075605090886"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.385620600005746"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.754351526419968"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.84165907229483"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.74484798021522"/>
+			<UserParam type="float" name="PrecursorMZ" value="569.752618393021"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_10306100746905639127">
+			<position dim="0">1749.12956152037</position>
+			<position dim="1">443.711267907821</position>
+			<intensity>3.6544e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.77097</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1720.42810058594" y="443.661267907821" />
+				<pt x="1794.18957519531" y="443.661267907821" />
+				<pt x="1794.18957519531" y="443.761267907821" />
+				<pt x="1720.42810058594" y="443.761267907821" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1720.42810058594" y="444.162945326721" />
+				<pt x="1794.18957519531" y="444.162945326721" />
+				<pt x="1794.18957519531" y="444.262945326721" />
+				<pt x="1720.42810058594" y="444.262945326721" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_10306100746905639127_12524258085768770586">
+					<position dim="0">1749.12956152037</position>
+					<position dim="1">443.711267907821</position>
+					<intensity>2.5289e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="443.711267907821"/>
+					<UserParam type="string" name="native_id" value="DDSPDLPK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="2805595.68164062"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.691417156355378"/>
+				</feature>
+				<feature id="f_10306100746905639127_1755235105885170967">
+					<position dim="0">1749.12956152037</position>
+					<position dim="1">444.212945326721</position>
+					<intensity>1.12549e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="444.212945326721"/>
+					<UserParam type="string" name="native_id" value="DDSPDLPK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="1242968.625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.308582843644622"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="443.711242675781" RT="1738.03344726562" >
+				<PeptideHit score="0.0344827586206897" sequence="DDSPDLPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.00395109914742618"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="DDSPDLPK/2"/>
+			<UserParam type="float" name="leftWidth" value="1720.42810058594"/>
+			<UserParam type="float" name="rightWidth" value="1794.18957519531"/>
+			<UserParam type="float" name="total_xic" value="36892001.3114014"/>
+			<UserParam type="float" name="peak_apices_sum" value="4048564.30664062"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999913661505798"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999889473186652"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00059963032698801"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00104554317450789"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00059963032698801"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.000675051683031891"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999789234646"/>
+			<UserParam type="float" name="var_intensity_score" value="0.990566158000927"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="90.798258417387"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.50864010499805"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.996718049049377"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.47518657598361"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.990743065551955"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.307983219623566"/>
+			<UserParam type="float" name="var_massdev_score" value="0.760948674247052"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.544374916743954"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="1"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.767922678010944"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.870417252673125"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.77097449225763"/>
+			<UserParam type="float" name="PrecursorMZ" value="443.711267907821"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_14811341817612382122">
+			<position dim="0">1851.03387353231</position>
+			<position dim="1">487.732534471621</position>
+			<intensity>8.88504e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.57637</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1825.08544921875" y="487.682534471621" />
+				<pt x="2023.54016113281" y="487.682534471621" />
+				<pt x="2023.54016113281" y="487.782534471621" />
+				<pt x="1825.08544921875" y="487.782534471621" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1825.08544921875" y="488.184211890521" />
+				<pt x="2023.54016113281" y="488.184211890521" />
+				<pt x="2023.54016113281" y="488.284211890521" />
+				<pt x="1825.08544921875" y="488.284211890521" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_14811341817612382122_2684106197423007927">
+					<position dim="0">1851.03387353231</position>
+					<position dim="1">487.732534471621</position>
+					<intensity>5.83658e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="487.732534471621"/>
+					<UserParam type="string" name="native_id" value="DLGEEHFK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="4428198.99023438"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.658472827804029"/>
+				</feature>
+				<feature id="f_14811341817612382122_8119044117483804262">
+					<position dim="0">1851.03387353231</position>
+					<position dim="1">488.234211890521</position>
+					<intensity>3.04846e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="488.234211890521"/>
+					<UserParam type="string" name="native_id" value="DLGEEHFK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="2308221"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.341527172195971"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732299804688" RT="1875.54736328125" >
+				<PeptideHit score="0.0344827586206897" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0435747980539929"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732391357422" RT="1906.96594238281" >
+				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0917668515948288"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732177734375" RT="1942.3701171875" >
+				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0918514920664644"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732208251953" RT="2013.36364746094" >
+				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.212602001856198"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="DLGEEHFK/2"/>
+			<UserParam type="float" name="leftWidth" value="1825.08544921875"/>
+			<UserParam type="float" name="rightWidth" value="2023.54016113281"/>
+			<UserParam type="float" name="total_xic" value="89292199.7976074"/>
+			<UserParam type="float" name="peak_apices_sum" value="6736419.99023438"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999943413075745"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999923646234517"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00157333246564981"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0028620088739425"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00157333246564981"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00170135372459251"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999998625615363"/>
+			<UserParam type="float" name="var_intensity_score" value="0.995052470444129"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="97.3835316174288"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.57865711644968"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.979667752981186"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.55568349628391"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.990054921294836"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.343100517988205"/>
+			<UserParam type="float" name="var_massdev_score" value="1.09774247106677"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.949193493234851"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.758326801488211"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.855211785668372"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.57637126739238"/>
+			<UserParam type="float" name="PrecursorMZ" value="487.732534471621"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="4"/>
+			<UserParam type="int" name="n_matching_ids" value="4"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_17314619952666245179">
+			<position dim="0">1850.92089781596</position>
+			<position dim="1">325.490781803338</position>
+			<intensity>6.42808e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.60759</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1825.08544921875" y="325.440781803338" />
+				<pt x="2033.83422851562" y="325.440781803338" />
+				<pt x="2033.83422851562" y="325.540781803338" />
+				<pt x="1825.08544921875" y="325.540781803338" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1825.08544921875" y="325.775233415938" />
+				<pt x="2033.83422851562" y="325.775233415938" />
+				<pt x="2033.83422851562" y="325.875233415938" />
+				<pt x="1825.08544921875" y="325.875233415938" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_17314619952666245179_3023658190814908261">
+					<position dim="0">1850.92089781596</position>
+					<position dim="1">325.490781803338</position>
+					<intensity>4.23901e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="325.490781803338"/>
+					<UserParam type="string" name="native_id" value="DLGEEHFK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="3052206.5"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.658472827804029"/>
+				</feature>
+				<feature id="f_17314619952666245179_7898004582401008768">
+					<position dim="0">1850.92089781596</position>
+					<position dim="1">325.825233415938</position>
+					<intensity>2.18907e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="325.825233415938"/>
+					<UserParam type="string" name="native_id" value="DLGEEHFK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="1595702"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.341527172195971"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="325.491180419922" RT="1840.79333496094" >
+				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0602120422006692"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="DLGEEHFK/3"/>
+			<UserParam type="float" name="leftWidth" value="1825.08544921875"/>
+			<UserParam type="float" name="rightWidth" value="2033.83422851562"/>
+			<UserParam type="float" name="total_xic" value="64501995.4766235"/>
+			<UserParam type="float" name="peak_apices_sum" value="4647908.5"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999871189538208"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999826193702505"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.000978723446304119"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00177775802205168"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.000978723446304119"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00105977533224411"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999467196415"/>
+			<UserParam type="float" name="var_intensity_score" value="0.99657059483216"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="94.9971897725802"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.55384730982174"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.978527456521988"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.54108684338325"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.989630306349789"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.340548455715179"/>
+			<UserParam type="float" name="var_massdev_score" value="0.592963683327705"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.76320776477179"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.77193385755908"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.00330450428431"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.60759112266476"/>
+			<UserParam type="float" name="PrecursorMZ" value="325.490781803338"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_15050004366391181853">
+			<position dim="0">2074.91557012392</position>
+			<position dim="1">554.260602012071</position>
+			<intensity>1.62116e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.6453</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2047.82275390625" y="554.210602012071" />
+				<pt x="2133.37890625" y="554.210602012071" />
+				<pt x="2133.37890625" y="554.310602012071" />
+				<pt x="2047.82275390625" y="554.310602012071" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2047.82275390625" y="554.712279430971" />
+				<pt x="2133.37890625" y="554.712279430971" />
+				<pt x="2133.37890625" y="554.812279430971" />
+				<pt x="2047.82275390625" y="554.812279430971" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_15050004366391181853_17716858074023296841">
+					<position dim="0">2074.91557012392</position>
+					<position dim="1">554.260602012071</position>
+					<intensity>1.02444e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="554.260602012071"/>
+					<UserParam type="string" name="native_id" value="EAC(Carbamidomethyl)FAVEGPK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="1290034.34765625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.630481343594174"/>
+				</feature>
+				<feature id="f_15050004366391181853_16250062551099875712">
+					<position dim="0">2074.91557012392</position>
+					<position dim="1">554.762279430971</position>
+					<intensity>5.96714e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="554.762279430971"/>
+					<UserParam type="string" name="native_id" value="EAC(Carbamidomethyl)FAVEGPK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="740503.5625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.369518656405826"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260375976562" RT="2058.83471679688" >
+				<PeptideHit score="0.0454545454545455" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0548595335303417"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260559082031" RT="2098.17504882812" >
+				<PeptideHit score="0" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="4.91092752369064e-05"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="EAC(Carbamidomethyl)FAVEGPK/2"/>
+			<UserParam type="float" name="leftWidth" value="2047.82275390625"/>
+			<UserParam type="float" name="rightWidth" value="2133.37890625"/>
+			<UserParam type="float" name="total_xic" value="16298802.2630615"/>
+			<UserParam type="float" name="peak_apices_sum" value="2030537.91015625"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999826714315203"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999757773001665"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00144004892103053"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00269456187368486"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00144004892103053"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00151895727538698"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999998886455478"/>
+			<UserParam type="float" name="var_intensity_score" value="0.994648915812717"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="100.706242859935"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.61220779243982"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.99474048614502"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.55149925994001"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.98736710195524"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.368078619241714"/>
+			<UserParam type="float" name="var_massdev_score" value="0.431614306179453"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.347966095008153"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.735829552475677"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.901264010563115"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.6453048191596"/>
+			<UserParam type="float" name="PrecursorMZ" value="554.260602012071"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_16177748921272733768">
+			<position dim="0">1766.28153652464</position>
+			<position dim="1">646.304684132271</position>
+			<intensity>1.15352e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.46475</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1744.55932617188" y="646.254684132271" />
+				<pt x="1848.68237304688" y="646.254684132271" />
+				<pt x="1848.68237304688" y="646.354684132271" />
+				<pt x="1744.55932617188" y="646.354684132271" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1744.55932617188" y="646.756361551171" />
+				<pt x="1848.68237304688" y="646.756361551171" />
+				<pt x="1848.68237304688" y="646.856361551171" />
+				<pt x="1744.55932617188" y="646.856361551171" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_16177748921272733768_1147219038608936718">
+					<position dim="0">1766.28153652464</position>
+					<position dim="1">646.304684132271</position>
+					<intensity>740116</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="646.304684132271"/>
+					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="59630.41796875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
+				</feature>
+				<feature id="f_16177748921272733768_11115414975438642789">
+					<position dim="0">1766.28153652464</position>
+					<position dim="1">646.806361551171</position>
+					<intensity>413408</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="646.806361551171"/>
+					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="32722.078125"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.397061689621381"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.304504394531" RT="1759.0947265625" >
+				<PeptideHit score="0.0454545454545455" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.161429888187637"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" >
+				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0423622396613216"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2"/>
+			<UserParam type="float" name="leftWidth" value="1744.55932617188"/>
+			<UserParam type="float" name="rightWidth" value="1848.68237304688"/>
+			<UserParam type="float" name="total_xic" value="1258179.40576172"/>
+			<UserParam type="float" name="peak_apices_sum" value="92352.49609375"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.996687864987247"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.995242375653698"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0386749522384563"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0729584275113503"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0386749522384563"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0405203562071071"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999204154558718"/>
+			<UserParam type="float" name="var_intensity_score" value="0.91682016468998"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="90.4728415543284"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.50504971234653"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.980602443218231"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.3707575924871"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.968902708499444"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.358386725187302"/>
+			<UserParam type="float" name="var_massdev_score" value="0.552052115383353"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.543039773386319"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.64068624221483"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.04013836171084"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.46474611990348"/>
+			<UserParam type="float" name="PrecursorMZ" value="646.304684132271"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_12665713047548007769">
+			<position dim="0">1766.55652075376</position>
+			<position dim="1">431.205548243771</position>
+			<intensity>1.41524e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>3.70728</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1746.17114257812" y="431.155548243771" />
+				<pt x="1918.98767089844" y="431.155548243771" />
+				<pt x="1918.98767089844" y="431.255548243771" />
+				<pt x="1746.17114257812" y="431.255548243771" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1746.17114257812" y="431.489999856371" />
+				<pt x="1918.98767089844" y="431.489999856371" />
+				<pt x="1918.98767089844" y="431.589999856371" />
+				<pt x="1746.17114257812" y="431.589999856371" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_12665713047548007769_17092894204355333314">
+					<position dim="0">1766.55652075376</position>
+					<position dim="1">431.205548243771</position>
+					<intensity>8.63596e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="431.205548243771"/>
+					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="536289.844238281"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
+				</feature>
+				<feature id="f_12665713047548007769_3491056946625602141">
+					<position dim="0">1766.55652075376</position>
+					<position dim="1">431.539999856371</position>
+					<intensity>5.51648e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="431.539999856371"/>
+					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="332317.34375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.397061689621381"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" >
+				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.042177146646692"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3"/>
+			<UserParam type="float" name="leftWidth" value="1746.17114257812"/>
+			<UserParam type="float" name="rightWidth" value="1918.98767089844"/>
+			<UserParam type="float" name="total_xic" value="14319538.267334"/>
+			<UserParam type="float" name="peak_apices_sum" value="868607.187988281"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999360251977443"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999081051721655"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0072716568743896"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0139110994886304"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0072716568743896"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00752932229758962"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999972302719226"/>
+			<UserParam type="float" name="var_intensity_score" value="0.988331099493958"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="22.6689159856313"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.12099464624477"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.981038093566895"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.46880384807173"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.98312975722697"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.389790028333664"/>
+			<UserParam type="float" name="var_massdev_score" value="0.344572194406841"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.300077406541411"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.712039883282362"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.04508823818716"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.7072817470113"/>
+			<UserParam type="float" name="PrecursorMZ" value="431.205548243771"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_10627069796380146481">
 			<position dim="0">2007.51161653761</position>
 			<position dim="1">379.715100772821</position>
 			<intensity>3.17959e+07</intensity>
@@ -122,7 +1101,7 @@
 				<pt x="1974.81298828125" y="380.266778191721" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_5233264595117471314_4835329514588776807">
+				<feature id="f_10627069796380146481_10052793688680741109">
 					<position dim="0">2007.51161653761</position>
 					<position dim="1">379.715100772821</position>
 					<intensity>2.2799e+07</intensity>
@@ -136,7 +1115,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.710034950213183"/>
 				</feature>
-				<feature id="f_5233264595117471314_17749660155506638460">
+				<feature id="f_10627069796380146481_15166508592180818156">
 					<position dim="0">2007.51161653761</position>
 					<position dim="1">380.216778191721</position>
 					<intensity>8.9969e+06</intensity>
@@ -181,12 +1160,12 @@
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.999815237705664"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999771760935785"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00700750452065485"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00700750452065474"/>
 			<UserParam type="float" name="var_library_sangle" value="0.011853004652809"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00700750452065485"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00813985718240712"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999969969287406"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00700750452065474"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00813985718240695"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999969969287405"/>
 			<UserParam type="float" name="var_intensity_score" value="0.993388624131706"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
 			<UserParam type="float" name="sn_ratio" value="91.3637373498437"/>
@@ -196,7 +1175,7 @@
 			<UserParam type="float" name="var_isotope_correlation_score" value="0.989964675776816"/>
 			<UserParam type="float" name="var_isotope_overlap_score" value="0.282957553863525"/>
 			<UserParam type="float" name="var_massdev_score" value="0.807860618118897"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.50420457618941"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.504204576189409"/>
 			<UserParam type="float" name="var_bseries_score" value="0"/>
 			<UserParam type="float" name="var_yseries_score" value="0"/>
 			<UserParam type="float" name="var_dotprod_score" value="0.774286696585701"/>
@@ -208,7 +1187,286 @@
 			<UserParam type="int" name="n_matching_ids" value="3"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 		</feature>
-		<feature id="f_7804704400743266335">
+		<feature id="f_15885522598119108466">
+			<position dim="0">1871.44516101075</position>
+			<position dim="1">408.874238280604</position>
+			<intensity>351473</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.203844</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1857.064453125" y="408.824238280604" />
+				<pt x="1890.11450195312" y="408.824238280604" />
+				<pt x="1890.11450195312" y="408.924238280604" />
+				<pt x="1857.064453125" y="408.924238280604" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1857.064453125" y="409.158689893204" />
+				<pt x="1890.11450195312" y="409.158689893204" />
+				<pt x="1890.11450195312" y="409.258689893204" />
+				<pt x="1857.064453125" y="409.258689893204" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_15885522598119108466_15120290131060441429">
+					<position dim="0">1871.44516101075</position>
+					<position dim="1">408.874238280604</position>
+					<intensity>221846</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="408.874238280604"/>
+					<UserParam type="string" name="native_id" value="GM(Oxidation)LWAVFEQK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="14049.859375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.592413860111113"/>
+				</feature>
+				<feature id="f_15885522598119108466_11275867043381640475">
+					<position dim="0">1871.44516101075</position>
+					<position dim="1">409.208689893204</position>
+					<intensity>129627</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="409.208689893204"/>
+					<UserParam type="string" name="native_id" value="GM(Oxidation)LWAVFEQK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="4732.01318359375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.407586139888887"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="408.840087890625" RT="1880.01599121094" >
+				<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_5">
+					<UserParam type="float" name="OMSSA_score" value="0.0850109548251393"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="GM(Oxidation)LWAVFEQK/3"/>
+			<UserParam type="float" name="leftWidth" value="1857.064453125"/>
+			<UserParam type="float" name="rightWidth" value="1890.11450195312"/>
+			<UserParam type="float" name="total_xic" value="2487624.58416748"/>
+			<UserParam type="float" name="peak_apices_sum" value="18781.8725585938"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="6.37478521766071"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="3.38043549843109"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.859158419623954"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.795954623732148"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0387753364781597"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0738293770300598"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0387753364781597"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0403113938333929"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999208292111752"/>
+			<UserParam type="float" name="var_intensity_score" value="0.141288564394706"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="0.826036901072732"/>
+			<UserParam type="float" name="var_log_sn_score" value="0"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.857296228408813"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="2.92605467806292"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0"/>
+			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0"/>
+			<UserParam type="float" name="var_manhatt_score" value="2"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.203844374870718"/>
+			<UserParam type="float" name="PrecursorMZ" value="408.874238280604"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_17569764383250687096">
+			<position dim="0">2298.14719526402</position>
+			<position dim="1">435.910228820904</position>
+			<intensity>107152</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>2.28768</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="2290.19189453125" y="435.860228820904" />
+				<pt x="2307.17138671875" y="435.860228820904" />
+				<pt x="2307.17138671875" y="435.960228820904" />
+				<pt x="2290.19189453125" y="435.960228820904" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2290.19189453125" y="436.194680433504" />
+				<pt x="2307.17138671875" y="436.194680433504" />
+				<pt x="2307.17138671875" y="436.294680433504" />
+				<pt x="2290.19189453125" y="436.294680433504" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_17569764383250687096_14317784148091680644">
+					<position dim="0">2298.14719526402</position>
+					<position dim="1">435.910228820904</position>
+					<intensity>70587.9</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="435.910228820904"/>
+					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="15366.9287109375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.586748524736467"/>
+				</feature>
+				<feature id="f_17569764383250687096_17671779025680303814">
+					<position dim="0">2298.14719526402</position>
+					<position dim="1">436.244680433504</position>
+					<intensity>36564</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="436.244680433504"/>
+					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="8652.01141357422"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.413251475263533"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.909851074219" RT="2295.90209960938" >
+				<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0137458569950031"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="HLVDEPQNLIK/3"/>
+			<UserParam type="float" name="leftWidth" value="2290.19189453125"/>
+			<UserParam type="float" name="rightWidth" value="2307.17138671875"/>
+			<UserParam type="float" name="total_xic" value="10639599.0813599"/>
+			<UserParam type="float" name="peak_apices_sum" value="24018.9401245117"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.987321606844706"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.981554863036929"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999998"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0720162439304342"/>
+			<UserParam type="float" name="var_library_sangle" value="0.13567334952461"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0720162439304342"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0755707134178571"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.997235692613535"/>
+			<UserParam type="float" name="var_intensity_score" value="0.0100710436895339"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="2.98262189450483"/>
+			<UserParam type="float" name="var_log_sn_score" value="1.0928027440642"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.98598974943161"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="4.71687160277937"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.958229731481322"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.341235220432281"/>
+			<UserParam type="float" name="var_massdev_score" value="0.295951363727171"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.283335711262804"/>
+			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.654268103487712"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.07431043140929"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.28767931417546"/>
+			<UserParam type="float" name="PrecursorMZ" value="435.910228820904"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_1196373166564353753">
+			<position dim="0">1658.35957629977</position>
+			<position dim="1">532.248746583271</position>
+			<intensity>128355</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>3.27253</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1634.86328125" y="532.198746583271" />
+				<pt x="1685.81030273438" y="532.198746583271" />
+				<pt x="1685.81030273438" y="532.298746583271" />
+				<pt x="1634.86328125" y="532.298746583271" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1634.86328125" y="532.700424002171" />
+				<pt x="1685.81030273438" y="532.700424002171" />
+				<pt x="1685.81030273438" y="532.800424002171" />
+				<pt x="1634.86328125" y="532.800424002171" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_1196373166564353753_7539502987715517688">
+					<position dim="0">1658.35957629977</position>
+					<position dim="1">532.248746583271</position>
+					<intensity>86477.8</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="532.248746583271"/>
+					<UserParam type="string" name="native_id" value="KSDDGGEVEK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="16335.642578125"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.66039156605171"/>
+				</feature>
+				<feature id="f_1196373166564353753_9126387050458671424">
+					<position dim="0">1658.35957629977</position>
+					<position dim="1">532.750424002171</position>
+					<intensity>41877.4</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="532.750424002171"/>
+					<UserParam type="string" name="native_id" value="KSDDGGEVEK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="4576.82275390625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.33960843394829"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" >
+				<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_2">
+					<UserParam type="float" name="OMSSA_score" value="0.140841796155119"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="KSDDGGEVEK/2"/>
+			<UserParam type="float" name="leftWidth" value="1634.86328125"/>
+			<UserParam type="float" name="rightWidth" value="1685.81030273438"/>
+			<UserParam type="float" name="total_xic" value="141144.40447998"/>
+			<UserParam type="float" name="peak_apices_sum" value="20912.4653320312"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.976751222648202"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.968715346150462"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0133467853267937"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0240119555958121"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0133467853267937"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0145806315400125"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.99989973059223"/>
+			<UserParam type="float" name="var_intensity_score" value="0.909389242867262"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="97.517435020494"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.5800311827403"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.975244373083115"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.39723611286629"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.974755927449578"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="16.5563312629803"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="16.8438426877962"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.654000990960296"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.09969813062877"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.27252665585312"/>
+			<UserParam type="float" name="PrecursorMZ" value="532.248746583271"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_13113514917555180171">
 			<position dim="0">2005.79703137669</position>
 			<position dim="1">404.203412328071</position>
 			<intensity>419303</intensity>
@@ -229,7 +1487,7 @@
 				<pt x="1961.46557617188" y="404.755089746971" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_7804704400743266335_3332699010107892018">
+				<feature id="f_13113514917555180171_6182960951962378739">
 					<position dim="0">2005.79703137669</position>
 					<position dim="1">404.203412328071</position>
 					<intensity>387704</intensity>
@@ -243,7 +1501,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.701130386577533"/>
 				</feature>
-				<feature id="f_7804704400743266335_13440783915218733453">
+				<feature id="f_13113514917555180171_14891455924036538147">
 					<position dim="0">2005.79703137669</position>
 					<position dim="1">404.705089746971</position>
 					<intensity>31598.8</intensity>
@@ -301,7 +1559,200 @@
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 		</feature>
-		<feature id="f_6408859317243173796">
+		<feature id="f_17287849381738438716">
+			<position dim="0">1782.51151069112</position>
+			<position dim="1">300.195528597604</position>
+			<intensity>1.17056e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>3.20901</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1763.34350585938" y="300.145528597604" />
+				<pt x="1851.12512207031" y="300.145528597604" />
+				<pt x="1851.12512207031" y="300.245528597604" />
+				<pt x="1763.34350585938" y="300.245528597604" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1763.34350585938" y="300.479980210204" />
+				<pt x="1851.12512207031" y="300.479980210204" />
+				<pt x="1851.12512207031" y="300.579980210204" />
+				<pt x="1763.34350585938" y="300.579980210204" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_17287849381738438716_2660422259164526995">
+					<position dim="0">1782.51151069112</position>
+					<position dim="1">300.195528597604</position>
+					<intensity>8.21652e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="300.195528597604"/>
+					<UserParam type="string" name="native_id" value="LALDLVVR/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="576644.387084961"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.668051514852376"/>
+				</feature>
+				<feature id="f_17287849381738438716_5495827884756377090">
+					<position dim="0">1782.51151069112</position>
+					<position dim="1">300.529980210204</position>
+					<intensity>3.48903e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="300.529980210204"/>
+					<UserParam type="string" name="native_id" value="LALDLVVR/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="265400.1875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.331948485147624"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" >
+				<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_4">
+					<UserParam type="float" name="OMSSA_score" value="0.00409018563530312"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LALDLVVR/3"/>
+			<UserParam type="float" name="leftWidth" value="1763.34350585938"/>
+			<UserParam type="float" name="rightWidth" value="1851.12512207031"/>
+			<UserParam type="float" name="total_xic" value="17485659.3833618"/>
+			<UserParam type="float" name="peak_apices_sum" value="842044.574584961"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999219220116872"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998961131663337"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0338819666057769"/>
+			<UserParam type="float" name="var_library_sangle" value="0.059594307856544"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0338819666057769"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0378305231519567"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999334609191848"/>
+			<UserParam type="float" name="var_intensity_score" value="0.669437494083765"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="44.4383949049717"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.79410384586919"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.98045688867569"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.88090703930314"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.70019046030159"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="9.54360336593331"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="12.751237371524"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.729948670007111"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.16861748604685"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.20901495370698"/>
+			<UserParam type="float" name="PrecursorMZ" value="300.195528597604"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_4143272592559840046">
+			<position dim="0">1617.1483410699</position>
+			<position dim="1">368.862109904738</position>
+			<intensity>9.25278e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.878065</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1595.50939941406" y="368.812109904738" />
+				<pt x="1764.53942871094" y="368.812109904738" />
+				<pt x="1764.53942871094" y="368.912109904738" />
+				<pt x="1595.50939941406" y="368.912109904738" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1595.50939941406" y="369.146561517338" />
+				<pt x="1764.53942871094" y="369.146561517338" />
+				<pt x="1764.53942871094" y="369.246561517338" />
+				<pt x="1595.50939941406" y="369.246561517338" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_4143272592559840046_5342974036930030800">
+					<position dim="0">1617.1483410699</position>
+					<position dim="1">368.862109904738</position>
+					<intensity>5.79311e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="368.862109904738"/>
+					<UserParam type="string" name="native_id" value="LAMTLAEAER/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="301442.201293945"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.637366103952144"/>
+				</feature>
+				<feature id="f_4143272592559840046_11399299100673837381">
+					<position dim="0">1617.1483410699</position>
+					<position dim="1">369.196561517338</position>
+					<intensity>3.45967e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="369.196561517338"/>
+					<UserParam type="string" name="native_id" value="LAMTLAEAER/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="164956.921875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.362633896047856"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" >
+				<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_3">
+					<UserParam type="float" name="OMSSA_score" value="0.134752265696133"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" >
+				<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_3">
+					<UserParam type="float" name="OMSSA_score" value="0.0325713993888641"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LAMTLAEAER/3"/>
+			<UserParam type="float" name="leftWidth" value="1595.50939941406"/>
+			<UserParam type="float" name="rightWidth" value="1764.53942871094"/>
+			<UserParam type="float" name="total_xic" value="10395361.7129517"/>
+			<UserParam type="float" name="peak_apices_sum" value="466399.123168945"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.97124963771702"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.960129477115842"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0112721013675148"/>
+			<UserParam type="float" name="var_library_sangle" value="0.021080330114212"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0112721013675148"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0118955544334975"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999931728221565"/>
+			<UserParam type="float" name="var_intensity_score" value="0.890087065317977"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="16.9401516016668"/>
+			<UserParam type="float" name="var_log_sn_score" value="2.82968663851485"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.940495908260345"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.15988578920748"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.509134767132634"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="28.1440905745226"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="35.8761787175195"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.567734792584532"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.42292916274579"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.87806461617499"/>
+			<UserParam type="float" name="PrecursorMZ" value="368.862109904738"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_12561328592123678330">
 			<position dim="0">1782.34333734102</position>
 			<position dim="1">449.744389900421</position>
 			<intensity>1.7437e+06</intensity>
@@ -322,7 +1773,7 @@
 				<pt x="1761.75610351562" y="450.296067319321" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_6408859317243173796_16907355690727166316">
+				<feature id="f_12561328592123678330_13574947772324278593">
 					<position dim="0">1782.34333734102</position>
 					<position dim="1">449.744389900421</position>
 					<intensity>1.27819e+06</intensity>
@@ -336,7 +1787,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
 				</feature>
-				<feature id="f_6408859317243173796_10306100746905639127">
+				<feature id="f_12561328592123678330_3689406389503231823">
 					<position dim="0">1782.34333734102</position>
 					<position dim="1">450.246067319321</position>
 					<intensity>465501</intensity>
@@ -368,9 +1819,9 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.995444848298674"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.994000524898595"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0584307399821589"/>
-			<UserParam type="float" name="var_library_sangle" value="0.100167183533034"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0584307399821589"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0584307399821588"/>
+			<UserParam type="float" name="var_library_sangle" value="0.100167183533035"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0584307399821588"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.0670063315124288"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.997948935934463"/>
 			<UserParam type="float" name="var_intensity_score" value="0.719835873312806"/>
@@ -382,10 +1833,10 @@
 			<UserParam type="float" name="var_isotope_correlation_score" value="0.984152837341836"/>
 			<UserParam type="float" name="var_isotope_overlap_score" value="0.26696240901947"/>
 			<UserParam type="float" name="var_massdev_score" value="0.43272982427065"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.447953512388762"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.447953512388763"/>
 			<UserParam type="float" name="var_bseries_score" value="0"/>
 			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.698534764147427"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.698534764147426"/>
 			<UserParam type="float" name="var_manhatt_score" value="1.07117517832204"/>
 			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.66305280471362"/>
 			<UserParam type="float" name="PrecursorMZ" value="449.744389900421"/>
@@ -394,7 +1845,7 @@
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 		</feature>
-		<feature id="f_16250062551099875712">
+		<feature id="f_17325731682080510033">
 			<position dim="0">1978.65907624188</position>
 			<position dim="1">300.165352089204</position>
 			<intensity>2.92954e+06</intensity>
@@ -415,7 +1866,7 @@
 				<pt x="1939.34069824219" y="300.549803701804" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_16250062551099875712_13424404046998308790">
+				<feature id="f_17325731682080510033_18390135059454481268">
 					<position dim="0">1978.65907624188</position>
 					<position dim="1">300.165352089204</position>
 					<intensity>2.22186e+06</intensity>
@@ -429,7 +1880,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
 				</feature>
-				<feature id="f_16250062551099875712_12665713047548007769">
+				<feature id="f_17325731682080510033_15721057298497490036">
 					<position dim="0">1978.65907624188</position>
 					<position dim="1">300.499803701804</position>
 					<intensity>707673</intensity>
@@ -494,7 +1945,7 @@
 			<UserParam type="int" name="n_matching_ids" value="2"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 		</feature>
-		<feature id="f_10627069796380146481">
+		<feature id="f_7344192187426184761">
 			<position dim="0">1943.3004011853</position>
 			<position dim="1">395.239463487571</position>
 			<intensity>8.95401e+07</intensity>
@@ -515,7 +1966,7 @@
 				<pt x="1918.98767089844" y="395.791140906471" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_10627069796380146481_10052793688680741109">
+				<feature id="f_7344192187426184761_7283948392886265699">
 					<position dim="0">1943.3004011853</position>
 					<position dim="1">395.239463487571</position>
 					<intensity>6.31944e+07</intensity>
@@ -529,7 +1980,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.704209887318509"/>
 				</feature>
-				<feature id="f_10627069796380146481_15166508592180818156">
+				<feature id="f_7344192187426184761_2130311522918743509">
 					<position dim="0">1943.3004011853</position>
 					<position dim="1">395.741140906471</position>
 					<intensity>2.63457e+07</intensity>
@@ -560,11 +2011,11 @@
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.999855522861782"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999819433927319"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00155698400061227"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00266588296521212"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00155698400061227"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00178551886317935"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00155698400061233"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00266588296529541"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00155698400061233"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0017855188631794"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999998543005867"/>
 			<UserParam type="float" name="var_intensity_score" value="0.995940359920697"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
@@ -587,1658 +2038,7 @@
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 		</feature>
-		<feature id="f_14768204679546465715">
-			<position dim="0">2336.46435114133</position>
-			<position dim="1">464.250362519471</position>
-			<intensity>1.26835e+08</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.31915</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2307.17138671875" y="464.200362519471" />
-				<pt x="2424.5244140625" y="464.200362519471" />
-				<pt x="2424.5244140625" y="464.300362519471" />
-				<pt x="2307.17138671875" y="464.300362519471" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2307.17138671875" y="464.702039938371" />
-				<pt x="2424.5244140625" y="464.702039938371" />
-				<pt x="2424.5244140625" y="464.802039938371" />
-				<pt x="2307.17138671875" y="464.802039938371" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_14768204679546465715_12156709473159629610">
-					<position dim="0">2336.46435114133</position>
-					<position dim="1">464.250362519471</position>
-					<intensity>8.30316e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="464.250362519471"/>
-					<UserParam type="string" name="native_id" value="YLYEIAR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="3748789.63964844"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.655742026441336"/>
-				</feature>
-				<feature id="f_14768204679546465715_15885522598119108466">
-					<position dim="0">2336.46435114133</position>
-					<position dim="1">464.752039938371</position>
-					<intensity>4.3803e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="464.752039938371"/>
-					<UserParam type="string" name="native_id" value="YLYEIAR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="1970969.68359375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.344257973558664"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250213623047" RT="2321.49926757812" >
-				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.000528980302830806"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250030517578" RT="2357.07421875" >
-				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="9.1724848717909e-05"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250335693359" RT="2398.77709960938" >
-				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="4.18055390056644e-05"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="YLYEIAR/2"/>
-			<UserParam type="float" name="leftWidth" value="2307.17138671875"/>
-			<UserParam type="float" name="rightWidth" value="2424.5244140625"/>
-			<UserParam type="float" name="total_xic" value="127750490.772278"/>
-			<UserParam type="float" name="peak_apices_sum" value="5719759.32324219"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.99989185157427"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999853516577379"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00109704639804184"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00200128800156997"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00109704639804184"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00118326541192143"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999334090534"/>
-			<UserParam type="float" name="var_intensity_score" value="0.992830315040351"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="65.000081378898"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.1743885218779"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.985577464103699"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.2506009186205"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.990654856489394"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.345355033874512"/>
-			<UserParam type="float" name="var_massdev_score" value="1.19333451667543"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.03625577733313"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.761987351682086"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.862442874603575"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.31914514059437"/>
-			<UserParam type="float" name="PrecursorMZ" value="464.250362519471"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="3"/>
-			<UserParam type="int" name="n_matching_ids" value="3"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_3823858840059792698">
-			<position dim="0">2024.60123336381</position>
-			<position dim="1">461.747653035421</position>
-			<intensity>7.80702e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.74809</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1998.99108886719" y="461.697653035421" />
-				<pt x="2087.48876953125" y="461.697653035421" />
-				<pt x="2087.48876953125" y="461.797653035421" />
-				<pt x="1998.99108886719" y="461.797653035421" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1998.99108886719" y="462.199330454321" />
-				<pt x="2087.48876953125" y="462.199330454321" />
-				<pt x="2087.48876953125" y="462.299330454321" />
-				<pt x="1998.99108886719" y="462.299330454321" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_3823858840059792698_893904610286969204">
-					<position dim="0">2024.60123336381</position>
-					<position dim="1">461.747653035421</position>
-					<intensity>5.1932e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="461.747653035421"/>
-					<UserParam type="string" name="native_id" value="AEFVEVTK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="7271544.12011719"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.66642596900412"/>
-				</feature>
-				<feature id="f_3823858840059792698_14851350658635457156">
-					<position dim="0">2024.60123336381</position>
-					<position dim="1">462.249330454321</position>
-					<intensity>2.61382e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="462.249330454321"/>
-					<UserParam type="string" name="native_id" value="AEFVEVTK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="3647712.47851562"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.33357403099588"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="461.747497558594" RT="2015.59265136719" >
-				<PeptideHit score="0" sequence="AEFVEVTK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.000296258184030238"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="461.74755859375" RT="2038.95886230469" >
-				<PeptideHit score="0" sequence="AEFVEVTK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.00012753925040404"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="AEFVEVTK/2"/>
-			<UserParam type="float" name="leftWidth" value="1998.99108886719"/>
-			<UserParam type="float" name="rightWidth" value="2087.48876953125"/>
-			<UserParam type="float" name="total_xic" value="78856149.1257324"/>
-			<UserParam type="float" name="peak_apices_sum" value="10919256.5986328"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999964845503361"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999953110426824"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00123025228850396"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00221672421717551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00123025228850396"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00134201647916654"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999149732785"/>
-			<UserParam type="float" name="var_intensity_score" value="0.990032925340049"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="99.118612261271"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.59631723663037"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.99825581908226"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.53469293463408"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.990778825707125"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.33480429649353"/>
-			<UserParam type="float" name="var_massdev_score" value="1.5081557298974"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.29524029783514"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="1"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.764252063684777"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.860376056103046"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.74808804926625"/>
-			<UserParam type="float" name="PrecursorMZ" value="461.747653035421"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_17447818880105247092">
-			<position dim="0">2072.67445045983</position>
-			<position dim="1">395.726522907821</position>
-			<intensity>2.40993e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>2.90616</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2045.21923828125" y="395.676522907821" />
-				<pt x="2151.267578125" y="395.676522907821" />
-				<pt x="2151.267578125" y="395.776522907821" />
-				<pt x="2045.21923828125" y="395.776522907821" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2045.21923828125" y="396.178200326721" />
-				<pt x="2151.267578125" y="396.178200326721" />
-				<pt x="2151.267578125" y="396.278200326721" />
-				<pt x="2045.21923828125" y="396.278200326721" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_17447818880105247092_1003624456647096845">
-					<position dim="0">2072.67445045983</position>
-					<position dim="1">395.726522907821</position>
-					<intensity>1.72337e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="395.726522907821"/>
-					<UserParam type="string" name="native_id" value="AGAFSLPK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="1920706.55371094"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.692511512336989"/>
-				</feature>
-				<feature id="f_17447818880105247092_15120290131060441429">
-					<position dim="0">2072.67445045983</position>
-					<position dim="1">396.228200326721</position>
-					<intensity>6.86563e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="396.228200326721"/>
-					<UserParam type="string" name="native_id" value="AGAFSLPK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="787648.461669922"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.307488487663011"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.700897216797" RT="2085.73901367188" >
-				<PeptideHit score="0.0454545454545455" sequence="AGAFSLPK" charge="2" aa_before="R" aa_after="D" protein_refs="PH_1">
-					<UserParam type="float" name="OMSSA_score" value="0.0631960134592704"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="AGAFSLPK/2"/>
-			<UserParam type="float" name="leftWidth" value="2045.21923828125"/>
-			<UserParam type="float" name="rightWidth" value="2151.267578125"/>
-			<UserParam type="float" name="total_xic" value="25676793.1026611"/>
-			<UserParam type="float" name="peak_apices_sum" value="2708355.01538086"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999783302096998"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999723138978434"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0225991493463209"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0387559354182129"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0225991493463209"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0258785056107158"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999693670468852"/>
-			<UserParam type="float" name="var_intensity_score" value="0.93856284558769"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="90.1918622910647"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.50193920449604"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.994698405265808"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.40764334991993"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.819453547569494"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.284889370203018"/>
-			<UserParam type="float" name="var_massdev_score" value="17.9434489619426"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="15.8733115429516"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.629640200535799"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.22548465137465"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.90615800346689"/>
-			<UserParam type="float" name="PrecursorMZ" value="395.726522907821"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_11275867043381640475">
-			<position dim="0">2123.35043908495</position>
-			<position dim="1">455.755280535421</position>
-			<intensity>5.95285e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>2.1168</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2094.08325195312" y="455.705280535421" />
-				<pt x="2197.34326171875" y="455.705280535421" />
-				<pt x="2197.34326171875" y="455.805280535421" />
-				<pt x="2094.08325195312" y="455.805280535421" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2094.08325195312" y="456.206957954321" />
-				<pt x="2197.34326171875" y="456.206957954321" />
-				<pt x="2197.34326171875" y="456.306957954321" />
-				<pt x="2094.08325195312" y="456.306957954321" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_11275867043381640475_3713543811689521337">
-					<position dim="0">2123.35043908495</position>
-					<position dim="1">455.755280535421</position>
-					<intensity>4.14411e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="455.755280535421"/>
-					<UserParam type="string" name="native_id" value="AGDLLFFK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="309924.96875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.652807062123664"/>
-				</feature>
-				<feature id="f_11275867043381640475_8666254306116808202">
-					<position dim="0">2123.35043908495</position>
-					<position dim="1">456.256957954321</position>
-					<intensity>1.80875e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="456.256957954321"/>
-					<UserParam type="string" name="native_id" value="AGDLLFFK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="157846.099365234"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.347192937876336"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="455.713287353516" RT="2155.63891601562" >
-				<PeptideHit score="0.0454545454545455" sequence="AGDLLFFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_0">
-					<UserParam type="float" name="OMSSA_score" value="0.0676769400449016"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="AGDLLFFK/2"/>
-			<UserParam type="float" name="leftWidth" value="2094.08325195312"/>
-			<UserParam type="float" name="rightWidth" value="2197.34326171875"/>
-			<UserParam type="float" name="total_xic" value="5997125.0446167"/>
-			<UserParam type="float" name="peak_apices_sum" value="467771.068115234"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.99795112736991"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997213738088641"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0433476733099385"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0772597046512233"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0433476733099385"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0477934471432183"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.9989293261486"/>
-			<UserParam type="float" name="var_intensity_score" value="0.992617455149373"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="83.2032969856814"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.42128697427377"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.995112538337708"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.27554241539011"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.0260724897716084"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="21.253494592472"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="14.7581264553983"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.411466872246703"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.5437174435549"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.11679838595154"/>
-			<UserParam type="float" name="PrecursorMZ" value="455.755280535421"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_3246735940528705071">
-			<position dim="0">1749.12956152037</position>
-			<position dim="1">443.711267907821</position>
-			<intensity>3.6544e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.77097</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1720.42810058594" y="443.661267907821" />
-				<pt x="1794.18957519531" y="443.661267907821" />
-				<pt x="1794.18957519531" y="443.761267907821" />
-				<pt x="1720.42810058594" y="443.761267907821" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1720.42810058594" y="444.162945326721" />
-				<pt x="1794.18957519531" y="444.162945326721" />
-				<pt x="1794.18957519531" y="444.262945326721" />
-				<pt x="1720.42810058594" y="444.262945326721" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_3246735940528705071_4584897071539917580">
-					<position dim="0">1749.12956152037</position>
-					<position dim="1">443.711267907821</position>
-					<intensity>2.5289e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="443.711267907821"/>
-					<UserParam type="string" name="native_id" value="DDSPDLPK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="2805595.68164062"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.691417156355378"/>
-				</feature>
-				<feature id="f_3246735940528705071_260132145239717571">
-					<position dim="0">1749.12956152037</position>
-					<position dim="1">444.212945326721</position>
-					<intensity>1.12549e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="444.212945326721"/>
-					<UserParam type="string" name="native_id" value="DDSPDLPK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="1242968.625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.308582843644622"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="443.711242675781" RT="1738.03344726562" >
-				<PeptideHit score="0.0344827586206897" sequence="DDSPDLPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.00395109914742618"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="DDSPDLPK/2"/>
-			<UserParam type="float" name="leftWidth" value="1720.42810058594"/>
-			<UserParam type="float" name="rightWidth" value="1794.18957519531"/>
-			<UserParam type="float" name="total_xic" value="36892001.3114014"/>
-			<UserParam type="float" name="peak_apices_sum" value="4048564.30664062"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999913661505798"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999889473186652"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.000599630326988065"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00104554317429552"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.000599630326988065"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.000675051683031891"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999789234646"/>
-			<UserParam type="float" name="var_intensity_score" value="0.990566158000927"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="90.798258417387"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.50864010499805"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.996718049049377"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.47518657598361"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.990743065551955"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.307983219623566"/>
-			<UserParam type="float" name="var_massdev_score" value="0.760948673990978"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.544374916487825"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="1"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.767922678010944"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.870417252673124"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.7709744922802"/>
-			<UserParam type="float" name="PrecursorMZ" value="443.711267907821"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_17569764383250687096">
-			<position dim="0">1851.03387353231</position>
-			<position dim="1">487.732534471621</position>
-			<intensity>8.88504e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.57637</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1825.08544921875" y="487.682534471621" />
-				<pt x="2023.54016113281" y="487.682534471621" />
-				<pt x="2023.54016113281" y="487.782534471621" />
-				<pt x="1825.08544921875" y="487.782534471621" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1825.08544921875" y="488.184211890521" />
-				<pt x="2023.54016113281" y="488.184211890521" />
-				<pt x="2023.54016113281" y="488.284211890521" />
-				<pt x="1825.08544921875" y="488.284211890521" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_17569764383250687096_14317784148091680644">
-					<position dim="0">1851.03387353231</position>
-					<position dim="1">487.732534471621</position>
-					<intensity>5.83658e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="487.732534471621"/>
-					<UserParam type="string" name="native_id" value="DLGEEHFK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="4428198.99023438"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.658472827804029"/>
-				</feature>
-				<feature id="f_17569764383250687096_17671779025680303814">
-					<position dim="0">1851.03387353231</position>
-					<position dim="1">488.234211890521</position>
-					<intensity>3.04846e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="488.234211890521"/>
-					<UserParam type="string" name="native_id" value="DLGEEHFK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="2308221"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.341527172195971"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732299804688" RT="1875.54736328125" >
-				<PeptideHit score="0.0344827586206897" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0435747980539929"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732391357422" RT="1906.96594238281" >
-				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0917668515948288"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732177734375" RT="1942.3701171875" >
-				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0918514920664644"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732208251953" RT="2013.36364746094" >
-				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.212602001856198"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="DLGEEHFK/2"/>
-			<UserParam type="float" name="leftWidth" value="1825.08544921875"/>
-			<UserParam type="float" name="rightWidth" value="2023.54016113281"/>
-			<UserParam type="float" name="total_xic" value="89292199.7976074"/>
-			<UserParam type="float" name="peak_apices_sum" value="6736419.99023438"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999943413075745"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999923646234517"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00157333246564978"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00286200887402008"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00157333246564978"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00170135372459251"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999998625615363"/>
-			<UserParam type="float" name="var_intensity_score" value="0.995052470444129"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="97.3835316174288"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.57865711644968"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.979667752981186"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.55568349628391"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.990054921294836"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.343100517988205"/>
-			<UserParam type="float" name="var_massdev_score" value="1.09774247106677"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.949193493234851"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.758326801488211"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.855211785668372"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.57637126739238"/>
-			<UserParam type="float" name="PrecursorMZ" value="487.732534471621"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="4"/>
-			<UserParam type="int" name="n_matching_ids" value="4"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_1196373166564353753">
-			<position dim="0">1850.92089781596</position>
-			<position dim="1">325.490781803338</position>
-			<intensity>6.42808e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.60759</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1825.08544921875" y="325.440781803338" />
-				<pt x="2033.83422851562" y="325.440781803338" />
-				<pt x="2033.83422851562" y="325.540781803338" />
-				<pt x="1825.08544921875" y="325.540781803338" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1825.08544921875" y="325.775233415938" />
-				<pt x="2033.83422851562" y="325.775233415938" />
-				<pt x="2033.83422851562" y="325.875233415938" />
-				<pt x="1825.08544921875" y="325.875233415938" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_1196373166564353753_7539502987715517688">
-					<position dim="0">1850.92089781596</position>
-					<position dim="1">325.490781803338</position>
-					<intensity>4.23901e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="325.490781803338"/>
-					<UserParam type="string" name="native_id" value="DLGEEHFK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="3052206.5"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.658472827804029"/>
-				</feature>
-				<feature id="f_1196373166564353753_9126387050458671424">
-					<position dim="0">1850.92089781596</position>
-					<position dim="1">325.825233415938</position>
-					<intensity>2.18907e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="325.825233415938"/>
-					<UserParam type="string" name="native_id" value="DLGEEHFK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="1595702"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.341527172195971"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="325.491180419922" RT="1840.79333496094" >
-				<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0602120422006692"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="DLGEEHFK/3"/>
-			<UserParam type="float" name="leftWidth" value="1825.08544921875"/>
-			<UserParam type="float" name="rightWidth" value="2033.83422851562"/>
-			<UserParam type="float" name="total_xic" value="64501995.4766235"/>
-			<UserParam type="float" name="peak_apices_sum" value="4647908.5"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999871189538208"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999826193702506"/>
-			<UserParam type="float" name="var_library_corr" value="0.999999999999998"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.000978723446304147"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00177775802217658"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.000978723446304147"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00105977533224411"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999467196415"/>
-			<UserParam type="float" name="var_intensity_score" value="0.99657059483216"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="94.9971897725802"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.55384730982174"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.978527456521988"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.54108684338325"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.989630306349789"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.340548455715179"/>
-			<UserParam type="float" name="var_massdev_score" value="0.592963683327705"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.76320776477179"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.77193385755908"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.00330450428431"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.60759112266476"/>
-			<UserParam type="float" name="PrecursorMZ" value="325.490781803338"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_13113514917555180171">
-			<position dim="0">1782.51151069112</position>
-			<position dim="1">300.195528597604</position>
-			<intensity>1.17056e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.20901</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1763.34350585938" y="300.145528597604" />
-				<pt x="1851.12512207031" y="300.145528597604" />
-				<pt x="1851.12512207031" y="300.245528597604" />
-				<pt x="1763.34350585938" y="300.245528597604" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1763.34350585938" y="300.479980210204" />
-				<pt x="1851.12512207031" y="300.479980210204" />
-				<pt x="1851.12512207031" y="300.579980210204" />
-				<pt x="1763.34350585938" y="300.579980210204" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_13113514917555180171_7316644956366259183">
-					<position dim="0">1782.51151069112</position>
-					<position dim="1">300.195528597604</position>
-					<intensity>8.21652e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="300.195528597604"/>
-					<UserParam type="string" name="native_id" value="LALDLVVR/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="576644.387084961"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.668051514852376"/>
-				</feature>
-				<feature id="f_13113514917555180171_6182960951962378739">
-					<position dim="0">1782.51151069112</position>
-					<position dim="1">300.529980210204</position>
-					<intensity>3.48903e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="300.529980210204"/>
-					<UserParam type="string" name="native_id" value="LALDLVVR/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="265400.1875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.331948485147624"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" >
-				<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_4">
-					<UserParam type="float" name="OMSSA_score" value="0.00409018563530312"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LALDLVVR/3"/>
-			<UserParam type="float" name="leftWidth" value="1763.34350585938"/>
-			<UserParam type="float" name="rightWidth" value="1851.12512207031"/>
-			<UserParam type="float" name="total_xic" value="17485659.3833618"/>
-			<UserParam type="float" name="peak_apices_sum" value="842044.574584961"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999219220116872"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998961131663337"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.033881966605777"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0595943078565422"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.033881966605777"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0378305231519566"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999334609191848"/>
-			<UserParam type="float" name="var_intensity_score" value="0.669437494083765"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="44.4383949049717"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.79410384586919"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.98045688867569"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.88090703930314"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.70019046030159"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="9.54360336593331"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="12.751237371524"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.72994867000711"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.16861748604685"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.20901495370698"/>
-			<UserParam type="float" name="PrecursorMZ" value="300.195528597604"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_14891455924036538147">
-			<position dim="0">2090.16589783288</position>
-			<position dim="1">421.758354535421</position>
-			<intensity>1.18347e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.38766</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2038.14636230469" y="421.708354535421" />
-				<pt x="2210.38159179688" y="421.708354535421" />
-				<pt x="2210.38159179688" y="421.808354535421" />
-				<pt x="2038.14636230469" y="421.808354535421" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2038.14636230469" y="422.210031954321" />
-				<pt x="2210.38159179688" y="422.210031954321" />
-				<pt x="2210.38159179688" y="422.310031954321" />
-				<pt x="2038.14636230469" y="422.310031954321" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_14891455924036538147_5860084234476467938">
-					<position dim="0">2090.16589783288</position>
-					<position dim="1">421.758354535421</position>
-					<intensity>8.41674e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="421.758354535421"/>
-					<UserParam type="string" name="native_id" value="VATVSLPR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="508755.363769531"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.688369804746839"/>
-				</feature>
-				<feature id="f_14891455924036538147_12758854762884412659">
-					<position dim="0">2090.16589783288</position>
-					<position dim="1">422.260031954321</position>
-					<intensity>3.41801e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="422.260031954321"/>
-					<UserParam type="string" name="native_id" value="VATVSLPR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="228173.1875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.311630195253161"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="421.758056640625" RT="2091.08642578125" >
-				<PeptideHit score="0.0344827586206897" sequence="VATVSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_13">
-					<UserParam type="float" name="OMSSA_score" value="0.00302546175573277"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="VATVSLPR/2"/>
-			<UserParam type="float" name="leftWidth" value="2038.14636230469"/>
-			<UserParam type="float" name="rightWidth" value="2210.38159179688"/>
-			<UserParam type="float" name="total_xic" value="11877391.0214233"/>
-			<UserParam type="float" name="peak_apices_sum" value="736928.551269531"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.998724868242001"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998358776766715"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0228190172847642"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0393524588734662"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0228190172847642"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0259805444640457"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999690100670513"/>
-			<UserParam type="float" name="var_intensity_score" value="0.99640947903909"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="73.7619026004993"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.30084237339098"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.993695646524429"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.25604411976596"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.988314481916404"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.288811177015305"/>
-			<UserParam type="float" name="var_massdev_score" value="0.890803718434335"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.77537503092"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.742374379756163"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.976100444864031"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.38766373143232"/>
-			<UserParam type="float" name="PrecursorMZ" value="421.758354535421"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_17287849381738438716">
-			<position dim="0">1760.25657093773</position>
-			<position dim="1">569.752618393021</position>
-			<intensity>1.41459e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.74485</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1735.69311523438" y="569.702618393021" />
-				<pt x="1806.53210449219" y="569.702618393021" />
-				<pt x="1806.53210449219" y="569.802618393021" />
-				<pt x="1735.69311523438" y="569.802618393021" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1735.69311523438" y="570.204295811921" />
-				<pt x="1806.53210449219" y="570.204295811921" />
-				<pt x="1806.53210449219" y="570.304295811921" />
-				<pt x="1735.69311523438" y="570.304295811921" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_17287849381738438716_5495827884756377090">
-					<position dim="0">1760.25657093773</position>
-					<position dim="1">569.752618393021</position>
-					<intensity>9.09907e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="569.752618393021"/>
-					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="1354679.41699219"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.644498608917742"/>
-				</feature>
-				<feature id="f_17287849381738438716_4143272592559840046">
-					<position dim="0">1760.25657093773</position>
-					<position dim="1">570.254295811921</position>
-					<intensity>5.04683e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="570.254295811921"/>
-					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="754406.354980469"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.355501391082258"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
-				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
-				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2"/>
-			<UserParam type="float" name="leftWidth" value="1735.69311523438"/>
-			<UserParam type="float" name="rightWidth" value="1806.53210449219"/>
-			<UserParam type="float" name="total_xic" value="14486678.1954346"/>
-			<UserParam type="float" name="peak_apices_sum" value="2109085.77197266"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999786313233063"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999706240332848"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00126828605193471"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00234262974544488"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00126828605193471"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00135289409378486"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999123130552"/>
-			<UserParam type="float" name="var_intensity_score" value="0.976475891102353"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="117.627765815645"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.76752511147092"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.99731856584549"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.66028853965821"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.993260451842917"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.356769680976868"/>
-			<UserParam type="float" name="var_massdev_score" value="0.482075605090886"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.385620600005746"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.754351526419968"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.84165907229483"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.74484798021522"/>
-			<UserParam type="float" name="PrecursorMZ" value="569.752618393021"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_11399299100673837381">
-			<position dim="0">1558.9325598625</position>
-			<position dim="1">358.174576486338</position>
-			<intensity>1.27675e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.16365</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1539.38354492188" y="358.124576486338" />
-				<pt x="1615.81567382812" y="358.124576486338" />
-				<pt x="1615.81567382812" y="358.224576486338" />
-				<pt x="1539.38354492188" y="358.224576486338" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1539.38354492188" y="358.459028098938" />
-				<pt x="1615.81567382812" y="358.459028098938" />
-				<pt x="1615.81567382812" y="358.559028098938" />
-				<pt x="1539.38354492188" y="358.559028098938" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_11399299100673837381_16164338904207598736">
-					<position dim="0">1558.9325598625</position>
-					<position dim="1">358.174576486338</position>
-					<intensity>903200</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="358.174576486338"/>
-					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="54360.2887573242"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.646660950740033"/>
-				</feature>
-				<feature id="f_11399299100673837381_4410447320637600518">
-					<position dim="0">1558.9325598625</position>
-					<position dim="1">358.509028098938</position>
-					<intensity>373548</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="358.509028098938"/>
-					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="26582.2421875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.353339049259967"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
-				<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="SHC(Carbamidomethyl)IAEVEK/3"/>
-			<UserParam type="float" name="leftWidth" value="1539.38354492188"/>
-			<UserParam type="float" name="rightWidth" value="1615.81567382812"/>
-			<UserParam type="float" name="total_xic" value="1534200.08959961"/>
-			<UserParam type="float" name="peak_apices_sum" value="80942.5309448242"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.995859874004335"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99432412161936"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0607613750242852"/>
-			<UserParam type="float" name="var_library_sangle" value="0.107918735760252"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0607613750242852"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0672493863158573"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.997885894058429"/>
-			<UserParam type="float" name="var_intensity_score" value="0.832191728872341"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="11.7494826105578"/>
-			<UserParam type="float" name="var_log_sn_score" value="2.46380920647666"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.977227956056595"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="5.81651671719193"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.985290582455854"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.292577654123306"/>
-			<UserParam type="float" name="var_massdev_score" value="0.776434922758457"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.740130209172225"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.755976718319793"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.967667974449062"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.16365489172794"/>
-			<UserParam type="float" name="PrecursorMZ" value="358.174576486338"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_12561328592123678330">
-			<position dim="0">2074.91557012392</position>
-			<position dim="1">554.260602012071</position>
-			<intensity>1.62116e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.6453</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2047.82275390625" y="554.210602012071" />
-				<pt x="2133.37890625" y="554.210602012071" />
-				<pt x="2133.37890625" y="554.310602012071" />
-				<pt x="2047.82275390625" y="554.310602012071" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2047.82275390625" y="554.712279430971" />
-				<pt x="2133.37890625" y="554.712279430971" />
-				<pt x="2133.37890625" y="554.812279430971" />
-				<pt x="2047.82275390625" y="554.812279430971" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_12561328592123678330_8795943655088158336">
-					<position dim="0">2074.91557012392</position>
-					<position dim="1">554.260602012071</position>
-					<intensity>1.02444e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="554.260602012071"/>
-					<UserParam type="string" name="native_id" value="EAC(Carbamidomethyl)FAVEGPK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="1290034.34765625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.630481343594174"/>
-				</feature>
-				<feature id="f_12561328592123678330_6878260161865568505">
-					<position dim="0">2074.91557012392</position>
-					<position dim="1">554.762279430971</position>
-					<intensity>5.96714e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="554.762279430971"/>
-					<UserParam type="string" name="native_id" value="EAC(Carbamidomethyl)FAVEGPK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="740503.5625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.369518656405826"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260375976562" RT="2058.83471679688" >
-				<PeptideHit score="0.0454545454545455" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0548595335303417"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260559082031" RT="2098.17504882812" >
-				<PeptideHit score="0" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="4.91092752369064e-05"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="EAC(Carbamidomethyl)FAVEGPK/2"/>
-			<UserParam type="float" name="leftWidth" value="2047.82275390625"/>
-			<UserParam type="float" name="rightWidth" value="2133.37890625"/>
-			<UserParam type="float" name="total_xic" value="16298802.2630615"/>
-			<UserParam type="float" name="peak_apices_sum" value="2030537.91015625"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999826714315203"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999757773001666"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00144004892103047"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00269456187368486"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00144004892103047"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00151895727538698"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999998886455478"/>
-			<UserParam type="float" name="var_intensity_score" value="0.994648915812717"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="100.706242859935"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.61220779243982"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.99474048614502"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.55149925994001"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.98736710195524"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.368078619241714"/>
-			<UserParam type="float" name="var_massdev_score" value="0.431614306179453"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.347966095008153"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.735829552475677"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.901264010563115"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.6453048191596"/>
-			<UserParam type="float" name="PrecursorMZ" value="554.260602012071"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_4021463513649428920">
-			<position dim="0">1766.28153652464</position>
-			<position dim="1">646.304684132271</position>
-			<intensity>1.15352e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.46475</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1744.55932617188" y="646.254684132271" />
-				<pt x="1848.68237304688" y="646.254684132271" />
-				<pt x="1848.68237304688" y="646.354684132271" />
-				<pt x="1744.55932617188" y="646.354684132271" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1744.55932617188" y="646.756361551171" />
-				<pt x="1848.68237304688" y="646.756361551171" />
-				<pt x="1848.68237304688" y="646.856361551171" />
-				<pt x="1744.55932617188" y="646.856361551171" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_4021463513649428920_13574947772324278593">
-					<position dim="0">1766.28153652464</position>
-					<position dim="1">646.304684132271</position>
-					<intensity>740116</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="646.304684132271"/>
-					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="59630.41796875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
-				</feature>
-				<feature id="f_4021463513649428920_3689406389503231823">
-					<position dim="0">1766.28153652464</position>
-					<position dim="1">646.806361551171</position>
-					<intensity>413408</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="646.806361551171"/>
-					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="32722.078125"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.397061689621381"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.304504394531" RT="1759.0947265625" >
-				<PeptideHit score="0.0454545454545455" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.161429888187637"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" >
-				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0423622396613216"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2"/>
-			<UserParam type="float" name="leftWidth" value="1744.55932617188"/>
-			<UserParam type="float" name="rightWidth" value="1848.68237304688"/>
-			<UserParam type="float" name="total_xic" value="1258179.40576172"/>
-			<UserParam type="float" name="peak_apices_sum" value="92352.49609375"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.996687864987247"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.995242375653698"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0386749522384563"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0729584275113503"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0386749522384563"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0405203562071071"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999204154558718"/>
-			<UserParam type="float" name="var_intensity_score" value="0.91682016468998"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="90.4728415543284"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.50504971234653"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.980602443218231"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.3707575924871"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.968902708499444"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.358386725187302"/>
-			<UserParam type="float" name="var_massdev_score" value="0.552052115383353"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.543039773386319"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.64068624221483"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.04013836171084"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.46474611990348"/>
-			<UserParam type="float" name="PrecursorMZ" value="646.304684132271"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_575144564576995072">
-			<position dim="0">1766.55652075376</position>
-			<position dim="1">431.205548243771</position>
-			<intensity>1.41524e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.70728</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1746.17114257812" y="431.155548243771" />
-				<pt x="1918.98767089844" y="431.155548243771" />
-				<pt x="1918.98767089844" y="431.255548243771" />
-				<pt x="1746.17114257812" y="431.255548243771" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1746.17114257812" y="431.489999856371" />
-				<pt x="1918.98767089844" y="431.489999856371" />
-				<pt x="1918.98767089844" y="431.589999856371" />
-				<pt x="1746.17114257812" y="431.589999856371" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_575144564576995072_5805590394902791448">
-					<position dim="0">1766.55652075376</position>
-					<position dim="1">431.205548243771</position>
-					<intensity>8.63596e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="431.205548243771"/>
-					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="536289.844238281"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
-				</feature>
-				<feature id="f_575144564576995072_11586291247413769442">
-					<position dim="0">1766.55652075376</position>
-					<position dim="1">431.539999856371</position>
-					<intensity>5.51648e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="431.539999856371"/>
-					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="332317.34375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.397061689621381"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" >
-				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.042177146646692"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3"/>
-			<UserParam type="float" name="leftWidth" value="1746.17114257812"/>
-			<UserParam type="float" name="rightWidth" value="1918.98767089844"/>
-			<UserParam type="float" name="total_xic" value="14319538.267334"/>
-			<UserParam type="float" name="peak_apices_sum" value="868607.187988281"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999360251977443"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999081051721655"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00727165687438958"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0139110994886224"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00727165687438958"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00752932229758962"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999972302719226"/>
-			<UserParam type="float" name="var_intensity_score" value="0.988331099493958"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="22.6689159856313"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.12099464624477"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.981038093566895"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.46880384807173"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.98312975722697"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.389790028333664"/>
-			<UserParam type="float" name="var_massdev_score" value="0.344572194406841"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.300077406541411"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.712039883282362"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.04508823818716"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.7072817470113"/>
-			<UserParam type="float" name="PrecursorMZ" value="431.205548243771"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_3395379003172100421">
-			<position dim="0">1871.44516101075</position>
-			<position dim="1">408.874238280604</position>
-			<intensity>351473</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.203844</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1857.064453125" y="408.824238280604" />
-				<pt x="1890.11450195312" y="408.824238280604" />
-				<pt x="1890.11450195312" y="408.924238280604" />
-				<pt x="1857.064453125" y="408.924238280604" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1857.064453125" y="409.158689893204" />
-				<pt x="1890.11450195312" y="409.158689893204" />
-				<pt x="1890.11450195312" y="409.258689893204" />
-				<pt x="1857.064453125" y="409.258689893204" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_3395379003172100421_4041634828915281168">
-					<position dim="0">1871.44516101075</position>
-					<position dim="1">408.874238280604</position>
-					<intensity>221846</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="408.874238280604"/>
-					<UserParam type="string" name="native_id" value="GM(Oxidation)LWAVFEQK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="14049.859375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.592413860111113"/>
-				</feature>
-				<feature id="f_3395379003172100421_17078574238716611972">
-					<position dim="0">1871.44516101075</position>
-					<position dim="1">409.208689893204</position>
-					<intensity>129627</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="409.208689893204"/>
-					<UserParam type="string" name="native_id" value="GM(Oxidation)LWAVFEQK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="4732.01318359375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.407586139888887"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="408.840087890625" RT="1880.01599121094" >
-				<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_5">
-					<UserParam type="float" name="OMSSA_score" value="0.0850109548251393"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="GM(Oxidation)LWAVFEQK/3"/>
-			<UserParam type="float" name="leftWidth" value="1857.064453125"/>
-			<UserParam type="float" name="rightWidth" value="1890.11450195312"/>
-			<UserParam type="float" name="total_xic" value="2487624.58416748"/>
-			<UserParam type="float" name="peak_apices_sum" value="18781.8725585938"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="6.37478521766071"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="3.38043549843109"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.859158419623954"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.795954623732148"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0387753364781598"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0738293770300613"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0387753364781598"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0403113938333929"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999208292111752"/>
-			<UserParam type="float" name="var_intensity_score" value="0.141288564394706"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="0.826036901072732"/>
-			<UserParam type="float" name="var_log_sn_score" value="0"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.857296228408813"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="2.92605467806292"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0"/>
-			<UserParam type="float" name="var_manhatt_score" value="2"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.203844374870718"/>
-			<UserParam type="float" name="PrecursorMZ" value="408.874238280604"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_15721057298497490036">
-			<position dim="0">1658.35957629977</position>
-			<position dim="1">532.248746583271</position>
-			<intensity>128355</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.27253</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1634.86328125" y="532.198746583271" />
-				<pt x="1685.81030273438" y="532.198746583271" />
-				<pt x="1685.81030273438" y="532.298746583271" />
-				<pt x="1634.86328125" y="532.298746583271" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1634.86328125" y="532.700424002171" />
-				<pt x="1685.81030273438" y="532.700424002171" />
-				<pt x="1685.81030273438" y="532.800424002171" />
-				<pt x="1634.86328125" y="532.800424002171" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_15721057298497490036_2608380305220684729">
-					<position dim="0">1658.35957629977</position>
-					<position dim="1">532.248746583271</position>
-					<intensity>86477.8</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="532.248746583271"/>
-					<UserParam type="string" name="native_id" value="KSDDGGEVEK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="16335.642578125"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.66039156605171"/>
-				</feature>
-				<feature id="f_15721057298497490036_11422463686885200558">
-					<position dim="0">1658.35957629977</position>
-					<position dim="1">532.750424002171</position>
-					<intensity>41877.4</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="532.750424002171"/>
-					<UserParam type="string" name="native_id" value="KSDDGGEVEK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="4576.82275390625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.33960843394829"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" >
-				<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_2">
-					<UserParam type="float" name="OMSSA_score" value="0.140841796155119"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="KSDDGGEVEK/2"/>
-			<UserParam type="float" name="leftWidth" value="1634.86328125"/>
-			<UserParam type="float" name="rightWidth" value="1685.81030273438"/>
-			<UserParam type="float" name="total_xic" value="141144.40447998"/>
-			<UserParam type="float" name="peak_apices_sum" value="20912.4653320312"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.976751222648202"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.968715346150462"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0133467853267937"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0240119555958121"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0133467853267937"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0145806315400125"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.99989973059223"/>
-			<UserParam type="float" name="var_intensity_score" value="0.909389242867262"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="97.517435020494"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.5800311827403"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.975244373083115"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.39723611286629"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.974755927449578"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="16.5563312629803"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="16.8438426877962"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.654000990960296"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.09969813062877"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.27252665585312"/>
-			<UserParam type="float" name="PrecursorMZ" value="532.248746583271"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_7344192187426184761">
-			<position dim="0">1617.1483410699</position>
-			<position dim="1">368.862109904738</position>
-			<intensity>9.25278e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.878065</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1595.50939941406" y="368.812109904738" />
-				<pt x="1764.53942871094" y="368.812109904738" />
-				<pt x="1764.53942871094" y="368.912109904738" />
-				<pt x="1595.50939941406" y="368.912109904738" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1595.50939941406" y="369.146561517338" />
-				<pt x="1764.53942871094" y="369.146561517338" />
-				<pt x="1764.53942871094" y="369.246561517338" />
-				<pt x="1595.50939941406" y="369.246561517338" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_7344192187426184761_2130311522918743509">
-					<position dim="0">1617.1483410699</position>
-					<position dim="1">368.862109904738</position>
-					<intensity>5.79311e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="368.862109904738"/>
-					<UserParam type="string" name="native_id" value="LAMTLAEAER/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="301442.201293945"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.637366103952144"/>
-				</feature>
-				<feature id="f_7344192187426184761_9140546320740515641">
-					<position dim="0">1617.1483410699</position>
-					<position dim="1">369.196561517338</position>
-					<intensity>3.45967e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="369.196561517338"/>
-					<UserParam type="string" name="native_id" value="LAMTLAEAER/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="164956.921875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.362633896047856"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" >
-				<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_3">
-					<UserParam type="float" name="OMSSA_score" value="0.134752265696133"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" >
-				<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_3">
-					<UserParam type="float" name="OMSSA_score" value="0.0325713993888641"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LAMTLAEAER/3"/>
-			<UserParam type="float" name="leftWidth" value="1595.50939941406"/>
-			<UserParam type="float" name="rightWidth" value="1764.53942871094"/>
-			<UserParam type="float" name="total_xic" value="10395361.7129517"/>
-			<UserParam type="float" name="peak_apices_sum" value="466399.123168945"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.97124963771702"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.960129477115842"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0112721013675148"/>
-			<UserParam type="float" name="var_library_sangle" value="0.021080330114212"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0112721013675148"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0118955544334974"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999931728221565"/>
-			<UserParam type="float" name="var_intensity_score" value="0.890087065317977"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="16.9401516016668"/>
-			<UserParam type="float" name="var_log_sn_score" value="2.82968663851485"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.940495908260345"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.15988578920748"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.509134767132634"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="28.1440905745226"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="35.8761787175195"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.567734792584532"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.42292916274579"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.87806461617499"/>
-			<UserParam type="float" name="PrecursorMZ" value="368.862109904738"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-		</feature>
-		<feature id="f_16616557306000669869">
+		<feature id="f_9140546320740515641">
 			<position dim="0">2391.85092347612</position>
 			<position dim="1">501.795134726821</position>
 			<intensity>3.70448e+07</intensity>
@@ -2259,7 +2059,7 @@
 				<pt x="2367.25073242188" y="502.346812145721" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_16616557306000669869_8984402899352117479">
+				<feature id="f_9140546320740515641_12049315334424432437">
 					<position dim="0">2391.85092347612</position>
 					<position dim="1">501.795134726821</position>
 					<intensity>2.43122e+07</intensity>
@@ -2273,7 +2073,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.653030735732608"/>
 				</feature>
-				<feature id="f_16616557306000669869_1621338151966755474">
+				<feature id="f_9140546320740515641_9868242461570157420">
 					<position dim="0">2391.85092347612</position>
 					<position dim="1">502.296812145721</position>
 					<intensity>1.27326e+07</intensity>
@@ -2331,100 +2131,193 @@
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 		</feature>
-		<feature id="f_12520536430934325912">
-			<position dim="0">2298.14719526402</position>
-			<position dim="1">435.910228820904</position>
-			<intensity>107152</intensity>
+		<feature id="f_16616557306000669869">
+			<position dim="0">1558.9325598625</position>
+			<position dim="1">358.174576486338</position>
+			<intensity>1.27675e+06</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>2.28768</overallquality>
+			<overallquality>3.16365</overallquality>
 			<charge>3</charge>
 			<convexhull nr="0">
-				<pt x="2290.19189453125" y="435.860228820904" />
-				<pt x="2307.17138671875" y="435.860228820904" />
-				<pt x="2307.17138671875" y="435.960228820904" />
-				<pt x="2290.19189453125" y="435.960228820904" />
+				<pt x="1539.38354492188" y="358.124576486338" />
+				<pt x="1615.81567382812" y="358.124576486338" />
+				<pt x="1615.81567382812" y="358.224576486338" />
+				<pt x="1539.38354492188" y="358.224576486338" />
 			</convexhull>
 			<convexhull nr="1">
-				<pt x="2290.19189453125" y="436.194680433504" />
-				<pt x="2307.17138671875" y="436.194680433504" />
-				<pt x="2307.17138671875" y="436.294680433504" />
-				<pt x="2290.19189453125" y="436.294680433504" />
+				<pt x="1539.38354492188" y="358.459028098938" />
+				<pt x="1615.81567382812" y="358.459028098938" />
+				<pt x="1615.81567382812" y="358.559028098938" />
+				<pt x="1539.38354492188" y="358.559028098938" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_12520536430934325912_3619468215685938204">
-					<position dim="0">2298.14719526402</position>
-					<position dim="1">435.910228820904</position>
-					<intensity>70587.9</intensity>
+				<feature id="f_16616557306000669869_8984402899352117479">
+					<position dim="0">1558.9325598625</position>
+					<position dim="1">358.174576486338</position>
+					<intensity>903200</intensity>
 					<quality dim="0">0</quality>
 					<quality dim="1">0</quality>
 					<overallquality>0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="435.910228820904"/>
-					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="15366.9287109375"/>
+					<UserParam type="float" name="MZ" value="358.174576486338"/>
+					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="54360.2887573242"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.586748524736467"/>
+					<UserParam type="float" name="isotope_probability" value="0.646660950740033"/>
 				</feature>
-				<feature id="f_12520536430934325912_15246437841577070383">
-					<position dim="0">2298.14719526402</position>
-					<position dim="1">436.244680433504</position>
-					<intensity>36564</intensity>
+				<feature id="f_16616557306000669869_1621338151966755474">
+					<position dim="0">1558.9325598625</position>
+					<position dim="1">358.509028098938</position>
+					<intensity>373548</intensity>
 					<quality dim="0">0</quality>
 					<quality dim="1">0</quality>
 					<overallquality>0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="436.244680433504"/>
-					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="8652.01141357422"/>
+					<UserParam type="float" name="MZ" value="358.509028098938"/>
+					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="26582.2421875"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.413251475263533"/>
+					<UserParam type="float" name="isotope_probability" value="0.353339049259967"/>
 				</feature>
 			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.909851074219" RT="2295.90209960938" >
-				<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0137458569950031"/>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
+				<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
 					<UserParam type="string" name="target_decoy" value="target"/>
 				</PeptideHit>
 				<UserParam type="string" name="FFId_category" value="internal"/>
 			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="HLVDEPQNLIK/3"/>
-			<UserParam type="float" name="leftWidth" value="2290.19189453125"/>
-			<UserParam type="float" name="rightWidth" value="2307.17138671875"/>
-			<UserParam type="float" name="total_xic" value="10639599.0813599"/>
-			<UserParam type="float" name="peak_apices_sum" value="24018.9401245117"/>
+			<UserParam type="string" name="PeptideRef" value="SHC(Carbamidomethyl)IAEVEK/3"/>
+			<UserParam type="float" name="leftWidth" value="1539.38354492188"/>
+			<UserParam type="float" name="rightWidth" value="1615.81567382812"/>
+			<UserParam type="float" name="total_xic" value="1534200.08959961"/>
+			<UserParam type="float" name="peak_apices_sum" value="80942.5309448242"/>
 			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.987321606844706"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.981554863036929"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.995859874004335"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99432412161936"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0720162439304341"/>
-			<UserParam type="float" name="var_library_sangle" value="0.13567334952461"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0720162439304341"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0755707134178571"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.997235692613535"/>
-			<UserParam type="float" name="var_intensity_score" value="0.0100710436895339"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0607613750242852"/>
+			<UserParam type="float" name="var_library_sangle" value="0.107918735760252"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0607613750242852"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0672493863158573"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.997885894058429"/>
+			<UserParam type="float" name="var_intensity_score" value="0.832191728872341"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="2.98262189450483"/>
-			<UserParam type="float" name="var_log_sn_score" value="1.0928027440642"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.98598974943161"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="4.71687160277937"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.958229731481322"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.341235220432281"/>
-			<UserParam type="float" name="var_massdev_score" value="0.295951363727171"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.283335711262804"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="sn_ratio" value="11.7494826105578"/>
+			<UserParam type="float" name="var_log_sn_score" value="2.46380920647666"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.977227956056595"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="5.81651671719193"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.985290582455854"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.292577654123306"/>
+			<UserParam type="float" name="var_massdev_score" value="0.776434922758457"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.740130209172225"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
 			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.654268103487712"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.07431043140929"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.28767931417546"/>
-			<UserParam type="float" name="PrecursorMZ" value="435.910228820904"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.755976718319793"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.967667974449062"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.16365489172794"/>
+			<UserParam type="float" name="PrecursorMZ" value="358.174576486338"/>
 			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 		</feature>
-		<feature id="f_17876486934271562208">
+		<feature id="f_25974125700937907">
+			<position dim="0">2090.16589783288</position>
+			<position dim="1">421.758354535421</position>
+			<intensity>1.18347e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.38766</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2038.14636230469" y="421.708354535421" />
+				<pt x="2210.38159179688" y="421.708354535421" />
+				<pt x="2210.38159179688" y="421.808354535421" />
+				<pt x="2038.14636230469" y="421.808354535421" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2038.14636230469" y="422.210031954321" />
+				<pt x="2210.38159179688" y="422.210031954321" />
+				<pt x="2210.38159179688" y="422.310031954321" />
+				<pt x="2038.14636230469" y="422.310031954321" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_25974125700937907_7444998229116103684">
+					<position dim="0">2090.16589783288</position>
+					<position dim="1">421.758354535421</position>
+					<intensity>8.41674e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="421.758354535421"/>
+					<UserParam type="string" name="native_id" value="VATVSLPR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="508755.363769531"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.688369804746839"/>
+				</feature>
+				<feature id="f_25974125700937907_11583213259935596392">
+					<position dim="0">2090.16589783288</position>
+					<position dim="1">422.260031954321</position>
+					<intensity>3.41801e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="422.260031954321"/>
+					<UserParam type="string" name="native_id" value="VATVSLPR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="228173.1875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.311630195253161"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="421.758056640625" RT="2091.08642578125" >
+				<PeptideHit score="0.0344827586206897" sequence="VATVSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_13">
+					<UserParam type="float" name="OMSSA_score" value="0.00302546175573277"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="VATVSLPR/2"/>
+			<UserParam type="float" name="leftWidth" value="2038.14636230469"/>
+			<UserParam type="float" name="rightWidth" value="2210.38159179688"/>
+			<UserParam type="float" name="total_xic" value="11877391.0214233"/>
+			<UserParam type="float" name="peak_apices_sum" value="736928.551269531"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.998724868242001"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998358776766715"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0228190172847642"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0393524588734662"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0228190172847642"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0259805444640457"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999690100670513"/>
+			<UserParam type="float" name="var_intensity_score" value="0.99640947903909"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="73.7619026004993"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.30084237339098"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.993695646524429"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.25604411976596"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.988314481916404"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.288811177015305"/>
+			<UserParam type="float" name="var_massdev_score" value="0.890803718434335"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.77537503092"/>
+			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.742374379756163"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.976100444864031"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.38766373143232"/>
+			<UserParam type="float" name="PrecursorMZ" value="421.758354535421"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_12520536430934325912">
 			<position dim="0">1788.6797447244</position>
 			<position dim="1">722.324660331071</position>
 			<intensity>2.35379e+07</intensity>
@@ -2445,7 +2338,7 @@
 				<pt x="1763.34350585938" y="722.876337749971" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_17876486934271562208_8474756626526195362">
+				<feature id="f_12520536430934325912_15246437841577070383">
 					<position dim="0">1788.6797447244</position>
 					<position dim="1">722.324660331071</position>
 					<intensity>1.35914e+07</intensity>
@@ -2459,7 +2352,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.579648044979989"/>
 				</feature>
-				<feature id="f_17876486934271562208_16603831684342283009">
+				<feature id="f_12520536430934325912_17876486934271562208">
 					<position dim="0">1788.6797447244</position>
 					<position dim="1">722.826337749971</position>
 					<intensity>9.94654e+06</intensity>
@@ -2491,11 +2384,11 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.999930643615412"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999898605325919"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00222326540194354"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00222326540194348"/>
 			<UserParam type="float" name="var_library_sangle" value="0.00433946169809374"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00222326540194354"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00226527208671562"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999997466024098"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00222326540194348"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00226527208671551"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999997466024099"/>
 			<UserParam type="float" name="var_intensity_score" value="0.976390288421209"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
 			<UserParam type="float" name="sn_ratio" value="153.107524061801"/>
@@ -2515,6 +2408,113 @@
 			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="int" name="n_total_ids" value="3"/>
 			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+		</feature>
+		<feature id="f_16603831684342283009">
+			<position dim="0">2336.46435114133</position>
+			<position dim="1">464.250362519471</position>
+			<intensity>1.26835e+08</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.31915</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2307.17138671875" y="464.200362519471" />
+				<pt x="2424.5244140625" y="464.200362519471" />
+				<pt x="2424.5244140625" y="464.300362519471" />
+				<pt x="2307.17138671875" y="464.300362519471" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2307.17138671875" y="464.702039938371" />
+				<pt x="2424.5244140625" y="464.702039938371" />
+				<pt x="2424.5244140625" y="464.802039938371" />
+				<pt x="2307.17138671875" y="464.802039938371" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_16603831684342283009_3607574553438867574">
+					<position dim="0">2336.46435114133</position>
+					<position dim="1">464.250362519471</position>
+					<intensity>8.30316e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="464.250362519471"/>
+					<UserParam type="string" name="native_id" value="YLYEIAR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="3748789.63964844"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.655742026441336"/>
+				</feature>
+				<feature id="f_16603831684342283009_4906628401344677738">
+					<position dim="0">2336.46435114133</position>
+					<position dim="1">464.752039938371</position>
+					<intensity>4.3803e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="464.752039938371"/>
+					<UserParam type="string" name="native_id" value="YLYEIAR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="1970969.68359375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.344257973558664"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250213623047" RT="2321.49926757812" >
+				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.000528980302830806"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250030517578" RT="2357.07421875" >
+				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="9.1724848717909e-05"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250335693359" RT="2398.77709960938" >
+				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="4.18055390056644e-05"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="YLYEIAR/2"/>
+			<UserParam type="float" name="leftWidth" value="2307.17138671875"/>
+			<UserParam type="float" name="rightWidth" value="2424.5244140625"/>
+			<UserParam type="float" name="total_xic" value="127750490.772278"/>
+			<UserParam type="float" name="peak_apices_sum" value="5719759.32324219"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.99989185157427"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999853516577379"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00109704639804178"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00200128800168092"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00109704639804178"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00118326541192137"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999334090534"/>
+			<UserParam type="float" name="var_intensity_score" value="0.992830315040351"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="65.000081378898"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.1743885218779"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.985577464103699"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.2506009186205"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.990654856489394"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.345355033874512"/>
+			<UserParam type="float" name="var_massdev_score" value="1.19333451667543"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.03625577733313"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.761987351682086"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.862442874603575"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.31914514059437"/>
+			<UserParam type="float" name="PrecursorMZ" value="464.250362519471"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="3"/>
+			<UserParam type="int" name="n_matching_ids" value="3"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 		</feature>
 	</featureList>

--- a/src/tests/topp/FeatureFinderIdentification_2_output.featureXML
+++ b/src/tests/topp/FeatureFinderIdentification_2_output.featureXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <featureMap version="1.9" id="fm_5156711929824391485" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<UserParam type="floatList" name="FDR_probabilities" value="[0.0643545612692833, 0.221371740102768, 0.840408563613892]"/>
+	<UserParam type="floatList" name="FDR_probabilities" value="[0.0648797824978828, 0.234535679221153, 0.866869628429413]"/>
 	<UserParam type="floatList" name="FDR_qvalues_raw" value="[0.117647058823529, 0.0625, 0]"/>
 	<UserParam type="floatList" name="FDR_qvalues_corrected" value="[0.040920716112532, 0.0217391304347826, 0]"/>
 	<dataProcessing completion_time="1999-12-31T23:59:59">
@@ -102,226 +102,9 @@
 			</ProteinHit>
 		</ProteinIdentification>
 	</IdentificationRun>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" >
-		<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.188627296280199"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="internal"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="653.361755371094" RT="2490.31689453125" >
-		<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0117575719819199"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="internal"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="722.325378417969" RT="1736.66821289062" >
-		<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0173429321700537"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="internal"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
-		<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" >
-		<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_14">
-			<UserParam type="float" name="OMSSA_score" value="0.134752265696133"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" >
-		<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_13">
-			<UserParam type="float" name="OMSSA_score" value="0.140841796155119"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" >
-		<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_14">
-			<UserParam type="float" name="OMSSA_score" value="0.0325713993888641"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="722.325378417969" RT="1736.66821289062" >
-		<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0173429321700537"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="443.711242675781" RT="1738.03344726562" >
-		<PeptideHit score="0.0344827586206897" sequence="DDSPDLPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.00395109914742618"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
-		<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.304504394531" RT="1759.0947265625" >
-		<PeptideHit score="0.0454545454545455" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.161429888187637"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" >
-		<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_15">
-			<UserParam type="float" name="OMSSA_score" value="0.00409018563530312"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="449.744232177734" RT="1776.05004882812" >
-		<PeptideHit score="0.0344827586206897" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0227663017779976"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
-		<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" >
-		<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.042177146646692"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
-		<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="722.32470703125" RT="1804.15795898438" >
-		<PeptideHit score="0" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="3.85390695500564e-05"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" >
-		<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0423622396613216"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="325.491180419922" RT="1840.79333496094" >
-		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0602120422006692"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732299804688" RT="1875.54736328125" >
-		<PeptideHit score="0.0344827586206897" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0435747980539929"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="408.840087890625" RT="1880.01599121094" >
-		<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_16">
-			<UserParam type="float" name="OMSSA_score" value="0.0850109548251393"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732391357422" RT="1906.96594238281" >
-		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0917668515948288"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="722.327209472656" RT="1918.60864257812" >
-		<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0326599590408071"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" >
-		<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.00108437147303181"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732177734375" RT="1942.3701171875" >
-		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0918514920664644"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" >
-		<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.188627296280199"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.166046142578" RT="1970.11474609375" >
-		<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0707872514634683"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="404.203002929688" RT="2003.33984375" >
-		<PeptideHit score="0.0454545454545455" sequence="LAADDFR" charge="2" aa_before="K X X X X X X" aa_after="T X X X X X X" protein_refs="PH_20 PH_21 PH_22 PH_23 PH_18 PH_17 PH_19">
-			<UserParam type="float" name="OMSSA_score" value="0.060731076753908"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.71484375" RT="2010.87902832031" >
-		<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.00167901373867858"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732208251953" RT="2013.36364746094" >
-		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.212602001856198"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="461.747497558594" RT="2015.59265136719" >
 		<PeptideHit score="0" sequence="AEFVEVTK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
 			<UserParam type="float" name="OMSSA_score" value="0.000296258184030238"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715118408203" RT="2032.04125976562" >
-		<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.00115485160103966"/>
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="external"/>
@@ -333,37 +116,9 @@
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="external"/>
 	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260375976562" RT="2058.83471679688" >
-		<PeptideHit score="0.0454545454545455" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0548595335303417"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715393066406" RT="2069.04321289062" >
-		<PeptideHit score="0.0344827586206897" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.00937487962378574"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.700897216797" RT="2085.73901367188" >
 		<PeptideHit score="0.0454545454545455" sequence="AGAFSLPK" charge="2" aa_before="R" aa_after="D" protein_refs="PH_12">
 			<UserParam type="float" name="OMSSA_score" value="0.0631960134592704"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="421.758056640625" RT="2091.08642578125" >
-		<PeptideHit score="0.0344827586206897" sequence="VATVSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_24">
-			<UserParam type="float" name="OMSSA_score" value="0.00302546175573277"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260559082031" RT="2098.17504882812" >
-		<PeptideHit score="0" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="4.91092752369064e-05"/>
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="external"/>
@@ -375,9 +130,282 @@
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="external"/>
 	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
+		<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
+		<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="443.711242675781" RT="1738.03344726562" >
+		<PeptideHit score="0.0344827586206897" sequence="DDSPDLPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.00395109914742618"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732299804688" RT="1875.54736328125" >
+		<PeptideHit score="0.0344827586206897" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0435747980539929"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732391357422" RT="1906.96594238281" >
+		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0917668515948288"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732177734375" RT="1942.3701171875" >
+		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0918514920664644"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="487.732208251953" RT="2013.36364746094" >
+		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="2" aa_before="K" aa_after="G" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.212602001856198"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="325.491180419922" RT="1840.79333496094" >
+		<PeptideHit score="0.0454545454545455" sequence="DLGEEHFK" charge="3" aa_before="K" aa_after="G" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0602120422006692"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260375976562" RT="2058.83471679688" >
+		<PeptideHit score="0.0454545454545455" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0548595335303417"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260559082031" RT="2098.17504882812" >
+		<PeptideHit score="0" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="4.91092752369064e-05"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.304504394531" RT="1759.0947265625" >
+		<PeptideHit score="0.0454545454545455" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.161429888187637"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" >
+		<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0423622396613216"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" >
+		<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.042177146646692"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.71484375" RT="2010.87902832031" >
+		<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.00167901373867858"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715118408203" RT="2032.04125976562" >
+		<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.00115485160103966"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715393066406" RT="2069.04321289062" >
+		<PeptideHit score="0.0344827586206897" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.00937487962378574"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="408.840087890625" RT="1880.01599121094" >
+		<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_16">
+			<UserParam type="float" name="OMSSA_score" value="0.0850109548251393"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="653.361755371094" RT="2490.31689453125" >
+		<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0117575719819199"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="internal"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="653.361755371094" RT="2490.31689453125" >
+		<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0117575719819199"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.909851074219" RT="2295.90209960938" >
 		<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_25">
 			<UserParam type="float" name="OMSSA_score" value="0.0137458569950031"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.910125732422" RT="2488.0380859375" >
+		<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="3.09620313351901e-07"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" >
+		<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_13">
+			<UserParam type="float" name="OMSSA_score" value="0.140841796155119"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="404.203002929688" RT="2003.33984375" >
+		<PeptideHit score="0.0454545454545455" sequence="LAADDFR" charge="2" aa_before="K X X X X X X" aa_after="T X X X X X X" protein_refs="PH_20 PH_21 PH_22 PH_23 PH_18 PH_17 PH_19">
+			<UserParam type="float" name="OMSSA_score" value="0.060731076753908"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" >
+		<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_15">
+			<UserParam type="float" name="OMSSA_score" value="0.00409018563530312"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" >
+		<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_14">
+			<UserParam type="float" name="OMSSA_score" value="0.134752265696133"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" >
+		<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_14">
+			<UserParam type="float" name="OMSSA_score" value="0.0325713993888641"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="449.744232177734" RT="1776.05004882812" >
+		<PeptideHit score="0.0344827586206897" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0227663017779976"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
+		<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" >
+		<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.188627296280199"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" >
+		<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.188627296280199"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="internal"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.166046142578" RT="1970.11474609375" >
+		<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0707872514634683"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="526.261108398438" RT="2495.662109375" >
+		<PeptideHit score="0" sequence="LKPDPNTLC(Carbamidomethyl)DEFK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.00026056879779557"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" >
+		<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.00108437147303181"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.794891357422" RT="2431.52172851562" >
+		<PeptideHit score="0.0454545454545455" sequence="LVVSTQTALA" charge="2" aa_before="K" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.128894553541144"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
+		<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="421.758056640625" RT="2091.08642578125" >
+		<PeptideHit score="0.0344827586206897" sequence="VATVSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_24">
+			<UserParam type="float" name="OMSSA_score" value="0.00302546175573277"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="722.325378417969" RT="1736.66821289062" >
+		<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0173429321700537"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="722.325378417969" RT="1736.66821289062" >
+		<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0173429321700537"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="internal"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="722.32470703125" RT="1804.15795898438" >
+		<PeptideHit score="0" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="3.85390695500564e-05"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="external"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="722.327209472656" RT="1918.60864257812" >
+		<PeptideHit score="0.0344827586206897" sequence="YIC(Carbamidomethyl)DNQDTISSK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_25">
+			<UserParam type="float" name="OMSSA_score" value="0.0326599590408071"/>
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="external"/>
@@ -403,622 +431,14 @@
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="external"/>
 	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.794891357422" RT="2431.52172851562" >
-		<PeptideHit score="0.0454545454545455" sequence="LVVSTQTALA" charge="2" aa_before="K" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.128894553541144"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.910125732422" RT="2488.0380859375" >
-		<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="3.09620313351901e-07"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="653.361755371094" RT="2490.31689453125" >
-		<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.0117575719819199"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="526.261108398438" RT="2495.662109375" >
-		<PeptideHit score="0" sequence="LKPDPNTLC(Carbamidomethyl)DEFK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_25">
-			<UserParam type="float" name="OMSSA_score" value="0.00026056879779557"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="external"/>
-	</UnassignedPeptideIdentification>
 	<featureList count="24">
 		<feature id="f_5233264595117471314">
-			<position dim="0">2007.51161653761</position>
-			<position dim="1">379.715100772821</position>
-			<intensity>3.18473e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.935259</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1973.24267578125" y="379.665100772821" />
-				<pt x="2084.91577148438" y="379.665100772821" />
-				<pt x="2084.91577148438" y="379.765100772821" />
-				<pt x="1973.24267578125" y="379.765100772821" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1973.24267578125" y="380.166778191721" />
-				<pt x="2084.91577148438" y="380.166778191721" />
-				<pt x="2084.91577148438" y="380.266778191721" />
-				<pt x="1973.24267578125" y="380.266778191721" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">2007.51161653761</position>
-					<position dim="1">379.715100772821</position>
-					<intensity>2.28382e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="379.715100772821"/>
-					<UserParam type="string" name="native_id" value="GAC(Carbamidomethyl)LLPK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="2254385.11621094"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.710034950213183"/>
-				</feature>
-				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">2007.51161653761</position>
-					<position dim="1">380.216778191721</position>
-					<intensity>9.00904e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="380.216778191721"/>
-					<UserParam type="string" name="native_id" value="GAC(Carbamidomethyl)LLPK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="911381.791015625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.289965049786817"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715118408203" RT="2032.04125976562" >
-				<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
-					<UserParam type="float" name="OMSSA_score" value="0.00115485160103966"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="GAC(Carbamidomethyl)LLPK/2"/>
-			<UserParam type="float" name="leftWidth" value="1973.24267578125"/>
-			<UserParam type="float" name="rightWidth" value="2084.91577148438"/>
-			<UserParam type="float" name="total_xic" value="32035565.7826538"/>
-			<UserParam type="float" name="peak_apices_sum" value="3165766.90722656"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.9998135456195"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99976967068158"/>
-			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00708243948867987"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0119791052800022"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00708243948867987"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00822738059597"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999969321163731"/>
-			<UserParam type="float" name="var_intensity_score" value="0.99412241432128"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="113.415519519411"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.73105823836186"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.997186601161957"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.61670900288192"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.989965181699822"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.28288260102272"/>
-			<UserParam type="float" name="var_massdev_score" value="0.807860618118897"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.50420457618941"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.774286696585701"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.917152435225103"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.7038225074551"/>
-			<UserParam type="float" name="PrecursorMZ" value="379.715100772821"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.935259243664438"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_15004869347769368353">
-			<position dim="0">2005.79703137669</position>
-			<position dim="1">404.203412328071</position>
-			<intensity>444698</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.886536</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1953.46435546875" y="404.153412328071" />
-				<pt x="2033.83422851562" y="404.153412328071" />
-				<pt x="2033.83422851562" y="404.253412328071" />
-				<pt x="1953.46435546875" y="404.253412328071" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1953.46435546875" y="404.655089746971" />
-				<pt x="2033.83422851562" y="404.655089746971" />
-				<pt x="2033.83422851562" y="404.755089746971" />
-				<pt x="1953.46435546875" y="404.755089746971" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_15004869347769368353_6408859317243173796">
-					<position dim="0">2005.79703137669</position>
-					<position dim="1">404.203412328071</position>
-					<intensity>413099</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="404.203412328071"/>
-					<UserParam type="string" name="native_id" value="LAADDFR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="24527.0495605469"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.701130386577533"/>
-				</feature>
-				<feature id="f_15004869347769368353_474525871221756682">
-					<position dim="0">2005.79703137669</position>
-					<position dim="1">404.705089746971</position>
-					<intensity>31598.8</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="404.705089746971"/>
-					<UserParam type="string" name="native_id" value="LAADDFR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="4520.375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.298869613422467"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="404.203002929688" RT="2003.33984375" >
-				<PeptideHit score="0.0454545454545455" sequence="LAADDFR" charge="2" aa_before="K X X X X X X" aa_after="T X X X X X X" protein_refs="PH_20 PH_21 PH_22 PH_23 PH_18 PH_17 PH_19">
-					<UserParam type="float" name="OMSSA_score" value="0.060731076753908"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LAADDFR/2"/>
-			<UserParam type="float" name="leftWidth" value="1953.46435546875"/>
-			<UserParam type="float" name="rightWidth" value="2033.83422851562"/>
-			<UserParam type="float" name="total_xic" value="7252377.52032471"/>
-			<UserParam type="float" name="peak_apices_sum" value="29047.4245605469"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.82136720504592"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.838186270380688"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.920064684864184"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.899498974501908"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.227812828189622"/>
-			<UserParam type="float" name="var_library_sangle" value="0.326600963424246"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.227812828189622"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.356695561353588"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.952766208159461"/>
-			<UserParam type="float" name="var_intensity_score" value="0.0613175513828036"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="46.6384662366484"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.84242565635246"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.919530034065247"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="5.82705715280964"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.977395240636197"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.0710567831993103"/>
-			<UserParam type="float" name="var_massdev_score" value="0.175924713032794"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.20257301257106"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.624270529344654"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.34607058455137"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.38617833618714"/>
-			<UserParam type="float" name="PrecursorMZ" value="404.203412328071"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.886536006559636"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_10306100746905639127">
-			<position dim="0">1782.34333734102</position>
-			<position dim="1">449.744389900421</position>
-			<intensity>1.7437e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.974479</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1761.75610351562" y="449.694389900421" />
-				<pt x="1881.08850097656" y="449.694389900421" />
-				<pt x="1881.08850097656" y="449.794389900421" />
-				<pt x="1761.75610351562" y="449.794389900421" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1761.75610351562" y="450.196067319321" />
-				<pt x="1881.08850097656" y="450.196067319321" />
-				<pt x="1881.08850097656" y="450.296067319321" />
-				<pt x="1761.75610351562" y="450.296067319321" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_10306100746905639127_17314619952666245179">
-					<position dim="0">1782.34333734102</position>
-					<position dim="1">449.744389900421</position>
-					<intensity>1.27819e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="449.744389900421"/>
-					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="91264.109375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
-				</feature>
-				<feature id="f_10306100746905639127_3023658190814908261">
-					<position dim="0">1782.34333734102</position>
-					<position dim="1">450.246067319321</position>
-					<intensity>465501</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="450.246067319321"/>
-					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="32936.89453125"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.325393160206819"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="449.744389900421" RT="1782.34333734102" >
-				<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_25">
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="implied"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LC(Carbamidomethyl)VLHEK/2"/>
-			<UserParam type="float" name="leftWidth" value="1761.75610351562"/>
-			<UserParam type="float" name="rightWidth" value="1881.08850097656"/>
-			<UserParam type="float" name="total_xic" value="2582006.26055908"/>
-			<UserParam type="float" name="peak_apices_sum" value="124201.00390625"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.995444848298674"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.994000524898595"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0584307399821589"/>
-			<UserParam type="float" name="var_library_sangle" value="0.100167183533034"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0584307399821589"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0670063315124288"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.997948935934463"/>
-			<UserParam type="float" name="var_intensity_score" value="0.675325870287564"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="62.4978560025402"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.1351322521946"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.981171160936356"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.03356612799787"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.984152837341836"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.26696240901947"/>
-			<UserParam type="float" name="var_massdev_score" value="0.43272982427065"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.447953512388762"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.698534764147427"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.07117517832204"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.2391476607732"/>
-			<UserParam type="float" name="PrecursorMZ" value="449.744389900421"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="0"/>
-			<UserParam type="int" name="n_matching_ids" value="-1"/>
-			<UserParam type="string" name="feature_class" value="unknown"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.974479317836809"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_17092894204355333314">
-			<position dim="0">1782.50461751663</position>
-			<position dim="1">300.165352089204</position>
-			<intensity>1.17279e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.886603</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1761.75610351562" y="300.115352089204" />
-				<pt x="1851.12512207031" y="300.115352089204" />
-				<pt x="1851.12512207031" y="300.215352089204" />
-				<pt x="1761.75610351562" y="300.215352089204" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1761.75610351562" y="300.449803701804" />
-				<pt x="1851.12512207031" y="300.449803701804" />
-				<pt x="1851.12512207031" y="300.549803701804" />
-				<pt x="1761.75610351562" y="300.549803701804" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_17092894204355333314_12156709473159629610">
-					<position dim="0">1782.50461751663</position>
-					<position dim="1">300.165352089204</position>
-					<intensity>8.23888e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="300.165352089204"/>
-					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="576644.387084961"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
-				</feature>
-				<feature id="f_17092894204355333314_15885522598119108466">
-					<position dim="0">1782.50461751663</position>
-					<position dim="1">300.499803701804</position>
-					<intensity>3.48903e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="300.499803701804"/>
-					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="265400.1875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.325393160206819"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
-				<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
-					<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LC(Carbamidomethyl)VLHEK/3"/>
-			<UserParam type="float" name="leftWidth" value="1761.75610351562"/>
-			<UserParam type="float" name="rightWidth" value="1851.12512207031"/>
-			<UserParam type="float" name="total_xic" value="36322088.9429321"/>
-			<UserParam type="float" name="peak_apices_sum" value="842044.574584961"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999223453079938"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998977229691247"/>
-			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0278949113172731"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0488381457118354"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0278949113172731"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0312839115958893"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.99954626385961"/>
-			<UserParam type="float" name="var_intensity_score" value="0.322886577873493"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="16.5705354263045"/>
-			<UserParam type="float" name="var_log_sn_score" value="2.80762614391005"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.980328291654587"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.17903100293939"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.990141545208339"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.297498255968094"/>
-			<UserParam type="float" name="var_massdev_score" value="1.05310642007867"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.22714620827016"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.821176744139309"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.859179305085471"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.43790858147046"/>
-			<UserParam type="float" name="PrecursorMZ" value="300.165352089204"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.886603016771461"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_11275867043381640475">
-			<position dim="0">1943.3004011853</position>
-			<position dim="1">395.239463487571</position>
-			<intensity>8.96624e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.886551</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1918.98767089844" y="395.189463487571" />
-				<pt x="2002.17077636719" y="395.189463487571" />
-				<pt x="2002.17077636719" y="395.289463487571" />
-				<pt x="1918.98767089844" y="395.289463487571" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1918.98767089844" y="395.691140906471" />
-				<pt x="2002.17077636719" y="395.691140906471" />
-				<pt x="2002.17077636719" y="395.791140906471" />
-				<pt x="1918.98767089844" y="395.791140906471" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_11275867043381640475_8666254306116808202">
-					<position dim="0">1943.3004011853</position>
-					<position dim="1">395.239463487571</position>
-					<intensity>6.32974e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="395.239463487571"/>
-					<UserParam type="string" name="native_id" value="LVTDLTK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="11353591.1308594"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.704209887318509"/>
-				</feature>
-				<feature id="f_11275867043381640475_3246735940528705071">
-					<position dim="0">1943.3004011853</position>
-					<position dim="1">395.741140906471</position>
-					<intensity>2.6365e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="395.741140906471"/>
-					<UserParam type="string" name="native_id" value="LVTDLTK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="4777608.1171875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.295790112681491"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" >
-				<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_25">
-					<UserParam type="float" name="OMSSA_score" value="0.00108437147303181"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LVTDLTK/2"/>
-			<UserParam type="float" name="leftWidth" value="1918.98767089844"/>
-			<UserParam type="float" name="rightWidth" value="2002.17077636719"/>
-			<UserParam type="float" name="total_xic" value="106505972.974854"/>
-			<UserParam type="float" name="peak_apices_sum" value="16131199.2480469"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999857333290542"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999821696582955"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0017426793038198"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00298344304196402"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0017426793038198"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00199874144393369"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999998174406389"/>
-			<UserParam type="float" name="var_intensity_score" value="0.841853555210182"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="126.830124379947"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.84284858776125"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.997866630554199"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.71322313299286"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.991768882855086"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.294047445058823"/>
-			<UserParam type="float" name="var_massdev_score" value="1.34876090913977"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.0324552849287"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="1"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.784624367602911"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.867806593918273"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.928179684801"/>
-			<UserParam type="float" name="PrecursorMZ" value="395.239463487571"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.88655060328118"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_17569764383250687096">
-			<position dim="0">2336.46435114133</position>
-			<position dim="1">464.250362519471</position>
-			<intensity>1.26924e+08</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.941624</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2307.17138671875" y="464.200362519471" />
-				<pt x="2426.22387695312" y="464.200362519471" />
-				<pt x="2426.22387695312" y="464.300362519471" />
-				<pt x="2307.17138671875" y="464.300362519471" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2307.17138671875" y="464.702039938371" />
-				<pt x="2426.22387695312" y="464.702039938371" />
-				<pt x="2426.22387695312" y="464.802039938371" />
-				<pt x="2307.17138671875" y="464.802039938371" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_17569764383250687096_14317784148091680644">
-					<position dim="0">2336.46435114133</position>
-					<position dim="1">464.250362519471</position>
-					<intensity>8.3097e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="464.250362519471"/>
-					<UserParam type="string" name="native_id" value="YLYEIAR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="3748789.63964844"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.655742026441336"/>
-				</feature>
-				<feature id="f_17569764383250687096_17671779025680303814">
-					<position dim="0">2336.46435114133</position>
-					<position dim="1">464.752039938371</position>
-					<intensity>4.38269e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="464.752039938371"/>
-					<UserParam type="string" name="native_id" value="YLYEIAR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="1970969.68359375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.344257973558664"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250030517578" RT="2357.07421875" >
-				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
-					<UserParam type="float" name="OMSSA_score" value="9.1724848717909e-05"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="YLYEIAR/2"/>
-			<UserParam type="float" name="leftWidth" value="2307.17138671875"/>
-			<UserParam type="float" name="rightWidth" value="2426.22387695312"/>
-			<UserParam type="float" name="total_xic" value="127756402.797302"/>
-			<UserParam type="float" name="peak_apices_sum" value="5719759.32324219"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999895292390075"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999858177047213"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00104262185989198"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00190194541013619"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00104262185989198"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00112459476550769"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999398500781"/>
-			<UserParam type="float" name="var_intensity_score" value="0.993483075767066"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="72.0472246760353"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.27732180228706"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.985681295394897"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.32571806860717"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.990655613883382"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.345300585031509"/>
-			<UserParam type="float" name="var_massdev_score" value="1.19333451667543"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.03625577733313"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.761987351682086"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.862442874603575"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.38282606095421"/>
-			<UserParam type="float" name="PrecursorMZ" value="464.250362519471"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.9416235089372"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_1196373166564353753">
 			<position dim="0">2024.60123336381</position>
 			<position dim="1">461.747653035421</position>
 			<intensity>7.81384e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.895415</overallquality>
+			<overallquality>0.915508</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="1998.99108886719" y="461.697653035421" />
@@ -1033,7 +453,7 @@
 				<pt x="1998.99108886719" y="462.299330454321" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_1196373166564353753_7539502987715517688">
+				<feature id="f_5233264595117471314_4835329514588776807">
 					<position dim="0">2024.60123336381</position>
 					<position dim="1">461.747653035421</position>
 					<intensity>5.19798e+07</intensity>
@@ -1047,7 +467,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.66642596900412"/>
 				</feature>
-				<feature id="f_1196373166564353753_9126387050458671424">
+				<feature id="f_5233264595117471314_17749660155506638460">
 					<position dim="0">2024.60123336381</position>
 					<position dim="1">462.249330454321</position>
 					<intensity>2.61586e+07</intensity>
@@ -1076,11 +496,11 @@
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.99996493554237"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99995323052215"/>
-			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00119903865892781"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00216044182078575"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00119903865892781"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00130798975756907"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0011990386589279"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00216044182083714"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0011990386589279"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00130798975756924"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999999192312186"/>
 			<UserParam type="float" name="var_intensity_score" value="0.989215257928315"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
@@ -1104,16 +524,16 @@
 			<UserParam type="string" name="feature_class" value="unknown"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.895415179727194"/>
+			<UserParam type="float" name="predicted_probability" value="0.915508204763859"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_7316644956366259183">
+		<feature id="f_15004869347769368353">
 			<position dim="0">2072.67445045983</position>
 			<position dim="1">395.726522907821</position>
 			<intensity>2.40299e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.886563</overallquality>
+			<overallquality>0.90784</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="2045.21923828125" y="395.676522907821" />
@@ -1128,7 +548,7 @@
 				<pt x="2045.21923828125" y="396.278200326721" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_7316644956366259183_12758854762884412659">
+				<feature id="f_15004869347769368353_15157403601844400700">
 					<position dim="0">2072.67445045983</position>
 					<position dim="1">395.726522907821</position>
 					<intensity>1.71804e+07</intensity>
@@ -1142,7 +562,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.692511512336989"/>
 				</feature>
-				<feature id="f_7316644956366259183_17287849381738438716">
+				<feature id="f_15004869347769368353_6408859317243173796">
 					<position dim="0">2072.67445045983</position>
 					<position dim="1">396.228200326721</position>
 					<intensity>6.84952e+06</intensity>
@@ -1201,16 +621,16 @@
 			<UserParam type="string" name="feature_class" value="positive"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.886563173874776"/>
+			<UserParam type="float" name="predicted_probability" value="0.907839726540635"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_4143272592559840046">
+		<feature id="f_17413765565443951891">
 			<position dim="0">2123.35043908495</position>
 			<position dim="1">455.755280535421</position>
 			<intensity>5.9601e+06</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.396445</overallquality>
+			<overallquality>0.425157</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="2092.81127929688" y="455.705280535421" />
@@ -1225,7 +645,7 @@
 				<pt x="2092.81127929688" y="456.306957954321" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_4143272592559840046_7870901012988979006">
+				<feature id="f_17413765565443951891_2927519776102075938">
 					<position dim="0">2123.35043908495</position>
 					<position dim="1">455.755280535421</position>
 					<intensity>4.14596e+06</intensity>
@@ -1239,7 +659,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.652807062123664"/>
 				</feature>
-				<feature id="f_4143272592559840046_5342974036930030800">
+				<feature id="f_17413765565443951891_16907355690727166316">
 					<position dim="0">2123.35043908495</position>
 					<position dim="1">456.256957954321</position>
 					<intensity>1.81414e+06</intensity>
@@ -1269,10 +689,10 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.997907555270713"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997154484390482"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0428115169988116"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0763300771795289"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0428115169988116"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0471864463106846"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0428115169988115"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0763300771795275"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0428115169988115"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0471864463106845"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.998956115412773"/>
 			<UserParam type="float" name="var_intensity_score" value="0.993096455194858"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
@@ -1296,16 +716,120 @@
 			<UserParam type="string" name="feature_class" value="unknown"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="0"/>
-			<UserParam type="float" name="predicted_probability" value="0.396445109221612"/>
+			<UserParam type="float" name="predicted_probability" value="0.425157462299421"/>
 			<UserParam type="float" name="q-value" value="0.0217391304347826"/>
 		</feature>
-		<feature id="f_11399299100673837381">
+		<feature id="f_10306100746905639127">
+			<position dim="0">1760.25657093773</position>
+			<position dim="1">569.752618393021</position>
+			<intensity>1.41631e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.86687</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1735.69311523438" y="569.702618393021" />
+				<pt x="1807.84582519531" y="569.702618393021" />
+				<pt x="1807.84582519531" y="569.802618393021" />
+				<pt x="1735.69311523438" y="569.802618393021" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1735.69311523438" y="570.204295811921" />
+				<pt x="1807.84582519531" y="570.204295811921" />
+				<pt x="1807.84582519531" y="570.304295811921" />
+				<pt x="1735.69311523438" y="570.304295811921" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_10306100746905639127_1755235105885170967">
+					<position dim="0">1760.25657093773</position>
+					<position dim="1">569.752618393021</position>
+					<intensity>9.11098e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="569.752618393021"/>
+					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="1354679.41699219"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.644498608917742"/>
+				</feature>
+				<feature id="f_10306100746905639127_14811341817612382122">
+					<position dim="0">1760.25657093773</position>
+					<position dim="1">570.254295811921</position>
+					<intensity>5.05212e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="570.254295811921"/>
+					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="754406.354980469"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.355501391082258"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
+				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
+					<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
+				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
+					<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2"/>
+			<UserParam type="float" name="leftWidth" value="1735.69311523438"/>
+			<UserParam type="float" name="rightWidth" value="1807.84582519531"/>
+			<UserParam type="float" name="total_xic" value="14499495.8618774"/>
+			<UserParam type="float" name="peak_apices_sum" value="2109085.77197266"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999789273851081"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99971031035635"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00120883289124374"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00223274433170125"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00120883289124374"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00128951053314119"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999203383641"/>
+			<UserParam type="float" name="var_intensity_score" value="0.976799754620304"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="142.496872084488"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.9593200491835"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.997347682714462"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.80041851077005"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.99326139284813"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.356710225343704"/>
+			<UserParam type="float" name="var_massdev_score" value="0.482075605090886"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.385620600005746"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.754351526419968"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.84165907229483"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.86338104873934"/>
+			<UserParam type="float" name="PrecursorMZ" value="569.752618393021"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.866869606461152"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_17314619952666245179">
 			<position dim="0">1749.12956152037</position>
 			<position dim="1">443.711267907821</position>
 			<intensity>3.6544e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.934592</overallquality>
+			<overallquality>0.948762</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="1718.70336914062" y="443.661267907821" />
@@ -1320,7 +844,7 @@
 				<pt x="1718.70336914062" y="444.262945326721" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_11399299100673837381_16164338904207598736">
+				<feature id="f_17314619952666245179_3023658190814908261">
 					<position dim="0">1749.12956152037</position>
 					<position dim="1">443.711267907821</position>
 					<intensity>2.5289e+07</intensity>
@@ -1334,7 +858,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.691417156355378"/>
 				</feature>
-				<feature id="f_11399299100673837381_4410447320637600518">
+				<feature id="f_17314619952666245179_7898004582401008768">
 					<position dim="0">1749.12956152037</position>
 					<position dim="1">444.212945326721</position>
 					<intensity>1.12549e+07</intensity>
@@ -1364,9 +888,9 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.999913661505798"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999889473186652"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.000599630326988065"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00104554317429552"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.000599630326988065"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00059963032698801"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00104554317450789"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00059963032698801"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.000675051683031891"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999999789234646"/>
 			<UserParam type="float" name="var_intensity_score" value="0.990500209419735"/>
@@ -1377,13 +901,13 @@
 			<UserParam type="float" name="xx_lda_prelim_score" value="7.62759562870664"/>
 			<UserParam type="float" name="var_isotope_correlation_score" value="0.990743065551955"/>
 			<UserParam type="float" name="var_isotope_overlap_score" value="0.307983219623566"/>
-			<UserParam type="float" name="var_massdev_score" value="0.760948673990978"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.544374916487825"/>
+			<UserParam type="float" name="var_massdev_score" value="0.760948674247052"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.544374916743954"/>
 			<UserParam type="float" name="var_bseries_score" value="0"/>
 			<UserParam type="float" name="var_yseries_score" value="1"/>
 			<UserParam type="float" name="var_dotprod_score" value="0.767922678010944"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.870417252673124"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.89983501502894"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.870417252673125"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.89983501500637"/>
 			<UserParam type="float" name="PrecursorMZ" value="443.711267907821"/>
 			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="int" name="n_total_ids" value="0"/>
@@ -1391,16 +915,16 @@
 			<UserParam type="string" name="feature_class" value="unknown"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.934591733019469"/>
+			<UserParam type="float" name="predicted_probability" value="0.948762241220119"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_12561328592123678330">
+		<feature id="f_15050004366391181853">
 			<position dim="0">1851.03387353231</position>
 			<position dim="1">487.732534471621</position>
 			<intensity>8.88946e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.922066</overallquality>
+			<overallquality>0.938268</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="1825.08544921875" y="487.682534471621" />
@@ -1415,7 +939,7 @@
 				<pt x="1825.08544921875" y="488.284211890521" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_12561328592123678330_8795943655088158336">
+				<feature id="f_15050004366391181853_17716858074023296841">
 					<position dim="0">1851.03387353231</position>
 					<position dim="1">487.732534471621</position>
 					<intensity>5.83912e+07</intensity>
@@ -1429,7 +953,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.658472827804029"/>
 				</feature>
-				<feature id="f_12561328592123678330_6878260161865568505">
+				<feature id="f_15050004366391181853_16250062551099875712">
 					<position dim="0">1851.03387353231</position>
 					<position dim="1">488.234211890521</position>
 					<intensity>3.05034e+07</intensity>
@@ -1475,9 +999,9 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.999943240299027"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999923413103751"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0016142458229231"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00293650216154963"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0016142458229231"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00161424582292313"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00293650216151183"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00161424582292313"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.00174555908066731"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999998553247625"/>
 			<UserParam type="float" name="var_intensity_score" value="0.99259899477053"/>
@@ -1502,16 +1026,16 @@
 			<UserParam type="string" name="feature_class" value="positive"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.922065856590641"/>
+			<UserParam type="float" name="predicted_probability" value="0.93826774591314"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_4021463513649428920">
+		<feature id="f_16177748921272733768">
 			<position dim="0">1850.92089781596</position>
 			<position dim="1">325.490781803338</position>
 			<intensity>6.43095e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.931038</overallquality>
+			<overallquality>0.9458</overallquality>
 			<charge>3</charge>
 			<convexhull nr="0">
 				<pt x="1825.08544921875" y="325.440781803338" />
@@ -1526,7 +1050,7 @@
 				<pt x="1825.08544921875" y="325.875233415938" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_4021463513649428920_13574947772324278593">
+				<feature id="f_16177748921272733768_1147219038608936718">
 					<position dim="0">1850.92089781596</position>
 					<position dim="1">325.490781803338</position>
 					<intensity>4.24122e+07</intensity>
@@ -1540,7 +1064,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.658472827804029"/>
 				</feature>
-				<feature id="f_4021463513649428920_3689406389503231823">
+				<feature id="f_16177748921272733768_11115414975438642789">
 					<position dim="0">1850.92089781596</position>
 					<position dim="1">325.825233415938</position>
 					<intensity>2.18973e+07</intensity>
@@ -1570,9 +1094,9 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.999871525769583"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999826647385611"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00102805665291883"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00186731386098852"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00102805665291883"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0010280566529188"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00186731386110743"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0010280566529188"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.00111322293345628"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999999412109526"/>
 			<UserParam type="float" name="var_intensity_score" value="0.982419403524766"/>
@@ -1597,409 +1121,16 @@
 			<UserParam type="string" name="feature_class" value="unknown"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.931038371643043"/>
+			<UserParam type="float" name="predicted_probability" value="0.94579950165904"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_5805590394902791448">
-			<position dim="0">1782.51151069112</position>
-			<position dim="1">300.195528597604</position>
-			<intensity>1.17056e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.922578</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1763.34350585938" y="300.145528597604" />
-				<pt x="1851.12512207031" y="300.145528597604" />
-				<pt x="1851.12512207031" y="300.245528597604" />
-				<pt x="1763.34350585938" y="300.245528597604" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1763.34350585938" y="300.479980210204" />
-				<pt x="1851.12512207031" y="300.479980210204" />
-				<pt x="1851.12512207031" y="300.579980210204" />
-				<pt x="1763.34350585938" y="300.579980210204" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_5805590394902791448_3395379003172100421">
-					<position dim="0">1782.51151069112</position>
-					<position dim="1">300.195528597604</position>
-					<intensity>8.21652e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="300.195528597604"/>
-					<UserParam type="string" name="native_id" value="LALDLVVR/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="576644.387084961"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.668051514852376"/>
-				</feature>
-				<feature id="f_5805590394902791448_11630589982317102322">
-					<position dim="0">1782.51151069112</position>
-					<position dim="1">300.529980210204</position>
-					<intensity>3.48903e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="300.529980210204"/>
-					<UserParam type="string" name="native_id" value="LALDLVVR/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="265400.1875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.331948485147624"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" >
-				<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_15">
-					<UserParam type="float" name="OMSSA_score" value="0.00409018563530312"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LALDLVVR/3"/>
-			<UserParam type="float" name="leftWidth" value="1763.34350585938"/>
-			<UserParam type="float" name="rightWidth" value="1851.12512207031"/>
-			<UserParam type="float" name="total_xic" value="31535012.6876221"/>
-			<UserParam type="float" name="peak_apices_sum" value="842044.574584961"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999219220116872"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998961131663337"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.033881966605777"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0595943078565422"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.033881966605777"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0378305231519566"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999334609191848"/>
-			<UserParam type="float" name="var_intensity_score" value="0.371192366908246"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="52.4369845237061"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.9596121538803"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.98045688867569"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.00171086149572"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.70019046030159"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="9.54360336593331"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="12.751237371524"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.72994867000711"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.16861748604685"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.31115353012128"/>
-			<UserParam type="float" name="PrecursorMZ" value="300.195528597604"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.922577983946589"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_13641829453453140763">
-			<position dim="0">2090.16589783288</position>
-			<position dim="1">421.758354535421</position>
-			<intensity>1.18363e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.94868</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2036.53295898438" y="421.708354535421" />
-				<pt x="2208.7734375" y="421.708354535421" />
-				<pt x="2208.7734375" y="421.808354535421" />
-				<pt x="2036.53295898438" y="421.808354535421" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2036.53295898438" y="422.210031954321" />
-				<pt x="2208.7734375" y="422.210031954321" />
-				<pt x="2208.7734375" y="422.310031954321" />
-				<pt x="2036.53295898438" y="422.310031954321" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_13641829453453140763_4041634828915281168">
-					<position dim="0">2090.16589783288</position>
-					<position dim="1">421.758354535421</position>
-					<intensity>8.41822e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="421.758354535421"/>
-					<UserParam type="string" name="native_id" value="VATVSLPR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="508755.363769531"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.688369804746839"/>
-				</feature>
-				<feature id="f_13641829453453140763_17078574238716611972">
-					<position dim="0">2090.16589783288</position>
-					<position dim="1">422.260031954321</position>
-					<intensity>3.41811e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="422.260031954321"/>
-					<UserParam type="string" name="native_id" value="VATVSLPR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="228173.1875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.311630195253161"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="421.758354535421" RT="2090.16589783288" >
-				<PeptideHit score="0" sequence="VATVSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_24">
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="implied"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="VATVSLPR/2"/>
-			<UserParam type="float" name="leftWidth" value="2036.53295898438"/>
-			<UserParam type="float" name="rightWidth" value="2208.7734375"/>
-			<UserParam type="float" name="total_xic" value="12180094.9179688"/>
-			<UserParam type="float" name="peak_apices_sum" value="736928.551269531"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.998725787587908"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998359960057659"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0228491945584772"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0394036750093723"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0228491945584772"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0260154723185835"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999689271317972"/>
-			<UserParam type="float" name="var_intensity_score" value="0.971776335054532"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="91.5868187514056"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.51728736123165"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.993696182966232"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.41394051806747"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.988314835244555"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.288780987262726"/>
-			<UserParam type="float" name="var_massdev_score" value="0.890803718434335"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.77537503092"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.742374379756163"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.976100444864031"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.52117391367391"/>
-			<UserParam type="float" name="PrecursorMZ" value="421.758354535421"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="0"/>
-			<UserParam type="int" name="n_matching_ids" value="-1"/>
-			<UserParam type="string" name="feature_class" value="unknown"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.948680369241687"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_15721057298497490036">
-			<position dim="0">1760.25657093773</position>
-			<position dim="1">569.752618393021</position>
-			<intensity>1.41631e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.840409</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1735.69311523438" y="569.702618393021" />
-				<pt x="1807.84582519531" y="569.702618393021" />
-				<pt x="1807.84582519531" y="569.802618393021" />
-				<pt x="1735.69311523438" y="569.802618393021" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1735.69311523438" y="570.204295811921" />
-				<pt x="1807.84582519531" y="570.204295811921" />
-				<pt x="1807.84582519531" y="570.304295811921" />
-				<pt x="1735.69311523438" y="570.304295811921" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_15721057298497490036_11422463686885200558">
-					<position dim="0">1760.25657093773</position>
-					<position dim="1">569.752618393021</position>
-					<intensity>9.11098e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="569.752618393021"/>
-					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="1354679.41699219"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.644498608917742"/>
-				</feature>
-				<feature id="f_15721057298497490036_7344192187426184761">
-					<position dim="0">1760.25657093773</position>
-					<position dim="1">570.254295811921</position>
-					<intensity>5.05212e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="570.254295811921"/>
-					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="754406.354980469"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.355501391082258"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
-				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
-					<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
-				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
-					<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2"/>
-			<UserParam type="float" name="leftWidth" value="1735.69311523438"/>
-			<UserParam type="float" name="rightWidth" value="1807.84582519531"/>
-			<UserParam type="float" name="total_xic" value="14499495.8618774"/>
-			<UserParam type="float" name="peak_apices_sum" value="2109085.77197266"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999789273851081"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99971031035635"/>
-			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00120883289124371"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00223274433170125"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00120883289124371"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00128951053314114"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999203383641"/>
-			<UserParam type="float" name="var_intensity_score" value="0.976799754620304"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="142.496872084488"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.9593200491835"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.997347682714462"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.80041851077005"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.99326139284813"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.356710225343704"/>
-			<UserParam type="float" name="var_massdev_score" value="0.482075605090886"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.385620600005746"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.754351526419968"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.84165907229483"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.86338104873934"/>
-			<UserParam type="float" name="PrecursorMZ" value="569.752618393021"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.840408536568184"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_9140546320740515641">
-			<position dim="0">1558.9325598625</position>
-			<position dim="1">358.174576486338</position>
-			<intensity>1.33422e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.886472</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1537.60900878906" y="358.124576486338" />
-				<pt x="1636.51171875" y="358.124576486338" />
-				<pt x="1636.51171875" y="358.224576486338" />
-				<pt x="1537.60900878906" y="358.224576486338" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1537.60900878906" y="358.459028098938" />
-				<pt x="1636.51171875" y="358.459028098938" />
-				<pt x="1636.51171875" y="358.559028098938" />
-				<pt x="1537.60900878906" y="358.559028098938" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_9140546320740515641_16616557306000669869">
-					<position dim="0">1558.9325598625</position>
-					<position dim="1">358.174576486338</position>
-					<intensity>941962</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="358.174576486338"/>
-					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="54360.2887573242"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.646660950740033"/>
-				</feature>
-				<feature id="f_9140546320740515641_8984402899352117479">
-					<position dim="0">1558.9325598625</position>
-					<position dim="1">358.509028098938</position>
-					<intensity>392257</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="358.509028098938"/>
-					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="26582.2421875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.353339049259967"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
-				<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_25">
-					<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="SHC(Carbamidomethyl)IAEVEK/3"/>
-			<UserParam type="float" name="leftWidth" value="1537.60900878906"/>
-			<UserParam type="float" name="rightWidth" value="1636.51171875"/>
-			<UserParam type="float" name="total_xic" value="1732748.10748291"/>
-			<UserParam type="float" name="peak_apices_sum" value="80942.5309448242"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.9957892536018"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.994227305045081"/>
-			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0593418626095539"/>
-			<UserParam type="float" name="var_library_sangle" value="0.105494126637743"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0593418626095539"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0656174027045489"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.997986000179241"/>
-			<UserParam type="float" name="var_intensity_score" value="0.770001778814904"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="13.5847359594873"/>
-			<UserParam type="float" name="var_log_sn_score" value="2.60894680650888"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.977909862995148"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="5.92500330698142"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.985285171590345"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.293997198343277"/>
-			<UserParam type="float" name="var_massdev_score" value="0.776434922758457"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.740130209172225"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.755976718319793"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.967667974449062"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.25613594588742"/>
-			<UserParam type="float" name="PrecursorMZ" value="358.174576486338"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.886471876894272"/>
-			<UserParam type="float" name="q-value" value="0"/>
-		</feature>
-		<feature id="f_12520536430934325912">
+		<feature id="f_12665713047548007769">
 			<position dim="0">2074.91557012392</position>
 			<position dim="1">554.260602012071</position>
 			<intensity>1.62243e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.896289</overallquality>
+			<overallquality>0.916278</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="2047.82275390625" y="554.210602012071" />
@@ -2014,7 +1145,7 @@
 				<pt x="2047.82275390625" y="554.812279430971" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_12520536430934325912_3619468215685938204">
+				<feature id="f_12665713047548007769_17092894204355333314">
 					<position dim="0">2074.91557012392</position>
 					<position dim="1">554.260602012071</position>
 					<intensity>1.02517e+07</intensity>
@@ -2028,7 +1159,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.630481343594174"/>
 				</feature>
-				<feature id="f_12520536430934325912_15246437841577070383">
+				<feature id="f_12665713047548007769_3491056946625602141">
 					<position dim="0">2074.91557012392</position>
 					<position dim="1">554.762279430971</position>
 					<intensity>5.9726e+06</intensity>
@@ -2067,11 +1198,11 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.999827653936028"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999759086448487"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00139132563753933"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0013913256375393"/>
 			<UserParam type="float" name="var_library_sangle" value="0.00260345517646773"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00139132563753933"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00146753406007655"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.99999896056168"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0013913256375393"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00146753406007644"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999998960561681"/>
 			<UserParam type="float" name="var_intensity_score" value="0.994558871900434"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
 			<UserParam type="float" name="sn_ratio" value="124.541261443466"/>
@@ -2094,16 +1225,16 @@
 			<UserParam type="string" name="feature_class" value="positive"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.896289142348986"/>
+			<UserParam type="float" name="predicted_probability" value="0.916277740735144"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_17876486934271562208">
+		<feature id="f_10627069796380146481">
 			<position dim="0">1766.28153652464</position>
 			<position dim="1">646.304684132271</position>
 			<intensity>1.15352e+06</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.936839</overallquality>
+			<overallquality>0.950638</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="1744.55932617188" y="646.254684132271" />
@@ -2118,7 +1249,7 @@
 				<pt x="1744.55932617188" y="646.856361551171" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_17876486934271562208_3607574553438867574">
+				<feature id="f_10627069796380146481_12156709473159629610">
 					<position dim="0">1766.28153652464</position>
 					<position dim="1">646.304684132271</position>
 					<intensity>740116</intensity>
@@ -2132,7 +1263,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
 				</feature>
-				<feature id="f_17876486934271562208_4906628401344677738">
+				<feature id="f_10627069796380146481_15885522598119108466">
 					<position dim="0">1766.28153652464</position>
 					<position dim="1">646.806361551171</position>
 					<intensity>413408</intensity>
@@ -2163,7 +1294,7 @@
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.996687864987247"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.995242375653698"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
 			<UserParam type="float" name="var_library_rmsd" value="0.0386749522384563"/>
 			<UserParam type="float" name="var_library_sangle" value="0.0729584275113503"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.0386749522384563"/>
@@ -2191,16 +1322,16 @@
 			<UserParam type="string" name="feature_class" value="positive"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.936839182239694"/>
+			<UserParam type="float" name="predicted_probability" value="0.950638129450958"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_2067209405782217684">
+		<feature id="f_11275867043381640475">
 			<position dim="0">1766.55652075376</position>
 			<position dim="1">431.205548243771</position>
 			<intensity>1.49441e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.902112</overallquality>
+			<overallquality>0.921307</overallquality>
 			<charge>3</charge>
 			<convexhull nr="0">
 				<pt x="1746.17114257812" y="431.155548243771" />
@@ -2215,7 +1346,7 @@
 				<pt x="1746.17114257812" y="431.589999856371" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_2067209405782217684_7619024488371696138">
+				<feature id="f_11275867043381640475_3713543811689521337">
 					<position dim="0">1766.55652075376</position>
 					<position dim="1">431.205548243771</position>
 					<intensity>9.1312e+06</intensity>
@@ -2229,7 +1360,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
 				</feature>
-				<feature id="f_2067209405782217684_1253235807487386477">
+				<feature id="f_11275867043381640475_8666254306116808202">
 					<position dim="0">1766.55652075376</position>
 					<position dim="1">431.539999856371</position>
 					<intensity>5.81293e+06</intensity>
@@ -2258,10 +1389,10 @@
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.999344217844031"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999058019936054"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00808392340072364"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0154598316046801"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00808392340072364"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999998"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00808392340072367"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0154598316046945"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00808392340072367"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.00837267607337994"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.99996575680108"/>
 			<UserParam type="float" name="var_intensity_score" value="0.980683786895208"/>
@@ -2269,7 +1400,7 @@
 			<UserParam type="float" name="sn_ratio" value="34.1997289973724"/>
 			<UserParam type="float" name="var_log_sn_score" value="3.53221771998372"/>
 			<UserParam type="float" name="var_elution_model_fit_score" value="0.98182600736618"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.76495114765419"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.76495114765418"/>
 			<UserParam type="float" name="var_isotope_correlation_score" value="0.983135704847892"/>
 			<UserParam type="float" name="var_isotope_overlap_score" value="0.388977766036987"/>
 			<UserParam type="float" name="var_massdev_score" value="0.344572194406841"/>
@@ -2286,16 +1417,113 @@
 			<UserParam type="string" name="feature_class" value="unknown"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.902111562750173"/>
+			<UserParam type="float" name="predicted_probability" value="0.921307164333322"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_15595829921891090644">
+		<feature id="f_3246735940528705071">
+			<position dim="0">2007.51161653761</position>
+			<position dim="1">379.715100772821</position>
+			<intensity>3.18473e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.94932</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1973.24267578125" y="379.665100772821" />
+				<pt x="2084.91577148438" y="379.665100772821" />
+				<pt x="2084.91577148438" y="379.765100772821" />
+				<pt x="1973.24267578125" y="379.765100772821" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1973.24267578125" y="380.166778191721" />
+				<pt x="2084.91577148438" y="380.166778191721" />
+				<pt x="2084.91577148438" y="380.266778191721" />
+				<pt x="1973.24267578125" y="380.266778191721" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_3246735940528705071_4584897071539917580">
+					<position dim="0">2007.51161653761</position>
+					<position dim="1">379.715100772821</position>
+					<intensity>2.28382e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="379.715100772821"/>
+					<UserParam type="string" name="native_id" value="GAC(Carbamidomethyl)LLPK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="2254385.11621094"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.710034950213183"/>
+				</feature>
+				<feature id="f_3246735940528705071_260132145239717571">
+					<position dim="0">2007.51161653761</position>
+					<position dim="1">380.216778191721</position>
+					<intensity>9.00904e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="380.216778191721"/>
+					<UserParam type="string" name="native_id" value="GAC(Carbamidomethyl)LLPK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="911381.791015625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.289965049786817"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715118408203" RT="2032.04125976562" >
+				<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_25">
+					<UserParam type="float" name="OMSSA_score" value="0.00115485160103966"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="GAC(Carbamidomethyl)LLPK/2"/>
+			<UserParam type="float" name="leftWidth" value="1973.24267578125"/>
+			<UserParam type="float" name="rightWidth" value="2084.91577148438"/>
+			<UserParam type="float" name="total_xic" value="32035565.7826538"/>
+			<UserParam type="float" name="peak_apices_sum" value="3165766.90722656"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.9998135456195"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99976967068158"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00708243948867976"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0119791052800022"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00708243948867976"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00822738059596984"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999969321163731"/>
+			<UserParam type="float" name="var_intensity_score" value="0.99412241432128"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="113.415519519411"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.73105823836186"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.997186601161957"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.61670900288192"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.989965181699822"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.28288260102272"/>
+			<UserParam type="float" name="var_massdev_score" value="0.807860618118897"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.504204576189409"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.774286696585701"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.917152435225103"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.7038225074551"/>
+			<UserParam type="float" name="PrecursorMZ" value="379.715100772821"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.94931958110708"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_17671779025680303814">
 			<position dim="0">1871.44516101075</position>
 			<position dim="1">408.874238280604</position>
 			<intensity>351473</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.0631001</overallquality>
+			<overallquality>0.0636001</overallquality>
 			<charge>3</charge>
 			<convexhull nr="0">
 				<pt x="1857.064453125" y="408.824238280604" />
@@ -2310,7 +1538,7 @@
 				<pt x="1857.064453125" y="409.258689893204" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_15595829921891090644_7138020121190169918">
+				<feature id="f_17671779025680303814_6182960951962378739">
 					<position dim="0">1871.44516101075</position>
 					<position dim="1">408.874238280604</position>
 					<intensity>221846</intensity>
@@ -2324,7 +1552,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.592413860111113"/>
 				</feature>
-				<feature id="f_15595829921891090644_9239964739177281349">
+				<feature id="f_17671779025680303814_14891455924036538147">
 					<position dim="0">1871.44516101075</position>
 					<position dim="1">409.208689893204</position>
 					<intensity>129627</intensity>
@@ -2381,16 +1609,113 @@
 			<UserParam type="string" name="feature_class" value="unknown"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="0"/>
-			<UserParam type="float" name="predicted_probability" value="0.0631001343348121"/>
+			<UserParam type="float" name="predicted_probability" value="0.0636000869226747"/>
 			<UserParam type="float" name="q-value" value="0.040920716112532"/>
 		</feature>
-		<feature id="f_7273255783824449336">
+		<feature id="f_7870901012988979006">
+			<position dim="0">2298.1472125613</position>
+			<position dim="1">435.910228820904</position>
+			<intensity>107976</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.234536</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="2288.541015625" y="435.860228820904" />
+				<pt x="2307.17138671875" y="435.860228820904" />
+				<pt x="2307.17138671875" y="435.960228820904" />
+				<pt x="2288.541015625" y="435.960228820904" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2288.541015625" y="436.194680433504" />
+				<pt x="2307.17138671875" y="436.194680433504" />
+				<pt x="2307.17138671875" y="436.294680433504" />
+				<pt x="2288.541015625" y="436.294680433504" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_7870901012988979006_16164338904207598736">
+					<position dim="0">2298.1472125613</position>
+					<position dim="1">435.910228820904</position>
+					<intensity>71412.4</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="435.910228820904"/>
+					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="15366.9287109375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.586748524736467"/>
+				</feature>
+				<feature id="f_7870901012988979006_4410447320637600518">
+					<position dim="0">2298.1472125613</position>
+					<position dim="1">436.244680433504</position>
+					<intensity>36564</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="436.244680433504"/>
+					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="8652.01141357422"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.413251475263533"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.909851074219" RT="2295.90209960938" >
+				<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_25">
+					<UserParam type="float" name="OMSSA_score" value="0.0137458569950031"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="HLVDEPQNLIK/3"/>
+			<UserParam type="float" name="leftWidth" value="2288.541015625"/>
+			<UserParam type="float" name="rightWidth" value="2307.17138671875"/>
+			<UserParam type="float" name="total_xic" value="10938972.6016846"/>
+			<UserParam type="float" name="peak_apices_sum" value="24018.9401245117"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.988941249028221"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.983911196488666"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0746219903334129"/>
+			<UserParam type="float" name="var_library_sangle" value="0.140400378484357"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0746219903334129"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0783955537745727"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.997027549236094"/>
+			<UserParam type="float" name="var_intensity_score" value="0.00987079887382403"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="3.25746767712157"/>
+			<UserParam type="float" name="var_log_sn_score" value="1.18095010736489"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.987454652786255"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="4.77992760107149"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.958327911516158"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.338629484176636"/>
+			<UserParam type="float" name="var_massdev_score" value="0.295951363727171"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.283335711262804"/>
+			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.654268103487712"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.07431043140929"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.33851910441421"/>
+			<UserParam type="float" name="PrecursorMZ" value="435.910228820904"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="0"/>
+			<UserParam type="float" name="predicted_probability" value="0.234535673882784"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_12561328592123678330">
 			<position dim="0">1658.35957629977</position>
 			<position dim="1">532.248746583271</position>
 			<intensity>128355</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.88662</overallquality>
+			<overallquality>0.907919</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="1633.28234863281" y="532.198746583271" />
@@ -2405,7 +1730,7 @@
 				<pt x="1633.28234863281" y="532.800424002171" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_7273255783824449336_17732694574582820772">
+				<feature id="f_12561328592123678330_6878260161865568505">
 					<position dim="0">1658.35957629977</position>
 					<position dim="1">532.248746583271</position>
 					<intensity>86477.8</intensity>
@@ -2419,7 +1744,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.66039156605171"/>
 				</feature>
-				<feature id="f_7273255783824449336_15974525296577096328">
+				<feature id="f_12561328592123678330_4021463513649428920">
 					<position dim="0">1658.35957629977</position>
 					<position dim="1">532.750424002171</position>
 					<intensity>41877.4</intensity>
@@ -2478,16 +1803,210 @@
 			<UserParam type="string" name="feature_class" value="positive"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.886619825840035"/>
+			<UserParam type="float" name="predicted_probability" value="0.907918888620816"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_4804931408721345291">
+		<feature id="f_11106716189850669289">
+			<position dim="0">2005.79703137669</position>
+			<position dim="1">404.203412328071</position>
+			<intensity>444698</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.907812</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1953.46435546875" y="404.153412328071" />
+				<pt x="2033.83422851562" y="404.153412328071" />
+				<pt x="2033.83422851562" y="404.253412328071" />
+				<pt x="1953.46435546875" y="404.253412328071" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1953.46435546875" y="404.655089746971" />
+				<pt x="2033.83422851562" y="404.655089746971" />
+				<pt x="2033.83422851562" y="404.755089746971" />
+				<pt x="1953.46435546875" y="404.755089746971" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_11106716189850669289_7061025990090747374">
+					<position dim="0">2005.79703137669</position>
+					<position dim="1">404.203412328071</position>
+					<intensity>413099</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="404.203412328071"/>
+					<UserParam type="string" name="native_id" value="LAADDFR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="24527.0495605469"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.701130386577533"/>
+				</feature>
+				<feature id="f_11106716189850669289_8195437834883133454">
+					<position dim="0">2005.79703137669</position>
+					<position dim="1">404.705089746971</position>
+					<intensity>31598.8</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="404.705089746971"/>
+					<UserParam type="string" name="native_id" value="LAADDFR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="4520.375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.298869613422467"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="404.203002929688" RT="2003.33984375" >
+				<PeptideHit score="0.0454545454545455" sequence="LAADDFR" charge="2" aa_before="K X X X X X X" aa_after="T X X X X X X" protein_refs="PH_20 PH_21 PH_22 PH_23 PH_18 PH_17 PH_19">
+					<UserParam type="float" name="OMSSA_score" value="0.060731076753908"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LAADDFR/2"/>
+			<UserParam type="float" name="leftWidth" value="1953.46435546875"/>
+			<UserParam type="float" name="rightWidth" value="2033.83422851562"/>
+			<UserParam type="float" name="total_xic" value="7252377.52032471"/>
+			<UserParam type="float" name="peak_apices_sum" value="29047.4245605469"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.82136720504592"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.838186270380688"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.920064684864184"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.899498974501908"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.227812828189622"/>
+			<UserParam type="float" name="var_library_sangle" value="0.326600963424246"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.227812828189622"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.356695561353588"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.952766208159461"/>
+			<UserParam type="float" name="var_intensity_score" value="0.0613175513828036"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="46.6384662366484"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.84242565635246"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.919530034065247"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="5.82705715280964"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.977395240636197"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.0710567831993103"/>
+			<UserParam type="float" name="var_massdev_score" value="0.175924713032794"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.20257301257106"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.624270529344654"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.34607058455137"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.38617833618714"/>
+			<UserParam type="float" name="PrecursorMZ" value="404.203412328071"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.907812056180384"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_12388384985798314387">
+			<position dim="0">1782.51151069112</position>
+			<position dim="1">300.195528597604</position>
+			<intensity>1.17056e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.938717</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1763.34350585938" y="300.145528597604" />
+				<pt x="1851.12512207031" y="300.145528597604" />
+				<pt x="1851.12512207031" y="300.245528597604" />
+				<pt x="1763.34350585938" y="300.245528597604" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1763.34350585938" y="300.479980210204" />
+				<pt x="1851.12512207031" y="300.479980210204" />
+				<pt x="1851.12512207031" y="300.579980210204" />
+				<pt x="1763.34350585938" y="300.579980210204" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_12388384985798314387_18390135059454481268">
+					<position dim="0">1782.51151069112</position>
+					<position dim="1">300.195528597604</position>
+					<intensity>8.21652e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="300.195528597604"/>
+					<UserParam type="string" name="native_id" value="LALDLVVR/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="576644.387084961"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.668051514852376"/>
+				</feature>
+				<feature id="f_12388384985798314387_15721057298497490036">
+					<position dim="0">1782.51151069112</position>
+					<position dim="1">300.529980210204</position>
+					<intensity>3.48903e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="300.529980210204"/>
+					<UserParam type="string" name="native_id" value="LALDLVVR/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="265400.1875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.331948485147624"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165985107422" RT="1772.36950683594" >
+				<PeptideHit score="0.0344827586206897" sequence="LALDLVVR" charge="3" aa_before="K" aa_after="E" protein_refs="PH_15">
+					<UserParam type="float" name="OMSSA_score" value="0.00409018563530312"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LALDLVVR/3"/>
+			<UserParam type="float" name="leftWidth" value="1763.34350585938"/>
+			<UserParam type="float" name="rightWidth" value="1851.12512207031"/>
+			<UserParam type="float" name="total_xic" value="31535012.6876221"/>
+			<UserParam type="float" name="peak_apices_sum" value="842044.574584961"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999219220116872"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998961131663337"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0338819666057769"/>
+			<UserParam type="float" name="var_library_sangle" value="0.059594307856544"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0338819666057769"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0378305231519567"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999334609191848"/>
+			<UserParam type="float" name="var_intensity_score" value="0.371192366908246"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="52.4369845237061"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.9596121538803"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.98045688867569"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.00171086149572"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.70019046030159"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="9.54360336593331"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="12.751237371524"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.72994867000711"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.16861748604685"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.31115353012128"/>
+			<UserParam type="float" name="PrecursorMZ" value="300.195528597604"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.938717146258226"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_7344192187426184761">
 			<position dim="0">1617.1483410699</position>
 			<position dim="1">368.862109904738</position>
 			<intensity>9.25278e+06</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.365252</overallquality>
+			<overallquality>0.394079</overallquality>
 			<charge>3</charge>
 			<convexhull nr="0">
 				<pt x="1595.50939941406" y="368.812109904738" />
@@ -2502,7 +2021,7 @@
 				<pt x="1595.50939941406" y="369.246561517338" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_4804931408721345291_12855069628258305325">
+				<feature id="f_7344192187426184761_9140546320740515641">
 					<position dim="0">1617.1483410699</position>
 					<position dim="1">368.862109904738</position>
 					<intensity>5.79311e+06</intensity>
@@ -2516,7 +2035,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.637366103952144"/>
 				</feature>
-				<feature id="f_4804931408721345291_9774290362926279551">
+				<feature id="f_7344192187426184761_12049315334424432437">
 					<position dim="0">1617.1483410699</position>
 					<position dim="1">369.196561517338</position>
 					<intensity>3.45967e+06</intensity>
@@ -2549,7 +2068,7 @@
 			<UserParam type="float" name="var_library_rmsd" value="0.0112721013675148"/>
 			<UserParam type="float" name="var_library_sangle" value="0.021080330114212"/>
 			<UserParam type="float" name="var_library_rootmeansquare" value="0.0112721013675148"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0118955544334974"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0118955544334975"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999931728221565"/>
 			<UserParam type="float" name="var_intensity_score" value="0.840154044545519"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
@@ -2573,16 +2092,305 @@
 			<UserParam type="string" name="feature_class" value="unknown"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="0"/>
-			<UserParam type="float" name="predicted_probability" value="0.365252206073173"/>
+			<UserParam type="float" name="predicted_probability" value="0.394079133722073"/>
 			<UserParam type="float" name="q-value" value="0.0217391304347826"/>
 		</feature>
-		<feature id="f_17623301629315165502">
+		<feature id="f_25974125700937907">
+			<position dim="0">1782.34333734102</position>
+			<position dim="1">449.744389900421</position>
+			<intensity>1.7437e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.981494</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1761.75610351562" y="449.694389900421" />
+				<pt x="1881.08850097656" y="449.694389900421" />
+				<pt x="1881.08850097656" y="449.794389900421" />
+				<pt x="1761.75610351562" y="449.794389900421" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1761.75610351562" y="450.196067319321" />
+				<pt x="1881.08850097656" y="450.196067319321" />
+				<pt x="1881.08850097656" y="450.296067319321" />
+				<pt x="1761.75610351562" y="450.296067319321" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_25974125700937907_17876486934271562208">
+					<position dim="0">1782.34333734102</position>
+					<position dim="1">449.744389900421</position>
+					<intensity>1.27819e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="449.744389900421"/>
+					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="91264.109375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
+				</feature>
+				<feature id="f_25974125700937907_9949257177078866781">
+					<position dim="0">1782.34333734102</position>
+					<position dim="1">450.246067319321</position>
+					<intensity>465501</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="450.246067319321"/>
+					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="32936.89453125"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.325393160206819"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="449.744389900421" RT="1782.34333734102" >
+				<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_25">
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="implied"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LC(Carbamidomethyl)VLHEK/2"/>
+			<UserParam type="float" name="leftWidth" value="1761.75610351562"/>
+			<UserParam type="float" name="rightWidth" value="1881.08850097656"/>
+			<UserParam type="float" name="total_xic" value="2582006.26055908"/>
+			<UserParam type="float" name="peak_apices_sum" value="124201.00390625"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.995444848298674"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.994000524898595"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0584307399821589"/>
+			<UserParam type="float" name="var_library_sangle" value="0.100167183533034"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0584307399821589"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0670063315124288"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.997948935934463"/>
+			<UserParam type="float" name="var_intensity_score" value="0.675325870287564"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="62.4978560025402"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.1351322521946"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.981171160936356"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.03356612799787"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.984152837341836"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.26696240901947"/>
+			<UserParam type="float" name="var_massdev_score" value="0.43272982427065"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.447953512388762"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.698534764147426"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.07117517832204"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.2391476607732"/>
+			<UserParam type="float" name="PrecursorMZ" value="449.744389900421"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="0"/>
+			<UserParam type="int" name="n_matching_ids" value="-1"/>
+			<UserParam type="string" name="feature_class" value="unknown"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.981494175701799"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_7619024488371696138">
+			<position dim="0">1782.50461751663</position>
+			<position dim="1">300.165352089204</position>
+			<intensity>1.17279e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.907933</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1761.75610351562" y="300.115352089204" />
+				<pt x="1851.12512207031" y="300.115352089204" />
+				<pt x="1851.12512207031" y="300.215352089204" />
+				<pt x="1761.75610351562" y="300.215352089204" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1761.75610351562" y="300.449803701804" />
+				<pt x="1851.12512207031" y="300.449803701804" />
+				<pt x="1851.12512207031" y="300.549803701804" />
+				<pt x="1761.75610351562" y="300.549803701804" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_7619024488371696138_16459288859473286876">
+					<position dim="0">1782.50461751663</position>
+					<position dim="1">300.165352089204</position>
+					<intensity>8.23888e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="300.165352089204"/>
+					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="576644.387084961"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
+				</feature>
+				<feature id="f_7619024488371696138_6330535588886112108">
+					<position dim="0">1782.50461751663</position>
+					<position dim="1">300.499803701804</position>
+					<intensity>3.48903e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="300.499803701804"/>
+					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="265400.1875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.325393160206819"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
+				<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_25">
+					<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LC(Carbamidomethyl)VLHEK/3"/>
+			<UserParam type="float" name="leftWidth" value="1761.75610351562"/>
+			<UserParam type="float" name="rightWidth" value="1851.12512207031"/>
+			<UserParam type="float" name="total_xic" value="36322088.9429321"/>
+			<UserParam type="float" name="peak_apices_sum" value="842044.574584961"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999223453079938"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998977229691247"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0278949113172731"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0488381457118354"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0278949113172731"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0312839115958893"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.99954626385961"/>
+			<UserParam type="float" name="var_intensity_score" value="0.322886577873493"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="16.5705354263045"/>
+			<UserParam type="float" name="var_log_sn_score" value="2.80762614391005"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.980328291654587"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.17903100293939"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.990141545208339"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.297498255968094"/>
+			<UserParam type="float" name="var_massdev_score" value="1.05310642007867"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.22714620827016"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.821176744139309"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.859179305085471"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.43790858147046"/>
+			<UserParam type="float" name="PrecursorMZ" value="300.165352089204"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.907933294765693"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_7273255783824449336">
+			<position dim="0">1943.3004011853</position>
+			<position dim="1">395.239463487571</position>
+			<intensity>8.96624e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.90784</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1918.98767089844" y="395.189463487571" />
+				<pt x="2002.17077636719" y="395.189463487571" />
+				<pt x="2002.17077636719" y="395.289463487571" />
+				<pt x="1918.98767089844" y="395.289463487571" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1918.98767089844" y="395.691140906471" />
+				<pt x="2002.17077636719" y="395.691140906471" />
+				<pt x="2002.17077636719" y="395.791140906471" />
+				<pt x="1918.98767089844" y="395.791140906471" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_7273255783824449336_17732694574582820772">
+					<position dim="0">1943.3004011853</position>
+					<position dim="1">395.239463487571</position>
+					<intensity>6.32974e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="395.239463487571"/>
+					<UserParam type="string" name="native_id" value="LVTDLTK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="11353591.1308594"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.704209887318509"/>
+				</feature>
+				<feature id="f_7273255783824449336_15974525296577096328">
+					<position dim="0">1943.3004011853</position>
+					<position dim="1">395.741140906471</position>
+					<intensity>2.6365e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="395.741140906471"/>
+					<UserParam type="string" name="native_id" value="LVTDLTK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="4777608.1171875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.295790112681491"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" >
+				<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_25">
+					<UserParam type="float" name="OMSSA_score" value="0.00108437147303181"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LVTDLTK/2"/>
+			<UserParam type="float" name="leftWidth" value="1918.98767089844"/>
+			<UserParam type="float" name="rightWidth" value="2002.17077636719"/>
+			<UserParam type="float" name="total_xic" value="106505972.974854"/>
+			<UserParam type="float" name="peak_apices_sum" value="16131199.2480469"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999857333290542"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999821696582955"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0017426793038198"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00298344304196402"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0017426793038198"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00199874144393369"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999998174406389"/>
+			<UserParam type="float" name="var_intensity_score" value="0.841853555210182"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="126.830124379947"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.84284858776125"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.997866630554199"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.71322313299286"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.991768882855086"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.294047445058823"/>
+			<UserParam type="float" name="var_massdev_score" value="1.34876090913977"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.0324552849287"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="1"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.784624367602911"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.867806593918273"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.928179684801"/>
+			<UserParam type="float" name="PrecursorMZ" value="395.239463487571"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.907839725643447"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_4804931408721345291">
 			<position dim="0">2391.85092347612</position>
 			<position dim="1">501.795134726821</position>
 			<intensity>3.71667e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.886536</overallquality>
+			<overallquality>0.907795</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="2367.25073242188" y="501.745134726821" />
@@ -2597,7 +2405,7 @@
 				<pt x="2367.25073242188" y="502.346812145721" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_17623301629315165502_8226270557132872791">
+				<feature id="f_4804931408721345291_17559911639132578699">
 					<position dim="0">2391.85092347612</position>
 					<position dim="1">501.795134726821</position>
 					<intensity>2.4399e+07</intensity>
@@ -2611,7 +2419,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.653030735732608"/>
 				</feature>
-				<feature id="f_17623301629315165502_15355009979912333657">
+				<feature id="f_4804931408721345291_16987762588190708774">
 					<position dim="0">2391.85092347612</position>
 					<position dim="1">502.296812145721</position>
 					<intensity>1.27677e+07</intensity>
@@ -2670,104 +2478,296 @@
 			<UserParam type="string" name="feature_class" value="positive"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
 			<UserParam type="int" name="predicted_class" value="1"/>
-			<UserParam type="float" name="predicted_probability" value="0.886535778107013"/>
+			<UserParam type="float" name="predicted_probability" value="0.907795140040147"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
-		<feature id="f_7207737926139754191">
-			<position dim="0">2298.1472125613</position>
-			<position dim="1">435.910228820904</position>
-			<intensity>107976</intensity>
+		<feature id="f_12855069628258305325">
+			<position dim="0">1558.9325598625</position>
+			<position dim="1">358.174576486338</position>
+			<intensity>1.33422e+06</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.221372</overallquality>
+			<overallquality>0.90779</overallquality>
 			<charge>3</charge>
 			<convexhull nr="0">
-				<pt x="2288.541015625" y="435.860228820904" />
-				<pt x="2307.17138671875" y="435.860228820904" />
-				<pt x="2307.17138671875" y="435.960228820904" />
-				<pt x="2288.541015625" y="435.960228820904" />
+				<pt x="1537.60900878906" y="358.124576486338" />
+				<pt x="1636.51171875" y="358.124576486338" />
+				<pt x="1636.51171875" y="358.224576486338" />
+				<pt x="1537.60900878906" y="358.224576486338" />
 			</convexhull>
 			<convexhull nr="1">
-				<pt x="2288.541015625" y="436.194680433504" />
-				<pt x="2307.17138671875" y="436.194680433504" />
-				<pt x="2307.17138671875" y="436.294680433504" />
-				<pt x="2288.541015625" y="436.294680433504" />
+				<pt x="1537.60900878906" y="358.459028098938" />
+				<pt x="1636.51171875" y="358.459028098938" />
+				<pt x="1636.51171875" y="358.559028098938" />
+				<pt x="1537.60900878906" y="358.559028098938" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_7207737926139754191_15012949867540041090">
-					<position dim="0">2298.1472125613</position>
-					<position dim="1">435.910228820904</position>
-					<intensity>71412.4</intensity>
+				<feature id="f_12855069628258305325_435931305321438914">
+					<position dim="0">1558.9325598625</position>
+					<position dim="1">358.174576486338</position>
+					<intensity>941962</intensity>
 					<quality dim="0">0</quality>
 					<quality dim="1">0</quality>
 					<overallquality>0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="435.910228820904"/>
-					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="15366.9287109375"/>
+					<UserParam type="float" name="MZ" value="358.174576486338"/>
+					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="54360.2887573242"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.586748524736467"/>
+					<UserParam type="float" name="isotope_probability" value="0.646660950740033"/>
 				</feature>
-				<feature id="f_7207737926139754191_276808963686810837">
-					<position dim="0">2298.1472125613</position>
-					<position dim="1">436.244680433504</position>
-					<intensity>36564</intensity>
+				<feature id="f_12855069628258305325_6432949088199598535">
+					<position dim="0">1558.9325598625</position>
+					<position dim="1">358.509028098938</position>
+					<intensity>392257</intensity>
 					<quality dim="0">0</quality>
 					<quality dim="1">0</quality>
 					<overallquality>0</overallquality>
 					<charge>0</charge>
-					<UserParam type="float" name="MZ" value="436.244680433504"/>
-					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="8652.01141357422"/>
+					<UserParam type="float" name="MZ" value="358.509028098938"/>
+					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="26582.2421875"/>
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.413251475263533"/>
+					<UserParam type="float" name="isotope_probability" value="0.353339049259967"/>
 				</feature>
 			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.909851074219" RT="2295.90209960938" >
-				<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_25">
-					<UserParam type="float" name="OMSSA_score" value="0.0137458569950031"/>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
+				<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_25">
+					<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
 					<UserParam type="string" name="target_decoy" value="target"/>
 				</PeptideHit>
 				<UserParam type="string" name="FFId_category" value="internal"/>
 			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="HLVDEPQNLIK/3"/>
-			<UserParam type="float" name="leftWidth" value="2288.541015625"/>
-			<UserParam type="float" name="rightWidth" value="2307.17138671875"/>
-			<UserParam type="float" name="total_xic" value="10938972.6016846"/>
-			<UserParam type="float" name="peak_apices_sum" value="24018.9401245117"/>
+			<UserParam type="string" name="PeptideRef" value="SHC(Carbamidomethyl)IAEVEK/3"/>
+			<UserParam type="float" name="leftWidth" value="1537.60900878906"/>
+			<UserParam type="float" name="rightWidth" value="1636.51171875"/>
+			<UserParam type="float" name="total_xic" value="1732748.10748291"/>
+			<UserParam type="float" name="peak_apices_sum" value="80942.5309448242"/>
 			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.988941249028221"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.983911196488666"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0746219903334129"/>
-			<UserParam type="float" name="var_library_sangle" value="0.140400378484357"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0746219903334129"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0783955537745727"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.997027549236094"/>
-			<UserParam type="float" name="var_intensity_score" value="0.00987079887382403"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.9957892536018"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.994227305045081"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0593418626095539"/>
+			<UserParam type="float" name="var_library_sangle" value="0.105494126637743"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0593418626095539"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0656174027045489"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.997986000179241"/>
+			<UserParam type="float" name="var_intensity_score" value="0.770001778814904"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="3.25746767712157"/>
-			<UserParam type="float" name="var_log_sn_score" value="1.18095010736489"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.987454652786255"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="4.7799276010715"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.958327911516158"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.338629484176636"/>
-			<UserParam type="float" name="var_massdev_score" value="0.295951363727171"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.283335711262804"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="sn_ratio" value="13.5847359594873"/>
+			<UserParam type="float" name="var_log_sn_score" value="2.60894680650888"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.977909862995148"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="5.92500330698142"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.985285171590345"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.293997198343277"/>
+			<UserParam type="float" name="var_massdev_score" value="0.776434922758457"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.740130209172225"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
 			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.654268103487712"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.07431043140929"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.33851910441421"/>
-			<UserParam type="float" name="PrecursorMZ" value="435.910228820904"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.755976718319793"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.967667974449062"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.25613594588742"/>
+			<UserParam type="float" name="PrecursorMZ" value="358.174576486338"/>
 			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="int" name="n_total_ids" value="1"/>
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
 			<UserParam type="float" name="rt_delta" value="0"/>
-			<UserParam type="int" name="predicted_class" value="0"/>
-			<UserParam type="float" name="predicted_probability" value="0.221371733104722"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.907790328616306"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_12175240310315893095">
+			<position dim="0">2090.16589783288</position>
+			<position dim="1">421.758354535421</position>
+			<intensity>1.18363e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.961975</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2036.53295898438" y="421.708354535421" />
+				<pt x="2208.7734375" y="421.708354535421" />
+				<pt x="2208.7734375" y="421.808354535421" />
+				<pt x="2036.53295898438" y="421.808354535421" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2036.53295898438" y="422.210031954321" />
+				<pt x="2208.7734375" y="422.210031954321" />
+				<pt x="2208.7734375" y="422.310031954321" />
+				<pt x="2036.53295898438" y="422.310031954321" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_12175240310315893095_18365384202816725379">
+					<position dim="0">2090.16589783288</position>
+					<position dim="1">421.758354535421</position>
+					<intensity>8.41822e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="421.758354535421"/>
+					<UserParam type="string" name="native_id" value="VATVSLPR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="508755.363769531"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.688369804746839"/>
+				</feature>
+				<feature id="f_12175240310315893095_3115030544351500350">
+					<position dim="0">2090.16589783288</position>
+					<position dim="1">422.260031954321</position>
+					<intensity>3.41811e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="422.260031954321"/>
+					<UserParam type="string" name="native_id" value="VATVSLPR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="228173.1875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.311630195253161"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="421.758354535421" RT="2090.16589783288" >
+				<PeptideHit score="0" sequence="VATVSLPR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_24">
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="implied"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="VATVSLPR/2"/>
+			<UserParam type="float" name="leftWidth" value="2036.53295898438"/>
+			<UserParam type="float" name="rightWidth" value="2208.7734375"/>
+			<UserParam type="float" name="total_xic" value="12180094.9179688"/>
+			<UserParam type="float" name="peak_apices_sum" value="736928.551269531"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.998725787587908"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998359960057659"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0228491945584772"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0394036750093723"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0228491945584772"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0260154723185836"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999689271317972"/>
+			<UserParam type="float" name="var_intensity_score" value="0.971776335054532"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="91.5868187514056"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.51728736123165"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.993696182966232"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.41394051806747"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.988314835244555"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.288780987262726"/>
+			<UserParam type="float" name="var_massdev_score" value="0.890803718434335"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.77537503092"/>
+			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.742374379756163"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.976100444864031"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.52117391367391"/>
+			<UserParam type="float" name="PrecursorMZ" value="421.758354535421"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="0"/>
+			<UserParam type="int" name="n_matching_ids" value="-1"/>
+			<UserParam type="string" name="feature_class" value="unknown"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.961974770987438"/>
+			<UserParam type="float" name="q-value" value="0"/>
+		</feature>
+		<feature id="f_15490049804574065229">
+			<position dim="0">2336.46435114133</position>
+			<position dim="1">464.250362519471</position>
+			<intensity>1.26924e+08</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.956574</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2307.17138671875" y="464.200362519471" />
+				<pt x="2426.22387695312" y="464.200362519471" />
+				<pt x="2426.22387695312" y="464.300362519471" />
+				<pt x="2307.17138671875" y="464.300362519471" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2307.17138671875" y="464.702039938371" />
+				<pt x="2426.22387695312" y="464.702039938371" />
+				<pt x="2426.22387695312" y="464.802039938371" />
+				<pt x="2307.17138671875" y="464.802039938371" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_15490049804574065229_17052620940680608488">
+					<position dim="0">2336.46435114133</position>
+					<position dim="1">464.250362519471</position>
+					<intensity>8.3097e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="464.250362519471"/>
+					<UserParam type="string" name="native_id" value="YLYEIAR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="3748789.63964844"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.655742026441336"/>
+				</feature>
+				<feature id="f_15490049804574065229_6748518772549940365">
+					<position dim="0">2336.46435114133</position>
+					<position dim="1">464.752039938371</position>
+					<intensity>4.38269e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<UserParam type="float" name="MZ" value="464.752039938371"/>
+					<UserParam type="string" name="native_id" value="YLYEIAR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="1970969.68359375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.344257973558664"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_1" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250030517578" RT="2357.07421875" >
+				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_25">
+					<UserParam type="float" name="OMSSA_score" value="9.1724848717909e-05"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="YLYEIAR/2"/>
+			<UserParam type="float" name="leftWidth" value="2307.17138671875"/>
+			<UserParam type="float" name="rightWidth" value="2426.22387695312"/>
+			<UserParam type="float" name="total_xic" value="127756402.797302"/>
+			<UserParam type="float" name="peak_apices_sum" value="5719759.32324219"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999895292390075"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999858177047213"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00104262185989193"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00190194541025294"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00104262185989193"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00112459476550764"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999398500781"/>
+			<UserParam type="float" name="var_intensity_score" value="0.993483075767066"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="72.0472246760353"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.27732180228706"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.985681295394897"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.32571806860717"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.990655613883382"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.345300585031509"/>
+			<UserParam type="float" name="var_massdev_score" value="1.19333451667543"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.03625577733313"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.761987351682086"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.862442874603575"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.38282606095421"/>
+			<UserParam type="float" name="PrecursorMZ" value="464.250362519471"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="rt_delta" value="0"/>
+			<UserParam type="int" name="predicted_class" value="1"/>
+			<UserParam type="float" name="predicted_probability" value="0.956574020333033"/>
 			<UserParam type="float" name="q-value" value="0"/>
 		</feature>
 	</featureList>

--- a/src/tests/topp/FeatureFinderIdentification_3_output.featureXML
+++ b/src/tests/topp/FeatureFinderIdentification_3_output.featureXML
@@ -58,13 +58,6 @@
 			</ProteinHit>
 		</ProteinIdentification>
 	</IdentificationRun>
-	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
-		<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_14">
-			<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="internal"/>
-	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="653.361755371094" RT="2490.31689453125" >
 		<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="2" aa_before="K" aa_after="Q" protein_refs="PH_14">
 			<UserParam type="float" name="OMSSA_score" value="0.0117575719819199"/>
@@ -75,6 +68,20 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.910125732422" RT="2488.0380859375" >
 		<PeptideHit score="0" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_14">
 			<UserParam type="float" name="OMSSA_score" value="3.09620313351901e-07"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="internal"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165954589844" RT="1800.23291015625" >
+		<PeptideHit score="0" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_14">
+			<UserParam type="float" name="OMSSA_score" value="0.000343916960401279"/>
+			<UserParam type="string" name="target_decoy" value="target"/>
+		</PeptideHit>
+		<UserParam type="string" name="FFId_category" value="internal"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="526.261108398438" RT="2495.662109375" >
+		<PeptideHit score="0" sequence="LKPDPNTLC(Carbamidomethyl)DEFK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_14">
+			<UserParam type="float" name="OMSSA_score" value="0.00026056879779557"/>
 			<UserParam type="string" name="target_decoy" value="target"/>
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
@@ -93,1272 +100,8 @@
 		</PeptideHit>
 		<UserParam type="string" name="FFId_category" value="internal"/>
 	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="526.261108398438" RT="2495.662109375" >
-		<PeptideHit score="0" sequence="LKPDPNTLC(Carbamidomethyl)DEFK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_14">
-			<UserParam type="float" name="OMSSA_score" value="0.00026056879779557"/>
-			<UserParam type="string" name="target_decoy" value="target"/>
-		</PeptideHit>
-		<UserParam type="string" name="FFId_category" value="internal"/>
-	</UnassignedPeptideIdentification>
 	<featureList count="25">
 		<feature id="f_5233264595117471314">
-			<position dim="0">2007.51161653761</position>
-			<position dim="1">379.715100772821</position>
-			<intensity>6.46014e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.57056</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1974.81298828125" y="379.665100772821" />
-				<pt x="2079.67431640625" y="379.665100772821" />
-				<pt x="2079.67431640625" y="379.765100772821" />
-				<pt x="1974.81298828125" y="379.765100772821" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1974.81298828125" y="380.166778191721" />
-				<pt x="2079.67431640625" y="380.166778191721" />
-				<pt x="2079.67431640625" y="380.266778191721" />
-				<pt x="1974.81298828125" y="380.266778191721" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_5233264595117471314_4835329514588776807">
-					<position dim="0">2007.51161653761</position>
-					<position dim="1">379.715100772821</position>
-					<intensity>2.2799e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1977.380859375" y="5343.935546875" />
-						<pt x="1979.2890625" y="10122.3056640625" />
-						<pt x="1980.87292480469" y="14866.7265625" />
-						<pt x="1982.46655273438" y="29726.138671875" />
-						<pt x="1984.07604980469" y="50026.51953125" />
-						<pt x="1985.6865234375" y="79834.8515625" />
-						<pt x="1986.94934082031" y="117087.8984375" />
-						<pt x="1989.31274414062" y="200441.109375" />
-						<pt x="1991.31884765625" y="308676.6875" />
-						<pt x="1993.19482421875" y="454452.4375" />
-						<pt x="1995.119140625" y="696092.209228516" />
-						<pt x="1997.05432128906" y="952511.767089844" />
-						<pt x="1998.99108886719" y="1233409.55786133" />
-						<pt x="2000.96350097656" y="1505903.34631348" />
-						<pt x="2002.17077636719" y="1926265.09326172" />
-						<pt x="2004.77075195312" y="2131711.69482422" />
-						<pt x="2007.42565917969" y="2254385.11621094" />
-						<pt x="2010.10522460938" y="2180638.93164062" />
-						<pt x="2012.57043457031" y="1773602.20410156" />
-						<pt x="2014.81372070312" y="1391961.25" />
-						<pt x="2016.57385253906" y="1076110.26074219" />
-						<pt x="2019.23095703125" y="799858.0625" />
-						<pt x="2021.03356933594" y="640803.1875" />
-						<pt x="2023.54016113281" y="473214.90625" />
-						<pt x="2026.06115722656" y="378525.71875" />
-						<pt x="2028.66284179688" y="297604.1875" />
-						<pt x="2031.287109375" y="254117.90625" />
-						<pt x="2033.83422851562" y="204335.0625" />
-						<pt x="2036.53295898438" y="160107.21875" />
-						<pt x="2038.14636230469" y="171379.140625" />
-						<pt x="2040.25524902344" y="143065.578125" />
-						<pt x="2042.58959960938" y="149759.90625" />
-						<pt x="2045.21923828125" y="110920.4140625" />
-						<pt x="2047.82275390625" y="95053.34375" />
-						<pt x="2050.6005859375" y="81308.25" />
-						<pt x="2053.314453125" y="67745.0703125" />
-						<pt x="2056.00952148438" y="68310.0234375" />
-						<pt x="2057.59716796875" y="58802.84765625" />
-						<pt x="2059.96704101562" y="45729.27734375" />
-						<pt x="2062.72436523438" y="38095.62890625" />
-						<pt x="2065.51806640625" y="33166.87109375" />
-						<pt x="2068.21630859375" y="35984.1953125" />
-						<pt x="2070.92919921875" y="27664.173828125" />
-						<pt x="2072.11108398438" y="24341.630859375" />
-						<pt x="2074.3701171875" y="23377.802734375" />
-						<pt x="2077.0185546875" y="22594.8984375" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="379.715100772821"/>
-					<UserParam type="string" name="native_id" value="GAC(Carbamidomethyl)LLPK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="2254385.11621094"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.710034950213183"/>
-				</feature>
-				<feature id="f_5233264595117471314_17749660155506638460">
-					<position dim="0">2007.51161653761</position>
-					<position dim="1">380.216778191721</position>
-					<intensity>8.9969e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1977.380859375" y="0" />
-						<pt x="1979.2890625" y="0" />
-						<pt x="1980.87292480469" y="4553.60986328125" />
-						<pt x="1982.46655273438" y="8400.7412109375" />
-						<pt x="1984.07604980469" y="15770.0460205078" />
-						<pt x="1985.6865234375" y="26215.04296875" />
-						<pt x="1986.94934082031" y="38516.140625" />
-						<pt x="1989.31274414062" y="64205.30859375" />
-						<pt x="1991.31884765625" y="113444.59375" />
-						<pt x="1993.19482421875" y="188749.722290039" />
-						<pt x="1995.119140625" y="278151.125" />
-						<pt x="1997.05432128906" y="391664.5" />
-						<pt x="1998.99108886719" y="491383.5625" />
-						<pt x="2000.96350097656" y="621691.939697266" />
-						<pt x="2002.17077636719" y="793325.3125" />
-						<pt x="2004.77075195312" y="884184.929199219" />
-						<pt x="2007.42565917969" y="911381.791015625" />
-						<pt x="2010.10522460938" y="907719.744140625" />
-						<pt x="2012.57043457031" y="699974" />
-						<pt x="2014.81372070312" y="576524.125" />
-						<pt x="2016.57385253906" y="419844.15625" />
-						<pt x="2019.23095703125" y="321471" />
-						<pt x="2021.03356933594" y="231057.0625" />
-						<pt x="2023.54016113281" y="163966.984375" />
-						<pt x="2026.06115722656" y="131360" />
-						<pt x="2028.66284179688" y="107665.3515625" />
-						<pt x="2031.287109375" y="93214.8984375" />
-						<pt x="2033.83422851562" y="73707.421875" />
-						<pt x="2036.53295898438" y="57697.23046875" />
-						<pt x="2038.14636230469" y="60205.05859375" />
-						<pt x="2040.25524902344" y="43696.06640625" />
-						<pt x="2042.58959960938" y="52858.5546875" />
-						<pt x="2045.21923828125" y="38286.71484375" />
-						<pt x="2047.82275390625" y="29519.384765625" />
-						<pt x="2050.6005859375" y="25218.064453125" />
-						<pt x="2053.314453125" y="21741.349609375" />
-						<pt x="2056.00952148438" y="18290.69140625" />
-						<pt x="2057.59716796875" y="16849.134765625" />
-						<pt x="2059.96704101562" y="9788.75" />
-						<pt x="2062.72436523438" y="16186.9150390625" />
-						<pt x="2065.51806640625" y="9978.5498046875" />
-						<pt x="2068.21630859375" y="10535.7646484375" />
-						<pt x="2070.92919921875" y="8868.109375" />
-						<pt x="2072.11108398438" y="6984.0244140625" />
-						<pt x="2074.3701171875" y="5154.5439453125" />
-						<pt x="2077.0185546875" y="6898.37841796875" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="380.216778191721"/>
-					<UserParam type="string" name="native_id" value="GAC(Carbamidomethyl)LLPK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="911381.791015625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.289965049786817"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.71484375" RT="2010.87902832031" >
-				<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.00167901373867858"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715118408203" RT="2032.04125976562" >
-				<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.00115485160103966"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715393066406" RT="2069.04321289062" >
-				<PeptideHit score="0.0344827586206897" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.00937487962378574"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="GAC(Carbamidomethyl)LLPK/2"/>
-			<UserParam type="float" name="leftWidth" value="1974.81298828125"/>
-			<UserParam type="float" name="rightWidth" value="2079.67431640625"/>
-			<UserParam type="float" name="total_xic" value="32007549.9432983"/>
-			<UserParam type="float" name="peak_apices_sum" value="3165766.90722656"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999815237705664"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999771760935785"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00700750452065485"/>
-			<UserParam type="float" name="var_library_sangle" value="0.011853004652809"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00700750452065485"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00813985718240712"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999969969287406"/>
-			<UserParam type="float" name="var_intensity_score" value="0.993388624131706"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="91.3637373498437"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.51484865301587"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.99712461233139"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.45924885107846"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.989964675776816"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.282957553863525"/>
-			<UserParam type="float" name="var_massdev_score" value="0.807860618118897"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.50420457618941"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.774286696585701"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.917152435225103"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.57055511048922"/>
-			<UserParam type="float" name="PrecursorMZ" value="379.715100772821"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="3"/>
-			<UserParam type="int" name="n_matching_ids" value="3"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="3096261.22539626"/>
-			<UserParam type="float" name="model_FWHM" value="19.6007396687949"/>
-			<UserParam type="float" name="model_center" value="2007.57358304916"/>
-			<UserParam type="float" name="model_lower" value="1986.76441327313"/>
-			<UserParam type="float" name="model_upper" value="2028.38275282519"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="8.32366791041138"/>
-			<UserParam type="float" name="model_error" value="0.130467244130366"/>
-			<UserParam type="float" name="model_area" value="64601443.9845574"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="31795936"/>
-		</feature>
-		<feature id="f_7804704400743266335">
-			<position dim="0">2005.79703137669</position>
-			<position dim="1">404.203412328071</position>
-			<intensity>1.08434e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.2291</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1961.46557617188" y="404.153412328071" />
-				<pt x="2026.06115722656" y="404.153412328071" />
-				<pt x="2026.06115722656" y="404.253412328071" />
-				<pt x="1961.46557617188" y="404.253412328071" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1961.46557617188" y="404.655089746971" />
-				<pt x="2026.06115722656" y="404.655089746971" />
-				<pt x="2026.06115722656" y="404.755089746971" />
-				<pt x="1961.46557617188" y="404.755089746971" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_7804704400743266335_3332699010107892018">
-					<position dim="0">2005.79703137669</position>
-					<position dim="1">404.203412328071</position>
-					<intensity>387704</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1961.46557617188" y="6844.62634277344" />
-						<pt x="1963.85095214844" y="8177.09417724609" />
-						<pt x="1966.54650878906" y="6179.28662109375" />
-						<pt x="1969.21594238281" y="5334.84423828125" />
-						<pt x="1971.63354492188" y="8433.30810546875" />
-						<pt x="1973.24267578125" y="6292.0478515625" />
-						<pt x="1974.81298828125" y="11316.9248046875" />
-						<pt x="1977.380859375" y="9129.91015625" />
-						<pt x="1979.2890625" y="10587.720703125" />
-						<pt x="1980.87292480469" y="9501.9765625" />
-						<pt x="1982.46655273438" y="9202.78747558594" />
-						<pt x="1984.07604980469" y="7931.97351074219" />
-						<pt x="1985.6865234375" y="5744.78820800781" />
-						<pt x="1986.94934082031" y="7136.15301513672" />
-						<pt x="1989.31274414062" y="3368.05053710938" />
-						<pt x="1991.31884765625" y="3994.09252929688" />
-						<pt x="1993.19482421875" y="7268.14526367188" />
-						<pt x="1995.119140625" y="9562.3857421875" />
-						<pt x="1997.05432128906" y="16848.9475097656" />
-						<pt x="1998.99108886719" y="26898.01953125" />
-						<pt x="2000.96350097656" y="23991.6324462891" />
-						<pt x="2002.17077636719" y="33353.1411132812" />
-						<pt x="2004.77075195312" y="24527.0495605469" />
-						<pt x="2007.42565917969" y="22630.5537109375" />
-						<pt x="2010.10522460938" y="30324.4699707031" />
-						<pt x="2012.57043457031" y="24164.2170410156" />
-						<pt x="2014.81372070312" y="21600.6245117188" />
-						<pt x="2016.57385253906" y="9852.5234375" />
-						<pt x="2019.23095703125" y="0" />
-						<pt x="2021.03356933594" y="9876.9013671875" />
-						<pt x="2023.54016113281" y="0" />
-						<pt x="2026.06115722656" y="7629.51171875" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="404.203412328071"/>
-					<UserParam type="string" name="native_id" value="LAADDFR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="24527.0495605469"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.701130386577533"/>
-				</feature>
-				<feature id="f_7804704400743266335_13440783915218733453">
-					<position dim="0">2005.79703137669</position>
-					<position dim="1">404.705089746971</position>
-					<intensity>31598.8</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1961.46557617188" y="0" />
-						<pt x="1963.85095214844" y="0" />
-						<pt x="1966.54650878906" y="0" />
-						<pt x="1969.21594238281" y="0" />
-						<pt x="1971.63354492188" y="0" />
-						<pt x="1973.24267578125" y="0" />
-						<pt x="1974.81298828125" y="0" />
-						<pt x="1977.380859375" y="0" />
-						<pt x="1979.2890625" y="0" />
-						<pt x="1980.87292480469" y="0" />
-						<pt x="1982.46655273438" y="0" />
-						<pt x="1984.07604980469" y="0" />
-						<pt x="1985.6865234375" y="0" />
-						<pt x="1986.94934082031" y="0" />
-						<pt x="1989.31274414062" y="0" />
-						<pt x="1991.31884765625" y="0" />
-						<pt x="1993.19482421875" y="1440.1552734375" />
-						<pt x="1995.119140625" y="2219.85131835938" />
-						<pt x="1997.05432128906" y="3369.732421875" />
-						<pt x="1998.99108886719" y="6984.9580078125" />
-						<pt x="2000.96350097656" y="5368.5009765625" />
-						<pt x="2002.17077636719" y="7695.240234375" />
-						<pt x="2004.77075195312" y="4520.375" />
-						<pt x="2007.42565917969" y="0" />
-						<pt x="2010.10522460938" y="0" />
-						<pt x="2012.57043457031" y="0" />
-						<pt x="2014.81372070312" y="0" />
-						<pt x="2016.57385253906" y="0" />
-						<pt x="2019.23095703125" y="0" />
-						<pt x="2021.03356933594" y="0" />
-						<pt x="2023.54016113281" y="0" />
-						<pt x="2026.06115722656" y="0" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="404.705089746971"/>
-					<UserParam type="string" name="native_id" value="LAADDFR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="4520.375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.298869613422467"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="404.203002929688" RT="2003.33984375" >
-				<PeptideHit score="0.0454545454545455" sequence="LAADDFR" charge="2" aa_before="K X X X X X X" aa_after="T X X X X X X" protein_refs="PH_9 PH_10 PH_11 PH_12 PH_7 PH_6 PH_8">
-					<UserParam type="float" name="OMSSA_score" value="0.060731076753908"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LAADDFR/2"/>
-			<UserParam type="float" name="leftWidth" value="1961.46557617188"/>
-			<UserParam type="float" name="rightWidth" value="2026.06115722656"/>
-			<UserParam type="float" name="total_xic" value="981633.10760498"/>
-			<UserParam type="float" name="peak_apices_sum" value="29047.4245605469"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="1.82136720504592"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.838186270380688"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.918517349916209"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.897553542138299"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.223509199055781"/>
-			<UserParam type="float" name="var_library_sangle" value="0.321621638280063"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.223509199055781"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.345831080663618"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.955242826825954"/>
-			<UserParam type="float" name="var_intensity_score" value="0.427147910967497"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="35.7331345136229"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.57607839596868"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.921455174684525"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="5.63303054486374"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.977395240636197"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.0753604173660278"/>
-			<UserParam type="float" name="var_massdev_score" value="0.175924713032794"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.20257301257106"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.624270529344654"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.34607058455137"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.22910093393967"/>
-			<UserParam type="float" name="PrecursorMZ" value="404.203412328071"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="36724.7017989613"/>
-			<UserParam type="float" name="model_FWHM" value="27.7380259710097"/>
-			<UserParam type="float" name="model_center" value="2006.40574830729"/>
-			<UserParam type="float" name="model_lower" value="1976.95761005149"/>
-			<UserParam type="float" name="model_upper" value="2035.85388656309"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="11.7792553023202"/>
-			<UserParam type="float" name="model_error" value="0.874616056968454"/>
-			<UserParam type="float" name="model_area" value="1084341.30010212"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="419302.53125"/>
-		</feature>
-		<feature id="f_6408859317243173796">
-			<position dim="0">1782.34333734102</position>
-			<position dim="1">449.744389900421</position>
-			<intensity>1.97055e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.66305</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1761.75610351562" y="449.694389900421" />
-				<pt x="1881.08850097656" y="449.694389900421" />
-				<pt x="1881.08850097656" y="449.794389900421" />
-				<pt x="1761.75610351562" y="449.794389900421" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1761.75610351562" y="450.196067319321" />
-				<pt x="1881.08850097656" y="450.196067319321" />
-				<pt x="1881.08850097656" y="450.296067319321" />
-				<pt x="1761.75610351562" y="450.296067319321" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_6408859317243173796_16907355690727166316">
-					<position dim="0">1782.34333734102</position>
-					<position dim="1">449.744389900421</position>
-					<intensity>1.27819e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1763.34350585938" y="0" />
-						<pt x="1764.53942871094" y="0" />
-						<pt x="1766.20935058594" y="0" />
-						<pt x="1767.45556640625" y="0" />
-						<pt x="1768.78759765625" y="0" />
-						<pt x="1770.08776855469" y="3295.35131835938" />
-						<pt x="1771.37548828125" y="5336.0361328125" />
-						<pt x="1772.72485351562" y="14621.490234375" />
-						<pt x="1775.10119628906" y="38825.13671875" />
-						<pt x="1776.7529296875" y="70122.59375" />
-						<pt x="1778.41467285156" y="92902.5390625" />
-						<pt x="1779.78234863281" y="109567.890625" />
-						<pt x="1781.03625488281" y="105582.53125" />
-						<pt x="1782.70874023438" y="91264.109375" />
-						<pt x="1784.005859375" y="77221.625" />
-						<pt x="1785.66430664062" y="66398.7890625" />
-						<pt x="1788.00903320312" y="41742.73046875" />
-						<pt x="1789.64514160156" y="37536.06640625" />
-						<pt x="1791.29907226562" y="28678.564453125" />
-						<pt x="1792.96655273438" y="30591.322265625" />
-						<pt x="1794.18957519531" y="23455.078125" />
-						<pt x="1796.90112304688" y="21046.619140625" />
-						<pt x="1799.29284667969" y="19297.240234375" />
-						<pt x="1802.06115722656" y="15114.0146484375" />
-						<pt x="1802.93933105469" y="16104.576171875" />
-						<pt x="1805.2861328125" y="15887.0087890625" />
-						<pt x="1806.53210449219" y="12995.1220703125" />
-						<pt x="1807.84582519531" y="13539.0859375" />
-						<pt x="1809.5546875" y="9603.3642578125" />
-						<pt x="1811.23205566406" y="10904.3125" />
-						<pt x="1812.84313964844" y="12828.8017578125" />
-						<pt x="1814.09313964844" y="13939.5845947266" />
-						<pt x="1816.15393066406" y="10785.16796875" />
-						<pt x="1817.87463378906" y="11836.541015625" />
-						<pt x="1819.56494140625" y="11571.638671875" />
-						<pt x="1821.21337890625" y="9596.5" />
-						<pt x="1823.14038085938" y="8762.31640625" />
-						<pt x="1825.08544921875" y="8781.783203125" />
-						<pt x="1827.03564453125" y="10076.1904296875" />
-						<pt x="1828.62902832031" y="10676.5869140625" />
-						<pt x="1829.82446289062" y="8912.7099609375" />
-						<pt x="1831.02966308594" y="8341.4443359375" />
-						<pt x="1832.62158203125" y="8517.91796875" />
-						<pt x="1834.48815917969" y="7672.2802734375" />
-						<pt x="1836.81677246094" y="7246.2275390625" />
-						<pt x="1839.52209472656" y="8453.00549316406" />
-						<pt x="1842.24621582031" y="9317.779296875" />
-						<pt x="1843.86376953125" y="9674.85986328125" />
-						<pt x="1846.10339355469" y="8584.6328125" />
-						<pt x="1847.20849609375" y="6910.87255859375" />
-						<pt x="1848.68237304688" y="0" />
-						<pt x="1850.09631347656" y="7750.4560546875" />
-						<pt x="1851.12512207031" y="7976.46630859375" />
-						<pt x="1853.71057128906" y="6641.52685546875" />
-						<pt x="1855.52624511719" y="7921.99365234375" />
-						<pt x="1857.064453125" y="4502.91650390625" />
-						<pt x="1858.97082519531" y="7918.28125" />
-						<pt x="1861.28601074219" y="6991.912109375" />
-						<pt x="1863.56823730469" y="8192.130859375" />
-						<pt x="1865.85095214844" y="5404.07958984375" />
-						<pt x="1867.78442382812" y="6909.56640625" />
-						<pt x="1869.03576660156" y="7695.20361328125" />
-						<pt x="1871.33630371094" y="6777.1318359375" />
-						<pt x="1872.57312011719" y="6729.103515625" />
-						<pt x="1874.54077148438" y="4768.60009765625" />
-						<pt x="1876.48901367188" y="4750.97509765625" />
-						<pt x="1878.7314453125" y="7574.9267578125" />
-						<pt x="1881.08850097656" y="5569.12451171875" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="449.744389900421"/>
-					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="91264.109375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
-				</feature>
-				<feature id="f_6408859317243173796_10306100746905639127">
-					<position dim="0">1782.34333734102</position>
-					<position dim="1">450.246067319321</position>
-					<intensity>465501</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1763.34350585938" y="0" />
-						<pt x="1764.53942871094" y="0" />
-						<pt x="1766.20935058594" y="0" />
-						<pt x="1767.45556640625" y="0" />
-						<pt x="1768.78759765625" y="0" />
-						<pt x="1770.08776855469" y="1165.43957519531" />
-						<pt x="1771.37548828125" y="1393.00817871094" />
-						<pt x="1772.72485351562" y="6394.92431640625" />
-						<pt x="1775.10119628906" y="16525.09765625" />
-						<pt x="1776.7529296875" y="28931.640625" />
-						<pt x="1778.41467285156" y="40418.69140625" />
-						<pt x="1779.78234863281" y="44756.20703125" />
-						<pt x="1781.03625488281" y="43344.69921875" />
-						<pt x="1782.70874023438" y="32936.89453125" />
-						<pt x="1784.005859375" y="26178.119140625" />
-						<pt x="1785.66430664062" y="22287.62890625" />
-						<pt x="1788.00903320312" y="13541.138671875" />
-						<pt x="1789.64514160156" y="14404.34765625" />
-						<pt x="1791.29907226562" y="9481.017578125" />
-						<pt x="1792.96655273438" y="12832.8779296875" />
-						<pt x="1794.18957519531" y="10743.8603515625" />
-						<pt x="1796.90112304688" y="5956.55517578125" />
-						<pt x="1799.29284667969" y="8550.466796875" />
-						<pt x="1802.06115722656" y="2810.3857421875" />
-						<pt x="1802.93933105469" y="5481.55224609375" />
-						<pt x="1805.2861328125" y="4969.7568359375" />
-						<pt x="1806.53210449219" y="4854.69482421875" />
-						<pt x="1807.84582519531" y="3595.94653320312" />
-						<pt x="1809.5546875" y="4655.9443359375" />
-						<pt x="1811.23205566406" y="2883.03759765625" />
-						<pt x="1812.84313964844" y="4796.408203125" />
-						<pt x="1814.09313964844" y="6333.505859375" />
-						<pt x="1816.15393066406" y="4753.25012207031" />
-						<pt x="1817.87463378906" y="3065.50634765625" />
-						<pt x="1819.56494140625" y="4645.6494140625" />
-						<pt x="1821.21337890625" y="3406.87841796875" />
-						<pt x="1823.14038085938" y="4329.94140625" />
-						<pt x="1825.08544921875" y="2906.20581054688" />
-						<pt x="1827.03564453125" y="4323.2568359375" />
-						<pt x="1828.62902832031" y="3738.16040039062" />
-						<pt x="1829.82446289062" y="0" />
-						<pt x="1831.02966308594" y="3923.69555664062" />
-						<pt x="1832.62158203125" y="4150.80810546875" />
-						<pt x="1834.48815917969" y="3102.2333984375" />
-						<pt x="1836.81677246094" y="3262.21557617188" />
-						<pt x="1839.52209472656" y="1837.95385742188" />
-						<pt x="1842.24621582031" y="3682.50024414062" />
-						<pt x="1843.86376953125" y="0" />
-						<pt x="1846.10339355469" y="0" />
-						<pt x="1847.20849609375" y="0" />
-						<pt x="1848.68237304688" y="0" />
-						<pt x="1850.09631347656" y="0" />
-						<pt x="1851.12512207031" y="0" />
-						<pt x="1853.71057128906" y="0" />
-						<pt x="1855.52624511719" y="0" />
-						<pt x="1857.064453125" y="2697.66723632812" />
-						<pt x="1858.97082519531" y="2741.68212890625" />
-						<pt x="1861.28601074219" y="2791.84643554688" />
-						<pt x="1863.56823730469" y="0" />
-						<pt x="1865.85095214844" y="3051.03784179688" />
-						<pt x="1867.78442382812" y="3314.49487304688" />
-						<pt x="1869.03576660156" y="3835.66821289062" />
-						<pt x="1871.33630371094" y="2987.119140625" />
-						<pt x="1872.57312011719" y="4232.16455078125" />
-						<pt x="1874.54077148438" y="3003.31518554688" />
-						<pt x="1876.48901367188" y="1637.94262695312" />
-						<pt x="1878.7314453125" y="1404.9755859375" />
-						<pt x="1881.08850097656" y="2451.17114257812" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="450.246067319321"/>
-					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="32936.89453125"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.325393160206819"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="449.744232177734" RT="1776.05004882812" >
-				<PeptideHit score="0.0344827586206897" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0227663017779976"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LC(Carbamidomethyl)VLHEK/2"/>
-			<UserParam type="float" name="leftWidth" value="1761.75610351562"/>
-			<UserParam type="float" name="rightWidth" value="1881.08850097656"/>
-			<UserParam type="float" name="total_xic" value="2422351.66326904"/>
-			<UserParam type="float" name="peak_apices_sum" value="124201.00390625"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.995444848298674"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.994000524898595"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0584307399821589"/>
-			<UserParam type="float" name="var_library_sangle" value="0.100167183533034"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0584307399821589"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0670063315124288"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.997948935934463"/>
-			<UserParam type="float" name="var_intensity_score" value="0.719835873312806"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="24.5720952313712"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.20161145889938"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.981171160936356"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.35219320308861"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.984152837341836"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.26696240901947"/>
-			<UserParam type="float" name="var_massdev_score" value="0.43272982427065"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.447953512388762"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.698534764147427"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.07117517832204"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.66305280471362"/>
-			<UserParam type="float" name="PrecursorMZ" value="449.744389900421"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="146461.170161814"/>
-			<UserParam type="float" name="model_FWHM" value="12.6395633276552"/>
-			<UserParam type="float" name="model_center" value="1781.58469240699"/>
-			<UserParam type="float" name="model_lower" value="1768.16587130001"/>
-			<UserParam type="float" name="model_upper" value="1795.00351351397"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="5.36752844279191"/>
-			<UserParam type="float" name="model_error" value="0.516282686849734"/>
-			<UserParam type="float" name="model_area" value="1970546.74096382"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="1743695.5"/>
-		</feature>
-		<feature id="f_16250062551099875712">
-			<position dim="0">1978.65907624188</position>
-			<position dim="1">300.165352089204</position>
-			<intensity>4.4964e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.889465</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1939.34069824219" y="300.115352089204" />
-				<pt x="2036.53295898438" y="300.115352089204" />
-				<pt x="2036.53295898438" y="300.215352089204" />
-				<pt x="1939.34069824219" y="300.215352089204" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1939.34069824219" y="300.449803701804" />
-				<pt x="2036.53295898438" y="300.449803701804" />
-				<pt x="2036.53295898438" y="300.549803701804" />
-				<pt x="1939.34069824219" y="300.549803701804" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_16250062551099875712_13424404046998308790">
-					<position dim="0">1978.65907624188</position>
-					<position dim="1">300.165352089204</position>
-					<intensity>2.22186e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1939.34069824219" y="36680.62109375" />
-						<pt x="1941.74328613281" y="45794.234375" />
-						<pt x="1943.79846191406" y="47713.0234375" />
-						<pt x="1946.22692871094" y="33048.3984375" />
-						<pt x="1948.33605957031" y="58252.2221679688" />
-						<pt x="1950.83435058594" y="50551.5576171875" />
-						<pt x="1953.46435546875" y="49472.1899414062" />
-						<pt x="1956.12158203125" y="50716.2943115234" />
-						<pt x="1958.88928222656" y="53463.3280029297" />
-						<pt x="1961.46557617188" y="45161.8560791016" />
-						<pt x="1963.85095214844" y="52877.5782470703" />
-						<pt x="1966.54650878906" y="54868.1848144531" />
-						<pt x="1969.21594238281" y="55264.8072509766" />
-						<pt x="1971.63354492188" y="52805.6440429688" />
-						<pt x="1973.24267578125" y="56724.41015625" />
-						<pt x="1974.81298828125" y="60130.0043945312" />
-						<pt x="1977.380859375" y="48982.4614257812" />
-						<pt x="1979.2890625" y="50742.7026367188" />
-						<pt x="1980.87292480469" y="52880.7604980469" />
-						<pt x="1982.46655273438" y="55716.388671875" />
-						<pt x="1984.07604980469" y="53652.4938964844" />
-						<pt x="1985.6865234375" y="61659.5291137695" />
-						<pt x="1986.94934082031" y="56493.3591308594" />
-						<pt x="1989.31274414062" y="57605.4466552734" />
-						<pt x="1991.31884765625" y="49399.6843261719" />
-						<pt x="1993.19482421875" y="46582.6325683594" />
-						<pt x="1995.119140625" y="48921.4417724609" />
-						<pt x="1997.05432128906" y="51598.0784912109" />
-						<pt x="1998.99108886719" y="51620.6519775391" />
-						<pt x="2000.96350097656" y="51072.5512695312" />
-						<pt x="2002.17077636719" y="59742.7866210938" />
-						<pt x="2004.77075195312" y="49408.6408691406" />
-						<pt x="2007.42565917969" y="36029.41015625" />
-						<pt x="2010.10522460938" y="60046.412109375" />
-						<pt x="2012.57043457031" y="46714.6420898438" />
-						<pt x="2014.81372070312" y="44301.7006835938" />
-						<pt x="2016.57385253906" y="52117.0034179688" />
-						<pt x="2019.23095703125" y="46844.5078125" />
-						<pt x="2021.03356933594" y="45801.375" />
-						<pt x="2023.54016113281" y="47041.3671875" />
-						<pt x="2026.06115722656" y="58026.18359375" />
-						<pt x="2028.66284179688" y="46704.36328125" />
-						<pt x="2031.287109375" y="44216.0402832031" />
-						<pt x="2033.83422851562" y="44416.7150878906" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="300.165352089204"/>
-					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="50742.7026367188"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
-				</feature>
-				<feature id="f_16250062551099875712_12665713047548007769">
-					<position dim="0">1978.65907624188</position>
-					<position dim="1">300.499803701804</position>
-					<intensity>707673</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1939.34069824219" y="18473.921875" />
-						<pt x="1941.74328613281" y="0" />
-						<pt x="1943.79846191406" y="21973.2578125" />
-						<pt x="1946.22692871094" y="11365.859375" />
-						<pt x="1948.33605957031" y="18171.76171875" />
-						<pt x="1950.83435058594" y="14074.0419921875" />
-						<pt x="1953.46435546875" y="12252.080078125" />
-						<pt x="1956.12158203125" y="16608.580078125" />
-						<pt x="1958.88928222656" y="18796.513671875" />
-						<pt x="1961.46557617188" y="14309.8837890625" />
-						<pt x="1963.85095214844" y="16591.025390625" />
-						<pt x="1966.54650878906" y="17604.376953125" />
-						<pt x="1969.21594238281" y="17657.005859375" />
-						<pt x="1971.63354492188" y="8704.1591796875" />
-						<pt x="1973.24267578125" y="17008.806640625" />
-						<pt x="1974.81298828125" y="17888.96875" />
-						<pt x="1977.380859375" y="18511.80078125" />
-						<pt x="1979.2890625" y="21832.7421875" />
-						<pt x="1980.87292480469" y="15260.240234375" />
-						<pt x="1982.46655273438" y="20862.427734375" />
-						<pt x="1984.07604980469" y="14933.685546875" />
-						<pt x="1985.6865234375" y="13568.525390625" />
-						<pt x="1986.94934082031" y="17189.716796875" />
-						<pt x="1989.31274414062" y="20236.34765625" />
-						<pt x="1991.31884765625" y="17097.77734375" />
-						<pt x="1993.19482421875" y="16976.74609375" />
-						<pt x="1995.119140625" y="18632.2578125" />
-						<pt x="1997.05432128906" y="12982.8173828125" />
-						<pt x="1998.99108886719" y="12441.716796875" />
-						<pt x="2000.96350097656" y="19018.88671875" />
-						<pt x="2002.17077636719" y="16565.154296875" />
-						<pt x="2004.77075195312" y="13100.724609375" />
-						<pt x="2007.42565917969" y="15414.400390625" />
-						<pt x="2010.10522460938" y="18686.56640625" />
-						<pt x="2012.57043457031" y="18238.216796875" />
-						<pt x="2014.81372070312" y="10422.1982421875" />
-						<pt x="2016.57385253906" y="20035.880859375" />
-						<pt x="2019.23095703125" y="11692.9423828125" />
-						<pt x="2021.03356933594" y="17873.365234375" />
-						<pt x="2023.54016113281" y="12206.4658203125" />
-						<pt x="2026.06115722656" y="16360.0458984375" />
-						<pt x="2028.66284179688" y="19794.029296875" />
-						<pt x="2031.287109375" y="20121.05859375" />
-						<pt x="2033.83422851562" y="16135.64453125" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="300.499803701804"/>
-					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="21832.7421875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.325393160206819"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" >
-				<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.188627296280199"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.166046142578" RT="1970.11474609375" >
-				<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0707872514634683"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LC(Carbamidomethyl)VLHEK/3"/>
-			<UserParam type="float" name="leftWidth" value="1939.34069824219"/>
-			<UserParam type="float" name="rightWidth" value="2036.53295898438"/>
-			<UserParam type="float" name="total_xic" value="22159990.6004639"/>
-			<UserParam type="float" name="peak_apices_sum" value="72575.4448242188"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="3.64273441009184"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="1.75609961197951"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.775115723638661"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.70381060715617"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0838284433324637"/>
-			<UserParam type="float" name="var_library_sangle" value="0.141078652799303"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0838284433324637"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.098194929215271"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.995657255203499"/>
-			<UserParam type="float" name="var_intensity_score" value="0.1321993453345"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="1.2668993900222"/>
-			<UserParam type="float" name="var_log_sn_score" value="0.236572490153024"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.687795549631119"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="3.06104265743219"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.981719188551002"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.241564720869064"/>
-			<UserParam type="float" name="var_massdev_score" value="1.82587790799991"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.84036734399487"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.902884840789147"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.615088901235478"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.889465319224237"/>
-			<UserParam type="float" name="PrecursorMZ" value="300.165352089204"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="3"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="78234.9574169087"/>
-			<UserParam type="float" name="model_FWHM" value="177.892763391079"/>
-			<UserParam type="float" name="model_center" value="1985.73122965242"/>
-			<UserParam type="float" name="model_lower" value="1796.87097346396"/>
-			<UserParam type="float" name="model_upper" value="2174.59148584087"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="75.5441024753821"/>
-			<UserParam type="float" name="model_error" value="0.163589773941564"/>
-			<UserParam type="float" name="model_area" value="14814646.8375859"/>
-			<UserParam type="string" name="model_status" value="3 (left side out of bounds)"/>
-			<UserParam type="float" name="raw_intensity" value="2929536.5"/>
-		</feature>
-		<feature id="f_10627069796380146481">
-			<position dim="0">1943.3004011853</position>
-			<position dim="1">395.239463487571</position>
-			<intensity>1.82822e+08</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.80547</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1918.98767089844" y="395.189463487571" />
-				<pt x="1998.99108886719" y="395.189463487571" />
-				<pt x="1998.99108886719" y="395.289463487571" />
-				<pt x="1918.98767089844" y="395.289463487571" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1918.98767089844" y="395.691140906471" />
-				<pt x="1998.99108886719" y="395.691140906471" />
-				<pt x="1998.99108886719" y="395.791140906471" />
-				<pt x="1918.98767089844" y="395.791140906471" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_10627069796380146481_10052793688680741109">
-					<position dim="0">1943.3004011853</position>
-					<position dim="1">395.239463487571</position>
-					<intensity>6.31944e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1918.98767089844" y="6117.03076171875" />
-						<pt x="1921.35717773438" y="6379.58154296875" />
-						<pt x="1923.42529296875" y="4494.837890625" />
-						<pt x="1925.10778808594" y="3110.54248046875" />
-						<pt x="1927.1669921875" y="1101.01733398438" />
-						<pt x="1928.453125" y="1140.63757324219" />
-						<pt x="1930.11804199219" y="11769.837890625" />
-						<pt x="1932.48400878906" y="174317.203125" />
-						<pt x="1934.46069335938" y="1082928.66845703" />
-						<pt x="1936.77783203125" y="3927904.15917969" />
-						<pt x="1939.34069824219" y="9982069.45507812" />
-						<pt x="1941.74328613281" y="12176436.2207031" />
-						<pt x="1943.79846191406" y="11353591.1308594" />
-						<pt x="1946.22692871094" y="7025028.234375" />
-						<pt x="1948.33605957031" y="5408893.00878906" />
-						<pt x="1950.83435058594" y="3091029.03417969" />
-						<pt x="1953.46435546875" y="1989076.11254883" />
-						<pt x="1956.12158203125" y="1374127.81286621" />
-						<pt x="1958.88928222656" y="971337.754150391" />
-						<pt x="1961.46557617188" y="705683.325195312" />
-						<pt x="1963.85095214844" y="555706.5" />
-						<pt x="1966.54650878906" y="533741.25" />
-						<pt x="1969.21594238281" y="354351.875" />
-						<pt x="1971.63354492188" y="298141.90625" />
-						<pt x="1973.24267578125" y="268639.53125" />
-						<pt x="1974.81298828125" y="256455.015625" />
-						<pt x="1977.380859375" y="162474.875" />
-						<pt x="1979.2890625" y="167706.221191406" />
-						<pt x="1980.87292480469" y="144897.78125" />
-						<pt x="1982.46655273438" y="166323.244506836" />
-						<pt x="1984.07604980469" y="154813.89642334" />
-						<pt x="1985.6865234375" y="156140.25" />
-						<pt x="1986.94934082031" y="156258.48046875" />
-						<pt x="1989.31274414062" y="128527.629394531" />
-						<pt x="1991.31884765625" y="118223.734863281" />
-						<pt x="1993.19482421875" y="106780.689575195" />
-						<pt x="1995.119140625" y="93174.603515625" />
-						<pt x="1997.05432128906" y="75538.9014892578" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="395.239463487571"/>
-					<UserParam type="string" name="native_id" value="LVTDLTK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="11353591.1308594"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.704209887318509"/>
-				</feature>
-				<feature id="f_10627069796380146481_15166508592180818156">
-					<position dim="0">1943.3004011853</position>
-					<position dim="1">395.741140906471</position>
-					<intensity>2.63457e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1918.98767089844" y="2078.59594726562" />
-						<pt x="1921.35717773438" y="835.552795410156" />
-						<pt x="1923.42529296875" y="961.776000976562" />
-						<pt x="1925.10778808594" y="0" />
-						<pt x="1927.1669921875" y="0" />
-						<pt x="1928.453125" y="0" />
-						<pt x="1930.11804199219" y="4380.9111328125" />
-						<pt x="1932.48400878906" y="74131.1328125" />
-						<pt x="1934.46069335938" y="475151.880859375" />
-						<pt x="1936.77783203125" y="1692338.80615234" />
-						<pt x="1939.34069824219" y="4399968.90625" />
-						<pt x="1941.74328613281" y="5051440.5" />
-						<pt x="1943.79846191406" y="4777608.1171875" />
-						<pt x="1946.22692871094" y="2883425.86328125" />
-						<pt x="1948.33605957031" y="2219362" />
-						<pt x="1950.83435058594" y="1329996.52636719" />
-						<pt x="1953.46435546875" y="844074.666503906" />
-						<pt x="1956.12158203125" y="564934.267333984" />
-						<pt x="1958.88928222656" y="397141.96875" />
-						<pt x="1961.46557617188" y="292772.025634766" />
-						<pt x="1963.85095214844" y="221408.15625" />
-						<pt x="1966.54650878906" y="217641.828125" />
-						<pt x="1969.21594238281" y="139387.8125" />
-						<pt x="1971.63354492188" y="124288.9921875" />
-						<pt x="1973.24267578125" y="106670.7265625" />
-						<pt x="1974.81298828125" y="100245.890625" />
-						<pt x="1977.380859375" y="61358.453125" />
-						<pt x="1979.2890625" y="60064.0078125" />
-						<pt x="1980.87292480469" y="48254.83984375" />
-						<pt x="1982.46655273438" y="52144.85546875" />
-						<pt x="1984.07604980469" y="39635.41015625" />
-						<pt x="1985.6865234375" y="37483.0546875" />
-						<pt x="1986.94934082031" y="38913.83984375" />
-						<pt x="1989.31274414062" y="22485.8828125" />
-						<pt x="1991.31884765625" y="22267.365234375" />
-						<pt x="1993.19482421875" y="17794.16015625" />
-						<pt x="1995.119140625" y="15023.083984375" />
-						<pt x="1997.05432128906" y="9990.9580078125" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="395.741140906471"/>
-					<UserParam type="string" name="native_id" value="LVTDLTK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="4777608.1171875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.295790112681491"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" >
-				<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.00108437147303181"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LVTDLTK/2"/>
-			<UserParam type="float" name="leftWidth" value="1918.98767089844"/>
-			<UserParam type="float" name="rightWidth" value="1998.99108886719"/>
-			<UserParam type="float" name="total_xic" value="89905078.2590332"/>
-			<UserParam type="float" name="peak_apices_sum" value="16131199.2480469"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999855522861782"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999819433927319"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00155698400061227"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00266588296521212"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00155698400061227"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00178551886317935"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999998543005867"/>
-			<UserParam type="float" name="var_intensity_score" value="0.995940359920697"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="103.895258829532"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.64338326500946"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.997846633195877"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.56821623209286"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.99176717726236"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.294233113527298"/>
-			<UserParam type="float" name="var_massdev_score" value="1.34876090913977"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.0324552849287"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="1"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.784624367602911"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.867806593918273"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.8054747289921"/>
-			<UserParam type="float" name="PrecursorMZ" value="395.239463487571"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="17031259.5112929"/>
-			<UserParam type="float" name="model_FWHM" value="10.0843824121398"/>
-			<UserParam type="float" name="model_center" value="1942.62990566799"/>
-			<UserParam type="float" name="model_lower" value="1931.92379818192"/>
-			<UserParam type="float" name="model_upper" value="1953.33601315406"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="4.28244299442838"/>
-			<UserParam type="float" name="model_error" value="0.285464271809724"/>
-			<UserParam type="float" name="model_area" value="182821910.768885"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="89540096"/>
-		</feature>
-		<feature id="f_14768204679546465715">
-			<position dim="0">2336.46435114133</position>
-			<position dim="1">464.250362519471</position>
-			<intensity>2.36477e+08</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.31915</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2307.17138671875" y="464.200362519471" />
-				<pt x="2424.5244140625" y="464.200362519471" />
-				<pt x="2424.5244140625" y="464.300362519471" />
-				<pt x="2307.17138671875" y="464.300362519471" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2307.17138671875" y="464.702039938371" />
-				<pt x="2424.5244140625" y="464.702039938371" />
-				<pt x="2424.5244140625" y="464.802039938371" />
-				<pt x="2307.17138671875" y="464.802039938371" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_14768204679546465715_12156709473159629610">
-					<position dim="0">2336.46435114133</position>
-					<position dim="1">464.250362519471</position>
-					<intensity>8.30316e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="2308.75170898438" y="5170.44689941406" />
-						<pt x="2310.283203125" y="7568.296875" />
-						<pt x="2311.82763671875" y="12898.9326171875" />
-						<pt x="2312.98388671875" y="20828.0078125" />
-						<pt x="2314.55151367188" y="35469.68359375" />
-						<pt x="2316.0009765625" y="44699.03125" />
-						<pt x="2317.59106445312" y="37272.953125" />
-						<pt x="2319.16381835938" y="51843.94921875" />
-						<pt x="2320.703125" y="129319.545898438" />
-						<pt x="2321.84399414062" y="261265.784667969" />
-						<pt x="2323.42333984375" y="718391.005126953" />
-						<pt x="2324.95239257812" y="1680718.30761719" />
-						<pt x="2326.453125" y="2862705.30419922" />
-						<pt x="2327.91772460938" y="3810648.71875" />
-						<pt x="2330.51977539062" y="4030730.61230469" />
-						<pt x="2332.01708984375" y="3981413.81054688" />
-						<pt x="2333.87475585938" y="3838215.43164062" />
-						<pt x="2335.84326171875" y="3748789.63964844" />
-						<pt x="2337.3740234375" y="3667954.17529297" />
-						<pt x="2339.23681640625" y="3319220.17285156" />
-						<pt x="2340.73510742188" y="2964764.16357422" />
-						<pt x="2343.35791015625" y="2724365.54296875" />
-						<pt x="2344.91845703125" y="2504833.00048828" />
-						<pt x="2346.482421875" y="2477456.90234375" />
-						<pt x="2347.72998046875" y="2402664.64990234" />
-						<pt x="2349.72998046875" y="2401385.66625977" />
-						<pt x="2351.62377929688" y="2313886.29467773" />
-						<pt x="2353.62329101562" y="2412982.62353516" />
-						<pt x="2356.2490234375" y="2219565.79980469" />
-						<pt x="2358.01000976562" y="2170206.04736328" />
-						<pt x="2360.29638671875" y="2243400.45800781" />
-						<pt x="2362.99853515625" y="2088614.36767578" />
-						<pt x="2364.60131835938" y="1934220.44921875" />
-						<pt x="2367.25073242188" y="1725569.37353516" />
-						<pt x="2369.20751953125" y="1705975.34106445" />
-						<pt x="2370.35498046875" y="1615968.98583984" />
-						<pt x="2371.9755859375" y="1791504.01489258" />
-						<pt x="2373.9287109375" y="1740227.65234375" />
-						<pt x="2376.5869140625" y="1367103.4074707" />
-						<pt x="2377.77197265625" y="1300431.06237793" />
-						<pt x="2380.13623046875" y="1235396.0078125" />
-						<pt x="2381.28979492188" y="1146183.93261719" />
-						<pt x="2383.62573242188" y="1047449.32250977" />
-						<pt x="2386.21655273438" y="794766.4375" />
-						<pt x="2388.87280273438" y="722664.375" />
-						<pt x="2391.34716796875" y="628879.4375" />
-						<pt x="2393.150390625" y="564806.4375" />
-						<pt x="2395.32104492188" y="490325.21875" />
-						<pt x="2397.95825195312" y="387533.466308594" />
-						<pt x="2400.6484375" y="314348.34375" />
-						<pt x="2403.47192382812" y="232345.125" />
-						<pt x="2405.06005859375" y="222822.625" />
-						<pt x="2407.34887695312" y="164976.15625" />
-						<pt x="2410.00390625" y="127394.859375" />
-						<pt x="2411.24560546875" y="111891.4375" />
-						<pt x="2413.26293945312" y="106960.609375" />
-						<pt x="2414.81225585938" y="75139.296875" />
-						<pt x="2416.37377929688" y="76863.7578125" />
-						<pt x="2417.87133789062" y="61287.6328125" />
-						<pt x="2419.4033203125" y="58543.515625" />
-						<pt x="2420.93139648438" y="53635.5" />
-						<pt x="2422.56640625" y="37143.96484375" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="464.250362519471"/>
-					<UserParam type="string" name="native_id" value="YLYEIAR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="3748789.63964844"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.655742026441336"/>
-				</feature>
-				<feature id="f_14768204679546465715_15885522598119108466">
-					<position dim="0">2336.46435114133</position>
-					<position dim="1">464.752039938371</position>
-					<intensity>4.3803e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="2308.75170898438" y="0" />
-						<pt x="2310.283203125" y="1495.52514648438" />
-						<pt x="2311.82763671875" y="4830.3173828125" />
-						<pt x="2312.98388671875" y="8243.0048828125" />
-						<pt x="2314.55151367188" y="17170.59375" />
-						<pt x="2316.0009765625" y="13212.544921875" />
-						<pt x="2317.59106445312" y="16092.6564941406" />
-						<pt x="2319.16381835938" y="25123.279296875" />
-						<pt x="2320.703125" y="67158.3818359375" />
-						<pt x="2321.84399414062" y="138877.617431641" />
-						<pt x="2323.42333984375" y="404226.15625" />
-						<pt x="2324.95239257812" y="896589.120849609" />
-						<pt x="2326.453125" y="1523648.64257812" />
-						<pt x="2327.91772460938" y="2044045.18701172" />
-						<pt x="2330.51977539062" y="2132513.25" />
-						<pt x="2332.01708984375" y="2149916.96875" />
-						<pt x="2333.87475585938" y="2041992.375" />
-						<pt x="2335.84326171875" y="1970969.68359375" />
-						<pt x="2337.3740234375" y="1889403.84619141" />
-						<pt x="2339.23681640625" y="1802509.5" />
-						<pt x="2340.73510742188" y="1601953.04370117" />
-						<pt x="2343.35791015625" y="1432775.47705078" />
-						<pt x="2344.91845703125" y="1316177.25488281" />
-						<pt x="2346.482421875" y="1302207.00463867" />
-						<pt x="2347.72998046875" y="1253727.17529297" />
-						<pt x="2349.72998046875" y="1262369.0402832" />
-						<pt x="2351.62377929688" y="1191727.875" />
-						<pt x="2353.62329101562" y="1276700.00244141" />
-						<pt x="2356.2490234375" y="1132648.44482422" />
-						<pt x="2358.01000976562" y="1153031.75" />
-						<pt x="2360.29638671875" y="1164172.68920898" />
-						<pt x="2362.99853515625" y="1105369.05517578" />
-						<pt x="2364.60131835938" y="1014387.16259766" />
-						<pt x="2367.25073242188" y="927975.391113281" />
-						<pt x="2369.20751953125" y="930792.232421875" />
-						<pt x="2370.35498046875" y="865361.120361328" />
-						<pt x="2371.9755859375" y="917209.790893555" />
-						<pt x="2373.9287109375" y="942302.777832031" />
-						<pt x="2376.5869140625" y="743061.032958984" />
-						<pt x="2377.77197265625" y="669594.745605469" />
-						<pt x="2380.13623046875" y="643537.1875" />
-						<pt x="2381.28979492188" y="581447.5546875" />
-						<pt x="2383.62573242188" y="559372.121582031" />
-						<pt x="2386.21655273438" y="428437.09375" />
-						<pt x="2388.87280273438" y="383014.375" />
-						<pt x="2391.34716796875" y="319424.8125" />
-						<pt x="2393.150390625" y="305418.65625" />
-						<pt x="2395.32104492188" y="251123.59375" />
-						<pt x="2397.95825195312" y="189521.046875" />
-						<pt x="2400.6484375" y="160275.734375" />
-						<pt x="2403.47192382812" y="119724.125" />
-						<pt x="2405.06005859375" y="115157.8203125" />
-						<pt x="2407.34887695312" y="83020.34375" />
-						<pt x="2410.00390625" y="65361.6015625" />
-						<pt x="2411.24560546875" y="50701.60546875" />
-						<pt x="2413.26293945312" y="50538.5" />
-						<pt x="2414.81225585938" y="28087.138671875" />
-						<pt x="2416.37377929688" y="25405.73046875" />
-						<pt x="2417.87133789062" y="29897.2421875" />
-						<pt x="2419.4033203125" y="24073.78125" />
-						<pt x="2420.93139648438" y="20535.697265625" />
-						<pt x="2422.56640625" y="17314.8828125" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="464.752039938371"/>
-					<UserParam type="string" name="native_id" value="YLYEIAR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="1970969.68359375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.344257973558664"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250213623047" RT="2321.49926757812" >
-				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.000528980302830806"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250030517578" RT="2357.07421875" >
-				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="9.1724848717909e-05"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250335693359" RT="2398.77709960938" >
-				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="4.18055390056644e-05"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="YLYEIAR/2"/>
-			<UserParam type="float" name="leftWidth" value="2307.17138671875"/>
-			<UserParam type="float" name="rightWidth" value="2424.5244140625"/>
-			<UserParam type="float" name="total_xic" value="127750490.772278"/>
-			<UserParam type="float" name="peak_apices_sum" value="5719759.32324219"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.99989185157427"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999853516577379"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00109704639804184"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00200128800156997"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00109704639804184"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00118326541192143"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999334090534"/>
-			<UserParam type="float" name="var_intensity_score" value="0.992830315040351"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="65.000081378898"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.1743885218779"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.985577464103699"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.2506009186205"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.990654856489394"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.345355033874512"/>
-			<UserParam type="float" name="var_massdev_score" value="1.19333451667543"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="1.03625577733313"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.761987351682086"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.862442874603575"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.31914514059437"/>
-			<UserParam type="float" name="PrecursorMZ" value="464.250362519471"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="3"/>
-			<UserParam type="int" name="n_matching_ids" value="3"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="4738315.40029383"/>
-			<UserParam type="float" name="model_FWHM" value="46.8848026379525"/>
-			<UserParam type="float" name="model_center" value="2346.69910501276"/>
-			<UserParam type="float" name="model_lower" value="2296.92374783265"/>
-			<UserParam type="float" name="model_upper" value="2396.47446219288"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="19.9101428720465"/>
-			<UserParam type="float" name="model_error" value="0.574338452996325"/>
-			<UserParam type="float" name="model_area" value="236476630.558207"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="126834560"/>
-		</feature>
-		<feature id="f_3823858840059792698">
 			<position dim="0">2024.60123336381</position>
 			<position dim="1">461.747653035421</position>
 			<intensity>1.56702e+08</intensity>
@@ -1379,7 +122,7 @@
 				<pt x="1998.99108886719" y="462.299330454321" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_3823858840059792698_893904610286969204">
+				<feature id="f_5233264595117471314_4835329514588776807">
 					<position dim="0">2024.60123336381</position>
 					<position dim="1">461.747653035421</position>
 					<intensity>5.1932e+07</intensity>
@@ -1432,7 +175,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.66642596900412"/>
 				</feature>
-				<feature id="f_3823858840059792698_14851350658635457156">
+				<feature id="f_5233264595117471314_17749660155506638460">
 					<position dim="0">2024.60123336381</position>
 					<position dim="1">462.249330454321</position>
 					<intensity>2.61382e+07</intensity>
@@ -1508,12 +251,12 @@
 			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.999964845503361"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999953110426824"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00123025228850396"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00221672421717551"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00123025228850396"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00134201647916654"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999953110426825"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00123025228850404"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00221672421707534"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00123025228850404"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00134201647916671"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999999149732785"/>
 			<UserParam type="float" name="var_intensity_score" value="0.990032925340049"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
@@ -1535,18 +278,18 @@
 			<UserParam type="int" name="n_total_ids" value="2"/>
 			<UserParam type="int" name="n_matching_ids" value="2"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="11051570.9831695"/>
-			<UserParam type="float" name="model_FWHM" value="13.3204732760108"/>
-			<UserParam type="float" name="model_center" value="2024.03698200017"/>
-			<UserParam type="float" name="model_lower" value="2009.8952713004"/>
-			<UserParam type="float" name="model_upper" value="2038.17869269993"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="5.6566842799071"/>
-			<UserParam type="float" name="model_error" value="0.726455352858386"/>
-			<UserParam type="float" name="model_area" value="156702470.684672"/>
+			<UserParam type="float" name="model_height" value="11051570.983186"/>
+			<UserParam type="float" name="model_FWHM" value="13.3204732759154"/>
+			<UserParam type="float" name="model_center" value="2024.03698200016"/>
+			<UserParam type="float" name="model_lower" value="2009.8952713005"/>
+			<UserParam type="float" name="model_upper" value="2038.17869269983"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="5.65668427986655"/>
+			<UserParam type="float" name="model_error" value="0.726455352884203"/>
+			<UserParam type="float" name="model_area" value="156702470.683784"/>
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="78070184"/>
 		</feature>
-		<feature id="f_17447818880105247092">
+		<feature id="f_7804704400743266335">
 			<position dim="0">2072.67445045983</position>
 			<position dim="1">395.726522907821</position>
 			<intensity>4.84442e+07</intensity>
@@ -1567,7 +310,7 @@
 				<pt x="2045.21923828125" y="396.278200326721" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_17447818880105247092_1003624456647096845">
+				<feature id="f_7804704400743266335_15004869347769368353">
 					<position dim="0">2072.67445045983</position>
 					<position dim="1">395.726522907821</position>
 					<intensity>1.72337e+07</intensity>
@@ -1634,7 +377,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.692511512336989"/>
 				</feature>
-				<feature id="f_17447818880105247092_15120290131060441429">
+				<feature id="f_7804704400743266335_3332699010107892018">
 					<position dim="0">2072.67445045983</position>
 					<position dim="1">396.228200326721</position>
 					<intensity>6.86563e+06</intensity>
@@ -1755,7 +498,7 @@
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="24099286"/>
 		</feature>
-		<feature id="f_11275867043381640475">
+		<feature id="f_13440783915218733453">
 			<position dim="0">2123.35043908495</position>
 			<position dim="1">455.755280535421</position>
 			<intensity>9.99986e+06</intensity>
@@ -1776,7 +519,7 @@
 				<pt x="2094.08325195312" y="456.306957954321" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_11275867043381640475_3713543811689521337">
+				<feature id="f_13440783915218733453_15916652588957785155">
 					<position dim="0">2123.35043908495</position>
 					<position dim="1">455.755280535421</position>
 					<intensity>4.14411e+06</intensity>
@@ -1852,7 +595,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.652807062123664"/>
 				</feature>
-				<feature id="f_11275867043381640475_8666254306116808202">
+				<feature id="f_13440783915218733453_15157403601844400700">
 					<position dim="0">2123.35043908495</position>
 					<position dim="1">456.256957954321</position>
 					<intensity>1.80875e+06</intensity>
@@ -1945,11 +688,11 @@
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.99795112736991"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.997213738088641"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0433476733099385"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0772597046512233"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0433476733099385"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0477934471432183"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0433476733099384"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0772597046512218"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0433476733099384"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0477934471432182"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.9989293261486"/>
 			<UserParam type="float" name="var_intensity_score" value="0.992617455149373"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
@@ -1971,18 +714,216 @@
 			<UserParam type="int" name="n_total_ids" value="1"/>
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="439132.818090229"/>
-			<UserParam type="float" name="model_FWHM" value="21.3927103100675"/>
-			<UserParam type="float" name="model_center" value="2124.05652881491"/>
-			<UserParam type="float" name="model_lower" value="2101.34490933861"/>
-			<UserParam type="float" name="model_upper" value="2146.7681482912"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="9.08464779051795"/>
-			<UserParam type="float" name="model_error" value="0.482129285534524"/>
-			<UserParam type="float" name="model_area" value="9999858.9883989"/>
+			<UserParam type="float" name="model_height" value="439132.818096073"/>
+			<UserParam type="float" name="model_FWHM" value="21.3927103093398"/>
+			<UserParam type="float" name="model_center" value="2124.0565288148"/>
+			<UserParam type="float" name="model_lower" value="2101.34490933927"/>
+			<UserParam type="float" name="model_upper" value="2146.76814829032"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="9.08464779020893"/>
+			<UserParam type="float" name="model_error" value="0.482129285606667"/>
+			<UserParam type="float" name="model_area" value="9999858.98819183"/>
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="5952851"/>
 		</feature>
-		<feature id="f_3246735940528705071">
+		<feature id="f_6408859317243173796">
+			<position dim="0">1760.25657093773</position>
+			<position dim="1">569.752618393021</position>
+			<intensity>2.0629e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.74485</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1735.69311523438" y="569.702618393021" />
+				<pt x="1806.53210449219" y="569.702618393021" />
+				<pt x="1806.53210449219" y="569.802618393021" />
+				<pt x="1735.69311523438" y="569.802618393021" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1735.69311523438" y="570.204295811921" />
+				<pt x="1806.53210449219" y="570.204295811921" />
+				<pt x="1806.53210449219" y="570.304295811921" />
+				<pt x="1735.69311523438" y="570.304295811921" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_6408859317243173796_12999979801269632061">
+					<position dim="0">1760.25657093773</position>
+					<position dim="1">569.752618393021</position>
+					<intensity>9.09907e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1735.69311523438" y="0" />
+						<pt x="1737.05261230469" y="0" />
+						<pt x="1738.2958984375" y="0" />
+						<pt x="1740.13562011719" y="0" />
+						<pt x="1742.16540527344" y="0" />
+						<pt x="1744.55932617188" y="0" />
+						<pt x="1746.17114257812" y="0" />
+						<pt x="1747.40344238281" y="0" />
+						<pt x="1749.72985839844" y="18509.880859375" />
+						<pt x="1751.63122558594" y="83788.8125" />
+						<pt x="1753.181640625" y="261643.15625" />
+						<pt x="1754.70849609375" y="561154.6875" />
+						<pt x="1756.63635253906" y="1057437.25" />
+						<pt x="1758.22473144531" y="1291446.5" />
+						<pt x="1759.81530761719" y="1354679.41699219" />
+						<pt x="1761.75610351562" y="1162693.41821289" />
+						<pt x="1763.34350585938" y="781237.9375" />
+						<pt x="1764.53942871094" y="603374.328613281" />
+						<pt x="1766.20935058594" y="377011.59375" />
+						<pt x="1767.45556640625" y="296376.96875" />
+						<pt x="1768.78759765625" y="228238.265625" />
+						<pt x="1770.08776855469" y="180287.15625" />
+						<pt x="1771.37548828125" y="138572.09375" />
+						<pt x="1772.72485351562" y="124504.578125" />
+						<pt x="1775.10119628906" y="90972.8515625" />
+						<pt x="1776.7529296875" y="79513.1162109375" />
+						<pt x="1778.41467285156" y="61972.140625" />
+						<pt x="1779.78234863281" y="59201.09765625" />
+						<pt x="1781.03625488281" y="45934.63671875" />
+						<pt x="1782.70874023438" y="41144.109375" />
+						<pt x="1784.005859375" y="34639.359375" />
+						<pt x="1785.66430664062" y="26685.29296875" />
+						<pt x="1788.00903320312" y="24262.755859375" />
+						<pt x="1789.64514160156" y="20025.701171875" />
+						<pt x="1791.29907226562" y="20927.953125" />
+						<pt x="1792.96655273438" y="15381.3466796875" />
+						<pt x="1794.18957519531" y="15000.53515625" />
+						<pt x="1796.90112304688" y="12211.6181640625" />
+						<pt x="1799.29284667969" y="9903.77734375" />
+						<pt x="1802.06115722656" y="6677.27880859375" />
+						<pt x="1802.93933105469" y="7866.50146484375" />
+						<pt x="1805.2861328125" y="5790.8994140625" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="569.752618393021"/>
+					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="1354679.41699219"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.644498608917742"/>
+				</feature>
+				<feature id="f_6408859317243173796_17413765565443951891">
+					<position dim="0">1760.25657093773</position>
+					<position dim="1">570.254295811921</position>
+					<intensity>5.04683e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1735.69311523438" y="0" />
+						<pt x="1737.05261230469" y="0" />
+						<pt x="1738.2958984375" y="0" />
+						<pt x="1740.13562011719" y="0" />
+						<pt x="1742.16540527344" y="0" />
+						<pt x="1744.55932617188" y="0" />
+						<pt x="1746.17114257812" y="0" />
+						<pt x="1747.40344238281" y="0" />
+						<pt x="1749.72985839844" y="8986.8115234375" />
+						<pt x="1751.63122558594" y="52224.08203125" />
+						<pt x="1753.181640625" y="161934.0625" />
+						<pt x="1754.70849609375" y="321664.15625" />
+						<pt x="1756.63635253906" y="616271.230957031" />
+						<pt x="1758.22473144531" y="733171" />
+						<pt x="1759.81530761719" y="754406.354980469" />
+						<pt x="1761.75610351562" y="627629.3125" />
+						<pt x="1763.34350585938" y="437539.9375" />
+						<pt x="1764.53942871094" y="321101.329711914" />
+						<pt x="1766.20935058594" y="203640.328125" />
+						<pt x="1767.45556640625" y="161321.34375" />
+						<pt x="1768.78759765625" y="117180.109375" />
+						<pt x="1770.08776855469" y="108087.3671875" />
+						<pt x="1771.37548828125" y="77820.90625" />
+						<pt x="1772.72485351562" y="70044.84375" />
+						<pt x="1775.10119628906" y="47241.203125" />
+						<pt x="1776.7529296875" y="39962.79296875" />
+						<pt x="1778.41467285156" y="31583.787109375" />
+						<pt x="1779.78234863281" y="23770.244140625" />
+						<pt x="1781.03625488281" y="19617.638671875" />
+						<pt x="1782.70874023438" y="15318.6826171875" />
+						<pt x="1784.005859375" y="14336.6845703125" />
+						<pt x="1785.66430664062" y="11963.017578125" />
+						<pt x="1788.00903320312" y="10488.1298828125" />
+						<pt x="1789.64514160156" y="10806.5380859375" />
+						<pt x="1791.29907226562" y="9637.36328125" />
+						<pt x="1792.96655273438" y="9727.61328125" />
+						<pt x="1794.18957519531" y="5487.93408203125" />
+						<pt x="1796.90112304688" y="5579.2353515625" />
+						<pt x="1799.29284667969" y="5431.78173828125" />
+						<pt x="1802.06115722656" y="4058.3056640625" />
+						<pt x="1802.93933105469" y="5636.17163085938" />
+						<pt x="1805.2861328125" y="3155.05395507812" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="570.254295811921"/>
+					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="754406.354980469"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.355501391082258"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
+				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
+				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2"/>
+			<UserParam type="float" name="leftWidth" value="1735.69311523438"/>
+			<UserParam type="float" name="rightWidth" value="1806.53210449219"/>
+			<UserParam type="float" name="total_xic" value="14486678.1954346"/>
+			<UserParam type="float" name="peak_apices_sum" value="2109085.77197266"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999786313233063"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999706240332848"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00126828605193474"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00234262974539749"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00126828605193474"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00135289409378492"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999123130552"/>
+			<UserParam type="float" name="var_intensity_score" value="0.976475891102353"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="117.627765815645"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.76752511147092"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.99731856584549"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.66028853965821"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.993260451842917"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.356769680976868"/>
+			<UserParam type="float" name="var_massdev_score" value="0.482075605090886"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.385620600005746"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.754351526419968"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.84165907229483"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.74484798021522"/>
+			<UserParam type="float" name="PrecursorMZ" value="569.752618393021"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="2085091.18923653"/>
+			<UserParam type="float" name="model_FWHM" value="9.2944112925879"/>
+			<UserParam type="float" name="model_center" value="1759.73649271721"/>
+			<UserParam type="float" name="model_lower" value="1749.86905986397"/>
+			<UserParam type="float" name="model_upper" value="1769.60392557046"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="3.94697314129653"/>
+			<UserParam type="float" name="model_error" value="0.242313540895784"/>
+			<UserParam type="float" name="model_area" value="20629044.4099255"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="14145892"/>
+		</feature>
+		<feature id="f_10306100746905639127">
 			<position dim="0">1749.12956152037</position>
 			<position dim="1">443.711267907821</position>
 			<intensity>6.25575e+07</intensity>
@@ -2003,7 +944,7 @@
 				<pt x="1720.42810058594" y="444.262945326721" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_3246735940528705071_4584897071539917580">
+				<feature id="f_10306100746905639127_12524258085768770586">
 					<position dim="0">1749.12956152037</position>
 					<position dim="1">443.711267907821</position>
 					<intensity>2.5289e+07</intensity>
@@ -2066,7 +1007,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.691417156355378"/>
 				</feature>
-				<feature id="f_3246735940528705071_260132145239717571">
+				<feature id="f_10306100746905639127_1755235105885170967">
 					<position dim="0">1749.12956152037</position>
 					<position dim="1">444.212945326721</position>
 					<intensity>1.12549e+07</intensity>
@@ -2147,9 +1088,9 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.999913661505798"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999889473186652"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.000599630326988065"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00104554317429552"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.000599630326988065"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00059963032698801"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00104554317450789"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00059963032698801"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.000675051683031891"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999999789234646"/>
 			<UserParam type="float" name="var_intensity_score" value="0.990566158000927"/>
@@ -2160,30 +1101,30 @@
 			<UserParam type="float" name="xx_lda_prelim_score" value="7.47518657598361"/>
 			<UserParam type="float" name="var_isotope_correlation_score" value="0.990743065551955"/>
 			<UserParam type="float" name="var_isotope_overlap_score" value="0.307983219623566"/>
-			<UserParam type="float" name="var_massdev_score" value="0.760948673990978"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.544374916487825"/>
+			<UserParam type="float" name="var_massdev_score" value="0.760948674247052"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.544374916743954"/>
 			<UserParam type="float" name="var_bseries_score" value="0"/>
 			<UserParam type="float" name="var_yseries_score" value="1"/>
 			<UserParam type="float" name="var_dotprod_score" value="0.767922678010944"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.870417252673124"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.7709744922802"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.870417252673125"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.77097449225763"/>
 			<UserParam type="float" name="PrecursorMZ" value="443.711267907821"/>
 			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
 			<UserParam type="int" name="n_total_ids" value="1"/>
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="4157652.62760452"/>
-			<UserParam type="float" name="model_FWHM" value="14.1350984101506"/>
-			<UserParam type="float" name="model_center" value="1749.13408279592"/>
-			<UserParam type="float" name="model_lower" value="1734.12752347276"/>
-			<UserParam type="float" name="model_upper" value="1764.14064211909"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="6.00262372926617"/>
-			<UserParam type="float" name="model_error" value="0.0695800861456952"/>
-			<UserParam type="float" name="model_area" value="62557474.6328581"/>
+			<UserParam type="float" name="model_height" value="4157652.62764879"/>
+			<UserParam type="float" name="model_FWHM" value="14.135098409806"/>
+			<UserParam type="float" name="model_center" value="1749.13408279591"/>
+			<UserParam type="float" name="model_lower" value="1734.12752347312"/>
+			<UserParam type="float" name="model_upper" value="1764.14064211871"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="6.00262372911986"/>
+			<UserParam type="float" name="model_error" value="0.0695800861613577"/>
+			<UserParam type="float" name="model_area" value="62557474.6319995"/>
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="36543968"/>
 		</feature>
-		<feature id="f_17569764383250687096">
+		<feature id="f_14811341817612382122">
 			<position dim="0">1851.03387353231</position>
 			<position dim="1">487.732534471621</position>
 			<intensity>9.13243e+07</intensity>
@@ -2204,7 +1145,7 @@
 				<pt x="1825.08544921875" y="488.284211890521" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_17569764383250687096_14317784148091680644">
+				<feature id="f_14811341817612382122_2684106197423007927">
 					<position dim="0">1851.03387353231</position>
 					<position dim="1">487.732534471621</position>
 					<intensity>5.83658e+07</intensity>
@@ -2315,7 +1256,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.658472827804029"/>
 				</feature>
-				<feature id="f_17569764383250687096_17671779025680303814">
+				<feature id="f_14811341817612382122_8119044117483804262">
 					<position dim="0">1851.03387353231</position>
 					<position dim="1">488.234211890521</position>
 					<intensity>3.04846e+07</intensity>
@@ -2465,9 +1406,9 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.999943413075745"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999923646234517"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00157333246564978"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00286200887402008"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00157333246564978"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00157333246564981"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0028620088739425"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00157333246564981"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.00170135372459251"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999998625615363"/>
 			<UserParam type="float" name="var_intensity_score" value="0.995052470444129"/>
@@ -2490,18 +1431,18 @@
 			<UserParam type="int" name="n_total_ids" value="4"/>
 			<UserParam type="int" name="n_matching_ids" value="4"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="7680585.46163937"/>
-			<UserParam type="float" name="model_FWHM" value="11.1701665370559"/>
+			<UserParam type="float" name="model_height" value="7680585.46164106"/>
+			<UserParam type="float" name="model_FWHM" value="11.1701665370523"/>
 			<UserParam type="float" name="model_center" value="1849.84767672415"/>
 			<UserParam type="float" name="model_lower" value="1837.98884405642"/>
 			<UserParam type="float" name="model_upper" value="1861.70650939189"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="4.74353306709466"/>
-			<UserParam type="float" name="model_error" value="0.663353054762782"/>
-			<UserParam type="float" name="model_area" value="91324256.4402821"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="4.74353306709315"/>
+			<UserParam type="float" name="model_error" value="0.663353054764041"/>
+			<UserParam type="float" name="model_area" value="91324256.4402731"/>
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="88850424"/>
 		</feature>
-		<feature id="f_1196373166564353753">
+		<feature id="f_17314619952666245179">
 			<position dim="0">1850.92089781596</position>
 			<position dim="1">325.490781803338</position>
 			<intensity>6.74388e+07</intensity>
@@ -2522,7 +1463,7 @@
 				<pt x="1825.08544921875" y="325.875233415938" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_1196373166564353753_7539502987715517688">
+				<feature id="f_17314619952666245179_3023658190814908261">
 					<position dim="0">1850.92089781596</position>
 					<position dim="1">325.490781803338</position>
 					<intensity>4.23901e+07</intensity>
@@ -2637,7 +1578,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.658472827804029"/>
 				</feature>
-				<feature id="f_1196373166564353753_9126387050458671424">
+				<feature id="f_17314619952666245179_7898004582401008768">
 					<position dim="0">1850.92089781596</position>
 					<position dim="1">325.825233415938</position>
 					<intensity>2.18907e+07</intensity>
@@ -2768,11 +1709,11 @@
 			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.999871189538208"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999826193702506"/>
-			<UserParam type="float" name="var_library_corr" value="0.999999999999998"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.000978723446304147"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00177775802217658"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.000978723446304147"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999826193702505"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.000978723446304119"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00177775802205168"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.000978723446304119"/>
 			<UserParam type="float" name="var_library_manhattan" value="0.00105977533224411"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999999467196415"/>
 			<UserParam type="float" name="var_intensity_score" value="0.99657059483216"/>
@@ -2795,18 +1736,1554 @@
 			<UserParam type="int" name="n_total_ids" value="1"/>
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="5409014.21548966"/>
-			<UserParam type="float" name="model_FWHM" value="11.7127762722939"/>
+			<UserParam type="float" name="model_height" value="5409014.21548964"/>
+			<UserParam type="float" name="model_FWHM" value="11.7127762722903"/>
 			<UserParam type="float" name="model_center" value="1850.08683474535"/>
-			<UserParam type="float" name="model_lower" value="1837.65193922011"/>
+			<UserParam type="float" name="model_lower" value="1837.65193922012"/>
 			<UserParam type="float" name="model_upper" value="1862.52173027058"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="4.97395821009415"/>
-			<UserParam type="float" name="model_error" value="0.310756560591184"/>
-			<UserParam type="float" name="model_area" value="67438847.7724187"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="4.97395821009261"/>
+			<UserParam type="float" name="model_error" value="0.31075656059151"/>
+			<UserParam type="float" name="model_area" value="67438847.7723977"/>
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="64280792"/>
 		</feature>
+		<feature id="f_15050004366391181853">
+			<position dim="0">2074.91557012392</position>
+			<position dim="1">554.260602012071</position>
+			<intensity>3.18162e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.6453</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2047.82275390625" y="554.210602012071" />
+				<pt x="2133.37890625" y="554.210602012071" />
+				<pt x="2133.37890625" y="554.310602012071" />
+				<pt x="2047.82275390625" y="554.310602012071" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2047.82275390625" y="554.712279430971" />
+				<pt x="2133.37890625" y="554.712279430971" />
+				<pt x="2133.37890625" y="554.812279430971" />
+				<pt x="2047.82275390625" y="554.812279430971" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_15050004366391181853_17716858074023296841">
+					<position dim="0">2074.91557012392</position>
+					<position dim="1">554.260602012071</position>
+					<intensity>1.02444e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="2050.6005859375" y="0" />
+						<pt x="2053.314453125" y="0" />
+						<pt x="2056.00952148438" y="1464.11181640625" />
+						<pt x="2057.59716796875" y="6656.9111328125" />
+						<pt x="2059.96704101562" y="31106.14453125" />
+						<pt x="2062.72436523438" y="113531.78125" />
+						<pt x="2065.51806640625" y="337220.21875" />
+						<pt x="2068.21630859375" y="780004.0625" />
+						<pt x="2070.92919921875" y="1141430.60449219" />
+						<pt x="2072.11108398438" y="1266922.51293945" />
+						<pt x="2074.3701171875" y="1290034.34765625" />
+						<pt x="2077.0185546875" y="1201289.75" />
+						<pt x="2079.67431640625" y="776324.1875" />
+						<pt x="2082.2451171875" y="508657.53125" />
+						<pt x="2084.91577148438" y="397614.688598633" />
+						<pt x="2087.48876953125" y="340966.21875" />
+						<pt x="2090.21142578125" y="264668.428222656" />
+						<pt x="2092.81127929688" y="210135.4375" />
+						<pt x="2094.08325195312" y="205738.609375" />
+						<pt x="2095.73828125" y="194823.859375" />
+						<pt x="2097.31640625" y="152789.40625" />
+						<pt x="2099.32836914062" y="138612.984375" />
+						<pt x="2101.30908203125" y="125377.640625" />
+						<pt x="2102.9033203125" y="115069.3359375" />
+						<pt x="2104.3916015625" y="103734.84375" />
+						<pt x="2106.23901367188" y="85781.25" />
+						<pt x="2107.77758789062" y="73361.46875" />
+						<pt x="2109.30712890625" y="63799.04296875" />
+						<pt x="2110.5263671875" y="52959.33203125" />
+						<pt x="2112.11962890625" y="50864.953125" />
+						<pt x="2113.7138671875" y="43671.35546875" />
+						<pt x="2115.34301757812" y="39902.0203857422" />
+						<pt x="2117.66967773438" y="27115.052734375" />
+						<pt x="2120.35668945312" y="21859.474609375" />
+						<pt x="2121.99658203125" y="17359.1953125" />
+						<pt x="2123.63012695312" y="15257.845703125" />
+						<pt x="2126.00024414062" y="12886.3564453125" />
+						<pt x="2127.62622070312" y="16277.0492553711" />
+						<pt x="2128.90795898438" y="10384.6552734375" />
+						<pt x="2130.9794921875" y="8795.642578125" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="554.260602012071"/>
+					<UserParam type="string" name="native_id" value="EAC(Carbamidomethyl)FAVEGPK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="1290034.34765625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.630481343594174"/>
+				</feature>
+				<feature id="f_15050004366391181853_16250062551099875712">
+					<position dim="0">2074.91557012392</position>
+					<position dim="1">554.762279430971</position>
+					<intensity>5.96714e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="2050.6005859375" y="0" />
+						<pt x="2053.314453125" y="0" />
+						<pt x="2056.00952148438" y="0" />
+						<pt x="2057.59716796875" y="3326.02905273438" />
+						<pt x="2059.96704101562" y="20605.509765625" />
+						<pt x="2062.72436523438" y="64523.6875" />
+						<pt x="2065.51806640625" y="198748.75" />
+						<pt x="2068.21630859375" y="469266.625" />
+						<pt x="2070.92919921875" y="684896.125" />
+						<pt x="2072.11108398438" y="732414.073486328" />
+						<pt x="2074.3701171875" y="740503.5625" />
+						<pt x="2077.0185546875" y="715651.9375" />
+						<pt x="2079.67431640625" y="467081.90625" />
+						<pt x="2082.2451171875" y="309542.21875" />
+						<pt x="2084.91577148438" y="234674.765625" />
+						<pt x="2087.48876953125" y="185601.147583008" />
+						<pt x="2090.21142578125" y="147670.109375" />
+						<pt x="2092.81127929688" y="132688.296875" />
+						<pt x="2094.08325195312" y="128964.265625" />
+						<pt x="2095.73828125" y="99422.2265625" />
+						<pt x="2097.31640625" y="85598.421875" />
+						<pt x="2099.32836914062" y="76393.4296875" />
+						<pt x="2101.30908203125" y="64358.53125" />
+						<pt x="2102.9033203125" y="65353.8984375" />
+						<pt x="2104.3916015625" y="56986.8203125" />
+						<pt x="2106.23901367188" y="44439.1640625" />
+						<pt x="2107.77758789062" y="41171.45703125" />
+						<pt x="2109.30712890625" y="32239.224609375" />
+						<pt x="2110.5263671875" y="32997.02734375" />
+						<pt x="2112.11962890625" y="23756.591796875" />
+						<pt x="2113.7138671875" y="21147.939453125" />
+						<pt x="2115.34301757812" y="17123.509765625" />
+						<pt x="2117.66967773438" y="20223.796875" />
+						<pt x="2120.35668945312" y="10842.4189453125" />
+						<pt x="2121.99658203125" y="9585.947265625" />
+						<pt x="2123.63012695312" y="8708.2578125" />
+						<pt x="2126.00024414062" y="5408.68408203125" />
+						<pt x="2127.62622070312" y="6814.92529296875" />
+						<pt x="2128.90795898438" y="3961.70703125" />
+						<pt x="2130.9794921875" y="4444.78076171875" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="554.762279430971"/>
+					<UserParam type="string" name="native_id" value="EAC(Carbamidomethyl)FAVEGPK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="740503.5625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.369518656405826"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260375976562" RT="2058.83471679688" >
+				<PeptideHit score="0.0454545454545455" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0548595335303417"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260559082031" RT="2098.17504882812" >
+				<PeptideHit score="0" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="4.91092752369064e-05"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="EAC(Carbamidomethyl)FAVEGPK/2"/>
+			<UserParam type="float" name="leftWidth" value="2047.82275390625"/>
+			<UserParam type="float" name="rightWidth" value="2133.37890625"/>
+			<UserParam type="float" name="total_xic" value="16298802.2630615"/>
+			<UserParam type="float" name="peak_apices_sum" value="2030537.91015625"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999826714315203"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999757773001665"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00144004892103053"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00269456187368486"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00144004892103053"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00151895727538698"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999998886455478"/>
+			<UserParam type="float" name="var_intensity_score" value="0.994648915812717"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="100.706242859935"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.61220779243982"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.99474048614502"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.55149925994001"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.98736710195524"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.368078619241714"/>
+			<UserParam type="float" name="var_massdev_score" value="0.431614306179453"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.347966095008153"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.735829552475677"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.901264010563115"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.6453048191596"/>
+			<UserParam type="float" name="PrecursorMZ" value="554.260602012071"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="2040254.19971613"/>
+			<UserParam type="float" name="model_FWHM" value="14.6497912410151"/>
+			<UserParam type="float" name="model_center" value="2074.59767787736"/>
+			<UserParam type="float" name="model_lower" value="2059.04469374161"/>
+			<UserParam type="float" name="model_upper" value="2090.15066201311"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="6.22119365429846"/>
+			<UserParam type="float" name="model_error" value="0.279655025917838"/>
+			<UserParam type="float" name="model_area" value="31816169.1887067"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="16211586"/>
+		</feature>
+		<feature id="f_16177748921272733768">
+			<position dim="0">1766.28153652464</position>
+			<position dim="1">646.304684132271</position>
+			<intensity>1.23033e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.46475</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1744.55932617188" y="646.254684132271" />
+				<pt x="1848.68237304688" y="646.254684132271" />
+				<pt x="1848.68237304688" y="646.354684132271" />
+				<pt x="1744.55932617188" y="646.354684132271" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1744.55932617188" y="646.756361551171" />
+				<pt x="1848.68237304688" y="646.756361551171" />
+				<pt x="1848.68237304688" y="646.856361551171" />
+				<pt x="1744.55932617188" y="646.856361551171" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_16177748921272733768_1147219038608936718">
+					<position dim="0">1766.28153652464</position>
+					<position dim="1">646.304684132271</position>
+					<intensity>740116</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1744.55932617188" y="0" />
+						<pt x="1746.17114257812" y="0" />
+						<pt x="1747.40344238281" y="0" />
+						<pt x="1749.72985839844" y="0" />
+						<pt x="1751.63122558594" y="0" />
+						<pt x="1753.181640625" y="0" />
+						<pt x="1754.70849609375" y="0" />
+						<pt x="1756.63635253906" y="5618.89599609375" />
+						<pt x="1758.22473144531" y="17633.9375" />
+						<pt x="1759.81530761719" y="28330.728515625" />
+						<pt x="1761.75610351562" y="56678.69921875" />
+						<pt x="1763.34350585938" y="60389.07421875" />
+						<pt x="1764.53942871094" y="62205.6015625" />
+						<pt x="1766.20935058594" y="59630.41796875" />
+						<pt x="1767.45556640625" y="41738.98046875" />
+						<pt x="1768.78759765625" y="38886.83203125" />
+						<pt x="1770.08776855469" y="35996.87109375" />
+						<pt x="1771.37548828125" y="25342.6640625" />
+						<pt x="1772.72485351562" y="19701.9609375" />
+						<pt x="1775.10119628906" y="17275.80859375" />
+						<pt x="1776.7529296875" y="15327.755859375" />
+						<pt x="1778.41467285156" y="18893.212890625" />
+						<pt x="1779.78234863281" y="13283.9326171875" />
+						<pt x="1781.03625488281" y="16514.10546875" />
+						<pt x="1782.70874023438" y="11351.4013671875" />
+						<pt x="1784.005859375" y="10528.86328125" />
+						<pt x="1785.66430664062" y="11620.4384765625" />
+						<pt x="1788.00903320312" y="11422.298828125" />
+						<pt x="1789.64514160156" y="9156.2294921875" />
+						<pt x="1791.29907226562" y="6365.79345703125" />
+						<pt x="1792.96655273438" y="9501.8232421875" />
+						<pt x="1794.18957519531" y="8323.71484375" />
+						<pt x="1796.90112304688" y="7045.005859375" />
+						<pt x="1799.29284667969" y="6350.4130859375" />
+						<pt x="1802.06115722656" y="6942.82080078125" />
+						<pt x="1802.93933105469" y="6853.0361328125" />
+						<pt x="1805.2861328125" y="6175.37451171875" />
+						<pt x="1806.53210449219" y="7108" />
+						<pt x="1807.84582519531" y="4591.65380859375" />
+						<pt x="1809.5546875" y="4195.447265625" />
+						<pt x="1811.23205566406" y="5540.77001953125" />
+						<pt x="1812.84313964844" y="4546.31640625" />
+						<pt x="1814.09313964844" y="4898.837890625" />
+						<pt x="1816.15393066406" y="4239.1513671875" />
+						<pt x="1817.87463378906" y="3863.26171875" />
+						<pt x="1819.56494140625" y="5963.3134765625" />
+						<pt x="1821.21337890625" y="4745.412109375" />
+						<pt x="1823.14038085938" y="3646.91430664062" />
+						<pt x="1825.08544921875" y="4587.80224609375" />
+						<pt x="1827.03564453125" y="5237.30908203125" />
+						<pt x="1828.62902832031" y="3581.37622070312" />
+						<pt x="1829.82446289062" y="5317.24560546875" />
+						<pt x="1831.02966308594" y="4088.28002929687" />
+						<pt x="1832.62158203125" y="3990.6240234375" />
+						<pt x="1834.48815917969" y="3099.44482421875" />
+						<pt x="1836.81677246094" y="3561.595703125" />
+						<pt x="1839.52209472656" y="3956.63305664062" />
+						<pt x="1842.24621582031" y="4270.359375" />
+						<pt x="1843.86376953125" y="0" />
+						<pt x="1846.10339355469" y="0" />
+						<pt x="1847.20849609375" y="0" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="646.304684132271"/>
+					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="59630.41796875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
+				</feature>
+				<feature id="f_16177748921272733768_11115414975438642789">
+					<position dim="0">1766.28153652464</position>
+					<position dim="1">646.806361551171</position>
+					<intensity>413408</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1744.55932617188" y="0" />
+						<pt x="1746.17114257812" y="0" />
+						<pt x="1747.40344238281" y="0" />
+						<pt x="1749.72985839844" y="0" />
+						<pt x="1751.63122558594" y="0" />
+						<pt x="1753.181640625" y="0" />
+						<pt x="1754.70849609375" y="0" />
+						<pt x="1756.63635253906" y="4794.111328125" />
+						<pt x="1758.22473144531" y="9616.705078125" />
+						<pt x="1759.81530761719" y="16590.177734375" />
+						<pt x="1761.75610351562" y="34365.33203125" />
+						<pt x="1763.34350585938" y="36101.05859375" />
+						<pt x="1764.53942871094" y="37560.74609375" />
+						<pt x="1766.20935058594" y="32722.078125" />
+						<pt x="1767.45556640625" y="25932.046875" />
+						<pt x="1768.78759765625" y="20847.99609375" />
+						<pt x="1770.08776855469" y="20277.916015625" />
+						<pt x="1771.37548828125" y="15145.2177734375" />
+						<pt x="1772.72485351562" y="14357.904296875" />
+						<pt x="1775.10119628906" y="9716.0048828125" />
+						<pt x="1776.7529296875" y="9807.6201171875" />
+						<pt x="1778.41467285156" y="8012.634765625" />
+						<pt x="1779.78234863281" y="7657.19287109375" />
+						<pt x="1781.03625488281" y="7050.89892578125" />
+						<pt x="1782.70874023438" y="7264.6962890625" />
+						<pt x="1784.005859375" y="5521.16455078125" />
+						<pt x="1785.66430664062" y="7948.07568359375" />
+						<pt x="1788.00903320312" y="4186.552734375" />
+						<pt x="1789.64514160156" y="5509.72412109375" />
+						<pt x="1791.29907226562" y="5880.82421875" />
+						<pt x="1792.96655273438" y="3936.30395507812" />
+						<pt x="1794.18957519531" y="4454.94921875" />
+						<pt x="1796.90112304688" y="4287.3330078125" />
+						<pt x="1799.29284667969" y="4434.11572265625" />
+						<pt x="1802.06115722656" y="3715.302734375" />
+						<pt x="1802.93933105469" y="3319.2236328125" />
+						<pt x="1805.2861328125" y="3812.72485351563" />
+						<pt x="1806.53210449219" y="3350.0712890625" />
+						<pt x="1807.84582519531" y="4502.27392578125" />
+						<pt x="1809.5546875" y="2826.93774414062" />
+						<pt x="1811.23205566406" y="2564.65551757812" />
+						<pt x="1812.84313964844" y="2605.59033203125" />
+						<pt x="1814.09313964844" y="3408.65600585938" />
+						<pt x="1816.15393066406" y="2960.27709960938" />
+						<pt x="1817.87463378906" y="1310.25646972656" />
+						<pt x="1819.56494140625" y="2919.8310546875" />
+						<pt x="1821.21337890625" y="2963.24169921875" />
+						<pt x="1823.14038085938" y="0" />
+						<pt x="1825.08544921875" y="0" />
+						<pt x="1827.03564453125" y="0" />
+						<pt x="1828.62902832031" y="0" />
+						<pt x="1829.82446289062" y="0" />
+						<pt x="1831.02966308594" y="0" />
+						<pt x="1832.62158203125" y="3439.13891601562" />
+						<pt x="1834.48815917969" y="1739.96130371094" />
+						<pt x="1836.81677246094" y="0" />
+						<pt x="1839.52209472656" y="2127.626953125" />
+						<pt x="1842.24621582031" y="1862.63549804688" />
+						<pt x="1843.86376953125" y="0" />
+						<pt x="1846.10339355469" y="0" />
+						<pt x="1847.20849609375" y="0" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="646.806361551171"/>
+					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="32722.078125"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.397061689621381"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.304504394531" RT="1759.0947265625" >
+				<PeptideHit score="0.0454545454545455" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.161429888187637"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" >
+				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0423622396613216"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2"/>
+			<UserParam type="float" name="leftWidth" value="1744.55932617188"/>
+			<UserParam type="float" name="rightWidth" value="1848.68237304688"/>
+			<UserParam type="float" name="total_xic" value="1258179.40576172"/>
+			<UserParam type="float" name="peak_apices_sum" value="92352.49609375"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.996687864987247"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.995242375653698"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0386749522384563"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0729584275113503"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0386749522384563"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0405203562071071"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999204154558718"/>
+			<UserParam type="float" name="var_intensity_score" value="0.91682016468998"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="90.4728415543284"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.50504971234653"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.980602443218231"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.3707575924871"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.968902708499444"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.358386725187302"/>
+			<UserParam type="float" name="var_massdev_score" value="0.552052115383353"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.543039773386319"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.64068624221483"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.04013836171084"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.46474611990348"/>
+			<UserParam type="float" name="PrecursorMZ" value="646.304684132271"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="93547.917902052"/>
+			<UserParam type="float" name="model_FWHM" value="12.3554037030781"/>
+			<UserParam type="float" name="model_center" value="1765.18563964854"/>
+			<UserParam type="float" name="model_lower" value="1752.06849725223"/>
+			<UserParam type="float" name="model_upper" value="1778.30278204486"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="5.24685695852682"/>
+			<UserParam type="float" name="model_error" value="0.362565251427283"/>
+			<UserParam type="float" name="model_area" value="1230334.59810182"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="1153524.25"/>
+		</feature>
+		<feature id="f_12665713047548007769">
+			<position dim="0">1766.55652075376</position>
+			<position dim="1">431.205548243771</position>
+			<intensity>1.24277e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>3.70728</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1746.17114257812" y="431.155548243771" />
+				<pt x="1918.98767089844" y="431.155548243771" />
+				<pt x="1918.98767089844" y="431.255548243771" />
+				<pt x="1746.17114257812" y="431.255548243771" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1746.17114257812" y="431.489999856371" />
+				<pt x="1918.98767089844" y="431.489999856371" />
+				<pt x="1918.98767089844" y="431.589999856371" />
+				<pt x="1746.17114257812" y="431.589999856371" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_12665713047548007769_17092894204355333314">
+					<position dim="0">1766.55652075376</position>
+					<position dim="1">431.205548243771</position>
+					<intensity>8.63596e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1747.40344238281" y="0" />
+						<pt x="1749.72985839844" y="0" />
+						<pt x="1751.63122558594" y="0" />
+						<pt x="1753.181640625" y="3893.10473632812" />
+						<pt x="1754.70849609375" y="17853.01171875" />
+						<pt x="1756.63635253906" y="63899.55078125" />
+						<pt x="1758.22473144531" y="153680.9375" />
+						<pt x="1759.81530761719" y="301562.913085938" />
+						<pt x="1761.75610351562" y="478558.21875" />
+						<pt x="1763.34350585938" y="567884.814697266" />
+						<pt x="1764.53942871094" y="576804.491455078" />
+						<pt x="1766.20935058594" y="536289.844238281" />
+						<pt x="1767.45556640625" y="429313.012939453" />
+						<pt x="1768.78759765625" y="391838.75" />
+						<pt x="1770.08776855469" y="334616.15625" />
+						<pt x="1771.37548828125" y="257977.0625" />
+						<pt x="1772.72485351562" y="232562.185668945" />
+						<pt x="1775.10119628906" y="177309.921875" />
+						<pt x="1776.7529296875" y="172382.671875" />
+						<pt x="1778.41467285156" y="152055.890625" />
+						<pt x="1779.78234863281" y="155505.234375" />
+						<pt x="1781.03625488281" y="136960.15625" />
+						<pt x="1782.70874023438" y="125436.703125" />
+						<pt x="1784.005859375" y="121897.375" />
+						<pt x="1785.66430664062" y="115781.9140625" />
+						<pt x="1788.00903320312" y="114228.671875" />
+						<pt x="1789.64514160156" y="106950.828125" />
+						<pt x="1791.29907226562" y="102316.3984375" />
+						<pt x="1792.96655273438" y="95473.234375" />
+						<pt x="1794.18957519531" y="83683.625" />
+						<pt x="1796.90112304688" y="79988.0625" />
+						<pt x="1799.29284667969" y="73219.921875" />
+						<pt x="1802.06115722656" y="73837.3359375" />
+						<pt x="1802.93933105469" y="77921.0859375" />
+						<pt x="1805.2861328125" y="63842.875" />
+						<pt x="1806.53210449219" y="59494.83984375" />
+						<pt x="1807.84582519531" y="62523.7578125" />
+						<pt x="1809.5546875" y="58562.9140625" />
+						<pt x="1811.23205566406" y="62712.15234375" />
+						<pt x="1812.84313964844" y="57009.78125" />
+						<pt x="1814.09313964844" y="59816.4921875" />
+						<pt x="1816.15393066406" y="48252.92578125" />
+						<pt x="1817.87463378906" y="59158.484375" />
+						<pt x="1819.56494140625" y="55579.75390625" />
+						<pt x="1821.21337890625" y="58156.49609375" />
+						<pt x="1823.14038085938" y="52843.16796875" />
+						<pt x="1825.08544921875" y="47516.26953125" />
+						<pt x="1827.03564453125" y="53623.5078125" />
+						<pt x="1828.62902832031" y="44575.81640625" />
+						<pt x="1829.82446289062" y="43441.4609375" />
+						<pt x="1831.02966308594" y="47902.91796875" />
+						<pt x="1832.62158203125" y="49981.47265625" />
+						<pt x="1834.48815917969" y="42807.09375" />
+						<pt x="1836.81677246094" y="43721.14453125" />
+						<pt x="1839.52209472656" y="43136.39453125" />
+						<pt x="1842.24621582031" y="34536.1796875" />
+						<pt x="1843.86376953125" y="34576.76171875" />
+						<pt x="1846.10339355469" y="37851.37109375" />
+						<pt x="1847.20849609375" y="38154.3046875" />
+						<pt x="1848.68237304688" y="40636.2578125" />
+						<pt x="1850.09631347656" y="39506.81640625" />
+						<pt x="1851.12512207031" y="43529.86328125" />
+						<pt x="1853.71057128906" y="45555.0546875" />
+						<pt x="1855.52624511719" y="39585.0625" />
+						<pt x="1857.064453125" y="37899.3984375" />
+						<pt x="1858.97082519531" y="33756.015625" />
+						<pt x="1861.28601074219" y="35045.8046875" />
+						<pt x="1863.56823730469" y="36440.2109375" />
+						<pt x="1865.85095214844" y="33016.1015625" />
+						<pt x="1867.78442382812" y="32963.625" />
+						<pt x="1869.03576660156" y="38026.78515625" />
+						<pt x="1871.33630371094" y="35044.1171875" />
+						<pt x="1872.57312011719" y="40903.34765625" />
+						<pt x="1874.54077148438" y="30388.6796875" />
+						<pt x="1876.48901367188" y="34719.51953125" />
+						<pt x="1878.7314453125" y="34117.0848388672" />
+						<pt x="1881.08850097656" y="28225.4255371094" />
+						<pt x="1883.11645507812" y="35310.9515380859" />
+						<pt x="1885.83068847656" y="29596.2572021484" />
+						<pt x="1887.43872070312" y="29664.5765380859" />
+						<pt x="1890.11450195312" y="30201.7828369141" />
+						<pt x="1892.81237792969" y="26844.25" />
+						<pt x="1895.1689453125" y="30084.345703125" />
+						<pt x="1897.92785644531" y="23347.78125" />
+						<pt x="1900.26635742188" y="22483.48828125" />
+						<pt x="1902.93041992188" y="28873.224609375" />
+						<pt x="1904.12365722656" y="23925.6953125" />
+						<pt x="1906.11572265625" y="25751.412109375" />
+						<pt x="1908.81591796875" y="26212.3203125" />
+						<pt x="1911.60192871094" y="23676.900390625" />
+						<pt x="1914.27954101562" y="21842.6328125" />
+						<pt x="1916.62109375" y="27326.400390625" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="431.205548243771"/>
+					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="536289.844238281"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
+				</feature>
+				<feature id="f_12665713047548007769_3491056946625602141">
+					<position dim="0">1766.55652075376</position>
+					<position dim="1">431.539999856371</position>
+					<intensity>5.51648e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1747.40344238281" y="0" />
+						<pt x="1749.72985839844" y="0" />
+						<pt x="1751.63122558594" y="0" />
+						<pt x="1753.181640625" y="5043.9580078125" />
+						<pt x="1754.70849609375" y="10526.390625" />
+						<pt x="1756.63635253906" y="46748.43359375" />
+						<pt x="1758.22473144531" y="104771.28125" />
+						<pt x="1759.81530761719" y="203016.453125" />
+						<pt x="1761.75610351562" y="328397.6875" />
+						<pt x="1763.34350585938" y="371091.34375" />
+						<pt x="1764.53942871094" y="383256.839111328" />
+						<pt x="1766.20935058594" y="332317.34375" />
+						<pt x="1767.45556640625" y="289202.130737305" />
+						<pt x="1768.78759765625" y="246120.03125" />
+						<pt x="1770.08776855469" y="223702.078125" />
+						<pt x="1771.37548828125" y="174255.578125" />
+						<pt x="1772.72485351562" y="159775.203125" />
+						<pt x="1775.10119628906" y="128084.9453125" />
+						<pt x="1776.7529296875" y="112418.21875" />
+						<pt x="1778.41467285156" y="99594.5859375" />
+						<pt x="1779.78234863281" y="93866.28125" />
+						<pt x="1781.03625488281" y="96036.203125" />
+						<pt x="1782.70874023438" y="85240.7109375" />
+						<pt x="1784.005859375" y="82254.15625" />
+						<pt x="1785.66430664062" y="76704.6640625" />
+						<pt x="1788.00903320312" y="74431.9609375" />
+						<pt x="1789.64514160156" y="68738.9453125" />
+						<pt x="1791.29907226562" y="72554.4296875" />
+						<pt x="1792.96655273438" y="71128.765625" />
+						<pt x="1794.18957519531" y="56707.1796875" />
+						<pt x="1796.90112304688" y="55151.66015625" />
+						<pt x="1799.29284667969" y="50673.26953125" />
+						<pt x="1802.06115722656" y="39306.8125" />
+						<pt x="1802.93933105469" y="42695.1875" />
+						<pt x="1805.2861328125" y="33672.05859375" />
+						<pt x="1806.53210449219" y="44182.81640625" />
+						<pt x="1807.84582519531" y="35600.05078125" />
+						<pt x="1809.5546875" y="37480.9921875" />
+						<pt x="1811.23205566406" y="40265.625" />
+						<pt x="1812.84313964844" y="36055.83984375" />
+						<pt x="1814.09313964844" y="36424.79296875" />
+						<pt x="1816.15393066406" y="32929.71875" />
+						<pt x="1817.87463378906" y="35810.68359375" />
+						<pt x="1819.56494140625" y="35488.546875" />
+						<pt x="1821.21337890625" y="39133.82421875" />
+						<pt x="1823.14038085938" y="32421.828125" />
+						<pt x="1825.08544921875" y="25253.21484375" />
+						<pt x="1827.03564453125" y="29905.49609375" />
+						<pt x="1828.62902832031" y="24240.64453125" />
+						<pt x="1829.82446289062" y="22994.6875" />
+						<pt x="1831.02966308594" y="26960.76171875" />
+						<pt x="1832.62158203125" y="30486.85546875" />
+						<pt x="1834.48815917969" y="27260.103515625" />
+						<pt x="1836.81677246094" y="26864.091796875" />
+						<pt x="1839.52209472656" y="18236.869140625" />
+						<pt x="1842.24621582031" y="16691.56640625" />
+						<pt x="1843.86376953125" y="25199.42578125" />
+						<pt x="1846.10339355469" y="18786.236328125" />
+						<pt x="1847.20849609375" y="20379.953125" />
+						<pt x="1848.68237304688" y="16349.81640625" />
+						<pt x="1850.09631347656" y="19790.80859375" />
+						<pt x="1851.12512207031" y="23057.232421875" />
+						<pt x="1853.71057128906" y="19746.009765625" />
+						<pt x="1855.52624511719" y="24023.46484375" />
+						<pt x="1857.064453125" y="15847.3330078125" />
+						<pt x="1858.97082519531" y="21433.52734375" />
+						<pt x="1861.28601074219" y="22632.181640625" />
+						<pt x="1863.56823730469" y="25753.09375" />
+						<pt x="1865.85095214844" y="19353.47265625" />
+						<pt x="1867.78442382812" y="20177.392578125" />
+						<pt x="1869.03576660156" y="21811.146484375" />
+						<pt x="1871.33630371094" y="20310" />
+						<pt x="1872.57312011719" y="21205.9609375" />
+						<pt x="1874.54077148438" y="19003.294921875" />
+						<pt x="1876.48901367188" y="15160.271484375" />
+						<pt x="1878.7314453125" y="16183.14453125" />
+						<pt x="1881.08850097656" y="20049.296875" />
+						<pt x="1883.11645507812" y="16959.734375" />
+						<pt x="1885.83068847656" y="18829.41015625" />
+						<pt x="1887.43872070312" y="16984.279296875" />
+						<pt x="1890.11450195312" y="17107.35546875" />
+						<pt x="1892.81237792969" y="13349.96875" />
+						<pt x="1895.1689453125" y="13224.87109375" />
+						<pt x="1897.92785644531" y="11749.224609375" />
+						<pt x="1900.26635742188" y="13628.0458984375" />
+						<pt x="1902.93041992188" y="11071.6982421875" />
+						<pt x="1904.12365722656" y="15864.44921875" />
+						<pt x="1906.11572265625" y="11922.4189453125" />
+						<pt x="1908.81591796875" y="14101.6875" />
+						<pt x="1911.60192871094" y="13337.5771484375" />
+						<pt x="1914.27954101562" y="13005.681640625" />
+						<pt x="1916.62109375" y="16918.73046875" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="431.539999856371"/>
+					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="332317.34375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.397061689621381"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" >
+				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.042177146646692"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3"/>
+			<UserParam type="float" name="leftWidth" value="1746.17114257812"/>
+			<UserParam type="float" name="rightWidth" value="1918.98767089844"/>
+			<UserParam type="float" name="total_xic" value="14319538.267334"/>
+			<UserParam type="float" name="peak_apices_sum" value="868607.187988281"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999360251977443"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999081051721655"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0072716568743896"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0139110994886304"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0072716568743896"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00752932229758962"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999972302719226"/>
+			<UserParam type="float" name="var_intensity_score" value="0.988331099493958"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="22.6689159856313"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.12099464624477"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.981038093566895"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.46880384807173"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.98312975722697"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.389790028333664"/>
+			<UserParam type="float" name="var_massdev_score" value="0.344572194406841"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.300077406541411"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.712039883282362"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.04508823818716"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.7072817470113"/>
+			<UserParam type="float" name="PrecursorMZ" value="431.205548243771"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="860182.075689536"/>
+			<UserParam type="float" name="model_FWHM" value="13.5727897372274"/>
+			<UserParam type="float" name="model_center" value="1765.71798463299"/>
+			<UserParam type="float" name="model_lower" value="1751.30840158925"/>
+			<UserParam type="float" name="model_upper" value="1780.12756767674"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="5.76383321749749"/>
+			<UserParam type="float" name="model_error" value="0.674733694165893"/>
+			<UserParam type="float" name="model_area" value="12427726.3186151"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="14152445"/>
+		</feature>
+		<feature id="f_10627069796380146481">
+			<position dim="0">2007.51161653761</position>
+			<position dim="1">379.715100772821</position>
+			<intensity>6.46014e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.57056</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1974.81298828125" y="379.665100772821" />
+				<pt x="2079.67431640625" y="379.665100772821" />
+				<pt x="2079.67431640625" y="379.765100772821" />
+				<pt x="1974.81298828125" y="379.765100772821" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1974.81298828125" y="380.166778191721" />
+				<pt x="2079.67431640625" y="380.166778191721" />
+				<pt x="2079.67431640625" y="380.266778191721" />
+				<pt x="1974.81298828125" y="380.266778191721" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_10627069796380146481_10052793688680741109">
+					<position dim="0">2007.51161653761</position>
+					<position dim="1">379.715100772821</position>
+					<intensity>2.2799e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1977.380859375" y="5343.935546875" />
+						<pt x="1979.2890625" y="10122.3056640625" />
+						<pt x="1980.87292480469" y="14866.7265625" />
+						<pt x="1982.46655273438" y="29726.138671875" />
+						<pt x="1984.07604980469" y="50026.51953125" />
+						<pt x="1985.6865234375" y="79834.8515625" />
+						<pt x="1986.94934082031" y="117087.8984375" />
+						<pt x="1989.31274414062" y="200441.109375" />
+						<pt x="1991.31884765625" y="308676.6875" />
+						<pt x="1993.19482421875" y="454452.4375" />
+						<pt x="1995.119140625" y="696092.209228516" />
+						<pt x="1997.05432128906" y="952511.767089844" />
+						<pt x="1998.99108886719" y="1233409.55786133" />
+						<pt x="2000.96350097656" y="1505903.34631348" />
+						<pt x="2002.17077636719" y="1926265.09326172" />
+						<pt x="2004.77075195312" y="2131711.69482422" />
+						<pt x="2007.42565917969" y="2254385.11621094" />
+						<pt x="2010.10522460938" y="2180638.93164062" />
+						<pt x="2012.57043457031" y="1773602.20410156" />
+						<pt x="2014.81372070312" y="1391961.25" />
+						<pt x="2016.57385253906" y="1076110.26074219" />
+						<pt x="2019.23095703125" y="799858.0625" />
+						<pt x="2021.03356933594" y="640803.1875" />
+						<pt x="2023.54016113281" y="473214.90625" />
+						<pt x="2026.06115722656" y="378525.71875" />
+						<pt x="2028.66284179688" y="297604.1875" />
+						<pt x="2031.287109375" y="254117.90625" />
+						<pt x="2033.83422851562" y="204335.0625" />
+						<pt x="2036.53295898438" y="160107.21875" />
+						<pt x="2038.14636230469" y="171379.140625" />
+						<pt x="2040.25524902344" y="143065.578125" />
+						<pt x="2042.58959960938" y="149759.90625" />
+						<pt x="2045.21923828125" y="110920.4140625" />
+						<pt x="2047.82275390625" y="95053.34375" />
+						<pt x="2050.6005859375" y="81308.25" />
+						<pt x="2053.314453125" y="67745.0703125" />
+						<pt x="2056.00952148438" y="68310.0234375" />
+						<pt x="2057.59716796875" y="58802.84765625" />
+						<pt x="2059.96704101562" y="45729.27734375" />
+						<pt x="2062.72436523438" y="38095.62890625" />
+						<pt x="2065.51806640625" y="33166.87109375" />
+						<pt x="2068.21630859375" y="35984.1953125" />
+						<pt x="2070.92919921875" y="27664.173828125" />
+						<pt x="2072.11108398438" y="24341.630859375" />
+						<pt x="2074.3701171875" y="23377.802734375" />
+						<pt x="2077.0185546875" y="22594.8984375" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="379.715100772821"/>
+					<UserParam type="string" name="native_id" value="GAC(Carbamidomethyl)LLPK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="2254385.11621094"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.710034950213183"/>
+				</feature>
+				<feature id="f_10627069796380146481_15166508592180818156">
+					<position dim="0">2007.51161653761</position>
+					<position dim="1">380.216778191721</position>
+					<intensity>8.9969e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1977.380859375" y="0" />
+						<pt x="1979.2890625" y="0" />
+						<pt x="1980.87292480469" y="4553.60986328125" />
+						<pt x="1982.46655273438" y="8400.7412109375" />
+						<pt x="1984.07604980469" y="15770.0460205078" />
+						<pt x="1985.6865234375" y="26215.04296875" />
+						<pt x="1986.94934082031" y="38516.140625" />
+						<pt x="1989.31274414062" y="64205.30859375" />
+						<pt x="1991.31884765625" y="113444.59375" />
+						<pt x="1993.19482421875" y="188749.722290039" />
+						<pt x="1995.119140625" y="278151.125" />
+						<pt x="1997.05432128906" y="391664.5" />
+						<pt x="1998.99108886719" y="491383.5625" />
+						<pt x="2000.96350097656" y="621691.939697266" />
+						<pt x="2002.17077636719" y="793325.3125" />
+						<pt x="2004.77075195312" y="884184.929199219" />
+						<pt x="2007.42565917969" y="911381.791015625" />
+						<pt x="2010.10522460938" y="907719.744140625" />
+						<pt x="2012.57043457031" y="699974" />
+						<pt x="2014.81372070312" y="576524.125" />
+						<pt x="2016.57385253906" y="419844.15625" />
+						<pt x="2019.23095703125" y="321471" />
+						<pt x="2021.03356933594" y="231057.0625" />
+						<pt x="2023.54016113281" y="163966.984375" />
+						<pt x="2026.06115722656" y="131360" />
+						<pt x="2028.66284179688" y="107665.3515625" />
+						<pt x="2031.287109375" y="93214.8984375" />
+						<pt x="2033.83422851562" y="73707.421875" />
+						<pt x="2036.53295898438" y="57697.23046875" />
+						<pt x="2038.14636230469" y="60205.05859375" />
+						<pt x="2040.25524902344" y="43696.06640625" />
+						<pt x="2042.58959960938" y="52858.5546875" />
+						<pt x="2045.21923828125" y="38286.71484375" />
+						<pt x="2047.82275390625" y="29519.384765625" />
+						<pt x="2050.6005859375" y="25218.064453125" />
+						<pt x="2053.314453125" y="21741.349609375" />
+						<pt x="2056.00952148438" y="18290.69140625" />
+						<pt x="2057.59716796875" y="16849.134765625" />
+						<pt x="2059.96704101562" y="9788.75" />
+						<pt x="2062.72436523438" y="16186.9150390625" />
+						<pt x="2065.51806640625" y="9978.5498046875" />
+						<pt x="2068.21630859375" y="10535.7646484375" />
+						<pt x="2070.92919921875" y="8868.109375" />
+						<pt x="2072.11108398438" y="6984.0244140625" />
+						<pt x="2074.3701171875" y="5154.5439453125" />
+						<pt x="2077.0185546875" y="6898.37841796875" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="380.216778191721"/>
+					<UserParam type="string" name="native_id" value="GAC(Carbamidomethyl)LLPK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="911381.791015625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.289965049786817"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.71484375" RT="2010.87902832031" >
+				<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.00167901373867858"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715118408203" RT="2032.04125976562" >
+				<PeptideHit score="0" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.00115485160103966"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="379.715393066406" RT="2069.04321289062" >
+				<PeptideHit score="0.0344827586206897" sequence="GAC(Carbamidomethyl)LLPK" charge="2" aa_before="K" aa_after="I" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.00937487962378574"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="GAC(Carbamidomethyl)LLPK/2"/>
+			<UserParam type="float" name="leftWidth" value="1974.81298828125"/>
+			<UserParam type="float" name="rightWidth" value="2079.67431640625"/>
+			<UserParam type="float" name="total_xic" value="32007549.9432983"/>
+			<UserParam type="float" name="peak_apices_sum" value="3165766.90722656"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999815237705664"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999771760935785"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00700750452065474"/>
+			<UserParam type="float" name="var_library_sangle" value="0.011853004652809"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00700750452065474"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00813985718240695"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999969969287405"/>
+			<UserParam type="float" name="var_intensity_score" value="0.993388624131706"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="91.3637373498437"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.51484865301587"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.99712461233139"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.45924885107846"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.989964675776816"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.282957553863525"/>
+			<UserParam type="float" name="var_massdev_score" value="0.807860618118897"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.504204576189409"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.774286696585701"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.917152435225103"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.57055511048922"/>
+			<UserParam type="float" name="PrecursorMZ" value="379.715100772821"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="3"/>
+			<UserParam type="int" name="n_matching_ids" value="3"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="3096261.22539644"/>
+			<UserParam type="float" name="model_FWHM" value="19.6007396688333"/>
+			<UserParam type="float" name="model_center" value="2007.57358304916"/>
+			<UserParam type="float" name="model_lower" value="1986.76441327309"/>
+			<UserParam type="float" name="model_upper" value="2028.38275282523"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="8.32366791042767"/>
+			<UserParam type="float" name="model_error" value="0.130467244129719"/>
+			<UserParam type="float" name="model_area" value="64601443.9846876"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="31795936"/>
+		</feature>
+		<feature id="f_15885522598119108466">
+			<position dim="0">1871.44516101075</position>
+			<position dim="1">408.874238280604</position>
+			<intensity>542935</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.203844</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1857.064453125" y="408.824238280604" />
+				<pt x="1890.11450195312" y="408.824238280604" />
+				<pt x="1890.11450195312" y="408.924238280604" />
+				<pt x="1857.064453125" y="408.924238280604" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1857.064453125" y="409.158689893204" />
+				<pt x="1890.11450195312" y="409.158689893204" />
+				<pt x="1890.11450195312" y="409.258689893204" />
+				<pt x="1857.064453125" y="409.258689893204" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_15885522598119108466_15120290131060441429">
+					<position dim="0">1871.44516101075</position>
+					<position dim="1">408.874238280604</position>
+					<intensity>221846</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1858.97082519531" y="12906.677734375" />
+						<pt x="1861.28601074219" y="9272.8466796875" />
+						<pt x="1863.56823730469" y="16160.4775390625" />
+						<pt x="1865.85095214844" y="13390.771484375" />
+						<pt x="1867.78442382812" y="13748.63671875" />
+						<pt x="1869.03576660156" y="17559.25" />
+						<pt x="1871.33630371094" y="14049.859375" />
+						<pt x="1872.57312011719" y="18097.568359375" />
+						<pt x="1874.54077148438" y="16522.45703125" />
+						<pt x="1876.48901367188" y="14085.330078125" />
+						<pt x="1878.7314453125" y="15600.0869140625" />
+						<pt x="1881.08850097656" y="13224.568359375" />
+						<pt x="1883.11645507812" y="12551.59765625" />
+						<pt x="1885.83068847656" y="12279.8447265625" />
+						<pt x="1887.43872070312" y="11758.8017578125" />
+						<pt x="1890.11450195312" y="10637.1318359375" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="408.874238280604"/>
+					<UserParam type="string" name="native_id" value="GM(Oxidation)LWAVFEQK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="14049.859375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.592413860111113"/>
+				</feature>
+				<feature id="f_15885522598119108466_11275867043381640475">
+					<position dim="0">1871.44516101075</position>
+					<position dim="1">409.208689893204</position>
+					<intensity>129627</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1858.97082519531" y="16764.3017578125" />
+						<pt x="1861.28601074219" y="14427.9965820312" />
+						<pt x="1863.56823730469" y="10278.5107421875" />
+						<pt x="1865.85095214844" y="6389.40234375" />
+						<pt x="1867.78442382812" y="8206.42602539062" />
+						<pt x="1869.03576660156" y="6546.6787109375" />
+						<pt x="1871.33630371094" y="4732.01318359375" />
+						<pt x="1872.57312011719" y="7897.94189453125" />
+						<pt x="1874.54077148438" y="5348.26123046875" />
+						<pt x="1876.48901367188" y="6070.77587890625" />
+						<pt x="1878.7314453125" y="6539.49462890625" />
+						<pt x="1881.08850097656" y="6765.68701171875" />
+						<pt x="1883.11645507812" y="7404.810546875" />
+						<pt x="1885.83068847656" y="7710.93310546875" />
+						<pt x="1887.43872070312" y="7260.2060546875" />
+						<pt x="1890.11450195312" y="7283.57177734375" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="409.208689893204"/>
+					<UserParam type="string" name="native_id" value="GM(Oxidation)LWAVFEQK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="4732.01318359375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.407586139888887"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="408.840087890625" RT="1880.01599121094" >
+				<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_5">
+					<UserParam type="float" name="OMSSA_score" value="0.0850109548251393"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="GM(Oxidation)LWAVFEQK/3"/>
+			<UserParam type="float" name="leftWidth" value="1857.064453125"/>
+			<UserParam type="float" name="rightWidth" value="1890.11450195312"/>
+			<UserParam type="float" name="total_xic" value="2487624.58416748"/>
+			<UserParam type="float" name="peak_apices_sum" value="18781.8725585938"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="6.37478521766071"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="3.38043549843109"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.859158419623954"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.795954623732148"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0387753364781598"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0738293770300613"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0387753364781598"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0403113938333929"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999208292111752"/>
+			<UserParam type="float" name="var_intensity_score" value="0.141288564394706"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="0.826036901072732"/>
+			<UserParam type="float" name="var_log_sn_score" value="0"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.857296228408813"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="2.92605467806292"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0"/>
+			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0"/>
+			<UserParam type="float" name="var_manhatt_score" value="2"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.203844374870718"/>
+			<UserParam type="float" name="PrecursorMZ" value="408.874238280604"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="24532.9566900487"/>
+			<UserParam type="float" name="model_FWHM" value="60.9208285308909"/>
+			<UserParam type="float" name="model_center" value="1869.57950255092"/>
+			<UserParam type="float" name="model_lower" value="1804.9027666105"/>
+			<UserParam type="float" name="model_upper" value="1934.25623849135"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="25.8706943761693"/>
+			<UserParam type="float" name="model_error" value="0.19478306804981"/>
+			<UserParam type="float" name="model_area" value="1590918.25137245"/>
+			<UserParam type="string" name="model_status" value="3 (left side out of bounds)"/>
+			<UserParam type="float" name="raw_intensity" value="351472.90625"/>
+		</feature>
+		<feature id="f_17569764383250687096">
+			<position dim="0">2298.14719526402</position>
+			<position dim="1">435.910228820904</position>
+			<intensity>225627</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>2.28768</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="2290.19189453125" y="435.860228820904" />
+				<pt x="2307.17138671875" y="435.860228820904" />
+				<pt x="2307.17138671875" y="435.960228820904" />
+				<pt x="2290.19189453125" y="435.960228820904" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2290.19189453125" y="436.194680433504" />
+				<pt x="2307.17138671875" y="436.194680433504" />
+				<pt x="2307.17138671875" y="436.294680433504" />
+				<pt x="2290.19189453125" y="436.294680433504" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_17569764383250687096_14317784148091680644">
+					<position dim="0">2298.14719526402</position>
+					<position dim="1">435.910228820904</position>
+					<intensity>70587.9</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="2292.24267578125" y="1960.69494628906" />
+						<pt x="2294.96948242188" y="11676.0048828125" />
+						<pt x="2297.37475585938" y="15366.9287109375" />
+						<pt x="2299.36645507812" y="16826.505859375" />
+						<pt x="2300.96337890625" y="13613.5927734375" />
+						<pt x="2302.21069335938" y="7983.30078125" />
+						<pt x="2303.49438476562" y="3160.84594726562" />
+						<pt x="2305.9091796875" y="0" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="435.910228820904"/>
+					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="15366.9287109375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.586748524736467"/>
+				</feature>
+				<feature id="f_17569764383250687096_17671779025680303814">
+					<position dim="0">2298.14719526402</position>
+					<position dim="1">436.244680433504</position>
+					<intensity>36564</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="2292.24267578125" y="2089.2724609375" />
+						<pt x="2294.96948242188" y="6488.93212890625" />
+						<pt x="2297.37475585938" y="8652.01141357422" />
+						<pt x="2299.36645507812" y="8293.5869140625" />
+						<pt x="2300.96337890625" y="5264.36767578125" />
+						<pt x="2302.21069335938" y="3496.77294921875" />
+						<pt x="2303.49438476562" y="2279.04956054688" />
+						<pt x="2305.9091796875" y="0" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="436.244680433504"/>
+					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="8652.01141357422"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.413251475263533"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.909851074219" RT="2295.90209960938" >
+				<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0137458569950031"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="HLVDEPQNLIK/3"/>
+			<UserParam type="float" name="leftWidth" value="2290.19189453125"/>
+			<UserParam type="float" name="rightWidth" value="2307.17138671875"/>
+			<UserParam type="float" name="total_xic" value="10639599.0813599"/>
+			<UserParam type="float" name="peak_apices_sum" value="24018.9401245117"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.987321606844706"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.981554863036929"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999998"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0720162439304342"/>
+			<UserParam type="float" name="var_library_sangle" value="0.13567334952461"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0720162439304342"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0755707134178571"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.997235692613535"/>
+			<UserParam type="float" name="var_intensity_score" value="0.0100710436895339"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="2.98262189450483"/>
+			<UserParam type="float" name="var_log_sn_score" value="1.0928027440642"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.98598974943161"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="4.71687160277937"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.958229731481322"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.341235220432281"/>
+			<UserParam type="float" name="var_massdev_score" value="0.295951363727171"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.283335711262804"/>
+			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.654268103487712"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.07431043140929"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.28767931417546"/>
+			<UserParam type="float" name="PrecursorMZ" value="435.910228820904"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="28333.8884113636"/>
+			<UserParam type="float" name="model_FWHM" value="7.48087654092941"/>
+			<UserParam type="float" name="model_center" value="2298.20512415454"/>
+			<UserParam type="float" name="model_lower" value="2290.26303458832"/>
+			<UserParam type="float" name="model_upper" value="2306.14721372076"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="3.17683582648755"/>
+			<UserParam type="float" name="model_error" value="0.204257719375889"/>
+			<UserParam type="float" name="model_area" value="225626.879799371"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="107151.8671875"/>
+		</feature>
+		<feature id="f_1196373166564353753">
+			<position dim="0">1658.35957629977</position>
+			<position dim="1">532.248746583271</position>
+			<intensity>202353</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>3.27253</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1634.86328125" y="532.198746583271" />
+				<pt x="1685.81030273438" y="532.198746583271" />
+				<pt x="1685.81030273438" y="532.298746583271" />
+				<pt x="1634.86328125" y="532.298746583271" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1634.86328125" y="532.700424002171" />
+				<pt x="1685.81030273438" y="532.700424002171" />
+				<pt x="1685.81030273438" y="532.800424002171" />
+				<pt x="1634.86328125" y="532.800424002171" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_1196373166564353753_7539502987715517688">
+					<position dim="0">1658.35957629977</position>
+					<position dim="1">532.248746583271</position>
+					<intensity>86477.8</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1636.51171875" y="0" />
+						<pt x="1638.07885742188" y="0" />
+						<pt x="1639.34729003906" y="0" />
+						<pt x="1641.09350585938" y="0" />
+						<pt x="1642.72119140625" y="0" />
+						<pt x="1644.31372070312" y="0" />
+						<pt x="1645.88134765625" y="0" />
+						<pt x="1647.48327636719" y="0" />
+						<pt x="1648.7275390625" y="0" />
+						<pt x="1650.03430175781" y="1006.83868408203" />
+						<pt x="1651.41906738281" y="2662.908203125" />
+						<pt x="1653.2470703125" y="5414.9912109375" />
+						<pt x="1655.34460449219" y="11212.4697265625" />
+						<pt x="1657.05285644531" y="15971.271484375" />
+						<pt x="1658.70886230469" y="16335.642578125" />
+						<pt x="1660.33129882812" y="12500.2021484375" />
+						<pt x="1661.97338867188" y="5910.51953125" />
+						<pt x="1663.23254394531" y="5365.7568359375" />
+						<pt x="1664.64367675781" y="2964.51831054688" />
+						<pt x="1666.41357421875" y="1623.86999511719" />
+						<pt x="1667.71862792969" y="1885.44714355469" />
+						<pt x="1669.111328125" y="1417.13305664062" />
+						<pt x="1670.86352539062" y="0" />
+						<pt x="1672.12548828125" y="876.161743164063" />
+						<pt x="1673.87194824219" y="1330.08959960937" />
+						<pt x="1675.19165039062" y="0" />
+						<pt x="1676.96154785156" y="0" />
+						<pt x="1678.55310058594" y="0" />
+						<pt x="1680.16735839844" y="0" />
+						<pt x="1681.75329589844" y="0" />
+						<pt x="1684.45397949219" y="0" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="532.248746583271"/>
+					<UserParam type="string" name="native_id" value="KSDDGGEVEK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="16335.642578125"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.66039156605171"/>
+				</feature>
+				<feature id="f_1196373166564353753_9126387050458671424">
+					<position dim="0">1658.35957629977</position>
+					<position dim="1">532.750424002171</position>
+					<intensity>41877.4</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1636.51171875" y="0" />
+						<pt x="1638.07885742188" y="0" />
+						<pt x="1639.34729003906" y="0" />
+						<pt x="1641.09350585938" y="0" />
+						<pt x="1642.72119140625" y="0" />
+						<pt x="1644.31372070312" y="0" />
+						<pt x="1645.88134765625" y="0" />
+						<pt x="1647.48327636719" y="0" />
+						<pt x="1648.7275390625" y="0" />
+						<pt x="1650.03430175781" y="0" />
+						<pt x="1651.41906738281" y="1539.76916503906" />
+						<pt x="1653.2470703125" y="2021.71569824219" />
+						<pt x="1655.34460449219" y="6869.59423828125" />
+						<pt x="1657.05285644531" y="8075.73193359375" />
+						<pt x="1658.70886230469" y="4576.82275390625" />
+						<pt x="1660.33129882812" y="7255.56787109375" />
+						<pt x="1661.97338867188" y="4015.666015625" />
+						<pt x="1663.23254394531" y="1721.34057617188" />
+						<pt x="1664.64367675781" y="2122.17016601562" />
+						<pt x="1666.41357421875" y="1802.19848632812" />
+						<pt x="1667.71862792969" y="0" />
+						<pt x="1669.111328125" y="0" />
+						<pt x="1670.86352539062" y="921.968505859375" />
+						<pt x="1672.12548828125" y="0" />
+						<pt x="1673.87194824219" y="0" />
+						<pt x="1675.19165039062" y="0" />
+						<pt x="1676.96154785156" y="0" />
+						<pt x="1678.55310058594" y="0" />
+						<pt x="1680.16735839844" y="0" />
+						<pt x="1681.75329589844" y="0" />
+						<pt x="1684.45397949219" y="954.835266113281" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="532.750424002171"/>
+					<UserParam type="string" name="native_id" value="KSDDGGEVEK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="4576.82275390625"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.33960843394829"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" >
+				<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_2">
+					<UserParam type="float" name="OMSSA_score" value="0.140841796155119"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="KSDDGGEVEK/2"/>
+			<UserParam type="float" name="leftWidth" value="1634.86328125"/>
+			<UserParam type="float" name="rightWidth" value="1685.81030273438"/>
+			<UserParam type="float" name="total_xic" value="141144.40447998"/>
+			<UserParam type="float" name="peak_apices_sum" value="20912.4653320312"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.976751222648202"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.968715346150462"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0133467853267937"/>
+			<UserParam type="float" name="var_library_sangle" value="0.0240119555958121"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0133467853267937"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0145806315400125"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.99989973059223"/>
+			<UserParam type="float" name="var_intensity_score" value="0.909389242867262"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="97.517435020494"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.5800311827403"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.975244373083115"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.39723611286629"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.974755927449578"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="16.5563312629803"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="16.8438426877962"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.654000990960296"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.09969813062877"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.27252665585312"/>
+			<UserParam type="float" name="PrecursorMZ" value="532.248746583271"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="24215.0698767113"/>
+			<UserParam type="float" name="model_FWHM" value="7.8504056642483"/>
+			<UserParam type="float" name="model_center" value="1657.97995934097"/>
+			<UserParam type="float" name="model_lower" value="1649.64555834191"/>
+			<UserParam type="float" name="model_upper" value="1666.31436034004"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="3.33376039962642"/>
+			<UserParam type="float" name="model_error" value="0.17115033895563"/>
+			<UserParam type="float" name="model_area" value="202353.162726458"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="128355.203125"/>
+		</feature>
 		<feature id="f_13113514917555180171">
+			<position dim="0">2005.79703137669</position>
+			<position dim="1">404.203412328071</position>
+			<intensity>1.08434e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>3.2291</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1961.46557617188" y="404.153412328071" />
+				<pt x="2026.06115722656" y="404.153412328071" />
+				<pt x="2026.06115722656" y="404.253412328071" />
+				<pt x="1961.46557617188" y="404.253412328071" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1961.46557617188" y="404.655089746971" />
+				<pt x="2026.06115722656" y="404.655089746971" />
+				<pt x="2026.06115722656" y="404.755089746971" />
+				<pt x="1961.46557617188" y="404.755089746971" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_13113514917555180171_6182960951962378739">
+					<position dim="0">2005.79703137669</position>
+					<position dim="1">404.203412328071</position>
+					<intensity>387704</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1961.46557617188" y="6844.62634277344" />
+						<pt x="1963.85095214844" y="8177.09417724609" />
+						<pt x="1966.54650878906" y="6179.28662109375" />
+						<pt x="1969.21594238281" y="5334.84423828125" />
+						<pt x="1971.63354492188" y="8433.30810546875" />
+						<pt x="1973.24267578125" y="6292.0478515625" />
+						<pt x="1974.81298828125" y="11316.9248046875" />
+						<pt x="1977.380859375" y="9129.91015625" />
+						<pt x="1979.2890625" y="10587.720703125" />
+						<pt x="1980.87292480469" y="9501.9765625" />
+						<pt x="1982.46655273438" y="9202.78747558594" />
+						<pt x="1984.07604980469" y="7931.97351074219" />
+						<pt x="1985.6865234375" y="5744.78820800781" />
+						<pt x="1986.94934082031" y="7136.15301513672" />
+						<pt x="1989.31274414062" y="3368.05053710938" />
+						<pt x="1991.31884765625" y="3994.09252929688" />
+						<pt x="1993.19482421875" y="7268.14526367188" />
+						<pt x="1995.119140625" y="9562.3857421875" />
+						<pt x="1997.05432128906" y="16848.9475097656" />
+						<pt x="1998.99108886719" y="26898.01953125" />
+						<pt x="2000.96350097656" y="23991.6324462891" />
+						<pt x="2002.17077636719" y="33353.1411132812" />
+						<pt x="2004.77075195312" y="24527.0495605469" />
+						<pt x="2007.42565917969" y="22630.5537109375" />
+						<pt x="2010.10522460938" y="30324.4699707031" />
+						<pt x="2012.57043457031" y="24164.2170410156" />
+						<pt x="2014.81372070312" y="21600.6245117188" />
+						<pt x="2016.57385253906" y="9852.5234375" />
+						<pt x="2019.23095703125" y="0" />
+						<pt x="2021.03356933594" y="9876.9013671875" />
+						<pt x="2023.54016113281" y="0" />
+						<pt x="2026.06115722656" y="7629.51171875" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="404.203412328071"/>
+					<UserParam type="string" name="native_id" value="LAADDFR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="24527.0495605469"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.701130386577533"/>
+				</feature>
+				<feature id="f_13113514917555180171_14891455924036538147">
+					<position dim="0">2005.79703137669</position>
+					<position dim="1">404.705089746971</position>
+					<intensity>31598.8</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1961.46557617188" y="0" />
+						<pt x="1963.85095214844" y="0" />
+						<pt x="1966.54650878906" y="0" />
+						<pt x="1969.21594238281" y="0" />
+						<pt x="1971.63354492188" y="0" />
+						<pt x="1973.24267578125" y="0" />
+						<pt x="1974.81298828125" y="0" />
+						<pt x="1977.380859375" y="0" />
+						<pt x="1979.2890625" y="0" />
+						<pt x="1980.87292480469" y="0" />
+						<pt x="1982.46655273438" y="0" />
+						<pt x="1984.07604980469" y="0" />
+						<pt x="1985.6865234375" y="0" />
+						<pt x="1986.94934082031" y="0" />
+						<pt x="1989.31274414062" y="0" />
+						<pt x="1991.31884765625" y="0" />
+						<pt x="1993.19482421875" y="1440.1552734375" />
+						<pt x="1995.119140625" y="2219.85131835938" />
+						<pt x="1997.05432128906" y="3369.732421875" />
+						<pt x="1998.99108886719" y="6984.9580078125" />
+						<pt x="2000.96350097656" y="5368.5009765625" />
+						<pt x="2002.17077636719" y="7695.240234375" />
+						<pt x="2004.77075195312" y="4520.375" />
+						<pt x="2007.42565917969" y="0" />
+						<pt x="2010.10522460938" y="0" />
+						<pt x="2012.57043457031" y="0" />
+						<pt x="2014.81372070312" y="0" />
+						<pt x="2016.57385253906" y="0" />
+						<pt x="2019.23095703125" y="0" />
+						<pt x="2021.03356933594" y="0" />
+						<pt x="2023.54016113281" y="0" />
+						<pt x="2026.06115722656" y="0" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="404.705089746971"/>
+					<UserParam type="string" name="native_id" value="LAADDFR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="4520.375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.298869613422467"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="404.203002929688" RT="2003.33984375" >
+				<PeptideHit score="0.0454545454545455" sequence="LAADDFR" charge="2" aa_before="K X X X X X X" aa_after="T X X X X X X" protein_refs="PH_9 PH_10 PH_11 PH_12 PH_7 PH_6 PH_8">
+					<UserParam type="float" name="OMSSA_score" value="0.060731076753908"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LAADDFR/2"/>
+			<UserParam type="float" name="leftWidth" value="1961.46557617188"/>
+			<UserParam type="float" name="rightWidth" value="2026.06115722656"/>
+			<UserParam type="float" name="total_xic" value="981633.10760498"/>
+			<UserParam type="float" name="peak_apices_sum" value="29047.4245605469"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="1.82136720504592"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0.838186270380688"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.918517349916209"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.897553542138299"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.223509199055781"/>
+			<UserParam type="float" name="var_library_sangle" value="0.321621638280063"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.223509199055781"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.345831080663618"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.955242826825954"/>
+			<UserParam type="float" name="var_intensity_score" value="0.427147910967497"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="35.7331345136229"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.57607839596868"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.921455174684525"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="5.63303054486374"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.977395240636197"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.0753604173660278"/>
+			<UserParam type="float" name="var_massdev_score" value="0.175924713032794"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.20257301257106"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.624270529344654"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.34607058455137"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.22910093393967"/>
+			<UserParam type="float" name="PrecursorMZ" value="404.203412328071"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="36724.7017989613"/>
+			<UserParam type="float" name="model_FWHM" value="27.7380259710097"/>
+			<UserParam type="float" name="model_center" value="2006.40574830729"/>
+			<UserParam type="float" name="model_lower" value="1976.95761005149"/>
+			<UserParam type="float" name="model_upper" value="2035.85388656309"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="11.7792553023202"/>
+			<UserParam type="float" name="model_error" value="0.874616056968454"/>
+			<UserParam type="float" name="model_area" value="1084341.30010212"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="419302.53125"/>
+		</feature>
+		<feature id="f_17287849381738438716">
 			<position dim="0">1782.51151069112</position>
 			<position dim="1">300.195528597604</position>
 			<intensity>1.34493e+07</intensity>
@@ -2827,7 +3304,7 @@
 				<pt x="1763.34350585938" y="300.579980210204" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_13113514917555180171_7316644956366259183">
+				<feature id="f_17287849381738438716_2660422259164526995">
 					<position dim="0">1782.51151069112</position>
 					<position dim="1">300.195528597604</position>
 					<intensity>8.21652e+06</intensity>
@@ -2896,7 +3373,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.668051514852376"/>
 				</feature>
-				<feature id="f_13113514917555180171_6182960951962378739">
+				<feature id="f_17287849381738438716_5495827884756377090">
 					<position dim="0">1782.51151069112</position>
 					<position dim="1">300.529980210204</position>
 					<intensity>3.48903e+06</intensity>
@@ -2982,11 +3459,11 @@
 			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
 			<UserParam type="float" name="var_xcorr_shape" value="0.999219220116872"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.998961131663337"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.033881966605777"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0595943078565422"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.033881966605777"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0378305231519566"/>
+			<UserParam type="float" name="var_library_corr" value="0.999999999999999"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0338819666057769"/>
+			<UserParam type="float" name="var_library_sangle" value="0.059594307856544"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0338819666057769"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0378305231519567"/>
 			<UserParam type="float" name="var_library_dotprod" value="0.999334609191848"/>
 			<UserParam type="float" name="var_intensity_score" value="0.669437494083765"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
@@ -3008,18 +3485,1370 @@
 			<UserParam type="int" name="n_total_ids" value="1"/>
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="887527.523766886"/>
-			<UserParam type="float" name="model_FWHM" value="14.2359229363329"/>
+			<UserParam type="float" name="model_height" value="887527.523766928"/>
+			<UserParam type="float" name="model_FWHM" value="14.2359229363362"/>
 			<UserParam type="float" name="model_center" value="1781.9917300983"/>
 			<UserParam type="float" name="model_lower" value="1766.87813018797"/>
 			<UserParam type="float" name="model_upper" value="1797.10533000863"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="6.04543996413011"/>
-			<UserParam type="float" name="model_error" value="0.55056340040958"/>
-			<UserParam type="float" name="model_area" value="13449298.4002421"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="6.04543996413154"/>
+			<UserParam type="float" name="model_error" value="0.55056340040907"/>
+			<UserParam type="float" name="model_area" value="13449298.4002459"/>
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="11705556"/>
 		</feature>
-		<feature id="f_14891455924036538147">
+		<feature id="f_4143272592559840046">
+			<position dim="0">1617.1483410699</position>
+			<position dim="1">368.862109904738</position>
+			<intensity>8.05591e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.878065</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1595.50939941406" y="368.812109904738" />
+				<pt x="1764.53942871094" y="368.812109904738" />
+				<pt x="1764.53942871094" y="368.912109904738" />
+				<pt x="1595.50939941406" y="368.912109904738" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1595.50939941406" y="369.146561517338" />
+				<pt x="1764.53942871094" y="369.146561517338" />
+				<pt x="1764.53942871094" y="369.246561517338" />
+				<pt x="1595.50939941406" y="369.246561517338" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_4143272592559840046_5342974036930030800">
+					<position dim="0">1617.1483410699</position>
+					<position dim="1">368.862109904738</position>
+					<intensity>5.79311e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1596.7958984375" y="0" />
+						<pt x="1598.55334472656" y="0" />
+						<pt x="1600.25183105469" y="0" />
+						<pt x="1601.50854492188" y="0" />
+						<pt x="1602.97534179688" y="0" />
+						<pt x="1604.69299316406" y="5177.01708984375" />
+						<pt x="1606.37744140625" y="30968.22265625" />
+						<pt x="1608.01416015625" y="82616.7109375" />
+						<pt x="1609.38244628906" y="141733.953125" />
+						<pt x="1611.11169433594" y="259860.171630859" />
+						<pt x="1612.80322265625" y="310930.346191406" />
+						<pt x="1614.45471191406" y="359892.321655273" />
+						<pt x="1615.81567382812" y="361844.1875" />
+						<pt x="1617.52429199219" y="301442.201293945" />
+						<pt x="1619.2216796875" y="256573.993286133" />
+						<pt x="1620.89306640625" y="214252.046875" />
+						<pt x="1622.54174804688" y="170041.6875" />
+						<pt x="1623.83837890625" y="131011.8359375" />
+						<pt x="1625.60412597656" y="123679.078125" />
+						<pt x="1627.24719238281" y="120382.5" />
+						<pt x="1628.48876953125" y="108680.125" />
+						<pt x="1629.88061523438" y="97691.4140625" />
+						<pt x="1631.66320800781" y="92193.1015625" />
+						<pt x="1633.28234863281" y="77823.7421875" />
+						<pt x="1634.86328125" y="85255.9609375" />
+						<pt x="1636.51171875" y="82935.8125" />
+						<pt x="1638.07885742188" y="77134.296875" />
+						<pt x="1639.34729003906" y="73134.59375" />
+						<pt x="1641.09350585938" y="71262.703125" />
+						<pt x="1642.72119140625" y="64132.14453125" />
+						<pt x="1644.31372070312" y="63242.65234375" />
+						<pt x="1645.88134765625" y="56334.7265625" />
+						<pt x="1647.48327636719" y="54439.61328125" />
+						<pt x="1648.7275390625" y="53092.765625" />
+						<pt x="1650.03430175781" y="45740.90625" />
+						<pt x="1651.41906738281" y="45981.84375" />
+						<pt x="1653.2470703125" y="52246.046875" />
+						<pt x="1655.34460449219" y="46828.7109375" />
+						<pt x="1657.05285644531" y="44011.13671875" />
+						<pt x="1658.70886230469" y="44025.11328125" />
+						<pt x="1660.33129882812" y="37324.25390625" />
+						<pt x="1661.97338867188" y="41503.9609375" />
+						<pt x="1663.23254394531" y="38759.32421875" />
+						<pt x="1664.64367675781" y="33337.16015625" />
+						<pt x="1666.41357421875" y="39421.80078125" />
+						<pt x="1667.71862792969" y="36692.05078125" />
+						<pt x="1669.111328125" y="31597.517578125" />
+						<pt x="1670.86352539062" y="40932.5625" />
+						<pt x="1672.12548828125" y="31674.111328125" />
+						<pt x="1673.87194824219" y="33902.72265625" />
+						<pt x="1675.19165039062" y="30318.212890625" />
+						<pt x="1676.96154785156" y="35048.07421875" />
+						<pt x="1678.55310058594" y="38674.86328125" />
+						<pt x="1680.16735839844" y="37594.875" />
+						<pt x="1681.75329589844" y="26210.80859375" />
+						<pt x="1684.45397949219" y="24797.056640625" />
+						<pt x="1685.81030273438" y="23726.97265625" />
+						<pt x="1687.5263671875" y="33630.45703125" />
+						<pt x="1689.21337890625" y="25846.96875" />
+						<pt x="1690.76647949219" y="25072.615234375" />
+						<pt x="1692.41857910156" y="26504.46875" />
+						<pt x="1693.71362304688" y="26198.08203125" />
+						<pt x="1695.46130371094" y="28848.556640625" />
+						<pt x="1697.08410644531" y="30072.3984375" />
+						<pt x="1698.99609375" y="22095.828125" />
+						<pt x="1701.0732421875" y="23786.494140625" />
+						<pt x="1702.7529296875" y="26816.1953125" />
+						<pt x="1704.38671875" y="23697.45703125" />
+						<pt x="1706.12316894531" y="27334.72265625" />
+						<pt x="1707.67224121094" y="23510.125" />
+						<pt x="1709.35302734375" y="24499.1015625" />
+						<pt x="1710.62609863281" y="20932.60546875" />
+						<pt x="1712.33923339844" y="26764.48046875" />
+						<pt x="1714.34643554688" y="20390" />
+						<pt x="1716.00524902344" y="17069.943359375" />
+						<pt x="1717.3720703125" y="19245.083984375" />
+						<pt x="1718.70336914062" y="20635.220703125" />
+						<pt x="1720.42810058594" y="21117.7734375" />
+						<pt x="1722.07409667969" y="24988.404296875" />
+						<pt x="1723.66687011719" y="22208.55078125" />
+						<pt x="1724.88122558594" y="20072.5859375" />
+						<pt x="1726.58349609375" y="23426.63671875" />
+						<pt x="1728.11975097656" y="20546.255859375" />
+						<pt x="1729.41674804688" y="16537.349609375" />
+						<pt x="1731.05224609375" y="20966.1953125" />
+						<pt x="1732.3154296875" y="16847.099609375" />
+						<pt x="1734.10437011719" y="21239.3671875" />
+						<pt x="1735.69311523438" y="18255.306640625" />
+						<pt x="1737.05261230469" y="22682.048828125" />
+						<pt x="1738.2958984375" y="19191.6015625" />
+						<pt x="1740.13562011719" y="20592.16796875" />
+						<pt x="1742.16540527344" y="23395.36328125" />
+						<pt x="1744.55932617188" y="21310.615234375" />
+						<pt x="1746.17114257812" y="15478.80859375" />
+						<pt x="1747.40344238281" y="17416.51171875" />
+						<pt x="1749.72985839844" y="17209.23828125" />
+						<pt x="1751.63122558594" y="13815.8369140625" />
+						<pt x="1753.181640625" y="12395.25" />
+						<pt x="1754.70849609375" y="17807.537109375" />
+						<pt x="1756.63635253906" y="16584.8046875" />
+						<pt x="1758.22473144531" y="20436.69140625" />
+						<pt x="1759.81530761719" y="14681.31640625" />
+						<pt x="1761.75610351562" y="17447.498046875" />
+						<pt x="1763.34350585938" y="15396.6708984375" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="368.862109904738"/>
+					<UserParam type="string" name="native_id" value="LAMTLAEAER/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="301442.201293945"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.637366103952144"/>
+				</feature>
+				<feature id="f_4143272592559840046_11399299100673837381">
+					<position dim="0">1617.1483410699</position>
+					<position dim="1">369.196561517338</position>
+					<intensity>3.45967e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1596.7958984375" y="0" />
+						<pt x="1598.55334472656" y="0" />
+						<pt x="1600.25183105469" y="0" />
+						<pt x="1601.50854492188" y="0" />
+						<pt x="1602.97534179688" y="0" />
+						<pt x="1604.69299316406" y="1869.17529296875" />
+						<pt x="1606.37744140625" y="14712.3701171875" />
+						<pt x="1608.01416015625" y="34977.7970581055" />
+						<pt x="1609.38244628906" y="80099.3203125" />
+						<pt x="1611.11169433594" y="130945.0234375" />
+						<pt x="1612.80322265625" y="173496.75" />
+						<pt x="1614.45471191406" y="208531.59375" />
+						<pt x="1615.81567382812" y="195640.046875" />
+						<pt x="1617.52429199219" y="164956.921875" />
+						<pt x="1619.2216796875" y="133660.696044922" />
+						<pt x="1620.89306640625" y="114413.2421875" />
+						<pt x="1622.54174804688" y="100173.2734375" />
+						<pt x="1623.83837890625" y="78988.9827880859" />
+						<pt x="1625.60412597656" y="74301.453125" />
+						<pt x="1627.24719238281" y="68368.9609375" />
+						<pt x="1628.48876953125" y="56432.6926269531" />
+						<pt x="1629.88061523438" y="56455.40625" />
+						<pt x="1631.66320800781" y="51672.53515625" />
+						<pt x="1633.28234863281" y="37000.28125" />
+						<pt x="1634.86328125" y="45038.921875" />
+						<pt x="1636.51171875" y="36389.03125" />
+						<pt x="1638.07885742188" y="36002.625" />
+						<pt x="1639.34729003906" y="31117.2578125" />
+						<pt x="1641.09350585938" y="31475.73828125" />
+						<pt x="1642.72119140625" y="27940.033203125" />
+						<pt x="1644.31372070312" y="30938.189453125" />
+						<pt x="1645.88134765625" y="25509.447265625" />
+						<pt x="1647.48327636719" y="28780.83203125" />
+						<pt x="1648.7275390625" y="21087.23046875" />
+						<pt x="1650.03430175781" y="21032.650390625" />
+						<pt x="1651.41906738281" y="19433.833984375" />
+						<pt x="1653.2470703125" y="21774.08203125" />
+						<pt x="1655.34460449219" y="19139.62890625" />
+						<pt x="1657.05285644531" y="22977.255859375" />
+						<pt x="1658.70886230469" y="27535.408203125" />
+						<pt x="1660.33129882812" y="21203.421875" />
+						<pt x="1661.97338867188" y="21989.1640625" />
+						<pt x="1663.23254394531" y="18492.743347168" />
+						<pt x="1664.64367675781" y="15860.5078125" />
+						<pt x="1666.41357421875" y="19013.779296875" />
+						<pt x="1667.71862792969" y="17693.15625" />
+						<pt x="1669.111328125" y="13517.3017578125" />
+						<pt x="1670.86352539062" y="17876.833984375" />
+						<pt x="1672.12548828125" y="12634.173828125" />
+						<pt x="1673.87194824219" y="15371.1162109375" />
+						<pt x="1675.19165039062" y="14991.24609375" />
+						<pt x="1676.96154785156" y="16055.552734375" />
+						<pt x="1678.55310058594" y="13005.2060546875" />
+						<pt x="1680.16735839844" y="16306.634765625" />
+						<pt x="1681.75329589844" y="15908.3388671875" />
+						<pt x="1684.45397949219" y="10510.0810546875" />
+						<pt x="1685.81030273438" y="13555.4306640625" />
+						<pt x="1687.5263671875" y="10415.58203125" />
+						<pt x="1689.21337890625" y="11749.34375" />
+						<pt x="1690.76647949219" y="13906.755859375" />
+						<pt x="1692.41857910156" y="11008.783203125" />
+						<pt x="1693.71362304688" y="11556.9501953125" />
+						<pt x="1695.46130371094" y="11376.8896484375" />
+						<pt x="1697.08410644531" y="9880.37109375" />
+						<pt x="1698.99609375" y="10109.595703125" />
+						<pt x="1701.0732421875" y="9135.697265625" />
+						<pt x="1702.7529296875" y="10913.6689453125" />
+						<pt x="1704.38671875" y="6939.59814453125" />
+						<pt x="1706.12316894531" y="11676.4853515625" />
+						<pt x="1707.67224121094" y="11669.0615234375" />
+						<pt x="1709.35302734375" y="9569.5615234375" />
+						<pt x="1710.62609863281" y="6364.845703125" />
+						<pt x="1712.33923339844" y="8145.91943359375" />
+						<pt x="1714.34643554688" y="9064.498046875" />
+						<pt x="1716.00524902344" y="9891.8291015625" />
+						<pt x="1717.3720703125" y="10346.1552734375" />
+						<pt x="1718.70336914062" y="7887.78076171875" />
+						<pt x="1720.42810058594" y="10289.8466796875" />
+						<pt x="1722.07409667969" y="12221.3131103516" />
+						<pt x="1723.66687011719" y="9412.00390625" />
+						<pt x="1724.88122558594" y="12240.80078125" />
+						<pt x="1726.58349609375" y="11340.734375" />
+						<pt x="1728.11975097656" y="8273.880859375" />
+						<pt x="1729.41674804688" y="11363.2099609375" />
+						<pt x="1731.05224609375" y="9867.80078125" />
+						<pt x="1732.3154296875" y="8855.0888671875" />
+						<pt x="1734.10437011719" y="11068.3828125" />
+						<pt x="1735.69311523438" y="7690.60546875" />
+						<pt x="1737.05261230469" y="8551.3857421875" />
+						<pt x="1738.2958984375" y="7198.0869140625" />
+						<pt x="1740.13562011719" y="7148.18359375" />
+						<pt x="1742.16540527344" y="9787.5263671875" />
+						<pt x="1744.55932617188" y="17886.8564453125" />
+						<pt x="1746.17114257812" y="42170.2978515625" />
+						<pt x="1747.40344238281" y="50283.1796875" />
+						<pt x="1749.72985839844" y="83261.640625" />
+						<pt x="1751.63122558594" y="82439.9765625" />
+						<pt x="1753.181640625" y="92369.9609375" />
+						<pt x="1754.70849609375" y="69276.3828125" />
+						<pt x="1756.63635253906" y="46668.56640625" />
+						<pt x="1758.22473144531" y="41100.25" />
+						<pt x="1759.81530761719" y="33414.75390625" />
+						<pt x="1761.75610351562" y="23601.478515625" />
+						<pt x="1763.34350585938" y="33424.1479492188" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="369.196561517338"/>
+					<UserParam type="string" name="native_id" value="LAMTLAEAER/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="164956.921875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.362633896047856"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" >
+				<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_3">
+					<UserParam type="float" name="OMSSA_score" value="0.134752265696133"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" >
+				<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_3">
+					<UserParam type="float" name="OMSSA_score" value="0.0325713993888641"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LAMTLAEAER/3"/>
+			<UserParam type="float" name="leftWidth" value="1595.50939941406"/>
+			<UserParam type="float" name="rightWidth" value="1764.53942871094"/>
+			<UserParam type="float" name="total_xic" value="10395361.7129517"/>
+			<UserParam type="float" name="peak_apices_sum" value="466399.123168945"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.97124963771702"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.960129477115842"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0112721013675148"/>
+			<UserParam type="float" name="var_library_sangle" value="0.021080330114212"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0112721013675148"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0118955544334975"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999931728221565"/>
+			<UserParam type="float" name="var_intensity_score" value="0.890087065317977"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="16.9401516016668"/>
+			<UserParam type="float" name="var_log_sn_score" value="2.82968663851485"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.940495908260345"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.15988578920748"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.509134767132634"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
+			<UserParam type="float" name="var_massdev_score" value="28.1440905745226"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="35.8761787175195"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.567734792584532"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.42292916274579"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.87806461617499"/>
+			<UserParam type="float" name="PrecursorMZ" value="368.862109904738"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="2"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="503395.786769317"/>
+			<UserParam type="float" name="model_FWHM" value="15.0339419712515"/>
+			<UserParam type="float" name="model_center" value="1616.65901604675"/>
+			<UserParam type="float" name="model_lower" value="1600.69819741597"/>
+			<UserParam type="float" name="model_upper" value="1632.61983467752"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="6.38432745231123"/>
+			<UserParam type="float" name="model_error" value="0.563895430921102"/>
+			<UserParam type="float" name="model_area" value="8055910.20711165"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="9252778"/>
+		</feature>
+		<feature id="f_12561328592123678330">
+			<position dim="0">1782.34333734102</position>
+			<position dim="1">449.744389900421</position>
+			<intensity>1.97055e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>3.66305</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1761.75610351562" y="449.694389900421" />
+				<pt x="1881.08850097656" y="449.694389900421" />
+				<pt x="1881.08850097656" y="449.794389900421" />
+				<pt x="1761.75610351562" y="449.794389900421" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1761.75610351562" y="450.196067319321" />
+				<pt x="1881.08850097656" y="450.196067319321" />
+				<pt x="1881.08850097656" y="450.296067319321" />
+				<pt x="1761.75610351562" y="450.296067319321" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_12561328592123678330_13574947772324278593">
+					<position dim="0">1782.34333734102</position>
+					<position dim="1">449.744389900421</position>
+					<intensity>1.27819e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1763.34350585938" y="0" />
+						<pt x="1764.53942871094" y="0" />
+						<pt x="1766.20935058594" y="0" />
+						<pt x="1767.45556640625" y="0" />
+						<pt x="1768.78759765625" y="0" />
+						<pt x="1770.08776855469" y="3295.35131835938" />
+						<pt x="1771.37548828125" y="5336.0361328125" />
+						<pt x="1772.72485351562" y="14621.490234375" />
+						<pt x="1775.10119628906" y="38825.13671875" />
+						<pt x="1776.7529296875" y="70122.59375" />
+						<pt x="1778.41467285156" y="92902.5390625" />
+						<pt x="1779.78234863281" y="109567.890625" />
+						<pt x="1781.03625488281" y="105582.53125" />
+						<pt x="1782.70874023438" y="91264.109375" />
+						<pt x="1784.005859375" y="77221.625" />
+						<pt x="1785.66430664062" y="66398.7890625" />
+						<pt x="1788.00903320312" y="41742.73046875" />
+						<pt x="1789.64514160156" y="37536.06640625" />
+						<pt x="1791.29907226562" y="28678.564453125" />
+						<pt x="1792.96655273438" y="30591.322265625" />
+						<pt x="1794.18957519531" y="23455.078125" />
+						<pt x="1796.90112304688" y="21046.619140625" />
+						<pt x="1799.29284667969" y="19297.240234375" />
+						<pt x="1802.06115722656" y="15114.0146484375" />
+						<pt x="1802.93933105469" y="16104.576171875" />
+						<pt x="1805.2861328125" y="15887.0087890625" />
+						<pt x="1806.53210449219" y="12995.1220703125" />
+						<pt x="1807.84582519531" y="13539.0859375" />
+						<pt x="1809.5546875" y="9603.3642578125" />
+						<pt x="1811.23205566406" y="10904.3125" />
+						<pt x="1812.84313964844" y="12828.8017578125" />
+						<pt x="1814.09313964844" y="13939.5845947266" />
+						<pt x="1816.15393066406" y="10785.16796875" />
+						<pt x="1817.87463378906" y="11836.541015625" />
+						<pt x="1819.56494140625" y="11571.638671875" />
+						<pt x="1821.21337890625" y="9596.5" />
+						<pt x="1823.14038085938" y="8762.31640625" />
+						<pt x="1825.08544921875" y="8781.783203125" />
+						<pt x="1827.03564453125" y="10076.1904296875" />
+						<pt x="1828.62902832031" y="10676.5869140625" />
+						<pt x="1829.82446289062" y="8912.7099609375" />
+						<pt x="1831.02966308594" y="8341.4443359375" />
+						<pt x="1832.62158203125" y="8517.91796875" />
+						<pt x="1834.48815917969" y="7672.2802734375" />
+						<pt x="1836.81677246094" y="7246.2275390625" />
+						<pt x="1839.52209472656" y="8453.00549316406" />
+						<pt x="1842.24621582031" y="9317.779296875" />
+						<pt x="1843.86376953125" y="9674.85986328125" />
+						<pt x="1846.10339355469" y="8584.6328125" />
+						<pt x="1847.20849609375" y="6910.87255859375" />
+						<pt x="1848.68237304688" y="0" />
+						<pt x="1850.09631347656" y="7750.4560546875" />
+						<pt x="1851.12512207031" y="7976.46630859375" />
+						<pt x="1853.71057128906" y="6641.52685546875" />
+						<pt x="1855.52624511719" y="7921.99365234375" />
+						<pt x="1857.064453125" y="4502.91650390625" />
+						<pt x="1858.97082519531" y="7918.28125" />
+						<pt x="1861.28601074219" y="6991.912109375" />
+						<pt x="1863.56823730469" y="8192.130859375" />
+						<pt x="1865.85095214844" y="5404.07958984375" />
+						<pt x="1867.78442382812" y="6909.56640625" />
+						<pt x="1869.03576660156" y="7695.20361328125" />
+						<pt x="1871.33630371094" y="6777.1318359375" />
+						<pt x="1872.57312011719" y="6729.103515625" />
+						<pt x="1874.54077148438" y="4768.60009765625" />
+						<pt x="1876.48901367188" y="4750.97509765625" />
+						<pt x="1878.7314453125" y="7574.9267578125" />
+						<pt x="1881.08850097656" y="5569.12451171875" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="449.744389900421"/>
+					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="91264.109375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
+				</feature>
+				<feature id="f_12561328592123678330_3689406389503231823">
+					<position dim="0">1782.34333734102</position>
+					<position dim="1">450.246067319321</position>
+					<intensity>465501</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1763.34350585938" y="0" />
+						<pt x="1764.53942871094" y="0" />
+						<pt x="1766.20935058594" y="0" />
+						<pt x="1767.45556640625" y="0" />
+						<pt x="1768.78759765625" y="0" />
+						<pt x="1770.08776855469" y="1165.43957519531" />
+						<pt x="1771.37548828125" y="1393.00817871094" />
+						<pt x="1772.72485351562" y="6394.92431640625" />
+						<pt x="1775.10119628906" y="16525.09765625" />
+						<pt x="1776.7529296875" y="28931.640625" />
+						<pt x="1778.41467285156" y="40418.69140625" />
+						<pt x="1779.78234863281" y="44756.20703125" />
+						<pt x="1781.03625488281" y="43344.69921875" />
+						<pt x="1782.70874023438" y="32936.89453125" />
+						<pt x="1784.005859375" y="26178.119140625" />
+						<pt x="1785.66430664062" y="22287.62890625" />
+						<pt x="1788.00903320312" y="13541.138671875" />
+						<pt x="1789.64514160156" y="14404.34765625" />
+						<pt x="1791.29907226562" y="9481.017578125" />
+						<pt x="1792.96655273438" y="12832.8779296875" />
+						<pt x="1794.18957519531" y="10743.8603515625" />
+						<pt x="1796.90112304688" y="5956.55517578125" />
+						<pt x="1799.29284667969" y="8550.466796875" />
+						<pt x="1802.06115722656" y="2810.3857421875" />
+						<pt x="1802.93933105469" y="5481.55224609375" />
+						<pt x="1805.2861328125" y="4969.7568359375" />
+						<pt x="1806.53210449219" y="4854.69482421875" />
+						<pt x="1807.84582519531" y="3595.94653320312" />
+						<pt x="1809.5546875" y="4655.9443359375" />
+						<pt x="1811.23205566406" y="2883.03759765625" />
+						<pt x="1812.84313964844" y="4796.408203125" />
+						<pt x="1814.09313964844" y="6333.505859375" />
+						<pt x="1816.15393066406" y="4753.25012207031" />
+						<pt x="1817.87463378906" y="3065.50634765625" />
+						<pt x="1819.56494140625" y="4645.6494140625" />
+						<pt x="1821.21337890625" y="3406.87841796875" />
+						<pt x="1823.14038085938" y="4329.94140625" />
+						<pt x="1825.08544921875" y="2906.20581054688" />
+						<pt x="1827.03564453125" y="4323.2568359375" />
+						<pt x="1828.62902832031" y="3738.16040039062" />
+						<pt x="1829.82446289062" y="0" />
+						<pt x="1831.02966308594" y="3923.69555664062" />
+						<pt x="1832.62158203125" y="4150.80810546875" />
+						<pt x="1834.48815917969" y="3102.2333984375" />
+						<pt x="1836.81677246094" y="3262.21557617188" />
+						<pt x="1839.52209472656" y="1837.95385742188" />
+						<pt x="1842.24621582031" y="3682.50024414062" />
+						<pt x="1843.86376953125" y="0" />
+						<pt x="1846.10339355469" y="0" />
+						<pt x="1847.20849609375" y="0" />
+						<pt x="1848.68237304688" y="0" />
+						<pt x="1850.09631347656" y="0" />
+						<pt x="1851.12512207031" y="0" />
+						<pt x="1853.71057128906" y="0" />
+						<pt x="1855.52624511719" y="0" />
+						<pt x="1857.064453125" y="2697.66723632812" />
+						<pt x="1858.97082519531" y="2741.68212890625" />
+						<pt x="1861.28601074219" y="2791.84643554688" />
+						<pt x="1863.56823730469" y="0" />
+						<pt x="1865.85095214844" y="3051.03784179688" />
+						<pt x="1867.78442382812" y="3314.49487304688" />
+						<pt x="1869.03576660156" y="3835.66821289062" />
+						<pt x="1871.33630371094" y="2987.119140625" />
+						<pt x="1872.57312011719" y="4232.16455078125" />
+						<pt x="1874.54077148438" y="3003.31518554688" />
+						<pt x="1876.48901367188" y="1637.94262695312" />
+						<pt x="1878.7314453125" y="1404.9755859375" />
+						<pt x="1881.08850097656" y="2451.17114257812" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="450.246067319321"/>
+					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="32936.89453125"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.325393160206819"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="449.744232177734" RT="1776.05004882812" >
+				<PeptideHit score="0.0344827586206897" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0227663017779976"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LC(Carbamidomethyl)VLHEK/2"/>
+			<UserParam type="float" name="leftWidth" value="1761.75610351562"/>
+			<UserParam type="float" name="rightWidth" value="1881.08850097656"/>
+			<UserParam type="float" name="total_xic" value="2422351.66326904"/>
+			<UserParam type="float" name="peak_apices_sum" value="124201.00390625"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.995444848298674"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.994000524898595"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0584307399821589"/>
+			<UserParam type="float" name="var_library_sangle" value="0.100167183533034"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0584307399821589"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0670063315124288"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.997948935934463"/>
+			<UserParam type="float" name="var_intensity_score" value="0.719835873312806"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="24.5720952313712"/>
+			<UserParam type="float" name="var_log_sn_score" value="3.20161145889938"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.981171160936356"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="6.35219320308861"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.984152837341836"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.26696240901947"/>
+			<UserParam type="float" name="var_massdev_score" value="0.43272982427065"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.447953512388762"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.698534764147426"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.07117517832204"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.66305280471362"/>
+			<UserParam type="float" name="PrecursorMZ" value="449.744389900421"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="146461.170161814"/>
+			<UserParam type="float" name="model_FWHM" value="12.6395633276427"/>
+			<UserParam type="float" name="model_center" value="1781.58469240699"/>
+			<UserParam type="float" name="model_lower" value="1768.16587130002"/>
+			<UserParam type="float" name="model_upper" value="1795.00351351396"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="5.36752844278658"/>
+			<UserParam type="float" name="model_error" value="0.516282686851667"/>
+			<UserParam type="float" name="model_area" value="1970546.74096187"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="1743695.5"/>
+		</feature>
+		<feature id="f_17325731682080510033">
+			<position dim="0">1978.65907624188</position>
+			<position dim="1">300.165352089204</position>
+			<intensity>4.4964e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>0.889465</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1939.34069824219" y="300.115352089204" />
+				<pt x="2036.53295898438" y="300.115352089204" />
+				<pt x="2036.53295898438" y="300.215352089204" />
+				<pt x="1939.34069824219" y="300.215352089204" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1939.34069824219" y="300.449803701804" />
+				<pt x="2036.53295898438" y="300.449803701804" />
+				<pt x="2036.53295898438" y="300.549803701804" />
+				<pt x="1939.34069824219" y="300.549803701804" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_17325731682080510033_18390135059454481268">
+					<position dim="0">1978.65907624188</position>
+					<position dim="1">300.165352089204</position>
+					<intensity>2.22186e+06</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1939.34069824219" y="36680.62109375" />
+						<pt x="1941.74328613281" y="45794.234375" />
+						<pt x="1943.79846191406" y="47713.0234375" />
+						<pt x="1946.22692871094" y="33048.3984375" />
+						<pt x="1948.33605957031" y="58252.2221679688" />
+						<pt x="1950.83435058594" y="50551.5576171875" />
+						<pt x="1953.46435546875" y="49472.1899414062" />
+						<pt x="1956.12158203125" y="50716.2943115234" />
+						<pt x="1958.88928222656" y="53463.3280029297" />
+						<pt x="1961.46557617188" y="45161.8560791016" />
+						<pt x="1963.85095214844" y="52877.5782470703" />
+						<pt x="1966.54650878906" y="54868.1848144531" />
+						<pt x="1969.21594238281" y="55264.8072509766" />
+						<pt x="1971.63354492188" y="52805.6440429688" />
+						<pt x="1973.24267578125" y="56724.41015625" />
+						<pt x="1974.81298828125" y="60130.0043945312" />
+						<pt x="1977.380859375" y="48982.4614257812" />
+						<pt x="1979.2890625" y="50742.7026367188" />
+						<pt x="1980.87292480469" y="52880.7604980469" />
+						<pt x="1982.46655273438" y="55716.388671875" />
+						<pt x="1984.07604980469" y="53652.4938964844" />
+						<pt x="1985.6865234375" y="61659.5291137695" />
+						<pt x="1986.94934082031" y="56493.3591308594" />
+						<pt x="1989.31274414062" y="57605.4466552734" />
+						<pt x="1991.31884765625" y="49399.6843261719" />
+						<pt x="1993.19482421875" y="46582.6325683594" />
+						<pt x="1995.119140625" y="48921.4417724609" />
+						<pt x="1997.05432128906" y="51598.0784912109" />
+						<pt x="1998.99108886719" y="51620.6519775391" />
+						<pt x="2000.96350097656" y="51072.5512695312" />
+						<pt x="2002.17077636719" y="59742.7866210938" />
+						<pt x="2004.77075195312" y="49408.6408691406" />
+						<pt x="2007.42565917969" y="36029.41015625" />
+						<pt x="2010.10522460938" y="60046.412109375" />
+						<pt x="2012.57043457031" y="46714.6420898438" />
+						<pt x="2014.81372070312" y="44301.7006835938" />
+						<pt x="2016.57385253906" y="52117.0034179688" />
+						<pt x="2019.23095703125" y="46844.5078125" />
+						<pt x="2021.03356933594" y="45801.375" />
+						<pt x="2023.54016113281" y="47041.3671875" />
+						<pt x="2026.06115722656" y="58026.18359375" />
+						<pt x="2028.66284179688" y="46704.36328125" />
+						<pt x="2031.287109375" y="44216.0402832031" />
+						<pt x="2033.83422851562" y="44416.7150878906" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="300.165352089204"/>
+					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="50742.7026367188"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.674606839793181"/>
+				</feature>
+				<feature id="f_17325731682080510033_15721057298497490036">
+					<position dim="0">1978.65907624188</position>
+					<position dim="1">300.499803701804</position>
+					<intensity>707673</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1939.34069824219" y="18473.921875" />
+						<pt x="1941.74328613281" y="0" />
+						<pt x="1943.79846191406" y="21973.2578125" />
+						<pt x="1946.22692871094" y="11365.859375" />
+						<pt x="1948.33605957031" y="18171.76171875" />
+						<pt x="1950.83435058594" y="14074.0419921875" />
+						<pt x="1953.46435546875" y="12252.080078125" />
+						<pt x="1956.12158203125" y="16608.580078125" />
+						<pt x="1958.88928222656" y="18796.513671875" />
+						<pt x="1961.46557617188" y="14309.8837890625" />
+						<pt x="1963.85095214844" y="16591.025390625" />
+						<pt x="1966.54650878906" y="17604.376953125" />
+						<pt x="1969.21594238281" y="17657.005859375" />
+						<pt x="1971.63354492188" y="8704.1591796875" />
+						<pt x="1973.24267578125" y="17008.806640625" />
+						<pt x="1974.81298828125" y="17888.96875" />
+						<pt x="1977.380859375" y="18511.80078125" />
+						<pt x="1979.2890625" y="21832.7421875" />
+						<pt x="1980.87292480469" y="15260.240234375" />
+						<pt x="1982.46655273438" y="20862.427734375" />
+						<pt x="1984.07604980469" y="14933.685546875" />
+						<pt x="1985.6865234375" y="13568.525390625" />
+						<pt x="1986.94934082031" y="17189.716796875" />
+						<pt x="1989.31274414062" y="20236.34765625" />
+						<pt x="1991.31884765625" y="17097.77734375" />
+						<pt x="1993.19482421875" y="16976.74609375" />
+						<pt x="1995.119140625" y="18632.2578125" />
+						<pt x="1997.05432128906" y="12982.8173828125" />
+						<pt x="1998.99108886719" y="12441.716796875" />
+						<pt x="2000.96350097656" y="19018.88671875" />
+						<pt x="2002.17077636719" y="16565.154296875" />
+						<pt x="2004.77075195312" y="13100.724609375" />
+						<pt x="2007.42565917969" y="15414.400390625" />
+						<pt x="2010.10522460938" y="18686.56640625" />
+						<pt x="2012.57043457031" y="18238.216796875" />
+						<pt x="2014.81372070312" y="10422.1982421875" />
+						<pt x="2016.57385253906" y="20035.880859375" />
+						<pt x="2019.23095703125" y="11692.9423828125" />
+						<pt x="2021.03356933594" y="17873.365234375" />
+						<pt x="2023.54016113281" y="12206.4658203125" />
+						<pt x="2026.06115722656" y="16360.0458984375" />
+						<pt x="2028.66284179688" y="19794.029296875" />
+						<pt x="2031.287109375" y="20121.05859375" />
+						<pt x="2033.83422851562" y="16135.64453125" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="300.499803701804"/>
+					<UserParam type="string" name="native_id" value="LC(Carbamidomethyl)VLHEK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="21832.7421875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.325393160206819"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.165802001953" RT="1949.05554199219" >
+				<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.188627296280199"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="300.166046142578" RT="1970.11474609375" >
+				<PeptideHit score="0.0454545454545455" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.0707872514634683"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LC(Carbamidomethyl)VLHEK/3"/>
+			<UserParam type="float" name="leftWidth" value="1939.34069824219"/>
+			<UserParam type="float" name="rightWidth" value="2036.53295898438"/>
+			<UserParam type="float" name="total_xic" value="22159990.6004639"/>
+			<UserParam type="float" name="peak_apices_sum" value="72575.4448242188"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="3.64273441009184"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="1.75609961197951"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.775115723638661"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.70381060715617"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0838284433324637"/>
+			<UserParam type="float" name="var_library_sangle" value="0.141078652799303"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0838284433324637"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.098194929215271"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.995657255203499"/>
+			<UserParam type="float" name="var_intensity_score" value="0.1321993453345"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="1.2668993900222"/>
+			<UserParam type="float" name="var_log_sn_score" value="0.236572490153024"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.687795549631119"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="3.06104265743219"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.981719188551002"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.241564720869064"/>
+			<UserParam type="float" name="var_massdev_score" value="1.82587790799991"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.84036734399487"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.902884840789147"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.615088901235478"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.889465319224237"/>
+			<UserParam type="float" name="PrecursorMZ" value="300.165352089204"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="3"/>
+			<UserParam type="int" name="n_matching_ids" value="2"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="78234.9574169088"/>
+			<UserParam type="float" name="model_FWHM" value="177.892763392108"/>
+			<UserParam type="float" name="model_center" value="1985.73122965242"/>
+			<UserParam type="float" name="model_lower" value="1796.87097346287"/>
+			<UserParam type="float" name="model_upper" value="2174.59148584196"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="75.5441024758191"/>
+			<UserParam type="float" name="model_error" value="0.163589773941473"/>
+			<UserParam type="float" name="model_area" value="14814646.8376716"/>
+			<UserParam type="string" name="model_status" value="3 (left side out of bounds)"/>
+			<UserParam type="float" name="raw_intensity" value="2929536.5"/>
+		</feature>
+		<feature id="f_7344192187426184761">
+			<position dim="0">1943.3004011853</position>
+			<position dim="1">395.239463487571</position>
+			<intensity>1.82822e+08</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.80547</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="1918.98767089844" y="395.189463487571" />
+				<pt x="1998.99108886719" y="395.189463487571" />
+				<pt x="1998.99108886719" y="395.289463487571" />
+				<pt x="1918.98767089844" y="395.289463487571" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1918.98767089844" y="395.691140906471" />
+				<pt x="1998.99108886719" y="395.691140906471" />
+				<pt x="1998.99108886719" y="395.791140906471" />
+				<pt x="1918.98767089844" y="395.791140906471" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_7344192187426184761_7283948392886265699">
+					<position dim="0">1943.3004011853</position>
+					<position dim="1">395.239463487571</position>
+					<intensity>6.31944e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1918.98767089844" y="6117.03076171875" />
+						<pt x="1921.35717773438" y="6379.58154296875" />
+						<pt x="1923.42529296875" y="4494.837890625" />
+						<pt x="1925.10778808594" y="3110.54248046875" />
+						<pt x="1927.1669921875" y="1101.01733398438" />
+						<pt x="1928.453125" y="1140.63757324219" />
+						<pt x="1930.11804199219" y="11769.837890625" />
+						<pt x="1932.48400878906" y="174317.203125" />
+						<pt x="1934.46069335938" y="1082928.66845703" />
+						<pt x="1936.77783203125" y="3927904.15917969" />
+						<pt x="1939.34069824219" y="9982069.45507812" />
+						<pt x="1941.74328613281" y="12176436.2207031" />
+						<pt x="1943.79846191406" y="11353591.1308594" />
+						<pt x="1946.22692871094" y="7025028.234375" />
+						<pt x="1948.33605957031" y="5408893.00878906" />
+						<pt x="1950.83435058594" y="3091029.03417969" />
+						<pt x="1953.46435546875" y="1989076.11254883" />
+						<pt x="1956.12158203125" y="1374127.81286621" />
+						<pt x="1958.88928222656" y="971337.754150391" />
+						<pt x="1961.46557617188" y="705683.325195312" />
+						<pt x="1963.85095214844" y="555706.5" />
+						<pt x="1966.54650878906" y="533741.25" />
+						<pt x="1969.21594238281" y="354351.875" />
+						<pt x="1971.63354492188" y="298141.90625" />
+						<pt x="1973.24267578125" y="268639.53125" />
+						<pt x="1974.81298828125" y="256455.015625" />
+						<pt x="1977.380859375" y="162474.875" />
+						<pt x="1979.2890625" y="167706.221191406" />
+						<pt x="1980.87292480469" y="144897.78125" />
+						<pt x="1982.46655273438" y="166323.244506836" />
+						<pt x="1984.07604980469" y="154813.89642334" />
+						<pt x="1985.6865234375" y="156140.25" />
+						<pt x="1986.94934082031" y="156258.48046875" />
+						<pt x="1989.31274414062" y="128527.629394531" />
+						<pt x="1991.31884765625" y="118223.734863281" />
+						<pt x="1993.19482421875" y="106780.689575195" />
+						<pt x="1995.119140625" y="93174.603515625" />
+						<pt x="1997.05432128906" y="75538.9014892578" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="395.239463487571"/>
+					<UserParam type="string" name="native_id" value="LVTDLTK/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="11353591.1308594"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.704209887318509"/>
+				</feature>
+				<feature id="f_7344192187426184761_2130311522918743509">
+					<position dim="0">1943.3004011853</position>
+					<position dim="1">395.741140906471</position>
+					<intensity>2.63457e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1918.98767089844" y="2078.59594726562" />
+						<pt x="1921.35717773438" y="835.552795410156" />
+						<pt x="1923.42529296875" y="961.776000976562" />
+						<pt x="1925.10778808594" y="0" />
+						<pt x="1927.1669921875" y="0" />
+						<pt x="1928.453125" y="0" />
+						<pt x="1930.11804199219" y="4380.9111328125" />
+						<pt x="1932.48400878906" y="74131.1328125" />
+						<pt x="1934.46069335938" y="475151.880859375" />
+						<pt x="1936.77783203125" y="1692338.80615234" />
+						<pt x="1939.34069824219" y="4399968.90625" />
+						<pt x="1941.74328613281" y="5051440.5" />
+						<pt x="1943.79846191406" y="4777608.1171875" />
+						<pt x="1946.22692871094" y="2883425.86328125" />
+						<pt x="1948.33605957031" y="2219362" />
+						<pt x="1950.83435058594" y="1329996.52636719" />
+						<pt x="1953.46435546875" y="844074.666503906" />
+						<pt x="1956.12158203125" y="564934.267333984" />
+						<pt x="1958.88928222656" y="397141.96875" />
+						<pt x="1961.46557617188" y="292772.025634766" />
+						<pt x="1963.85095214844" y="221408.15625" />
+						<pt x="1966.54650878906" y="217641.828125" />
+						<pt x="1969.21594238281" y="139387.8125" />
+						<pt x="1971.63354492188" y="124288.9921875" />
+						<pt x="1973.24267578125" y="106670.7265625" />
+						<pt x="1974.81298828125" y="100245.890625" />
+						<pt x="1977.380859375" y="61358.453125" />
+						<pt x="1979.2890625" y="60064.0078125" />
+						<pt x="1980.87292480469" y="48254.83984375" />
+						<pt x="1982.46655273438" y="52144.85546875" />
+						<pt x="1984.07604980469" y="39635.41015625" />
+						<pt x="1985.6865234375" y="37483.0546875" />
+						<pt x="1986.94934082031" y="38913.83984375" />
+						<pt x="1989.31274414062" y="22485.8828125" />
+						<pt x="1991.31884765625" y="22267.365234375" />
+						<pt x="1993.19482421875" y="17794.16015625" />
+						<pt x="1995.119140625" y="15023.083984375" />
+						<pt x="1997.05432128906" y="9990.9580078125" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="395.741140906471"/>
+					<UserParam type="string" name="native_id" value="LVTDLTK/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="4777608.1171875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.295790112681491"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="395.239349365234" RT="1933.40515136719" >
+				<PeptideHit score="0" sequence="LVTDLTK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.00108437147303181"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LVTDLTK/2"/>
+			<UserParam type="float" name="leftWidth" value="1918.98767089844"/>
+			<UserParam type="float" name="rightWidth" value="1998.99108886719"/>
+			<UserParam type="float" name="total_xic" value="89905078.2590332"/>
+			<UserParam type="float" name="peak_apices_sum" value="16131199.2480469"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999855522861782"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999819433927319"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00155698400061227"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00266588296521212"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00155698400061227"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00178551886317935"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999998543005867"/>
+			<UserParam type="float" name="var_intensity_score" value="0.995940359920697"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="103.895258829532"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.64338326500946"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.997846633195877"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.56821623209286"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.99176717726236"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.294233113527298"/>
+			<UserParam type="float" name="var_massdev_score" value="1.34876090913977"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.0324552849287"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="1"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.784624367602911"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.867806593918273"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.8054747289921"/>
+			<UserParam type="float" name="PrecursorMZ" value="395.239463487571"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="17031259.5112055"/>
+			<UserParam type="float" name="model_FWHM" value="10.0843824119691"/>
+			<UserParam type="float" name="model_center" value="1942.629905668"/>
+			<UserParam type="float" name="model_lower" value="1931.92379818211"/>
+			<UserParam type="float" name="model_upper" value="1953.33601315389"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="4.28244299435588"/>
+			<UserParam type="float" name="model_error" value="0.285464271814659"/>
+			<UserParam type="float" name="model_area" value="182821910.764851"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="89540096"/>
+		</feature>
+		<feature id="f_9140546320740515641">
+			<position dim="0">2391.85092347612</position>
+			<position dim="1">501.795134726821</position>
+			<intensity>7.77641e+07</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.67498</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2367.25073242188" y="501.745134726821" />
+				<pt x="2447.93408203125" y="501.745134726821" />
+				<pt x="2447.93408203125" y="501.845134726821" />
+				<pt x="2367.25073242188" y="501.845134726821" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2367.25073242188" y="502.246812145721" />
+				<pt x="2447.93408203125" y="502.246812145721" />
+				<pt x="2447.93408203125" y="502.346812145721" />
+				<pt x="2367.25073242188" y="502.346812145721" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_9140546320740515641_12049315334424432437">
+					<position dim="0">2391.85092347612</position>
+					<position dim="1">501.795134726821</position>
+					<intensity>2.43122e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="2367.25073242188" y="0" />
+						<pt x="2369.20751953125" y="0" />
+						<pt x="2370.35498046875" y="0" />
+						<pt x="2371.9755859375" y="0" />
+						<pt x="2373.9287109375" y="0" />
+						<pt x="2376.5869140625" y="2433.97705078125" />
+						<pt x="2377.77197265625" y="6171.642578125" />
+						<pt x="2380.13623046875" y="29049.7421875" />
+						<pt x="2381.28979492188" y="73028.1875" />
+						<pt x="2383.62573242188" y="421931.46875" />
+						<pt x="2386.21655273438" y="1893225.87255859" />
+						<pt x="2388.87280273438" y="4335401.91601562" />
+						<pt x="2391.34716796875" y="5217008.28320312" />
+						<pt x="2393.150390625" y="4967869.33007812" />
+						<pt x="2395.32104492188" y="3185805.18261719" />
+						<pt x="2397.95825195312" y="1366266.60620117" />
+						<pt x="2400.6484375" y="478780.656494141" />
+						<pt x="2403.47192382812" y="251020.90625" />
+						<pt x="2405.06005859375" y="195132.65625" />
+						<pt x="2407.34887695312" y="159410.640625" />
+						<pt x="2410.00390625" y="159829.59375" />
+						<pt x="2411.24560546875" y="143194.21875" />
+						<pt x="2413.26293945312" y="133373.9375" />
+						<pt x="2414.81225585938" y="120386.5234375" />
+						<pt x="2416.37377929688" y="118206.6796875" />
+						<pt x="2417.87133789062" y="101351.6171875" />
+						<pt x="2419.4033203125" y="94513.390625" />
+						<pt x="2420.93139648438" y="102115.15625" />
+						<pt x="2422.56640625" y="74304.109375" />
+						<pt x="2424.5244140625" y="68106.2890625" />
+						<pt x="2426.22387695312" y="68560.5" />
+						<pt x="2427.80981445312" y="61671.19140625" />
+						<pt x="2429.42407226562" y="67174.078125" />
+						<pt x="2430.58862304688" y="57929.328125" />
+						<pt x="2432.6376953125" y="49598.73046875" />
+						<pt x="2434.71142578125" y="42556.05078125" />
+						<pt x="2436.32397460938" y="40735.1953125" />
+						<pt x="2437.55200195312" y="41866.015625" />
+						<pt x="2438.87060546875" y="36309.2578125" />
+						<pt x="2440.08959960938" y="28907.3515625" />
+						<pt x="2441.35229492188" y="31006.46484375" />
+						<pt x="2442.61108398438" y="36277.6986694336" />
+						<pt x="2445.39599609375" y="26903.89453125" />
+						<pt x="2447.05639648438" y="24740.56640625" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="501.795134726821"/>
+					<UserParam type="string" name="native_id" value="LVVSTQTALA/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="5217008.28320312"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.653030735732608"/>
+				</feature>
+				<feature id="f_9140546320740515641_9868242461570157420">
+					<position dim="0">2391.85092347612</position>
+					<position dim="1">502.296812145721</position>
+					<intensity>1.27326e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="2367.25073242188" y="0" />
+						<pt x="2369.20751953125" y="0" />
+						<pt x="2370.35498046875" y="0" />
+						<pt x="2371.9755859375" y="0" />
+						<pt x="2373.9287109375" y="0" />
+						<pt x="2376.5869140625" y="1516.80078125" />
+						<pt x="2377.77197265625" y="2486.70141601562" />
+						<pt x="2380.13623046875" y="12878.775390625" />
+						<pt x="2381.28979492188" y="32565.173828125" />
+						<pt x="2383.62573242188" y="239022.984375" />
+						<pt x="2386.21655273438" y="1043269.37109375" />
+						<pt x="2388.87280273438" y="2282502.25" />
+						<pt x="2391.34716796875" y="2826096.25" />
+						<pt x="2393.150390625" y="2565665.75" />
+						<pt x="2395.32104492188" y="1697856.99072266" />
+						<pt x="2397.95825195312" y="668443.94140625" />
+						<pt x="2400.6484375" y="249026.078125" />
+						<pt x="2403.47192382812" y="127022.0078125" />
+						<pt x="2405.06005859375" y="101064.859375" />
+						<pt x="2407.34887695312" y="75298.640625" />
+						<pt x="2410.00390625" y="71698.0546875" />
+						<pt x="2411.24560546875" y="69159.453125" />
+						<pt x="2413.26293945312" y="59553.7578125" />
+						<pt x="2414.81225585938" y="59974.34375" />
+						<pt x="2416.37377929688" y="61227.94140625" />
+						<pt x="2417.87133789062" y="48590.63671875" />
+						<pt x="2419.4033203125" y="43869.00390625" />
+						<pt x="2420.93139648438" y="47888.48828125" />
+						<pt x="2422.56640625" y="39846.03125" />
+						<pt x="2424.5244140625" y="31481.748046875" />
+						<pt x="2426.22387695312" y="31749.45703125" />
+						<pt x="2427.80981445312" y="26097.3984375" />
+						<pt x="2429.42407226562" y="29518.203125" />
+						<pt x="2430.58862304688" y="23042.17578125" />
+						<pt x="2432.6376953125" y="20541.76171875" />
+						<pt x="2434.71142578125" y="22476.27734375" />
+						<pt x="2436.32397460938" y="16425.3933105469" />
+						<pt x="2437.55200195312" y="16248.763671875" />
+						<pt x="2438.87060546875" y="19545.37890625" />
+						<pt x="2440.08959960938" y="12967.4677734375" />
+						<pt x="2441.35229492188" y="13809.294921875" />
+						<pt x="2442.61108398438" y="14411.8955078125" />
+						<pt x="2445.39599609375" y="15910.0927734375" />
+						<pt x="2447.05639648438" y="11848.0859375" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="502.296812145721"/>
+					<UserParam type="string" name="native_id" value="LVVSTQTALA/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="2826096.25"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.346969264267392"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.794891357422" RT="2431.52172851562" >
+				<PeptideHit score="0.0454545454545455" sequence="LVVSTQTALA" charge="2" aa_before="K" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.128894553541144"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="LVVSTQTALA/2"/>
+			<UserParam type="float" name="leftWidth" value="2367.25073242188"/>
+			<UserParam type="float" name="rightWidth" value="2447.93408203125"/>
+			<UserParam type="float" name="total_xic" value="37515269.1315308"/>
+			<UserParam type="float" name="peak_apices_sum" value="8043104.53320312"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.999887755329832"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999847404542345"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00326071413321929"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00595193237417471"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00326071413321929"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00351508354354219"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999994121382001"/>
+			<UserParam type="float" name="var_intensity_score" value="0.987457983311246"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="110.753693509412"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.70730875834126"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.996165663003922"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.61313811537583"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.990584754099702"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.343708544969559"/>
+			<UserParam type="float" name="var_massdev_score" value="0.832902537954213"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.670716801858621"/>
+			<UserParam type="float" name="var_bseries_score" value="1"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.75280849938603"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.859198961033804"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.67498308999633"/>
+			<UserParam type="float" name="PrecursorMZ" value="501.795134726821"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="8191986.60739646"/>
+			<UserParam type="float" name="model_FWHM" value="8.91780398230993"/>
+			<UserParam type="float" name="model_center" value="2391.57709223505"/>
+			<UserParam type="float" name="model_lower" value="2382.10948538791"/>
+			<UserParam type="float" name="model_upper" value="2401.04469908218"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="3.78704273885475"/>
+			<UserParam type="float" name="model_error" value="0.146903598114083"/>
+			<UserParam type="float" name="model_area" value="77764131.6135644"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="37044752"/>
+		</feature>
+		<feature id="f_16616557306000669869">
+			<position dim="0">1558.9325598625</position>
+			<position dim="1">358.174576486338</position>
+			<intensity>1.53599e+06</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>3.16365</overallquality>
+			<charge>3</charge>
+			<convexhull nr="0">
+				<pt x="1539.38354492188" y="358.124576486338" />
+				<pt x="1615.81567382812" y="358.124576486338" />
+				<pt x="1615.81567382812" y="358.224576486338" />
+				<pt x="1539.38354492188" y="358.224576486338" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="1539.38354492188" y="358.459028098938" />
+				<pt x="1615.81567382812" y="358.459028098938" />
+				<pt x="1615.81567382812" y="358.559028098938" />
+				<pt x="1539.38354492188" y="358.559028098938" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_16616557306000669869_8984402899352117479">
+					<position dim="0">1558.9325598625</position>
+					<position dim="1">358.174576486338</position>
+					<intensity>903200</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1539.38354492188" y="0" />
+						<pt x="1541.00708007812" y="2239.18981933594" />
+						<pt x="1542.74108886719" y="933.978576660156" />
+						<pt x="1544.19909667969" y="1371.47583007812" />
+						<pt x="1545.931640625" y="2588.44946289062" />
+						<pt x="1547.58288574219" y="4737.96594238281" />
+						<pt x="1548.85375976562" y="7855.29052734375" />
+						<pt x="1550.318359375" y="17356.0825195312" />
+						<pt x="1552.02954101562" y="32417.9212646484" />
+						<pt x="1553.61145019531" y="55270.93359375" />
+						<pt x="1554.8564453125" y="72005.3453369141" />
+						<pt x="1556.25244140625" y="78982.9140625" />
+						<pt x="1558.00354003906" y="86037.9240722656" />
+						<pt x="1559.29125976562" y="54360.2887573242" />
+						<pt x="1561.01330566406" y="61414.8527832031" />
+						<pt x="1562.32336425781" y="48318.2103271484" />
+						<pt x="1564.07397460938" y="35354.3702392578" />
+						<pt x="1565.71118164062" y="29049.1350097656" />
+						<pt x="1567.046875" y="21024.9796142578" />
+						<pt x="1568.783203125" y="26093.1081542969" />
+						<pt x="1570.36181640625" y="21341.0754394531" />
+						<pt x="1571.69384765625" y="17459.3172607422" />
+						<pt x="1573.44921875" y="16360.7265625" />
+						<pt x="1574.71813964844" y="13635.46484375" />
+						<pt x="1576.45373535156" y="14134.0642089844" />
+						<pt x="1578.20324707031" y="11757.7280273438" />
+						<pt x="1579.85180664062" y="13311.9721679688" />
+						<pt x="1581.10729980469" y="7130.31787109375" />
+						<pt x="1582.80322265625" y="12689.5303955078" />
+						<pt x="1584.42724609375" y="9453.90576171875" />
+						<pt x="1585.71594238281" y="9054.861328125" />
+						<pt x="1587.12292480469" y="8105.44482421875" />
+						<pt x="1588.85363769531" y="6885.24755859375" />
+						<pt x="1590.55505371094" y="6519.04052734375" />
+						<pt x="1592.29345703125" y="10125.0245361328" />
+						<pt x="1593.861328125" y="6317.52294921875" />
+						<pt x="1595.50939941406" y="9787.1015625" />
+						<pt x="1596.7958984375" y="4873.326171875" />
+						<pt x="1598.55334472656" y="6004.79833984375" />
+						<pt x="1600.25183105469" y="9645.70764160156" />
+						<pt x="1601.50854492188" y="5301.7333984375" />
+						<pt x="1602.97534179688" y="6074.7373046875" />
+						<pt x="1604.69299316406" y="6185.77172851562" />
+						<pt x="1606.37744140625" y="5469.15380859375" />
+						<pt x="1608.01416015625" y="5975.05322265625" />
+						<pt x="1609.38244628906" y="4365.85693359375" />
+						<pt x="1611.11169433594" y="4958.79833984375" />
+						<pt x="1612.80322265625" y="5204.52392578125" />
+						<pt x="1614.45471191406" y="4368.63427734375" />
+						<pt x="1615.81567382812" y="3291.60571289062" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="358.174576486338"/>
+					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="54360.2887573242"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.646660950740033"/>
+				</feature>
+				<feature id="f_16616557306000669869_1621338151966755474">
+					<position dim="0">1558.9325598625</position>
+					<position dim="1">358.509028098938</position>
+					<intensity>373548</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="1539.38354492188" y="0" />
+						<pt x="1541.00708007812" y="0" />
+						<pt x="1542.74108886719" y="0" />
+						<pt x="1544.19909667969" y="0" />
+						<pt x="1545.931640625" y="0" />
+						<pt x="1547.58288574219" y="0" />
+						<pt x="1548.85375976562" y="0" />
+						<pt x="1550.318359375" y="6262.92529296875" />
+						<pt x="1552.02954101562" y="13017.2158203125" />
+						<pt x="1553.61145019531" y="24925.921875" />
+						<pt x="1554.8564453125" y="31720.091796875" />
+						<pt x="1556.25244140625" y="34598.8828125" />
+						<pt x="1558.00354003906" y="43015.8828125" />
+						<pt x="1559.29125976562" y="26582.2421875" />
+						<pt x="1561.01330566406" y="22726.515625" />
+						<pt x="1562.32336425781" y="18214.5859375" />
+						<pt x="1564.07397460938" y="16445.677734375" />
+						<pt x="1565.71118164062" y="9915.1513671875" />
+						<pt x="1567.046875" y="8902.1181640625" />
+						<pt x="1568.783203125" y="11286.6875" />
+						<pt x="1570.36181640625" y="6938.35400390625" />
+						<pt x="1571.69384765625" y="5063.97705078125" />
+						<pt x="1573.44921875" y="6453.58740234375" />
+						<pt x="1574.71813964844" y="4695.03125" />
+						<pt x="1576.45373535156" y="6751.689453125" />
+						<pt x="1578.20324707031" y="6045.24072265625" />
+						<pt x="1579.85180664062" y="4751.85400390625" />
+						<pt x="1581.10729980469" y="3581.35034179688" />
+						<pt x="1582.80322265625" y="4689.10302734375" />
+						<pt x="1584.42724609375" y="5094.8720703125" />
+						<pt x="1585.71594238281" y="2390.78784179688" />
+						<pt x="1587.12292480469" y="3773.33935546875" />
+						<pt x="1588.85363769531" y="4017.90698242188" />
+						<pt x="1590.55505371094" y="3224.69604492188" />
+						<pt x="1592.29345703125" y="4278.44091796875" />
+						<pt x="1593.861328125" y="3536.69409179688" />
+						<pt x="1595.50939941406" y="2354.60083007812" />
+						<pt x="1596.7958984375" y="1611.36206054687" />
+						<pt x="1598.55334472656" y="3083.95288085938" />
+						<pt x="1600.25183105469" y="1816.82897949219" />
+						<pt x="1601.50854492188" y="3115.00415039062" />
+						<pt x="1602.97534179688" y="1709.54516601562" />
+						<pt x="1604.69299316406" y="1897.40795898438" />
+						<pt x="1606.37744140625" y="3191.517578125" />
+						<pt x="1608.01416015625" y="2355.7861328125" />
+						<pt x="1609.38244628906" y="1842.47180175781" />
+						<pt x="1611.11169433594" y="2389.34326171875" />
+						<pt x="1612.80322265625" y="1767.15783691406" />
+						<pt x="1614.45471191406" y="2080.60668945312" />
+						<pt x="1615.81567382812" y="1431.70666503906" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="358.509028098938"/>
+					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="26582.2421875"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.353339049259967"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
+				<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="SHC(Carbamidomethyl)IAEVEK/3"/>
+			<UserParam type="float" name="leftWidth" value="1539.38354492188"/>
+			<UserParam type="float" name="rightWidth" value="1615.81567382812"/>
+			<UserParam type="float" name="total_xic" value="1534200.08959961"/>
+			<UserParam type="float" name="peak_apices_sum" value="80942.5309448242"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.995859874004335"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99432412161936"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.0607613750242852"/>
+			<UserParam type="float" name="var_library_sangle" value="0.107918735760252"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.0607613750242852"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.0672493863158573"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.997885894058429"/>
+			<UserParam type="float" name="var_intensity_score" value="0.832191728872341"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="11.7494826105578"/>
+			<UserParam type="float" name="var_log_sn_score" value="2.46380920647666"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.977227956056595"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="5.81651671719193"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.985290582455854"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.292577654123306"/>
+			<UserParam type="float" name="var_massdev_score" value="0.776434922758457"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="0.740130209172225"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.755976718319793"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.967667974449062"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.16365489172794"/>
+			<UserParam type="float" name="PrecursorMZ" value="358.174576486338"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="1"/>
+			<UserParam type="int" name="n_matching_ids" value="1"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="111785.030056947"/>
+			<UserParam type="float" name="model_FWHM" value="12.9084172565869"/>
+			<UserParam type="float" name="model_center" value="1558.22475307717"/>
+			<UserParam type="float" name="model_lower" value="1544.52050258606"/>
+			<UserParam type="float" name="model_upper" value="1571.92900356827"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="5.48170019644257"/>
+			<UserParam type="float" name="model_error" value="0.563856924835845"/>
+			<UserParam type="float" name="model_area" value="1535991.50601293"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="1276748.5"/>
+		</feature>
+		<feature id="f_25974125700937907">
 			<position dim="0">2090.16589783288</position>
 			<position dim="1">421.758354535421</position>
 			<intensity>2.05976e+07</intensity>
@@ -3040,7 +4869,7 @@
 				<pt x="2038.14636230469" y="422.310031954321" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_14891455924036538147_5860084234476467938">
+				<feature id="f_25974125700937907_7444998229116103684">
 					<position dim="0">2090.16589783288</position>
 					<position dim="1">421.758354535421</position>
 					<intensity>8.41674e+06</intensity>
@@ -3148,7 +4977,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.688369804746839"/>
 				</feature>
-				<feature id="f_14891455924036538147_12758854762884412659">
+				<feature id="f_25974125700937907_11583213259935596392">
 					<position dim="0">2090.16589783288</position>
 					<position dim="1">422.260031954321</position>
 					<intensity>3.41801e+06</intensity>
@@ -3305,2086 +5134,12 @@
 			<UserParam type="float" name="model_lower" value="2060.04775772547"/>
 			<UserParam type="float" name="model_upper" value="2123.48505826251"/>
 			<UserParam type="float" name="model_Gauss_sigma" value="12.6874601074066"/>
-			<UserParam type="float" name="model_error" value="0.463354345374508"/>
-			<UserParam type="float" name="model_area" value="20597628.6616102"/>
+			<UserParam type="float" name="model_error" value="0.463354345374507"/>
+			<UserParam type="float" name="model_area" value="20597628.6616101"/>
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="11834744"/>
 		</feature>
-		<feature id="f_17287849381738438716">
-			<position dim="0">1760.25657093773</position>
-			<position dim="1">569.752618393021</position>
-			<intensity>2.0629e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.74485</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1735.69311523438" y="569.702618393021" />
-				<pt x="1806.53210449219" y="569.702618393021" />
-				<pt x="1806.53210449219" y="569.802618393021" />
-				<pt x="1735.69311523438" y="569.802618393021" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1735.69311523438" y="570.204295811921" />
-				<pt x="1806.53210449219" y="570.204295811921" />
-				<pt x="1806.53210449219" y="570.304295811921" />
-				<pt x="1735.69311523438" y="570.304295811921" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_17287849381738438716_5495827884756377090">
-					<position dim="0">1760.25657093773</position>
-					<position dim="1">569.752618393021</position>
-					<intensity>9.09907e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1735.69311523438" y="0" />
-						<pt x="1737.05261230469" y="0" />
-						<pt x="1738.2958984375" y="0" />
-						<pt x="1740.13562011719" y="0" />
-						<pt x="1742.16540527344" y="0" />
-						<pt x="1744.55932617188" y="0" />
-						<pt x="1746.17114257812" y="0" />
-						<pt x="1747.40344238281" y="0" />
-						<pt x="1749.72985839844" y="18509.880859375" />
-						<pt x="1751.63122558594" y="83788.8125" />
-						<pt x="1753.181640625" y="261643.15625" />
-						<pt x="1754.70849609375" y="561154.6875" />
-						<pt x="1756.63635253906" y="1057437.25" />
-						<pt x="1758.22473144531" y="1291446.5" />
-						<pt x="1759.81530761719" y="1354679.41699219" />
-						<pt x="1761.75610351562" y="1162693.41821289" />
-						<pt x="1763.34350585938" y="781237.9375" />
-						<pt x="1764.53942871094" y="603374.328613281" />
-						<pt x="1766.20935058594" y="377011.59375" />
-						<pt x="1767.45556640625" y="296376.96875" />
-						<pt x="1768.78759765625" y="228238.265625" />
-						<pt x="1770.08776855469" y="180287.15625" />
-						<pt x="1771.37548828125" y="138572.09375" />
-						<pt x="1772.72485351562" y="124504.578125" />
-						<pt x="1775.10119628906" y="90972.8515625" />
-						<pt x="1776.7529296875" y="79513.1162109375" />
-						<pt x="1778.41467285156" y="61972.140625" />
-						<pt x="1779.78234863281" y="59201.09765625" />
-						<pt x="1781.03625488281" y="45934.63671875" />
-						<pt x="1782.70874023438" y="41144.109375" />
-						<pt x="1784.005859375" y="34639.359375" />
-						<pt x="1785.66430664062" y="26685.29296875" />
-						<pt x="1788.00903320312" y="24262.755859375" />
-						<pt x="1789.64514160156" y="20025.701171875" />
-						<pt x="1791.29907226562" y="20927.953125" />
-						<pt x="1792.96655273438" y="15381.3466796875" />
-						<pt x="1794.18957519531" y="15000.53515625" />
-						<pt x="1796.90112304688" y="12211.6181640625" />
-						<pt x="1799.29284667969" y="9903.77734375" />
-						<pt x="1802.06115722656" y="6677.27880859375" />
-						<pt x="1802.93933105469" y="7866.50146484375" />
-						<pt x="1805.2861328125" y="5790.8994140625" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="569.752618393021"/>
-					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="1354679.41699219"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.644498608917742"/>
-				</feature>
-				<feature id="f_17287849381738438716_4143272592559840046">
-					<position dim="0">1760.25657093773</position>
-					<position dim="1">570.254295811921</position>
-					<intensity>5.04683e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1735.69311523438" y="0" />
-						<pt x="1737.05261230469" y="0" />
-						<pt x="1738.2958984375" y="0" />
-						<pt x="1740.13562011719" y="0" />
-						<pt x="1742.16540527344" y="0" />
-						<pt x="1744.55932617188" y="0" />
-						<pt x="1746.17114257812" y="0" />
-						<pt x="1747.40344238281" y="0" />
-						<pt x="1749.72985839844" y="8986.8115234375" />
-						<pt x="1751.63122558594" y="52224.08203125" />
-						<pt x="1753.181640625" y="161934.0625" />
-						<pt x="1754.70849609375" y="321664.15625" />
-						<pt x="1756.63635253906" y="616271.230957031" />
-						<pt x="1758.22473144531" y="733171" />
-						<pt x="1759.81530761719" y="754406.354980469" />
-						<pt x="1761.75610351562" y="627629.3125" />
-						<pt x="1763.34350585938" y="437539.9375" />
-						<pt x="1764.53942871094" y="321101.329711914" />
-						<pt x="1766.20935058594" y="203640.328125" />
-						<pt x="1767.45556640625" y="161321.34375" />
-						<pt x="1768.78759765625" y="117180.109375" />
-						<pt x="1770.08776855469" y="108087.3671875" />
-						<pt x="1771.37548828125" y="77820.90625" />
-						<pt x="1772.72485351562" y="70044.84375" />
-						<pt x="1775.10119628906" y="47241.203125" />
-						<pt x="1776.7529296875" y="39962.79296875" />
-						<pt x="1778.41467285156" y="31583.787109375" />
-						<pt x="1779.78234863281" y="23770.244140625" />
-						<pt x="1781.03625488281" y="19617.638671875" />
-						<pt x="1782.70874023438" y="15318.6826171875" />
-						<pt x="1784.005859375" y="14336.6845703125" />
-						<pt x="1785.66430664062" y="11963.017578125" />
-						<pt x="1788.00903320312" y="10488.1298828125" />
-						<pt x="1789.64514160156" y="10806.5380859375" />
-						<pt x="1791.29907226562" y="9637.36328125" />
-						<pt x="1792.96655273438" y="9727.61328125" />
-						<pt x="1794.18957519531" y="5487.93408203125" />
-						<pt x="1796.90112304688" y="5579.2353515625" />
-						<pt x="1799.29284667969" y="5431.78173828125" />
-						<pt x="1802.06115722656" y="4058.3056640625" />
-						<pt x="1802.93933105469" y="5636.17163085938" />
-						<pt x="1805.2861328125" y="3155.05395507812" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="570.254295811921"/>
-					<UserParam type="string" name="native_id" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="754406.354980469"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.355501391082258"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752807617188" RT="1750.91589355469" >
-				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.00235357253308681"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="569.752258300781" RT="1793.82604980469" >
-				<PeptideHit score="0.0344827586206897" sequence="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0108172080557891"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="C(Carbamidomethyl)C(Carbamidomethyl)TESLVNR/2"/>
-			<UserParam type="float" name="leftWidth" value="1735.69311523438"/>
-			<UserParam type="float" name="rightWidth" value="1806.53210449219"/>
-			<UserParam type="float" name="total_xic" value="14486678.1954346"/>
-			<UserParam type="float" name="peak_apices_sum" value="2109085.77197266"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999786313233063"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999706240332848"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00126828605193471"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00234262974544488"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00126828605193471"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00135289409378486"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999999123130552"/>
-			<UserParam type="float" name="var_intensity_score" value="0.976475891102353"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="117.627765815645"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.76752511147092"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.99731856584549"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.66028853965821"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.993260451842917"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.356769680976868"/>
-			<UserParam type="float" name="var_massdev_score" value="0.482075605090886"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.385620600005746"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.754351526419968"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.84165907229483"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.74484798021522"/>
-			<UserParam type="float" name="PrecursorMZ" value="569.752618393021"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="2085091.18908788"/>
-			<UserParam type="float" name="model_FWHM" value="9.2944112937242"/>
-			<UserParam type="float" name="model_center" value="1759.73649271727"/>
-			<UserParam type="float" name="model_lower" value="1749.86905986282"/>
-			<UserParam type="float" name="model_upper" value="1769.60392557172"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="3.94697314177907"/>
-			<UserParam type="float" name="model_error" value="0.242313540768204"/>
-			<UserParam type="float" name="model_area" value="20629044.4109768"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="14145892"/>
-		</feature>
-		<feature id="f_11399299100673837381">
-			<position dim="0">1558.9325598625</position>
-			<position dim="1">358.174576486338</position>
-			<intensity>1.53599e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.16365</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1539.38354492188" y="358.124576486338" />
-				<pt x="1615.81567382812" y="358.124576486338" />
-				<pt x="1615.81567382812" y="358.224576486338" />
-				<pt x="1539.38354492188" y="358.224576486338" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1539.38354492188" y="358.459028098938" />
-				<pt x="1615.81567382812" y="358.459028098938" />
-				<pt x="1615.81567382812" y="358.559028098938" />
-				<pt x="1539.38354492188" y="358.559028098938" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_11399299100673837381_16164338904207598736">
-					<position dim="0">1558.9325598625</position>
-					<position dim="1">358.174576486338</position>
-					<intensity>903200</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1539.38354492188" y="0" />
-						<pt x="1541.00708007812" y="2239.18981933594" />
-						<pt x="1542.74108886719" y="933.978576660156" />
-						<pt x="1544.19909667969" y="1371.47583007812" />
-						<pt x="1545.931640625" y="2588.44946289062" />
-						<pt x="1547.58288574219" y="4737.96594238281" />
-						<pt x="1548.85375976562" y="7855.29052734375" />
-						<pt x="1550.318359375" y="17356.0825195312" />
-						<pt x="1552.02954101562" y="32417.9212646484" />
-						<pt x="1553.61145019531" y="55270.93359375" />
-						<pt x="1554.8564453125" y="72005.3453369141" />
-						<pt x="1556.25244140625" y="78982.9140625" />
-						<pt x="1558.00354003906" y="86037.9240722656" />
-						<pt x="1559.29125976562" y="54360.2887573242" />
-						<pt x="1561.01330566406" y="61414.8527832031" />
-						<pt x="1562.32336425781" y="48318.2103271484" />
-						<pt x="1564.07397460938" y="35354.3702392578" />
-						<pt x="1565.71118164062" y="29049.1350097656" />
-						<pt x="1567.046875" y="21024.9796142578" />
-						<pt x="1568.783203125" y="26093.1081542969" />
-						<pt x="1570.36181640625" y="21341.0754394531" />
-						<pt x="1571.69384765625" y="17459.3172607422" />
-						<pt x="1573.44921875" y="16360.7265625" />
-						<pt x="1574.71813964844" y="13635.46484375" />
-						<pt x="1576.45373535156" y="14134.0642089844" />
-						<pt x="1578.20324707031" y="11757.7280273438" />
-						<pt x="1579.85180664062" y="13311.9721679688" />
-						<pt x="1581.10729980469" y="7130.31787109375" />
-						<pt x="1582.80322265625" y="12689.5303955078" />
-						<pt x="1584.42724609375" y="9453.90576171875" />
-						<pt x="1585.71594238281" y="9054.861328125" />
-						<pt x="1587.12292480469" y="8105.44482421875" />
-						<pt x="1588.85363769531" y="6885.24755859375" />
-						<pt x="1590.55505371094" y="6519.04052734375" />
-						<pt x="1592.29345703125" y="10125.0245361328" />
-						<pt x="1593.861328125" y="6317.52294921875" />
-						<pt x="1595.50939941406" y="9787.1015625" />
-						<pt x="1596.7958984375" y="4873.326171875" />
-						<pt x="1598.55334472656" y="6004.79833984375" />
-						<pt x="1600.25183105469" y="9645.70764160156" />
-						<pt x="1601.50854492188" y="5301.7333984375" />
-						<pt x="1602.97534179688" y="6074.7373046875" />
-						<pt x="1604.69299316406" y="6185.77172851562" />
-						<pt x="1606.37744140625" y="5469.15380859375" />
-						<pt x="1608.01416015625" y="5975.05322265625" />
-						<pt x="1609.38244628906" y="4365.85693359375" />
-						<pt x="1611.11169433594" y="4958.79833984375" />
-						<pt x="1612.80322265625" y="5204.52392578125" />
-						<pt x="1614.45471191406" y="4368.63427734375" />
-						<pt x="1615.81567382812" y="3291.60571289062" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="358.174576486338"/>
-					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="54360.2887573242"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.646660950740033"/>
-				</feature>
-				<feature id="f_11399299100673837381_4410447320637600518">
-					<position dim="0">1558.9325598625</position>
-					<position dim="1">358.509028098938</position>
-					<intensity>373548</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1539.38354492188" y="0" />
-						<pt x="1541.00708007812" y="0" />
-						<pt x="1542.74108886719" y="0" />
-						<pt x="1544.19909667969" y="0" />
-						<pt x="1545.931640625" y="0" />
-						<pt x="1547.58288574219" y="0" />
-						<pt x="1548.85375976562" y="0" />
-						<pt x="1550.318359375" y="6262.92529296875" />
-						<pt x="1552.02954101562" y="13017.2158203125" />
-						<pt x="1553.61145019531" y="24925.921875" />
-						<pt x="1554.8564453125" y="31720.091796875" />
-						<pt x="1556.25244140625" y="34598.8828125" />
-						<pt x="1558.00354003906" y="43015.8828125" />
-						<pt x="1559.29125976562" y="26582.2421875" />
-						<pt x="1561.01330566406" y="22726.515625" />
-						<pt x="1562.32336425781" y="18214.5859375" />
-						<pt x="1564.07397460938" y="16445.677734375" />
-						<pt x="1565.71118164062" y="9915.1513671875" />
-						<pt x="1567.046875" y="8902.1181640625" />
-						<pt x="1568.783203125" y="11286.6875" />
-						<pt x="1570.36181640625" y="6938.35400390625" />
-						<pt x="1571.69384765625" y="5063.97705078125" />
-						<pt x="1573.44921875" y="6453.58740234375" />
-						<pt x="1574.71813964844" y="4695.03125" />
-						<pt x="1576.45373535156" y="6751.689453125" />
-						<pt x="1578.20324707031" y="6045.24072265625" />
-						<pt x="1579.85180664062" y="4751.85400390625" />
-						<pt x="1581.10729980469" y="3581.35034179688" />
-						<pt x="1582.80322265625" y="4689.10302734375" />
-						<pt x="1584.42724609375" y="5094.8720703125" />
-						<pt x="1585.71594238281" y="2390.78784179688" />
-						<pt x="1587.12292480469" y="3773.33935546875" />
-						<pt x="1588.85363769531" y="4017.90698242188" />
-						<pt x="1590.55505371094" y="3224.69604492188" />
-						<pt x="1592.29345703125" y="4278.44091796875" />
-						<pt x="1593.861328125" y="3536.69409179688" />
-						<pt x="1595.50939941406" y="2354.60083007812" />
-						<pt x="1596.7958984375" y="1611.36206054687" />
-						<pt x="1598.55334472656" y="3083.95288085938" />
-						<pt x="1600.25183105469" y="1816.82897949219" />
-						<pt x="1601.50854492188" y="3115.00415039062" />
-						<pt x="1602.97534179688" y="1709.54516601562" />
-						<pt x="1604.69299316406" y="1897.40795898438" />
-						<pt x="1606.37744140625" y="3191.517578125" />
-						<pt x="1608.01416015625" y="2355.7861328125" />
-						<pt x="1609.38244628906" y="1842.47180175781" />
-						<pt x="1611.11169433594" y="2389.34326171875" />
-						<pt x="1612.80322265625" y="1767.15783691406" />
-						<pt x="1614.45471191406" y="2080.60668945312" />
-						<pt x="1615.81567382812" y="1431.70666503906" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="358.509028098938"/>
-					<UserParam type="string" name="native_id" value="SHC(Carbamidomethyl)IAEVEK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="26582.2421875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.353339049259967"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="358.174682617188" RT="1554.4921875" >
-				<PeptideHit score="0" sequence="SHC(Carbamidomethyl)IAEVEK" charge="3" aa_before="K" aa_after="D" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.000624514018064888"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="SHC(Carbamidomethyl)IAEVEK/3"/>
-			<UserParam type="float" name="leftWidth" value="1539.38354492188"/>
-			<UserParam type="float" name="rightWidth" value="1615.81567382812"/>
-			<UserParam type="float" name="total_xic" value="1534200.08959961"/>
-			<UserParam type="float" name="peak_apices_sum" value="80942.5309448242"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.995859874004335"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.99432412161936"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0607613750242852"/>
-			<UserParam type="float" name="var_library_sangle" value="0.107918735760252"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0607613750242852"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0672493863158573"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.997885894058429"/>
-			<UserParam type="float" name="var_intensity_score" value="0.832191728872341"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="11.7494826105578"/>
-			<UserParam type="float" name="var_log_sn_score" value="2.46380920647666"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.977227956056595"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="5.81651671719193"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.985290582455854"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.292577654123306"/>
-			<UserParam type="float" name="var_massdev_score" value="0.776434922758457"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.740130209172225"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.755976718319793"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.967667974449062"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.16365489172794"/>
-			<UserParam type="float" name="PrecursorMZ" value="358.174576486338"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="111785.030056966"/>
-			<UserParam type="float" name="model_FWHM" value="12.9084172565956"/>
-			<UserParam type="float" name="model_center" value="1558.22475307716"/>
-			<UserParam type="float" name="model_lower" value="1544.52050258605"/>
-			<UserParam type="float" name="model_upper" value="1571.92900356828"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="5.48170019644627"/>
-			<UserParam type="float" name="model_error" value="0.563856924834217"/>
-			<UserParam type="float" name="model_area" value="1535991.50601423"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="1276748.5"/>
-		</feature>
-		<feature id="f_12561328592123678330">
-			<position dim="0">2074.91557012392</position>
-			<position dim="1">554.260602012071</position>
-			<intensity>3.18162e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.6453</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2047.82275390625" y="554.210602012071" />
-				<pt x="2133.37890625" y="554.210602012071" />
-				<pt x="2133.37890625" y="554.310602012071" />
-				<pt x="2047.82275390625" y="554.310602012071" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2047.82275390625" y="554.712279430971" />
-				<pt x="2133.37890625" y="554.712279430971" />
-				<pt x="2133.37890625" y="554.812279430971" />
-				<pt x="2047.82275390625" y="554.812279430971" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_12561328592123678330_8795943655088158336">
-					<position dim="0">2074.91557012392</position>
-					<position dim="1">554.260602012071</position>
-					<intensity>1.02444e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="2050.6005859375" y="0" />
-						<pt x="2053.314453125" y="0" />
-						<pt x="2056.00952148438" y="1464.11181640625" />
-						<pt x="2057.59716796875" y="6656.9111328125" />
-						<pt x="2059.96704101562" y="31106.14453125" />
-						<pt x="2062.72436523438" y="113531.78125" />
-						<pt x="2065.51806640625" y="337220.21875" />
-						<pt x="2068.21630859375" y="780004.0625" />
-						<pt x="2070.92919921875" y="1141430.60449219" />
-						<pt x="2072.11108398438" y="1266922.51293945" />
-						<pt x="2074.3701171875" y="1290034.34765625" />
-						<pt x="2077.0185546875" y="1201289.75" />
-						<pt x="2079.67431640625" y="776324.1875" />
-						<pt x="2082.2451171875" y="508657.53125" />
-						<pt x="2084.91577148438" y="397614.688598633" />
-						<pt x="2087.48876953125" y="340966.21875" />
-						<pt x="2090.21142578125" y="264668.428222656" />
-						<pt x="2092.81127929688" y="210135.4375" />
-						<pt x="2094.08325195312" y="205738.609375" />
-						<pt x="2095.73828125" y="194823.859375" />
-						<pt x="2097.31640625" y="152789.40625" />
-						<pt x="2099.32836914062" y="138612.984375" />
-						<pt x="2101.30908203125" y="125377.640625" />
-						<pt x="2102.9033203125" y="115069.3359375" />
-						<pt x="2104.3916015625" y="103734.84375" />
-						<pt x="2106.23901367188" y="85781.25" />
-						<pt x="2107.77758789062" y="73361.46875" />
-						<pt x="2109.30712890625" y="63799.04296875" />
-						<pt x="2110.5263671875" y="52959.33203125" />
-						<pt x="2112.11962890625" y="50864.953125" />
-						<pt x="2113.7138671875" y="43671.35546875" />
-						<pt x="2115.34301757812" y="39902.0203857422" />
-						<pt x="2117.66967773438" y="27115.052734375" />
-						<pt x="2120.35668945312" y="21859.474609375" />
-						<pt x="2121.99658203125" y="17359.1953125" />
-						<pt x="2123.63012695312" y="15257.845703125" />
-						<pt x="2126.00024414062" y="12886.3564453125" />
-						<pt x="2127.62622070312" y="16277.0492553711" />
-						<pt x="2128.90795898438" y="10384.6552734375" />
-						<pt x="2130.9794921875" y="8795.642578125" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="554.260602012071"/>
-					<UserParam type="string" name="native_id" value="EAC(Carbamidomethyl)FAVEGPK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="1290034.34765625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.630481343594174"/>
-				</feature>
-				<feature id="f_12561328592123678330_6878260161865568505">
-					<position dim="0">2074.91557012392</position>
-					<position dim="1">554.762279430971</position>
-					<intensity>5.96714e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="2050.6005859375" y="0" />
-						<pt x="2053.314453125" y="0" />
-						<pt x="2056.00952148438" y="0" />
-						<pt x="2057.59716796875" y="3326.02905273438" />
-						<pt x="2059.96704101562" y="20605.509765625" />
-						<pt x="2062.72436523438" y="64523.6875" />
-						<pt x="2065.51806640625" y="198748.75" />
-						<pt x="2068.21630859375" y="469266.625" />
-						<pt x="2070.92919921875" y="684896.125" />
-						<pt x="2072.11108398438" y="732414.073486328" />
-						<pt x="2074.3701171875" y="740503.5625" />
-						<pt x="2077.0185546875" y="715651.9375" />
-						<pt x="2079.67431640625" y="467081.90625" />
-						<pt x="2082.2451171875" y="309542.21875" />
-						<pt x="2084.91577148438" y="234674.765625" />
-						<pt x="2087.48876953125" y="185601.147583008" />
-						<pt x="2090.21142578125" y="147670.109375" />
-						<pt x="2092.81127929688" y="132688.296875" />
-						<pt x="2094.08325195312" y="128964.265625" />
-						<pt x="2095.73828125" y="99422.2265625" />
-						<pt x="2097.31640625" y="85598.421875" />
-						<pt x="2099.32836914062" y="76393.4296875" />
-						<pt x="2101.30908203125" y="64358.53125" />
-						<pt x="2102.9033203125" y="65353.8984375" />
-						<pt x="2104.3916015625" y="56986.8203125" />
-						<pt x="2106.23901367188" y="44439.1640625" />
-						<pt x="2107.77758789062" y="41171.45703125" />
-						<pt x="2109.30712890625" y="32239.224609375" />
-						<pt x="2110.5263671875" y="32997.02734375" />
-						<pt x="2112.11962890625" y="23756.591796875" />
-						<pt x="2113.7138671875" y="21147.939453125" />
-						<pt x="2115.34301757812" y="17123.509765625" />
-						<pt x="2117.66967773438" y="20223.796875" />
-						<pt x="2120.35668945312" y="10842.4189453125" />
-						<pt x="2121.99658203125" y="9585.947265625" />
-						<pt x="2123.63012695312" y="8708.2578125" />
-						<pt x="2126.00024414062" y="5408.68408203125" />
-						<pt x="2127.62622070312" y="6814.92529296875" />
-						<pt x="2128.90795898438" y="3961.70703125" />
-						<pt x="2130.9794921875" y="4444.78076171875" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="554.762279430971"/>
-					<UserParam type="string" name="native_id" value="EAC(Carbamidomethyl)FAVEGPK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="740503.5625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.369518656405826"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260375976562" RT="2058.83471679688" >
-				<PeptideHit score="0.0454545454545455" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0548595335303417"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="554.260559082031" RT="2098.17504882812" >
-				<PeptideHit score="0" sequence="EAC(Carbamidomethyl)FAVEGPK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="4.91092752369064e-05"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="EAC(Carbamidomethyl)FAVEGPK/2"/>
-			<UserParam type="float" name="leftWidth" value="2047.82275390625"/>
-			<UserParam type="float" name="rightWidth" value="2133.37890625"/>
-			<UserParam type="float" name="total_xic" value="16298802.2630615"/>
-			<UserParam type="float" name="peak_apices_sum" value="2030537.91015625"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999826714315203"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999757773001666"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00144004892103047"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00269456187368486"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00144004892103047"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00151895727538698"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999998886455478"/>
-			<UserParam type="float" name="var_intensity_score" value="0.994648915812717"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="100.706242859935"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.61220779243982"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.99474048614502"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.55149925994001"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.98736710195524"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.368078619241714"/>
-			<UserParam type="float" name="var_massdev_score" value="0.431614306179453"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.347966095008153"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.735829552475677"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.901264010563115"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.6453048191596"/>
-			<UserParam type="float" name="PrecursorMZ" value="554.260602012071"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="2040254.19971587"/>
-			<UserParam type="float" name="model_FWHM" value="14.649791241019"/>
-			<UserParam type="float" name="model_center" value="2074.59767787736"/>
-			<UserParam type="float" name="model_lower" value="2059.04469374161"/>
-			<UserParam type="float" name="model_upper" value="2090.15066201311"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="6.2211936543001"/>
-			<UserParam type="float" name="model_error" value="0.279655025917697"/>
-			<UserParam type="float" name="model_area" value="31816169.1887111"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="16211586"/>
-		</feature>
-		<feature id="f_4021463513649428920">
-			<position dim="0">1766.28153652464</position>
-			<position dim="1">646.304684132271</position>
-			<intensity>1.23033e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.46475</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1744.55932617188" y="646.254684132271" />
-				<pt x="1848.68237304688" y="646.254684132271" />
-				<pt x="1848.68237304688" y="646.354684132271" />
-				<pt x="1744.55932617188" y="646.354684132271" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1744.55932617188" y="646.756361551171" />
-				<pt x="1848.68237304688" y="646.756361551171" />
-				<pt x="1848.68237304688" y="646.856361551171" />
-				<pt x="1744.55932617188" y="646.856361551171" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_4021463513649428920_13574947772324278593">
-					<position dim="0">1766.28153652464</position>
-					<position dim="1">646.304684132271</position>
-					<intensity>740116</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1744.55932617188" y="0" />
-						<pt x="1746.17114257812" y="0" />
-						<pt x="1747.40344238281" y="0" />
-						<pt x="1749.72985839844" y="0" />
-						<pt x="1751.63122558594" y="0" />
-						<pt x="1753.181640625" y="0" />
-						<pt x="1754.70849609375" y="0" />
-						<pt x="1756.63635253906" y="5618.89599609375" />
-						<pt x="1758.22473144531" y="17633.9375" />
-						<pt x="1759.81530761719" y="28330.728515625" />
-						<pt x="1761.75610351562" y="56678.69921875" />
-						<pt x="1763.34350585938" y="60389.07421875" />
-						<pt x="1764.53942871094" y="62205.6015625" />
-						<pt x="1766.20935058594" y="59630.41796875" />
-						<pt x="1767.45556640625" y="41738.98046875" />
-						<pt x="1768.78759765625" y="38886.83203125" />
-						<pt x="1770.08776855469" y="35996.87109375" />
-						<pt x="1771.37548828125" y="25342.6640625" />
-						<pt x="1772.72485351562" y="19701.9609375" />
-						<pt x="1775.10119628906" y="17275.80859375" />
-						<pt x="1776.7529296875" y="15327.755859375" />
-						<pt x="1778.41467285156" y="18893.212890625" />
-						<pt x="1779.78234863281" y="13283.9326171875" />
-						<pt x="1781.03625488281" y="16514.10546875" />
-						<pt x="1782.70874023438" y="11351.4013671875" />
-						<pt x="1784.005859375" y="10528.86328125" />
-						<pt x="1785.66430664062" y="11620.4384765625" />
-						<pt x="1788.00903320312" y="11422.298828125" />
-						<pt x="1789.64514160156" y="9156.2294921875" />
-						<pt x="1791.29907226562" y="6365.79345703125" />
-						<pt x="1792.96655273438" y="9501.8232421875" />
-						<pt x="1794.18957519531" y="8323.71484375" />
-						<pt x="1796.90112304688" y="7045.005859375" />
-						<pt x="1799.29284667969" y="6350.4130859375" />
-						<pt x="1802.06115722656" y="6942.82080078125" />
-						<pt x="1802.93933105469" y="6853.0361328125" />
-						<pt x="1805.2861328125" y="6175.37451171875" />
-						<pt x="1806.53210449219" y="7108" />
-						<pt x="1807.84582519531" y="4591.65380859375" />
-						<pt x="1809.5546875" y="4195.447265625" />
-						<pt x="1811.23205566406" y="5540.77001953125" />
-						<pt x="1812.84313964844" y="4546.31640625" />
-						<pt x="1814.09313964844" y="4898.837890625" />
-						<pt x="1816.15393066406" y="4239.1513671875" />
-						<pt x="1817.87463378906" y="3863.26171875" />
-						<pt x="1819.56494140625" y="5963.3134765625" />
-						<pt x="1821.21337890625" y="4745.412109375" />
-						<pt x="1823.14038085938" y="3646.91430664062" />
-						<pt x="1825.08544921875" y="4587.80224609375" />
-						<pt x="1827.03564453125" y="5237.30908203125" />
-						<pt x="1828.62902832031" y="3581.37622070312" />
-						<pt x="1829.82446289062" y="5317.24560546875" />
-						<pt x="1831.02966308594" y="4088.28002929687" />
-						<pt x="1832.62158203125" y="3990.6240234375" />
-						<pt x="1834.48815917969" y="3099.44482421875" />
-						<pt x="1836.81677246094" y="3561.595703125" />
-						<pt x="1839.52209472656" y="3956.63305664062" />
-						<pt x="1842.24621582031" y="4270.359375" />
-						<pt x="1843.86376953125" y="0" />
-						<pt x="1846.10339355469" y="0" />
-						<pt x="1847.20849609375" y="0" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="646.304684132271"/>
-					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="59630.41796875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
-				</feature>
-				<feature id="f_4021463513649428920_3689406389503231823">
-					<position dim="0">1766.28153652464</position>
-					<position dim="1">646.806361551171</position>
-					<intensity>413408</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1744.55932617188" y="0" />
-						<pt x="1746.17114257812" y="0" />
-						<pt x="1747.40344238281" y="0" />
-						<pt x="1749.72985839844" y="0" />
-						<pt x="1751.63122558594" y="0" />
-						<pt x="1753.181640625" y="0" />
-						<pt x="1754.70849609375" y="0" />
-						<pt x="1756.63635253906" y="4794.111328125" />
-						<pt x="1758.22473144531" y="9616.705078125" />
-						<pt x="1759.81530761719" y="16590.177734375" />
-						<pt x="1761.75610351562" y="34365.33203125" />
-						<pt x="1763.34350585938" y="36101.05859375" />
-						<pt x="1764.53942871094" y="37560.74609375" />
-						<pt x="1766.20935058594" y="32722.078125" />
-						<pt x="1767.45556640625" y="25932.046875" />
-						<pt x="1768.78759765625" y="20847.99609375" />
-						<pt x="1770.08776855469" y="20277.916015625" />
-						<pt x="1771.37548828125" y="15145.2177734375" />
-						<pt x="1772.72485351562" y="14357.904296875" />
-						<pt x="1775.10119628906" y="9716.0048828125" />
-						<pt x="1776.7529296875" y="9807.6201171875" />
-						<pt x="1778.41467285156" y="8012.634765625" />
-						<pt x="1779.78234863281" y="7657.19287109375" />
-						<pt x="1781.03625488281" y="7050.89892578125" />
-						<pt x="1782.70874023438" y="7264.6962890625" />
-						<pt x="1784.005859375" y="5521.16455078125" />
-						<pt x="1785.66430664062" y="7948.07568359375" />
-						<pt x="1788.00903320312" y="4186.552734375" />
-						<pt x="1789.64514160156" y="5509.72412109375" />
-						<pt x="1791.29907226562" y="5880.82421875" />
-						<pt x="1792.96655273438" y="3936.30395507812" />
-						<pt x="1794.18957519531" y="4454.94921875" />
-						<pt x="1796.90112304688" y="4287.3330078125" />
-						<pt x="1799.29284667969" y="4434.11572265625" />
-						<pt x="1802.06115722656" y="3715.302734375" />
-						<pt x="1802.93933105469" y="3319.2236328125" />
-						<pt x="1805.2861328125" y="3812.72485351563" />
-						<pt x="1806.53210449219" y="3350.0712890625" />
-						<pt x="1807.84582519531" y="4502.27392578125" />
-						<pt x="1809.5546875" y="2826.93774414062" />
-						<pt x="1811.23205566406" y="2564.65551757812" />
-						<pt x="1812.84313964844" y="2605.59033203125" />
-						<pt x="1814.09313964844" y="3408.65600585938" />
-						<pt x="1816.15393066406" y="2960.27709960938" />
-						<pt x="1817.87463378906" y="1310.25646972656" />
-						<pt x="1819.56494140625" y="2919.8310546875" />
-						<pt x="1821.21337890625" y="2963.24169921875" />
-						<pt x="1823.14038085938" y="0" />
-						<pt x="1825.08544921875" y="0" />
-						<pt x="1827.03564453125" y="0" />
-						<pt x="1828.62902832031" y="0" />
-						<pt x="1829.82446289062" y="0" />
-						<pt x="1831.02966308594" y="0" />
-						<pt x="1832.62158203125" y="3439.13891601562" />
-						<pt x="1834.48815917969" y="1739.96130371094" />
-						<pt x="1836.81677246094" y="0" />
-						<pt x="1839.52209472656" y="2127.626953125" />
-						<pt x="1842.24621582031" y="1862.63549804688" />
-						<pt x="1843.86376953125" y="0" />
-						<pt x="1846.10339355469" y="0" />
-						<pt x="1847.20849609375" y="0" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="646.806361551171"/>
-					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="32722.078125"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.397061689621381"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.304504394531" RT="1759.0947265625" >
-				<PeptideHit score="0.0454545454545455" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.161429888187637"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="646.3037109375" RT="1804.53405761719" >
-				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="2" aa_before="K" aa_after="S" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0423622396613216"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/2"/>
-			<UserParam type="float" name="leftWidth" value="1744.55932617188"/>
-			<UserParam type="float" name="rightWidth" value="1848.68237304688"/>
-			<UserParam type="float" name="total_xic" value="1258179.40576172"/>
-			<UserParam type="float" name="peak_apices_sum" value="92352.49609375"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.996687864987247"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.995242375653698"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0386749522384563"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0729584275113503"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0386749522384563"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0405203562071071"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999204154558718"/>
-			<UserParam type="float" name="var_intensity_score" value="0.91682016468998"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="90.4728415543284"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.50504971234653"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.980602443218231"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.3707575924871"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.968902708499444"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.358386725187302"/>
-			<UserParam type="float" name="var_massdev_score" value="0.552052115383353"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.543039773386319"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.64068624221483"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.04013836171084"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.46474611990348"/>
-			<UserParam type="float" name="PrecursorMZ" value="646.304684132271"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="93547.9179020436"/>
-			<UserParam type="float" name="model_FWHM" value="12.3554037030786"/>
-			<UserParam type="float" name="model_center" value="1765.18563964854"/>
-			<UserParam type="float" name="model_lower" value="1752.06849725223"/>
-			<UserParam type="float" name="model_upper" value="1778.30278204486"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="5.24685695852702"/>
-			<UserParam type="float" name="model_error" value="0.362565251427234"/>
-			<UserParam type="float" name="model_area" value="1230334.59810176"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="1153524.25"/>
-		</feature>
-		<feature id="f_575144564576995072">
-			<position dim="0">1766.55652075376</position>
-			<position dim="1">431.205548243771</position>
-			<intensity>1.24277e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.70728</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1746.17114257812" y="431.155548243771" />
-				<pt x="1918.98767089844" y="431.155548243771" />
-				<pt x="1918.98767089844" y="431.255548243771" />
-				<pt x="1746.17114257812" y="431.255548243771" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1746.17114257812" y="431.489999856371" />
-				<pt x="1918.98767089844" y="431.489999856371" />
-				<pt x="1918.98767089844" y="431.589999856371" />
-				<pt x="1746.17114257812" y="431.589999856371" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_575144564576995072_5805590394902791448">
-					<position dim="0">1766.55652075376</position>
-					<position dim="1">431.205548243771</position>
-					<intensity>8.63596e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1747.40344238281" y="0" />
-						<pt x="1749.72985839844" y="0" />
-						<pt x="1751.63122558594" y="0" />
-						<pt x="1753.181640625" y="3893.10473632812" />
-						<pt x="1754.70849609375" y="17853.01171875" />
-						<pt x="1756.63635253906" y="63899.55078125" />
-						<pt x="1758.22473144531" y="153680.9375" />
-						<pt x="1759.81530761719" y="301562.913085938" />
-						<pt x="1761.75610351562" y="478558.21875" />
-						<pt x="1763.34350585938" y="567884.814697266" />
-						<pt x="1764.53942871094" y="576804.491455078" />
-						<pt x="1766.20935058594" y="536289.844238281" />
-						<pt x="1767.45556640625" y="429313.012939453" />
-						<pt x="1768.78759765625" y="391838.75" />
-						<pt x="1770.08776855469" y="334616.15625" />
-						<pt x="1771.37548828125" y="257977.0625" />
-						<pt x="1772.72485351562" y="232562.185668945" />
-						<pt x="1775.10119628906" y="177309.921875" />
-						<pt x="1776.7529296875" y="172382.671875" />
-						<pt x="1778.41467285156" y="152055.890625" />
-						<pt x="1779.78234863281" y="155505.234375" />
-						<pt x="1781.03625488281" y="136960.15625" />
-						<pt x="1782.70874023438" y="125436.703125" />
-						<pt x="1784.005859375" y="121897.375" />
-						<pt x="1785.66430664062" y="115781.9140625" />
-						<pt x="1788.00903320312" y="114228.671875" />
-						<pt x="1789.64514160156" y="106950.828125" />
-						<pt x="1791.29907226562" y="102316.3984375" />
-						<pt x="1792.96655273438" y="95473.234375" />
-						<pt x="1794.18957519531" y="83683.625" />
-						<pt x="1796.90112304688" y="79988.0625" />
-						<pt x="1799.29284667969" y="73219.921875" />
-						<pt x="1802.06115722656" y="73837.3359375" />
-						<pt x="1802.93933105469" y="77921.0859375" />
-						<pt x="1805.2861328125" y="63842.875" />
-						<pt x="1806.53210449219" y="59494.83984375" />
-						<pt x="1807.84582519531" y="62523.7578125" />
-						<pt x="1809.5546875" y="58562.9140625" />
-						<pt x="1811.23205566406" y="62712.15234375" />
-						<pt x="1812.84313964844" y="57009.78125" />
-						<pt x="1814.09313964844" y="59816.4921875" />
-						<pt x="1816.15393066406" y="48252.92578125" />
-						<pt x="1817.87463378906" y="59158.484375" />
-						<pt x="1819.56494140625" y="55579.75390625" />
-						<pt x="1821.21337890625" y="58156.49609375" />
-						<pt x="1823.14038085938" y="52843.16796875" />
-						<pt x="1825.08544921875" y="47516.26953125" />
-						<pt x="1827.03564453125" y="53623.5078125" />
-						<pt x="1828.62902832031" y="44575.81640625" />
-						<pt x="1829.82446289062" y="43441.4609375" />
-						<pt x="1831.02966308594" y="47902.91796875" />
-						<pt x="1832.62158203125" y="49981.47265625" />
-						<pt x="1834.48815917969" y="42807.09375" />
-						<pt x="1836.81677246094" y="43721.14453125" />
-						<pt x="1839.52209472656" y="43136.39453125" />
-						<pt x="1842.24621582031" y="34536.1796875" />
-						<pt x="1843.86376953125" y="34576.76171875" />
-						<pt x="1846.10339355469" y="37851.37109375" />
-						<pt x="1847.20849609375" y="38154.3046875" />
-						<pt x="1848.68237304688" y="40636.2578125" />
-						<pt x="1850.09631347656" y="39506.81640625" />
-						<pt x="1851.12512207031" y="43529.86328125" />
-						<pt x="1853.71057128906" y="45555.0546875" />
-						<pt x="1855.52624511719" y="39585.0625" />
-						<pt x="1857.064453125" y="37899.3984375" />
-						<pt x="1858.97082519531" y="33756.015625" />
-						<pt x="1861.28601074219" y="35045.8046875" />
-						<pt x="1863.56823730469" y="36440.2109375" />
-						<pt x="1865.85095214844" y="33016.1015625" />
-						<pt x="1867.78442382812" y="32963.625" />
-						<pt x="1869.03576660156" y="38026.78515625" />
-						<pt x="1871.33630371094" y="35044.1171875" />
-						<pt x="1872.57312011719" y="40903.34765625" />
-						<pt x="1874.54077148438" y="30388.6796875" />
-						<pt x="1876.48901367188" y="34719.51953125" />
-						<pt x="1878.7314453125" y="34117.0848388672" />
-						<pt x="1881.08850097656" y="28225.4255371094" />
-						<pt x="1883.11645507812" y="35310.9515380859" />
-						<pt x="1885.83068847656" y="29596.2572021484" />
-						<pt x="1887.43872070312" y="29664.5765380859" />
-						<pt x="1890.11450195312" y="30201.7828369141" />
-						<pt x="1892.81237792969" y="26844.25" />
-						<pt x="1895.1689453125" y="30084.345703125" />
-						<pt x="1897.92785644531" y="23347.78125" />
-						<pt x="1900.26635742188" y="22483.48828125" />
-						<pt x="1902.93041992188" y="28873.224609375" />
-						<pt x="1904.12365722656" y="23925.6953125" />
-						<pt x="1906.11572265625" y="25751.412109375" />
-						<pt x="1908.81591796875" y="26212.3203125" />
-						<pt x="1911.60192871094" y="23676.900390625" />
-						<pt x="1914.27954101562" y="21842.6328125" />
-						<pt x="1916.62109375" y="27326.400390625" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="431.205548243771"/>
-					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="536289.844238281"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.602938310378619"/>
-				</feature>
-				<feature id="f_575144564576995072_11586291247413769442">
-					<position dim="0">1766.55652075376</position>
-					<position dim="1">431.539999856371</position>
-					<intensity>5.51648e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1747.40344238281" y="0" />
-						<pt x="1749.72985839844" y="0" />
-						<pt x="1751.63122558594" y="0" />
-						<pt x="1753.181640625" y="5043.9580078125" />
-						<pt x="1754.70849609375" y="10526.390625" />
-						<pt x="1756.63635253906" y="46748.43359375" />
-						<pt x="1758.22473144531" y="104771.28125" />
-						<pt x="1759.81530761719" y="203016.453125" />
-						<pt x="1761.75610351562" y="328397.6875" />
-						<pt x="1763.34350585938" y="371091.34375" />
-						<pt x="1764.53942871094" y="383256.839111328" />
-						<pt x="1766.20935058594" y="332317.34375" />
-						<pt x="1767.45556640625" y="289202.130737305" />
-						<pt x="1768.78759765625" y="246120.03125" />
-						<pt x="1770.08776855469" y="223702.078125" />
-						<pt x="1771.37548828125" y="174255.578125" />
-						<pt x="1772.72485351562" y="159775.203125" />
-						<pt x="1775.10119628906" y="128084.9453125" />
-						<pt x="1776.7529296875" y="112418.21875" />
-						<pt x="1778.41467285156" y="99594.5859375" />
-						<pt x="1779.78234863281" y="93866.28125" />
-						<pt x="1781.03625488281" y="96036.203125" />
-						<pt x="1782.70874023438" y="85240.7109375" />
-						<pt x="1784.005859375" y="82254.15625" />
-						<pt x="1785.66430664062" y="76704.6640625" />
-						<pt x="1788.00903320312" y="74431.9609375" />
-						<pt x="1789.64514160156" y="68738.9453125" />
-						<pt x="1791.29907226562" y="72554.4296875" />
-						<pt x="1792.96655273438" y="71128.765625" />
-						<pt x="1794.18957519531" y="56707.1796875" />
-						<pt x="1796.90112304688" y="55151.66015625" />
-						<pt x="1799.29284667969" y="50673.26953125" />
-						<pt x="1802.06115722656" y="39306.8125" />
-						<pt x="1802.93933105469" y="42695.1875" />
-						<pt x="1805.2861328125" y="33672.05859375" />
-						<pt x="1806.53210449219" y="44182.81640625" />
-						<pt x="1807.84582519531" y="35600.05078125" />
-						<pt x="1809.5546875" y="37480.9921875" />
-						<pt x="1811.23205566406" y="40265.625" />
-						<pt x="1812.84313964844" y="36055.83984375" />
-						<pt x="1814.09313964844" y="36424.79296875" />
-						<pt x="1816.15393066406" y="32929.71875" />
-						<pt x="1817.87463378906" y="35810.68359375" />
-						<pt x="1819.56494140625" y="35488.546875" />
-						<pt x="1821.21337890625" y="39133.82421875" />
-						<pt x="1823.14038085938" y="32421.828125" />
-						<pt x="1825.08544921875" y="25253.21484375" />
-						<pt x="1827.03564453125" y="29905.49609375" />
-						<pt x="1828.62902832031" y="24240.64453125" />
-						<pt x="1829.82446289062" y="22994.6875" />
-						<pt x="1831.02966308594" y="26960.76171875" />
-						<pt x="1832.62158203125" y="30486.85546875" />
-						<pt x="1834.48815917969" y="27260.103515625" />
-						<pt x="1836.81677246094" y="26864.091796875" />
-						<pt x="1839.52209472656" y="18236.869140625" />
-						<pt x="1842.24621582031" y="16691.56640625" />
-						<pt x="1843.86376953125" y="25199.42578125" />
-						<pt x="1846.10339355469" y="18786.236328125" />
-						<pt x="1847.20849609375" y="20379.953125" />
-						<pt x="1848.68237304688" y="16349.81640625" />
-						<pt x="1850.09631347656" y="19790.80859375" />
-						<pt x="1851.12512207031" y="23057.232421875" />
-						<pt x="1853.71057128906" y="19746.009765625" />
-						<pt x="1855.52624511719" y="24023.46484375" />
-						<pt x="1857.064453125" y="15847.3330078125" />
-						<pt x="1858.97082519531" y="21433.52734375" />
-						<pt x="1861.28601074219" y="22632.181640625" />
-						<pt x="1863.56823730469" y="25753.09375" />
-						<pt x="1865.85095214844" y="19353.47265625" />
-						<pt x="1867.78442382812" y="20177.392578125" />
-						<pt x="1869.03576660156" y="21811.146484375" />
-						<pt x="1871.33630371094" y="20310" />
-						<pt x="1872.57312011719" y="21205.9609375" />
-						<pt x="1874.54077148438" y="19003.294921875" />
-						<pt x="1876.48901367188" y="15160.271484375" />
-						<pt x="1878.7314453125" y="16183.14453125" />
-						<pt x="1881.08850097656" y="20049.296875" />
-						<pt x="1883.11645507812" y="16959.734375" />
-						<pt x="1885.83068847656" y="18829.41015625" />
-						<pt x="1887.43872070312" y="16984.279296875" />
-						<pt x="1890.11450195312" y="17107.35546875" />
-						<pt x="1892.81237792969" y="13349.96875" />
-						<pt x="1895.1689453125" y="13224.87109375" />
-						<pt x="1897.92785644531" y="11749.224609375" />
-						<pt x="1900.26635742188" y="13628.0458984375" />
-						<pt x="1902.93041992188" y="11071.6982421875" />
-						<pt x="1904.12365722656" y="15864.44921875" />
-						<pt x="1906.11572265625" y="11922.4189453125" />
-						<pt x="1908.81591796875" y="14101.6875" />
-						<pt x="1911.60192871094" y="13337.5771484375" />
-						<pt x="1914.27954101562" y="13005.681640625" />
-						<pt x="1916.62109375" y="16918.73046875" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="431.539999856371"/>
-					<UserParam type="string" name="native_id" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="332317.34375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.397061689621381"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="431.205261230469" RT="1797.83959960938" >
-				<PeptideHit score="0.0344827586206897" sequence="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK" charge="3" aa_before="K" aa_after="S" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.042177146646692"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="EC(Carbamidomethyl)C(Carbamidomethyl)DKPLLEK/3"/>
-			<UserParam type="float" name="leftWidth" value="1746.17114257812"/>
-			<UserParam type="float" name="rightWidth" value="1918.98767089844"/>
-			<UserParam type="float" name="total_xic" value="14319538.267334"/>
-			<UserParam type="float" name="peak_apices_sum" value="868607.187988281"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999360251977443"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999081051721655"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00727165687438958"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0139110994886224"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00727165687438958"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00752932229758962"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999972302719226"/>
-			<UserParam type="float" name="var_intensity_score" value="0.988331099493958"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="22.6689159856313"/>
-			<UserParam type="float" name="var_log_sn_score" value="3.12099464624477"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.981038093566895"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.46880384807173"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.98312975722697"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.389790028333664"/>
-			<UserParam type="float" name="var_massdev_score" value="0.344572194406841"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.300077406541411"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.712039883282362"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.04508823818716"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.7072817470113"/>
-			<UserParam type="float" name="PrecursorMZ" value="431.205548243771"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="860182.075683379"/>
-			<UserParam type="float" name="model_FWHM" value="13.5727897362748"/>
-			<UserParam type="float" name="model_center" value="1765.71798463305"/>
-			<UserParam type="float" name="model_lower" value="1751.30840159032"/>
-			<UserParam type="float" name="model_upper" value="1780.12756767579"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="5.76383321709295"/>
-			<UserParam type="float" name="model_error" value="0.674733694369923"/>
-			<UserParam type="float" name="model_area" value="12427726.3176539"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="14152445"/>
-		</feature>
-		<feature id="f_3395379003172100421">
-			<position dim="0">1871.44516101075</position>
-			<position dim="1">408.874238280604</position>
-			<intensity>542935</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.203844</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1857.064453125" y="408.824238280604" />
-				<pt x="1890.11450195312" y="408.824238280604" />
-				<pt x="1890.11450195312" y="408.924238280604" />
-				<pt x="1857.064453125" y="408.924238280604" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1857.064453125" y="409.158689893204" />
-				<pt x="1890.11450195312" y="409.158689893204" />
-				<pt x="1890.11450195312" y="409.258689893204" />
-				<pt x="1857.064453125" y="409.258689893204" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_3395379003172100421_4041634828915281168">
-					<position dim="0">1871.44516101075</position>
-					<position dim="1">408.874238280604</position>
-					<intensity>221846</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1858.97082519531" y="12906.677734375" />
-						<pt x="1861.28601074219" y="9272.8466796875" />
-						<pt x="1863.56823730469" y="16160.4775390625" />
-						<pt x="1865.85095214844" y="13390.771484375" />
-						<pt x="1867.78442382812" y="13748.63671875" />
-						<pt x="1869.03576660156" y="17559.25" />
-						<pt x="1871.33630371094" y="14049.859375" />
-						<pt x="1872.57312011719" y="18097.568359375" />
-						<pt x="1874.54077148438" y="16522.45703125" />
-						<pt x="1876.48901367188" y="14085.330078125" />
-						<pt x="1878.7314453125" y="15600.0869140625" />
-						<pt x="1881.08850097656" y="13224.568359375" />
-						<pt x="1883.11645507812" y="12551.59765625" />
-						<pt x="1885.83068847656" y="12279.8447265625" />
-						<pt x="1887.43872070312" y="11758.8017578125" />
-						<pt x="1890.11450195312" y="10637.1318359375" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="408.874238280604"/>
-					<UserParam type="string" name="native_id" value="GM(Oxidation)LWAVFEQK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="14049.859375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.592413860111113"/>
-				</feature>
-				<feature id="f_3395379003172100421_17078574238716611972">
-					<position dim="0">1871.44516101075</position>
-					<position dim="1">409.208689893204</position>
-					<intensity>129627</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1858.97082519531" y="16764.3017578125" />
-						<pt x="1861.28601074219" y="14427.9965820312" />
-						<pt x="1863.56823730469" y="10278.5107421875" />
-						<pt x="1865.85095214844" y="6389.40234375" />
-						<pt x="1867.78442382812" y="8206.42602539062" />
-						<pt x="1869.03576660156" y="6546.6787109375" />
-						<pt x="1871.33630371094" y="4732.01318359375" />
-						<pt x="1872.57312011719" y="7897.94189453125" />
-						<pt x="1874.54077148438" y="5348.26123046875" />
-						<pt x="1876.48901367188" y="6070.77587890625" />
-						<pt x="1878.7314453125" y="6539.49462890625" />
-						<pt x="1881.08850097656" y="6765.68701171875" />
-						<pt x="1883.11645507812" y="7404.810546875" />
-						<pt x="1885.83068847656" y="7710.93310546875" />
-						<pt x="1887.43872070312" y="7260.2060546875" />
-						<pt x="1890.11450195312" y="7283.57177734375" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="409.208689893204"/>
-					<UserParam type="string" name="native_id" value="GM(Oxidation)LWAVFEQK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="4732.01318359375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.407586139888887"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="408.840087890625" RT="1880.01599121094" >
-				<PeptideHit score="0.0454545454545455" sequence="GM(Oxidation)LWAVFEQK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_5">
-					<UserParam type="float" name="OMSSA_score" value="0.0850109548251393"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="GM(Oxidation)LWAVFEQK/3"/>
-			<UserParam type="float" name="leftWidth" value="1857.064453125"/>
-			<UserParam type="float" name="rightWidth" value="1890.11450195312"/>
-			<UserParam type="float" name="total_xic" value="2487624.58416748"/>
-			<UserParam type="float" name="peak_apices_sum" value="18781.8725585938"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="6.37478521766071"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="3.38043549843109"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.859158419623954"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.795954623732148"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0387753364781598"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0738293770300613"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0387753364781598"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0403113938333929"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999208292111752"/>
-			<UserParam type="float" name="var_intensity_score" value="0.141288564394706"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="0.826036901072732"/>
-			<UserParam type="float" name="var_log_sn_score" value="0"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.857296228408813"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="2.92605467806292"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0"/>
-			<UserParam type="float" name="var_manhatt_score" value="2"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.203844374870718"/>
-			<UserParam type="float" name="PrecursorMZ" value="408.874238280604"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="24532.9566900489"/>
-			<UserParam type="float" name="model_FWHM" value="60.9208285308607"/>
-			<UserParam type="float" name="model_center" value="1869.57950255093"/>
-			<UserParam type="float" name="model_lower" value="1804.90276661054"/>
-			<UserParam type="float" name="model_upper" value="1934.25623849132"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="25.8706943761564"/>
-			<UserParam type="float" name="model_error" value="0.194783068049816"/>
-			<UserParam type="float" name="model_area" value="1590918.25137167"/>
-			<UserParam type="string" name="model_status" value="3 (left side out of bounds)"/>
-			<UserParam type="float" name="raw_intensity" value="351472.90625"/>
-		</feature>
-		<feature id="f_15721057298497490036">
-			<position dim="0">1658.35957629977</position>
-			<position dim="1">532.248746583271</position>
-			<intensity>202353</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>3.27253</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="1634.86328125" y="532.198746583271" />
-				<pt x="1685.81030273438" y="532.198746583271" />
-				<pt x="1685.81030273438" y="532.298746583271" />
-				<pt x="1634.86328125" y="532.298746583271" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1634.86328125" y="532.700424002171" />
-				<pt x="1685.81030273438" y="532.700424002171" />
-				<pt x="1685.81030273438" y="532.800424002171" />
-				<pt x="1634.86328125" y="532.800424002171" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_15721057298497490036_2608380305220684729">
-					<position dim="0">1658.35957629977</position>
-					<position dim="1">532.248746583271</position>
-					<intensity>86477.8</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1636.51171875" y="0" />
-						<pt x="1638.07885742188" y="0" />
-						<pt x="1639.34729003906" y="0" />
-						<pt x="1641.09350585938" y="0" />
-						<pt x="1642.72119140625" y="0" />
-						<pt x="1644.31372070312" y="0" />
-						<pt x="1645.88134765625" y="0" />
-						<pt x="1647.48327636719" y="0" />
-						<pt x="1648.7275390625" y="0" />
-						<pt x="1650.03430175781" y="1006.83868408203" />
-						<pt x="1651.41906738281" y="2662.908203125" />
-						<pt x="1653.2470703125" y="5414.9912109375" />
-						<pt x="1655.34460449219" y="11212.4697265625" />
-						<pt x="1657.05285644531" y="15971.271484375" />
-						<pt x="1658.70886230469" y="16335.642578125" />
-						<pt x="1660.33129882812" y="12500.2021484375" />
-						<pt x="1661.97338867188" y="5910.51953125" />
-						<pt x="1663.23254394531" y="5365.7568359375" />
-						<pt x="1664.64367675781" y="2964.51831054688" />
-						<pt x="1666.41357421875" y="1623.86999511719" />
-						<pt x="1667.71862792969" y="1885.44714355469" />
-						<pt x="1669.111328125" y="1417.13305664062" />
-						<pt x="1670.86352539062" y="0" />
-						<pt x="1672.12548828125" y="876.161743164063" />
-						<pt x="1673.87194824219" y="1330.08959960937" />
-						<pt x="1675.19165039062" y="0" />
-						<pt x="1676.96154785156" y="0" />
-						<pt x="1678.55310058594" y="0" />
-						<pt x="1680.16735839844" y="0" />
-						<pt x="1681.75329589844" y="0" />
-						<pt x="1684.45397949219" y="0" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="532.248746583271"/>
-					<UserParam type="string" name="native_id" value="KSDDGGEVEK/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="16335.642578125"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.66039156605171"/>
-				</feature>
-				<feature id="f_15721057298497490036_11422463686885200558">
-					<position dim="0">1658.35957629977</position>
-					<position dim="1">532.750424002171</position>
-					<intensity>41877.4</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1636.51171875" y="0" />
-						<pt x="1638.07885742188" y="0" />
-						<pt x="1639.34729003906" y="0" />
-						<pt x="1641.09350585938" y="0" />
-						<pt x="1642.72119140625" y="0" />
-						<pt x="1644.31372070312" y="0" />
-						<pt x="1645.88134765625" y="0" />
-						<pt x="1647.48327636719" y="0" />
-						<pt x="1648.7275390625" y="0" />
-						<pt x="1650.03430175781" y="0" />
-						<pt x="1651.41906738281" y="1539.76916503906" />
-						<pt x="1653.2470703125" y="2021.71569824219" />
-						<pt x="1655.34460449219" y="6869.59423828125" />
-						<pt x="1657.05285644531" y="8075.73193359375" />
-						<pt x="1658.70886230469" y="4576.82275390625" />
-						<pt x="1660.33129882812" y="7255.56787109375" />
-						<pt x="1661.97338867188" y="4015.666015625" />
-						<pt x="1663.23254394531" y="1721.34057617188" />
-						<pt x="1664.64367675781" y="2122.17016601562" />
-						<pt x="1666.41357421875" y="1802.19848632812" />
-						<pt x="1667.71862792969" y="0" />
-						<pt x="1669.111328125" y="0" />
-						<pt x="1670.86352539062" y="921.968505859375" />
-						<pt x="1672.12548828125" y="0" />
-						<pt x="1673.87194824219" y="0" />
-						<pt x="1675.19165039062" y="0" />
-						<pt x="1676.96154785156" y="0" />
-						<pt x="1678.55310058594" y="0" />
-						<pt x="1680.16735839844" y="0" />
-						<pt x="1681.75329589844" y="0" />
-						<pt x="1684.45397949219" y="954.835266113281" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="532.750424002171"/>
-					<UserParam type="string" name="native_id" value="KSDDGGEVEK/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="4576.82275390625"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.33960843394829"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="532.23974609375" RT="1654.26513671875" >
-				<PeptideHit score="0.0454545454545455" sequence="KSDDGGEVEK" charge="2" aa_before="R" aa_after="R" protein_refs="PH_2">
-					<UserParam type="float" name="OMSSA_score" value="0.140841796155119"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="KSDDGGEVEK/2"/>
-			<UserParam type="float" name="leftWidth" value="1634.86328125"/>
-			<UserParam type="float" name="rightWidth" value="1685.81030273438"/>
-			<UserParam type="float" name="total_xic" value="141144.40447998"/>
-			<UserParam type="float" name="peak_apices_sum" value="20912.4653320312"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.976751222648202"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.968715346150462"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0133467853267937"/>
-			<UserParam type="float" name="var_library_sangle" value="0.0240119555958121"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0133467853267937"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0145806315400125"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.99989973059223"/>
-			<UserParam type="float" name="var_intensity_score" value="0.909389242867262"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="97.517435020494"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.5800311827403"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.975244373083115"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.39723611286629"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.974755927449578"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="16.5563312629803"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="16.8438426877962"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.654000990960296"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.09969813062877"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="3.27252665585312"/>
-			<UserParam type="float" name="PrecursorMZ" value="532.248746583271"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="24215.0698767108"/>
-			<UserParam type="float" name="model_FWHM" value="7.8504056642442"/>
-			<UserParam type="float" name="model_center" value="1657.97995934097"/>
-			<UserParam type="float" name="model_lower" value="1649.64555834191"/>
-			<UserParam type="float" name="model_upper" value="1666.31436034004"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="3.33376039962468"/>
-			<UserParam type="float" name="model_error" value="0.171150338956436"/>
-			<UserParam type="float" name="model_area" value="202353.162726349"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="128355.203125"/>
-		</feature>
-		<feature id="f_7344192187426184761">
-			<position dim="0">1617.1483410699</position>
-			<position dim="1">368.862109904738</position>
-			<intensity>8.05591e+06</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>0.878065</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="1595.50939941406" y="368.812109904738" />
-				<pt x="1764.53942871094" y="368.812109904738" />
-				<pt x="1764.53942871094" y="368.912109904738" />
-				<pt x="1595.50939941406" y="368.912109904738" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="1595.50939941406" y="369.146561517338" />
-				<pt x="1764.53942871094" y="369.146561517338" />
-				<pt x="1764.53942871094" y="369.246561517338" />
-				<pt x="1595.50939941406" y="369.246561517338" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_7344192187426184761_2130311522918743509">
-					<position dim="0">1617.1483410699</position>
-					<position dim="1">368.862109904738</position>
-					<intensity>5.79311e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1596.7958984375" y="0" />
-						<pt x="1598.55334472656" y="0" />
-						<pt x="1600.25183105469" y="0" />
-						<pt x="1601.50854492188" y="0" />
-						<pt x="1602.97534179688" y="0" />
-						<pt x="1604.69299316406" y="5177.01708984375" />
-						<pt x="1606.37744140625" y="30968.22265625" />
-						<pt x="1608.01416015625" y="82616.7109375" />
-						<pt x="1609.38244628906" y="141733.953125" />
-						<pt x="1611.11169433594" y="259860.171630859" />
-						<pt x="1612.80322265625" y="310930.346191406" />
-						<pt x="1614.45471191406" y="359892.321655273" />
-						<pt x="1615.81567382812" y="361844.1875" />
-						<pt x="1617.52429199219" y="301442.201293945" />
-						<pt x="1619.2216796875" y="256573.993286133" />
-						<pt x="1620.89306640625" y="214252.046875" />
-						<pt x="1622.54174804688" y="170041.6875" />
-						<pt x="1623.83837890625" y="131011.8359375" />
-						<pt x="1625.60412597656" y="123679.078125" />
-						<pt x="1627.24719238281" y="120382.5" />
-						<pt x="1628.48876953125" y="108680.125" />
-						<pt x="1629.88061523438" y="97691.4140625" />
-						<pt x="1631.66320800781" y="92193.1015625" />
-						<pt x="1633.28234863281" y="77823.7421875" />
-						<pt x="1634.86328125" y="85255.9609375" />
-						<pt x="1636.51171875" y="82935.8125" />
-						<pt x="1638.07885742188" y="77134.296875" />
-						<pt x="1639.34729003906" y="73134.59375" />
-						<pt x="1641.09350585938" y="71262.703125" />
-						<pt x="1642.72119140625" y="64132.14453125" />
-						<pt x="1644.31372070312" y="63242.65234375" />
-						<pt x="1645.88134765625" y="56334.7265625" />
-						<pt x="1647.48327636719" y="54439.61328125" />
-						<pt x="1648.7275390625" y="53092.765625" />
-						<pt x="1650.03430175781" y="45740.90625" />
-						<pt x="1651.41906738281" y="45981.84375" />
-						<pt x="1653.2470703125" y="52246.046875" />
-						<pt x="1655.34460449219" y="46828.7109375" />
-						<pt x="1657.05285644531" y="44011.13671875" />
-						<pt x="1658.70886230469" y="44025.11328125" />
-						<pt x="1660.33129882812" y="37324.25390625" />
-						<pt x="1661.97338867188" y="41503.9609375" />
-						<pt x="1663.23254394531" y="38759.32421875" />
-						<pt x="1664.64367675781" y="33337.16015625" />
-						<pt x="1666.41357421875" y="39421.80078125" />
-						<pt x="1667.71862792969" y="36692.05078125" />
-						<pt x="1669.111328125" y="31597.517578125" />
-						<pt x="1670.86352539062" y="40932.5625" />
-						<pt x="1672.12548828125" y="31674.111328125" />
-						<pt x="1673.87194824219" y="33902.72265625" />
-						<pt x="1675.19165039062" y="30318.212890625" />
-						<pt x="1676.96154785156" y="35048.07421875" />
-						<pt x="1678.55310058594" y="38674.86328125" />
-						<pt x="1680.16735839844" y="37594.875" />
-						<pt x="1681.75329589844" y="26210.80859375" />
-						<pt x="1684.45397949219" y="24797.056640625" />
-						<pt x="1685.81030273438" y="23726.97265625" />
-						<pt x="1687.5263671875" y="33630.45703125" />
-						<pt x="1689.21337890625" y="25846.96875" />
-						<pt x="1690.76647949219" y="25072.615234375" />
-						<pt x="1692.41857910156" y="26504.46875" />
-						<pt x="1693.71362304688" y="26198.08203125" />
-						<pt x="1695.46130371094" y="28848.556640625" />
-						<pt x="1697.08410644531" y="30072.3984375" />
-						<pt x="1698.99609375" y="22095.828125" />
-						<pt x="1701.0732421875" y="23786.494140625" />
-						<pt x="1702.7529296875" y="26816.1953125" />
-						<pt x="1704.38671875" y="23697.45703125" />
-						<pt x="1706.12316894531" y="27334.72265625" />
-						<pt x="1707.67224121094" y="23510.125" />
-						<pt x="1709.35302734375" y="24499.1015625" />
-						<pt x="1710.62609863281" y="20932.60546875" />
-						<pt x="1712.33923339844" y="26764.48046875" />
-						<pt x="1714.34643554688" y="20390" />
-						<pt x="1716.00524902344" y="17069.943359375" />
-						<pt x="1717.3720703125" y="19245.083984375" />
-						<pt x="1718.70336914062" y="20635.220703125" />
-						<pt x="1720.42810058594" y="21117.7734375" />
-						<pt x="1722.07409667969" y="24988.404296875" />
-						<pt x="1723.66687011719" y="22208.55078125" />
-						<pt x="1724.88122558594" y="20072.5859375" />
-						<pt x="1726.58349609375" y="23426.63671875" />
-						<pt x="1728.11975097656" y="20546.255859375" />
-						<pt x="1729.41674804688" y="16537.349609375" />
-						<pt x="1731.05224609375" y="20966.1953125" />
-						<pt x="1732.3154296875" y="16847.099609375" />
-						<pt x="1734.10437011719" y="21239.3671875" />
-						<pt x="1735.69311523438" y="18255.306640625" />
-						<pt x="1737.05261230469" y="22682.048828125" />
-						<pt x="1738.2958984375" y="19191.6015625" />
-						<pt x="1740.13562011719" y="20592.16796875" />
-						<pt x="1742.16540527344" y="23395.36328125" />
-						<pt x="1744.55932617188" y="21310.615234375" />
-						<pt x="1746.17114257812" y="15478.80859375" />
-						<pt x="1747.40344238281" y="17416.51171875" />
-						<pt x="1749.72985839844" y="17209.23828125" />
-						<pt x="1751.63122558594" y="13815.8369140625" />
-						<pt x="1753.181640625" y="12395.25" />
-						<pt x="1754.70849609375" y="17807.537109375" />
-						<pt x="1756.63635253906" y="16584.8046875" />
-						<pt x="1758.22473144531" y="20436.69140625" />
-						<pt x="1759.81530761719" y="14681.31640625" />
-						<pt x="1761.75610351562" y="17447.498046875" />
-						<pt x="1763.34350585938" y="15396.6708984375" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="368.862109904738"/>
-					<UserParam type="string" name="native_id" value="LAMTLAEAER/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="301442.201293945"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.637366103952144"/>
-				</feature>
-				<feature id="f_7344192187426184761_9140546320740515641">
-					<position dim="0">1617.1483410699</position>
-					<position dim="1">369.196561517338</position>
-					<intensity>3.45967e+06</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="1596.7958984375" y="0" />
-						<pt x="1598.55334472656" y="0" />
-						<pt x="1600.25183105469" y="0" />
-						<pt x="1601.50854492188" y="0" />
-						<pt x="1602.97534179688" y="0" />
-						<pt x="1604.69299316406" y="1869.17529296875" />
-						<pt x="1606.37744140625" y="14712.3701171875" />
-						<pt x="1608.01416015625" y="34977.7970581055" />
-						<pt x="1609.38244628906" y="80099.3203125" />
-						<pt x="1611.11169433594" y="130945.0234375" />
-						<pt x="1612.80322265625" y="173496.75" />
-						<pt x="1614.45471191406" y="208531.59375" />
-						<pt x="1615.81567382812" y="195640.046875" />
-						<pt x="1617.52429199219" y="164956.921875" />
-						<pt x="1619.2216796875" y="133660.696044922" />
-						<pt x="1620.89306640625" y="114413.2421875" />
-						<pt x="1622.54174804688" y="100173.2734375" />
-						<pt x="1623.83837890625" y="78988.9827880859" />
-						<pt x="1625.60412597656" y="74301.453125" />
-						<pt x="1627.24719238281" y="68368.9609375" />
-						<pt x="1628.48876953125" y="56432.6926269531" />
-						<pt x="1629.88061523438" y="56455.40625" />
-						<pt x="1631.66320800781" y="51672.53515625" />
-						<pt x="1633.28234863281" y="37000.28125" />
-						<pt x="1634.86328125" y="45038.921875" />
-						<pt x="1636.51171875" y="36389.03125" />
-						<pt x="1638.07885742188" y="36002.625" />
-						<pt x="1639.34729003906" y="31117.2578125" />
-						<pt x="1641.09350585938" y="31475.73828125" />
-						<pt x="1642.72119140625" y="27940.033203125" />
-						<pt x="1644.31372070312" y="30938.189453125" />
-						<pt x="1645.88134765625" y="25509.447265625" />
-						<pt x="1647.48327636719" y="28780.83203125" />
-						<pt x="1648.7275390625" y="21087.23046875" />
-						<pt x="1650.03430175781" y="21032.650390625" />
-						<pt x="1651.41906738281" y="19433.833984375" />
-						<pt x="1653.2470703125" y="21774.08203125" />
-						<pt x="1655.34460449219" y="19139.62890625" />
-						<pt x="1657.05285644531" y="22977.255859375" />
-						<pt x="1658.70886230469" y="27535.408203125" />
-						<pt x="1660.33129882812" y="21203.421875" />
-						<pt x="1661.97338867188" y="21989.1640625" />
-						<pt x="1663.23254394531" y="18492.743347168" />
-						<pt x="1664.64367675781" y="15860.5078125" />
-						<pt x="1666.41357421875" y="19013.779296875" />
-						<pt x="1667.71862792969" y="17693.15625" />
-						<pt x="1669.111328125" y="13517.3017578125" />
-						<pt x="1670.86352539062" y="17876.833984375" />
-						<pt x="1672.12548828125" y="12634.173828125" />
-						<pt x="1673.87194824219" y="15371.1162109375" />
-						<pt x="1675.19165039062" y="14991.24609375" />
-						<pt x="1676.96154785156" y="16055.552734375" />
-						<pt x="1678.55310058594" y="13005.2060546875" />
-						<pt x="1680.16735839844" y="16306.634765625" />
-						<pt x="1681.75329589844" y="15908.3388671875" />
-						<pt x="1684.45397949219" y="10510.0810546875" />
-						<pt x="1685.81030273438" y="13555.4306640625" />
-						<pt x="1687.5263671875" y="10415.58203125" />
-						<pt x="1689.21337890625" y="11749.34375" />
-						<pt x="1690.76647949219" y="13906.755859375" />
-						<pt x="1692.41857910156" y="11008.783203125" />
-						<pt x="1693.71362304688" y="11556.9501953125" />
-						<pt x="1695.46130371094" y="11376.8896484375" />
-						<pt x="1697.08410644531" y="9880.37109375" />
-						<pt x="1698.99609375" y="10109.595703125" />
-						<pt x="1701.0732421875" y="9135.697265625" />
-						<pt x="1702.7529296875" y="10913.6689453125" />
-						<pt x="1704.38671875" y="6939.59814453125" />
-						<pt x="1706.12316894531" y="11676.4853515625" />
-						<pt x="1707.67224121094" y="11669.0615234375" />
-						<pt x="1709.35302734375" y="9569.5615234375" />
-						<pt x="1710.62609863281" y="6364.845703125" />
-						<pt x="1712.33923339844" y="8145.91943359375" />
-						<pt x="1714.34643554688" y="9064.498046875" />
-						<pt x="1716.00524902344" y="9891.8291015625" />
-						<pt x="1717.3720703125" y="10346.1552734375" />
-						<pt x="1718.70336914062" y="7887.78076171875" />
-						<pt x="1720.42810058594" y="10289.8466796875" />
-						<pt x="1722.07409667969" y="12221.3131103516" />
-						<pt x="1723.66687011719" y="9412.00390625" />
-						<pt x="1724.88122558594" y="12240.80078125" />
-						<pt x="1726.58349609375" y="11340.734375" />
-						<pt x="1728.11975097656" y="8273.880859375" />
-						<pt x="1729.41674804688" y="11363.2099609375" />
-						<pt x="1731.05224609375" y="9867.80078125" />
-						<pt x="1732.3154296875" y="8855.0888671875" />
-						<pt x="1734.10437011719" y="11068.3828125" />
-						<pt x="1735.69311523438" y="7690.60546875" />
-						<pt x="1737.05261230469" y="8551.3857421875" />
-						<pt x="1738.2958984375" y="7198.0869140625" />
-						<pt x="1740.13562011719" y="7148.18359375" />
-						<pt x="1742.16540527344" y="9787.5263671875" />
-						<pt x="1744.55932617188" y="17886.8564453125" />
-						<pt x="1746.17114257812" y="42170.2978515625" />
-						<pt x="1747.40344238281" y="50283.1796875" />
-						<pt x="1749.72985839844" y="83261.640625" />
-						<pt x="1751.63122558594" y="82439.9765625" />
-						<pt x="1753.181640625" y="92369.9609375" />
-						<pt x="1754.70849609375" y="69276.3828125" />
-						<pt x="1756.63635253906" y="46668.56640625" />
-						<pt x="1758.22473144531" y="41100.25" />
-						<pt x="1759.81530761719" y="33414.75390625" />
-						<pt x="1761.75610351562" y="23601.478515625" />
-						<pt x="1763.34350585938" y="33424.1479492188" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="369.196561517338"/>
-					<UserParam type="string" name="native_id" value="LAMTLAEAER/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="164956.921875"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.362633896047856"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832153320312" RT="1607.2958984375" >
-				<PeptideHit score="0.0454545454545455" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_3">
-					<UserParam type="float" name="OMSSA_score" value="0.134752265696133"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="368.832061767578" RT="1697.94360351562" >
-				<PeptideHit score="0.0344827586206897" sequence="LAMTLAEAER" charge="3" aa_before="R" aa_after="A" protein_refs="PH_3">
-					<UserParam type="float" name="OMSSA_score" value="0.0325713993888641"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LAMTLAEAER/3"/>
-			<UserParam type="float" name="leftWidth" value="1595.50939941406"/>
-			<UserParam type="float" name="rightWidth" value="1764.53942871094"/>
-			<UserParam type="float" name="total_xic" value="10395361.7129517"/>
-			<UserParam type="float" name="peak_apices_sum" value="466399.123168945"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.97124963771702"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.960129477115842"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0112721013675148"/>
-			<UserParam type="float" name="var_library_sangle" value="0.021080330114212"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0112721013675148"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0118955544334974"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999931728221565"/>
-			<UserParam type="float" name="var_intensity_score" value="0.890087065317977"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="16.9401516016668"/>
-			<UserParam type="float" name="var_log_sn_score" value="2.82968663851485"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.940495908260345"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="6.15988578920748"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.509134767132634"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0"/>
-			<UserParam type="float" name="var_massdev_score" value="28.1440905745226"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="35.8761787175195"/>
-			<UserParam type="float" name="var_bseries_score" value="0"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.567734792584532"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.42292916274579"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="0.87806461617499"/>
-			<UserParam type="float" name="PrecursorMZ" value="368.862109904738"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="2"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="503395.78676971"/>
-			<UserParam type="float" name="model_FWHM" value="15.0339419712409"/>
-			<UserParam type="float" name="model_center" value="1616.65901604674"/>
-			<UserParam type="float" name="model_lower" value="1600.69819741598"/>
-			<UserParam type="float" name="model_upper" value="1632.61983467751"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="6.38432745230673"/>
-			<UserParam type="float" name="model_error" value="0.563895430922925"/>
-			<UserParam type="float" name="model_area" value="8055910.20711226"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="9252778"/>
-		</feature>
-		<feature id="f_16616557306000669869">
-			<position dim="0">2391.85092347612</position>
-			<position dim="1">501.795134726821</position>
-			<intensity>7.77641e+07</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>4.67498</overallquality>
-			<charge>2</charge>
-			<convexhull nr="0">
-				<pt x="2367.25073242188" y="501.745134726821" />
-				<pt x="2447.93408203125" y="501.745134726821" />
-				<pt x="2447.93408203125" y="501.845134726821" />
-				<pt x="2367.25073242188" y="501.845134726821" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2367.25073242188" y="502.246812145721" />
-				<pt x="2447.93408203125" y="502.246812145721" />
-				<pt x="2447.93408203125" y="502.346812145721" />
-				<pt x="2367.25073242188" y="502.346812145721" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_16616557306000669869_8984402899352117479">
-					<position dim="0">2391.85092347612</position>
-					<position dim="1">501.795134726821</position>
-					<intensity>2.43122e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="2367.25073242188" y="0" />
-						<pt x="2369.20751953125" y="0" />
-						<pt x="2370.35498046875" y="0" />
-						<pt x="2371.9755859375" y="0" />
-						<pt x="2373.9287109375" y="0" />
-						<pt x="2376.5869140625" y="2433.97705078125" />
-						<pt x="2377.77197265625" y="6171.642578125" />
-						<pt x="2380.13623046875" y="29049.7421875" />
-						<pt x="2381.28979492188" y="73028.1875" />
-						<pt x="2383.62573242188" y="421931.46875" />
-						<pt x="2386.21655273438" y="1893225.87255859" />
-						<pt x="2388.87280273438" y="4335401.91601562" />
-						<pt x="2391.34716796875" y="5217008.28320312" />
-						<pt x="2393.150390625" y="4967869.33007812" />
-						<pt x="2395.32104492188" y="3185805.18261719" />
-						<pt x="2397.95825195312" y="1366266.60620117" />
-						<pt x="2400.6484375" y="478780.656494141" />
-						<pt x="2403.47192382812" y="251020.90625" />
-						<pt x="2405.06005859375" y="195132.65625" />
-						<pt x="2407.34887695312" y="159410.640625" />
-						<pt x="2410.00390625" y="159829.59375" />
-						<pt x="2411.24560546875" y="143194.21875" />
-						<pt x="2413.26293945312" y="133373.9375" />
-						<pt x="2414.81225585938" y="120386.5234375" />
-						<pt x="2416.37377929688" y="118206.6796875" />
-						<pt x="2417.87133789062" y="101351.6171875" />
-						<pt x="2419.4033203125" y="94513.390625" />
-						<pt x="2420.93139648438" y="102115.15625" />
-						<pt x="2422.56640625" y="74304.109375" />
-						<pt x="2424.5244140625" y="68106.2890625" />
-						<pt x="2426.22387695312" y="68560.5" />
-						<pt x="2427.80981445312" y="61671.19140625" />
-						<pt x="2429.42407226562" y="67174.078125" />
-						<pt x="2430.58862304688" y="57929.328125" />
-						<pt x="2432.6376953125" y="49598.73046875" />
-						<pt x="2434.71142578125" y="42556.05078125" />
-						<pt x="2436.32397460938" y="40735.1953125" />
-						<pt x="2437.55200195312" y="41866.015625" />
-						<pt x="2438.87060546875" y="36309.2578125" />
-						<pt x="2440.08959960938" y="28907.3515625" />
-						<pt x="2441.35229492188" y="31006.46484375" />
-						<pt x="2442.61108398438" y="36277.6986694336" />
-						<pt x="2445.39599609375" y="26903.89453125" />
-						<pt x="2447.05639648438" y="24740.56640625" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="501.795134726821"/>
-					<UserParam type="string" name="native_id" value="LVVSTQTALA/2_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="5217008.28320312"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.653030735732608"/>
-				</feature>
-				<feature id="f_16616557306000669869_1621338151966755474">
-					<position dim="0">2391.85092347612</position>
-					<position dim="1">502.296812145721</position>
-					<intensity>1.27326e+07</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="2367.25073242188" y="0" />
-						<pt x="2369.20751953125" y="0" />
-						<pt x="2370.35498046875" y="0" />
-						<pt x="2371.9755859375" y="0" />
-						<pt x="2373.9287109375" y="0" />
-						<pt x="2376.5869140625" y="1516.80078125" />
-						<pt x="2377.77197265625" y="2486.70141601562" />
-						<pt x="2380.13623046875" y="12878.775390625" />
-						<pt x="2381.28979492188" y="32565.173828125" />
-						<pt x="2383.62573242188" y="239022.984375" />
-						<pt x="2386.21655273438" y="1043269.37109375" />
-						<pt x="2388.87280273438" y="2282502.25" />
-						<pt x="2391.34716796875" y="2826096.25" />
-						<pt x="2393.150390625" y="2565665.75" />
-						<pt x="2395.32104492188" y="1697856.99072266" />
-						<pt x="2397.95825195312" y="668443.94140625" />
-						<pt x="2400.6484375" y="249026.078125" />
-						<pt x="2403.47192382812" y="127022.0078125" />
-						<pt x="2405.06005859375" y="101064.859375" />
-						<pt x="2407.34887695312" y="75298.640625" />
-						<pt x="2410.00390625" y="71698.0546875" />
-						<pt x="2411.24560546875" y="69159.453125" />
-						<pt x="2413.26293945312" y="59553.7578125" />
-						<pt x="2414.81225585938" y="59974.34375" />
-						<pt x="2416.37377929688" y="61227.94140625" />
-						<pt x="2417.87133789062" y="48590.63671875" />
-						<pt x="2419.4033203125" y="43869.00390625" />
-						<pt x="2420.93139648438" y="47888.48828125" />
-						<pt x="2422.56640625" y="39846.03125" />
-						<pt x="2424.5244140625" y="31481.748046875" />
-						<pt x="2426.22387695312" y="31749.45703125" />
-						<pt x="2427.80981445312" y="26097.3984375" />
-						<pt x="2429.42407226562" y="29518.203125" />
-						<pt x="2430.58862304688" y="23042.17578125" />
-						<pt x="2432.6376953125" y="20541.76171875" />
-						<pt x="2434.71142578125" y="22476.27734375" />
-						<pt x="2436.32397460938" y="16425.3933105469" />
-						<pt x="2437.55200195312" y="16248.763671875" />
-						<pt x="2438.87060546875" y="19545.37890625" />
-						<pt x="2440.08959960938" y="12967.4677734375" />
-						<pt x="2441.35229492188" y="13809.294921875" />
-						<pt x="2442.61108398438" y="14411.8955078125" />
-						<pt x="2445.39599609375" y="15910.0927734375" />
-						<pt x="2447.05639648438" y="11848.0859375" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="502.296812145721"/>
-					<UserParam type="string" name="native_id" value="LVVSTQTALA/2_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="2826096.25"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.346969264267392"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="501.794891357422" RT="2431.52172851562" >
-				<PeptideHit score="0.0454545454545455" sequence="LVVSTQTALA" charge="2" aa_before="K" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.128894553541144"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="LVVSTQTALA/2"/>
-			<UserParam type="float" name="leftWidth" value="2367.25073242188"/>
-			<UserParam type="float" name="rightWidth" value="2447.93408203125"/>
-			<UserParam type="float" name="total_xic" value="37515269.1315308"/>
-			<UserParam type="float" name="peak_apices_sum" value="8043104.53320312"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.999887755329832"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999847404542345"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00326071413321929"/>
-			<UserParam type="float" name="var_library_sangle" value="0.00595193237417471"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00326071413321929"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00351508354354219"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999994121382001"/>
-			<UserParam type="float" name="var_intensity_score" value="0.987457983311246"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="110.753693509412"/>
-			<UserParam type="float" name="var_log_sn_score" value="4.70730875834126"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.996165663003922"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="7.61313811537583"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.990584754099702"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.343708544969559"/>
-			<UserParam type="float" name="var_massdev_score" value="0.832902537954213"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.670716801858621"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.75280849938603"/>
-			<UserParam type="float" name="var_manhatt_score" value="0.859198961033804"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.67498308999633"/>
-			<UserParam type="float" name="PrecursorMZ" value="501.795134726821"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="1"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="8191986.60739646"/>
-			<UserParam type="float" name="model_FWHM" value="8.91780398230993"/>
-			<UserParam type="float" name="model_center" value="2391.57709223505"/>
-			<UserParam type="float" name="model_lower" value="2382.10948538791"/>
-			<UserParam type="float" name="model_upper" value="2401.04469908218"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="3.78704273885475"/>
-			<UserParam type="float" name="model_error" value="0.146903598114083"/>
-			<UserParam type="float" name="model_area" value="77764131.6135644"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="37044752"/>
-		</feature>
 		<feature id="f_12520536430934325912">
-			<position dim="0">2298.14719526402</position>
-			<position dim="1">435.910228820904</position>
-			<intensity>225627</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>2.28768</overallquality>
-			<charge>3</charge>
-			<convexhull nr="0">
-				<pt x="2290.19189453125" y="435.860228820904" />
-				<pt x="2307.17138671875" y="435.860228820904" />
-				<pt x="2307.17138671875" y="435.960228820904" />
-				<pt x="2290.19189453125" y="435.960228820904" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2290.19189453125" y="436.194680433504" />
-				<pt x="2307.17138671875" y="436.194680433504" />
-				<pt x="2307.17138671875" y="436.294680433504" />
-				<pt x="2290.19189453125" y="436.294680433504" />
-			</convexhull>
-			<subordinate>
-				<feature id="f_12520536430934325912_3619468215685938204">
-					<position dim="0">2298.14719526402</position>
-					<position dim="1">435.910228820904</position>
-					<intensity>70587.9</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="2292.24267578125" y="1960.69494628906" />
-						<pt x="2294.96948242188" y="11676.0048828125" />
-						<pt x="2297.37475585938" y="15366.9287109375" />
-						<pt x="2299.36645507812" y="16826.505859375" />
-						<pt x="2300.96337890625" y="13613.5927734375" />
-						<pt x="2302.21069335938" y="7983.30078125" />
-						<pt x="2303.49438476562" y="3160.84594726562" />
-						<pt x="2305.9091796875" y="0" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="435.910228820904"/>
-					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i1"/>
-					<UserParam type="float" name="peak_apex_int" value="15366.9287109375"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.586748524736467"/>
-				</feature>
-				<feature id="f_12520536430934325912_15246437841577070383">
-					<position dim="0">2298.14719526402</position>
-					<position dim="1">436.244680433504</position>
-					<intensity>36564</intensity>
-					<quality dim="0">0</quality>
-					<quality dim="1">0</quality>
-					<overallquality>0</overallquality>
-					<charge>0</charge>
-					<convexhull nr="0">
-						<pt x="2292.24267578125" y="2089.2724609375" />
-						<pt x="2294.96948242188" y="6488.93212890625" />
-						<pt x="2297.37475585938" y="8652.01141357422" />
-						<pt x="2299.36645507812" y="8293.5869140625" />
-						<pt x="2300.96337890625" y="5264.36767578125" />
-						<pt x="2302.21069335938" y="3496.77294921875" />
-						<pt x="2303.49438476562" y="2279.04956054688" />
-						<pt x="2305.9091796875" y="0" />
-					</convexhull>
-					<UserParam type="float" name="MZ" value="436.244680433504"/>
-					<UserParam type="string" name="native_id" value="HLVDEPQNLIK/3_i2"/>
-					<UserParam type="float" name="peak_apex_int" value="8652.01141357422"/>
-					<UserParam type="string" name="FeatureLevel" value="MS2"/>
-					<UserParam type="float" name="isotope_probability" value="0.413251475263533"/>
-				</feature>
-			</subordinate>
-			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="435.909851074219" RT="2295.90209960938" >
-				<PeptideHit score="0.0344827586206897" sequence="HLVDEPQNLIK" charge="3" aa_before="K" aa_after="Q" protein_refs="PH_14">
-					<UserParam type="float" name="OMSSA_score" value="0.0137458569950031"/>
-					<UserParam type="string" name="target_decoy" value="target"/>
-				</PeptideHit>
-				<UserParam type="string" name="FFId_category" value="internal"/>
-			</PeptideIdentification>
-			<UserParam type="string" name="PeptideRef" value="HLVDEPQNLIK/3"/>
-			<UserParam type="float" name="leftWidth" value="2290.19189453125"/>
-			<UserParam type="float" name="rightWidth" value="2307.17138671875"/>
-			<UserParam type="float" name="total_xic" value="10639599.0813599"/>
-			<UserParam type="float" name="peak_apices_sum" value="24018.9401245117"/>
-			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
-			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
-			<UserParam type="float" name="var_xcorr_shape" value="0.987321606844706"/>
-			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.981554863036929"/>
-			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.0720162439304341"/>
-			<UserParam type="float" name="var_library_sangle" value="0.13567334952461"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.0720162439304341"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.0755707134178571"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.997235692613535"/>
-			<UserParam type="float" name="var_intensity_score" value="0.0100710436895339"/>
-			<UserParam type="float" name="nr_peaks" value="2"/>
-			<UserParam type="float" name="sn_ratio" value="2.98262189450483"/>
-			<UserParam type="float" name="var_log_sn_score" value="1.0928027440642"/>
-			<UserParam type="float" name="var_elution_model_fit_score" value="0.98598974943161"/>
-			<UserParam type="float" name="xx_lda_prelim_score" value="4.71687160277937"/>
-			<UserParam type="float" name="var_isotope_correlation_score" value="0.958229731481322"/>
-			<UserParam type="float" name="var_isotope_overlap_score" value="0.341235220432281"/>
-			<UserParam type="float" name="var_massdev_score" value="0.295951363727171"/>
-			<UserParam type="float" name="var_massdev_score_weighted" value="0.283335711262804"/>
-			<UserParam type="float" name="var_bseries_score" value="1"/>
-			<UserParam type="float" name="var_yseries_score" value="0"/>
-			<UserParam type="float" name="var_dotprod_score" value="0.654268103487712"/>
-			<UserParam type="float" name="var_manhatt_score" value="1.07431043140929"/>
-			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.28767931417546"/>
-			<UserParam type="float" name="PrecursorMZ" value="435.910228820904"/>
-			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
-			<UserParam type="int" name="n_total_ids" value="2"/>
-			<UserParam type="int" name="n_matching_ids" value="1"/>
-			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="28333.888411445"/>
-			<UserParam type="float" name="model_FWHM" value="7.4808765409325"/>
-			<UserParam type="float" name="model_center" value="2298.20512415454"/>
-			<UserParam type="float" name="model_lower" value="2290.26303458832"/>
-			<UserParam type="float" name="model_upper" value="2306.14721372077"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="3.17683582648886"/>
-			<UserParam type="float" name="model_error" value="0.204257719376126"/>
-			<UserParam type="float" name="model_area" value="225626.879800111"/>
-			<UserParam type="string" name="model_status" value="0 (valid)"/>
-			<UserParam type="float" name="raw_intensity" value="107151.8671875"/>
-		</feature>
-		<feature id="f_17876486934271562208">
 			<position dim="0">1788.6797447244</position>
 			<position dim="1">722.324660331071</position>
 			<intensity>3.72562e+07</intensity>
@@ -5405,7 +5160,7 @@
 				<pt x="1763.34350585938" y="722.876337749971" />
 			</convexhull>
 			<subordinate>
-				<feature id="f_17876486934271562208_8474756626526195362">
+				<feature id="f_12520536430934325912_15246437841577070383">
 					<position dim="0">1788.6797447244</position>
 					<position dim="1">722.324660331071</position>
 					<intensity>1.35914e+07</intensity>
@@ -5462,7 +5217,7 @@
 					<UserParam type="string" name="FeatureLevel" value="MS2"/>
 					<UserParam type="float" name="isotope_probability" value="0.579648044979989"/>
 				</feature>
-				<feature id="f_17876486934271562208_16603831684342283009">
+				<feature id="f_12520536430934325912_17876486934271562208">
 					<position dim="0">1788.6797447244</position>
 					<position dim="1">722.826337749971</position>
 					<intensity>9.94654e+06</intensity>
@@ -5537,11 +5292,11 @@
 			<UserParam type="float" name="var_xcorr_shape" value="0.999930643615412"/>
 			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999898605325919"/>
 			<UserParam type="float" name="var_library_corr" value="1"/>
-			<UserParam type="float" name="var_library_rmsd" value="0.00222326540194354"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00222326540194348"/>
 			<UserParam type="float" name="var_library_sangle" value="0.00433946169809374"/>
-			<UserParam type="float" name="var_library_rootmeansquare" value="0.00222326540194354"/>
-			<UserParam type="float" name="var_library_manhattan" value="0.00226527208671562"/>
-			<UserParam type="float" name="var_library_dotprod" value="0.999997466024098"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00222326540194348"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00226527208671551"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999997466024099"/>
 			<UserParam type="float" name="var_intensity_score" value="0.976390288421209"/>
 			<UserParam type="float" name="nr_peaks" value="2"/>
 			<UserParam type="float" name="sn_ratio" value="153.107524061801"/>
@@ -5562,16 +5317,261 @@
 			<UserParam type="int" name="n_total_ids" value="3"/>
 			<UserParam type="int" name="n_matching_ids" value="1"/>
 			<UserParam type="string" name="feature_class" value="positive"/>
-			<UserParam type="float" name="model_height" value="4038679.50256687"/>
-			<UserParam type="float" name="model_FWHM" value="8.66616810431957"/>
-			<UserParam type="float" name="model_center" value="1788.00784460179"/>
-			<UserParam type="float" name="model_lower" value="1778.8073875559"/>
-			<UserParam type="float" name="model_upper" value="1797.20830164768"/>
-			<UserParam type="float" name="model_Gauss_sigma" value="3.68018281835536"/>
-			<UserParam type="float" name="model_error" value="0.324231840181708"/>
-			<UserParam type="float" name="model_area" value="37256209.7725197"/>
+			<UserParam type="float" name="model_height" value="4038679.50253901"/>
+			<UserParam type="float" name="model_FWHM" value="8.66616810397705"/>
+			<UserParam type="float" name="model_center" value="1788.0078446018"/>
+			<UserParam type="float" name="model_lower" value="1778.80738755628"/>
+			<UserParam type="float" name="model_upper" value="1797.20830164733"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="3.6801828182099"/>
+			<UserParam type="float" name="model_error" value="0.324231840237284"/>
+			<UserParam type="float" name="model_area" value="37256209.7707902"/>
 			<UserParam type="string" name="model_status" value="0 (valid)"/>
 			<UserParam type="float" name="raw_intensity" value="23537924"/>
+		</feature>
+		<feature id="f_16603831684342283009">
+			<position dim="0">2336.46435114133</position>
+			<position dim="1">464.250362519471</position>
+			<intensity>2.36477e+08</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>4.31915</overallquality>
+			<charge>2</charge>
+			<convexhull nr="0">
+				<pt x="2307.17138671875" y="464.200362519471" />
+				<pt x="2424.5244140625" y="464.200362519471" />
+				<pt x="2424.5244140625" y="464.300362519471" />
+				<pt x="2307.17138671875" y="464.300362519471" />
+			</convexhull>
+			<convexhull nr="1">
+				<pt x="2307.17138671875" y="464.702039938371" />
+				<pt x="2424.5244140625" y="464.702039938371" />
+				<pt x="2424.5244140625" y="464.802039938371" />
+				<pt x="2307.17138671875" y="464.802039938371" />
+			</convexhull>
+			<subordinate>
+				<feature id="f_16603831684342283009_3607574553438867574">
+					<position dim="0">2336.46435114133</position>
+					<position dim="1">464.250362519471</position>
+					<intensity>8.30316e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="2308.75170898438" y="5170.44689941406" />
+						<pt x="2310.283203125" y="7568.296875" />
+						<pt x="2311.82763671875" y="12898.9326171875" />
+						<pt x="2312.98388671875" y="20828.0078125" />
+						<pt x="2314.55151367188" y="35469.68359375" />
+						<pt x="2316.0009765625" y="44699.03125" />
+						<pt x="2317.59106445312" y="37272.953125" />
+						<pt x="2319.16381835938" y="51843.94921875" />
+						<pt x="2320.703125" y="129319.545898438" />
+						<pt x="2321.84399414062" y="261265.784667969" />
+						<pt x="2323.42333984375" y="718391.005126953" />
+						<pt x="2324.95239257812" y="1680718.30761719" />
+						<pt x="2326.453125" y="2862705.30419922" />
+						<pt x="2327.91772460938" y="3810648.71875" />
+						<pt x="2330.51977539062" y="4030730.61230469" />
+						<pt x="2332.01708984375" y="3981413.81054688" />
+						<pt x="2333.87475585938" y="3838215.43164062" />
+						<pt x="2335.84326171875" y="3748789.63964844" />
+						<pt x="2337.3740234375" y="3667954.17529297" />
+						<pt x="2339.23681640625" y="3319220.17285156" />
+						<pt x="2340.73510742188" y="2964764.16357422" />
+						<pt x="2343.35791015625" y="2724365.54296875" />
+						<pt x="2344.91845703125" y="2504833.00048828" />
+						<pt x="2346.482421875" y="2477456.90234375" />
+						<pt x="2347.72998046875" y="2402664.64990234" />
+						<pt x="2349.72998046875" y="2401385.66625977" />
+						<pt x="2351.62377929688" y="2313886.29467773" />
+						<pt x="2353.62329101562" y="2412982.62353516" />
+						<pt x="2356.2490234375" y="2219565.79980469" />
+						<pt x="2358.01000976562" y="2170206.04736328" />
+						<pt x="2360.29638671875" y="2243400.45800781" />
+						<pt x="2362.99853515625" y="2088614.36767578" />
+						<pt x="2364.60131835938" y="1934220.44921875" />
+						<pt x="2367.25073242188" y="1725569.37353516" />
+						<pt x="2369.20751953125" y="1705975.34106445" />
+						<pt x="2370.35498046875" y="1615968.98583984" />
+						<pt x="2371.9755859375" y="1791504.01489258" />
+						<pt x="2373.9287109375" y="1740227.65234375" />
+						<pt x="2376.5869140625" y="1367103.4074707" />
+						<pt x="2377.77197265625" y="1300431.06237793" />
+						<pt x="2380.13623046875" y="1235396.0078125" />
+						<pt x="2381.28979492188" y="1146183.93261719" />
+						<pt x="2383.62573242188" y="1047449.32250977" />
+						<pt x="2386.21655273438" y="794766.4375" />
+						<pt x="2388.87280273438" y="722664.375" />
+						<pt x="2391.34716796875" y="628879.4375" />
+						<pt x="2393.150390625" y="564806.4375" />
+						<pt x="2395.32104492188" y="490325.21875" />
+						<pt x="2397.95825195312" y="387533.466308594" />
+						<pt x="2400.6484375" y="314348.34375" />
+						<pt x="2403.47192382812" y="232345.125" />
+						<pt x="2405.06005859375" y="222822.625" />
+						<pt x="2407.34887695312" y="164976.15625" />
+						<pt x="2410.00390625" y="127394.859375" />
+						<pt x="2411.24560546875" y="111891.4375" />
+						<pt x="2413.26293945312" y="106960.609375" />
+						<pt x="2414.81225585938" y="75139.296875" />
+						<pt x="2416.37377929688" y="76863.7578125" />
+						<pt x="2417.87133789062" y="61287.6328125" />
+						<pt x="2419.4033203125" y="58543.515625" />
+						<pt x="2420.93139648438" y="53635.5" />
+						<pt x="2422.56640625" y="37143.96484375" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="464.250362519471"/>
+					<UserParam type="string" name="native_id" value="YLYEIAR/2_i1"/>
+					<UserParam type="float" name="peak_apex_int" value="3748789.63964844"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.655742026441336"/>
+				</feature>
+				<feature id="f_16603831684342283009_4906628401344677738">
+					<position dim="0">2336.46435114133</position>
+					<position dim="1">464.752039938371</position>
+					<intensity>4.3803e+07</intensity>
+					<quality dim="0">0</quality>
+					<quality dim="1">0</quality>
+					<overallquality>0</overallquality>
+					<charge>0</charge>
+					<convexhull nr="0">
+						<pt x="2308.75170898438" y="0" />
+						<pt x="2310.283203125" y="1495.52514648438" />
+						<pt x="2311.82763671875" y="4830.3173828125" />
+						<pt x="2312.98388671875" y="8243.0048828125" />
+						<pt x="2314.55151367188" y="17170.59375" />
+						<pt x="2316.0009765625" y="13212.544921875" />
+						<pt x="2317.59106445312" y="16092.6564941406" />
+						<pt x="2319.16381835938" y="25123.279296875" />
+						<pt x="2320.703125" y="67158.3818359375" />
+						<pt x="2321.84399414062" y="138877.617431641" />
+						<pt x="2323.42333984375" y="404226.15625" />
+						<pt x="2324.95239257812" y="896589.120849609" />
+						<pt x="2326.453125" y="1523648.64257812" />
+						<pt x="2327.91772460938" y="2044045.18701172" />
+						<pt x="2330.51977539062" y="2132513.25" />
+						<pt x="2332.01708984375" y="2149916.96875" />
+						<pt x="2333.87475585938" y="2041992.375" />
+						<pt x="2335.84326171875" y="1970969.68359375" />
+						<pt x="2337.3740234375" y="1889403.84619141" />
+						<pt x="2339.23681640625" y="1802509.5" />
+						<pt x="2340.73510742188" y="1601953.04370117" />
+						<pt x="2343.35791015625" y="1432775.47705078" />
+						<pt x="2344.91845703125" y="1316177.25488281" />
+						<pt x="2346.482421875" y="1302207.00463867" />
+						<pt x="2347.72998046875" y="1253727.17529297" />
+						<pt x="2349.72998046875" y="1262369.0402832" />
+						<pt x="2351.62377929688" y="1191727.875" />
+						<pt x="2353.62329101562" y="1276700.00244141" />
+						<pt x="2356.2490234375" y="1132648.44482422" />
+						<pt x="2358.01000976562" y="1153031.75" />
+						<pt x="2360.29638671875" y="1164172.68920898" />
+						<pt x="2362.99853515625" y="1105369.05517578" />
+						<pt x="2364.60131835938" y="1014387.16259766" />
+						<pt x="2367.25073242188" y="927975.391113281" />
+						<pt x="2369.20751953125" y="930792.232421875" />
+						<pt x="2370.35498046875" y="865361.120361328" />
+						<pt x="2371.9755859375" y="917209.790893555" />
+						<pt x="2373.9287109375" y="942302.777832031" />
+						<pt x="2376.5869140625" y="743061.032958984" />
+						<pt x="2377.77197265625" y="669594.745605469" />
+						<pt x="2380.13623046875" y="643537.1875" />
+						<pt x="2381.28979492188" y="581447.5546875" />
+						<pt x="2383.62573242188" y="559372.121582031" />
+						<pt x="2386.21655273438" y="428437.09375" />
+						<pt x="2388.87280273438" y="383014.375" />
+						<pt x="2391.34716796875" y="319424.8125" />
+						<pt x="2393.150390625" y="305418.65625" />
+						<pt x="2395.32104492188" y="251123.59375" />
+						<pt x="2397.95825195312" y="189521.046875" />
+						<pt x="2400.6484375" y="160275.734375" />
+						<pt x="2403.47192382812" y="119724.125" />
+						<pt x="2405.06005859375" y="115157.8203125" />
+						<pt x="2407.34887695312" y="83020.34375" />
+						<pt x="2410.00390625" y="65361.6015625" />
+						<pt x="2411.24560546875" y="50701.60546875" />
+						<pt x="2413.26293945312" y="50538.5" />
+						<pt x="2414.81225585938" y="28087.138671875" />
+						<pt x="2416.37377929688" y="25405.73046875" />
+						<pt x="2417.87133789062" y="29897.2421875" />
+						<pt x="2419.4033203125" y="24073.78125" />
+						<pt x="2420.93139648438" y="20535.697265625" />
+						<pt x="2422.56640625" y="17314.8828125" />
+					</convexhull>
+					<UserParam type="float" name="MZ" value="464.752039938371"/>
+					<UserParam type="string" name="native_id" value="YLYEIAR/2_i2"/>
+					<UserParam type="float" name="peak_apex_int" value="1970969.68359375"/>
+					<UserParam type="string" name="FeatureLevel" value="MS2"/>
+					<UserParam type="float" name="isotope_probability" value="0.344257973558664"/>
+				</feature>
+			</subordinate>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250213623047" RT="2321.49926757812" >
+				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="0.000528980302830806"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250030517578" RT="2357.07421875" >
+				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="9.1724848717909e-05"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<PeptideIdentification identification_run_ref="PI_0" score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="464.250335693359" RT="2398.77709960938" >
+				<PeptideHit score="0" sequence="YLYEIAR" charge="2" aa_before="K" aa_after="R" protein_refs="PH_14">
+					<UserParam type="float" name="OMSSA_score" value="4.18055390056644e-05"/>
+					<UserParam type="string" name="target_decoy" value="target"/>
+				</PeptideHit>
+				<UserParam type="string" name="FFId_category" value="internal"/>
+			</PeptideIdentification>
+			<UserParam type="string" name="PeptideRef" value="YLYEIAR/2"/>
+			<UserParam type="float" name="leftWidth" value="2307.17138671875"/>
+			<UserParam type="float" name="rightWidth" value="2424.5244140625"/>
+			<UserParam type="float" name="total_xic" value="127750490.772278"/>
+			<UserParam type="float" name="peak_apices_sum" value="5719759.32324219"/>
+			<UserParam type="float" name="var_xcorr_coelution" value="0"/>
+			<UserParam type="float" name="var_xcorr_coelution_weighted" value="0"/>
+			<UserParam type="float" name="var_xcorr_shape" value="0.99989185157427"/>
+			<UserParam type="float" name="var_xcorr_shape_weighted" value="0.999853516577379"/>
+			<UserParam type="float" name="var_library_corr" value="1"/>
+			<UserParam type="float" name="var_library_rmsd" value="0.00109704639804178"/>
+			<UserParam type="float" name="var_library_sangle" value="0.00200128800168092"/>
+			<UserParam type="float" name="var_library_rootmeansquare" value="0.00109704639804178"/>
+			<UserParam type="float" name="var_library_manhattan" value="0.00118326541192137"/>
+			<UserParam type="float" name="var_library_dotprod" value="0.999999334090534"/>
+			<UserParam type="float" name="var_intensity_score" value="0.992830315040351"/>
+			<UserParam type="float" name="nr_peaks" value="2"/>
+			<UserParam type="float" name="sn_ratio" value="65.000081378898"/>
+			<UserParam type="float" name="var_log_sn_score" value="4.1743885218779"/>
+			<UserParam type="float" name="var_elution_model_fit_score" value="0.985577464103699"/>
+			<UserParam type="float" name="xx_lda_prelim_score" value="7.2506009186205"/>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.990654856489394"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.345355033874512"/>
+			<UserParam type="float" name="var_massdev_score" value="1.19333451667543"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="1.03625577733313"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.761987351682086"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.862442874603575"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="4.31914514059437"/>
+			<UserParam type="float" name="PrecursorMZ" value="464.250362519471"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+			<UserParam type="int" name="n_total_ids" value="3"/>
+			<UserParam type="int" name="n_matching_ids" value="3"/>
+			<UserParam type="string" name="feature_class" value="positive"/>
+			<UserParam type="float" name="model_height" value="4738315.40029719"/>
+			<UserParam type="float" name="model_FWHM" value="46.884802637943"/>
+			<UserParam type="float" name="model_center" value="2346.69910501276"/>
+			<UserParam type="float" name="model_lower" value="2296.92374783265"/>
+			<UserParam type="float" name="model_upper" value="2396.47446219286"/>
+			<UserParam type="float" name="model_Gauss_sigma" value="19.9101428720425"/>
+			<UserParam type="float" name="model_error" value="0.574338452996639"/>
+			<UserParam type="float" name="model_area" value="236476630.558327"/>
+			<UserParam type="string" name="model_status" value="0 (valid)"/>
+			<UserParam type="float" name="raw_intensity" value="126834560"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/topp/FeatureFinderIdentification.cpp
+++ b/src/topp/FeatureFinderIdentification.cpp
@@ -1450,7 +1450,8 @@ protected:
       // extractor.setLogType(ProgressLogger::NONE);
       vector<OpenSwath::ChromatogramPtr> chrom_temp;
       vector<ChromatogramExtractor::ExtractionCoordinates> coords;
-      extractor.prepare_coordinates(chrom_temp, coords, library_, 0, false);
+      extractor.prepare_coordinates(chrom_temp, coords, library_,
+                                    numeric_limits<double>::quiet_NaN(), false);
 
       boost::shared_ptr<PeakMap> shared = boost::make_shared<PeakMap>(ms_data_);
       OpenSwath::SpectrumAccessPtr spec_temp =

--- a/src/topp/FeatureFinderIdentification.cpp
+++ b/src/topp/FeatureFinderIdentification.cpp
@@ -522,6 +522,7 @@ protected:
   void annotateFeatures_(FeatureMap& features, PeptideRefRTMap& ref_rt_map)
   {
     String previous_ref, peptide_ref;
+    RTMap transformed_internal;
     Size i = 0;
     map<Size, vector<PeptideIdentification*> > feat_ids;
     for (FeatureMap::Iterator feat_it = features.begin();
@@ -619,11 +620,12 @@ protected:
       // distance from feature to closest peptide ID:
       if (!trafo_external_.getDataPoints().empty())
       {
-        // use external IDs if available, otherwise RT-transformed internal IDs:
-        RTMap transformed_internal;
-        // @TODO: don't recompute this for every feature
-        if (rt_external.empty())
+        // use external IDs if available, otherwise RT-transformed internal IDs
+        // (but only compute the transform if necessary, once per assay!):
+        if (rt_external.empty() && (transformed_internal.empty() ||
+                                    (peptide_ref != previous_ref)))
         {
+          transformed_internal.clear();
           for (RTMap::const_iterator it = rt_internal.begin();
                it != rt_internal.end(); ++it)
           {
@@ -1453,7 +1455,6 @@ protected:
       //-------------------------------------------------------------
       // run feature detection
       //-------------------------------------------------------------
-      LOG_INFO << "Running feature detection..." << endl;
       keep_library_ = !lib_out.empty();
       keep_chromatograms_ = !chrom_out.empty();
 

--- a/src/topp/FeatureFinderIdentification.cpp
+++ b/src/topp/FeatureFinderIdentification.cpp
@@ -204,8 +204,6 @@ protected:
     setValidFormats_("lib_out", ListUtils::create<String>("traML"));
     registerOutputFile_("chrom_out", "<file>", "", "Output file: Chromatograms", false);
     setValidFormats_("chrom_out", ListUtils::create<String>("mzML"));
-    // registerOutputFile_("trafo_out", "<file>", "", "Output file: RT transformation", false);
-    // setValidFormats_("trafo_out", ListUtils::create<String>("trafoXML"));
     registerOutputFile_("candidates_out", "<file>", "", "Output file: Feature candidates (before filtering and model fitting)", false);
     setValidFormats_("candidates_out", ListUtils::create<String>("featureXML"));
     registerInputFile_("candidates_in", "<file>", "", "Input file: Feature candidates from a previous run. If set, only feature classification and elution model fitting are carried out, if enabled. Many parameters are ignored.", false, true);
@@ -805,6 +803,7 @@ protected:
             if (rt_regions.size() > 1) peptide.id += ":" + String(++counter);
 
             // store beginning and end of RT region:
+            peptide.rts.clear();
             addPeptideRT_(peptide, reg_it->start);
             addPeptideRT_(peptide, reg_it->end);
             library_.addPeptide(peptide);
@@ -1319,7 +1318,6 @@ protected:
       String id_ext = getStringOption_("id_ext");
       String lib_out = getStringOption_("lib_out");
       String chrom_out = getStringOption_("chrom_out");
-      // String trafo_out = getStringOption_("trafo_out");
       rt_window_ = getDoubleOption_("extract:rt_window");
       mz_window_ = getDoubleOption_("extract:mz_window");
       mz_window_ppm_ = mz_window_ >= 1;
@@ -1347,21 +1345,6 @@ protected:
       mzml.setLogType(log_type_);
       mzml.getOptions().addMSLevel(1);
       mzml.load(in, ms_data_);
-
-      /*
-      // RT transformation to range 0-1:
-      ms_data_.updateRanges();
-      double min_rt = ms_data_.getMinRT(), max_rt = ms_data_.getMaxRT();
-      TransformationDescription::DataPoints points;
-      points.push_back(make_pair(min_rt, 0.0));
-      points.push_back(make_pair(max_rt, 1.0));
-      trafo_.setDataPoints(points);
-      trafo_.fitModel("linear");
-      if (!trafo_out.empty())
-      {
-        TransformationXMLFile().store(trafo_out, trafo_);
-      }
-      */
 
       // initialize algorithm classes needed later:
       Param params = feat_finder_.getParameters();


### PR DESCRIPTION
Following discussion here: https://github.com/OpenMS/OpenMS/pull/2387#issuecomment-286886978
This pull request refactors FeatureFinderIdentification to extract chromatograms (and then detect/score chromatographic peaks) for all peptides together, rather than one by one. This can save several hours of runtime.
The results should be the same as before (except for ordering).

There's a small addition to `ChromatogramExtractor::prepare_coordinates` for convenient use of varying RT start/end points.