### PR TITLE
Use UniMod id as integer

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMAssay.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMAssay.h
@@ -170,15 +170,6 @@ protected:
     bool isInSwath_(const std::vector<std::pair<double, double> > swathes, const double precursor_mz, const double product_mz);
 
     /**
-      @brief Adds ResidueModification to vector of modifications
-
-      @param mods a vector of targeted experiment modifications
-      @param location the residue location of the modification
-      @param rmod the residue modification
-    */
-    void addModification_(std::vector<TargetedExperiment::Peptide::Modification>& mods, int location, ResidueModification& rmod);
-
-    /**
       @brief Generates random peptide sequence
 
       @param sequence_size length of peptide sequence

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathTSVWriter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathTSVWriter.h
@@ -194,7 +194,7 @@ namespace OpenMS
             {
               if (pep.modifications[modloc].location == loc)
               {
-                full_peptide_name += "(" + pep.modifications[modloc].unimod_id + ")";
+                full_peptide_name += "(UniMod:" + String(pep.modifications[modloc].unimod_id) + ")";
               }
             }
           }
@@ -204,6 +204,7 @@ namespace OpenMS
           String group_label = pep.peptide_group_label;
           if (group_label.empty()) group_label = id;
           if (group_label == "light") group_label = id; // legacy fix since there are many TraMLs floating around which have "light" in there
+          if (group_label == "NA") group_label = id; // legacy fix since there are many TraMLs floating around which have "NA" in there
 
           // If a protein is present, take the first one
           String protein_name = "";

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -115,8 +115,6 @@ public:
     };
     //@}
 
-
-
     /** @name Constructors and Destructors
     */
     //@{
@@ -152,11 +150,14 @@ public:
     /// returns the full id of the mod (UniMod accession + origin, if available)
     const String& getFullId() const;
 
-    /// sets the unimod accession
-    void setUniModAccession(const String& id);
+    /// sets the unimod record id
+    void setUniModRecordId(const Int& id);
+
+    /// sets the unimod record id
+    const Int& getUniModRecordId() const;
 
     /// returns the unimod accession if available
-    const String& getUniModAccession() const;
+    const String getUniModAccession() const;
 
     /// set the MOD:XXXXX accession of PSI-MOD
     void setPSIMODAccession(const String& id);
@@ -301,7 +302,8 @@ protected:
 
     String psi_mod_accession_;
 
-    String unimod_accession_;
+    // The UniMod record id (an integer)
+    Int unimod_record_id_;
 
     String full_name_;
 
@@ -335,4 +337,4 @@ protected:
   };
 }
 
-#endif
+#endif // OPENMS_CHEMISTRY_RESIDUEMODIFICATION_H

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -33,6 +33,8 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
+
+#include <OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 
 namespace OpenMS
