### PR TITLE
Feature/general spectrum reference annotation

### DIFF
--- a/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
@@ -288,14 +288,14 @@ namespace OpenMS
      * @brief Add missing "spectrum_reference"s to peptide identifications based on raw data
      *
      * @param peptides Peptide IDs with or without spectrum_reference
-     * @param lookup SpectrumMetaDataLookup with loaded spectra, metadata and optional spectra_data value for Proteins
+     * @param filename the name of the mz_file from which to draw spectrum_references
      * @param stop_on_error Stop when an ID could not be matched to a spectrum (or keep going)?
      * @param override_spectra_data if given ProteinIdentifications should be updated with new "spectra_data" values from SpectrumMetaDataLookup
-     * @param proteins
+     * @param proteins Protein IDs corresponding to the Peptide IDs
      *
      * @return True if all peptide IDs could be annotated successfully (including if all already had "spectrum_reference" values), false otherwise.
      *
-     * Look-up works by matching RT of a peptide ID to the native ID of a spectrum. All spectrum_references are updated/added.
+     * Look-up works by matching RT of a peptide identification with the given spectra. Matched spectra 'native ID' will be annotated to the identification. All spectrum_references are updated/added.
      */
     static bool addMissingSpectrumReferences(std::vector<PeptideIdentification>& peptides, const String& filename,
       bool stop_on_error = false, bool override_spectra_data = false, std::vector<ProteinIdentification> proteins = std::vector<ProteinIdentification>());

--- a/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
@@ -157,7 +157,6 @@ namespace OpenMS
     static const MetaDataFlags MDF_NATIVEID = 64;
     static const MetaDataFlags MDF_ALL = 127;
 
-    String spectra_data;
 
     /// Meta data of a spectrum
     struct SpectrumMetaData
@@ -181,8 +180,7 @@ namespace OpenMS
     };
 
     /// Constructor
-    SpectrumMetaDataLookup(): SpectrumLookup(),
-      spectra_data()
+    SpectrumMetaDataLookup(): SpectrumLookup()
     {}
 
     /// Destructor
@@ -225,15 +223,16 @@ namespace OpenMS
 
     /**
      * @brief encapsulates readSpectra with file loading convenience if only a file path is given
+     *
      * @param spectra_file file to the SpectrumContainer, must be valid path to mz file
      */
-    void readMzFile(const String& spectra_file)
+    void readMzFileMetaData(const String& spectra_file)
     {
       PeakMap exp;
       FileHandler().loadExperiment(spectra_file, exp, FileTypes::UNKNOWN, ProgressLogger::NONE,
                                    false, false);
-      this->readSpectra(exp.getSpectra());
-      this->setSpectraData(File::absolutePath(spectra_file));
+      readSpectra(exp.getSpectra());
+      setSpectraDataRef(File::absolutePath(spectra_file));
     }
 
     /**
@@ -241,9 +240,9 @@ namespace OpenMS
      *
      * @param spectra_data the name (and path) of the origin of the read SpectrumContainer
      */
-    void setSpectraData(const String& spectra_data)
+    void setSpectraDataRef(const String& spectra_data)
     {
-      this->spectra_data = spectra_data;
+      this->spectra_data_ref = spectra_data;
     }
 
 
@@ -295,29 +294,29 @@ namespace OpenMS
 
        Look-up works by matching the "spectrum_reference" (meta value) of a peptide ID to the native ID of a spectrum. Only peptide IDs without RT (where PeptideIdentification::getRT() returns "NaN") are looked up; the RT is set to that of the corresponding spectrum.
     */
