### PR TITLE
Infer fixed/variable modification definitions from data when necessary

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationDefinition.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationDefinition.h
@@ -63,8 +63,11 @@ public:
     /// copy constructor
     ModificationDefinition(const ModificationDefinition& rhs);
 
-    /// detailed constructor specifying the modifications name
-    explicit ModificationDefinition(const String& mod);
+    /// detailed constructor specifying the modification by name
+    explicit ModificationDefinition(const String& mod, bool fixed = true, UInt max_occur = 0);
+
+    /// detailed constructor specifying the modification by name
+    ModificationDefinition(const ResidueModification& mod, bool fixed = true, UInt max_occur = 0);
 
     /// destructor
     virtual ~ModificationDefinition();
@@ -79,11 +82,11 @@ public:
     /// returns if the modification if fixed true, else false
     bool isFixedModification() const;
 
-    /// set the maximal number of occurences per peptide, unbound if 0
-    void setMaxOccurences(UInt num);
+    /// set the maximal number of occurrences per peptide (unbounded if 0)
+    void setMaxOccurrences(UInt num);
 
-    /// returns the maximal number of occurences per peptide
-    UInt getMaxOccurences() const;
+    /// returns the maximal number of occurrences per peptide
+    UInt getMaxOccurrences() const;
 
     /// returns the name of the modification
     String getModificationName() const;
@@ -127,8 +130,8 @@ protected:
     /// fixed (true) or variable (false)
     bool fixed_modification_;
 
-    /// maximal number of occurences per peptide
-    UInt max_occurences_;
+    /// maximal number of occurrences per peptide
+    UInt max_occurrences_;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationDefinition.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationDefinition.h
@@ -66,7 +66,7 @@ public:
     /// detailed constructor specifying the modification by name
     explicit ModificationDefinition(const String& mod, bool fixed = true, UInt max_occur = 0);
 
-    /// detailed constructor specifying the modification by name
+    /// direct constructor from a residue modification
     explicit ModificationDefinition(const ResidueModification& mod, bool fixed = true, UInt max_occur = 0);
 
     /// destructor

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationDefinition.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationDefinition.h
@@ -67,7 +67,7 @@ public:
     explicit ModificationDefinition(const String& mod, bool fixed = true, UInt max_occur = 0);
 
     /// detailed constructor specifying the modification by name
-    ModificationDefinition(const ResidueModification& mod, bool fixed = true, UInt max_occur = 0);
+    explicit ModificationDefinition(const ResidueModification& mod, bool fixed = true, UInt max_occur = 0);
 
     /// destructor
     virtual ~ModificationDefinition();

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationDefinitionsSet.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationDefinitionsSet.h
@@ -36,12 +36,13 @@
 #ifndef OPENMS_CHEMISTRY_MODIFICATIONDEFINITIONSSET_H
 #define OPENMS_CHEMISTRY_MODIFICATIONDEFINITIONSSET_H
 
-#include <OpenMS/CONCEPT/Types.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
-#include <OpenMS/DATASTRUCTURES/StringListUtils.h>
-#include <OpenMS/DATASTRUCTURES/ListUtils.h>
-#include <OpenMS/CHEMISTRY/ModificationDefinition.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
+#include <OpenMS/CHEMISTRY/ModificationDefinition.h>
+#include <OpenMS/CONCEPT/Types.h> // for "UInt"
+#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/DATASTRUCTURES/ListUtils.h> // for "StringList"
+#include <OpenMS/DATASTRUCTURES/StringListUtils.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
 
 #include <set>
 
@@ -119,13 +120,16 @@ public:
     /// returns the stored variable modification definitions
     const std::set<ModificationDefinition>& getVariableModifications() const;
 
-    /// return only the names of the modifications stored in the set
+    /// returns only the names of the modifications stored in the set
     std::set<String> getModificationNames() const;
 
-    /// return only the names of the fixed modifications
+    /// populates the output lists with the modification names (use e.g. for ProteinIdentification::SearchParameters)
+    void getModificationNames(StringList& fixed_modifications, StringList& variable_modifications) const;
+
+    /// returns only the names of the fixed modifications
     std::set<String> getFixedModificationNames() const;
 
-    /// return only the names of the variable modifications
+    /// returns only the names of the variable modifications
     std::set<String> getVariableModificationNames() const;
     //@}
 
@@ -164,6 +168,9 @@ public:
        @throw Exception::IllegalArgument if both @p consider_variable and @p consider_fixed are false
     */
     void findMatches(std::multimap<double, ModificationDefinition>& matches, double mass, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY, bool consider_fixed = true, bool consider_variable = true, bool is_delta = true, double tolerance = 0.01) const;
+
+    /// Infers the sets of defined modifications from the modifications present on peptide identifications
+    void inferFromPeptides(const std::vector<PeptideIdentification>& peptides);
 
 protected:
 

--- a/src/openms/include/OpenMS/FORMAT/PercolatorOutfile.h
+++ b/src/openms/include/OpenMS/FORMAT/PercolatorOutfile.h
@@ -79,20 +79,6 @@ namespace OpenMS
 
     /// Resolve cases where N-terminal modifications may be misassigned to the first residue (for X! Tandem results)
     void resolveMisassignedNTermMods_(String& peptide) const;
-
-    /// Extracts allowed modifications from the search results
-    void getSearchModifications_(
-      const std::vector<PeptideIdentification>& peptides,
-      ProteinIdentification::SearchParameters& params) const;
-
-    /// Adds modifications to the search parameters (helper function for getSearchModifications_())
-    void addModsToSearchParams_(
-      const std::map<String, std::set<String> >::const_iterator& map_it,
-      ProteinIdentification::SearchParameters& params) const;
-
-    /// Gets the full name of a modification (incl. residue specificity)
-    String getFullModName_(const String& residue, const String& mod) const;
-
   };
 
 } // namespace OpenMS

--- a/src/openms/source/CHEMISTRY/ModificationDefinition.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationDefinition.cpp
@@ -43,23 +43,30 @@ namespace OpenMS
   ModificationDefinition::ModificationDefinition() :
     mod_(0),
     fixed_modification_(true),
-    max_occurences_(0)
+    max_occurrences_(0)
   {
   }
 
   ModificationDefinition::ModificationDefinition(const ModificationDefinition& rhs) :
     mod_(rhs.mod_),
     fixed_modification_(rhs.fixed_modification_),
-    max_occurences_(rhs.max_occurences_)
+    max_occurrences_(rhs.max_occurrences_)
   {
   }
 
-  ModificationDefinition::ModificationDefinition(const String& mod) :
+  ModificationDefinition::ModificationDefinition(const String& mod, bool fixed, UInt max_occur) :
     mod_(0),
-    fixed_modification_(true),
-    max_occurences_(0)
+    fixed_modification_(fixed),
+    max_occurrences_(max_occur)
   {
     setModification(mod);
+  }
+
+  ModificationDefinition::ModificationDefinition(const ResidueModification& mod, bool fixed, UInt max_occur) :
+    mod_(&mod),
+    fixed_modification_(fixed),
+    max_occurrences_(max_occur)
+  {
   }
 
   ModificationDefinition& ModificationDefinition::operator=(const ModificationDefinition& rhs)
@@ -68,7 +75,7 @@ namespace OpenMS
     {
       mod_ = rhs.mod_;
       fixed_modification_ = rhs.fixed_modification_;
-      max_occurences_ = rhs.max_occurences_;
+      max_occurrences_ = rhs.max_occurrences_;
     }
     return *this;
   }
@@ -77,7 +84,7 @@ namespace OpenMS
   {
     return mod_ == rhs.mod_ &&
            fixed_modification_ == rhs.fixed_modification_ &&
-           max_occurences_ == rhs.max_occurences_;
+           max_occurrences_ == rhs.max_occurrences_;
   }
 
   bool ModificationDefinition::operator!=(const ModificationDefinition& rhs) const
@@ -130,14 +137,14 @@ namespace OpenMS
     return "";
   }
 