@@ -193,7 +195,7 @@ namespace OpenMS
 
   void OpenSwathDataAccessHelper::convertTargetedCompound(const TargetedExperiment::Peptide& pep, OpenSwath::LightCompound & p)
   {
-    OpenSwath::LightModification m;
+    OpenSwath::LightModification light_mod;
 
     p.id = pep.id;
     if (!pep.rts.empty())
@@ -227,20 +229,22 @@ namespace OpenMS
     // Mapping of peptide modifications (don't do this for metabolites...)
     if (p.isPeptide())
     {
+
       OpenMS::AASequence aa_sequence = TargetedExperimentHelper::getAASequence(pep);
+
       if (aa_sequence.hasNTerminalModification())
       {
         const ResidueModification& rmod = *(aa_sequence.getNTerminalModification());
-        m.location = -1;
-        m.unimod_id = rmod.getUniModAccession();
-        p.modifications.push_back(m);
+        light_mod.location = -1;
+        light_mod.unimod_id = rmod.getUniModRecordId();
+        p.modifications.push_back(light_mod);
       }
       if (aa_sequence.hasCTerminalModification())
       {
         const ResidueModification& rmod = *(aa_sequence.getCTerminalModification());
-        m.location = boost::numeric_cast<int>(aa_sequence.size());
-        m.unimod_id = rmod.getUniModAccession();
-        p.modifications.push_back(m);
+        light_mod.location = boost::numeric_cast<int>(aa_sequence.size());
+        light_mod.unimod_id = rmod.getUniModRecordId();
+        p.modifications.push_back(light_mod);
       }
       for (Size i = 0; i != aa_sequence.size(); i++)
       {
@@ -248,9 +252,9 @@ namespace OpenMS
         {
           // search the residue in the modification database (if the sequence is valid, we should find it)
           const ResidueModification& rmod = *(aa_sequence.getResidue(i).getModification());
-          m.location = boost::numeric_cast<int>(i);
-          m.unimod_id = rmod.getUniModAccession();
-          p.modifications.push_back(m);
+          light_mod.location = boost::numeric_cast<int>(i);
+          light_mod.unimod_id = rmod.getUniModRecordId();
+          p.modifications.push_back(light_mod);
         }
       }
 
@@ -286,7 +290,7 @@ namespace OpenMS
     {
       TargetedExperimentHelper::setModification(it->location, 
                                                 boost::numeric_cast<int>(peptide.sequence.size()), 
-                                                it->unimod_id, aa_sequence);
+                                                "UniMod:" + String(it->unimod_id), aa_sequence);
     }
   }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -102,23 +102,6 @@ namespace OpenMS
     }
   }
 
-  void MRMAssay::addModification_(std::vector<TargetedExperiment::Peptide::Modification>& mods,
-                                  int location, ResidueModification& rmod)
-  {
-    TargetedExperiment::Peptide::Modification mod;
-    String unimod_str = rmod.getUniModAccession();
-    mod.location = location;
-    mod.mono_mass_delta = rmod.getDiffMonoMass();
-    mod.avg_mass_delta = rmod.getDiffAverageMass();
-    // CV term with the full unimod accession number and name
-    CVTerm unimod_name;
-    unimod_name.setCVIdentifierRef("UNIMOD");
-    unimod_name.setAccession(unimod_str.toUpper());
-    unimod_name.setName(rmod.getName());
-    mod.addCVTerm(unimod_name);
-    mods.push_back(mod);
-  }
-
   std::string MRMAssay::getRandomSequence_(size_t sequence_size, boost::variate_generator<boost::mt19937&, boost::uniform_int<> >
                                            pseudoRNG)
   {

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -159,6 +159,7 @@ namespace OpenMS
     std::vector<std::pair<double, double> > pairs; // store the RT pairs to write the output trafoXML
     std::map<std::string, double> best_features = OpenSwathHelper::simpleFindBestFeature(transition_group_map,
       estimateBestPeptides, irt_detection_param.getValue("OverallQualityCutoff"));
+    LOG_DEBUG << "Extracted best features: " << best_features.size() << std::endl;
 
     // Create pairs vector and store peaks
     OpenMS::MRMFeatureFinderScoring::TransitionGroupMapType trgrmap_allpeaks; // store all peaks above cutoff
@@ -201,6 +202,7 @@ namespace OpenMS
         String("Illegal argument '") + outlier_method +
         "' used for outlierMethod (valid: 'iter_residual', 'iter_jackknife', 'ransac', 'none').");
     }
+    LOG_DEBUG << "Performed outlier detection, left with features: " << pairs_corrected.size() << std::endl;
 
     // 5. Check whether the found peptides fulfill the binned coverage criteria
     // set by the user.

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
@@ -1056,7 +1056,9 @@ namespace OpenMS
 
     AASequence aa_sequence = AASequence::fromString(tr_it->FullPeptideName);
 
-    // in TraML, the modification the AA starts with residue 1 but the
+    // Unfortunately, we cannot store an AASequence here but have to work with
+    // the TraML modification object.
+    // In TraML, the modification the AA starts with residue 1 but the
     // OpenMS objects start with zero -> we start counting with zero here
     // and the TraML handler will add 1 when storing the file.
     if (std::string::npos == tr_it->FullPeptideName.find("["))
