### PR TITLE
[FIX] fix error with CMake 3.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ if (MSVC)
 	SET(CMAKE_DEBUG_POSTFIX d)
 	## copy build.bat to root of binary dir to enable convenient invokation (instead of typing path to source dir all the time)
 	if(NOT ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}"))
-		file(COPY "${PROJECT_SOURCE_DIR}/tools/build.bat" DESTINATION "${PROJECT_BINARY_DIR}/build.bat")
+		file(COPY "${PROJECT_SOURCE_DIR}/tools/build.bat" DESTINATION "${PROJECT_BINARY_DIR}")
 	endif()
 endif()
 


### PR DESCRIPTION
-- Compiler checks for conversion: OFF
CMake Error at CMakeLists.txt:278 (file):
  file COPY cannot copy file "C:/dev/OpenMS/tools/build.bat" to
  "C:/dev/OpenMS_build/build.bat/build.bat".
-- Boost version: 1.61.0