### PR TITLE
[FIX] Channel reference in mass map for tmt10plex for channel 128N in…

### DIFF
--- a/src/openms/source/ANALYSIS/QUANTITATION/TMTTenPlexQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/TMTTenPlexQuantitationMethod.cpp
@@ -64,17 +64,17 @@ TMTTenPlexQuantitationMethod::TMTTenPlexQuantitationMethod()
     //    "130C", 130.141145, 128C, 129C, x, x
     //    "131", 131.138180, 129N, 130N, x, x
 
-    // create the channel map
-    channels_.push_back(IsobaricChannelInformation("126", 0, "", 126.127726, -1, -1, 2, 4));
-    channels_.push_back(IsobaricChannelInformation("127N", 1, "", 127.124761, -1, -1, 3, 5));
-    channels_.push_back(IsobaricChannelInformation("127C", 2, "", 127.131081, -1, 0, 4, 6));
-    channels_.push_back(IsobaricChannelInformation("128N", 3, "", 128.128116, -1, 2, 5, 7));
-    channels_.push_back(IsobaricChannelInformation("128C", 4, "", 128.134436, 0, 2, 6, 8));
-    channels_.push_back(IsobaricChannelInformation("129N", 5, "", 129.131471, 1, 3, 7, 9));
-    channels_.push_back(IsobaricChannelInformation("129C", 6, "", 129.137790, 2, 4, 8, -1));
-    channels_.push_back(IsobaricChannelInformation("130N", 7, "", 130.134825, 3, 5, 9, -1));
-    channels_.push_back(IsobaricChannelInformation("130C", 8, "", 130.141145, 4, 6, -1, -1));
-    channels_.push_back(IsobaricChannelInformation("131", 9, "", 131.138180, 5, 7, -1, -1));
+    // create the channel map                                               //-2  -1  +1  +2
+    channels_.push_back(IsobaricChannelInformation("126",  0, "", 126.127726, -1, -1,  2,  4));
+    channels_.push_back(IsobaricChannelInformation("127N", 1, "", 127.124761, -1, -1,  3,  5));
+    channels_.push_back(IsobaricChannelInformation("127C", 2, "", 127.131081, -1,  0,  4,  6));
+    channels_.push_back(IsobaricChannelInformation("128N", 3, "", 128.128116, -1,  1,  5,  7));
+    channels_.push_back(IsobaricChannelInformation("128C", 4, "", 128.134436,  0,  2,  6,  8));
+    channels_.push_back(IsobaricChannelInformation("129N", 5, "", 129.131471,  1,  3,  7,  9));
+    channels_.push_back(IsobaricChannelInformation("129C", 6, "", 129.137790,  2,  4,  8, -1));
+    channels_.push_back(IsobaricChannelInformation("130N", 7, "", 130.134825,  3,  5,  9, -1));
+    channels_.push_back(IsobaricChannelInformation("130C", 8, "", 130.141145,  4,  6, -1, -1));
+    channels_.push_back(IsobaricChannelInformation("131",  9, "", 131.138180,  5,  7, -1, -1));
 
     // we assume 126 to be the reference
     reference_channel_ = 0;

--- a/src/tests/class_tests/openms/source/TMTTenPlexQuantitationMethod_test.cpp
+++ b/src/tests/class_tests/openms/source/TMTTenPlexQuantitationMethod_test.cpp
@@ -120,7 +120,7 @@ START_SECTION((const IsobaricChannelList& getChannelInformation() const ))
   TEST_EQUAL(channel_list[3].id, 3)
   TEST_EQUAL(channel_list[3].center, 128.128116)
   TEST_EQUAL(channel_list[3].channel_id_minus_2, -1)
-  TEST_EQUAL(channel_list[3].channel_id_minus_1, 2)
+  TEST_EQUAL(channel_list[3].channel_id_minus_1, 1)
   TEST_EQUAL(channel_list[3].channel_id_plus_1, 5)
   TEST_EQUAL(channel_list[3].channel_id_plus_2, 7)
 


### PR DESCRIPTION
I think there was a wrong entry in the channel map for tmt10 plex.

In the original, minus_1 in channel 128N referenced to 2, which is channel 127C. I think this should rather be 1, so referencing to channel 127N , which is then also consistent to the mass map [1]

[1] https://tools.thermofisher.com/content/sfs/COAPDFs/2015/SPECS_90111.pdf