-    static bool addMissingRTsToPeptideIDs(
-      std::vector<PeptideIdentification>& peptides, const SpectrumMetaDataLookup& lookup,
+    static bool addMissingRTsToPeptideIDs(std::vector<PeptideIdentification>& peptides, const String &filename,
       bool stop_on_error = false);
 
     /**
-     * @brief Add missing spectrum_references to peptide identifications vased on raw data
+     * @brief Add missing "spectrum_reference"s to peptide identifications based on raw data
      *
      * @param peptides Peptide IDs with or without spectrum_reference
      * @param lookup SpectrumMetaDataLookup with loaded spectra, metadata and optional spectra_data value for Proteins
      * @param stop_on_error Stop when an ID could not be matched to a spectrum (or keep going)?
-     * @param override_spectra_data if given ProteinIdentifications should be updated with new spectra_data values from SpectrumMetaDataLookup
+     * @param override_spectra_data if given ProteinIdentifications should be updated with new "spectra_data" values from SpectrumMetaDataLookup
      * @param proteins
      *
-     * @return True if all peptide IDs could be annotated successfully (including if all already had spectrum_referece values), false otherwise.
+     * @return True if all peptide IDs could be annotated successfully (including if all already had "spectrum_reference" values), false otherwise.
      *
      * Look-up works by matching RT of a peptide ID to the native ID of a spectrum. All spectrum_references are updated/added.
      */
-    static bool addMissingSpectrumReferences(std::vector<PeptideIdentification>& peptides, const SpectrumMetaDataLookup& lookup,
+    static bool addMissingSpectrumReferences(std::vector<PeptideIdentification>& peptides, const String& filename,
       bool stop_on_error = false, bool override_spectra_data = false, std::vector<ProteinIdentification> proteins = std::vector<ProteinIdentification>());
 
   protected:
 
     std::vector<SpectrumMetaData> metadata_; ///< Meta data for spectra
+    String spectra_data_ref;
 
   private:
 

--- a/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
@@ -39,6 +39,8 @@
 
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/KERNEL/MSExperiment.h>
 
 #include <limits> // for "quiet_NaN"
 
@@ -155,6 +157,8 @@ namespace OpenMS
     static const MetaDataFlags MDF_NATIVEID = 64;
     static const MetaDataFlags MDF_ALL = 127;
 
+    String spectra_data;
+
     /// Meta data of a spectrum
     struct SpectrumMetaData
     {
@@ -177,7 +181,9 @@ namespace OpenMS
     };
 
     /// Constructor
-    SpectrumMetaDataLookup(): SpectrumLookup() {}
+    SpectrumMetaDataLookup(): SpectrumLookup(),
+      spectra_data()
+    {}
 
     /// Destructor
     virtual ~SpectrumMetaDataLookup() {}
@@ -185,7 +191,7 @@ namespace OpenMS
     /**
        @brief Read spectra and store their meta data
 
-       @tparam SpectrumContainer Spectrum container class, must support @p size and @p operator[]
+       @param SpectrumContainer Spectrum container class, must support @p size and @p operator[]
 
        @param spectra Container of spectra
        @param scan_regexp Regular expression for matching scan numbers in spectrum native IDs (must contain the named group "?<SCAN>")
@@ -216,6 +222,30 @@ namespace OpenMS
         metadata_.push_back(meta);
       }
     }
+
+    /**
+     * @brief encapsulates readSpectra with file loading convenience if only a file path is given
+     * @param spectra_file file to the SpectrumContainer, must be valid path to mz file
+     */
+    void readMzFile(const String& spectra_file)
+    {
+      PeakMap exp;
+      FileHandler().loadExperiment(spectra_file, exp, FileTypes::UNKNOWN, ProgressLogger::NONE,
+                                   false, false);
+      this->readSpectra(exp.getSpectra());
+      this->setSpectraData(File::absolutePath(spectra_file));
+    }
+
+    /**
+     * @brief set spectra_data from read SpectrumContainer origin (i.e. filename)
+     *
+     * @param spectra_data the name (and path) of the origin of the read SpectrumContainer
+     */
+    void setSpectraData(const String& spectra_data)
+    {
+      this->spectra_data = spectra_data;
+    }
+
 
     /**
        @brief Look up meta data of a spectrum
@@ -264,12 +294,26 @@ namespace OpenMS
        @return True if all peptide IDs could be annotated successfully (including if all already had RT values), false otherwise.
 
        Look-up works by matching the "spectrum_reference" (meta value) of a peptide ID to the native ID of a spectrum. Only peptide IDs without RT (where PeptideIdentification::getRT() returns "NaN") are looked up; the RT is set to that of the corresponding spectrum.
-
-       The raw data is only loaded from @p filename if necessary, i.e. if there are any peptide IDs with missing RTs.
     */
     static bool addMissingRTsToPeptideIDs(
-      std::vector<PeptideIdentification>& peptides, const String& filename,
+      std::vector<PeptideIdentification>& peptides, const SpectrumMetaDataLookup& lookup,
       bool stop_on_error = false);
+
+    /**
+     * @brief Add missing spectrum_references to peptide identifications vased on raw data
+     *
+     * @param peptides Peptide IDs with or without spectrum_reference
+     * @param lookup SpectrumMetaDataLookup with loaded spectra, metadata and optional spectra_data value for Proteins
+     * @param stop_on_error Stop when an ID could not be matched to a spectrum (or keep going)?
+     * @param override_spectra_data if given ProteinIdentifications should be updated with new spectra_data values from SpectrumMetaDataLookup
+     * @param proteins
+     *
+     * @return True if all peptide IDs could be annotated successfully (including if all already had spectrum_referece values), false otherwise.
+     *
+     * Look-up works by matching RT of a peptide ID to the native ID of a spectrum. All spectrum_references are updated/added.
+     */
+    static bool addMissingSpectrumReferences(std::vector<PeptideIdentification>& peptides, const SpectrumMetaDataLookup& lookup,
+      bool stop_on_error = false, bool override_spectra_data = false, std::vector<ProteinIdentification> proteins = std::vector<ProteinIdentification>());
 
   protected:
 

--- a/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
@@ -221,19 +221,6 @@ namespace OpenMS
       }
     }
 
