### PR TITLE
Fixes for X! Tandem and Percolator (modification handling)

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -80,7 +80,6 @@ public:
 
             This does not describe the amino acids which are valid for a
             specific amino acid!
-
     */
     enum TermSpecificity
     {
@@ -93,7 +92,6 @@ public:
     };
 
     /** @brief Classification of the modification
-
     */
     enum SourceClassification
     {
@@ -190,10 +188,20 @@ public:
     /// returns the terminal specificity name which is set or given as parameter
     String getTermSpecificityName(TermSpecificity = NUMBER_OF_TERM_SPECIFICITY) const;
 
-    ///sets the origin (i.e. amino acid)
+    /**
+       @brief Sets the origin (i.e. amino acid or terminus)
+
+       @see getOrigin()
+    */
     void setOrigin(const String& origin);
 
-    /// returns the origin (i.e. amino acid) if set
+    /**
+       @brief Returns the origin (i.e. amino acid or terminus) if set
+
+       For modifications without terminal specificity, the origin is the residue that gets modified, e.g. "M" for "Oxidation (M)".
+       For modifications with purely terminal specificity, the origin is "N-term" or "C-term", e.g. "N-term" for "Acetyl (N-term)".
+       For modifications with terminal and residue specificity, the origin is the residue, e.g. "E" for "Glu->pyro-Glu (N-term E)".
+    */
     const String& getOrigin() const;
 
     /// classification as defined by the PSI-MOD

--- a/src/openms/include/OpenMS/FORMAT/PercolatorOutfile.h
+++ b/src/openms/include/OpenMS/FORMAT/PercolatorOutfile.h
@@ -77,6 +77,9 @@ namespace OpenMS
     /// Converts the peptide string to an 'AASequence' instance
     void getPeptideSequence_(String peptide, AASequence& seq) const;
 
+    /// Resolve cases where N-terminal modifications may be misassigned to the first residue (for X! Tandem results)
+    void resolveMisassignedNTermMods_(String& peptide) const;
+
     /// Extracts allowed modifications from the search results
     void getSearchModifications_(
       const std::vector<PeptideIdentification>& peptides,

--- a/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
+++ b/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
@@ -247,9 +247,10 @@ protected:
 
       @param mods The modifications to convert
       @param affected_origins Set of origins, which were used previously. Will be augmented with the current mods.
+      @param ignore_pyro_glu Ignore "Gln/Glu->pyro-Glu (N-term Q/E)" modifications (they are handled by a dedicated option)
       @return A X!Tandem compatible string representation.
     */
-    String convertModificationSet_(const std::set<ModificationDefinition>& mods, std::map<String, double>& affected_origins) const;
+    String convertModificationSet_(const std::set<ModificationDefinition>& mods, std::map<String, double>& affected_origins, bool ignore_pyro_glu = false) const;
 
     double fragment_mass_tolerance_;
 

--- a/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
+++ b/src/openms/include/OpenMS/FORMAT/XTandemInfile.h
@@ -79,18 +79,6 @@ public:
     /// constructor
     virtual ~XTandemInfile();
 
-    //<note type="input" label="spectrum, fragment monoisotopic mass error">0.4</note>
-    //<note type="input" label="spectrum, fragment monoisotopic mass error">0.4</note>
-    //<note type="input" label="spectrum, parent monoisotopic mass error plus">100</note>
-    //<note type="input" label="spectrum, parent monoisotopic mass error minus">100</note>
-    //<note type="input" label="spectrum, parent monoisotopic mass isotope error">yes</note>
-    //<note type="input" label="spectrum, fragment monoisotopic mass error units">Daltons</note>
-    //<note>The value for this parameter may be 'Daltons' or 'ppm': all other values are ignored</note>
-    //<note type="input" label="spectrum, parent monoisotopic mass error units">ppm</note>
-    //<note>The value for this parameter may be 'Daltons' or 'ppm': all other values are ignored</note>
-    //<note type="input" label="spectrum, fragment mass type">monoisotopic</note>
-    //<note>values are monoisotopic|average </note>
-
     /// setter for the fragment mass tolerance
     void setFragmentMassTolerance(double tolerance);
 
@@ -212,16 +200,18 @@ public:
     const String& getCleavageSite() const;
 
     /** 
-      @brief Writes the XTandemInfile to the given file
+      @brief Writes the X! Tandem input file to the given filename
 
-      If ignore_member_parameters is true, only a very limited number of
+      If @p ignore_member_parameters is true, only a very limited number of
       tags fed by member variables (i.e. in, out, database/taxonomy) is written.
       
       @param filename the name of the file which is written
       @param ignore_member_parameters Do not write tags for class members
+      @param force_default_mods Force writing of mods covered by special parameters
       @throw UnableToCreateFile is thrown if the given file could not be created
     */
-    void write(const String& filename, bool ignore_member_parameters = false);
+    void write(const String& filename, bool ignore_member_parameters = false,
+               bool force_default_mods = false);
 
 protected:
 
@@ -240,17 +230,17 @@ protected:
     /**
       @brief Converts the given set of Modifications into a format compatible to X!Tandem.
 
-      The set affected_origins can be used to avoid duplicate modifications, which are not supported in X!Tandem.
+      The set affected_origins can be used to avoid duplicate modifications, which are not supported in X! Tandem.
       Currently, a warning message is printed.
       Also, if a fixed mod is already given, a corresponding variable mods needs to have its delta mass reduced by the fixed modifications mass.
       This is also done automatically here.
 
       @param mods The modifications to convert
       @param affected_origins Set of origins, which were used previously. Will be augmented with the current mods.
-      @param ignore_pyro_glu Ignore "Gln/Glu->pyro-Glu (N-term Q/E)" modifications (they are handled by a dedicated option)
-      @return A X!Tandem compatible string representation.
+
+      @return An X! Tandem compatible string representation.
     */
-    String convertModificationSet_(const std::set<ModificationDefinition>& mods, std::map<String, double>& affected_origins, bool ignore_pyro_glu = false) const;
+    String convertModificationSet_(const std::set<ModificationDefinition>& mods, std::map<String, double>& affected_origins) const;
 
     double fragment_mass_tolerance_;
 
@@ -302,6 +292,9 @@ protected:
     String output_results_;
 
     double max_valid_evalue_;
+
+    // force writing of mods covered by special parameters?
+    bool force_default_mods_;
 
   };
 

--- a/src/openms/include/OpenMS/FORMAT/XTandemXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/XTandemXMLFile.h
@@ -65,22 +65,20 @@ public:
     /// Destructor
     virtual ~XTandemXMLFile();
     /**
-      @brief loads data from a XTandemXML file
+      @brief loads data from an X! Tandem XML file
 
       @param filename the file to be loaded
       @param protein_identification protein identifications belonging to the whole experiment
       @param id_data the identifications with m/z and RT
+      @param mod_def_set Fixed and variable modifications defined for the search. May be extended with additional (X! Tandem default) modifications if those are found in the file.
 
-      This class serves to read in a XTandemXML file. The information can be
+      This class serves to read in an X! Tandem XML file. The information can be
       retrieved via the load function.
 
       @ingroup FileIO
     */
-    void load(const String& filename, ProteinIdentification& protein_identification, std::vector<PeptideIdentification>& id_data);
+    void load(const String& filename, ProteinIdentification& protein_identification, std::vector<PeptideIdentification>& id_data, ModificationDefinitionsSet& mod_def_set);
 
-
-    /// sets the valid modifications
-    void setModificationDefinitionsSet(const ModificationDefinitionsSet& rhs);
 
 protected:
 

--- a/src/openms/source/CHEMISTRY/ModificationDefinitionsSet.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationDefinitionsSet.cpp
@@ -305,8 +305,10 @@ namespace OpenMS
     {
       const ResidueModification& mod = it->getModification();
       // do the residues match?
+      const String& origin = mod.getOrigin();
       if (!(residue.empty() || (residue == "X") || (residue == ".") ||
-            mod.getOrigin().empty() || (residue == mod.getOrigin()))) continue;
+            origin.empty() || (origin == "N-term") || (origin == "C-term") ||
+            (residue == origin))) continue;
       // do the term specificities match?
       if (!((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
             (term_spec == mod.getTermSpecificity()))) continue;

--- a/src/openms/source/FORMAT/PercolatorOutfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorOutfile.cpp
@@ -152,7 +152,7 @@ namespace OpenMS
             }
           }
           // if neither mod can be terminal, something is wrong -> let