@@ -1139,16 +1141,10 @@ namespace OpenMS
                                              int location, const ResidueModification& rmod)
   {
     TargetedExperiment::Peptide::Modification mod;
-    String unimod_str = rmod.getUniModAccession();
     mod.location = location;
     mod.mono_mass_delta = rmod.getDiffMonoMass();
     mod.avg_mass_delta = rmod.getDiffAverageMass();
-    // CV term with the full unimod accession number and name
-    CVTerm unimod_name;
-    unimod_name.setCVIdentifierRef("UNIMOD");
-    unimod_name.setAccession(unimod_str.toUpper());
-    unimod_name.setName(rmod.getId());
-    mod.addCVTerm(unimod_name);
+    mod.unimod_id = rmod.getUniModRecordId();
     mods.push_back(mod);
   }
 
@@ -1177,7 +1173,7 @@ namespace OpenMS
         mytransition.group_id = it->getPeptideRef();
 
 #ifdef TRANSITIONTSVREADER_TESTING
-      std::cout << "Peptide rts empty " <<
+        std::cout << "Peptide rts empty " <<
         pep.rts.empty()  << " or no cv term " << pep.rts[0].hasCVTerm("MS:1000896") << std::endl;
 #endif
 
@@ -1219,7 +1215,7 @@ namespace OpenMS
             {
               if (lightpep.modifications[modloc].location == loc)
               {
-                mytransition.FullPeptideName += "(" + lightpep.modifications[modloc].unimod_id + ")";
+                mytransition.FullPeptideName += "(UniMod:" + String(lightpep.modifications[modloc].unimod_id) + ")";
               }
             }
           }

--- a/src/openms/source/ANALYSIS/TARGETED/TargetedExperimentHelper.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/TargetedExperimentHelper.cpp
@@ -33,8 +33,10 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>
+
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CONCEPT/LogStream.h>
 #include <iostream>
 
 namespace OpenMS
@@ -63,19 +65,29 @@ namespace OpenMS
 
     OpenMS::AASequence getAASequence(const OpenMS::TargetedExperiment::Peptide& peptide)
     {
+
+      // Note that the peptide.sequence is the "naked sequence" without any
+      // modifications on it, therefore we have to populate the AASequence with
+      // the correct modifications afterwards.
       OpenMS::ModificationsDB* mod_db = OpenMS::ModificationsDB::getInstance();
       OpenMS::AASequence aas = AASequence::fromString(peptide.sequence);
 
+      // Populate the AASequence with the correct modifications derived from
+      // the Peptide::Modification objects.
       for (std::vector<Peptide::Modification>::const_iterator it = peptide.mods.begin(); 
           it != peptide.mods.end(); ++it)
       {
-        // Step 1: First look whether the UniMod ID is set (we dont use a CVTerm any more but a member)
+        // Step 1: First look whether the UniMod ID is set (we don't use a CVTerm any more but a member)
         if (it->unimod_id != -1)
         {
           setModification(it->location, boost::numeric_cast<int>(peptide.sequence.size()), 
               "UniMod:" + String(it->unimod_id), aas);
           continue;
         }
+
+        LOG_WARN << "Warning: No UniMod id set for modification on peptide " << peptide.sequence << 
+          ". Will try to infer modification id by mass next." << std::endl;
+
         // compare with code in source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
 
         // Step 2: If the above step fails, try to find the correct

--- a/src/openms/source/CHEMISTRY/CrossLinksDB.cpp
+++ b/src/openms/source/CHEMISTRY/CrossLinksDB.cpp
@@ -167,9 +167,8 @@ namespace OpenMS
           if (split[i].hasPrefix("UniMod:"))
           {
             // Parse UniMod identifier to int
-            std::vector<String> unimod_id;
-            split[i].split(":", unimod_id);
-            mod.setUniModRecordId(unimod_id[1].toInt());
+            String identifier = split[i].substr(7, split[i].size());
+            mod.setUniModRecordId(identifier.toInt());
           }
         }
       }

