### PR TITLE
[FIX] windows build fix

### DIFF
--- a/src/openms/source/KERNEL/MRMTransitionGroup.cpp
+++ b/src/openms/source/KERNEL/MRMTransitionGroup.cpp
@@ -43,7 +43,9 @@ namespace OpenMS
 {
   MRMTransitionGroup<MSSpectrum<Peak1D>, ReactionMonitoringTransition> default_mrmtransitiongroup_;
   MRMTransitionGroup<MSSpectrum<Peak1D>, OpenSwath::LightTransition> default_openswath_mrmtransitiongroup_;
-  MRMTransitionGroup<MSSpectrum<ChromatogramPeak>, ReactionMonitoringTransition> default_chrompeak_mrmtransitiongroup_;
-  MRMTransitionGroup<MSSpectrum<ChromatogramPeak>, OpenSwath::LightTransition> default_chrompeak_openswath_mrmtransitiongroup_;
+  MRMTransitionGroup<MSSpectrum<ChromatogramPeak>, ReactionMonitoringTransition> default_chrompeak_mrmtransitiongroup_; // legacy, remove
+  MRMTransitionGroup<MSSpectrum<ChromatogramPeak>, OpenSwath::LightTransition> default_chrompeak_openswath_mrmtransitiongroup_; // legacy, remove
+  MRMTransitionGroup<MSChromatogram<ChromatogramPeak>, ReactionMonitoringTransition> default_chrom_chrompeak_mrmtransitiongroup_;
+  MRMTransitionGroup<MSChromatogram<ChromatogramPeak>, OpenSwath::LightTransition> default_chrom_chrompeak_openswath_mrmtransitiongroup_;
 }
 


### PR DESCRIPTION
may fix the windows build

we still have some issues with the windows build: http://cdash.openms.de/viewBuildError.php?buildid=217346

```
OpenSwathMRMFeatureAccessOpenMS_test.obj : error LNK2019: unresolved external symbol "__declspec(dllimport) public: __thiscall OpenMS::TransitionGroupOpenMS<class OpenMS::MSChromatogram<class OpenMS::ChromatogramPeak>,class OpenMS::ReactionMonitoringTransition>::TransitionGroupOpenMS<class OpenMS::MSChromatogram<class OpenMS::ChromatogramPeak>,class OpenMS::ReactionMonitoringTransition>(class OpenMS::MRMTransitionGroup<class OpenMS::MSChromatogram<class OpenMS::ChromatogramPeak>,class OpenMS::ReactionMonitoringTransition> &)" (__imp_??0?$TransitionGroupOpenMS@V?$MSChromatogram@VChromatogramPeak@OpenMS@@@OpenMS@@VReactionMonitoringTransition@2@@OpenMS@@QAE@AAV?$MRMTransitionGroup@V?$MSChromatogram@VChromatogramPeak@OpenMS@@@OpenMS@@VReactionMonitoringTransition@2@@1@@Z) referenced in function __catch$_main$14 [C:\dev\NIGHTLY\builds\win8-VS12_x86-Debug\src\tests\class_tests\openms\OpenSwathMRMFeatureAccessOpenMS_test.vcxproj]
```

I hope the attached patch fixes this. Note that eventually `MSSpectrum<ChromatogramPeak>` will go away....