### PR TITLE
[BUILD] remove address sanitizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,17 +46,19 @@ matrix:
     - env: ENABLE_STYLE_TESTING=ON WITH_GUI=ON 
       os: linux
       compiler: gcc
+
 ## gcc tests class and TOPP tests (if we run into a time limit, we can split it)
 ## PP Wavelet is turned off due to unstable behavior ... 
-#
     - env: ENABLE_STYLE_TESTING=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=ON WITH_GUI=ON DISABLE_WAVELET2DTEST=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Release
       os: linux
       compiler: gcc
-## clang tests class and TOPP tests: without gui and with address sanitizer (needs debug build)
-    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=ON DISABLE_WAVELET2DTEST=ON ADDRESS_SANITIZER=On BUILD_TYPE=Debug
+
+## clang tests class and TOPP tests: without gui and without address sanitizer (debug build)
+    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=ON DISABLE_WAVELET2DTEST=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Debug
       os: linux
       compiler: clang
-## clang tests class and TOPP tests: without gui and without address sanitizer
+
+## clang tests class and TOPP tests: without gui and without address sanitizer (release build)
     - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=ON ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=ON DISABLE_WAVELET2DTEST=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Release
       os: linux
       compiler: clang


### PR DESCRIPTION
- remove from travis builds as they tend to time out
- running the tests takes too long when using the AS

- honestly, I am getting tired of time-outs on travis and the main reason is that building OpenMS is now pretty fast (20 min) but running the tests with AS is pretty slow since it adds extra code that makes the runtime go up a lot