--- a/src/openms/source/CHEMISTRY/CrossLinksDB.cpp
+++ b/src/openms/source/CHEMISTRY/CrossLinksDB.cpp
@@ -316,7 +316,7 @@ namespace OpenMS
     {
 
       // check whether a unimod definition already exists, then simply add synonyms to it
-      if (it->second.getUniModAccession() != "")
+      if (it->second.getUniModRecordId() > 0)
       {
         //cerr << "Found UniMod PSI-MOD mapping: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
         set<const ResidueModification*> mods = modification_names_[it->second.getUniModAccession()];

--- a/src/openms/source/CHEMISTRY/CrossLinksDB.cpp
+++ b/src/openms/source/CHEMISTRY/CrossLinksDB.cpp
@@ -166,7 +166,10 @@ namespace OpenMS
         {
           if (split[i].hasPrefix("UniMod:"))
           {
-            mod.setUniModAccession(split[i].trim());
+            // Parse UniMod identifier to int
+            std::vector<String> unimod_id;
+            split[i].split(":", unimod_id);
+            mod.setUniModRecordId(unimod_id[1].toInt());
           }
         }
       }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -410,7 +410,10 @@ namespace OpenMS
         {
           if (split[i].hasPrefix("UniMod:"))
           {
-            mod.setUniModAccession(split[i].trim());
+            // Parse UniMod identifier to int
+            std::vector<String> unimod_id;
+            split[i].split(":", unimod_id);
+            mod.setUniModRecordId(unimod_id[1].toInt());
           }
         }
       }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -560,7 +560,7 @@ namespace OpenMS
     {
 
       // check whether a unimod definition already exists, then simply add synonyms to it
-      if (it->second.getUniModAccession() != "")
+      if (it->second.getUniModRecordId() > 0)
       {
         //cerr << "Found UniMod PSI-MOD mapping: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
         set<const ResidueModification*> mods = modification_names_[it->second.getUniModAccession()];
@@ -603,7 +603,7 @@ namespace OpenMS
 
     for (vector<ResidueModification*>::const_iterator it = mods_.begin(); it != mods_.end(); ++it)
     {
-      if ((*it)->getUniModAccession() != "")
+      if ((*it)->getUniModRecordId() > 0)
       {
         modifications.push_back((*it)->getFullId());
       }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -411,9 +411,8 @@ namespace OpenMS
           if (split[i].hasPrefix("UniMod:"))
           {
             // Parse UniMod identifier to int
-            std::vector<String> unimod_id;
-            split[i].split(":", unimod_id);
-            mod.setUniModRecordId(unimod_id[1].toInt());
+            String identifier = split[i].substr(7, split[i].size());
+            mod.setUniModRecordId(identifier.toInt());
           }
         }
       }

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -43,6 +43,7 @@ namespace OpenMS
 {
 
   ResidueModification::ResidueModification() :
+    unimod_record_id_(-1),
     term_spec_(ResidueModification::ANYWHERE),
     classification_(ResidueModification::ARTIFACT),
     average_mass_(0.0),
@@ -58,7 +59,7 @@ namespace OpenMS
     id_(rhs.id_),
     full_id_(rhs.full_id_),
     psi_mod_accession_(rhs.psi_mod_accession_),
-    unimod_accession_(rhs.unimod_accession_),
+    unimod_record_id_(rhs.unimod_record_id_),
     full_name_(rhs.full_name_),
     name_(rhs.name_),
     term_spec_(rhs.term_spec_),
@@ -84,7 +85,7 @@ namespace OpenMS
       id_ = rhs.id_;
       full_id_ = rhs.full_id_;
       psi_mod_accession_ = rhs.psi_mod_accession_;
-      unimod_accession_ = rhs.unimod_accession_;
+      unimod_record_id_ = rhs.unimod_record_id_;
       full_name_ = rhs.full_name_;
       name_ = rhs.name_;
       term_spec_ = rhs.term_spec_;
@@ -110,7 +111,7 @@ namespace OpenMS
     return id_ == rhs.id_ &&
            full_id_ == rhs.full_id_ &&
            psi_mod_accession_ == rhs.psi_mod_accession_ &&
-           unimod_accession_ == rhs.unimod_accession_ &&
+           unimod_record_id_ == rhs.unimod_record_id_ &&
            full_name_ == rhs.full_name_ &&
            name_ == rhs.name_ &&
            term_spec_ == rhs.term_spec_ &&
@@ -168,14 +169,19 @@ namespace OpenMS
     return psi_mod_accession_;
   }
 
-  void ResidueModification::setUniModAccession(const String& id)
+  void ResidueModification::setUniModRecordId(const Int& id)
   {
-    unimod_accession_ = id;
+    unimod_record_id_ = id;
   }
 
-  const String& ResidueModification::getUniModAccession() const
+  const Int& ResidueModification::getUniModRecordId() const
   {
-    return unimod_accession_;
+    return unimod_record_id_;
+  }
+
+  const String ResidueModification::getUniModAccession() const
+  {
+    return String("UniMod:") + unimod_record_id_; // return copy of temp object
   }
 
   void ResidueModification::setFullName(const String& full_name)

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -181,6 +181,7 @@ namespace OpenMS
 
   const String ResidueModification::getUniModAccession() const
   {
+    if (unimod_record_id_ < 0) return "";
     return String("UniMod:") + unimod_record_id_; // return copy of temp object
   }
 

--- a/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
@@ -76,8 +76,8 @@ namespace OpenMS
         // deleted this in the unimod.xml file
         modification_->setFullName(full_name);
 
-        String record_id(attributeAsString_(attributes, "record_id"));
-        modification_->setUniModAccession("UniMod:" + record_id);
+        Int record_id(attributeAsInt_(attributes, "record_id"));
+        modification_->setUniModRecordId(record_id);
         return;
       }
 