-  void ModificationDefinition::setMaxOccurences(UInt max_occurences)
+  void ModificationDefinition::setMaxOccurrences(UInt max_occurrences)
   {
-    max_occurences_ = max_occurences;
+    max_occurrences_ = max_occurrences;
   }
 
-  UInt ModificationDefinition::getMaxOccurences() const
+  UInt ModificationDefinition::getMaxOccurrences() const
   {
-    return max_occurences_;
+    return max_occurrences_;
   }
 
 } // namespace OpenMS

--- a/src/openms/source/CHEMISTRY/ModificationDefinitionsSet.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationDefinitionsSet.cpp
@@ -132,17 +132,13 @@ namespace OpenMS
 
     for (StringList::const_iterator it = fixed_modifications.begin(); it != fixed_modifications.end(); ++it)
     {
-      ModificationDefinition def;
-      def.setModification(*it);
-      def.setFixedModification(true);
+      ModificationDefinition def(*it, true);
       fixed_mods_.insert(def);
     }
 
     for (StringList::const_iterator it = variable_modifications.begin(); it != variable_modifications.end(); ++it)
     {
-      ModificationDefinition def;
-      def.setModification(*it);
-      def.setFixedModification(false);
+      ModificationDefinition def(*it, false);
       variable_mods_.insert(def);
     }
   }
@@ -170,6 +166,22 @@ namespace OpenMS
       mod_names.insert(it->getModificationName());
     }
     return mod_names;
+  }
+
+  void ModificationDefinitionsSet::getModificationNames(StringList& fixed_modifications, StringList& variable_modifications) const
+  {
+    fixed_modifications.clear();
+    fixed_modifications.reserve(fixed_mods_.size());
+    for (set<ModificationDefinition>::const_iterator it = fixed_mods_.begin(); it != fixed_mods_.end(); ++it)
+    {
+      fixed_modifications.push_back(it->getModificationName());
+    }
+    variable_modifications.clear();
+    variable_modifications.reserve(variable_mods_.size());
+    for (set<ModificationDefinition>::const_iterator it = variable_mods_.begin(); it != variable_mods_.end(); ++it)
+    {
+      variable_modifications.push_back(it->getModificationName());
+    }
   }
 
   const set<ModificationDefinition>& ModificationDefinitionsSet::getFixedModifications() const
@@ -355,5 +367,57 @@ namespace OpenMS
       addMatches_(matches, mass, residue, term_spec, variable_mods_, is_delta, tolerance);
     }
   }
+
+  // @TODO: should this function handle "max_mods_per_peptide_" as well?
+  void ModificationDefinitionsSet::inferFromPeptides(const vector<PeptideIdentification>& peptides)
+  {
+    // amino acid (or terminus) -> set of modifications (incl. no mod. = 0):
+    map<String, set<const ResidueModification*> > mod_map;
+
+    for (vector<PeptideIdentification>::const_iterator pep_it =
+           peptides.begin(); pep_it != peptides.end(); ++pep_it)
+    {
+      for (vector<PeptideHit>::const_iterator hit_it =
+             pep_it->getHits().begin(); hit_it != pep_it->getHits().end();
+           ++hit_it)
+      {
+        const AASequence& seq = hit_it->getSequence();
+        mod_map["N-term"].insert(seq.getNTerminalModification());
+        mod_map["C-term"].insert(seq.getCTerminalModification());
+        for (AASequence::ConstIterator seq_it = seq.begin();
+             seq_it != seq.end(); ++seq_it)
+        {
+          mod_map[seq_it->getOneLetterCode()].insert(seq_it->getModification());
+        }
+      }
+    }
+
+    fixed_mods_.clear();
+    variable_mods_.clear();
+    for (map<String, set<const ResidueModification*> >::const_iterator map_it =
+           mod_map.begin(); map_it != mod_map.end(); ++map_it)
+    {
+      set<const ResidueModification*>::const_iterator set_it =
+        map_it->second.begin();
+      // if there's only one mod, it's probably a fixed one:
+      if ((map_it->second.size() == 1) && (*set_it != 0))
+      {
+        ModificationDefinition mod_def(**set_it, true);
+        fixed_mods_.insert(mod_def);
+      }
+      else // variable mod(s)
+      {
+        for (; set_it != map_it->second.end(); ++set_it)
+        {
+          if (*set_it != 0)
+          {
+            ModificationDefinition mod_def(**set_it, false);
+            variable_mods_.insert(mod_def);
+          }
+        }
+      }
+    }
+  }
+
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/CHEMISTRY/Residue.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
+#include <OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/Enzyme.h>
 #include <OpenMS/CONCEPT/UniqueIdGenerator.h>
@@ -524,40 +525,49 @@ namespace OpenMS
           sip += "\n\t\t\t" + cv_.getTermByName("cross-linking search").toXMLString(cv_ns) + "\n";
         }
         //remove MS:1001029 written if present in <SearchDatabase> as of SearchDatabase_may rule
-        ProteinIdentification::SearchParameters p = it->getSearchParameters();
-        p.removeMetaValue("MS:1001029");
-        writeMetaInfos_(sip, p, 3);
-        sip += String(3, '\t') + "<userParam name=\"charges\" unitName=\"xsd:string\" value=\"" + it->getSearchParameters().charges + "\"/>\n";
+        ProteinIdentification::SearchParameters search_params = it->getSearchParameters();
+        search_params.removeMetaValue("MS:1001029");
+        writeMetaInfos_(sip, search_params, 3);
+        sip += String(3, '\t') + "<userParam name=\"charges\" unitName=\"xsd:string\" value=\"" + search_params.charges + "\"/>\n";
 //        sip += String(3, '\t') + "<userParam name=\"" + "missed_cleavages" + "\" unitName=\"" + "xsd:integer" + "\" value=\"" + String(it->getSearchParameters().missed_cleavages) + "\"/>" + "\n";
         sip += "\t\t</AdditionalSearchParams>\n";
         // modifications:
-        if (!it->getSearchParameters().fixed_modifications.empty() ||
-            !it->getSearchParameters().variable_modifications.empty())
+        if (search_params.fixed_modifications.empty() &&
+            search_params.variable_modifications.empty())
+        {
+          // no modifications used or are they just missing from the parameters?
+          ModificationDefinitionsSet mod_defs;
+          mod_defs.inferFromPeptides(*cpep_id_);
+          mod_defs.getModificationNames(search_params.fixed_modifications,
+                                        search_params.variable_modifications);
+        }
+        if (!search_params.fixed_modifications.empty() ||
+            !search_params.variable_modifications.empty())
         {
           sip += "\t\t<ModificationParams>\n";
-          writeModParam_(sip, it->getSearchParameters().fixed_modifications, true, 2);
-          writeModParam_(sip, it->getSearchParameters().variable_modifications, false, 2);
+          writeModParam_(sip, search_params.fixed_modifications, true, 2);
+          writeModParam_(sip, search_params.variable_modifications, false, 2);
           sip += "\t\t</ModificationParams>\n";
         }
-        writeEnzyme_(sip, it->getSearchParameters().digestion_enzyme, it->getSearchParameters().missed_cleavages, 2);
+        writeEnzyme_(sip, search_params.digestion_enzyme, search_params.missed_cleavages, 2);
         // TODO MassTable section
         sip += String("\t\t<FragmentTolerance>\n");
         String unit_str = "unitCvRef=\"UO\" unitName=\"dalton\" unitAccession=\"UO:0000221\"";
-        if (it->getSearchParameters().fragment_mass_tolerance_ppm)
+        if (search_params.fragment_mass_tolerance_ppm)
         {
           unit_str = "unitCvRef=\"UO\" unitName=\"parts per million\" unitAccession=\"UO:0000169\"";
         }
