### PR TITLE
[FIX] TOPP-FileInfo

### DIFF
--- a/src/tests/topp/FileInfo_10_output.txt
+++ b/src/tests/topp/FileInfo_10_output.txt
@@ -10,9 +10,9 @@ Number of:
   (only hits that differ in the accession)
 
   matched spectra:            0
-  peptide hits:               0
+  peptide hits:               0 (avg. length: 0)
   modified top-hits:          0/0
   non-redundant peptide hits: 0
-  (only hits that differ in sequence and/ or modifications)
+  (only hits that differ in sequence and/or modifications)
 
 

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -37,28 +37,30 @@
 
 #include <OpenMS/config.h>
 
-#include <OpenMS/FORMAT/FileHandler.h>
-#include <OpenMS/FORMAT/FileTypes.h>
-#include <OpenMS/FORMAT/ConsensusXMLFile.h>
-#include <OpenMS/FORMAT/FeatureXMLFile.h>
-#include <OpenMS/FORMAT/MzDataFile.h>
-#include <OpenMS/FORMAT/IdXMLFile.h>
-#include <OpenMS/FORMAT/IndexedMzMLFile.h>
-#include <OpenMS/FORMAT/MzIdentMLFile.h>
-#include <OpenMS/FORMAT/MzMLFile.h>
-#include <OpenMS/FORMAT/MzXMLFile.h>
-#include <OpenMS/FORMAT/PepXMLFile.h>
-#include <OpenMS/FORMAT/TransformationXMLFile.h>
-#include <OpenMS/FORMAT/PeakTypeEstimator.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 #include <OpenMS/DATASTRUCTURES/Map.h>
-#include <OpenMS/SYSTEM/SysInfo.h>
+#include <OpenMS/FORMAT/ConsensusXMLFile.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/FileTypes.h>
+#include <OpenMS/FORMAT/IdXMLFile.h>
+#include <OpenMS/FORMAT/IndexedMzMLFile.h>
+#include <OpenMS/FORMAT/MzDataFile.h>
+#include <OpenMS/FORMAT/MzIdentMLFile.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
+#include <OpenMS/FORMAT/MzXMLFile.h>
+#include <OpenMS/FORMAT/PeakTypeEstimator.h>
+#include <OpenMS/FORMAT/PepXMLFile.h>
+#include <OpenMS/FORMAT/TransformationXMLFile.h>
+#include <OpenMS/MATH/MISC/MathFunctions.h>
+#include <OpenMS/MATH/STATISTICS/StatisticFunctions.h>
+#include <OpenMS/SYSTEM/SysInfo.h>
 
 #include <QtCore/QString>
 
-#include <OpenMS/MATH/STATISTICS/StatisticFunctions.h>
+
 
 using namespace OpenMS;
 using namespace std;
@@ -595,6 +597,7 @@ protected:
       set<String> proteins;
       Size modified_peptide_count(0);
       Map<String, int> mod_counts;
+      vector<uint16_t> peptide_length;
 
       // reading input
       mu.before();
@@ -640,6 +643,7 @@ protected:
           for (Size j = 0; j < temp_hits.size(); ++j)
           {
             peptides.insert(temp_hits[j].getSequence().toString());
+            peptide_length.push_back(temp_hits[j].getSequence().size());
           }
         }
       }
@@ -653,6 +657,7 @@ protected:
           proteins.insert(temp_hits[j].getAccession());
         }
       }
+      if (peptide_length.empty()) peptide_length.push_back(0); // avoid invalid-range exception when computing mean()
 
       os << "Number of:"
          << "\n";
@@ -663,10 +668,10 @@ protected:
          << "\n";
       os << "\n";
       os << "  matched spectra:    " << spectrum_count << "\n";
-      os << "  peptide hits:               " << peptide_hit_count << "\n";
-      os << "  modified top-hits:          " << modified_peptide_count << "/" << spectrum_count << (spectrum_count > 0 ? String(" (") + (modified_peptide_count * 100.0 / spectrum_count) + "%)" : "") << "\n";
+      os << "  peptide hits:               " << peptide_hit_count << " (avg. length: " << Math::round(Math::mean(peptide_length.begin(), peptide_length.end())) << ")\n";
+      os << "  modified top-hits:          " << modified_peptide_count << "/" << spectrum_count << (spectrum_count > 0 ? String(" (") + Math::round(modified_peptide_count * 1000.0 / spectrum_count) / 10 + "%)" : "") << "\n";
       os << "  non-redundant peptide hits: " << peptides.size() << "\n";
-      os << "  (only hits that differ in sequence and/ or modifications)"
+      os << "  (only hits that differ in sequence and/or modifications)"
          << "\n";
       for (Map<String, int>::ConstIterator it = mod_counts.begin(); it != mod_counts.end(); ++it)
       {
@@ -679,7 +684,7 @@ protected:
 
       os_tsv << "peptide hits"
              << "\t" << peptide_hit_count << "\n";
-      os_tsv << "non-redundant peptide hits (only hits that differ in sequence and/ or modifications): "
+      os_tsv << "non-redundant peptide hits (only hits that differ in sequence and/or modifications): "
              << "\t" << peptides.size() << "\n";
       os_tsv << "protein hits"
              << "\t" << protein_hit_count << "\n";

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -60,8 +60,6 @@
 
 #include <QtCore/QString>
 
-
-
 using namespace OpenMS;
 using namespace std;
 
@@ -657,7 +655,10 @@ protected:
           proteins.insert(temp_hits[j].getAccession());
         }
       }
-      if (peptide_length.empty()) peptide_length.push_back(0); // avoid invalid-range exception when computing mean()
+      if (peptide_length.empty())
+      { // avoid invalid-range exception when computing mean()
+        peptide_length.push_back(0); 
+      }
 
       os << "Number of:"
          << "\n";


### PR DESCRIPTION
[FIX]: percentage of modified peptides for idXML input had too many digits (e.g. 45.434242342 %) --> now fixed to 1 digit, e.g 45.4 %

[FEATURE] TOPP-FileInfo: compute average length of peptides in idXML