--- a/src/openswathalgo/include/OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h
+++ b/src/openswathalgo/include/OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h
@@ -138,7 +138,7 @@ public:
   struct OPENSWATHALGO_DLLAPI LightModification
   {
     int location;
-    std::string unimod_id;
+    int unimod_id;
   };
 
   // A compound is either a peptide or a metabolite

--- a/src/pyOpenMS/addons/CrossLinksDB.pyx
+++ b/src/pyOpenMS/addons/CrossLinksDB.pyx
@@ -1,6 +1,9 @@
 
 
     # NOTE: using shared_ptr for a singleton will lead to segfaults, use raw ptr instead
+    # Provides the same interface as expected by autowrap (get/assign) but
+    # simply holds the ptr and does not do any memory management.
+    # see autowrap/data_files/autowrap/README.md for implementation
     cdef AutowrapPtrHolder[_CrossLinksDB] inst
 
     def __init__(self):

--- a/src/pyOpenMS/pxds/LightTargetedExperiment.pxd
+++ b/src/pyOpenMS/pxds/LightTargetedExperiment.pxd
@@ -41,7 +41,7 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/Transition
         LightModification(LightModification) nogil except +
 
         int location
-        libcpp_string unimod_id
+        int unimod_id
 
     cdef cppclass LightCompound:
         LightCompound() nogil except +

--- a/src/pyOpenMS/pxds/ResidueModification.pxd
+++ b/src/pyOpenMS/pxds/ResidueModification.pxd
@@ -20,24 +20,30 @@ cdef extern from "<OpenMS/CHEMISTRY/ResidueModification.h>" namespace "OpenMS":
         String  getId() nogil except +
         void setFullId(String & full_id) nogil except +
         String  getFullId() nogil except +
-        void setUniModAccession(String & id_) nogil except +
+
+        Int getUniModRecordId() nogil except +
+        void setUniModRecordId(Int id_) nogil except +
         String  getUniModAccession() nogil except +
+
         void setPSIMODAccession(String & id_) nogil except +
-        String  getPSIMODAccession() nogil except +
+        String getPSIMODAccession() nogil except +
         void setFullName(String & full_name) nogil except +