-        sip += String(3, '\t') + "<cvParam accession=\"MS:1001412\" name=\"search tolerance plus value\" " + unit_str + " cvRef=\"PSI-MS\" value=\"" + String(it->getSearchParameters().fragment_mass_tolerance) + "\"/>\n";
-        sip += String(3, '\t') + "<cvParam accession=\"MS:1001413\" name=\"search tolerance minus value\" " + unit_str + " cvRef=\"PSI-MS\" value=\"" + String(it->getSearchParameters().fragment_mass_tolerance) + "\"/>\n";
+        sip += String(3, '\t') + "<cvParam accession=\"MS:1001412\" name=\"search tolerance plus value\" " + unit_str + " cvRef=\"PSI-MS\" value=\"" + String(search_params.fragment_mass_tolerance) + "\"/>\n";
+        sip += String(3, '\t') + "<cvParam accession=\"MS:1001413\" name=\"search tolerance minus value\" " + unit_str + " cvRef=\"PSI-MS\" value=\"" + String(search_params.fragment_mass_tolerance) + "\"/>\n";
         sip += String("\t\t</FragmentTolerance>\n");
         sip += String("\t\t<ParentTolerance>\n");
         unit_str = "unitCvRef=\"UO\" unitName=\"dalton\" unitAccession=\"UO:0000221\"";
-        if (it->getSearchParameters().precursor_mass_tolerance_ppm)
+        if (search_params.precursor_mass_tolerance_ppm)
         {
           unit_str = "unitCvRef=\"UO\" unitName=\"parts per million\" unitAccession=\"UO:0000169\"";
         }
-        sip += String(3, '\t') + "<cvParam accession=\"MS:1001412\" name=\"search tolerance plus value\" " + unit_str + " cvRef=\"PSI-MS\" value=\"" + String(it->getSearchParameters().precursor_mass_tolerance) + "\"/>\n";
-        sip += String(3, '\t') + "<cvParam accession=\"MS:1001413\" name=\"search tolerance minus value\" " + unit_str + " cvRef=\"PSI-MS\" value=\"" + String(it->getSearchParameters().precursor_mass_tolerance) + "\"/>\n";
+        sip += String(3, '\t') + "<cvParam accession=\"MS:1001412\" name=\"search tolerance plus value\" " + unit_str + " cvRef=\"PSI-MS\" value=\"" + String(search_params.precursor_mass_tolerance) + "\"/>\n";
+        sip += String(3, '\t') + "<cvParam accession=\"MS:1001413\" name=\"search tolerance minus value\" " + unit_str + " cvRef=\"PSI-MS\" value=\"" + String(search_params.precursor_mass_tolerance) + "\"/>\n";
         sip += String("\t\t</ParentTolerance>\n");
         sip += String("\t\t<Threshold>\n\t\t\t") + thcv + "\n";
         sip += String("\t\t</Threshold>\n");
@@ -608,7 +618,7 @@ namespace OpenMS
 
         //~ collect SearchDatabase element for each ProteinIdentification
         String sdb_id;
-        String sdb_file(it->getSearchParameters().db); //TODO @mths for several IdentificationRuns this must be something else, otherwise for two of the same db just one will be created
+        String sdb_file(search_params.db); //TODO @mths for several IdentificationRuns this must be something else, otherwise for two of the same db just one will be created
         std::map<String, String>::iterator dbit = sdb_ids.find(sdb_file);
         if (dbit == sdb_ids.end())
         {
@@ -616,17 +626,18 @@ namespace OpenMS
 
           search_database += String("\t\t<SearchDatabase ");
           search_database += String("location=\"") + sdb_file + "\" ";
-          if (!String(it->getSearchParameters().db_version).empty())
+          if (!String(search_params.db_version).empty())
           {
-            search_database += String("version=\"") + String(it->getSearchParameters().db_version) + "\" ";
+            search_database += String("version=\"") + String(search_params.db_version) + "\" ";
           }
           search_database += String("id=\"") + sdb_id + String("\">\n\t\t\t<FileFormat>\n");
           //TODO Searchdb file format type cvParam handling
           search_database += String(4, '\t') + cv_.getTermByName("FASTA format").toXMLString(cv_ns);
           search_database += String("\n\t\t\t</FileFormat>\n\t\t\t<DatabaseName>\n\t\t\t\t<userParam name=\"") + sdb_file + String("\"/>\n\t\t\t</DatabaseName>\n");
+          // "MS:1001029" was removed from the "search_params" copy!
           if (it->getSearchParameters().metaValueExists("MS:1001029"))
           {
-            search_database += String(3, '\t') + cv_.getTerm("MS:1001029").toXMLString(cv_ns, it->getSearchParameters().getMetaValue("MS:1001029")) + String(" \n");
+            search_database += String(3, '\t') + cv_.getTerm("MS:1001029").toXMLString(cv_ns, it->getSearchParameters().getMetaValue("MS:1001029")) + String("\n");
           }
           search_database += "\t\t</SearchDatabase>\n";
 
@@ -921,7 +932,7 @@ namespace OpenMS
                         double diffmass = mod->getMonoMass() - jt->getSequence()[i].getMonoWeight();
                         p += "\" monoisotopicMassDelta=\"" + String(diffmass); 
                       }
-                      p += "\">\n\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1001460\" name=\"unknown modification\" value=\"N-Glycan\"/>";
+                      p += "\">\n\t\t\t<cvParam cvRef=\"MS\" accession=\"MS:1001460\" name=\"unknown modification\"/>";
                       p += "\n\t\t</Modification>\n";
                     }
                   }
@@ -932,10 +943,10 @@ namespace OpenMS
                 {
                   p += "\t\t<Modification location=\"" + String(i + 1);
                   p += "\" residues=\"" + String(jt->getSequence()[i].getOneLetterCode());
-                  p += "\"> \n\t\t\t<cvParam accession=\"XLMOD:XXXXX";
+                  p += "\">\n\t\t\t<cvParam accession=\"XLMOD:XXXXX";
                   p += "\" name=\"" +  jt->getMetaValue("xl_mod").toString();
                   p += "\" cvRef=\"XLMOD\"/>";
-                  p += "\n\t\t</Modification> \n";
+                  p += "\n\t\t</Modification>\n";
                 }
               }
             }
@@ -1012,14 +1023,14 @@ namespace OpenMS
                 if (!acc.empty())
                 {
                   p += "\" residues=\"" + String(jt->getSequence()[i].getOneLetterCode());
-                  p += "\" monoisotopicMassDelta=\"" + jt->getMetaValue("xl_mass").toString() + "\"> \n";
+                  p += "\" monoisotopicMassDelta=\"" + jt->getMetaValue("xl_mass").toString() + "\">\n";
                   p += "\t\t\t<cvParam accession=\"" + acc + "\" cvRef=\"XLMOD\" name=\"" + name + "\"/>\n";
                 }
                 else // if there is no matching modification in the database, write out a placeholder
                 {
                   p += "\t\t<Modification location=\"" + String(i + 1);
                   p += "\" residues=\"" + String(jt->getSequence()[i].getOneLetterCode());
-                  p += "\" monoisotopicMassDelta=\"" + jt->getMetaValue("xl_mass").toString() + "\"> \n";
+                  p += "\" monoisotopicMassDelta=\"" + jt->getMetaValue("xl_mass").toString() + "\">\n";
                   p += "\t\t\t<cvParam accession=\"XLMOD:XXXXX\" cvRef=\"XLMOD\" name=\"" + jt->getMetaValue("xl_mod").toString() + "\"/>\n";
                 }
               }
@@ -1038,10 +1049,10 @@ namespace OpenMS
                   p += "\t\t<Modification location=\"" + String(i + 1);
                 }
                 p += "\" residues=\"" + String(jt->getSequence()[i].getOneLetterCode());
-                p += "\" monoisotopicMassDelta=\"0\"> \n";
+                p += "\" monoisotopicMassDelta=\"0\">\n";
               }
               p += "\t\t\t" + cv_.getTerm(jt->getMetaValue("xl_chain").toString()).toXMLString(cv_ns, DataValue(ppxl_linkid));
