### PR TITLE
[GUI, FIX] more robust PeakAnnotations in TOPPView

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -271,6 +271,10 @@ public:
       }
     }
 
+    /// updates the PeakAnnotations in the current PeptideHit with manually changed annotations
+    /// if no PeptideIdentification or PeptideHit for the spectrum exist, it is generated
+    void synchronizePeakAnnotations();
+
     /// if this layer is visible
     bool visible;
 
@@ -315,6 +319,9 @@ public:
     int peptide_hit_index;
 
 private:
+    /// updates the PeakAnnotations in the current PeptideHit with manually changed annotations
+    void updatePeptideHitAnnotations_(PeptideHit& hit);
+
     /// feature data
     FeatureMapSharedPtrType features;
 

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/VISUAL/LayerData.h>
+#include <OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h>
 
 using namespace std;
 
@@ -53,6 +54,167 @@ namespace OpenMS
     os << "number of peaks: " << rhs.getPeakData()->getSize() << std::endl;
     os << "--LayerData END--" << std::endl;
     return os;
+  }
+
+  void LayerData::synchronizePeakAnnotations()
+  {
+    // LayerData & current_layer = widget_1D->canvas()->getCurrentLayer();
+    int spectrum_index = getCurrentSpectrumIndex();
+
+    // Return if no valid peak layer attached
+    if (getPeakData()->size() == 0 || type != LayerData::DT_PEAK) { return; }
+
+    MSSpectrum<> & spectrum = (*getPeakData())[spectrum_index];
+    int ms_level = spectrum.getMSLevel();
+
+    if (ms_level == 2)
+    {
+      // store user fragment annotations
+      vector<PeptideIdentification>& pep_ids = spectrum.getPeptideIdentifications();
+
+      // no ID selected
+      if (peptide_id_index == -1 || peptide_hit_index == -1)
+      {
+        return;
+      }
+
+      if (!pep_ids.empty())
+      {
+        vector<PeptideHit>& hits = pep_ids[peptide_id_index].getHits();
+
+        if (!hits.empty())
+        {
+          PeptideHit& hit = hits[peptide_hit_index];
+          updatePeptideHitAnnotations_(hit);
+        }
+        else
+        {
+          PeptideHit hit;
+          updatePeptideHitAnnotations_(hit);
+          hits.push_back(hit);
+        }
+      }
+      else // PeptideIdentifications are empty, create new PepIDs and PeptideHits to store the PeakAnnotations
+      {
+        // copy user annotations to fragment annotation vector
+        Annotations1DContainer & las = getAnnotations(current_spectrum_);
+
+        // no annoations so we don't need to synchronize
+        bool has_peak_annotation(false);
+        for (auto& a : las)
+        {
+          // only store peak annotations
+          Annotation1DPeakItem* pa = dynamic_cast<Annotation1DPeakItem*>(a);
+          if (pa != nullptr) { has_peak_annotation = true; break; }
+        }
+        if (has_peak_annotation == false) return;
+
+        PeptideIdentification pep_id;
+        pep_id.setIdentifier("Unknown");
+
+        // create a dummy ProteinIdentification for all ID-less PeakAnnotations
+        vector<ProteinIdentification>& prot_ids = getPeakData()->getProteinIdentifications();
+        if (prot_ids.back().getIdentifier() != String("Unknown"))
+        {
+          ProteinIdentification prot_id;
+          prot_id.setIdentifier("Unknown");
+          prot_ids.push_back(prot_id);
+        }
+
+        PeptideHit hit;
+        if (spectrum.getPrecursors().empty() == false)
+        {
+          pep_id.setMZ(spectrum.getPrecursors()[0].getMZ());
+          hit.setCharge(spectrum.getPrecursors()[0].getCharge());
+        }
+        pep_id.setRT(spectrum.getRT());
+
+        updatePeptideHitAnnotations_(hit);
+        std::vector<PeptideHit> hits;
+        hits.push_back(hit);
+        pep_id.setHits(hits);
+        pep_ids.push_back(pep_id);
+      }
+    }
+  }
+
+  void LayerData::updatePeptideHitAnnotations_(PeptideHit& hit)
+  {
+    // copy user annotations to fragment annotation vector
+    Annotations1DContainer & las = getAnnotations(current_spectrum_);
+
+    vector<PeptideHit::PeakAnnotation> fas = hit.getPeakAnnotations();
+
+    bool annotations_changed(false);
+
+    // regular expression for a charge at the end of the annotation
+    QRegExp reg_exp("([\\+|\\-]\\d+)$");
+
+    // for each annotation item on the canvas
+    for (auto& a : las)
+    {
+      // only store peak annotations
+      Annotation1DPeakItem* pa = dynamic_cast<Annotation1DPeakItem*>(a);
+      if (pa == nullptr) { continue; }
+
+      int tmp_charge(0);
+
+      // if already annotated we want to keep mz, intensity, and charge information
+      bool already_annotated(false);
+      for (auto& tmp_a : fas)
+      {
+        if (fabs(tmp_a.mz - pa->getPeakPosition()[0]) < 1e-6)
+        {
+          QString peak_anno = pa->getText();
+          int match_pos = reg_exp.indexIn(peak_anno);
+          // if a charge was found at the annotation, remove it from the annotation string an fill the charge attribute
+          if (match_pos >= 0)
+          {
+            tmp_charge = reg_exp.cap(1).toInt();
+            peak_anno = peak_anno.left(match_pos);
+          }
+
+          if (tmp_a.annotation == String(peak_anno))
+          {
+            already_annotated = true;
+            break;
+          }
+          else // peak annotated but different text (e.g., changed by user)
+          {
+            tmp_a.annotation = peak_anno;
+            // if the new annotation has a charge, use the new one
+            if (tmp_charge != 0)
+            {
+              tmp_a.charge = tmp_charge;
+            }
+            annotations_changed = true;
+            already_annotated = true;
+            break;
+          }
+        }
+      }
+
+      // add new fragment annotation if peak not yet annotated
+      if (!already_annotated)
+      {
+        QString peak_anno = pa->getText();
+        int match_pos = reg_exp.indexIn(peak_anno);
+        if (match_pos >= 0)
+        {
+          tmp_charge = reg_exp.cap(1).toInt();
+          peak_anno = peak_anno.left(match_pos);
+        }
+
+        PeptideHit::PeakAnnotation fa;
+        fa.charge = tmp_charge;
+        fa.mz = pa->getPeakPosition()[0];
+        fa.intensity = pa->getPeakPosition()[1];
+        fa.annotation = peak_anno;
+        fas.push_back(fa);
+        annotations_changed = true;
+      }
+    }
+    if (annotations_changed) { hit.setPeakAnnotations(fas); }
   }
 
 } //Namespace