-        String  getFullName() nogil except +
+        String getFullName() nogil except +
         void setName(String & name) nogil except +
-        String  getName() nogil except +
+        String getName() nogil except +
         void setTermSpecificity(TermSpecificity term_spec) nogil except +
         void setTermSpecificity(String & name) nogil except +
+
         TermSpecificity getTermSpecificity() nogil except +
         String getTermSpecificityName(TermSpecificity ) nogil except +
         void setOrigin(String & origin) nogil except +
         String  getOrigin() nogil except +
+
         void setSourceClassification(String & classification) nogil except +
         void setSourceClassification(SourceClassification classification) nogil except +
         SourceClassification getSourceClassification() nogil except +
         String getSourceClassificationName(SourceClassification classification) nogil except +
+
         void setAverageMass(double mass) nogil except +
         double getAverageMass() nogil except +
         void setMonoMass(double mass) nogil except +
@@ -46,15 +52,19 @@ cdef extern from "<OpenMS/CHEMISTRY/ResidueModification.h>" namespace "OpenMS":
         double getDiffAverageMass() nogil except +
         void setDiffMonoMass(double mass) nogil except +
         double getDiffMonoMass() nogil except +
+
         void setFormula(String & composition) nogil except +
         String  getFormula() nogil except +
         void setDiffFormula(EmpiricalFormula & diff_formula) nogil except +
         EmpiricalFormula  getDiffFormula() nogil except +
+
         void setSynonyms(libcpp_set[ String ] & synonyms) nogil except +
         void addSynonym(String & synonym) nogil except +
-        libcpp_set[ String ]  getSynonyms() nogil except +
+        libcpp_set[ String ] getSynonyms() nogil except +
+
         void setNeutralLossDiffFormula(EmpiricalFormula & loss) nogil except +
-        EmpiricalFormula  getNeutralLossDiffFormula() nogil except +
+        EmpiricalFormula getNeutralLossDiffFormula() nogil except +
+
         void setNeutralLossMonoMass(double mono_mass) nogil except +
         double getNeutralLossMonoMass() nogil except +
         void setNeutralLossAverageMass(double average_mass) nogil except +

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -769,18 +769,26 @@ START_SECTION([EXTRA] Test integer vs float tags)
   AASequence seq11 = AASequence::fromString("PEPM[147.035405]TIDEK"); // UniMod oxMet is 147.035405
   TEST_EQUAL(seq11.isModified(), true);
   TEST_STRING_EQUAL(seq11[3].getModificationName(), "Oxidation");
+  TEST_EQUAL(seq11[3].getModification()->getUniModRecordId(), 35)
+  TEST_EQUAL(seq11[3].getModification()->getUniModAccession(), "UniMod:35")
 
   AASequence seq12 = AASequence::fromString("PEPT[181.014]TIDEK");
   TEST_EQUAL(seq12.isModified(), true);
   TEST_STRING_EQUAL(seq12[3].getModificationName(), "Phospho");
+  TEST_EQUAL(seq12[3].getModification()->getUniModRecordId(), 21)
+  TEST_EQUAL(seq12[3].getModification()->getUniModAccession(), "UniMod:21")
 
   AASequence seq13 = AASequence::fromString("PEPY[243.03]TIDEK");
   TEST_EQUAL(seq13.isModified(), true);
   TEST_STRING_EQUAL(seq13[3].getModificationName(), "Phospho");
+  TEST_EQUAL(seq13[3].getModification()->getUniModRecordId(), 21)
+  TEST_EQUAL(seq13[3].getModification()->getUniModAccession(), "UniMod:21")
 
   AASequence seq15 = AASequence::fromString("PEPC[160.0306]TIDE");
   TEST_EQUAL(seq15.isModified(), true);
   TEST_STRING_EQUAL(seq15[3].getModificationName(), "Carbamidomethyl");
+  TEST_EQUAL(seq15[3].getModification()->getUniModRecordId(), 4)
+  TEST_EQUAL(seq15[3].getModification()->getUniModAccession(), "UniMod:4")
   }
 
   // Test a few modifications with the accurate mass slightly off to match some other modification