-              p += "\n\t\t</Modification> \n";
+              p += "\n\t\t</Modification>\n";
             }
             if (jt->metaValueExists("xl_pos2"))  // TODO ppxl metavalue subject to change (location and upgrade to cv)
             {
@@ -1050,10 +1061,10 @@ namespace OpenMS
               p += "\" residues=\"" + String(jt->getSequence()[i].getOneLetterCode());
               p += "\" monoisotopicMassDelta=\"0";
               // ppxl crosslink loop xl_pos2 is always the acceptor ("MS:1002510")
-              p += "\"> \n\t\t\t" + cv_.getTerm("MS:1002510").toXMLString(cv_ns, DataValue(ppxl_linkid));
-              p += "\n\t\t</Modification> \n";
+              p += "\">\n\t\t\t" + cv_.getTerm("MS:1002510").toXMLString(cv_ns, DataValue(ppxl_linkid));
+              p += "\n\t\t</Modification>\n";
             }
-            p += "\t</Peptide> \n ";
+            p += "\t</Peptide>\n ";
             sen_set.insert(p);
             pep_ids.insert(std::make_pair(pepi, pepid));
           }
@@ -1184,7 +1195,7 @@ namespace OpenMS
           }
           for (std::vector<String>::const_iterator pevref = pevid_ids.begin(); pevref != pevid_ids.end(); ++pevref)
           {
-            sii_tmp += "\t\t\t\t\t<PeptideEvidenceRef peptideEvidence_ref=\"" +  String(*pevref) + "\"/> \n";
+            sii_tmp += "\t\t\t\t\t<PeptideEvidenceRef peptideEvidence_ref=\"" +  String(*pevref) + "\"/>\n";
           }
 
           if (! jt->getFragmentAnnotations().empty())
@@ -1416,14 +1427,14 @@ namespace OpenMS
       os << "<cvList>\n"
          << "\t<cv id=\"PSI-MS\" fullName=\"Proteomics Standards Initiative Mass Spectrometry Vocabularies\" "
          << "uri=\"https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo\" "
-         << "version=\"3.15.0\"></cv> \n "
-         << "\t<cv id=\"UNIMOD\" fullName=\"UNIMOD\" uri=\"http://www.unimod.org/obo/unimod.obo\"></cv> \n"
+         << "version=\"3.15.0\"></cv>\n "
+         << "\t<cv id=\"UNIMOD\" fullName=\"UNIMOD\" uri=\"http://www.unimod.org/obo/unimod.obo\"></cv>\n"
          << "\t<cv id=\"UO\"     fullName=\"UNIT-ONTOLOGY\" "
          << "uri=\"https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo\"></cv>\n";
       if (is_ppxl)
       {
           os << "\t<cv id=\"XLMOD\" fullName=\"PSI cross-link modifications\" "
-             << "uri=\"https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/cv/XLMOD-1.0.0.obo\"></cv> \n";
+             << "uri=\"https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/cv/XLMOD-1.0.0.obo\"></cv>\n";
       }
       os << "</cvList>\n";
 
@@ -1596,15 +1607,16 @@ namespace OpenMS
         ModificationsDB::getInstance()->searchModifications(mods, *it);
         if (!mods.empty())
         {
+          // @TODO: if multiple mods match, we write all of them?
           for (std::set<const ResidueModification*>::const_iterator mt = mods.begin(); mt != mods.end(); ++mt)
           {
-            String origin = (*mt)->getOrigin();
-            if ((origin == "C-term") || (origin == "N-term")) origin = ".";
+            char origin = (*mt)->getOrigin();
+            if (origin == 'X') origin = '.'; // terminal without res. spec.
 
             s += String(indent + 1, '\t') + "<SearchModification fixedMod=\"" + (fixed ? "true" : "false") + "\" massDelta=\"" + String((*mt)->getDiffMonoMass()) + "\" residues=\"" + origin + "\">\n";
 
-            ResidueModification::TermSpecificity spec = (*mt)->getTermSpecificity();
             // @TODO: handle protein C-term/N-term
+            ResidueModification::TermSpecificity spec = (*mt)->getTermSpecificity();
             if ((spec == ResidueModification::C_TERM) || (spec == ResidueModification::N_TERM))
             {
               const String& cv_name = "modification specificity peptide " + (*mt)->getTermSpecificityName();
@@ -1615,13 +1627,20 @@ namespace OpenMS
 
             String ac = (*mt)->getUniModAccession();
             if (ac.hasPrefix("UniMod:")) ac = "UNIMOD:" + ac.suffix(':');
-            s += String(indent + 2, '\t') + unimod_.getTerm(ac).toXMLString(cv_ns) + "\n";
+            if (!ac.empty())
+            {
+              s += String(indent + 2, '\t') + unimod_.getTerm(ac).toXMLString(cv_ns) + "\n";
+            }
+            else
+            {
+              s += String(indent + 2, '\t') + "<cvParam cvRef=\"MS\" accession=\"MS:1001460\" name=\"unknown modification\"/>\n";
+            }
             s += String(indent + 1, '\t') + "</SearchModification>\n";
           }
         }
         else
         {
-          LOG_WARN << String("Registered ") + (fixed ? "fixed" : "variable") + " modification not writable, unknown or unable to convert to cv parameter." << std::endl;
+          LOG_WARN << String("Registered ") + (fixed ? "fixed" : "variable") + " modification '" << *it << "' is unknown and will be ignored." << std::endl;
         }
       }
     }

--- a/src/openms/source/FORMAT/PercolatorOutfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorOutfile.cpp
@@ -34,6 +34,7 @@
 
 #include <OpenMS/FORMAT/PercolatorOutfile.h>
 
+#include <OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/CONCEPT/LogStream.h>
@@ -193,103 +194,6 @@ namespace OpenMS
   }
 
 
-  String PercolatorOutfile::getFullModName_(const String& residue,
-                                            const String& mod) const
-  {
-    if (residue == "N-term")
-    {
-      try
-      {
-        const ResidueModification& n_term_mod =
-          ModificationsDB::getInstance()->
-          getModification(mod, "", ResidueModification::N_TERM);
-        return n_term_mod.getFullId();
-      }
-      catch (Exception::ElementNotFound) {};
-    }
-    else if (residue == "C-term")
-    {
-      try
-      {
-        const ResidueModification& c_term_mod =
-          ModificationsDB::getInstance()->
-          getModification(mod, "", ResidueModification::C_TERM);
-        return c_term_mod.getFullId();
-      }
-      catch (Exception::ElementNotFound) {};
-    }
-
-    return mod + " (" + residue + ")";
-  }
-
-
-  void PercolatorOutfile::addModsToSearchParams_(
-    const map<String, set<String> >::const_iterator& map_it,
-    ProteinIdentification::SearchParameters& params) const
-  {
-    set<String>::const_iterator set_it = map_it->second.begin();
-
-    // if there's only one mod, it's probably a fixed one:
-    if ((map_it->second.size() == 1) && (!set_it->empty()))
-    {
-      params.fixed_modifications.push_back(getFullModName_(map_it->first,
-                                                           *set_it));
-    }
-    else // variable mod(s)
-    {
-      for (; set_it != map_it->second.end(); ++set_it)
-      {
-        if (!set_it->empty())
-        {
-          params.variable_modifications.push_back(getFullModName_(map_it->first,
-                                                                  *set_it));
-        }
-      }
-    }
-  }
-
-
-  void PercolatorOutfile::getSearchModifications_(
-    const vector<PeptideIdentification>& peptides,
-    ProteinIdentification::SearchParameters& params) const
-  {
-    // amino acid (or terminus) -> set of modifications (incl. no mod.):
-    map<String, set<String> > mod_map;
-
-    for (vector<PeptideIdentification>::const_iterator pep_it =
-           peptides.begin(); pep_it != peptides.end(); ++pep_it)
-    {
-      for (vector<PeptideHit>::const_iterator hit_it =
-             pep_it->getHits().begin(); hit_it != pep_it->getHits().end();
-           ++hit_it)
-      {
-        const String& n_term_mod =
-          hit_it->getSequence().getNTerminalModificationName();
-        mod_map["N-term"].insert(n_term_mod);
-        const String& c_term_mod =
-          hit_it->getSequence().getCTerminalModificationName();
-        mod_map["C-term"].insert(c_term_mod);
-
-        for (AASequence::ConstIterator seq_it = hit_it->getSequence().begin();
-             seq_it != hit_it->getSequence().end(); ++seq_it)
-        {
-          const String& mod = seq_it->getModificationName();
-          mod_map[seq_it->getOneLetterCode()].insert(mod);
-        }
-      }
-    }
-
-    for (map<String, set<String> >::const_iterator map_it =
-           mod_map.begin(); map_it != mod_map.end(); ++map_it)
-    {
-      addModsToSearchParams_(map_it, params);
-    }
-    sort(params.fixed_modifications.begin(), params.fixed_modifications.end());
-    sort(params.variable_modifications.begin(),
-         params.variable_modifications.end());
-  }
-
-
   void PercolatorOutfile::load(const String& filename,
                                ProteinIdentification& proteins,
                                vector<PeptideIdentification>& peptides,
@@ -429,8 +333,11 @@ namespace OpenMS
     }
 
     // add info about allowed modifications:
