### PR TITLE
TSG without charge defaults

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/TheoreticalSpectrumGenerator.h
@@ -86,7 +86,7 @@ namespace OpenMS
      */
     //@{
     /// returns a spectrum with the ion types, that are set in the tool parameters
-    virtual void getSpectrum(PeakSpectrum & spec, const AASequence & peptide, Int min_charge = 1, Int max_charge = 1) const;
+    virtual void getSpectrum(PeakSpectrum & spec, const AASequence & peptide, Int min_charge, Int max_charge) const;
 
     /// overwrite
     void updateMembers_();

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -492,8 +492,8 @@ namespace OpenMS
         }
       }
 
-      // we mono-charge spectra, generating b- and y-ions with charge 1 is the default behavior of the TSG
-      spectrum_generator.getSpectrum(th_spectra[i], seq);
+      // we mono-charge spectra, generating b- and y-ions is the default behavior of the TSG
+      spectrum_generator.getSpectrum(th_spectra[i], seq, 1, 1);
       th_spectra[i].setName(seq.toString());
     }
     return th_spectra;

--- a/src/tests/class_tests/openms/source/CompNovoIdentificationCID_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIdentificationCID_test.cpp
@@ -94,7 +94,7 @@ START_SECTION((void getIdentifications(std::vector<PeptideIdentification>& ids, 
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;
-  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"));
+  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"), 1, 1);
 
   PeakSpectrum spec;
   for (Size i = 0; i != rspec.size(); ++i)
@@ -133,7 +133,7 @@ START_SECTION((void getIdentification(PeptideIdentification& id, const PeakSpect
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;
-  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"));
+  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"), 1, 1);
 
   PeakSpectrum spec;
   for (Size i = 0; i != rspec.size(); ++i)

--- a/src/tests/class_tests/openms/source/CompNovoIdentification_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIdentification_test.cpp
@@ -86,7 +86,7 @@ START_SECTION((void getIdentifications(std::vector< PeptideIdentification > &ids
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;
-  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"));
+  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"), 1, 1);
 
   PeakSpectrum spec;
   for (Size i = 0; i != rspec.size(); ++i)
@@ -103,7 +103,7 @@ START_SECTION((void getIdentifications(std::vector< PeptideIdentification > &ids
   tsg_param.setValue("add_y_ions", "false");
   tsg_param.setValue("add_z_ions", "true");
   tsg.setParameters(tsg_param);
-  tsg.getSpectrum(rspec_ETD, AASequence::fromString("DFPIANGER"));
+  tsg.getSpectrum(rspec_ETD, AASequence::fromString("DFPIANGER"), 1, 1);
 
   tsg_param.setValue("add_z_ions", "false");
   tsg_param.setValue("add_precursor_peaks", "true");
@@ -152,7 +152,7 @@ START_SECTION((void getIdentification(PeptideIdentification &id, const PeakSpect
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;
-  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"));
+  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"), 1, 1);
 
   PeakSpectrum spec;
   for (Size i = 0; i != rspec.size(); ++i)
@@ -169,7 +169,7 @@ START_SECTION((void getIdentification(PeptideIdentification &id, const PeakSpect
   tsg_param.setValue("add_y_ions", "false");
   tsg_param.setValue("add_z_ions", "true");
   tsg.setParameters(tsg_param);
-  tsg.getSpectrum(rspec_ETD, AASequence::fromString("DFPIANGER"));
+  tsg.getSpectrum(rspec_ETD, AASequence::fromString("DFPIANGER"), 1, 1);
 
   tsg_param.setValue("add_z_ions", "false");
   tsg_param.setValue("add_precursor_peaks", "true");

--- a/src/tests/class_tests/openms/source/CompNovoIonScoringCID_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIonScoringCID_test.cpp
@@ -87,7 +87,7 @@ START_SECTION((void scoreSpectrum(Map<double, IonScore>& CID_ion_scores, PeakSpe
 	tsg.setParameters(tsg_param);
 
 	PeakSpectrum rspec;
-	tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"));
+	tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"), 1, 1);
 
 	PeakSpectrum spec;
 	for (Size i = 0; i != rspec.size(); ++i)

--- a/src/tests/class_tests/openms/source/CompNovoIonScoring_test.cpp
+++ b/src/tests/class_tests/openms/source/CompNovoIonScoring_test.cpp
@@ -87,7 +87,7 @@ START_SECTION((void scoreSpectra(Map< double, IonScore > &CID_ion_scores, PeakSp
   tsg.setParameters(tsg_param);
 
   PeakSpectrum rspec;
-  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"));
+  tsg.getSpectrum(rspec, AASequence::fromString("DFPIANGER"), 1, 1);
 
   PeakSpectrum spec;
   for (Size i = 0; i != rspec.size(); ++i)
@@ -104,7 +104,7 @@ START_SECTION((void scoreSpectra(Map< double, IonScore > &CID_ion_scores, PeakSp
   tsg_param.setValue("add_y_ions", "false");
   tsg_param.setValue("add_z_ions", "true");
   tsg.setParameters(tsg_param);
-  tsg.getSpectrum(rspec_ETD, AASequence::fromString("DFPIANGER"));
+  tsg.getSpectrum(rspec_ETD, AASequence::fromString("DFPIANGER"), 1, 1);
 
   tsg_param.setValue("add_z_ions", "false");
   tsg_param.setValue("add_precursor_peaks", "true");

--- a/src/tests/class_tests/openms/source/MRMFragmentSelection_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFragmentSelection_test.cpp
@@ -97,7 +97,7 @@ START_SECTION((void selectFragments(std::vector< Peak1D > &selected_peaks, const
 	Param tsg_param(tsg.getParameters());
 	tsg_param.setValue("add_metainfo", "true");
 	tsg.setParameters(tsg_param);
-	tsg.getSpectrum(spec, AASequence::fromString("DFPIANGER"));
+	tsg.getSpectrum(spec, AASequence::fromString("DFPIANGER"), 1, 1);
 
 	spec.sortByPosition();
 	Precursor prec;

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGenerator_test.cpp
@@ -316,7 +316,7 @@ START_SECTION(void getSpectrum(PeakSpectrum& spec, const AASequence& peptide, In
   param.setValue("add_abundant_immonium_ions", "true");
   ptr->setParameters(param);
   spec.clear(true);
-  ptr->getSpectrum(spec, AASequence::fromString("HFYLWCP"));
+  ptr->getSpectrum(spec, AASequence::fromString("HFYLWCP"), 1, 1);
   TEST_EQUAL(spec.size(), 7)
   TEST_REAL_SIMILAR(spec[0].getPosition()[0], 70.0656)
   TEST_REAL_SIMILAR(spec[1].getPosition()[0], 76.0221)
@@ -327,11 +327,11 @@ START_SECTION(void getSpectrum(PeakSpectrum& spec, const AASequence& peptide, In
   TEST_REAL_SIMILAR(spec[6].getPosition()[0], 159.0922)
 
   spec.clear(true);
-  ptr->getSpectrum(spec, AASequence::fromString("H"));
+  ptr->getSpectrum(spec, AASequence::fromString("H"), 1, 1);
   TEST_EQUAL(spec.size(), 1)
 
   spec.clear(true);
-  ptr->getSpectrum(spec, AASequence::fromString("A"));
+  ptr->getSpectrum(spec, AASequence::fromString("A"), 1, 1);
   TEST_EQUAL(spec.size(), 0)
 
 

--- a/src/utils/IDMassAccuracy.cpp
+++ b/src/utils/IDMassAccuracy.cpp
@@ -271,7 +271,7 @@ protected:
               PeptideHit hit = *it->getHits().begin();
 
               PeakSpectrum theo_spec;
-              tsg.getSpectrum(theo_spec, hit.getSequence());
+              tsg.getSpectrum(theo_spec, hit.getSequence(), 1, 1);
 
               vector<pair<Size, Size> > pairs;
               sa.getSpectrumAlignment(pairs, theo_spec, maps_raw[i][j]);


### PR DESCRIPTION
as discussed in #2613 

Removed charge default values for getSpectrum() and set mincharge = 1 and maxcharge = 1 everywhere getSpectrum() was called without specifying the charge.