### PR TITLE
[FIX] display and accept '--flag' as commandline flags 

### DIFF
--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -184,8 +184,8 @@ namespace OpenMS
       registerStringOption_("id_pool", "<file>", "", String("ID pool file to DocumentID's for all generated output files. Disabled by default. (Set to 'main' to use ") + String() + id_tagger_.getPoolFile() + ")", false);
     }
     registerFlag_("test", "Enables the test mode (needed for internal use only)", true);
-    registerFlag_("-help", "Shows options");
-    registerFlag_("-helphelp", "Shows all options (including advanced)", false);
+    registerFlag_("help", "Shows options");
+    registerFlag_("helphelp", "Shows all options (including advanced)", false);
 
     // parse command line parameters:
     try
@@ -233,7 +233,7 @@ namespace OpenMS
     }
 
     // '--help' given
-    if (param_cmdline_.exists("-help") || param_cmdline_.exists("-helphelp"))
+    if (param_cmdline_.exists("help") || param_cmdline_.exists("helphelp"))
     {
       printUsage_();
       return EXECUTION_OK;
@@ -574,7 +574,7 @@ namespace OpenMS
   void TOPPBase::printUsage_()
   {
     // show advanced options?
-    bool verbose = getFlag_("-helphelp");
+    bool verbose = getFlag_("helphelp");
 
     //common output
     cerr << "\n"
@@ -653,6 +653,7 @@ namespace OpenMS
 
       //NAME + ARGUMENT
       String str_tmp = "  -";
+      if (it->type == ParameterInformation::FLAG) str_tmp += "-"; // use "--" for flags (even though "-" would suffice)
       str_tmp += it->name + " " + it->argument;
       if (it->required)
         str_tmp += '*';
@@ -2032,7 +2033,7 @@ namespace OpenMS
     //parameters
     for (vector<ParameterInformation>::const_iterator it = parameters_.begin(); it != parameters_.end(); ++it)
     {
-      if (it->name == "ini" || it->name == "-help" || it->name == "-helphelp" || it->name == "instance" || it->name == "write_ini" || it->name == "write_wsdl" || it->name == "write_ctd") // do not store those params in ini file
+      if (it->name == "ini" || it->name == "help" || it->name == "helphelp" || it->name == "instance" || it->name == "write_ini" || it->name == "write_wsdl" || it->name == "write_ctd") // do not store those params in ini file
       {
         continue;
       }
@@ -2586,6 +2587,7 @@ namespace OpenMS
     for (int i = argc - 1; i > 0; --i)
     {
       String arg = argv[i];
+      if (arg.hasPrefix("--")) arg = arg.substr(1); // replace '--' by '-' such that it's found in param_map
       // options start with "-" or "--" followed by a letter:
       bool is_option = (arg.size() >= 2) && (arg[0] == '-') && (isalpha(arg[1]) || ((arg[1] == '-') && (arg.size() >= 3) &&  isalpha(arg[2])));
       if (is_option) // process content of the queue

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1644,7 +1644,7 @@ namespace OpenMS
           String donor_pep = xl_id_donor_map_.at(peptides[i]);      // map::at throws an out-of-range
           alpha.push_back(i);
         }
-        catch (const std::out_of_range& oor)
+        catch (const std::out_of_range& /*oor*/)
         {
           beta.push_back(i);
         }
@@ -1670,7 +1670,7 @@ namespace OpenMS
             xl_type = "loop-link";
           }
         }
-        catch (const std::out_of_range& oor)
+        catch (const std::out_of_range& /*oor*/)
         {
             // do nothing. Must be a mono-link, which is already set
         }


### PR DESCRIPTION
Allows users to better distinguish flags from other arguments
i.e.
`FileInfo -in bla.idxml -p`
becomes
`FileInfo -in bla.idxml --p`

The legacy behaviour '-flag' is still valid; old scripts still run and only the usage dialog changes.

Full example:
```
FileInfo -- Shows basic information about the file, such as data ranges and file type.
Version: 2.1.0 Apr 20 2017, 15:27:42, Revision: disabled

Usage:
  FileInfo <options>

Options (mandatory options marked with '*'):
  -in <file>*        Input file  (valid formats: 'mzData', 'mzXML', 'mzML', 'dta', 'dta2d', 'mgf', 'featureXML', 'consensusXML', 'idXML', 'pepXML', 'fid', 'mzid'
                     , 'trafoXML')
  -in_type <type>    Input file type -- default: determined from file extension or content (valid: 'mzData', 'mzXML', 'mzML', 'dta', 'dta2d', 'mgf', 'featureXML'
                     , 'consensusXML', 'idXML', 'pepXML', 'fid', 'mzid', 'trafoXML')
  -out <file>        Optional output file. If left out, the output is written to the command line. (valid formats: 'txt')
  --m                Show meta information about the whole experiment
  --p                Shows data processing information
  --s                Computes a five-number statistics of intensities, qualities, and widths
  --d                Show detailed listing of all spectra and chromatograms (peak files only)
  --c                Check for corrupt data in the file (peak files only)
  --v                Validate the file only (for mzML, mzData, mzXML, featureXML, idXML, consensusXML, pepXML)
  --i                Check whether a given mzML file contains valid indices (conforming to the indexedmzML standard)

Common TOPP options:
  -ini <file>        Use the given TOPP INI file
  -threads <n>       Sets the number of threads allowed to be used by the TOPP tool (default: '1')
  -write_ini <file>  Writes the default configuration file
  --help             Shows options
  --helphelp         Shows all options (including advanced)
```