+    ModificationDefinitionsSet mod_defs;
+    mod_defs.inferFromPeptides(peptides);
     ProteinIdentification::SearchParameters params;
-    getSearchModifications_(peptides, params);
+    mod_defs.getModificationNames(params.fixed_modifications,
+                                  params.variable_modifications);
     proteins.setSearchParameters(params);
 
     LOG_INFO << "Created " << proteins.getHits().size() << " protein hits.\n"

--- a/src/pyOpenMS/pxds/ModificationDefinition.pxd
+++ b/src/pyOpenMS/pxds/ModificationDefinition.pxd
@@ -12,6 +12,11 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationDefinition.h>" namespace "OpenMS
         ModificationDefinition() nogil except +
         ModificationDefinition(ModificationDefinition) nogil except +
         ModificationDefinition(String &mod) nogil except +
+        ModificationDefinition(String &mod, bool fixed) nogil except +
+        ModificationDefinition(String &mod, bool fixed, UInt max_occur) nogil except +
+        ModificationDefinition(ResidueModification &mod) nogil except +
+        ModificationDefinition(ResidueModification &mod, bool fixed) nogil except +
+        ModificationDefinition(ResidueModification &mod, bool fixed, UInt max_occur) nogil except +
 
         bool operator==(ModificationDefinition &rhs) nogil except +
         bool operator!=(ModificationDefinition &rhs) nogil except +
@@ -19,8 +24,8 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationDefinition.h>" namespace "OpenMS
 
         void setFixedModification(bool fixed) nogil except +
         bool isFixedModification() nogil except +
-        void setMaxOccurences(UInt num) nogil except +
-        UInt getMaxOccurences() nogil except +
+        void setMaxOccurrences(UInt num) nogil except +
+        UInt getMaxOccurrences() nogil except +
         String getModificationName() nogil except +
         void setModification(String &modification) nogil except +
 

--- a/src/pyOpenMS/pxds/ModificationDefinitionsSet.pxd
+++ b/src/pyOpenMS/pxds/ModificationDefinitionsSet.pxd
@@ -28,7 +28,8 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>" namespace "Op
         libcpp_set[ ModificationDefinition ]  getFixedModifications() nogil except +
         libcpp_set[ ModificationDefinition ]  getVariableModifications() nogil except +
         libcpp_set[ String ] getModificationNames() nogil except +
+        void getModificationNames(String &fixed_modifications, String &variable_modifications) nogil except +
         libcpp_set[ String ] getFixedModificationNames() nogil except +
         libcpp_set[ String ] getVariableModificationNames() nogil except +
         bool isCompatible(AASequence &peptide) nogil except +
-
+        void inferFromPeptides(libcpp_vector[ PeptideIdentification ] &peptides) nogil except +

--- a/src/pyOpenMS/pxds/ModificationDefinitionsSet.pxd
+++ b/src/pyOpenMS/pxds/ModificationDefinitionsSet.pxd
@@ -2,6 +2,7 @@ from libcpp.vector cimport vector as libcpp_vector
 from String cimport *
 from StringList cimport *
 from ModificationDefinition cimport *
+from PeptideIdentification cimport *
 from AASequence cimport *
 
 cdef extern from "<OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>" namespace "OpenMS":

--- a/src/tests/class_tests/openms/source/ModificationDefinition_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinition_test.cpp
@@ -52,14 +52,14 @@ ModificationDefinition* ptr = 0;
 ModificationDefinition* nullPointer = 0;
 START_SECTION(ModificationDefinition())
 {
-	ptr = new ModificationDefinition();
-	TEST_NOT_EQUAL(ptr, nullPointer)
+  ptr = new ModificationDefinition();
+  TEST_NOT_EQUAL(ptr, nullPointer)
 }
 END_SECTION
 
 START_SECTION((virtual ~ModificationDefinition()))
 {
-	delete ptr;
+  delete ptr;
 }
 END_SECTION
 
@@ -68,26 +68,26 @@ ptr = new ModificationDefinition();
 START_SECTION((ModificationDefinition(const ModificationDefinition& rhs)))
 {
   ModificationDefinition mod_def;
-	mod_def.setFixedModification(true);
-	ModificationDefinition copy(mod_def);
-	TEST_EQUAL(mod_def.isFixedModification(), copy.isFixedModification())
+  mod_def.setFixedModification(true);
+  ModificationDefinition copy(mod_def);
+  TEST_EQUAL(mod_def.isFixedModification(), copy.isFixedModification())
 
-	mod_def.setFixedModification(false);
-	ModificationDefinition copy2(mod_def);
-	TEST_EQUAL(mod_def.isFixedModification(), copy2.isFixedModification())
+  mod_def.setFixedModification(false);
+  ModificationDefinition copy2(mod_def);
+  TEST_EQUAL(mod_def.isFixedModification(), copy2.isFixedModification())
 }
 END_SECTION
 
 START_SECTION((ModificationDefinition(const String& mod, bool fixed = true, UInt max_occur = 0)))
 {
-	ModificationDefinition mod1("Acetyl (N-term)");
-	TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)");
-	ModificationDefinition mod2("Oxidation (M)");
-	TEST_EQUAL(mod2.getModificationName(), "Oxidation (M)");
+  ModificationDefinition mod1("Acetyl (N-term)");
+  TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)");
+  ModificationDefinition mod2("Oxidation (M)");
+  TEST_EQUAL(mod2.getModificationName(), "Oxidation (M)");
   TEST_EQUAL(mod2.isFixedModification(), true);
   TEST_EQUAL(mod2.getMaxOccurrences(), 0);
-	ModificationDefinition mod3("Carboxymethyl (C)", false, 2);
-	TEST_EQUAL(mod3.getModificationName(), "Carboxymethyl (C)");
+  ModificationDefinition mod3("Carboxymethyl (C)", false, 2);
+  TEST_EQUAL(mod3.getModificationName(), "Carboxymethyl (C)");
   TEST_EQUAL(mod3.isFixedModification(), false);
   TEST_EQUAL(mod3.getMaxOccurrences(), 2);
 }
@@ -96,12 +96,12 @@ END_SECTION
 START_SECTION((ModificationDefinition(const ResidueModification& mod, bool fixed = true, UInt max_occur = 0)))
 {
   const ResidueModification res_mod1 = ModificationsDB::getInstance()->getModification("Acetyl (N-term)");
-	ModificationDefinition mod1(res_mod1);
-	TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)");
+  ModificationDefinition mod1(res_mod1);
+  TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)");
   TEST_EQUAL(mod1.isFixedModification(), true);
   TEST_EQUAL(mod1.getMaxOccurrences(), 0);
   const ResidueModification res_mod2 = ModificationsDB::getInstance()->getModification("Oxidation (M)");
-	ModificationDefinition mod2(res_mod2, false, 2);
+  ModificationDefinition mod2(res_mod2, false, 2);
   TEST_EQUAL(mod2.isFixedModification(), false);
   TEST_EQUAL(mod2.getMaxOccurrences(), 2);
 }
