### PR TITLE
Removes unreachable code warning

### DIFF
--- a/src/openms/source/CONCEPT/ClassTest.cpp
+++ b/src/openms/source/CONCEPT/ClassTest.cpp
@@ -441,10 +441,6 @@ namespace OpenMS
             }
           }
         }
-        // We should never get here ... must have forgotten an condition branch above ... and then we need to fix that.
-        fuzzy_message
-          = "error: ClassTest.cpp:  You should never see this message.  Please report this bug along with the data that produced it.";
-        return false;
       }
 
       void


### PR DESCRIPTION
I think it causes hiccups with CTest sometimes, thinking it is a compiler error.