### PR TITLE
fixes to build.bat on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,10 +269,14 @@ foreach(p LIB BIN INCLUDE CMAKE DOC SHARE)
 endforeach()
 
 #------------------------------------------------------------------------------
-# lib naming when building with msvc
+# lib naming when building with msvc & convenience location of build.bat
 if (MSVC)
 	## use OpenMSd.dll in debug mode
 	SET(CMAKE_DEBUG_POSTFIX d)
+	## copy build.bat to root of binary dir to enable convenient invokation (instead of typing path to source dir all the time)
+	if(NOT ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}"))
+		file(COPY "${PROJECT_SOURCE_DIR}/tools/build.bat" DESTINATION "${PROJECT_BINARY_DIR}/build.bat")
+	endif()
 endif()
 
 #------------------------------------------------------------------------------

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -64,8 +64,11 @@ if not %ERRORLEVEL%==0 (
   ECHO Visual Studio's 'MSBuild.exe' was not found. Please modify this build.bat to point to the correct location or make it available in %%PATH%%.
   goto end
 )
-REM run with low priority, so the machine is usable, but on full steam when idle
-start /WAIT /B /LOW MSBuild.exe %SLN% /maxcpucount /target:%TARGET% /p:Configuration=%CFG%
+REM Invoke MSBuild.exe
+REM do not use "START /WAIT /B /LOW ..." since: 
+REM   - it does not allow to cancel the job on the console (it will keep running in the background)
+REM   - it might trick MSBuild.exe into assuming only single-core CPU, even if /maxcpucount is specified
+MSBuild.exe %SLN% /maxcpucount /target:%TARGET% /p:Configuration=%CFG%
 
 
 :end


### PR DESCRIPTION
[FIX] remove subprocess with low prio from build.bat since it caused trouble:
  - it does not allow to cancel the job on the console (it will keep running in the background)
  - it might trick MSBuild.exe into assuming only single-core CPU, even if /maxcpucount is specified
fixed now by just not spawning a child process

[FEATURE] convenience feature for Windows builds (to enable similar behaviour as in 'make ...') for MSVS generators.
before (in root binary dir): `$ ..\openms\tools\build.bat ....`
now: `$ build.bat ..`
This goes along nicely with other commands like `ctest ...` in the same directory