@@ -110,15 +110,15 @@ END_SECTION
 START_SECTION((void setFixedModification(bool fixed)))
 {
   ptr->setFixedModification(true);
-	TEST_EQUAL(ptr->isFixedModification(), true)
-	ptr->setFixedModification(false);
-	TEST_EQUAL(ptr->isFixedModification(), false)
+  TEST_EQUAL(ptr->isFixedModification(), true)
+  ptr->setFixedModification(false);
+  TEST_EQUAL(ptr->isFixedModification(), false)
 }
 END_SECTION
 
 START_SECTION((bool isFixedModification() const))
 {
-	// tested above
+  // tested above
   NOT_TESTABLE
 }
 END_SECTION
@@ -126,24 +126,24 @@ END_SECTION
 START_SECTION((void setMaxOccurrences(UInt num)))
 {
   ptr->setMaxOccurrences(1);
-	TEST_EQUAL(ptr->getMaxOccurrences(), 1)
-	ptr->setMaxOccurrences(1000);
-	TEST_EQUAL(ptr->getMaxOccurrences(), 1000)
+  TEST_EQUAL(ptr->getMaxOccurrences(), 1)
+  ptr->setMaxOccurrences(1000);
+  TEST_EQUAL(ptr->getMaxOccurrences(), 1000)
 }
 END_SECTION
 
 START_SECTION((UInt getMaxOccurrences() const))
 {
-	// tested above
+  // tested above
   NOT_TESTABLE
 }
 END_SECTION
 
 START_SECTION((String getModificationName() const))
 {
-	ModificationDefinition mod1;
-	mod1.setModification("Acetyl (N-term)");
-	TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)")
+  ModificationDefinition mod1;
+  mod1.setModification("Acetyl (N-term)");
+  TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)")
   mod1.setModification("Oxidation (M)");
   TEST_EQUAL(mod1.getModificationName(), "Oxidation (M)")
 }
@@ -152,7 +152,7 @@ END_SECTION
 START_SECTION((String getModification() const))
 {
   const ResidueModification& rm = ModificationsDB::getInstance()->getModification("Acetyl (N-term)");
-	ModificationDefinition mod1;
+  ModificationDefinition mod1;
   mod1.setModification(rm.getFullId());
   TEST_EQUAL(&rm, &(mod1.getModification()));
 }
@@ -160,7 +160,7 @@ END_SECTION
 
 START_SECTION((void setModification(const String& modification)))
 {
-	// tested above
+  // tested above
   NOT_TESTABLE
 }
 END_SECTION
