### PR TITLE
Fix long filename issue in TOPPAS

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -146,8 +146,13 @@ public:
     */
     static String findDoc(const String& filename);
     
-    /// Returns a string, consisting of date, time, hostname, process id, and a incrementing number.  This can be used for temporary files.
-    static String getUniqueName();
+    /**
+      @brief Returns a string, consisting of date, time, hostname, process id, and a incrementing number. This can be used for temporary files.
+
+      @param include_hostname add hostname into result - potentially a long string
+      @return a unique name
+    */
+    static String getUniqueName(bool include_hostname = true);
 
     /// Returns the OpenMS data path (environment variable overwrites the default installation path)
     static String getOpenMSDataPath();

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -334,7 +334,7 @@ namespace OpenMS
     return File::find(filename, search_dirs);
   }
 
-  String File::getUniqueName()
+  String File::getUniqueName(bool include_hostname)
   {
     DateTime now = DateTime::now();
     String pid;
@@ -344,7 +344,7 @@ namespace OpenMS
     pid = (String)getpid();
 #endif
     static int number = 0;
-    return now.getDate() + "_" + now.getTime().remove(':') + "_" + String(QHostInfo::localHostName()) + "_" + pid + "_" + (++number);
+    return now.getDate().remove('-') + "_" + now.getTime().remove(':') + "_" + (include_hostname ? String(QHostInfo::localHostName()) + "_" : "")  + pid + "_" + (++number);
   }
 
   String File::getOpenMSDataPath()

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
@@ -258,7 +258,7 @@ namespace OpenMS
     current_path_ = param_.getValue("preferences:default_path");
 
     // set & create temporary path -- make sure its a new subdirectory, as it will be deleted later
-    QString new_tmp_dir = File::getUniqueName().toQString();
+    QString new_tmp_dir = File::getUniqueName(false).toQString();
     QDir qd(File::getTempDirectory().toQString());
     qd.mkdir(new_tmp_dir);
     qd.cd(new_tmp_dir);

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -964,7 +964,10 @@ namespace OpenMS
         String type = FileTypes::typeToName(FileHandler::getTypeByFileName(fn));
         // try to find it -- might not be present, since it could be 'unknown'
         size_t pos = fn.rfind("." + type.toLower());
-        filename.truncate(pos); // if pos==NPOS, i.e. not found, nothing happens
+        if (pos != std::string::npos)
+        {
+          filename.truncate((int)pos);
+        }
       }
       per_round_basenames.push_back(filenames);
       //std::cerr << "  output filenames (round " << i  <<"): " << per_round_basenames.back().join(", ") << std::endl;
