### PR TITLE
[FEATURE] extended search for MS2 scans

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
@@ -46,6 +46,8 @@
 // QT
 class QPainter;
 class QMouseEvent;
+class QAction;
+class QMenu;
 
 namespace OpenMS
 {
@@ -142,6 +144,9 @@ protected slots:
 protected:
     // Docu in base class
     bool finishAdding_();
+
+    /// Collects fragment ion scans in the indicated RT/mz area and adds them to the indicated action
+    bool collectFragmentScansInArea(double rt_min, double rt_max, double mz_min, double mz_max, QAction* a, QMenu * msn_scans, QMenu * msn_meta);
 
     /// Draws the coordinates (or coordinate deltas) to the widget's upper left corner
     void drawCoordinates_(QPainter& painter, const PeakIndex& peak);

--- a/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
@@ -2302,8 +2302,7 @@ namespace OpenMS
       double rt_max = max(p1[1], p2[1]);
       double mz_min = min(p1[0], p2[0]);
       double mz_max = max(p1[0], p2[0]);
-      bool item_added = false;
-      item_added = collectFragmentScansInArea(rt_min, rt_max, mz_min, mz_max, a, msn_scans, msn_meta);
+      bool item_added = collectFragmentScansInArea(rt_min, rt_max, mz_min, mz_max, a, msn_scans, msn_meta);
       if (!item_added)
       {
         // Now simply go for the 5 closest points in RT and check whether there


### PR DESCRIPTION
- when clicking in TOPPView 2D view on a data point, it currently looks
  for close by fragment ion spectra.
- However, the current definition of close by is not very useful and
  often it comes up empty (e.g. no fragment ion scans are found).
- This commit changes this by looking further if no data are found close
  by, first within +/- 5 RT scans and then within the whole visible
  window (this assumes the user clicked on something interesting in the
  data such as a feature).