### PR TITLE
[FIX] LuciPhorAdapter - Delete internal conversion to 64bit  

### DIFF
--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -521,7 +521,7 @@ protected:
     PeakMap exp;
     MzMLFile file;
     file.setLogType(log_type_);
-    String in_tmp;
+    //String in_tmp;
     PeakFileOptions options;
     options.clearMSLevels();
     options.addMSLevel(2);
@@ -530,13 +530,13 @@ protected:
     exp.sortSpectra(true);
 
     // check if mz/intenisty precision have different values - set them to 64-bit - see issue #2381
-    writeLog_("Warning: Luciphor requires a precision of either 32 or 64-bit float. Precision is automtically converted to 64-bit float.");
+    //writeLog_("Warning: Luciphor requires a precision of either 32 or 64-bit float. Precision is automtically converted to 64-bit float.");
 
-    file.getOptions().setMz32Bit(false);
-    file.getOptions().setIntensity32Bit(false);
-    String in_file_name = File::removeExtension(File::basename(in));
-    in_tmp = temp_dir + in_file_name + ".mzML";
-    file.store(in_tmp, exp);
+    //file.getOptions().setMz32Bit(false);
+    //file.getOptions().setIntensity32Bit(false);
+    //String in_file_name = File::removeExtension(File::basename(in));
+    //in_tmp = temp_dir + in_file_name + ".mzML";
+    //file.store(in_tmp, exp);
 
     // convert input to pepXML if necessary
     if (in_type == FileTypes::IDXML)
@@ -548,7 +548,7 @@ protected:
       String id_file_name = File::removeExtension(File::basename(id));
       id = temp_dir + id_file_name + ".pepXML";
       
-      PepXMLFile().store(id, prot_ids, pep_ids, in_tmp, "", false);
+      PepXMLFile().store(id, prot_ids, pep_ids, in, "", false);
     }
     else
     {
@@ -568,7 +568,7 @@ protected:
     map<String, vector<String> > config_map;
     String selection_method = getSelectionMethod_(pep_ids[0], prot_ids.begin()->getSearchEngine());
     
-    ExitCodes ret = parseParameters_(config_map, id, in_tmp, out, target_mods, selection_method);
+    ExitCodes ret = parseParameters_(config_map, id, in, out, target_mods, selection_method);
     if (ret != EXECUTION_OK)
     {
       return ret;

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -521,22 +521,12 @@ protected:
     PeakMap exp;
     MzMLFile file;
     file.setLogType(log_type_);
-    //String in_tmp;
     PeakFileOptions options;
     options.clearMSLevels();
     options.addMSLevel(2);
 
     file.load(in, exp);
     exp.sortSpectra(true);
-
-    // check if mz/intenisty precision have different values - set them to 64-bit - see issue #2381
-    //writeLog_("Warning: Luciphor requires a precision of either 32 or 64-bit float. Precision is automtically converted to 64-bit float.");
-
-    //file.getOptions().setMz32Bit(false);
-    //file.getOptions().setIntensity32Bit(false);
-    //String in_file_name = File::removeExtension(File::basename(in));
-    //in_tmp = temp_dir + in_file_name + ".mzML";
-    //file.store(in_tmp, exp);
 
     // convert input to pepXML if necessary
     if (in_type == FileTypes::IDXML)


### PR DESCRIPTION
Issue #2381 was fixed on the LuXor side [1].
Right now the updated version is available on damians webserver [2].

[1] https://github.com/dfermin/lucXor/issues/2
[2] http://dfermin.com/files/downloads/luciphorUpdate.zip