-    /**
-     * @brief encapsulates readSpectra with file loading convenience if only a file path is given
-     *
-     * @param spectra_file file to the SpectrumContainer, must be valid path to mz file
-     */
-    void readMzFileMetaData(const String& spectra_file)
-    {
-      PeakMap exp;
-      FileHandler().loadExperiment(spectra_file, exp, FileTypes::UNKNOWN, ProgressLogger::NONE,
-                                   false, false);
-      readSpectra(exp.getSpectra());
-      setSpectraDataRef(File::absolutePath(spectra_file));
-    }
 
     /**
      * @brief set spectra_data from read SpectrumContainer origin (i.e. filename)

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1291,7 +1291,7 @@ namespace OpenMS
               {
                 pep_id_->push_back(PeptideIdentification());
                 pep_id_->back().setHigherScoreBetter(false); //either a q-value or an e-value, only if neither available there will be another
-                pep_id_->back().setMetaValue("spectrum_reference", spectrumID); // TODO @mths consider SpectrumIDFormat to get just a index number here
+                pep_id_->back().setMetaValue("spectrum_reference", spectrumID);  // as spectrumID is taken from the mz_file and varies widely from vendor to vendor, spectrum_reference as string will reference the spectrum internally
 
                 //fill pep_id_->back() with content
                 DOMElement* parent = dynamic_cast<xercesc::DOMElement*>(element_res->getParentNode());
@@ -1311,18 +1311,23 @@ namespace OpenMS
 
               // TODO @mths: setSignificanceThreshold, but from where?
 
-  //              String identi = si_pro_map_[id]->getSearchEngine()+"_"
-  //                      +si_pro_map_[id]->getDateTime().getDate()
-  //                      +"T"+si_pro_map_[id]->getDateTime().getTime();
               pep_id_->back().setIdentifier(pro_id_->at(si_pro_map_[id]).getIdentifier());
-              //pep_id_->back().setMetaValue("spectrum_reference", spectrumID); //String scannr = substrings.back().reverse().chop(5);
 
               pep_id_->back().sortByRank();
 
               //adopt cv s
               for (map<String, vector<CVTerm> >::const_iterator cvit =  params.first.getCVTerms().begin(); cvit != params.first.getCVTerms().end(); ++cvit)
               {
-              // check for retention time or scan time entry
+                // check for retention time or scan time entry
+                /* N.B.: MzIdentML does not impose the requirement to store
+                   'redundant' data (e.g. RT) as the identified spectrum is
+                   unambiguously referencable by the spectrumID (OpenMS
+                   internally spectrum_reference) and hence such data can be
+                   looked up in the mz file. For convenience, and as OpenMS
+                   relies on the smallest common denominator to reference a
+                   spectrum (RT/precursor MZ), we provide functionality to amend
+                   RT data to identifications and support reading such from mzid
+                */
                 if (cvit->first == "MS:1000894" || cvit->first == "MS:1000016") //TODO use subordinate terms which define units
                 {
                   double rt = cvit->second.front().getValue().toString().toDouble();

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1291,7 +1291,7 @@ namespace OpenMS
               {
                 pep_id_->push_back(PeptideIdentification());
                 pep_id_->back().setHigherScoreBetter(false); //either a q-value or an e-value, only if neither available there will be another
-                pep_id_->back().setMetaValue("spectrum_reference", spectrumID);  // as spectrumID is taken from the mz_file and varies widely from vendor to vendor, spectrum_reference as string will reference the spectrum internally
+                pep_id_->back().setMetaValue("spectrum_reference", spectrumID);  // SpectrumIdentificationResult attribute spectrumID is taken from the mz_file and should correspond to MSSpectrum.nativeID, thus spectrum_reference will serve as reference. As the format of the 'reference' widely varies from vendor to vendor, spectrum_reference as string will serve best, indices are not recommended.
 
                 //fill pep_id_->back() with content
                 DOMElement* parent = dynamic_cast<xercesc::DOMElement*>(element_res->getParentNode());

--- a/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
@@ -204,7 +204,7 @@ namespace OpenMS
         }
         catch (Exception::ElementNotFound&)
         {
-          LOG_ERROR << "Error: Failed to look up retention time for peptide ID with spectrum reference '" + spectrum_id + "' - no spectrum with corresponding native ID found." << endl;
+          LOG_ERROR << "Error: Failed to look up retention time for peptide identification with spectrum reference '" + spectrum_id + "' - no spectrum with corresponding native ID found." << endl;
           success = false;
           if (stop_on_error) break;
         }
@@ -249,7 +249,7 @@ namespace OpenMS
       }
       catch (Exception::ElementNotFound&)
       {
-        LOG_ERROR << "Error: Failed to look up spectrum native ID for peptide ID with retention time '" + String(it->getRT()) + "'." << endl;
+        LOG_ERROR << "Error: Failed to look up spectrum native ID for peptide identification with retention time '" + String(it->getRT()) + "'." << endl;
         success = false;
         if (stop_on_error) break;
       }