--- a/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
@@ -862,6 +862,9 @@ namespace OpenMS
       return;
     }
 
+    // synchronize PeptideHits with the annotations in the spectrum
+    layer_->synchronizePeakAnnotations();
+
     QString selectedFilter;
     QString filename = QFileDialog::getSaveFileName(this, "Save File", "", "idXML file (*.idXML);;mzIdentML file (*.mzid)", &selectedFilter);
     vector<ProteinIdentification> prot_id = (*layer_->getPeakData()).getProteinIdentifications();

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -85,7 +85,7 @@ namespace OpenMS
     //Parameter handling
     defaults_.setValue("highlighted_peak_color", "#ff0000", "Highlighted peak color.");
     defaults_.setValue("icon_color", "#000000", "Peak icon color.");
-    defaults_.setValue("peak_color", "#0000ff", "Peak color.");
+    defaults_.setValue("peak_color", "#000000", "Peak color.");
     defaults_.setValue("annotation_color", "#000055", "Annotation color.");
     defaults_.setValue("background_color", "#ffffff", "Background color.");
     defaults_.setValue("show_legend", "false", "Annotate each layer with its name on the canvas.");
@@ -1319,13 +1319,13 @@ namespace OpenMS
               {
                 PeptideHit& hit = hits[pep_hit_index];
 
-                vector<PeptideHit::PeakAnnotation> fas = hit.getPeakAnnotations();         
+                vector<PeptideHit::PeakAnnotation> fas = hit.getPeakAnnotations();
 
                 // erase fragment annotations that match the visual peak annotation
                 fas.erase(std::remove_if(fas.begin(), fas.end(),
-                  [pa](const PeptideHit::PeakAnnotation& p) 
-                  { 
-                   return (fabs(p.mz - pa->getPeakPosition()[0]) < 1e-6); 
+                  [pa](const PeptideHit::PeakAnnotation& p)
+                  {
+                   return (fabs(p.mz - pa->getPeakPosition()[0]) < 1e-6);
                   }), fas.end());
                 hit.setPeakAnnotations(fas);
               }
@@ -1626,7 +1626,6 @@ namespace OpenMS
       zoomBack_();
     } else
     {
-   
       const PointType::CoordinateType zoom_factor = 0.8;
       AreaType new_area;
       if (isMzToXAxis())
@@ -1688,7 +1687,7 @@ namespace OpenMS
       newLo -= shift;
       newHi -= shift;
     }
-    else if (m == Qt::ShiftModifier) 
+    else if (m == Qt::ShiftModifier)
     { // jump to the next peak (useful for sparse data)
       const LayerData::ExperimentType::SpectrumType& spec = getCurrentLayer_().getCurrentSpectrum();
       PeakType p_temp(visible_area_.minX(), 0);
@@ -1720,7 +1719,7 @@ namespace OpenMS
       newLo += shift;
       newHi += shift;
     }
-    else if (m == Qt::ShiftModifier) 
+    else if (m == Qt::ShiftModifier)
     { // jump to the next peak (useful for sparse data)
       const LayerData::ExperimentType::SpectrumType& spec = getCurrentLayer_().getCurrentSpectrum();
       PeakType p_temp(visible_area_.maxX(), 0);


### PR DESCRIPTION
PeakAnnotations in PeptideHits are updated on pressing the save IDs button or when changing the selected spectrum or ID.
Charges are now only contained in the charge field and should not be part
of the annotation string.