### PR TITLE
Feature/mzidentml mods

### DIFF
--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1144,11 +1144,13 @@ namespace OpenMS
         {
           new_mod->setMonoMass(mass + residue->getMonoWeight());
           new_mod->setAverageMass(mass + residue->getAverageWeight());
+          new_mod->setDiffMonoMass(mass);
         }
         else
         {
           new_mod->setMonoMass(mass);
           new_mod->setAverageMass(mass);
+          new_mod->setDiffMonoMass(mass - residue->getMonoWeight());
         }
 
         mod_db->addModification(new_mod);

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -708,13 +708,24 @@ namespace OpenMS
           ++count;
           String id = XMLString::transcode(element_pep->getAttribute(XMLString::transcode("id")));
 
-
           //DOMNodeList* pep_sib = element_pep->getChildNodes();
           AASequence aas;
           try
           {
             //aas = parsePeptideSiblings_(pep_sib);
-            aas = parsePeptideSiblings_(element_pep);
+            try
+            {
+              aas = parsePeptideSiblings_(element_pep);
+            }
+            catch (Exception::MissingInformation)
+            {
+              // We found an unknown modification, we could try to rescue this
+              // situation. The "name" attribute, if present, may be parsable:
+              //   The potentially ambiguous common identifier, such as a
+              //   human-readable name for the instance.
+              String name = XMLString::transcode(element_pep->getAttribute(XMLString::transcode("name")));
+              if (!name.empty()) aas = AASequence::fromString(name);
+            }
           }
           catch (...)
           {
@@ -2386,6 +2397,11 @@ namespace OpenMS
               while (cvp)
               {
                 CVTerm cv = parseCvParam_(cvp);
+                if (cv.getAccession() == "MS:1001460") // unknown modification
+                {
+                  // e.g. <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value="N-Glycan"/>
+                  throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown modification");
+                }
                 if (cv.getCVIdentifierRef() != "UNIMOD")
                 {
                   //                 e.g.  <cvParam accession="MS:1001524" name="fragment neutral loss" cvRef="PSI-MS" value="0" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO"/>

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -2399,6 +2399,8 @@ namespace OpenMS
                 CVTerm cv = parseCvParam_(cvp);
                 if (cv.getAccession() == "MS:1001460") // unknown modification
                 {
+                  // TODO: actually parse this and add a new modification of
+                  // mass "monoisotopicMassDelta" to the AASequence
                   // e.g. <cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value="N-Glycan"/>
                   throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown modification");
                 }

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -816,7 +816,9 @@ namespace OpenMS
           {
             String p;
             //~ TODO simplify mod cv param write
-            p += String("\t<Peptide id=\"") + pepid + String("\">\n\t\t<PeptideSequence>") + jt->getSequence().toUnmodifiedString() + String("</PeptideSequence>\n");
+            // write peptide id with conversion to universal, "human-readable" bracket string notation
+            p += String("\t<Peptide id=\"") + pepid + String("\" name=\"") + 
+                  jt->getSequence().toBracketString(false) + String("\">\n\t\t<PeptideSequence>") + jt->getSequence().toUnmodifiedString() + String("</PeptideSequence>\n");
             if (jt->getSequence().isModified() || jt->metaValueExists("xl_chain"))
             {
               const ResidueModification* n_term_mod = jt->getSequence().getNTerminalModification();
@@ -892,10 +894,30 @@ namespace OpenMS
                   else
                   {
                     acc = mod->getPSIMODAccession();
-                    p += "\">\n\t\t\t<cvParam accession=\"XLMOD:" + acc.suffix(':');
-                    p += "\" name=\"" +  mod->getId();
-                    p += "\" cvRef=\"XLMOD\"/>";
-                    p += "\n\t\t</Modification>\n";
+                    if (!acc.empty())
+                    {
+                      p += "\">\n\t\t\t<cvParam accession=\"XLMOD:" + acc.suffix(':');
+                      p += "\" name=\"" +  mod->getId();
+                      p += "\" cvRef=\"XLMOD\"/>";
+                      p += "\n\t\t</Modification>\n";
+                    }
+                    else
+                    {
+                      // We have an unknown modification, so lets write unknown
+                      // and at least try to write down the delta mass.
+                      if (mod->getDiffMonoMass() > 0.0)
+                      {
+                        double diffmass = mod->getDiffMonoMass();
+                        p += "\" monoisotopicMassDelta=\"" + String(diffmass); 
+                      }
+                      else if (mod->getMonoMass() > 0.0)
+                      {
+                        double diffmass = mod->getMonoMass() - jt->getSequence()[i].getMonoWeight();
+                        p += "\" monoisotopicMassDelta=\"" + String(diffmass); 
+                      }
+                      p += "\">\n\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1001460\" name=\"unknown modification\" value=\"N-Glycan\"/>";
+                      p += "\n\t\t</Modification>\n";
+                    }
                   }
                 }
                 /* <psi-pi:SubstitutionModification originalResidue="A" replacementResidue="A"/> */

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -905,7 +905,7 @@ namespace OpenMS
                     {
                       // We have an unknown modification, so lets write unknown
                       // and at least try to write down the delta mass.
-                      if (mod->getDiffMonoMass() > 0.0)
+                      if (mod->getDiffMonoMass() != 0.0)
                       {
                         double diffmass = mod->getDiffMonoMass();
                         p += "\" monoisotopicMassDelta=\"" + String(diffmass); 

--- a/src/tests/topp/IDFileConverter_8_input.mzid
+++ b/src/tests/topp/IDFileConverter_8_input.mzid
@@ -36,10 +36,16 @@
 		<PeptideSequence>PEPTIDERR</PeptideSequence> 
 	</Peptide> 
  	<Peptide id="4943767272410482976"> 
-		<PeptideSequence>PEPTIDERRR</PeptideSequence> 
+		<PeptideSequence>PEPTIDECK</PeptideSequence> 
+		<Modification location="8" monoisotopicMassDelta="57.021464">
+			<cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl" value=""/>
+		</Modification>
 	</Peptide> 
- 	<Peptide id="7485621129914001920"> 
-		<PeptideSequence>PEPTIDERRRR</PeptideSequence> 
+ 	<Peptide id="7485621129914001920" name="N[+3785.30710]PEPTIDEK"> 
+		<PeptideSequence>NPEPTIDEK</PeptideSequence> 
+		<Modification location="1" monoisotopicMassDelta="3785.3070989">
+			<cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value="N-Glycan"/>
+		</Modification>
 	</Peptide> 
  	<PeptideEvidence id="10918478775903385808" peptide_ref="12687397162581935028" dBSequence_ref="1370410586476450684" post="B" pre="A" isDecoy="0"/> 
 	<PeptideEvidence id="11064349190525804944" peptide_ref="354584743404697772" dBSequence_ref="5172702226708088127" post="B" pre="A" isDecoy="1"/> 

--- a/src/tests/topp/IDFileConverter_8_output.idXML
+++ b/src/tests/topp/IDFileConverter_8_output.idXML
@@ -30,13 +30,13 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="X\!Tandem:hyperscore" higher_score_better="true" significance_threshold="0" MZ="0.7" RT="1.6" spectrum_reference="45" >
-			<PeptideHit score="44.4" sequence="PEPTIDERRR" charge="2" aa_before="A" aa_after="B" protein_refs="PH_1" >
+			<PeptideHit score="44.4" sequence="PEPTIDEC(Carbamidomethyl)K" charge="2" aa_before="A" aa_after="B" protein_refs="PH_1" >
 				<UserParam type="float" name="calcMZ" value="634.838928386321"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="MS:1001331" value="44.4"/>
 			</PeptideHit>
-			<PeptideHit score="33.3" sequence="PEPTIDERRRR" charge="2" aa_before="A" aa_after="B" protein_refs="PH_0" >
+			<PeptideHit score="33.3" sequence="N[+3785.30710]PEPTIDEK" charge="2" aa_before="A" aa_after="B" protein_refs="PH_0" >
 				<UserParam type="float" name="calcMZ" value="712.889484077721"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
@@ -44,13 +44,13 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot:score" higher_score_better="true" significance_threshold="0" MZ="987.6" RT="5432.1" spectrum_reference="99" >
-			<PeptideHit score="99.4" sequence="PEPTIDERRR" charge="2" aa_before="A" aa_after="B" protein_refs="PH_1" >
+			<PeptideHit score="99.4" sequence="PEPTIDEC(Carbamidomethyl)K" charge="2" aa_before="A" aa_after="B" protein_refs="PH_1" >
 				<UserParam type="float" name="calcMZ" value="634.838928386321"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="MS:1001171" value="99.4"/>
 			</PeptideHit>
-			<PeptideHit score="33.3" sequence="PEPTIDERRRR" charge="1" aa_before="A" aa_after="B" protein_refs="PH_0" >
+			<PeptideHit score="33.3" sequence="N[+3785.30710]PEPTIDEK" charge="1" aa_before="A" aa_after="B" protein_refs="PH_0" >
 				<UserParam type="float" name="calcMZ" value="1424.77169168867"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>

--- a/src/tests/topp/IDFileConverter_9_input.idXML
+++ b/src/tests/topp/IDFileConverter_9_input.idXML
@@ -31,7 +31,7 @@
 		<PeptideIdentification score_type="MOWSE" higher_score_better="true" significance_threshold="0" >
 			<PeptideHit score="44.4" sequence="PEPTIDERRR" charge="2" >
 			</PeptideHit>
-			<PeptideHit score="33.3" sequence="PEPTIDERRRR" charge="2" >
+			<PeptideHit score="33.3" sequence="N[+3785.30710]PEPTIDEK" charge="2" >
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/IDFileConverter_9_output.mzid
+++ b/src/tests/topp/IDFileConverter_9_output.mzid
@@ -4,7 +4,7 @@
 	xmlns="http://psidev.info/psi/pi/mzIdentML/1.1"
 	version="1.1.0"
 	id="OpenMS_14509930621887606273"
-	creationDate="2017-03-28T21:46:58">
+	creationDate="2017-04-26T17:30:00">
 <cvList>
 	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv> 
  	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv> 
@@ -34,19 +34,22 @@
 	<DBSequence accession="PROT3" searchDatabase_ref="SDB_3332699010107892018" id="PROT_12999979801269632061">
 		<cvParam accession="MS:1001088" cvRef="PSI-MS" name="protein description" value="PROT3"/>
 	</DBSequence>
-	<Peptide id="PEP_14811341817612382122">
+	<Peptide id="PEP_14811341817612382122" name="PEPTIDERR">
 		<PeptideSequence>PEPTIDERR</PeptideSequence>
 	</Peptide> 
- 	<Peptide id="PEP_15050004366391181853">
-		<PeptideSequence>PEPTIDERRRR</PeptideSequence>
+ 	<Peptide id="PEP_15050004366391181853" name="N[3899.3500281914]PEPTIDEK">
+		<PeptideSequence>NPEPTIDEK</PeptideSequence>
+		<Modification location="1" residues="N" monoisotopicMassDelta="3785.3071">
+			<cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value="N-Glycan"/>
+		</Modification>
 	</Peptide> 
- 	<Peptide id="PEP_16907355690727166316">
+ 	<Peptide id="PEP_16907355690727166316" name="PEPTIDER">
 		<PeptideSequence>PEPTIDER</PeptideSequence>
 	</Peptide> 
- 	<Peptide id="PEP_3023658190814908261">
+ 	<Peptide id="PEP_3023658190814908261" name="PEPTIDERRR">
 		<PeptideSequence>PEPTIDERRR</PeptideSequence>
 	</Peptide> 
- 	<Peptide id="PEP_7276556891837796968">
+ 	<Peptide id="PEP_7276556891837796968" name="PEPTIDERRRRR">
 		<PeptideSequence>PEPTIDERRRRR</PeptideSequence>
 	</Peptide> 
  	<PeptideEvidence id="PEV_10306100746905639127" peptide_ref="PEP_16907355690727166316" dBSequence_ref="PROT_13440783915218733453" post="B" pre="A"/>
@@ -204,7 +207,7 @@
 					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="44.4"/>
 				</SpectrumIdentificationItem>
-				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_15050004366391181853" calculatedMassToCharge="712.889484077721" experimentalMassToCharge="nan" chargeState="2" id="SII_17716858074023296841">
+				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_15050004366391181853" calculatedMassToCharge="2414.40975709922" experimentalMassToCharge="nan" chargeState="2" id="SII_17716858074023296841">
 					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="33.3"/>
 				</SpectrumIdentificationItem>


### PR DESCRIPTION
fixes for unknown modifications in mzIdentML which often occur in certain workflows, such as Glycan search. We ran into this by parsing a file produced by Byonic which we used for Glycan search - their mzIdentML looked pretty good but we could not parse it. 

from the standard:
```
If the modification is not present in the CV (and this will be checked by the semantic validator
within a given tolerance window), there is a â€œunknown modificationâ€• CV term that MUST
be used instead.
```

the current solution tries to parse the file and if it encounters an unknown mod, it basically throws and we try to parse the "name" field if present. Same for writing mzIdentML if there is no accession number we have to assume its a "custom" modification that we dont know and we just write unknown but try to give as much information as possible for other parsers so that they can do something useful with it (e.g. write an "universal" and "human-readable" bracket string and write down the monoisotopic mass).