@@ -788,18 +796,22 @@ START_SECTION([EXTRA] Test integer vs float tags)
   AASequence seq11 = AASequence::fromString("PEPM[147.035399]TIDEK"); // PSI-MOD oxMet is 147.035399
   TEST_EQUAL(seq11.isModified(), true);
   TEST_STRING_EQUAL(seq11[3].getModificationName(), "MOD:00719")
+  TEST_EQUAL(seq11[3].getModification()->getUniModRecordId(), -1) // no UniMod id gets assigned
 
   AASequence seq12 = AASequence::fromString("PEPT[181.004]TIDEK");
   TEST_EQUAL(seq12.isModified(), true);
   TEST_STRING_EQUAL(seq12[3].getModificationName(), "Sulfo");
+  TEST_EQUAL(seq11[3].getModification()->getUniModRecordId(), -1) // no UniMod id gets assigned
 
   AASequence seq13 = AASequence::fromString("PEPY[243.02]TIDEK");
   TEST_EQUAL(seq13.isModified(), true);
   TEST_STRING_EQUAL(seq13[3].getModificationName(), "Sulfo");
+  TEST_EQUAL(seq11[3].getModification()->getUniModRecordId(), -1) // no UniMod id gets assigned
 
   AASequence seq14 = AASequence::fromString("PEPTC[159.035405]IDE");
   TEST_EQUAL(seq14.isModified(), true);
   TEST_STRING_EQUAL(seq14[4].getModificationName(), "Delta:H(4)C(3)O(1)");
+  TEST_EQUAL(seq11[3].getModification()->getUniModRecordId(), -1) // no UniMod id gets assigned
   }
 
 

--- a/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
@@ -190,6 +190,47 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
     TEST_EQUAL(shuffled.sequence, expected_sequence)
   }
 
+  {
+    OpenMS::TargetedExperiment::Peptide original_input;
+    OpenMS::TargetedExperiment::Peptide::Modification mod;
+    // std::vector<TargetedExperiment::Peptide::Modification> mods;
+    std::vector<TargetedExperiment::Peptide::Modification> mods;
+    // original_input.sequence = "EPAHLMSLFGGKPM(UniMod:35)";
+    original_input.sequence = "EPAHLMSLFGGKPM";
+    mod.location = 13; // non-C terminal
+    mod.unimod_id = 35;
+    mods.push_back(mod);
+    original_input.mods = mods;
+    expected_sequence = "MPGHLMGASLEKPF";
+    OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00;
+    shuffled = gen.shufflePeptide(original_input, 0.7, 42, 20);
+    TEST_EQUAL(shuffled.sequence[shuffled.sequence.size() - 1], 'F')
+    TEST_EQUAL(shuffled.sequence, expected_sequence)
+    TEST_EQUAL(shuffled.mods.size(), 1)
+    TEST_EQUAL(shuffled.mods[0].location, 5) // the second M moved to position 5
+  }
+
+  {
+    OpenMS::TargetedExperiment::Peptide original_input;
+    OpenMS::TargetedExperiment::Peptide::Modification mod;
+    // std::vector<TargetedExperiment::Peptide::Modification> mods;
+    std::vector<TargetedExperiment::Peptide::Modification> mods;
+    // original_input.sequence = "EPAHLMSLFGGKPM(UniMod:35)";
+    original_input.sequence = "EPAHLMSLFGGKPM";
+    mod.location = 14; // C terminal
+    mod.unimod_id = 35;
+    mods.push_back(mod);
+    original_input.mods = mods;
+    expected_sequence = "MPGHLMGASLEKPF";
+    OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00;
+    shuffled = gen.shufflePeptide(original_input, 0.7, 42, 20);
+    TEST_EQUAL(shuffled.sequence[shuffled.sequence.size() - 1], 'F')
+    TEST_EQUAL(shuffled.sequence, expected_sequence)
+    TEST_EQUAL(shuffled.mods.size(), 1)
+    TEST_EQUAL(shuffled.mods[0].location, 14) // Problem: this modification cannot be C terminal any more for F!
+    // TODO: report and fix this
+  }
+
 }
 
 END_SECTION