--- a/src/pyOpenMS/pxds/SpectrumMetaDataLookup.pxd
+++ b/src/pyOpenMS/pxds/SpectrumMetaDataLookup.pxd
@@ -16,8 +16,6 @@ cdef extern from "<OpenMS/METADATA/SpectrumMetaDataLookup.h>" namespace "OpenMS"
 
         void readSpectra(MSExperiment spectra, String scan_regexp, bool get_precursor_rt) nogil except +
 
-        void readMzFileMetaData(String spectra_file) nogil except +
-
         void getSpectrumMetaData(Size index, SpectrumMetaData& meta) nogil except +
 
         void getSpectrumMetaData(String spectrum_ref, SpectrumMetaData& meta) nogil except +

--- a/src/pyOpenMS/pxds/SpectrumMetaDataLookup.pxd
+++ b/src/pyOpenMS/pxds/SpectrumMetaDataLookup.pxd
@@ -16,6 +16,8 @@ cdef extern from "<OpenMS/METADATA/SpectrumMetaDataLookup.h>" namespace "OpenMS"
 
         void readSpectra(MSExperiment spectra, String scan_regexp, bool get_precursor_rt) nogil except +
 
+        void readMzFileMetaData(String spectra_file) nogil except +
+
         void getSpectrumMetaData(Size index, SpectrumMetaData& meta) nogil except +
 
         void getSpectrumMetaData(String spectrum_ref, SpectrumMetaData& meta) nogil except +
@@ -36,6 +38,10 @@ cdef extern from "<OpenMS/METADATA/SpectrumMetaDataLookup.h>" namespace "OpenMS:
     bool addMissingRTsToPeptideIDs(libcpp_vector[PeptideIdentification], 
                                    String filename, bool stop_on_error) nogil except + # wrap-attach:SpectrumMetaDataLookup
 
+    bool addMissingSpectrumReferences(libcpp_vector[PeptideIdentification], 
+                                   String filename, bool stop_on_error, 
+                                   bool override_spectra_data, 
+                                   libcpp_vector[ProteinIdentification] proteins) nogil except + # wrap-attach:SpectrumMetaDataLookup
 
 cdef extern from "<OpenMS/METADATA/SpectrumMetaDataLookup.h>" namespace "OpenMS::SpectrumMetaDataLookup":
 

