### PR TITLE
fix msexperiment windows

### DIFF
--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -788,7 +788,7 @@ public:
       // be referenced by peptide IDs (via run ID)
 
       // filter peptide hits:
-      for (typename PeakMap::Iterator exp_it = experiment.begin();
+      for (PeakMap::Iterator exp_it = experiment.begin();
            exp_it != experiment.end(); ++exp_it)
       {
         filterHitsByScore(exp_it->getPeptideIdentifications(), 
@@ -812,7 +812,7 @@ public:
       // be referenced by peptide IDs (via run ID)
 
       // filter peptide hits:
-      for (typename PeakMap::Iterator exp_it = experiment.begin();
+      for (PeakMap::Iterator exp_it = experiment.begin();
            exp_it != experiment.end(); ++exp_it)
       {
         filterHitsBySignificance(exp_it->getPeptideIdentifications(),
@@ -832,7 +832,7 @@ public:
       std::vector<PeptideIdentification> all_peptides; // IDs from all spectra
 
       // filter peptide hits:
-      for (typename PeakMap::Iterator exp_it = experiment.begin();
+      for (PeakMap::Iterator exp_it = experiment.begin();
            exp_it != experiment.end(); ++exp_it)
       {
         std::vector<PeptideIdentification>& peptides = 
@@ -867,7 +867,7 @@ public:
       updateHitRanks(experiment.getProteinIdentifications());
 
       // filter peptide hits:
-      for (typename PeakMap::Iterator exp_it = experiment.begin();
+      for (PeakMap::Iterator exp_it = experiment.begin();
            exp_it != experiment.end(); ++exp_it)
       {
         if (exp_it->getMSLevel() == 2)

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzDataHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzDataHandler.h
@@ -106,7 +106,7 @@ private:
 protected:
 
       /// Peak type
-      typedef typename MapType::PeakType PeakType;
+      typedef MapType::PeakType PeakType;
       /// Spectrum type
       typedef MSSpectrum<PeakType> SpectrumType;
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -189,9 +189,9 @@ public:
 protected:
 
       /// Peak type
-      typedef typename MapType::PeakType PeakType;
+      typedef MapType::PeakType PeakType;
       /// Chromatogram peak type
-      typedef typename MapType::ChromatogramPeakType ChromatogramPeakType;
+      typedef MapType::ChromatogramPeakType ChromatogramPeakType;
       /// Spectrum type
       typedef MSSpectrum<PeakType> SpectrumType;
       /// Spectrum type

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzXMLHandler.h
@@ -117,7 +117,7 @@ private:
 protected:
 
       /// Peak type
-      typedef typename MapType::PeakType PeakType;
+      typedef MapType::PeakType PeakType;
       /// Spectrum type
       typedef MSSpectrum<PeakType> SpectrumType;
 

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -94,9 +94,9 @@ public:
     /// Area type
     typedef DRange<2> AreaType;
     /// Coordinate type of peak positions
-    typedef typename PeakType::CoordinateType CoordinateType;
+    typedef PeakType::CoordinateType CoordinateType;
     /// Intensity type of peaks
-    typedef typename PeakType::IntensityType IntensityType;
+    typedef PeakType::IntensityType IntensityType;
     /// RangeManager type
     typedef RangeManager<2> RangeManagerType;
     /// Spectrum Type
@@ -110,9 +110,9 @@ public:
     /// @name Iterator type definitions
     //@{
     /// Mutable iterator
-    typedef typename std::vector<SpectrumType>::iterator Iterator;
+    typedef std::vector<SpectrumType>::iterator Iterator;
     /// Non-mutable iterator
-    typedef typename std::vector<SpectrumType>::const_iterator ConstIterator;
+    typedef std::vector<SpectrumType>::const_iterator ConstIterator;
     /// Mutable area iterator type (for traversal of a rectangular subset of the peaks)
     typedef Internal::AreaIterator<PeakT, PeakT &, PeakT *, Iterator, typename SpectrumType::Iterator> AreaIterator;
     /// Immutable area iterator type (for traversal of a rectangular subset of the peaks)
@@ -122,9 +122,9 @@ public:
     /// @name Delegations of calls to the vector of MSSpectra
     // Attention: these refer to the spectra vector only!
     //@{
-    typedef typename Base::value_type value_type; 
-    typedef typename Base::iterator iterator; 
-    typedef typename Base::const_iterator const_iterator; 
+    typedef Base::value_type value_type; 
+    typedef Base::iterator iterator; 
+    typedef Base::const_iterator const_iterator; 
 
     inline Size size() const
     {
@@ -421,7 +421,7 @@ public:
     {
       SpectrumType s;
       s.setRT(rt);
-      return lower_bound(spectra_.begin(), spectra_.end(), s, typename SpectrumType::RTLess());
+      return lower_bound(spectra_.begin(), spectra_.end(), s, SpectrumType::RTLess());
     }
 
     /**
@@ -435,7 +435,7 @@ public:
     {
       SpectrumType s;
       s.setRT(rt);
-      return upper_bound(spectra_.begin(), spectra_.end(), s, typename SpectrumType::RTLess());
+      return upper_bound(spectra_.begin(), spectra_.end(), s, SpectrumType::RTLess());
     }
 
     /**
@@ -447,7 +447,7 @@ public:
     {
       SpectrumType s;
       s.setRT(rt);
-      return lower_bound(spectra_.begin(), spectra_.end(), s, typename SpectrumType::RTLess());
+      return lower_bound(spectra_.begin(), spectra_.end(), s, SpectrumType::RTLess());
     }
 
     /**
@@ -459,7 +459,7 @@ public:
     {
       SpectrumType s;
       s.setRT(rt);
-      return upper_bound(spectra_.begin(), spectra_.end(), s, typename SpectrumType::RTLess());
+      return upper_bound(spectra_.begin(), spectra_.end(), s, SpectrumType::RTLess());
     }
 
     //@}
@@ -498,7 +498,7 @@ public:
       }
 
       //update
-      for (typename Base::iterator it = spectra_.begin(); it != spectra_.end(); ++it)
+      for (Base::iterator it = spectra_.begin(); it != spectra_.end(); ++it)
       {
         if (ms_level < Int(0) || Int(it->getMSLevel()) == ms_level)
         {
@@ -557,7 +557,7 @@ public:
 
       //TODO CHROM update intensity, m/z and RT according to chromatograms as well! (done????)
 
-      for (typename std::vector<ChromatogramType>::iterator it = chromatograms_.begin(); it != chromatograms_.end(); ++it)
+      for (std::vector<ChromatogramType>::iterator it = chromatograms_.begin(); it != chromatograms_.end(); ++it)
       {
 
         // ignore TICs and ECs (as these are usually positioned at 0 and therefor lead to a large white margin in plots if included)
@@ -645,7 +645,7 @@ public:
     */
     void sortSpectra(bool sort_mz = true)
     {
-      std::sort(spectra_.begin(), spectra_.end(), typename SpectrumType::RTLess());
+      std::sort(spectra_.begin(), spectra_.end(), SpectrumType::RTLess());
 
       if (sort_mz)
       {
@@ -665,11 +665,11 @@ public:
     void sortChromatograms(bool sort_rt = true)
     {
       // sort the chromatograms according to their product m/z
-      std::sort(chromatograms_.begin(), chromatograms_.end(), typename ChromatogramType::MZLess());
+      std::sort(chromatograms_.begin(), chromatograms_.end(), ChromatogramType::MZLess());
 
       if (sort_rt)
       {
-        for (typename std::vector<ChromatogramType>::iterator it = chromatograms_.begin(); it != chromatograms_.end(); ++it)
+        for (std::vector<ChromatogramType>::iterator it = chromatograms_.begin(); it != chromatograms_.end(); ++it)
         {
           it->sortByPosition();
         }
@@ -900,13 +900,13 @@ public:
     {
       // The TIC is (re)calculated from the MS1 spectra. Even if MSExperiment does not contain a TIC chromatogram explicitly, it can be reported.
       MSChromatogram<ChromatogramPeakType> TIC;
-      for (typename Base::const_iterator spec_it = spectra_.begin(); spec_it != spectra_.end(); ++spec_it)
+      for (Base::const_iterator spec_it = spectra_.begin(); spec_it != spectra_.end(); ++spec_it)
       {
         if (spec_it->getMSLevel() == 1)
         {
           double totalIntensity = 0;
           // sum intensities of a spectrum
-          for (typename SpectrumType::const_iterator peak_it = spec_it->begin(); peak_it != spec_it->end(); ++peak_it)
+          for (SpectrumType::const_iterator peak_it = spec_it->begin(); peak_it != spec_it->end(); ++peak_it)
           {
             totalIntensity += peak_it->getIntensity();
           }
@@ -1020,7 +1020,7 @@ private:
       @param rt RT of new spectrum
       @return Pointer to newly created spectrum
     */
-    SpectrumType* createSpec_(typename PeakType::CoordinateType rt)
+    SpectrumType* createSpec_(PeakType::CoordinateType rt)
     {
       SpectrumType* spectrum = 0;
       spectra_.insert(spectra_.end(), SpectrumType());
@@ -1037,7 +1037,7 @@ private:
       @param metadata_names Names of floatdata arrays attached to this spectrum
       @return Pointer to newly created spectrum
     */
-    SpectrumType* createSpec_(typename PeakType::CoordinateType rt, const StringList& metadata_names)
+    SpectrumType* createSpec_(PeakType::CoordinateType rt, const StringList& metadata_names)
     {
       SpectrumType* spectrum = createSpec_(rt);
       // create metadata arrays
@@ -1062,13 +1062,13 @@ private:
     os << static_cast<const ExperimentalSettings &>(exp);
 
     //spectra
-    for (typename std::vector<MSSpectrum<> >::const_iterator it = exp.getSpectra().begin(); it != exp.getSpectra().end(); ++it)
+    for (std::vector<MSSpectrum<> >::const_iterator it = exp.getSpectra().begin(); it != exp.getSpectra().end(); ++it)
     {
       os << *it;
     }
 
     //chromatograms
-    for (typename std::vector<MSChromatogram<> >::const_iterator it = exp.getChromatograms().begin(); it != exp.getChromatograms().end(); ++it)
+    for (std::vector<MSChromatogram<> >::const_iterator it = exp.getChromatograms().begin(); it != exp.getChromatograms().end(); ++it)
     {
       os << *it;
     }

--- a/src/openms/source/ANALYSIS/TARGETED/OfflinePrecursorIonSelection.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/OfflinePrecursorIonSelection.cpp
@@ -123,7 +123,7 @@ namespace OpenMS
     }
   }
 
-  bool enclosesBoundingBox(const Feature& f, typename PeakMap::CoordinateType rt, typename PeakMap::CoordinateType mz)
+  bool enclosesBoundingBox(const Feature& f, PeakMap::CoordinateType rt, PeakMap::CoordinateType mz)
   {
     bool enclose_hit = false;
     const std::vector<ConvexHull2D>& hulls = f.getConvexHulls();
@@ -158,8 +158,8 @@ namespace OpenMS
         std::pair<Size, Size> end;
         bool start_found = false;
         bool end_found = false;
-        typename MSSpectrum<Peak1D>::ConstIterator mz_iter = experiment[rt].MZBegin(features[f].getMZ());
-        typename MSSpectrum<Peak1D>::ConstIterator mz_end = mz_iter;
+        MSSpectrum<Peak1D>::ConstIterator mz_iter = experiment[rt].MZBegin(features[f].getMZ());
+        MSSpectrum<Peak1D>::ConstIterator mz_end = mz_iter;
         if (mz_iter == experiment[rt].end())
           continue;
         // check to the left
@@ -215,7 +215,7 @@ namespace OpenMS
                   << features[f].getRT() << " " << features[f].getMZ() << " " << features[f].getCharge() << std::endl;
 #endif
         // we estimate the convex hull
-        typename PeakMap::ConstIterator spec_iter = experiment.RTBegin(features[f].getRT());
+        PeakMap::ConstIterator spec_iter = experiment.RTBegin(features[f].getRT());
         if (spec_iter == experiment.end())
           --spec_iter;
 
@@ -243,7 +243,7 @@ namespace OpenMS
         start.first = distance(experiment.begin(), spec_iter);
         end.first = start.first;
 
-        typename MSSpectrum<Peak1D>::ConstIterator mz_iter = spec_iter->MZBegin(features[f].getMZ());
+        MSSpectrum<Peak1D>::ConstIterator mz_iter = spec_iter->MZBegin(features[f].getMZ());
         if (spec_iter->begin() == spec_iter->end())
         {
           indices.push_back(vec);
@@ -259,7 +259,7 @@ namespace OpenMS
             break;
         }
         start.second = distance(spec_iter->begin(), mz_iter);
-        typename MSSpectrum<Peak1D>::ConstIterator mz_end = mz_iter;
+        MSSpectrum<Peak1D>::ConstIterator mz_end = mz_iter;
 #ifdef DEBUG_OPS
         std::cout << features[f].getMZ() << " Start: " << experiment[start.first].getRT() << " " << experiment[start.first][start.second].getMZ();
 #endif
@@ -367,8 +367,8 @@ namespace OpenMS
       {
         Size feature_index = variable_indices[solution_indices[i]].feature;
         Size feature_scan_idx = variable_indices[solution_indices[i]].scan;
-        typename PeakMap::ConstIterator scan = experiment.begin() + feature_scan_idx;
-        typename PeakMap::SpectrumType ms2_spec;
+        PeakMap::ConstIterator scan = experiment.begin() + feature_scan_idx;
+        PeakMap::SpectrumType ms2_spec;
         Precursor p;
         std::vector<Precursor> pcs;
         p.setIntensity(features[feature_index].getIntensity());
@@ -428,7 +428,7 @@ namespace OpenMS
         {
           Size lower_rt = features[feat_idx].getConvexHull().getBoundingBox().minX();
           Size upper_rt = features[feat_idx].getConvexHull().getBoundingBox().maxX();
-          typename PeakMap::ConstIterator it;
+          PeakMap::ConstIterator it;
           for (it = experiment.RTBegin(lower_rt); it != experiment.RTEnd(upper_rt); ++it)
           {
             scan_features[it - experiment.begin()].push_back(feat_idx);
@@ -456,7 +456,7 @@ namespace OpenMS
           const std::vector<ConvexHull2D> mass_traces = features[feature_num].getConvexHulls();
           for (Size mass_trace_num = 0; mass_trace_num < mass_traces.size(); ++mass_trace_num)
           {
-            typename OpenMS::DBoundingBox<2> tmp_bbox = mass_traces[mass_trace_num].getBoundingBox();
+            OpenMS::DBoundingBox<2> tmp_bbox = mass_traces[mass_trace_num].getBoundingBox();
             tmp_bbox.setMinY(tmp_bbox.minY() - mz_isolation_window);
             tmp_bbox.setMaxY(tmp_bbox.maxY() + mz_isolation_window);
             bounding_boxes.insert(std::make_pair(std::make_pair(feature_num, mass_trace_num), tmp_bbox));
@@ -496,7 +496,7 @@ namespace OpenMS
           ++selected_peaks;
 
           // find all features (mass traces that are in the window around peak_mz)
-          typename PeakMap::SpectrumType ms2_spec;
+          PeakMap::SpectrumType ms2_spec;
           std::vector<Precursor> pcs;
           IntList parent_feature_ids;
 

--- a/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
@@ -347,7 +347,7 @@ namespace OpenMS
       {
 
         //create FloatDataArray
-        typename MapType::SpectrumType::FloatDataArray mda;
+        MapType::SpectrumType::FloatDataArray mda;
         //Assign the right MetaInfoDescription ("supDesc" tag)
         String id = attributeAsString_(attributes, s_id);
         for (Size i = 0; i < meta_id_descs_.size(); ++i)
@@ -1040,7 +1040,7 @@ namespace OpenMS
             //write supplemental data arrays
             for (Size i = 0; i < spec.getFloatDataArrays().size(); ++i)
             {
-              const typename MapType::SpectrumType::FloatDataArray & mda = spec.getFloatDataArrays()[i];
+              const MapType::SpectrumType::FloatDataArray & mda = spec.getFloatDataArrays()[i];
               //check if spectrum and meta data array have the same length
               if (mda.size() != spec.size())
               {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -277,7 +277,7 @@ namespace OpenMS
                                   Size& default_arr_length, const PeakFileOptions& peak_file_options,
                                   SpectrumType& spectrum)
     {
-      typedef typename SpectrumType::PeakType PeakType;
+      typedef SpectrumType::PeakType PeakType;
 
       //decode all base64 arrays
       MzMLHandlerHelper::decodeBase64Arrays(input_data, options_.getSkipXMLChecks());
@@ -445,7 +445,7 @@ namespace OpenMS
                                         Size& default_arr_length, const PeakFileOptions& peak_file_options,
                                         ChromatogramType& inp_chromatogram)
     {
-      typedef typename ChromatogramType::PeakType ChromatogramPeakType;
+      typedef ChromatogramType::PeakType ChromatogramPeakType;
 
       //decode all base64 arrays
       MzMLHandlerHelper::decodeBase64Arrays(input_data, options_.getSkipXMLChecks());
@@ -4846,7 +4846,7 @@ namespace OpenMS
         //write float data array
         for (Size m = 0; m < spec.getFloatDataArrays().size(); ++m)
         {
-          const typename SpectrumType::FloatDataArray& array = spec.getFloatDataArrays()[m];
+          const SpectrumType::FloatDataArray& array = spec.getFloatDataArrays()[m];
           std::vector<double> data64_to_encode(array.size());
           for (Size p = 0; p < array.size(); ++p)
             data64_to_encode[p] = array[p];
@@ -4876,7 +4876,7 @@ namespace OpenMS
         //write integer data array
         for (Size m = 0; m < spec.getIntegerDataArrays().size(); ++m)
         {
-          const typename SpectrumType::IntegerDataArray& array = spec.getIntegerDataArrays()[m];
+          const SpectrumType::IntegerDataArray& array = spec.getIntegerDataArrays()[m];
           std::vector<Int64> data64_to_encode(array.size());
           for (Size p = 0; p < array.size(); ++p)
             data64_to_encode[p] = array[p];
@@ -4905,7 +4905,7 @@ namespace OpenMS
         //write string data arrays
         for (Size m = 0; m < spec.getStringDataArrays().size(); ++m)
         {
-          const typename SpectrumType::StringDataArray& array = spec.getStringDataArrays()[m];
+          const SpectrumType::StringDataArray& array = spec.getStringDataArrays()[m];
           std::vector<String> data_to_encode;
           data_to_encode.resize(array.size());
           for (Size p = 0; p < array.size(); ++p)
@@ -5127,7 +5127,7 @@ namespace OpenMS
       //write float data array
       for (Size m = 0; m < chromatogram.getFloatDataArrays().size(); ++m)
       {
-        const typename ChromatogramType::FloatDataArray& array = chromatogram.getFloatDataArrays()[m];
+        const ChromatogramType::FloatDataArray& array = chromatogram.getFloatDataArrays()[m];
         std::vector<double> data64_to_encode(array.size());
         for (Size p = 0; p < array.size(); ++p)
           data64_to_encode[p] = array[p];
@@ -5157,7 +5157,7 @@ namespace OpenMS
       //write integer data array
       for (Size m = 0; m < chromatogram.getIntegerDataArrays().size(); ++m)
       {
-        const typename ChromatogramType::IntegerDataArray& array = chromatogram.getIntegerDataArrays()[m];
+        const ChromatogramType::IntegerDataArray& array = chromatogram.getIntegerDataArrays()[m];
         std::vector<Int64> data64_to_encode(array.size());
         for (Size p = 0; p < array.size(); ++p)
           data64_to_encode[p] = array[p];
@@ -5186,7 +5186,7 @@ namespace OpenMS
       //write string data arrays
       for (Size m = 0; m < chromatogram.getStringDataArrays().size(); ++m)
       {
-        const typename ChromatogramType::StringDataArray& array = chromatogram.getStringDataArrays()[m];
+        const ChromatogramType::StringDataArray& array = chromatogram.getStringDataArrays()[m];
         std::vector<String> data_to_encode;
         data_to_encode.resize(array.size());
         for (Size p = 0; p < array.size(); ++p)

--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -1057,7 +1057,7 @@ namespace OpenMS
 
     void MzXMLHandler::doPopulateSpectraWithData_(SpectrumData & spectrum_data)
     {
-      typedef typename SpectrumType::PeakType PeakType;
+      typedef SpectrumType::PeakType PeakType;
 
       //std::cout << "reading scan" << "\n";
       if (spectrum_data.char_rest_ == "") // no peaks


### PR DESCRIPTION
typedef typename caused error in VS 11 2012 when not part of template.

We'll need to check whether the fixed files work under linux