--- a/src/tests/class_tests/openms/source/ResidueModification_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueModification_test.cpp
@@ -146,13 +146,18 @@ START_SECTION((const String& getFullId() const))
 	NOT_TESTABLE
 END_SECTION
 
-START_SECTION((void setUniModAccession(const String& id)))
-	ptr->setUniModAccession("blubb_new_UniModAccession");
-	TEST_STRING_EQUAL(ptr->getUniModAccession(), "blubb_new_UniModAccession")
+START_SECTION((void setUniModRecordId(const Int& id)))
+	ptr->setUniModRecordId(42);
+	TEST_EQUAL(ptr->getUniModRecordId(), 42)
+END_SECTION
+
+START_SECTION((const String& getUniModRecordId() const))
+	NOT_TESTABLE
 END_SECTION
 
 START_SECTION((const String& getUniModAccession() const))
-	NOT_TESTABLE
+	ptr->setUniModRecordId(42);
+	TEST_STRING_EQUAL(ptr->getUniModAccession(), "UniMod:42")
 END_SECTION
 
 START_SECTION((void setPSIMODAccession(const String& id)))

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -761,6 +761,27 @@ protected:
       feature_finder_param.setValue("Scores:use_uis_scores", "true");
     }
 
+    ///////////////////////////////////
+    // Load the transitions
+    ///////////////////////////////////
+    OpenSwath::LightTargetedExperiment transition_exp;
+    ProgressLogger progresslogger;
+    progresslogger.setLogType(log_type_);
+    progresslogger.startProgress(0, 1, "Load TraML file");
+    FileTypes::Type tr_file_type = FileTypes::nameToType(tr_file);
+    if (tr_file_type == FileTypes::TRAML || tr_file.suffix(5).toLower() == "traml"  )
+    {
+      TargetedExperiment targeted_exp;
+      TraMLFile().load(tr_file, targeted_exp);
+      OpenSwathDataAccessHelper::convertTargetedExp(targeted_exp, transition_exp);
+    }
+    else
+    {
+      std::cout << " ok here!!" << std::endl;
+      TransitionTSVReader().convertTSVToTargetedExperiment(tr_file.c_str(), tr_type, transition_exp);
+    }
+    progresslogger.endProgress();
+
 
     ///////////////////////////////////
     // Load the SWATH files
@@ -835,26 +856,6 @@ protected:
         irt_tr_file, swath_maps, min_rsq, min_coverage, feature_finder_param,
         cp_irt, irt_detection_param, mz_correction_function, debug_level,
         sonar);
-
-    ///////////////////////////////////
-    // Load the transitions
-    ///////////////////////////////////
-    OpenSwath::LightTargetedExperiment transition_exp;
-    ProgressLogger progresslogger;
-    progresslogger.setLogType(log_type_);
-    progresslogger.startProgress(0, swath_maps.size(), "Load TraML file");
-    FileTypes::Type tr_file_type = FileTypes::nameToType(tr_file);
-    if (tr_file_type == FileTypes::TRAML || tr_file.suffix(5).toLower() == "traml"  )
-    {
-      TargetedExperiment targeted_exp;
-      TraMLFile().load(tr_file, targeted_exp);
-      OpenSwathDataAccessHelper::convertTargetedExp(targeted_exp, transition_exp);
-    }
-    else
-    {
-      TransitionTSVReader().convertTSVToTargetedExperiment(tr_file.c_str(), tr_type, transition_exp);
-    }
-    progresslogger.endProgress();
 
     ///////////////////////////////////
     // Set up chrom.mzML output


### PR DESCRIPTION
- consistently use unimod identifier as integer and only convert to "UniMod:XX" when necessary

- some stuff that was forgotten in #2059 
- some code paths still relied on CV terms 
