### PR TITLE
[FIX] Rename parameter small to tiny in XQuestResultXMLHandler

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XQuestResultXMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XQuestResultXMLHandler.h
@@ -61,13 +61,6 @@ namespace OpenMS
       // Decoy string used by xQuest
       static const String decoy_string;
 
-      /**
-       * @brief Removes a substring from a larger string
-       * @param large String from which `small` should be removed
-       * @param small Substring to be removed from `large`
-       */
-      static void removeSubstring(String & large, const String & small);
-
       XQuestResultXMLHandler(const String & filename,
                              std::vector< std::vector< PeptideIdentification > > & csms,
                              std::vector< ProteinIdentification > & prot_ids,

--- a/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
@@ -54,15 +54,6 @@ namespace OpenMS
 {
   namespace Internal
   {
-    void XQuestResultXMLHandler::removeSubstring(String &  large, const String & small)
-    {
-      std::string::size_type i = large.find(small);
-      if (i != std::string::npos)
-      {
-        large.erase(i, small.length());
-      }
-    }
-
     // Initialize static const members
     std::map< Size, String > XQuestResultXMLHandler::enzymes = boost::assign::map_list_of(0, "no_enzyme")
         (1, "trypsin") (2, "chymotrypsin") (3, "unknown_enzyme") (9, "unknown_enzyme")
@@ -485,20 +476,23 @@ namespace OpenMS
           this->setPeptideEvidence_(prot2_string, peptide_hit_beta);
 
           // Determine if protein is intra/inter protein, check all protein ID combinations
-          XQuestResultXMLHandler::removeSubstring(prot1_string, "reverse_");
-          XQuestResultXMLHandler::removeSubstring(prot1_string, XQuestResultXMLHandler::decoy_string);
           StringList prot1_list;
-          StringUtils::split(prot1_string, ",", prot1_list);
-          XQuestResultXMLHandler::removeSubstring(prot2_string, "reverse_");
-          XQuestResultXMLHandler::removeSubstring(prot2_string, XQuestResultXMLHandler::decoy_string);
+          prot1_string.split(",", prot1_list);
           StringList prot2_list;
-          StringUtils::split(prot2_string, ",", prot2_list);
+          prot2_string.split( ",", prot2_list);
 
           for (StringList::const_iterator it1 = prot1_list.begin(); it1 != prot1_list.end(); ++it1)
           {
             for (StringList::const_iterator it2 = prot2_list.begin(); it2 != prot2_list.end(); ++it2)
             {
-              this->setMetaValue_((*it1 == *it2) ? "OpenXQuest:is_intraprotein" : "OpenXQuest:is_interprotein",
+              String s1 = *it1;
+              String s2 = *it2;
+              s1.substitute("reverse_", "");
+              s2.substitute("reverse_", "");
+              s1.substitute(XQuestResultXMLHandler::decoy_string, "");
+              s2.substitute(XQuestResultXMLHandler::decoy_string, "");
+
+              this->setMetaValue_((s1.compare(s2) == 0) ? "OpenXQuest:is_intraprotein" : "OpenXQuest:is_interprotein",
                                  DataValue(), peptide_identification, peptide_hit_alpha, peptide_hit_beta);
             }
           }

--- a/src/tests/topp/XFDR_test_out1.idXML
+++ b/src/tests/topp/XFDR_test_out1.idXML
@@ -9,7 +9,7 @@
 				<UserParam type="float" name="cross_link:mass" value="138.068"/>
 				<UserParam type="floatList" name="cross_link:mass_monolink" value="[]"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-03-19T10:18:40" search_engine="OpenXQuest" search_engine_version="2.1.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-03-19T10:18:40" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q00610|CLH1_HUMAN" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16220,6 +16220,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16240,6 +16241,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>
@@ -16279,6 +16281,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16299,6 +16302,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>
@@ -16338,6 +16342,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16358,6 +16363,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>
@@ -16397,6 +16403,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16417,6 +16424,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>
@@ -16456,6 +16464,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16476,6 +16485,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>

--- a/src/tests/topp/XFDR_test_out1.mzid
+++ b/src/tests/topp/XFDR_test_out1.mzid
@@ -4,7 +4,7 @@
 	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
 	version="1.2.0"
 	id="OpenMS_14193355489762212779"
-	creationDate="2017-05-29T19:01:23">
+	creationDate="2017-06-29T15:49:38">
 <cvList>
 	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv>
  	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv>
@@ -12,12 +12,12 @@
 	<cv id="XLMOD" fullName="PSI cross-link modifications" uri="https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/cv/XLMOD-1.0.0.obo"></cv>
 </cvList>
 <AnalysisSoftwareList>
-	<AnalysisSoftware version="2.1.0" name="OpenXQuest" id="SOF_5233264595117471314">
+	<AnalysisSoftware version="2.2.0" name="OpenXQuest" id="SOF_5233264595117471314">
 		<SoftwareName>
 			<cvParam accession="MS:1002673" cvRef="PSI-MS" name="OpenXQuest"/>
 		</SoftwareName>
 	</AnalysisSoftware>
-	<AnalysisSoftware version="OpenMS TOPP v2.1.0" name="TOPP software" id="SOF_5423254966924642681">
+	<AnalysisSoftware version="OpenMS TOPP v2.2.0" name="TOPP software" id="SOF_5423254966924642681">
 		<SoftwareName>
 			<cvParam accession="MS:1000752" cvRef="PSI-MS" name="TOPP software"/>
 		</SoftwareName>
@@ -14473,7 +14473,7 @@
 
 			</SpectrumIdentificationResult>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:1519.37@RT:6765.9618" id="SIR_16101088304003132387">
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_3601688524572798328" calculatedMassToCharge="1495.03234485711" experimentalMassToCharge="1519.37" chargeState="3" id="SII_11184329573663994065">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_3601688524572798328" calculatedMassToCharge="1495.0323448571" experimentalMassToCharge="1519.37" chargeState="3" id="SII_11184329573663994065">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_539559773257577354"/>
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_9262076981138252282"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0.8"/>
@@ -14493,7 +14493,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="6765.9618" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_10556180959338053167" calculatedMassToCharge="1495.03234485711" experimentalMassToCharge="1519.37" chargeState="3" id="SII_4157858707185633848">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_10556180959338053167" calculatedMassToCharge="1495.0323448571" experimentalMassToCharge="1519.37" chargeState="3" id="SII_4157858707185633848">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_5553431058032124892"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0.8"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="9573169573964579006"/>
@@ -15222,7 +15222,7 @@
 
 			</SpectrumIdentificationResult>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:1541.5@RT:930.80898" id="SIR_1086578445474264001">
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_16432043867125160671" calculatedMassToCharge="1536.17307371641" experimentalMassToCharge="1541.5" chargeState="3" id="SII_5633142567047727860">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_16432043867125160671" calculatedMassToCharge="1536.1730737164" experimentalMassToCharge="1541.5" chargeState="3" id="SII_5633142567047727860">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_4044805094374952298"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="1.16666666666667"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="10456593414727933644"/>
@@ -15241,7 +15241,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="930.80898" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_18267342391176846178" calculatedMassToCharge="1536.17307371641" experimentalMassToCharge="1541.5" chargeState="3" id="SII_871689549992079890">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_18267342391176846178" calculatedMassToCharge="1536.1730737164" experimentalMassToCharge="1541.5" chargeState="3" id="SII_871689549992079890">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_6920816173396981611"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="1.16666666666667"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="10456593414727933644"/>
@@ -16446,6 +16446,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16465,6 +16466,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16487,6 +16489,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16506,6 +16509,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16528,6 +16532,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16547,6 +16552,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16569,6 +16575,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16588,6 +16595,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16610,6 +16618,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16629,6 +16638,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -19160,7 +19170,7 @@
 
 			</SpectrumIdentificationResult>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:892.79@RT:2410.39818" id="SIR_4058429415078032668">
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_4940712765740728464" calculatedMassToCharge="887.458449153305" experimentalMassToCharge="892.79" chargeState="3" id="SII_18334097326180128378">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_4940712765740728464" calculatedMassToCharge="887.458449153304" experimentalMassToCharge="892.79" chargeState="3" id="SII_18334097326180128378">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_2816703895052184855"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0.8"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="6801914501498646962"/>
@@ -19179,7 +19189,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="2410.39818" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_607610266770354631" calculatedMassToCharge="887.458449153305" experimentalMassToCharge="892.79" chargeState="3" id="SII_14219463416683378859">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_607610266770354631" calculatedMassToCharge="887.458449153304" experimentalMassToCharge="892.79" chargeState="3" id="SII_14219463416683378859">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_250585267694080513"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0.8"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="6801914501498646962"/>
@@ -19392,7 +19402,7 @@
 
 			</SpectrumIdentificationResult>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:899.431@RT:3329.38374" id="SIR_5943838227366773324">
-				<SpectrumIdentificationItem passThreshold="1" rank="2" peptide_ref="PEP_3236868036104089185" calculatedMassToCharge="875.092194324905" experimentalMassToCharge="899.431" chargeState="6" id="SII_13324810634805258923">
+				<SpectrumIdentificationItem passThreshold="1" rank="2" peptide_ref="PEP_3236868036104089185" calculatedMassToCharge="875.092194324904" experimentalMassToCharge="899.431" chargeState="6" id="SII_13324810634805258923">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_17814092663284306397"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="16249502597361826150"/>
@@ -19411,7 +19421,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="3329.38374" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="2" peptide_ref="PEP_18377228393002342968" calculatedMassToCharge="875.092194324905" experimentalMassToCharge="899.431" chargeState="6" id="SII_14234156667786692686">
+				<SpectrumIdentificationItem passThreshold="1" rank="2" peptide_ref="PEP_18377228393002342968" calculatedMassToCharge="875.092194324904" experimentalMassToCharge="899.431" chargeState="6" id="SII_14234156667786692686">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_194534777427100740"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="16249502597361826150"/>
@@ -19430,7 +19440,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="3329.38374" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="4" peptide_ref="PEP_4948782538710141753" calculatedMassToCharge="875.092194324905" experimentalMassToCharge="899.431" chargeState="6" id="SII_12949425920353303179">
+				<SpectrumIdentificationItem passThreshold="1" rank="4" peptide_ref="PEP_4948782538710141753" calculatedMassToCharge="875.092194324904" experimentalMassToCharge="899.431" chargeState="6" id="SII_12949425920353303179">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_4069130788001053166"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="3991982789787860427"/>
@@ -19449,7 +19459,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="3329.38374" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="4" peptide_ref="PEP_2010809438251300505" calculatedMassToCharge="875.092194324905" experimentalMassToCharge="899.431" chargeState="6" id="SII_3825773810782407075">
+				<SpectrumIdentificationItem passThreshold="1" rank="4" peptide_ref="PEP_2010809438251300505" calculatedMassToCharge="875.092194324904" experimentalMassToCharge="899.431" chargeState="6" id="SII_3825773810782407075">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_3812015869957966874"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="3991982789787860427"/>

--- a/src/tests/topp/XFDR_test_out2.idXML
+++ b/src/tests/topp/XFDR_test_out2.idXML
@@ -9,7 +9,7 @@
 				<UserParam type="float" name="cross_link:mass" value="138.068"/>
 				<UserParam type="floatList" name="cross_link:mass_monolink" value="[]"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-03-19T10:18:40" search_engine="OpenXQuest" search_engine_version="2.1.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-03-19T10:18:40" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q00610|CLH1_HUMAN" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16220,6 +16220,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16240,6 +16241,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>
@@ -16279,6 +16281,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16299,6 +16302,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>
@@ -16338,6 +16342,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16358,6 +16363,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>
@@ -16397,6 +16403,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16417,6 +16424,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>
@@ -16456,6 +16464,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="7"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<PeptideHit score="3" sequence="DGDKK" charge="3" protein_refs="PH_21" >
 				<UserParam type="string" name="target_decoy" value="target"/>
@@ -16476,6 +16485,7 @@
 				<UserParam type="string" name="xl_type" value="cross-link"/>
 				<UserParam type="int" name="xl_pos" value="3"/>
 				<UserParam type="string" name="OpenXQuest:is_interprotein" value=""/>
+				<UserParam type="string" name="OpenXQuest:is_intraprotein" value=""/>
 			</PeptideHit>
 			<UserParam type="string" name="target_decoy" value="decoy"/>
 			<UserParam type="float" name="OpenXQuest:error_rel" value="-8.70138"/>

--- a/src/tests/topp/XFDR_test_out2.mzid
+++ b/src/tests/topp/XFDR_test_out2.mzid
@@ -4,7 +4,7 @@
 	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
 	version="1.2.0"
 	id="OpenMS_14193355489762212779"
-	creationDate="2017-05-29T19:01:57">
+	creationDate="2017-06-29T15:54:11">
 <cvList>
 	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv>
  	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv>
@@ -12,12 +12,12 @@
 	<cv id="XLMOD" fullName="PSI cross-link modifications" uri="https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/cv/XLMOD-1.0.0.obo"></cv>
 </cvList>
 <AnalysisSoftwareList>
-	<AnalysisSoftware version="2.1.0" name="OpenXQuest" id="SOF_5233264595117471314">
+	<AnalysisSoftware version="2.2.0" name="OpenXQuest" id="SOF_5233264595117471314">
 		<SoftwareName>
 			<cvParam accession="MS:1002673" cvRef="PSI-MS" name="OpenXQuest"/>
 		</SoftwareName>
 	</AnalysisSoftware>
-	<AnalysisSoftware version="OpenMS TOPP v2.1.0" name="TOPP software" id="SOF_5423254966924642681">
+	<AnalysisSoftware version="OpenMS TOPP v2.2.0" name="TOPP software" id="SOF_5423254966924642681">
 		<SoftwareName>
 			<cvParam accession="MS:1000752" cvRef="PSI-MS" name="TOPP software"/>
 		</SoftwareName>
@@ -14473,7 +14473,7 @@
 
 			</SpectrumIdentificationResult>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:1519.37@RT:6765.9618" id="SIR_16101088304003132387">
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_3601688524572798328" calculatedMassToCharge="1495.03234485711" experimentalMassToCharge="1519.37" chargeState="3" id="SII_11184329573663994065">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_3601688524572798328" calculatedMassToCharge="1495.0323448571" experimentalMassToCharge="1519.37" chargeState="3" id="SII_11184329573663994065">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_539559773257577354"/>
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_9262076981138252282"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0.8"/>
@@ -14493,7 +14493,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="6765.9618" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_10556180959338053167" calculatedMassToCharge="1495.03234485711" experimentalMassToCharge="1519.37" chargeState="3" id="SII_4157858707185633848">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_10556180959338053167" calculatedMassToCharge="1495.0323448571" experimentalMassToCharge="1519.37" chargeState="3" id="SII_4157858707185633848">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_5553431058032124892"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0.8"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="9573169573964579006"/>
@@ -15222,7 +15222,7 @@
 
 			</SpectrumIdentificationResult>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:1541.5@RT:930.80898" id="SIR_1086578445474264001">
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_16432043867125160671" calculatedMassToCharge="1536.17307371641" experimentalMassToCharge="1541.5" chargeState="3" id="SII_5633142567047727860">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_16432043867125160671" calculatedMassToCharge="1536.1730737164" experimentalMassToCharge="1541.5" chargeState="3" id="SII_5633142567047727860">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_4044805094374952298"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="1.18181818181818"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="10456593414727933644"/>
@@ -15241,7 +15241,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="930.80898" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_18267342391176846178" calculatedMassToCharge="1536.17307371641" experimentalMassToCharge="1541.5" chargeState="3" id="SII_871689549992079890">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_18267342391176846178" calculatedMassToCharge="1536.1730737164" experimentalMassToCharge="1541.5" chargeState="3" id="SII_871689549992079890">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_6920816173396981611"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="1.18181818181818"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="10456593414727933644"/>
@@ -16446,6 +16446,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16465,6 +16466,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16487,6 +16489,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16506,6 +16509,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16528,6 +16532,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16547,6 +16552,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16569,6 +16575,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16588,6 +16595,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16610,6 +16618,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="0"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="decoy_reverse_sp|Q9UPN3|MACF1_HUMAN,tr|Q8TBA7|Q8TBA7_HUMAN,decoy_reverse_sp|P07900|HS90A_HUMAN,decoy_reverse_tr|Q8TBA7|Q8TBA7_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -16629,6 +16638,7 @@
 					<userParam name="OpenXQuest:num_of_matched_ions" unitName="xsd:integer" value="1"/>
 					<userParam name="OpenXQuest:prot" unitName="xsd:string" value="sp|P07900|HS90A_HUMAN"/>
 					<userParam name="OpenXQuest:is_interprotein" unitName="xsd:string" value=""/>
+					<userParam name="OpenXQuest:is_intraprotein" unitName="xsd:string" value=""/>
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5849.43138" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
@@ -19160,7 +19170,7 @@
 
 			</SpectrumIdentificationResult>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:892.79@RT:2410.39818" id="SIR_4058429415078032668">
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_4940712765740728464" calculatedMassToCharge="887.458449153305" experimentalMassToCharge="892.79" chargeState="3" id="SII_18334097326180128378">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_4940712765740728464" calculatedMassToCharge="887.458449153304" experimentalMassToCharge="892.79" chargeState="3" id="SII_18334097326180128378">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_2816703895052184855"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="1.28571428571429"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="6801914501498646962"/>
@@ -19179,7 +19189,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="2410.39818" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_607610266770354631" calculatedMassToCharge="887.458449153305" experimentalMassToCharge="892.79" chargeState="3" id="SII_14219463416683378859">
+				<SpectrumIdentificationItem passThreshold="1" rank="5" peptide_ref="PEP_607610266770354631" calculatedMassToCharge="887.458449153304" experimentalMassToCharge="892.79" chargeState="3" id="SII_14219463416683378859">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_250585267694080513"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="1.28571428571429"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="6801914501498646962"/>
@@ -19392,7 +19402,7 @@
 
 			</SpectrumIdentificationResult>
 			<SpectrumIdentificationResult spectraData_ref="SDAT_15004869347769368353" spectrumID="MZ:899.431@RT:3329.38374" id="SIR_5943838227366773324">
-				<SpectrumIdentificationItem passThreshold="1" rank="2" peptide_ref="PEP_3236868036104089185" calculatedMassToCharge="875.092194324905" experimentalMassToCharge="899.431" chargeState="6" id="SII_13324810634805258923">
+				<SpectrumIdentificationItem passThreshold="1" rank="2" peptide_ref="PEP_3236868036104089185" calculatedMassToCharge="875.092194324904" experimentalMassToCharge="899.431" chargeState="6" id="SII_13324810634805258923">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_17814092663284306397"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="16249502597361826150"/>
@@ -19411,7 +19421,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="3329.38374" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="2" peptide_ref="PEP_18377228393002342968" calculatedMassToCharge="875.092194324905" experimentalMassToCharge="899.431" chargeState="6" id="SII_14234156667786692686">
+				<SpectrumIdentificationItem passThreshold="1" rank="2" peptide_ref="PEP_18377228393002342968" calculatedMassToCharge="875.092194324904" experimentalMassToCharge="899.431" chargeState="6" id="SII_14234156667786692686">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_194534777427100740"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="16249502597361826150"/>
@@ -19430,7 +19440,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="3329.38374" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="4" peptide_ref="PEP_4948782538710141753" calculatedMassToCharge="875.092194324905" experimentalMassToCharge="899.431" chargeState="6" id="SII_12949425920353303179">
+				<SpectrumIdentificationItem passThreshold="1" rank="4" peptide_ref="PEP_4948782538710141753" calculatedMassToCharge="875.092194324904" experimentalMassToCharge="899.431" chargeState="6" id="SII_12949425920353303179">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_4069130788001053166"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="3991982789787860427"/>
@@ -19449,7 +19459,7 @@
 					<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="3329.38374" unitAccession="UO:0000010" unitName="second" unitCvRef="UO"/>
 				</SpectrumIdentificationItem>
 
-				<SpectrumIdentificationItem passThreshold="1" rank="4" peptide_ref="PEP_2010809438251300505" calculatedMassToCharge="875.092194324905" experimentalMassToCharge="899.431" chargeState="6" id="SII_3825773810782407075">
+				<SpectrumIdentificationItem passThreshold="1" rank="4" peptide_ref="PEP_2010809438251300505" calculatedMassToCharge="875.092194324904" experimentalMassToCharge="899.431" chargeState="6" id="SII_3825773810782407075">
 					<PeptideEvidenceRef peptideEvidence_ref="PEV_3812015869957966874"/>
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0"/>
 					<cvParam accession="MS:1002511" cvRef="PSI-MS" name="cross-link spectrum identification item" value="3991982789787860427"/>

--- a/src/tests/topp/XFDR_test_out3.idXML
+++ b/src/tests/topp/XFDR_test_out3.idXML
@@ -9,7 +9,7 @@
 				<UserParam type="float" name="cross_link:mass" value="138.068"/>
 				<UserParam type="floatList" name="cross_link:mass_monolink" value="[0, 156.079]"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-05-12T15:34:13" search_engine="OpenXQuest" search_engine_version="2.1.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-05-12T15:34:13" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Protein3" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/XFDR_test_out3.mzid
+++ b/src/tests/topp/XFDR_test_out3.mzid
@@ -4,7 +4,7 @@
 	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
 	version="1.2.0"
 	id="OpenMS_1254049432817454963"
-	creationDate="2017-05-29T19:02:21">
+	creationDate="2017-06-29T15:57:18">
 <cvList>
 	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv>
  	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv>
@@ -12,12 +12,12 @@
 	<cv id="XLMOD" fullName="PSI cross-link modifications" uri="https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/cv/XLMOD-1.0.0.obo"></cv>
 </cvList>
 <AnalysisSoftwareList>
-	<AnalysisSoftware version="2.1.0" name="OpenXQuest" id="SOF_5233264595117471314">
+	<AnalysisSoftware version="2.2.0" name="OpenXQuest" id="SOF_5233264595117471314">
 		<SoftwareName>
 			<cvParam accession="MS:1002673" cvRef="PSI-MS" name="OpenXQuest"/>
 		</SoftwareName>
 	</AnalysisSoftware>
-	<AnalysisSoftware version="OpenMS TOPP v2.1.0" name="TOPP software" id="SOF_11395164414789380109">
+	<AnalysisSoftware version="OpenMS TOPP v2.2.0" name="TOPP software" id="SOF_11395164414789380109">
 		<SoftwareName>
 			<cvParam accession="MS:1000752" cvRef="PSI-MS" name="TOPP software"/>
 		</SoftwareName>

--- a/src/tests/topp/XFDR_test_out4.idXML
+++ b/src/tests/topp/XFDR_test_out4.idXML
@@ -9,7 +9,7 @@
 				<UserParam type="float" name="cross_link:mass" value="138.068"/>
 				<UserParam type="floatList" name="cross_link:mass_monolink" value="[0, 156.079]"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-05-12T15:34:13" search_engine="OpenXQuest" search_engine_version="2.1.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-05-12T15:34:13" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Protein3" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/XFDR_test_out4.mzid
+++ b/src/tests/topp/XFDR_test_out4.mzid
@@ -4,7 +4,7 @@
 	xmlns="http://psidev.info/psi/pi/mzIdentML/1.2"
 	version="1.2.0"
 	id="OpenMS_1254049432817454963"
-	creationDate="2017-05-29T19:02:56">
+	creationDate="2017-06-29T15:59:57">
 <cvList>
 	<cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri="https://raw.githubusercontent.com/HUPO-PSI/psi-ms-CV/master/psi-ms.obo" version="3.15.0"></cv>
  	<cv id="UNIMOD" fullName="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo"></cv>
@@ -12,12 +12,12 @@
 	<cv id="XLMOD" fullName="PSI cross-link modifications" uri="https://raw.githubusercontent.com/HUPO-PSI/mzIdentML/master/cv/XLMOD-1.0.0.obo"></cv>
 </cvList>
 <AnalysisSoftwareList>
-	<AnalysisSoftware version="2.1.0" name="OpenXQuest" id="SOF_5233264595117471314">
+	<AnalysisSoftware version="2.2.0" name="OpenXQuest" id="SOF_5233264595117471314">
 		<SoftwareName>
 			<cvParam accession="MS:1002673" cvRef="PSI-MS" name="OpenXQuest"/>
 		</SoftwareName>
 	</AnalysisSoftware>
-	<AnalysisSoftware version="OpenMS TOPP v2.1.0" name="TOPP software" id="SOF_11395164414789380109">
+	<AnalysisSoftware version="OpenMS TOPP v2.2.0" name="TOPP software" id="SOF_11395164414789380109">
 		<SoftwareName>
 			<cvParam accession="MS:1000752" cvRef="PSI-MS" name="TOPP software"/>
 		</SoftwareName>

--- a/src/utils/XFDR.cpp
+++ b/src/utils/XFDR.cpp
@@ -357,10 +357,10 @@ class TOPPXFDR :
               String alpha_prot = alpha_ev_it->getProteinAccession();
               String beta_prot = beta_ev_it->getProteinAccession();
 
-              Internal::XQuestResultXMLHandler::removeSubstring(alpha_prot, "reverse_");
-              Internal::XQuestResultXMLHandler::removeSubstring(alpha_prot, Internal::XQuestResultXMLHandler::decoy_string);
-              Internal::XQuestResultXMLHandler::removeSubstring(beta_prot, "reverse_");
-              Internal::XQuestResultXMLHandler::removeSubstring(beta_prot, Internal::XQuestResultXMLHandler::decoy_string);
+              alpha_prot.substitute("reverse_", "");
+              alpha_prot.substitute(Internal::XQuestResultXMLHandler::decoy_string, "");
+              beta_prot.substitute("reverse_", "");
+              beta_prot.substitute(Internal::XQuestResultXMLHandler::decoy_string, "");
               pep_id.setMetaValue( alpha_prot == beta_prot ? "OpenXQuest:is_intraprotein" : "OpenXQuest:is_interprotein" , DataValue());
             }
           }


### PR DESCRIPTION
Fixes #2718