### PR TITLE
[FIX] intensity_percentage_ and intensity_percentage_optional were swapped

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -411,9 +411,9 @@ namespace OpenMS
         d.estimateFromPeptideWeight(0.5 * mass_window_width_ + index * mass_window_width_);
         //trim left and right. And store the number of isotopes on the left, to reconstruct the monoisotopic peak
         Size size_before = d.size();
-        d.trimLeft(intensity_percentage_optional_);
+        d.trimLeft(intensity_percentage_);
         isotope_distributions_[index].trimmed_left = size_before - d.size();
-        d.trimRight(intensity_percentage_optional_);
+        d.trimRight(intensity_percentage_);
 
         for (IsotopeDistribution::Iterator it = d.begin(); it != d.end(); ++it)
         {
@@ -429,7 +429,7 @@ namespace OpenMS
 
         for (Size i = 0; i < isotope_distributions_[index].intensity.size(); ++i)
         {
-          if (isotope_distributions_[index].intensity[i] < intensity_percentage_)
+          if (isotope_distributions_[index].intensity[i] < intensity_percentage_optional_)
           {
             if (!is_end && !is_begin) is_end = true;
             if (is_begin) ++begin;

--- a/src/tests/class_tests/openms/source/FeatureFinderAlgorithmPicked_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureFinderAlgorithmPicked_test.cpp
@@ -103,24 +103,24 @@ START_SECTION((virtual void run()))
 	TEST_EQUAL(output.size(), 8);
 
 	TOLERANCE_ABSOLUTE(0.001);
-	TEST_REAL_SIMILAR(output[0].getOverallQuality(), 0.8826);
-	TEST_REAL_SIMILAR(output[1].getOverallQuality(), 0.8680);
-	TEST_REAL_SIMILAR(output[2].getOverallQuality(), 0.9077);
-	TEST_REAL_SIMILAR(output[3].getOverallQuality(), 0.9270);
-	TEST_REAL_SIMILAR(output[4].getOverallQuality(), 0.9398);
-	TEST_REAL_SIMILAR(output[5].getOverallQuality(), 0.9098);
-	TEST_REAL_SIMILAR(output[6].getOverallQuality(), 0.9403);
-	TEST_REAL_SIMILAR(output[7].getOverallQuality(), 0.9245);
+	TEST_REAL_SIMILAR(output[0].getOverallQuality(), 0.942488);
+	TEST_REAL_SIMILAR(output[1].getOverallQuality(), 0.909863);
+	TEST_REAL_SIMILAR(output[2].getOverallQuality(), 0.943981);
+	TEST_REAL_SIMILAR(output[3].getOverallQuality(), 0.919197);
+	TEST_REAL_SIMILAR(output[4].getOverallQuality(), 0.95209);
+	TEST_REAL_SIMILAR(output[5].getOverallQuality(), 0.907868);
+	TEST_REAL_SIMILAR(output[6].getOverallQuality(), 0.939295);
+	TEST_REAL_SIMILAR(output[7].getOverallQuality(), 0.937429);
 
 	TOLERANCE_ABSOLUTE(20.0);
-	TEST_REAL_SIMILAR(output[0].getIntensity(), 51366.2);
-	TEST_REAL_SIMILAR(output[1].getIntensity(), 44767.6);
-	TEST_REAL_SIMILAR(output[2].getIntensity(), 34731.1);
-	TEST_REAL_SIMILAR(output[3].getIntensity(), 19494.2);
-	TEST_REAL_SIMILAR(output[4].getIntensity(), 12570.2);
-	TEST_REAL_SIMILAR(output[5].getIntensity(), 8532.26);
-	TEST_REAL_SIMILAR(output[6].getIntensity(), 7318.62);
-	TEST_REAL_SIMILAR(output[7].getIntensity(), 5038.81);
+	TEST_REAL_SIMILAR(output[0].getIntensity(), 49891.6);
+	TEST_REAL_SIMILAR(output[1].getIntensity(), 44652.2);
+	TEST_REAL_SIMILAR(output[2].getIntensity(), 34198.8);
+	TEST_REAL_SIMILAR(output[3].getIntensity(), 19236);
+	TEST_REAL_SIMILAR(output[4].getIntensity(), 12544);
+	TEST_REAL_SIMILAR(output[5].getIntensity(), 8394.53);
+	TEST_REAL_SIMILAR(output[6].getIntensity(), 6582.05);
+	TEST_REAL_SIMILAR(output[7].getIntensity(), 4874.3);
 
 END_SECTION
 

--- a/src/tests/topp/FeatureFinderCentroided_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderCentroided_1_output.featureXML
@@ -8,12 +8,12 @@
 	</dataProcessing>
 	<featureList count="8">
 		<feature id="f_4835329514588776807">
-			<position dim="0">4407.28168968115</position>
+			<position dim="0">4407.27440543387</position>
 			<position dim="1">646.240184561428</position>
-			<intensity>51392.2</intensity>
+			<intensity>49891.6</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.881839</overallquality>
+			<overallquality>0.942488</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="4374.19" y="646.22900390625" />
@@ -33,26 +33,20 @@
 				<pt x="4443.42" y="647.262512207031" />
 				<pt x="4374.19" y="647.262512207031" />
 			</convexhull>
-			<convexhull nr="3">
-				<pt x="4370.78" y="647.729736328125" />
-				<pt x="4443.42" y="647.729736328125" />
-				<pt x="4443.42" y="647.759094238281" />
-				<pt x="4370.78" y="647.759094238281" />
-			</convexhull>
 			<UserParam type="int" name="label" value="0"/>
-			<UserParam type="float" name="score_fit" value="0.780681400453095"/>
-			<UserParam type="float" name="score_correlation" value="0.996103938241421"/>
-			<UserParam type="float" name="FWHM" value="35.4671211242676"/>
+			<UserParam type="float" name="score_fit" value="0.891709636574233"/>
+			<UserParam type="float" name="score_correlation" value="0.996158113966108"/>
+			<UserParam type="float" name="FWHM" value="34.8263740539551"/>
 			<UserParam type="int" name="spectrum_index" value="88"/>
 			<UserParam type="string" name="spectrum_native_id" value="spectrum=89"/>
 		</feature>
-		<feature id="f_17749660155506638460">
-			<position dim="0">4389.14969426277</position>
+		<feature id="f_7804704400743266335">
+			<position dim="0">4389.1440010009</position>
 			<position dim="1">648.256624914625</position>
-			<intensity>44789.1</intensity>
+			<intensity>44652.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.867352</overallquality>
+			<overallquality>0.909863</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="4357.34" y="648.251525878906" />
@@ -72,32 +66,20 @@
 				<pt x="4420.95" y="649.276672363281" />
 				<pt x="4357.34" y="649.276672363281" />
 			</convexhull>
-			<convexhull nr="3">
-				<pt x="4357.34" y="649.740112304688" />
-				<pt x="4420.95" y="649.740112304688" />
-				<pt x="4420.95" y="649.772705078125" />
-				<pt x="4357.34" y="649.772705078125" />
-			</convexhull>
-			<convexhull nr="4">
-				<pt x="4357.34" y="650.251281738281" />
-				<pt x="4420.95" y="650.251281738281" />
-				<pt x="4420.95" y="650.283813476562" />
-				<pt x="4357.34" y="650.283813476562" />
-			</convexhull>
 			<UserParam type="int" name="label" value="1"/>
-			<UserParam type="float" name="score_fit" value="0.756850925195886"/>
-			<UserParam type="float" name="score_correlation" value="0.99398593629452"/>
-			<UserParam type="float" name="FWHM" value="32.5498046875"/>
+			<UserParam type="float" name="score_fit" value="0.834973161853418"/>
+			<UserParam type="float" name="score_correlation" value="0.991469978762308"/>
+			<UserParam type="float" name="FWHM" value="32.5120849609375"/>
 			<UserParam type="int" name="spectrum_index" value="83"/>
 			<UserParam type="string" name="spectrum_native_id" value="spectrum=84"/>
 		</feature>
-		<feature id="f_7804704400743266335">
-			<position dim="0">4301.01833559824</position>
+		<feature id="f_3332699010107892018">
+			<position dim="0">4301.17456189451</position>
 			<position dim="1">651.758480538276</position>
-			<intensity>34711.1</intensity>
+			<intensity>34198.8</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.907883</overallquality>
+			<overallquality>0.943981</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="4267.04" y="651.742919921875" />
@@ -117,26 +99,20 @@
 				<pt x="4336.86" y="652.780212402344" />
 				<pt x="4267.04" y="652.780212402344" />
 			</convexhull>
-			<convexhull nr="3">
-				<pt x="4267.04" y="653.247924804688" />
-				<pt x="4336.86" y="653.247924804688" />
-				<pt x="4336.86" y="653.279479980469" />
-				<pt x="4267.04" y="653.279479980469" />
-			</convexhull>
 			<UserParam type="int" name="label" value="2"/>
-			<UserParam type="float" name="score_fit" value="0.826825636476524"/>
-			<UserParam type="float" name="score_correlation" value="0.996886103247654"/>
-			<UserParam type="float" name="FWHM" value="34.6419563293457"/>
+			<UserParam type="float" name="score_fit" value="0.893575642414669"/>
+			<UserParam type="float" name="score_correlation" value="0.997229412547709"/>
+			<UserParam type="float" name="FWHM" value="34.1466979980469"/>
 			<UserParam type="int" name="spectrum_index" value="57"/>
 			<UserParam type="string" name="spectrum_native_id" value="spectrum=58"/>
 		</feature>
-		<feature id="f_15004869347769368353">
-			<position dim="0">4278.27031165772</position>
+		<feature id="f_15916652588957785155">
+			<position dim="0">4278.25831148028</position>
 			<position dim="1">653.77196829474</position>
-			<intensity>19482.3</intensity>
+			<intensity>19236</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.927023</overallquality>
+			<overallquality>0.919197</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="4247.77" y="653.760437011719" />
@@ -151,31 +127,25 @@
 				<pt x="4247.77" y="654.288879394531" />
 			</convexhull>
 			<convexhull nr="2">
-				<pt x="4247.77" y="654.755676269531" />
+				<pt x="4250.98" y="654.755676269531" />
 				<pt x="4309.57" y="654.755676269531" />
-				<pt x="4309.57" y="654.787109375" />
-				<pt x="4247.77" y="654.787109375" />
-			</convexhull>
-			<convexhull nr="3">
-				<pt x="4257.41" y="655.268920898438" />
-				<pt x="4295.93" y="655.268920898438" />
-				<pt x="4295.93" y="655.285339355469" />
-				<pt x="4257.41" y="655.285339355469" />
+				<pt x="4309.57" y="654.78662109375" />
+				<pt x="4250.98" y="654.78662109375" />
 			</convexhull>
 			<UserParam type="int" name="label" value="3"/>
-			<UserParam type="float" name="score_fit" value="0.865684990740331"/>
-			<UserParam type="float" name="score_correlation" value="0.992707260188494"/>
-			<UserParam type="float" name="FWHM" value="30.5024929046631"/>
+			<UserParam type="float" name="score_fit" value="0.852086705668905"/>
+			<UserParam type="float" name="score_correlation" value="0.991593622565935"/>
+			<UserParam type="float" name="FWHM" value="30.2051239013672"/>
 			<UserParam type="int" name="spectrum_index" value="50"/>
 			<UserParam type="string" name="spectrum_native_id" value="spectrum=51"/>
 		</feature>
-		<feature id="f_3332699010107892018">
-			<position dim="0">4201.87061903829</position>
+		<feature id="f_15157403601844400700">
+			<position dim="0">4201.85875251808</position>
 			<position dim="1">652.766081964071</position>
-			<intensity>12563.5</intensity>
+			<intensity>12544</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.940149</overallquality>
+			<overallquality>0.95209</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="4168.9" y="652.75146484375" />
@@ -195,26 +165,20 @@
 				<pt x="4234.93" y="653.791442871094" />
 				<pt x="4175.73" y="653.791442871094" />
 			</convexhull>
-			<convexhull nr="3">
-				<pt x="4168.9" y="654.244995117188" />
-				<pt x="4234.93" y="654.244995117188" />
-				<pt x="4234.93" y="654.276123046875" />
-				<pt x="4168.9" y="654.276123046875" />
-			</convexhull>
 			<UserParam type="int" name="label" value="4"/>
-			<UserParam type="float" name="score_fit" value="0.890737872632706"/>
-			<UserParam type="float" name="score_correlation" value="0.992300204965193"/>
-			<UserParam type="float" name="FWHM" value="31.8137855529785"/>
+			<UserParam type="float" name="score_fit" value="0.915175556112176"/>
+			<UserParam type="float" name="score_correlation" value="0.990492446404266"/>
+			<UserParam type="float" name="FWHM" value="31.7168941497803"/>
 			<UserParam type="int" name="spectrum_index" value="26"/>
 			<UserParam type="string" name="spectrum_native_id" value="spectrum=27"/>
 		</feature>
-		<feature id="f_13440783915218733453">
-			<position dim="0">4221.99674643751</position>
+		<feature id="f_6408859317243173796">
+			<position dim="0">4222.01988987457</position>
 			<position dim="1">646.766487275415</position>
-			<intensity>8535.3</intensity>
+			<intensity>8394.53</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.909414</overallquality>
+			<overallquality>0.907868</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="4189.18" y="646.752868652344" />
@@ -225,8 +189,8 @@
 			<convexhull nr="1">
 				<pt x="4189.18" y="647.247009277344" />
 				<pt x="4250.98" y="647.247009277344" />
-				<pt x="4250.98" y="647.280212402344" />
-				<pt x="4189.18" y="647.280212402344" />
+				<pt x="4250.98" y="647.277954101562" />
+				<pt x="4189.18" y="647.277954101562" />
 			</convexhull>
 			<convexhull nr="2">
 				<pt x="4192.58" y="647.757690429688" />
@@ -235,19 +199,19 @@
 				<pt x="4192.58" y="647.773559570312" />
 			</convexhull>
 			<UserParam type="int" name="label" value="5"/>
-			<UserParam type="float" name="score_fit" value="0.846636192139078"/>
-			<UserParam type="float" name="score_correlation" value="0.976845805903649"/>
-			<UserParam type="float" name="FWHM" value="33.2515983581543"/>
+			<UserParam type="float" name="score_fit" value="0.84307807005319"/>
+			<UserParam type="float" name="score_correlation" value="0.977636164076356"/>
+			<UserParam type="float" name="FWHM" value="32.9067230224609"/>
 			<UserParam type="int" name="spectrum_index" value="32"/>
 			<UserParam type="string" name="spectrum_native_id" value="spectrum=33"/>
 		</feature>
-		<feature id="f_15916652588957785155">
-			<position dim="0">4183.18673135949</position>
+		<feature id="f_474525871221756682">
+			<position dim="0">4183.14945685087</position>
 			<position dim="1">654.780693193393</position>
-			<intensity>7315.64</intensity>
+			<intensity>6582.05</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.940377</overallquality>
+			<overallquality>0.939295</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="4165.49" y="654.77197265625" />
@@ -268,31 +232,31 @@
 				<pt x="4182.35" y="655.799865722656" />
 			</convexhull>
 			<UserParam type="int" name="label" value="6"/>
-			<UserParam type="float" name="score_fit" value="0.901068050532372"/>
-			<UserParam type="float" name="score_correlation" value="0.981399776708481"/>
-			<UserParam type="float" name="FWHM" value="33.5274658203125"/>
+			<UserParam type="float" name="score_fit" value="0.898146274165583"/>
+			<UserParam type="float" name="score_correlation" value="0.982329344576769"/>
+			<UserParam type="float" name="FWHM" value="31.439510345459"/>
 			<UserParam type="int" name="spectrum_index" value="21"/>
 			<UserParam type="string" name="spectrum_native_id" value="spectrum=22"/>
 		</feature>
-		<feature id="f_15157403601844400700">
-			<position dim="0">4201.88444160688</position>
-			<position dim="1">648.774249926495</position>
-			<intensity>5041.25</intensity>
+		<feature id="f_12999979801269632061">
+			<position dim="0">4202.10845514052</position>
+			<position dim="1">648.773794372358</position>
+			<intensity>4874.3</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
-			<overallquality>0.924328</overallquality>
+			<overallquality>0.937429</overallquality>
 			<charge>2</charge>
 			<convexhull nr="0">
 				<pt x="4175.73" y="648.763305664062" />
-				<pt x="4238.14" y="648.763305664062" />
-				<pt x="4238.14" y="648.793823242188" />
-				<pt x="4175.73" y="648.793823242188" />
+				<pt x="4234.93" y="648.763305664062" />
+				<pt x="4234.93" y="648.779724121094" />
+				<pt x="4175.73" y="648.779724121094" />
 			</convexhull>
 			<convexhull nr="1">
-				<pt x="4175.73" y="649.259155273438" />
-				<pt x="4238.14" y="649.259155273438" />
-				<pt x="4238.14" y="649.291015625" />
-				<pt x="4175.73" y="649.291015625" />
+				<pt x="4192.58" y="649.260925292969" />
+				<pt x="4231.72" y="649.260925292969" />
+				<pt x="4231.72" y="649.290893554688" />
+				<pt x="4192.58" y="649.290893554688" />
 			</convexhull>
 			<convexhull nr="2">
 				<pt x="4175.73" y="649.769897460938" />
@@ -300,10 +264,10 @@
 				<pt x="4218.89" y="649.787719726562" />
 				<pt x="4175.73" y="649.787719726562" />
 			</convexhull>
-			<UserParam type="int" name="label" value="7"/>
-			<UserParam type="float" name="score_fit" value="0.876181697141472"/>
-			<UserParam type="float" name="score_correlation" value="0.975119900688293"/>
-			<UserParam type="float" name="FWHM" value="34.3662261962891"/>
+			<UserParam type="int" name="label" value="8"/>
+			<UserParam type="float" name="score_fit" value="0.897450889389463"/>
+			<UserParam type="float" name="score_correlation" value="0.979188610407514"/>
+			<UserParam type="float" name="FWHM" value="33.2339820861816"/>
 			<UserParam type="int" name="spectrum_index" value="26"/>
 			<UserParam type="string" name="spectrum_native_id" value="spectrum=27"/>
 		</feature>


### PR DESCRIPTION
In FeatureFinderAlgorithmPicked, based on the documentation and code, intensity_percentage_ is meant to be a hard threshold on isotope probabilities (the default value FeatureFinderCentroided is 0.01) and intensity_percentage_optional_ was meant to be a soft threshold (the default value in FeatureFinderCentroided is 0.10).

A theoretical isotope whose probability is below intensity_percentage_ should be trimmed from the IsotopeDistribution, and then anything below intensity_percentage_optional_ should be labeled as optional in the TheoreticalIsotopePattern. However, right now intensity_percentage_optional_ is being used to trim the IsotopeDistribution, and intensity_percentage_ is being used for the "optional" annotations. So with the current defaults, anything below 0.1 is trimmed off completely, and then anything below 0.01 is labeled optional, but obviously nothing gets that label because they've already been trimmed off.

This PR just swaps the variables so they are used in the correct places and the unit tests were updated. They appear to be regression tests.

Here are the results of FeatureFinderCentroided using default values on a whole cell HeLa lysate:

Before bug fix:
=========================================================================
16:58:44 NOTICE: FeatureFinderCentroided of node #2 started. Processing ...
Found 227865 seeds for charge 1.
Found 42583 feature candidates for charge 1.
Found 133510 seeds for charge 2.
Found 33193 feature candidates for charge 2.
Found 59601 seeds for charge 3.
Found 12212 feature candidates for charge 3.
Found 8719 seeds for charge 4.
Found 1413 feature candidates for charge 4.
Removed 36039 overlapping features.
53362 features left.

Abort reasons during feature construction:
- Could not extend seed: 83498
- Could not find good enough isotope pattern containing the seed: 18611
- Feature quality too low after fit: 5618
- Invalid feature after fit - too few traces or peaks left: 107782
- Invalid fit: Center outside of feature bounds: 1123
- Invalid fit: Fitted model is bigger than 'max_rt_span': 18974
- Invalid fit: Less than 'min_rt_span' left after fit: 14
FeatureFinderCentroided took 09:10 m (wall), 09:02 m (CPU), 0.00 s (system), 09:02 m (user).

After bug fix
=========================================================================
17:10:04 NOTICE: FeatureFinderCentroided of node #2 started. Processing ...
Found 221279 seeds for charge 1.
Found 47125 feature candidates for charge 1.
Found 128414 seeds for charge 2.
Found 39522 feature candidates for charge 2.
Found 55138 seeds for charge 3.
Found 12799 feature candidates for charge 3.
Found 7297 seeds for charge 4.
Found 1346 feature candidates for charge 4.
Removed 44820 overlapping features.
55972 features left.

Abort reasons during feature construction:
- Could not extend seed: 82786
- Could not find good enough isotope pattern containing the seed: 12035
- Feature quality too low after fit: 6444
- Invalid feature after fit - too few traces or peaks left: 98872
- Invalid fit: Center outside of feature bounds: 1010
- Invalid fit: Fitted model is bigger than 'max_rt_span': 19406
- Invalid fit: Less than 'min_rt_span' left after fit: 10
FeatureFinderCentroided took 10:25 m (wall), 08:56 m (CPU), 0.00 s (system), 08:56 m (user).

So that's an improvement of almost 5% in total number of features!