-          // AASequence deal with
+          // AASequence deal with it
         }
       }
     }

--- a/src/openms/source/FORMAT/XTandemInfile.cpp
+++ b/src/openms/source/FORMAT/XTandemInfile.cpp
@@ -178,6 +178,8 @@ namespace OpenMS
     // required by Percolator to recognize output file
     // (see https://github.com/percolator/percolator/issues/180):
     writeNote_(os, "output, xsl path", "tandem-style.xsl");
+    // to help diagnose problems:
+    writeNote_(os, "output, parameters", true);
 
     if (!ignore_member_parameters)
     {

--- a/src/openms/source/FORMAT/XTandemInfile.cpp
+++ b/src/openms/source/FORMAT/XTandemInfile.cpp
@@ -89,20 +89,18 @@ namespace OpenMS
     return;
   }
 
-  String XTandemInfile::convertModificationSet_(const set<ModificationDefinition>& mods, std::map<String, double>& affected_origins) const
+  String XTandemInfile::convertModificationSet_(const set<ModificationDefinition>& mods, std::map<String, double>& affected_origins, bool ignore_pyro_glu) const
   {
     std::map<String, double> origin_set;
 
     StringList xtandem_mods;
-    for (set<ModificationDefinition>::const_iterator it = mods.begin(); it != mods.end(); ++it)
+    for (set<ModificationDefinition>::const_iterator it = mods.begin();
+         it != mods.end(); ++it)
     {
-      // special cases:
-      // @TODO: Include "Acetyl (N-term)" here? Should do for "Acetyl (Protein
-      // N-term)", but that's not supported by OpenMS.
-      if ((it->getModificationName() == "Gln->pyro-Glu (N-term Q)") ||
-          (it->getModificationName() == "Glu->pyro-Glu (N-term E)"))
+      if (ignore_pyro_glu &&
+          ((it->getModificationName() == "Gln->pyro-Glu (N-term Q)") ||
+           (it->getModificationName() == "Glu->pyro-Glu (N-term E)")))
       {
-        LOG_INFO << "X! Tandem automatically includes the modifications 'Gln->pyro-Glu (N-term Q)' and 'Glu->pyro-Glu (N-term E)' in searches (see X! Tandem parameter 'protein, quick pyrolidone'); no need to set them explicitly." << endl;
         continue;
       }
 
@@ -266,46 +264,11 @@ namespace OpenMS
       ////////////////////////////////////////////////////////////////////////////////
 
 
-      //////////////// residue modification parameters
-      //<note type="input" label="residue, modification mass">57.022@C</note>
-      //<note>The format of this parameter is m@X, where m is the modification
-      //mass in Daltons and X is the appropriate residue to modify. Lists of
-      //modifications are separated by commas. For example, to modify M and C
-      //with the addition of 16.0 Daltons, the parameter line would be
-      //+16.0@M,+16.0@C
-      //Positive and negative values are allowed.
-      //</note>
-
-      std::map<String, double> affected_origins;
-      writeNote_(os, "residue, modification mass", convertModificationSet_(modifications_.getFixedModifications(), affected_origins));
-
-      //<note type="input" label="residue, potential modification mass"></note>
-      //<note>The format of this parameter is the same as the format
-      //for residue, modification mass (see above).</note>
-
-      writeNote_(os, "residue, potential modification mass", convertModificationSet_(modifications_.getVariableModifications(), affected_origins));
-
+      //////////////// protein parameters
+      //<note type="input" label="protein, taxon">other mammals</note>
+      //<note>This value is interpreted using the information in taxonomy.xml.</note>
       writeNote_(os, "protein, taxon", taxon_);
 
-  /*
-      //<note type="input" label="residue, potential modification motif"></note>
-      //<note>The format of this parameter is similar to residue, modification mass,
-      //with the addition of a modified PROSITE notation sequence motif specification.
-      //For example, a value of 80@[ST!]PX[KR] indicates a modification
-      //of either S or T when followed by P, and residue and the a K or an R.
-      //A value of 204@N!{P}[ST]{P} indicates a modification of N by 204, if it
-      //is NOT followed by a P, then either an S or a T, NOT followed by a P.
-      //Positive and negative values are allowed.
-      //</note>
-          writeNote_(os, "residue, potential modification motif", variable_modification_motif_);
-          ////////////////////////////////////////////////////////////////////////////////
-
-
-          //////////////// protein parameters
-          //<note type="input" label="protein, taxon">other mammals</note>
-      //<note>This value is interpreted using the information in taxonomy.xml.</note>
-          writeNote_(os, "protein, taxon", taxon_);
-  */
       //<note type="input" label="protein, cleavage site">[RK]|{P}</note>
       //<note>this setting corresponds to the enzyme trypsin. The first characters
       //in brackets represent residues N-terminal to the bond - the '|' pipe -
@@ -340,7 +303,50 @@ namespace OpenMS
       //<note type="input" label="protein, homolog management">no</note>
       //<note>if yes, an upper limit is set on the number of homologues kept for a particular spectrum</note>
       //writeNote_(os, "protein, homolog management", protein_homolog_management_);
+
+      // special case for "pyro-Glu" modifications:
+      bool ignore_pyro_glu = false;
+      set<String> var_mods = modifications_.getVariableModificationNames();
+      if ((var_mods.find("Gln->pyro-Glu (N-term Q)") != var_mods.end()) &&
+          (var_mods.find("Glu->pyro-Glu (N-term E)") != var_mods.end()))
+      {
+        writeNote_(os, "protein, quick pyrolidone", true);
+        ignore_pyro_glu = true;
+      }
+
       ////////////////////////////////////////////////////////////////////////////////
+
+
+      //////////////// residue modification parameters
+      //<note type="input" label="residue, modification mass">57.022@C</note>
+      //<note>The format of this parameter is m@X, where m is the modification
+      //mass in Daltons and X is the appropriate residue to modify. Lists of
+      //modifications are separated by commas. For example, to modify M and C
+      //with the addition of 16.0 Daltons, the parameter line would be
+      //+16.0@M,+16.0@C
+      //Positive and negative values are allowed.
+      //</note>
+
+      std::map<String, double> affected_origins;
+      writeNote_(os, "residue, modification mass", convertModificationSet_(modifications_.getFixedModifications(), affected_origins));
+
+      //<note type="input" label="residue, potential modification mass"></note>
+      //<note>The format of this parameter is the same as the format
+      //for residue, modification mass (see above).</note>
+      writeNote_(os, "residue, potential modification mass", convertModificationSet_(modifications_.getVariableModifications(), affected_origins, ignore_pyro_glu));
+
+      //<note type="input" label="residue, potential modification motif"></note>
+      //<note>The format of this parameter is similar to residue, modification mass,
+      //with the addition of a modified PROSITE notation sequence motif specification.
+      //For example, a value of 80@[ST!]PX[KR] indicates a modification
+      //of either S or T when followed by P, and residue and the a K or an R.
+      //A value of 204@N!{P}[ST]{P} indicates a modification of N by 204, if it
+      //is NOT followed by a P, then either an S or a T, NOT followed by a P.
+      //Positive and negative values are allowed.
+      //</note>
+      //    writeNote_(os, "residue, potential modification motif", variable_modification_motif_);
+      ////////////////////////////////////////////////////////////////////////////////
+
 
       //////////////// model refinement parameters
       //<note type="input" label="refine">yes</note>
@@ -380,6 +386,7 @@ namespace OpenMS
       //writeNote_(os, "refine, potential modification motif", refine_var_mod_motif_);
       ////////////////////////////////////////////////////////////////////////////////
 
+
       //////////////// scoring parameters
       //<note type="input" label="scoring, minimum ion count">4</note>
       //writeNote_(os, "scoring, minimum ion count", String(scoring_min_ion_count_));
@@ -404,6 +411,7 @@ namespace OpenMS
       //<note>if yes, then reversed sequences are searched at the same time as forward sequences</note>
       //writeNote_(os, "scoring, include reverse", scoring_include_reverse_);
       ////////////////////////////////////////////////////////////////////////////////
+
 
       //////////////// output parameters
       //<note type="input" label="output, log path"></note>

--- a/src/tests/class_tests/openms/data/XTandemInfile_test_write.xml
+++ b/src/tests/class_tests/openms/data/XTandemInfile_test_write.xml
@@ -10,6 +10,7 @@
 	<note type="input" label="output, spectra">yes</note>
 	<note type="input" label="output, sort results by">spectrum</note>
 	<note type="input" label="output, xsl path">tandem-style.xsl</note>
+    <note type="input" label="output, parameters">yes</note>
 	<note type="input" label="spectrum, fragment monoisotopic mass error">13</note>
 	<note type="input" label="spectrum, parent monoisotopic mass error plus">14</note>
 	<note type="input" label="spectrum, parent monoisotopic mass error minus">15</note>
@@ -19,11 +20,11 @@
 	<note type="input" label="spectrum, fragment mass type">monoisotopic</note>
 	<note type="input" label="spectrum, maximum parent charge">17</note>
 	<note type="input" label="spectrum, threads">16</note>
-	<note type="input" label="residue, modification mass">+58.005479@C,+28.0313@[,+15.994915@M</note>
-	<note type="input" label="residue, potential modification mass">+17.026549@],+80.062601@C</note>
 	<note type="input" label="protein, taxon">blubb_taxon</note>
 	<note type="input" label="protein, cleavage site">[KR]|{P}</note>
 	<note type="input" label="protein, cleavage semi">yes</note>
+	<note type="input" label="residue, modification mass">+58.005479@C,+28.0313@[,+15.994915@M</note>
+	<note type="input" label="residue, potential modification mass">+17.026549@],+80.062601@C</note>
 	<note type="input" label="scoring, maximum missed cleavage sites">18</note>
 	<note type="input" label="output, results">all</note>
 	<note type="input" label="output, maximum valid expectation value">19</note>

--- a/src/tests/class_tests/openms/source/XTandemInfile_test.cpp
+++ b/src/tests/class_tests/openms/source/XTandemInfile_test.cpp
@@ -218,7 +218,7 @@ START_SECTION(ErrorUnit getFragmentMassErrorUnit() const)
   NOT_TESTABLE // tested above
 END_SECTION
 
-START_SECTION(void write(const String& filename, bool ignore_member_parameters = false))
+  START_SECTION(void write(const String& filename, bool ignore_member_parameters = false, bool force_default_mods = false))
 	String filename("XTandemInfile_test.tmp");
 	NEW_TMP_FILE(filename);
   ModificationDefinitionsSet sets(ListUtils::create<String>("Oxidation (M),Dimethyl (N-term),Carboxymethyl (C)"), ListUtils::create<String>("Ammonium (C-term),ICDID (C)"));

--- a/src/tests/class_tests/openms/source/XTandemXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/XTandemXMLFile_test.cpp
@@ -69,23 +69,24 @@ END_SECTION
 
 XTandemXMLFile xml_file;
 
-START_SECTION(void setModificationDefinitionsSet(const ModificationDefinitionsSet &rhs))
+START_SECTION(void load(const String& filename, ProteinIdentification& protein_identification, std::vector<PeptideIdentification>& id_data, ModificationDefinitionsSet& mod_def_set))
 {
 	ModificationDefinitionsSet mod_set(ListUtils::create<String>(""), ListUtils::create<String>("Carbamidomethyl (C),Oxidation (M),Carboxymethyl (C)"));
-	xml_file.setModificationDefinitionsSet(mod_set);
-  NOT_TESTABLE // tested below
-}
-END_SECTION
 
-START_SECTION(void load(const String& filename, ProteinIdentification& protein_identification, std::vector<PeptideIdentification>& id_data))
-{
-	xml_file.load(OPENMS_GET_TEST_DATA_PATH("XTandemXMLFile_test.xml"), protein_identification, peptide_identifications);
+	xml_file.load(OPENMS_GET_TEST_DATA_PATH("XTandemXMLFile_test.xml"), protein_identification, peptide_identifications, mod_set);
 	TEST_EQUAL(peptide_identifications.size(), 303);
 	TEST_EQUAL(protein_identification.getHits().size(), 497);
+  // should have picked up the default N-terminal modifications:
+  TEST_EQUAL(mod_set.getNumberOfVariableModifications(), 6);
+  TEST_EQUAL(mod_set.getNumberOfFixedModifications(), 0);
 
-	xml_file.load(OPENMS_GET_TEST_DATA_PATH("XTandemXMLFile_test_2.xml"), protein_identification, peptide_identifications);
+  mod_set.setModifications("", "Carbamidomethyl (C),Oxidation (M),Carboxymethyl (C)");
+	xml_file.load(OPENMS_GET_TEST_DATA_PATH("XTandemXMLFile_test_2.xml"), protein_identification, peptide_identifications, mod_set);
 	TEST_EQUAL(peptide_identifications.size(), 2);
 	TEST_EQUAL(protein_identification.getHits().size(), 21);
+  // no additional modifications in this case:
+  TEST_EQUAL(mod_set.getNumberOfVariableModifications(), 3);
+  TEST_EQUAL(mod_set.getNumberOfFixedModifications(), 0);
 }
 END_SECTION
 

--- a/src/topp/IDFileConverter.cpp
+++ b/src/topp/IDFileConverter.cpp
@@ -379,7 +379,9 @@ protected:
       else if (in_type == FileTypes::XML) // X! Tandem
       {
         ProteinIdentification protein_id;
-        XTandemXMLFile().load(in, protein_id, peptide_identifications);
+        ModificationDefinitionsSet mod_defs;
+        XTandemXMLFile().load(in, protein_id, peptide_identifications,
+                              mod_defs);
         protein_id.setSearchEngineVersion("");
         protein_id.setSearchEngine("XTandem");
         protein_identifications.push_back(protein_id);

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -243,7 +243,7 @@ protected:
     {
       if (!getFlag_("force"))
       {
-        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected. To enforce processing of the data set the -force flag.");
+        throw OpenMS::Exception::IllegalArgument(__FILE__, __LINE__, __FUNCTION__, "Error: Profile data provided but centroided MS2 spectra expected. To enforce processing of the data set the 'force' flag.");
       }
     }
 
@@ -308,7 +308,8 @@ protected:
       infile.setDefaultParametersFilename(default_XML_config);
     }
 
-    infile.write(input_filename, getFlag_("ignore_adapter_param"));
+    infile.write(input_filename, getFlag_("ignore_adapter_param"),
+                 getFlag_("force"));
 
     //-------------------------------------------------------------
     // calculations
@@ -331,8 +332,8 @@ protected:
 
     // read the output of X! Tandem and write it to idXML
     XTandemXMLFile tandem_output;
-    tandem_output.setModificationDefinitionsSet(ModificationDefinitionsSet(getStringList_("fixed_modifications"), getStringList_("variable_modifications")));
-    tandem_output.load(tandem_output_filename, protein_id, peptide_ids);
+    ModificationDefinitionsSet mod_def_set(getStringList_("fixed_modifications"), getStringList_("variable_modifications"));
+    tandem_output.load(tandem_output_filename, protein_id, peptide_ids, mod_def_set);
 
     // add RT and precursor m/z to the peptide IDs (look them up in the spectra):
     SpectrumLookup lookup;
@@ -385,8 +386,15 @@ protected:
 
       ProteinIdentification::PeakMassType mass_type = ProteinIdentification::MONOISOTOPIC;
       search_parameters.mass_type = mass_type;
-      search_parameters.fixed_modifications = getStringList_("fixed_modifications");
-      search_parameters.variable_modifications = getStringList_("variable_modifications");
+      set<String> mods = mod_def_set.getFixedModificationNames();
+      search_parameters.fixed_modifications.reserve(mods.size());
+      search_parameters.fixed_modifications.insert(
+        search_parameters.fixed_modifications.end(), mods.begin(), mods.end());
+      mods = mod_def_set.getVariableModificationNames();
+      search_parameters.variable_modifications.reserve(mods.size());
+      search_parameters.variable_modifications.insert(
+        search_parameters.variable_modifications.end(), mods.begin(),
+        mods.end());
       search_parameters.missed_cleavages = getIntOption_("missed_cleavages");
       search_parameters.fragment_mass_tolerance = getDoubleOption_("fragment_mass_tolerance");
       search_parameters.precursor_mass_tolerance = getDoubleOption_("precursor_mass_tolerance");


### PR DESCRIPTION
This addresses problems in XTandemAdapter and with the reading of Percolator result files (derived from X! Tandem searches).

In XTandemAdapter, support for X! Tandem's default N-terminal mods (pyro-Glus and acetylation), which are covered by special parameters, was improved. When reading results, these mods are now added to the search parameters when found. When running searches, they should now be handled correctly when set by the user (in particular, there's an annoying interaction with other variable N-terminal mods).

In the Percolator results, the problem was that N-terminal modifications got attributed to the first residue (the notation in the X! Tandem output is ambiguous). The information about where the mod belongs is essentially lost at that point, so it takes a lot of heuristics to (hopefully) recover it - see new function `PercolatorOutfile::resolveMisassignedNTermMods_`.

Also fixed an oversight in `ModificationDefinitionsSet::addMatches_`, which was due to the idiotic use of "C-term" and "N-term" as origin (i.e. modified residue) of terminal modifications. (I hope to address this problem generally in a future PR.)