### PR TITLE
[FIX] pyOpenMS macOS fixes

### DIFF
--- a/src/pyOpenMS/MANIFEST.in
+++ b/src/pyOpenMS/MANIFEST.in
@@ -7,6 +7,7 @@ include pyopenms/libOpenSwathAlgo.*
 include pyopenms/libSuperHirn.*
 include pyopenms/QtCore*
 include pyopenms/QtNetwork*
+include pyopenms/libz.*
 exclude pyopenms/*.cpp
 global-exclude pyopenms.cpp
 global-exclude HMDB2StructMapping.tsv

--- a/src/pyOpenMS/create_cpp_extension.py
+++ b/src/pyOpenMS/create_cpp_extension.py
@@ -168,6 +168,9 @@ elif sys.platform == "darwin":
     shutil.copy(j(OPEN_MS_BUILD_DIR, "lib", "libOpenSwathAlgo.dylib"), "pyopenms")
     shutil.copy(j(QT_LIBRARY_DIR, "QtCore.framework", "QtCore"), "pyopenms")
     shutil.copy(j(QT_LIBRARY_DIR, "QtNetwork.framework", "QtNetwork"), "pyopenms")
+    os.chmod("pyopenms/QtCore", 0744)
+    os.chmod("pyopenms/QtNetwork", 0744)
+    shutil.copy(j(os.path.expanduser(OPEN_MS_CONTRIB_BUILD_DIR), "lib", "libz.1.dylib"), "pyopenms")
 
 else:
     print("\n")

--- a/src/pyOpenMS/fix_pyopenms_dependencies_on_mac.sh
+++ b/src/pyOpenMS/fix_pyopenms_dependencies_on_mac.sh
@@ -31,7 +31,7 @@ for TOFIX in $(find . -name libOpenMS.dylib); do
     echo
     echo "fix $TOFIX now:"
     echo
-    for LIB in libOpenSwathAlgo.dylib QtNetwork QtCore; do
+    for LIB in libOpenSwathAlgo.dylib QtNetwork QtCore libz.1.dylib; do
         # find absolute path
         REF=$(otool -L $TOFIX | grep $LIB | cut -d " " -f 1)
         echo "    found link $REF"
@@ -50,7 +50,25 @@ for TOFIX in $(find . -name libSuperHirn.dylib); do
     echo
     echo "fix $TOFIX now:"
     echo
-    for LIB in libOpenMS.dylib libOpenSwathAlgo.dylib QtCore QtNetwork; do
+    for LIB in libOpenMS.dylib libOpenSwathAlgo.dylib QtCore QtNetwork libz.1.dylib; do
+        # find absolute path
+        REF=$(otool -L $TOFIX | grep $LIB | cut -d " " -f 1)
+        echo "    found link $REF"
+        install_name_tool -change $REF @loader_path/$LIB $TOFIX
+    done;
+    echo
+    echo "    now otool -L says:"
+    echo
+    otool -L $TOFIX | while read -r line ; do
+        echo "    $line"
+        done
+done;
+
+for TOFIX in $(find . -name QtNetwork); do
+    echo
+    echo "fix $TOFIX now:"
+    echo
+    for LIB in QtCore; do
         # find absolute path
         REF=$(otool -L $TOFIX | grep $LIB | cut -d " " -f 1)
         echo "    found link $REF"


### PR DESCRIPTION
This PR intends to fix the current problems when building pyOpenMS on macOS. Attached is a file [pyopenms-2.2.0-cp27-cp27m-macosx_10_12_intel.whl.zip](https://github.com/OpenMS/OpenMS/files/1194121/pyopenms-2.2.0-cp27-cp27m-macosx_10_12_intel.whl.zip) for the standard Python 2.7.10 shipped with macOS 10.12 that was created using the patch and it would be great if people with the same or different systems could check whether it works for them.

