### PR TITLE
[INTERNAL] ignore macOS *.DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin
 build
 *.user
 *.pyc
+*.DS_Store
 moc_*.cxx*
 .idea
 OpenMS.config


### PR DESCRIPTION
macOS generates `*.DS_Store` in any folder opened by Finder [1]. In future, these files will be ignored by `git`.  

[1] https://en.wikipedia.org/wiki/.DS_Store