@@ -169,7 +169,7 @@ START_SECTION((ModificationDefinition& operator=(const ModificationDefinition& e
 {
   ModificationDefinition mod_def;
   mod_def.setFixedModification(true);
-	*ptr = mod_def;
+  *ptr = mod_def;
   TEST_EQUAL(mod_def.isFixedModification(), ptr->isFixedModification())
 
   mod_def.setFixedModification(false);
@@ -182,17 +182,17 @@ END_SECTION
 START_SECTION((bool operator==(const ModificationDefinition& rhs) const))
 {
   ModificationDefinition m1, m2;
-	TEST_EQUAL(m1 == m2, true)
-	m1.setFixedModification(false);
-	TEST_EQUAL(m1 == m2, false)
-	m1.setFixedModification(true);
-	m1.setMaxOccurrences(15);
-	TEST_EQUAL(m1 == m2, false)
-	m1.setMaxOccurrences(0);
-	m1.setModification("Oxidation (M)");
-	TEST_EQUAL(m1 == m2, false)
-	m2.setModification("Oxidation (M)");
-	TEST_EQUAL(m1 == m2, true)
+  TEST_EQUAL(m1 == m2, true)
+  m1.setFixedModification(false);
+  TEST_EQUAL(m1 == m2, false)
+  m1.setFixedModification(true);
+  m1.setMaxOccurrences(15);
+  TEST_EQUAL(m1 == m2, false)
+  m1.setMaxOccurrences(0);
+  m1.setModification("Oxidation (M)");
+  TEST_EQUAL(m1 == m2, false)
+  m2.setModification("Oxidation (M)");
+  TEST_EQUAL(m1 == m2, true)
 }
 END_SECTION
 
@@ -216,11 +216,11 @@ END_SECTION
 START_SECTION((bool operator<(const OpenMS::ModificationDefinition& rhs) const))
 {
   ModificationDefinition m1, m2;
-	m1.setModification("Oxidation (M)");
-	m2.setModification("Carboxymethyl (C)");
-	TEST_EQUAL(m1 < m2, false)
-	TEST_EQUAL(m1 < m1, false)
-	TEST_EQUAL(m2 < m1, true)
+  m1.setModification("Oxidation (M)");
+  m2.setModification("Carboxymethyl (C)");
+  TEST_EQUAL(m1 < m2, false)
+  TEST_EQUAL(m1 < m1, false)
+  TEST_EQUAL(m2 < m1, true)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ModificationDefinition_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinition_test.cpp
@@ -65,7 +65,7 @@ END_SECTION
 
 ptr = new ModificationDefinition();
 
-START_SECTION((ModificationDefinition(const ModificationDefinition &rhs)))
+START_SECTION((ModificationDefinition(const ModificationDefinition& rhs)))
 {
   ModificationDefinition mod_def;
 	mod_def.setFixedModification(true);
@@ -78,14 +78,32 @@ START_SECTION((ModificationDefinition(const ModificationDefinition &rhs)))
 }
 END_SECTION
 
-START_SECTION((ModificationDefinition(const String &mod)))
+START_SECTION((ModificationDefinition(const String& mod, bool fixed = true, UInt max_occur = 0)))
 {
 	ModificationDefinition mod1("Acetyl (N-term)");
 	TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)");
 	ModificationDefinition mod2("Oxidation (M)");
 	TEST_EQUAL(mod2.getModificationName(), "Oxidation (M)");
-	ModificationDefinition mod3("Carboxymethyl (C)");
-	TEST_EQUAL(mod3.getModificationName(), "Carboxymethyl (C)");	
+  TEST_EQUAL(mod2.isFixedModification(), true);
+  TEST_EQUAL(mod2.getMaxOccurrences(), 0);
+	ModificationDefinition mod3("Carboxymethyl (C)", false, 2);
+	TEST_EQUAL(mod3.getModificationName(), "Carboxymethyl (C)");
+  TEST_EQUAL(mod3.isFixedModification(), false);
+  TEST_EQUAL(mod3.getMaxOccurrences(), 2);
+}
+END_SECTION
+
+START_SECTION((ModificationDefinition(const ResidueModification& mod, bool fixed = true, UInt max_occur = 0)))
+{
+  const ResidueModification res_mod1 = ModificationsDB::getInstance()->getModification("Acetyl (N-term)");
+	ModificationDefinition mod1(res_mod1);
+	TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)");
+  TEST_EQUAL(mod1.isFixedModification(), true);
+  TEST_EQUAL(mod1.getMaxOccurrences(), 0);
+  const ResidueModification res_mod2 = ModificationsDB::getInstance()->getModification("Oxidation (M)");
+	ModificationDefinition mod2(res_mod2, false, 2);
+  TEST_EQUAL(mod2.isFixedModification(), false);
+  TEST_EQUAL(mod2.getMaxOccurrences(), 2);
 }
 END_SECTION
 
@@ -98,30 +116,30 @@ START_SECTION((void setFixedModification(bool fixed)))
 }
 END_SECTION
 
-START_SECTION((bool isFixedModification() const ))
+START_SECTION((bool isFixedModification() const))
 {
 	// tested above
   NOT_TESTABLE
 }
 END_SECTION
 
-START_SECTION((void setMaxOccurences(UInt num)))
+START_SECTION((void setMaxOccurrences(UInt num)))
 {
-  ptr->setMaxOccurences(1);
-	TEST_EQUAL(ptr->getMaxOccurences(), 1)
-	ptr->setMaxOccurences(1000);
-	TEST_EQUAL(ptr->getMaxOccurences(), 1000)
+  ptr->setMaxOccurrences(1);
+	TEST_EQUAL(ptr->getMaxOccurrences(), 1)
+	ptr->setMaxOccurrences(1000);
+	TEST_EQUAL(ptr->getMaxOccurrences(), 1000)
 }
 END_SECTION
 
-START_SECTION((UInt getMaxOccurences() const ))
+START_SECTION((UInt getMaxOccurrences() const))
 {
 	// tested above
   NOT_TESTABLE
 }
 END_SECTION
 
-START_SECTION((String getModificationName() const ))
+START_SECTION((String getModificationName() const))
 {
 	ModificationDefinition mod1;
 	mod1.setModification("Acetyl (N-term)");
@@ -131,7 +149,7 @@ START_SECTION((String getModificationName() const ))
 }
 END_SECTION
 
-START_SECTION((String getModification() const ))
+START_SECTION((String getModification() const))
 {
   const ResidueModification& rm = ModificationsDB::getInstance()->getModification("Acetyl (N-term)");
 	ModificationDefinition mod1;
@@ -140,14 +158,14 @@ START_SECTION((String getModification() const ))
 }
 END_SECTION
 
-START_SECTION((void setModification(const String &modification)))
+START_SECTION((void setModification(const String& modification)))
 {
 	// tested above
   NOT_TESTABLE
 }
 END_SECTION
 
-START_SECTION((ModificationDefinition& operator=(const ModificationDefinition &element)))
+START_SECTION((ModificationDefinition& operator=(const ModificationDefinition& element)))
 {
   ModificationDefinition mod_def;
   mod_def.setFixedModification(true);
@@ -161,16 +179,16 @@ START_SECTION((ModificationDefinition& operator=(const ModificationDefinition &e
 }
 END_SECTION
 
-START_SECTION((bool operator==(const ModificationDefinition &rhs) const ))
+START_SECTION((bool operator==(const ModificationDefinition& rhs) const))
 {
   ModificationDefinition m1, m2;
 	TEST_EQUAL(m1 == m2, true)
 	m1.setFixedModification(false);
 	TEST_EQUAL(m1 == m2, false)
 	m1.setFixedModification(true);
-	m1.setMaxOccurences(15);
+	m1.setMaxOccurrences(15);
 	TEST_EQUAL(m1 == m2, false)
-	m1.setMaxOccurences(0);
+	m1.setMaxOccurrences(0);
 	m1.setModification("Oxidation (M)");
 	TEST_EQUAL(m1 == m2, false)
 	m2.setModification("Oxidation (M)");
@@ -178,16 +196,16 @@ START_SECTION((bool operator==(const ModificationDefinition &rhs) const ))
 }
 END_SECTION
 
-START_SECTION((bool operator!=(const ModificationDefinition &rhs) const ))
+START_SECTION((bool operator!=(const ModificationDefinition& rhs) const))
 {
   ModificationDefinition m1, m2;
   TEST_EQUAL(m1 != m2, false)
   m1.setFixedModification(false);
   TEST_EQUAL(m1 != m2, true)
   m1.setFixedModification(true);
-  m1.setMaxOccurences(15);
+  m1.setMaxOccurrences(15);
   TEST_EQUAL(m1 != m2, true)
-  m1.setMaxOccurences(0);
+  m1.setMaxOccurrences(0);
   m1.setModification("Oxidation (M)");
   TEST_EQUAL(m1 != m2, true)
   m2.setModification("Oxidation (M)");
@@ -195,7 +213,7 @@ START_SECTION((bool operator!=(const ModificationDefinition &rhs) const ))
 }
 END_SECTION
 
-START_SECTION((bool operator<(const OpenMS::ModificationDefinition &) const ))
+START_SECTION((bool operator<(const OpenMS::ModificationDefinition& rhs) const))
 {
   ModificationDefinition m1, m2;
 	m1.setModification("Oxidation (M)");

--- a/src/tests/class_tests/openms/source/ModificationDefinitionsSet_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinitionsSet_test.cpp
@@ -56,7 +56,7 @@ START_SECTION(ModificationDefinitionsSet())
 }
 END_SECTION
 
-START_SECTION((ModificationDefinitionsSet(const ModificationDefinitionsSet &rhs)))
+START_SECTION((ModificationDefinitionsSet(const ModificationDefinitionsSet& rhs)))
 {
   ModificationDefinitionsSet mod_set;
   mod_set.setMaxModifications(2);
@@ -65,7 +65,7 @@ START_SECTION((ModificationDefinitionsSet(const ModificationDefinitionsSet &rhs)
   mod_def.setFixedModification(true);
   mod_def2.setModification("Phospho (T)");
   mod_def2.setFixedModification(false);
-  mod_def2.setMaxOccurences(10);
+  mod_def2.setMaxOccurrences(10);
   ModificationDefinitionsSet mod_set2(mod_set);
 
   TEST_EQUAL(mod_set == mod_set2, true)
@@ -88,14 +88,14 @@ START_SECTION((void setMaxModifications(Size max_mod)))
 }
 END_SECTION
 
-START_SECTION((Size getMaxModifications() const ))
+START_SECTION((Size getMaxModifications() const))
 {
   // tested above
   NOT_TESTABLE
 }
 END_SECTION
 
-START_SECTION((Size getNumberOfModifications() const ))
+START_SECTION((Size getNumberOfModifications() const))
 {
   ModificationDefinitionsSet mod_set(ListUtils::create<String>("Phospho (S),Phospho (T),Phospho (Y)"), ListUtils::create<String>("Carbamidomethyl (C)"));
   TEST_EQUAL(mod_set.getNumberOfModifications(), 4)
@@ -107,7 +107,7 @@ START_SECTION((Size getNumberOfModifications() const ))
 }
 END_SECTION
 
-START_SECTION((Size getNumberOfFixedModifications() const ))
+START_SECTION((Size getNumberOfFixedModifications() const))
 {
   ModificationDefinitionsSet mod_set(ListUtils::create<String>("Phospho (S),Phospho (T),Phospho (Y)"), ListUtils::create<String>("Carbamidomethyl (C)"));
   TEST_EQUAL(mod_set.getNumberOfFixedModifications(), 3)
@@ -119,7 +119,7 @@ START_SECTION((Size getNumberOfFixedModifications() const ))
 }
 END_SECTION
 
-START_SECTION((Size getNumberOfVariableModifications() const ))
+START_SECTION((Size getNumberOfVariableModifications() const))
 {
   ModificationDefinitionsSet mod_set(ListUtils::create<String>("Phospho (S),Phospho (T)"), ListUtils::create<String>("Carbamidomethyl (C),Phospho (Y)"));
   TEST_EQUAL(mod_set.getNumberOfVariableModifications(), 2)
@@ -199,7 +199,7 @@ START_SECTION((void setModifications(const String& fixed_modifications, const St
 }
 END_SECTION
 
-START_SECTION((std::set<ModificationDefinition> getModifications() const ))
+START_SECTION((std::set<ModificationDefinition> getModifications() const))
 {
   ModificationDefinitionsSet mod_set1(ListUtils::create<String>("Phospho (S),Phospho (T),Phospho (Y)"), ListUtils::create<String>("Carbamidomethyl (C)"));
   set<String> fixed_mods, var_mods;
@@ -259,7 +259,7 @@ START_SECTION(const std::set<ModificationDefinition>& getVariableModifications()
 }
 END_SECTION
 
-START_SECTION((std::set<String> getModificationNames() const ))
+START_SECTION((std::set<String> getModificationNames() const))
 {
   ModificationDefinitionsSet mod_set1(ListUtils::create<String>("Phospho (S),Phospho (T),Phospho (Y)"), ListUtils::create<String>("Carbamidomethyl (C)"));
   set<String> mods;
@@ -272,7 +272,23 @@ START_SECTION((std::set<String> getModificationNames() const ))
 }
 END_SECTION
 
-START_SECTION((std::set<String> getFixedModificationNames() const ))
+START_SECTION((void getModificationNames(StringList& fixed_modifications, StringList& variable_modifications) const ))
+{
+  StringList fixed_mods = ListUtils::create<String>("Phospho (S),Phospho (T),Phospho (Y)");
+  StringList var_mods = ListUtils::create<String>("Carbamidomethyl (C)");
+  ModificationDefinitionsSet mod_set(fixed_mods, var_mods);
+
+  StringList fixed_mods_out, var_mods_out;
+  mod_set.getModificationNames(fixed_mods_out, var_mods_out);
+
+  TEST_STRING_EQUAL(ListUtils::concatenate<String>(fixed_mods, ","), 
+                    ListUtils::concatenate<String>(fixed_mods_out, ","));
+  TEST_STRING_EQUAL(ListUtils::concatenate<String>(var_mods, ","), 
+                    ListUtils::concatenate<String>(var_mods_out, ","));
+}
+END_SECTION
+
+START_SECTION((std::set<String> getFixedModificationNames() const))
 {
   ModificationDefinitionsSet mod_set1(ListUtils::create<String>("Phospho (S),Phospho (T),Phospho (Y)"), ListUtils::create<String>("Carbamidomethyl (C)"));
   set<String> mods;
@@ -283,7 +299,7 @@ START_SECTION((std::set<String> getFixedModificationNames() const ))
 }
 END_SECTION
 
-START_SECTION((std::set<String> getVariableModificationNames() const ))
+START_SECTION((std::set<String> getVariableModificationNames() const))
 {
   ModificationDefinitionsSet mod_set1(ListUtils::create<String>("Phospho (S),Phospho (T)"), ListUtils::create<String>("Phospho (Y),Carbamidomethyl (C)"));
   set<String> mods;
@@ -430,6 +446,32 @@ START_SECTION((void findMatches(multimap<double, ModificationDefinition>& matche
   TEST_EQUAL(matches.size(), 2);
   TEST_EQUAL(matches.begin()->second.getModificationName(), "Glu->pyro-Glu (N-term E)");
   TEST_EQUAL((++matches.begin())->second.getModificationName(), "Gln->pyro-Glu (N-term Q)");
+}
+END_SECTION
+
+START_SECTION(void inferFromPeptides(const vector<PeptideIdentification>& peptides))
+{
+  vector<PeptideIdentification> peptides(2);
+  PeptideHit hit;
+  hit.setSequence(AASequence::fromString("AC(Carbamidomethyl)M"));
+  peptides[0].insertHit(hit);
+  hit.setSequence(AASequence::fromString("(Acetyl)AEM"));
+  peptides[0].insertHit(hit);
+  hit.setSequence(AASequence::fromString("AC(Carbamidomethyl)M(Oxidation)"));
+  peptides[1].insertHit(hit);
+
+  ModificationDefinitionsSet mod_defs;
+  mod_defs.inferFromPeptides(peptides);
+  set<String> mods = mod_defs.getFixedModificationNames();
+  TEST_EQUAL(mods.size(), 1);
+  set<String>::const_iterator it = mods.begin();
+  TEST_STRING_EQUAL(*it, "Carbamidomethyl (C)");
+  mods = mod_defs.getVariableModificationNames();
+  TEST_EQUAL(mods.size(), 2);
+  it = mods.begin();
+  TEST_STRING_EQUAL(*it, "Acetyl (N-term)");
+  ++it;
+  TEST_STRING_EQUAL(*it, "Oxidation (M)");
 }
 END_SECTION
 

--- a/src/tests/topp/IDFileConverter_9_output.mzid
+++ b/src/tests/topp/IDFileConverter_9_output.mzid
@@ -74,8 +74,6 @@
 		<AdditionalSearchParams>
 			<userParam name="charges" unitName="xsd:string" value="+1, +2"/>
 		</AdditionalSearchParams>
-		<ModificationParams>
-		</ModificationParams>
 		<Enzymes independent="false">
 			<Enzyme missedCleavages="0" id="ENZ_7804704400743266335">
 				<EnzymeName>

--- a/src/tests/topp/IDFileConverter_9_output.mzid
+++ b/src/tests/topp/IDFileConverter_9_output.mzid
@@ -6,8 +6,8 @@
 	id="OpenMS_14509930621887606273"
 	creationDate="2017-04-26T17:30:00">
 <cvList>
-	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv> 
- 	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv> 
+	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv>
+ 	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv>
 	<cv id="UO"     fullName="UNIT-ONTOLOGY" uri="https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo"></cv>
 </cvList>
 <AnalysisSoftwareList>
@@ -36,22 +36,22 @@
 	</DBSequence>
 	<Peptide id="PEP_14811341817612382122" name="PEPTIDERR">
 		<PeptideSequence>PEPTIDERR</PeptideSequence>
-	</Peptide> 
+	</Peptide>
  	<Peptide id="PEP_15050004366391181853" name="N[3899.3500281914]PEPTIDEK">
 		<PeptideSequence>NPEPTIDEK</PeptideSequence>
 		<Modification location="1" residues="N" monoisotopicMassDelta="3785.3071">
-			<cvParam cvRef="MS" accession="MS:1001460" name="unknown modification" value="N-Glycan"/>
+			<cvParam cvRef="MS" accession="MS:1001460" name="unknown modification"/>
 		</Modification>
-	</Peptide> 
+	</Peptide>
  	<Peptide id="PEP_16907355690727166316" name="PEPTIDER">
 		<PeptideSequence>PEPTIDER</PeptideSequence>
-	</Peptide> 
+	</Peptide>
  	<Peptide id="PEP_3023658190814908261" name="PEPTIDERRR">
 		<PeptideSequence>PEPTIDERRR</PeptideSequence>
-	</Peptide> 
+	</Peptide>
  	<Peptide id="PEP_7276556891837796968" name="PEPTIDERRRRR">
 		<PeptideSequence>PEPTIDERRRRR</PeptideSequence>
-	</Peptide> 
+	</Peptide>
  	<PeptideEvidence id="PEV_10306100746905639127" peptide_ref="PEP_16907355690727166316" dBSequence_ref="PROT_13440783915218733453" post="B" pre="A"/>
 	<PeptideEvidence id="PEV_1147219038608936718" peptide_ref="PEP_7276556891837796968" dBSequence_ref="PROT_12999979801269632061"/>
 	<PeptideEvidence id="PEV_12524258085768770586" peptide_ref="PEP_16907355690727166316" dBSequence_ref="PROT_15916652588957785155"/>
@@ -74,6 +74,11 @@
 		<AdditionalSearchParams>
 			<userParam name="charges" unitName="xsd:string" value="+1, +2"/>
 		</AdditionalSearchParams>
+		<ModificationParams>
+			<SearchModification fixedMod="true" massDelta="3785.3071" residues="N">
+				<cvParam cvRef="MS" accession="MS:1001460" name="unknown modification"/>
+			</SearchModification>
+		</ModificationParams>
 		<Enzymes independent="false">
 			<Enzyme missedCleavages="0" id="ENZ_7804704400743266335">
 				<EnzymeName>
@@ -168,7 +173,7 @@
 			</FragmentationTable>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:nan@RT:nan" id="SIR_16250062551099875712">
 				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_7276556891837796968" calculatedMassToCharge="1580.87280307147" experimentalMassToCharge="nan" chargeState="1" id="SII_11115414975438642789">
-					<PeptideEvidenceRef peptideEvidence_ref="PEV_1147219038608936718"/> 
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_1147219038608936718"/>
 					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="1.4"/>
 				</SpectrumIdentificationItem>
@@ -188,8 +193,8 @@
 			</FragmentationTable>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="17" id="SIR_17413765565443951891">
 				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="PEP_16907355690727166316" calculatedMassToCharge="956.468357540271" experimentalMassToCharge="675.9" chargeState="1" id="SII_1755235105885170967">
-					<PeptideEvidenceRef peptideEvidence_ref="PEV_10306100746905639127"/> 
-					<PeptideEvidenceRef peptideEvidence_ref="PEV_12524258085768770586"/> 
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_10306100746905639127"/>
+					<PeptideEvidenceRef peptideEvidence_ref="PEV_12524258085768770586"/>
 					<cvParam accession="MS:1001143" cvRef="PSI-MS" name="PSM-level search engine specific statistic"/>
 					<userParam name="MOWSE" unitName="xsd:double" value="0.9"/>
 					<userParam name="name" unitName="xsd:string" value="PeptideHit"/>


### PR DESCRIPTION
As discussed in #2528:
When writing mzIdentML, infer fixed/variable modifications used from search results (peptide IDs), if none are defined in the search parameters.