### PR TITLE
[FIX] fix for boost 1.64

### DIFF
--- a/src/openms/include/OpenMS/MATH/STATISTICS/StatisticFunctions.h
+++ b/src/openms/include/OpenMS/MATH/STATISTICS/StatisticFunctions.h
@@ -38,6 +38,8 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/Types.h>
 
+// array_wrapper needs to be included before it is used
+// only in boost1.64+. See issue #2790
 #if OPENMS_BOOST_VERSION_MINOR >= 64
 #include <boost/serialization/array_wrapper.hpp>
 #endif

--- a/src/openms/include/OpenMS/MATH/STATISTICS/StatisticFunctions.h
+++ b/src/openms/include/OpenMS/MATH/STATISTICS/StatisticFunctions.h
@@ -38,6 +38,9 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/Types.h>
 
+#if OPENMS_BOOST_VERSION_MINOR >= 64
+#include <boost/serialization/array_wrapper.hpp>
+#endif
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/covariance.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
@@ -47,9 +50,6 @@
 #include <boost/function/function_base.hpp>
 #include <boost/lambda/casts.hpp>
 #include <boost/lambda/lambda.hpp>
-#if OPENMS_BOOST_VERSION_MINOR >= 64
-#include <boost/serialization/array_wrapper.hpp>
-#endif
 
 #include <iterator>
 #include <algorithm>


### PR DESCRIPTION
see #2793 
Include required for boost 1.64 occurs before including the other boost header files.
Fixes build on Debian distro.