@@ -1062,7 +1065,7 @@ namespace OpenMS
           if (!fn.endsWith(file_suffix.toQString()))
           {
             fn += file_suffix.toQString();
-            LOG_DEBUG << "  Suffix-add: " << file_suffix.toQString() << "\n";
+            LOG_DEBUG << "  Suffix-add: " << file_suffix << "\n";
           }
           fn = QDir::toNativeSeparators(fn);
           if (filename_output_set.count(fn) > 0)

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -1041,23 +1041,23 @@ namespace OpenMS
         for (const QString &input_file : per_round_basenames[r])
         {
           QString fn = path + QFileInfo(input_file).fileName(); // out_path + filename
-          LOG_DEBUG << "Single:" << fn << "\n";
+          LOG_DEBUG << "Single:" << fn.toStdString() << "\n";
           if (list_to_single)
           {
             if (fn.contains(QRegExp(".*_to_.*_mrgd")))
             {
               fn = fn.left(fn.indexOf("_to_"));
-              LOG_DEBUG << "  first merge in merge: " << fn << "\n";
+              LOG_DEBUG << "  first merge in merge: " << fn.toStdString() << "\n";
             }
             QString fn_last = QFileInfo(per_round_basenames[r].last()).fileName();
             if (fn_last.contains(QRegExp(".*_to_.*_mrgd")))
             {
               int i_start = fn_last.indexOf("_to_") + 4;
               fn_last = fn_last.mid(i_start, fn_last.indexOf("_mrgd", i_start) - i_start);
-              LOG_DEBUG << "  last merge in merge: " << fn_last << "\n";
+              LOG_DEBUG << "  last merge in merge: " << fn_last.toStdString() << "\n";
             }
             fn += "_to_" + fn_last + "_mrgd";
-            LOG_DEBUG << "  List: ..." << "_to_" + fn_last + "_mrgd" << "\n";
+            LOG_DEBUG << "  List: ..." << "_to_" + fn_last.toStdString() + "_mrgd" << "\n";
           }
           if (!fn.endsWith(file_suffix.toQString()))
           {

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -952,7 +952,21 @@ namespace OpenMS
     std::vector<QStringList> per_round_basenames;
     for (Size i = 0; i < pkg.size(); ++i)
     {
-      per_round_basenames.push_back(pkg[i].find(max_size_index)->second.filenames.get());
+      QStringList filenames = pkg[i].find(max_size_index)->second.filenames.get();
+      //
+      // remove suffix to avoid chaining .mzML.idxml.tsv
+      // a new suffix is added later, depending on edge-type etc
+      //
+      // try to find the type (only by looking at the suffix); not doing it manually, since it could be .mzXML.gz
+      for (QString& filename : filenames)
+      {
+        String fn = filename.toLower(); // tolower() is required for robust rfind() below
+        String type = FileTypes::typeToName(FileHandler::getTypeByFileName(fn));
+        // try to find it -- might not be present, since it could be 'unknown'
+        size_t pos = fn.rfind("." + type.toLower());
+        filename.truncate(pos); // if pos==NPOS, i.e. not found, nothing happens
+      }
+      per_round_basenames.push_back(filenames);
       //std::cerr << "  output filenames (round " << i  <<"): " << per_round_basenames.back().join(", ") << std::endl;
     }
 
@@ -1024,16 +1038,31 @@ namespace OpenMS
 
         // list --> single file (e.g. IDMerger or FileMerger)
         bool list_to_single = (per_round_basenames[r].size() > 1 && out_params[param_index].type == IOInfo::IOT_FILE);
-        foreach(const QString &input_file, per_round_basenames[r])
+        for (const QString &input_file : per_round_basenames[r])
         {
           QString fn = path + QFileInfo(input_file).fileName(); // out_path + filename
+          LOG_DEBUG << "Single:" << fn << "\n";
           if (list_to_single)
           {
-            fn += "_to_" + QFileInfo(per_round_basenames[r].last()).fileName() + "_merged";
+            if (fn.contains(QRegExp(".*_to_.*_mrgd")))
+            {
+              fn = fn.left(fn.indexOf("_to_"));
+              LOG_DEBUG << "  first merge in merge: " << fn << "\n";
+            }
+            QString fn_last = QFileInfo(per_round_basenames[r].last()).fileName();
+            if (fn_last.contains(QRegExp(".*_to_.*_mrgd")))
+            {
+              int i_start = fn_last.indexOf("_to_") + 4;
+              fn_last = fn_last.mid(i_start, fn_last.indexOf("_mrgd", i_start) - i_start);
+              LOG_DEBUG << "  last merge in merge: " << fn_last << "\n";
+            }
+            fn += "_to_" + fn_last + "_mrgd";
+            LOG_DEBUG << "  List: ..." << "_to_" + fn_last + "_mrgd" << "\n";
           }
           if (!fn.endsWith(file_suffix.toQString()))
           {
             fn += file_suffix.toQString();
+            LOG_DEBUG << "  Suffix-add: " << file_suffix.toQString() << "\n";
           }
           fn = QDir::toNativeSeparators(fn);
           if (filename_output_set.count(fn) > 0)
@@ -1178,9 +1207,7 @@ namespace OpenMS
     {
       workflow_dir = "Untitled_workflow";
     }
-    String dir = String("TOPPAS_tmp") +
-                 String(QDir::separator()) +
-                 workflow_dir +
+    String dir = workflow_dir +
                  String(QDir::separator()) +
                  get3CharsNumber_(topo_nr_) + "_" + getName();
     if (getType() != "")

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -53,54 +53,54 @@ START_TEST(TextFile, "$Id$")
 /////////////////////////////////////////////////////////////
 
 START_SECTION((static String getExecutablePath()))
-	TEST_NOT_EQUAL(File::getExecutablePath().size(), 0)
+  TEST_NOT_EQUAL(File::getExecutablePath().size(), 0)
 END_SECTION
 
 START_SECTION((static bool exists(const String &file)))
-	TEST_EQUAL(File::exists("does_not_exists.txt"), false)
-	TEST_EQUAL(File::exists(""), false)
-	TEST_EQUAL(File::exists(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt")), true)
+  TEST_EQUAL(File::exists("does_not_exists.txt"), false)
+  TEST_EQUAL(File::exists(""), false)
+  TEST_EQUAL(File::exists(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt")), true)
 END_SECTION
 
 START_SECTION((static bool empty(const String &file)))
-	TEST_EQUAL(File::empty("does_not_exists.txt"), true)
-	TEST_EQUAL(File::empty(OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
-	TEST_EQUAL(File::empty(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt")), false)
+  TEST_EQUAL(File::empty("does_not_exists.txt"), true)
+  TEST_EQUAL(File::empty(OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
+  TEST_EQUAL(File::empty(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt")), false)
 END_SECTION
 
 START_SECTION((static bool remove(const String &file)))
-	//deleting non-existing file
-	TEST_EQUAL(File::remove("does_not_exists.txt"), true)
+  //deleting non-existing file
+  TEST_EQUAL(File::remove("does_not_exists.txt"), true)
 
-	//deleting existing file
-	String filename;
-	NEW_TMP_FILE(filename);
-	ofstream os;
-	os.open (filename.c_str(), ofstream::out);
-	os << "File_test dummy file to delete" << endl;
-	os.close();
-	TEST_EQUAL(File::remove(filename), true)
+  //deleting existing file
+  String filename;
+  NEW_TMP_FILE(filename);
+  ofstream os;
+  os.open (filename.c_str(), ofstream::out);
+  os << "File_test dummy file to delete" << endl;
+  os.close();
+  TEST_EQUAL(File::remove(filename), true)
 END_SECTION
 
 START_SECTION((static bool readable(const String &file)))
-	TEST_EQUAL(File::readable("does_not_exists.txt"), false)
-	TEST_EQUAL(File::readable(OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
-	TEST_EQUAL(File::readable(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt")), true)
-	TEST_EQUAL(File::readable(""), false)
+  TEST_EQUAL(File::readable("does_not_exists.txt"), false)
+  TEST_EQUAL(File::readable(OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
+  TEST_EQUAL(File::readable(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt")), true)
+  TEST_EQUAL(File::readable(""), false)
 END_SECTION
 
 START_SECTION((static bool writable(const String &file)))
-	TEST_EQUAL(File::writable("/this/file/cannot/be/written.txt"), false)
-	TEST_EQUAL(File::writable(OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
-	TEST_EQUAL(File::writable(OPENMS_GET_TEST_DATA_PATH("File_test_imaginary.txt")), true)
+  TEST_EQUAL(File::writable("/this/file/cannot/be/written.txt"), false)
+  TEST_EQUAL(File::writable(OPENMS_GET_TEST_DATA_PATH("File_test_empty.txt")), true)
+  TEST_EQUAL(File::writable(OPENMS_GET_TEST_DATA_PATH("File_test_imaginary.txt")), true)
 
-	String filename;
-	NEW_TMP_FILE(filename);
-	TEST_EQUAL(File::writable(filename), true)
+  String filename;
+  NEW_TMP_FILE(filename);
+  TEST_EQUAL(File::writable(filename), true)
 END_SECTION
 
 START_SECTION((static String find(const String &filename, StringList directories=StringList())))
-	TEST_EXCEPTION(Exception::FileNotFound, File::find("File.h"))
+  TEST_EXCEPTION(Exception::FileNotFound, File::find("File.h"))
   String s_obo = File::find("CV/psi-ms.obo");
   TEST_EQUAL(s_obo.empty(), false);
   TEST_EQUAL(File::find(s_obo), s_obo); // iterative finding should return the identical file
@@ -109,7 +109,7 @@ START_SECTION((static String find(const String &filename, StringList directories
 END_SECTION
 
 START_SECTION((static String findDoc(const String& filename)))
-	TEST_EXCEPTION(Exception::FileNotFound,File::findDoc("non-existing-documentation"))
+  TEST_EXCEPTION(Exception::FileNotFound,File::findDoc("non-existing-documentation"))
   // should exist in every valid source tree (we cannot test for Doxyfile since doxygen might not be installed)
   TEST_EQUAL(File::findDoc("doxygen/Doxyfile.in").hasSuffix("Doxyfile.in"), true)
   // a file from the build tree
@@ -117,56 +117,56 @@ START_SECTION((static String findDoc(const String& filename)))
 END_SECTION
 
 START_SECTION((static String absolutePath(const String &file)))
-	NOT_TESTABLE
+  NOT_TESTABLE
 END_SECTION
 
 START_SECTION((static String path(const String &file)))
-	NOT_TESTABLE
+  NOT_TESTABLE
 END_SECTION
 
 START_SECTION((static String basename(const String &file)))
-	TEST_EQUAL(File::basename("/souce/config/bla/bluff.h"), "bluff.h");
+  TEST_EQUAL(File::basename("/souce/config/bla/bluff.h"), "bluff.h");
 END_SECTION
 
 START_SECTION((static bool fileList(const String &dir, const String &file_pattern, StringList &output, bool full_path=false)))
-StringList vec;
-TEST_EQUAL(File::fileList(OPENMS_GET_TEST_DATA_PATH(""), "*.bliblaluff", vec), false);
-TEST_EQUAL(File::fileList(OPENMS_GET_TEST_DATA_PATH(""), "File_test_text.txt", vec), true);
-TEST_EQUAL(vec[0], "File_test_text.txt");
-TEST_EQUAL(File::fileList(OPENMS_GET_TEST_DATA_PATH(""), "File_test_text.txt", vec, true), true);
-// can't use "path + separator + filename", because sep. might be "/" or "\\"
-TEST_EQUAL(vec[0].hasPrefix(OPENMS_GET_TEST_DATA_PATH("")), true);
-TEST_EQUAL(vec[0].hasSuffix("File_test_text.txt"), true);
+  StringList vec;
+  TEST_EQUAL(File::fileList(OPENMS_GET_TEST_DATA_PATH(""), "*.bliblaluff", vec), false);
+  TEST_EQUAL(File::fileList(OPENMS_GET_TEST_DATA_PATH(""), "File_test_text.txt", vec), true);
+  TEST_EQUAL(vec[0], "File_test_text.txt");
+  TEST_EQUAL(File::fileList(OPENMS_GET_TEST_DATA_PATH(""), "File_test_text.txt", vec, true), true);
+  // can't use "path + separator + filename", because sep. might be "/" or "\\"
+  TEST_EQUAL(vec[0].hasPrefix(OPENMS_GET_TEST_DATA_PATH("")), true);
+  TEST_EQUAL(vec[0].hasSuffix("File_test_text.txt"), true);
 END_SECTION
 
 START_SECTION((static String getUniqueName(bool include_hostname = true)))
-	String unique_name = File::getUniqueName();
-	String unique_name_no_host = File::getUniqueName(false);
-	TEST_EQUAL(unique_name.size() > unique_name_no_host.size(), true)
-	
-	// test if the string consists of four parts
-	StringList split;
-	unique_name.split('_', split);
-	TEST_EQUAL(split.size() >= 4, true) // if name of machine also contains '_' ...
+  String unique_name = File::getUniqueName();
+  String unique_name_no_host = File::getUniqueName(false);
+  TEST_EQUAL(unique_name.size() > unique_name_no_host.size(), true)
+  
+  // test if the string consists of four parts
+  StringList split;
+  unique_name.split('_', split);
+  TEST_EQUAL(split.size() >= 4, true) // if name of machine also contains '_' ...
 END_SECTION
 
 START_SECTION((static String getOpenMSDataPath()))
-	NOT_TESTABLE
+  NOT_TESTABLE
 END_SECTION
 
 START_SECTION((static String removeExtension(const String& file)))
-	TEST_STRING_EQUAL(File::removeExtension(""),"")
-	TEST_STRING_EQUAL(File::removeExtension("/home/doe/file"),"/home/doe/file")
-	TEST_STRING_EQUAL(File::removeExtension("/home/doe/file.txt"),"/home/doe/file")
-	TEST_STRING_EQUAL(File::removeExtension("/home/doe/file.txt.tgz"),"/home/doe/file.txt")
+  TEST_STRING_EQUAL(File::removeExtension(""),"")
+  TEST_STRING_EQUAL(File::removeExtension("/home/doe/file"),"/home/doe/file")
+  TEST_STRING_EQUAL(File::removeExtension("/home/doe/file.txt"),"/home/doe/file")
+  TEST_STRING_EQUAL(File::removeExtension("/home/doe/file.txt.tgz"),"/home/doe/file.txt")
 END_SECTION
 
 START_SECTION((static bool isDirectory(const String& path)))
-	TEST_EQUAL(File::isDirectory(""),false)
-	TEST_EQUAL(File::isDirectory("."),true)
-	TEST_EQUAL(File::isDirectory(OPENMS_GET_TEST_DATA_PATH("")),true)
-	TEST_EQUAL(File::isDirectory(OPENMS_GET_TEST_DATA_PATH("does_not_exists.txt")),false)
-	TEST_EQUAL(File::isDirectory(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt")),false)
+  TEST_EQUAL(File::isDirectory(""),false)
+  TEST_EQUAL(File::isDirectory("."),true)
+  TEST_EQUAL(File::isDirectory(OPENMS_GET_TEST_DATA_PATH("")),true)
+  TEST_EQUAL(File::isDirectory(OPENMS_GET_TEST_DATA_PATH("does_not_exists.txt")),false)
+  TEST_EQUAL(File::isDirectory(OPENMS_GET_TEST_DATA_PATH("File_test_text.txt")),false)
 END_SECTION
 
 START_SECTION(static bool removeDirRecursively(const String &dir_name))
@@ -219,8 +219,8 @@ END_SECTION
 
 START_SECTION(static String findExecutable(const OpenMS::String& toolName))
 {
-	TEST_EXCEPTION(Exception::FileNotFound, File::findExecutable("executable_does_not_exist"))
-	TEST_EQUAL(File::path(File::findExecutable("File_test")) + "/", File::getExecutablePath())
+  TEST_EXCEPTION(Exception::FileNotFound, File::findExecutable("executable_does_not_exist"))
+  TEST_EQUAL(File::path(File::findExecutable("File_test")) + "/", File::getExecutablePath())
 }
 END_SECTION
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/File_test.cpp
+++ b/src/tests/class_tests/openms/source/File_test.cpp
@@ -139,10 +139,12 @@ TEST_EQUAL(vec[0].hasPrefix(OPENMS_GET_TEST_DATA_PATH("")), true);
 TEST_EQUAL(vec[0].hasSuffix("File_test_text.txt"), true);
 END_SECTION
 
-START_SECTION((static String getUniqueName()))
+START_SECTION((static String getUniqueName(bool include_hostname = true)))
 	String unique_name = File::getUniqueName();
-
-	// test if the string consists of three parts
+	String unique_name_no_host = File::getUniqueName(false);
+	TEST_EQUAL(unique_name.size() > unique_name_no_host.size(), true)
+	
+	// test if the string consists of four parts
 	StringList split;
 	unique_name.split('_', split);
 	TEST_EQUAL(split.size() >= 4, true) // if name of machine also contains '_' ...


### PR DESCRIPTION
[FIX] augment #2582 which introduced a long-filename problem, by adding a new suffix in every TOPPAS TOPP node resulting in chained suffices, e.g. mzml.idxml.tsv....
This commit removes old file extensions before adding new ones, thus keeping file length small.

Also shortens the path further by shorter unique names and not using the redundant ./toppas_tmp/ subdir anymore.

Successfully tested with all TOPPAS example pipelines and 'LabelFree_Fusion_20170802.toppas' from @lars20070.