--- a/src/tests/class_tests/openms/source/SpectrumMetaDataLookup_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumMetaDataLookup_test.cpp
@@ -196,7 +196,7 @@ START_SECTION((bool addMissingSpectrumReferences(vector<PeptideIdentification>& 
   String filename = "this_file_does_not_exist.mzML";
   SpectrumMetaDataLookup lookup;
   // missing file -> exception, no non-effective executions
-  TEST_EXCEPTION(Exception::FileNotFound, lookup.readMzFileMetaData(filename));  
+  TEST_EXCEPTION(Exception::FileNotFound, lookup.readMzFileMetaData(filename));
   TEST_EXCEPTION(Exception::FileNotFound, SpectrumMetaDataLookup::addMissingSpectrumReferences(peptides, filename, false));
   // no lookup, no spectrum_references
   TEST_EQUAL(peptides[0].getMetaValue("spectrum_reference"), "index=666");
@@ -209,6 +209,17 @@ START_SECTION((bool addMissingSpectrumReferences(vector<PeptideIdentification>& 
 
   TEST_EQUAL(peptides[0].getMetaValue("spectrum_reference"), "index=0"); // gets updated
   TEST_EQUAL(peptides[1].getMetaValue("spectrum_reference"), "index=2");
+}
+END_SECTION
+
+
+START_SECTION((void readMzFileMetaData(const String&)))
+{
+  SpectrumMetaDataLookup newlookup;
+  TEST_EQUAL(newlookup.empty(), true);
+  String filename = OPENMS_GET_TEST_DATA_PATH("MzMLFile_1.mzML");
+  newlookup.readMzFileMetaData(filename);
+  TEST_EQUAL(newlookup.empty(), false);
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/SpectrumMetaDataLookup_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumMetaDataLookup_test.cpp
@@ -168,33 +168,27 @@ START_SECTION((void getSpectrumMetaData(const String&, SpectrumMetaData&, MetaDa
 END_SECTION
 
 
-START_SECTION((bool addMissingRTsToPeptideIDs(vector<PeptideIdentification>& peptides, const SpectrumMetaDataLookup& lookup, bool stop_on_error)))
+START_SECTION((bool addMissingRTsToPeptideIDs(vector<PeptideIdentification>& peptides, const String& filename, bool stop_on_error)))
 {
   vector<PeptideIdentification> peptides(1);
   peptides[0].setRT(1.0);
   String filename = "this_file_does_not_exist.mzML";
-  SpectrumMetaDataLookup lookup;
-  // missing file -> exception
-  TEST_EXCEPTION(Exception::FileNotFound, lookup.readMzFile(filename));
-  // no lookup, no RTs
-  SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptides, lookup, false);
+  // no missing RTs -> no attempt to load mzML file:
+  SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptides, filename);
   TEST_EQUAL(peptides[0].getRT(), 1.0);
 
   peptides.resize(2);
   peptides[0].setMetaValue("spectrum_reference", "index=0");
   peptides[1].setMetaValue("spectrum_reference", "index=2");
   filename = OPENMS_GET_TEST_DATA_PATH("MzMLFile_1.mzML");
-
-  lookup.readMzFile(filename);
-  SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptides, lookup, false);
-
+  SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptides, filename);
   TEST_EQUAL(peptides[0].getRT(), 1.0); // this doesn't get overwritten
   TEST_REAL_SIMILAR(peptides[1].getRT(), 5.3);
 }
 END_SECTION
 
 
-START_SECTION((bool addMissingSpectrumReferences(vector<PeptideIdentification>& peptides, const SpectrumMetaDataLookup& lookup, bool stop_on_error, bool override_spectra_data, vector<ProteinIdentification> proteins)))
+START_SECTION((bool addMissingSpectrumReferences(vector<PeptideIdentification>& peptides, const String& filename, bool stop_on_error, bool override_spectra_data, vector<ProteinIdentification> proteins)))
 {
   vector<PeptideIdentification> peptides(1);
   peptides[0].setRT(5.1);
@@ -202,16 +196,16 @@ START_SECTION((bool addMissingSpectrumReferences(vector<PeptideIdentification>& 
   String filename = "this_file_does_not_exist.mzML";
   SpectrumMetaDataLookup lookup;
   // missing file -> exception, no non-effective executions
-  TEST_EXCEPTION(Exception::FileNotFound, lookup.readMzFile(filename));
+  TEST_EXCEPTION(Exception::FileNotFound, lookup.readMzFileMetaData(filename));  
+  TEST_EXCEPTION(Exception::FileNotFound, SpectrumMetaDataLookup::addMissingSpectrumReferences(peptides, filename, false));
   // no lookup, no spectrum_references
-  SpectrumMetaDataLookup::addMissingSpectrumReferences(peptides, lookup, false);
   TEST_EQUAL(peptides[0].getMetaValue("spectrum_reference"), "index=666");
+
   peptides.resize(2);
   peptides[1].setRT(5.3);
   filename = OPENMS_GET_TEST_DATA_PATH("MzMLFile_1.mzML");
 
-  lookup.readMzFile(filename);
-  SpectrumMetaDataLookup::addMissingSpectrumReferences(peptides, lookup, false);
+  SpectrumMetaDataLookup::addMissingSpectrumReferences(peptides, filename, false);
 
   TEST_EQUAL(peptides[0].getMetaValue("spectrum_reference"), "index=0"); // gets updated
   TEST_EQUAL(peptides[1].getMetaValue("spectrum_reference"), "index=2");

--- a/src/tests/class_tests/openms/source/SpectrumMetaDataLookup_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumMetaDataLookup_test.cpp
@@ -196,7 +196,6 @@ START_SECTION((bool addMissingSpectrumReferences(vector<PeptideIdentification>& 
   String filename = "this_file_does_not_exist.mzML";
   SpectrumMetaDataLookup lookup;
   // missing file -> exception, no non-effective executions
-  TEST_EXCEPTION(Exception::FileNotFound, lookup.readMzFileMetaData(filename));
   TEST_EXCEPTION(Exception::FileNotFound, SpectrumMetaDataLookup::addMissingSpectrumReferences(peptides, filename, false));
   // no lookup, no spectrum_references
   TEST_EQUAL(peptides[0].getMetaValue("spectrum_reference"), "index=666");
@@ -212,16 +211,6 @@ START_SECTION((bool addMissingSpectrumReferences(vector<PeptideIdentification>& 
 }
 END_SECTION
 
-
-START_SECTION((void readMzFileMetaData(const String&)))
-{
-  SpectrumMetaDataLookup newlookup;
-  TEST_EQUAL(newlookup.empty(), true);
-  String filename = OPENMS_GET_TEST_DATA_PATH("MzMLFile_1.mzML");
-  newlookup.readMzFileMetaData(filename);
-  TEST_EQUAL(newlookup.empty(), false);
-}
-END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -809,6 +809,10 @@ set_tests_properties("TOPP_IDFileConverter_19_out1" PROPERTIES DEPENDS "TOPP_IDF
 add_test("TOPP_IDFileConverter_20" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${DATA_DIR_TOPP}/IDFileConverter_20_input.idXML -out IDFileConverter_20_output.tmp -out_type pepXML)
 add_test("TOPP_IDFileConverter_20_out1" ${DIFF} -in1 IDFileConverter_17_output.tmp -in2 ${DATA_DIR_TOPP}/IDFileConverter_17_output.pepXML)
 set_tests_properties("TOPP_IDFileConverter_20_out1" PROPERTIES DEPENDS "TOPP_IDFileConverter_20")
+# Testing spectrum_reference addition
+add_test("TOPP_IDFileConverter_21_out" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${DATA_DIR_TOPP}/IDFileConverter_21_input.idXML -out_type idXML -out IDFileConverter_21_output.tmp -mz_file ${DATA_DIR_TOPP}/IDMapper_4_input.mzML)
+add_test("TOPP_IDFileConverter_21_out1" ${DIFF} -in1 IDFileConverter_21_output.tmp -in2 ${DATA_DIR_TOPP}/IDFileConverter_21_output.idXML -whitelist "creationDate" "id" "spectraData_ref" "searchDatabase_ref")
+set_tests_properties("TOPP_IDFileConverter_21_out1" PROPERTIES DEPENDS "TOPP_IDFileConverter_21")
 
 #------------------------------------------------------------------------------
 # IDFilter tests

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -810,7 +810,7 @@ add_test("TOPP_IDFileConverter_20" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${
 add_test("TOPP_IDFileConverter_20_out1" ${DIFF} -in1 IDFileConverter_17_output.tmp -in2 ${DATA_DIR_TOPP}/IDFileConverter_17_output.pepXML)
 set_tests_properties("TOPP_IDFileConverter_20_out1" PROPERTIES DEPENDS "TOPP_IDFileConverter_20")
 # Testing spectrum_reference addition
-add_test("TOPP_IDFileConverter_21_out" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${DATA_DIR_TOPP}/IDFileConverter_21_input.idXML -out_type idXML -out IDFileConverter_21_output.tmp -mz_file ${DATA_DIR_TOPP}/IDMapper_4_input.mzML)
+add_test("TOPP_IDFileConverter_21" ${TOPP_BIN_PATH}/IDFileConverter -test -in ${DATA_DIR_TOPP}/IDFileConverter_21_input.idXML -out_type idXML -out IDFileConverter_21_output.tmp -mz_file ${DATA_DIR_TOPP}/IDMapper_4_input.mzML)
 add_test("TOPP_IDFileConverter_21_out1" ${DIFF} -in1 IDFileConverter_21_output.tmp -in2 ${DATA_DIR_TOPP}/IDFileConverter_21_output.idXML -whitelist "creationDate" "id" "spectraData_ref" "searchDatabase_ref")
 set_tests_properties("TOPP_IDFileConverter_21_out1" PROPERTIES DEPENDS "TOPP_IDFileConverter_21")
 

--- a/src/tests/topp/IDFileConverter_21_input.idXML
+++ b/src/tests/topp/IDFileConverter_21_input.idXML
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<IdXML version="1.4" id="LSID1234" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="MSDB" db_version="1.0" taxonomy="" mass_type="average" charges="+1, +2" enzyme="trypsin" missed_cleavages="0" precursor_peak_tolerance="1" peak_mass_tolerance="0.3" >
+	</SearchParameters>
+	<IdentificationRun date="2007-01-12T12:13:14" search_engine="Mascot"  search_engine_version="2.1.1" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="MOWSE" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_2" accession="PROT3" score="100.0" sequence="" >
+			</ProteinHit>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="MOWSE" higher_score_better="true" significance_threshold="0" RT="2521.44" MZ="1025.95" >
+			<PeptideHit score="1.4" sequence="PEPTIDERRRRR" charge="1" protein_refs="PH_2" >
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/tests/topp/IDFileConverter_21_output.idXML
+++ b/src/tests/topp/IDFileConverter_21_output.idXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
-<IdXML version="1.4" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="MSDB" db_version="1.0" taxonomy="" mass_type="average" charges="+1, +2" enzyme="trypsin" missed_cleavages="0" precursor_peak_tolerance="1" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
 	</SearchParameters>
 	<IdentificationRun date="2007-01-12T12:13:14" search_engine="Mascot" search_engine_version="2.1.1" search_parameters_ref="SP_0" >

--- a/src/tests/topp/IDFileConverter_21_output.idXML
+++ b/src/tests/topp/IDFileConverter_21_output.idXML
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<IdXML version="1.4" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/SCHEMAS/IdXML_1_4.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="MSDB" db_version="1.0" taxonomy="" mass_type="average" charges="+1, +2" enzyme="trypsin" missed_cleavages="0" precursor_peak_tolerance="1" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
+	</SearchParameters>
+	<IdentificationRun date="2007-01-12T12:13:14" search_engine="Mascot" search_engine_version="2.1.1" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="MOWSE" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="PROT3" score="100" sequence="" >
+			</ProteinHit>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="MOWSE" higher_score_better="true" significance_threshold="0" MZ="1025.95" RT="2521.44" spectrum_reference="controllerType=0 controllerNumber=1 scan=6089" >
+			<PeptideHit score="1.4" sequence="PEPTIDERRRRR" charge="1" protein_refs="PH_0" >
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/topp/IDFileConverter.cpp
+++ b/src/topp/IDFileConverter.cpp
@@ -159,7 +159,7 @@ protected:
     setValidStrings_("out_type", ListUtils::create<String>(formats));
 
     addEmptyLine_();
-    registerInputFile_("mz_file", "<file>", "", "[pepXML, Sequest, Mascot, X! Tandem, Percolator only] Retention times will be looked up in this file", false);
+    registerInputFile_("mz_file", "<file>", "", "[pepXML, Sequest, Mascot, X! Tandem, MS-GF+, Percolator only] Retention times and native spectrum ids (spectrum_references) will be looked up in this file", false);
     setValidFormats_("mz_file", ListUtils::create<String>("mzML,mzXML,mzData"));
     addEmptyLine_();
     registerStringOption_("mz_name", "<file>", "", "[pepXML only] Experiment filename/path (extension will be removed) to match in the pepXML file ('base_name' attribute). Only necessary if different from 'mz_file'.", false);
@@ -170,6 +170,7 @@ protected:
     registerFlag_("ignore_proteins_per_peptide", "[Sequest only] Workaround to deal with .out files that contain e.g. \"+1\" in references column,\n"
                                                  "but do not list extra references in subsequent lines (try -debug 3 or 4)", true);
     registerStringOption_("scan_regex", "<expression>", "", "[Mascot, pepXML, Percolator only] Regular expression used to extract the scan number or retention time. See documentation for details.", false, true);
+    registerFlag_("no_spectra_data_override", "[+mz_file only] Will switch off spectra_data override in ProteinIdentifications if mz_file is given and spectrum_references are added/updated. Switch off only if you are sure it is absolutely the same mz_file as used for identification.", true);
   }
 
   ExitCodes main_(int, const char**)
@@ -329,6 +330,20 @@ protected:
       else if (in_type == FileTypes::IDXML)
       {
         IdXMLFile().load(in, protein_identifications, peptide_identifications);
+        // get spectrum_references from the mz data, if necessary:
+        if (!mz_file.empty())
+        {
+          if (lookup.empty())
+          {
+            PeakMap exp;
+            fh.loadExperiment(mz_file, exp, FileTypes::UNKNOWN, log_type_,
+                                         false, false);
+            lookup.readSpectra(exp.getSpectra());
+            lookup.setSpectraData(File::absolutePath(mz_file));
+          }
+          SpectrumMetaDataLookup::addMissingSpectrumReferences(
+            peptide_identifications, lookup, false, !getFlag_("no_spectra_data_override"), protein_identifications);
+        }
       }
 
       else if (in_type == FileTypes::MZIDENTML)
@@ -337,11 +352,19 @@ protected:
         MzIdentMLFile().load(in, protein_identifications,
                              peptide_identifications);
 
-        // get retention times from the raw data, if necessary:
+        // get retention times from the mz data, if necessary:
         if (!mz_file.empty())
         {
+          if (lookup.empty())
+          {
+            PeakMap exp;
+            fh.loadExperiment(mz_file, exp, FileTypes::UNKNOWN, log_type_,
+                                         false, false);
+            lookup.readSpectra(exp.getSpectra());
+            lookup.setSpectraData(File::absolutePath(mz_file));
+          }
           SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(
-            peptide_identifications, mz_file, false);
+            peptide_identifications, lookup, false);
         }
       }
 
@@ -505,44 +528,6 @@ protected:
 
     else if (out_type == FileTypes::MZIDENTML)
     {
-      if (!mz_file.empty())
-      {
-        vector<String> spectra_data(1);
-        spectra_data[0] = "file://" + File::absolutePath(mz_file);
-        for (vector<ProteinIdentification>::iterator it =
-               protein_identifications.begin(); it !=
-               protein_identifications.end(); ++it)
-        {
-          // @TODO: should we add an option to *not* overwrite existing entries?
-          it->setMetaValue("spectra_data", spectra_data);
-        }
-        if (lookup.empty()) // raw data hasn't been read yet
-        {
-          PeakMap experiment;
-          fh.loadExperiment(mz_file, experiment, FileTypes::UNKNOWN, log_type_,
-                            false, false);
-          lookup.readSpectra(experiment.getSpectra());
-        }
-        if (!lookup.empty())
-        {
-          for (vector<PeptideIdentification>::iterator it =
-                 peptide_identifications.begin(); it !=
-                 peptide_identifications.end(); ++it)
-          {
-            try
-            {
-              Size index = lookup.findByRT(it->getRT());
-              SpectrumMetaDataLookup::SpectrumMetaData meta;
-              lookup.getSpectrumMetaData(index, meta);
-              it->setMetaValue("spectrum_reference", meta.native_id);
-            }
-            catch (Exception::ElementNotFound&)
-            {
-              LOG_ERROR << "Error: Failed to look up spectrum native ID for peptide ID with retention time '" + String(it->getRT()) + "'." << endl;
-            }
-          }
-        }
-      }
       MzIdentMLFile().store(out, protein_identifications,
                             peptide_identifications);
     }
@@ -586,6 +571,12 @@ protected:
     return EXECUTION_OK;
   }
 
+  void add_spectrum_reference_(std::vector<ProteinIdentification>& protein_identifications,
+                               std::vector<PeptideIdentification>& peptide_identifications,
+                               SpectrumMetaDataLookup& lookup,
+                               bool override_spectra_data)
+  {
+  }
 };
 
 int main(int argc, const char** argv)

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -731,7 +731,11 @@ protected:
         {
           switchScores_(*pep_it);
         }
-        SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptide_ids, in, false);
+
+        SpectrumMetaDataLookup lookup;
+        lookup.readMzFile(in);
+        SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptide_ids, lookup, false);
+
         IdXMLFile().store(out, protein_ids, peptide_ids);
       }
     }

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -732,9 +732,7 @@ protected:
           switchScores_(*pep_it);
         }
 
-        SpectrumMetaDataLookup lookup;
-        lookup.readMzFile(in);
-        SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptide_ids, lookup, false);
+        SpectrumMetaDataLookup::addMissingRTsToPeptideIDs(peptide_ids, in, false);
 
         IdXMLFile().store(out, protein_ids, peptide_ids);
       }


### PR DESCRIPTION
This is the split rework of #1797 , closed after scope creep.
PR is for consistent update/complementation  of id result files.
Some existing functionality for that was refactored from IDFileConverter into SpectrumMetaDataLookup.
Now, either adding missing RT or adding missing spectrum references is possible, available through IDFileConverter.

Rest of #1797 comes with another PR which is actually based on this.