### PR TITLE
[FEATURE] cleanup of unused code

### DIFF
--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -998,18 +998,10 @@ namespace OpenMS
       else // float mass -> use best-matching modification
       {
         const ResidueModification* res_mod = 0;
-        if (delta_mass)
-        {
-          res_mod = mod_db->getBestModificationByDiffMonoMass(
-            mass, tolerance, residue->getOneLetterCode(),
-            ResidueModification::ANYWHERE);
-        }
-        else // absolute mass
-        {
-          res_mod = mod_db->getBestModificationByMonoMass(
-            mass, tolerance, residue->getOneLetterCode(),
-            ResidueModification::ANYWHERE);
-        }
+        res_mod = mod_db->getBestModificationByDiffMonoMass(
+          mass, tolerance, residue->getOneLetterCode(),
+          ResidueModification::ANYWHERE);
+
         if (res_mod)
         {
           String id = res_mod->getId();
@@ -1020,18 +1012,10 @@ namespace OpenMS
         }
         else if (std::distance(mod_end, str.end()) == 1) // C-terminal mod.?
         {
-          if (delta_mass)
-          {
-            res_mod = mod_db->getBestModificationByDiffMonoMass(
-              mass, tolerance, residue->getOneLetterCode(),
-              ResidueModification::C_TERM);
-          }
-          else // absolute mass
-          {
-            res_mod = mod_db->getBestModificationByMonoMass(
-              mass, tolerance, residue->getOneLetterCode(),
-              ResidueModification::C_TERM);
-          }
+          res_mod = mod_db->getBestModificationByDiffMonoMass(
+            mass, tolerance, residue->getOneLetterCode(),
+            ResidueModification::C_TERM);
+
           if (res_mod)
           {
             aas.c_term_mod_ = res_mod;

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -1042,11 +1042,6 @@ END_SECTION
 
 START_SECTION([EXTRA] Peptide equivalence)
 {
-  // Test Carbamidomethyl
-  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC(Carbamidomethyl)IDE"))
-  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC(Iodoacetamide derivative)IDE"))
-  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[160.030654]IDE")) // 103.00919 + 57.02
-  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[+57.02]IDE"))
 
   // Test float mass tag leading to internal Acetylation
   TEST_EQUAL(AASequence::fromString("PEPTC(Acetyl)IDE"), AASequence::fromString("PEPTC[+42.011]IDE"))
@@ -1065,6 +1060,14 @@ START_SECTION([EXTRA] Peptide equivalence)
 
   // Test integer mass tag leading to N-terminal Acetylation
   TEST_EQUAL(AASequence::fromString("(Acetyl)PEPTCIDE"), AASequence::fromString("[+42]PEPTCIDE"))
+
+  // Test Carbamidomethyl
+  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC(Carbamidomethyl)IDE"))
+  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC(Iodoacetamide derivative)IDE"))
+  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[160.030654]IDE")) // 103.00919 + 57.02
+  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[+57.02]IDE"))
+  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[160]IDE")) // 103.00919 + 57.02
+  TEST_EQUAL(AASequence::fromString("PEPTC(UniMod:4)IDE"), AASequence::fromString("PEPTC[+57]IDE"))
 
   // Test Oxidation
   TEST_EQUAL(AASequence::fromString("DFPIAM(UniMod:35)GER"), AASequence::fromString("DFPIAM[+16]GER"))

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -202,7 +202,7 @@ START_SECTION((void searchModificationsByDiffMonoMass(std::vector<String>& mods,
   mods.clear();
   ptr->searchModificationsByDiffMonoMass(mods, 80.0, 1.0, "Y");
   TEST_EQUAL(mods.empty(), false)
-  TEST_EQUAL(mods[0], "Phospho (T)")
+  TEST_EQUAL(mods[0], "Phospho (Y)")
   mods.clear();
   ptr->searchModificationsByDiffMonoMass(mods, 16.0, 1.0, "M");
   TEST_EQUAL(mods.empty(), false)

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -188,6 +188,31 @@ START_SECTION((void searchModificationsByDiffMonoMass(std::vector<String>& mods,
   // something exotic.. mods should return empty (without clearing it before)
   ptr->searchModificationsByDiffMonoMass(mods, 800000000.0, 0.1);
   TEST_EQUAL(mods.size(), 0);
+
+  // make sure the common ones are also found for integer masses (this is how
+  // integer mass search is done)
+  mods.clear();
+  ptr->searchModificationsByDiffMonoMass(mods, 80.0, 1.0, "S");
+  TEST_EQUAL(mods.empty(), false)
+  TEST_EQUAL(mods[0], "Phospho (S)")
+  mods.clear();
+  ptr->searchModificationsByDiffMonoMass(mods, 80.0, 1.0, "T");
+  TEST_EQUAL(mods.empty(), false)
+  TEST_EQUAL(mods[0], "Phospho (T)")
+  mods.clear();
+  ptr->searchModificationsByDiffMonoMass(mods, 80.0, 1.0, "Y");
+  TEST_EQUAL(mods.empty(), false)
+  TEST_EQUAL(mods[0], "Phospho (T)")
+  mods.clear();
+  ptr->searchModificationsByDiffMonoMass(mods, 16.0, 1.0, "M");
+  TEST_EQUAL(mods.empty(), false)
+  TEST_EQUAL(mods[0], "Oxidation (M)")
+  ptr->searchModificationsByDiffMonoMass(mods, 1.0, 1.0, "N");
+  TEST_EQUAL(mods.empty(), false)
+  TEST_EQUAL(mods[0], "Deamidated (N)")
+  ptr->searchModificationsByDiffMonoMass(mods, 1.0, 1.0, "Q");
+  TEST_EQUAL(mods.empty(), false)
+  TEST_EQUAL(mods[0], "Deamidated (Q)")
 }
 END_SECTION
 


### PR DESCRIPTION
remove some dead code

basically we could remove `getBestModificationByMonoMass` from the code base as we dont really use it and its clunky - we only use `getBestModificationByDiffMonoMass` by simply calculating the mass difference first