### PR TITLE
[BUILD] use 2 parallel jobs for build

### DIFF
--- a/tools/travis/cibuild.cmake
+++ b/tools/travis/cibuild.cmake
@@ -45,7 +45,7 @@ set (CTEST_CUSTOM_WARNING_EXCEPTION
     )
 
 # try to speed up the builds so we don't get killed
-set(CTEST_BUILD_FLAGS -j5)
+set(CTEST_BUILD_FLAGS -j2)
 
 ## speed up compile time on GCC
 if (CMAKE_COMPILER_IS_GNUCXX)
@@ -61,13 +61,13 @@ ctest_start     (Continuous)
 ctest_configure (BUILD "${CTEST_BINARY_DIRECTORY}" RETURN_VALUE _configure_ret)
 # we only build when we do non-style testing
 if("$ENV{ENABLE_STYLE_TESTING}" STREQUAL "OFF")
-	ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors)
+    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors PARALLEL_LEVEL 2)
 else()
 	set(_build_errors 0)
 endif()
 
-## build lib&executables, run tests
-ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" PARALLEL_LEVEL 3)
+## build lib&executables, run tests in parallel
+ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" PARALLEL_LEVEL 2)
 ## send to CDash
 ctest_submit()
 

--- a/tools/travis/cibuild.cmake
+++ b/tools/travis/cibuild.cmake
@@ -61,7 +61,7 @@ ctest_start     (Continuous)
 ctest_configure (BUILD "${CTEST_BINARY_DIRECTORY}" RETURN_VALUE _configure_ret)
 # we only build when we do non-style testing
 if("$ENV{ENABLE_STYLE_TESTING}" STREQUAL "OFF")
-    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors PARALLEL_LEVEL 2)
+    ctest_build(BUILD "${CTEST_BINARY_DIRECTORY}" NUMBER_ERRORS _build_errors)
 else()
 	set(_build_errors 0)
 endif()

--- a/tools/travis/lnx-cibuild.before.sh
+++ b/tools/travis/lnx-cibuild.before.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function build_contrib {
-  cmake . -DBUILD_TYPE=$1
+  cmake . -DBUILD_TYPE=$1 -j2
 
   if [ $? -ne 0 ]; then
     # we give it another try
@@ -39,7 +39,7 @@ if [ "${ENABLE_STYLE_TESTING}" = "ON" ]; then
   git clone git://github.com/danmar/cppcheck.git
   pushd cppcheck
   git checkout 1.65
-  CXX=clang++ make SRCDIR=build CFGDIR=`pwd`/cfg HAVE_RULES=yes -j4
+  CXX=clang++ make SRCDIR=build CFGDIR=`pwd`/cfg HAVE_RULES=yes -j2
   popd
 else
   # regular builds .. get the search engine executables via githubs SVN interface (as git doesn't allow single folder checkouts)


### PR DESCRIPTION
According to this [1] we have 2 CPUs for our build, so it makes sense to use both of them but not use more than 2. 


Ref

1. https://docs.travis-ci.com/user/reference/precise/#Virtualization-environments