### PR TITLE
Fix/mzid XL-MS mods

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -1761,7 +1761,7 @@ namespace OpenMS
         ph_alpha.setMetaValue("xl_pos", ++alpha_pos);
         ph_alpha.setMetaValue("xl_term_spec", "N_TERM");
       }
-      else if (alpha_pos == static_cast<SignedSize>((*pep_map_.find(peptides[alpha[0]])).second.size()))
+      else if (alpha_pos == static_cast<SignedSize>(ph_alpha.getSequence().size()))
       {
         ph_alpha.setMetaValue("xl_pos", --alpha_pos);
         ph_alpha.setMetaValue("xl_term_spec", "C_TERM");
@@ -1821,7 +1821,7 @@ namespace OpenMS
           ph_beta.setMetaValue("xl_pos", ++beta_pos);
           ph_beta.setMetaValue("xl_term_spec", "N_TERM");
         }
-        else if (beta_pos == static_cast<SignedSize>((*pep_map_.find(peptides[beta[0]])).second.size()))
+        else if (beta_pos == static_cast<SignedSize>(ph_beta.getSequence().size()))
         {
           ph_beta.setMetaValue("xl_pos", --beta_pos);
           ph_beta.setMetaValue("xl_term_spec", "C_TERM");

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -958,12 +958,7 @@ namespace OpenMS
               {
                 CrossLinksDB* xl_db = CrossLinksDB::getInstance();
                 std::vector<String> mods;
-                xl_db->searchModificationsByDiffMonoMass(mods, double(jt->getMetaValue("xl_mass")), 0.0001, String(jt->getSequence()[i].getOneLetterCode()), ResidueModification::ANYWHERE);
-                if (mods.size() > 0)
-                {
-                  p += "\t\t<Modification location=\"" + String(i + 1);
-                }
-                else if (jt->metaValueExists("xl_term_spec") && jt->getMetaValue("xl_term_spec") == "N_TERM")
+                if (jt->metaValueExists("xl_term_spec") && jt->getMetaValue("xl_term_spec") == "N_TERM")
                 {
                   xl_db->searchModificationsByDiffMonoMass(mods, double(jt->getMetaValue("xl_mass")), 0.0001, "", ResidueModification::N_TERM);
                   if (mods.size() > 0)
@@ -977,6 +972,14 @@ namespace OpenMS
                   if (mods.size() > 0)
                   {
                     p += "\t\t<Modification location=\"" + String(i + 2);
+                  }
+                }
+                else
+                {
+                  xl_db->searchModificationsByDiffMonoMass(mods, double(jt->getMetaValue("xl_mass")), 0.0001, String(jt->getSequence()[i].getOneLetterCode()), ResidueModification::ANYWHERE);
+                  if (mods.size() > 0)
+                  {
+                    p += "\t\t<Modification location=\"" + String(i + 1);
                   }
                 }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -963,8 +963,7 @@ namespace OpenMS
                 {
                   p += "\t\t<Modification location=\"" + String(i + 1);
                 }
-
-                if (jt->metaValueExists("xl_term_spec") && jt->getMetaValue("xl_term_spec") == "N_TERM")
+                else if (jt->metaValueExists("xl_term_spec") && jt->getMetaValue("xl_term_spec") == "N_TERM")
                 {
                   xl_db->searchModificationsByDiffMonoMass(mods, double(jt->getMetaValue("xl_mass")), 0.0001, "", ResidueModification::N_TERM);
                   if (mods.size() > 0)

--- a/src/tests/class_tests/openms/data/MzIdentML_XLMS_unlabelled.mzid
+++ b/src/tests/class_tests/openms/data/MzIdentML_XLMS_unlabelled.mzid
@@ -57,7 +57,7 @@
 		</Modification> 
 	</Peptide> 
  	<Peptide id="PEP_16117466574459042045"> 
-		<PeptideSequence>LMVEMEKKLEK</PeptideSequence> 
+		<PeptideSequence>KMVEMEKKLEK</PeptideSequence> 
 		<Modification location="2" residues="M"> 
 			<cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD"/>
 		</Modification> 


### PR DESCRIPTION
fixed an error with terminal modifications, that appeared when a cross-link modification would be possible at both the peptide terminal and the side chain of the terminal residue