### PR TITLE
[FEATURE] faster idXML store; memory consumption report

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/FASTAFile.h
+++ b/src/openms/include/OpenMS/FORMAT/FASTAFile.h
@@ -41,6 +41,7 @@
 #include <functional>
 #include <fstream>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace OpenMS
@@ -77,9 +78,9 @@ public:
       String sequence;
 
       FASTAEntry() :
-        identifier(""),
-        description(""),
-        sequence("")
+        identifier(),
+        description(),
+        sequence()
       {
       }
 
@@ -89,6 +90,31 @@ public:
         sequence(seq)
       {
       }
+      
+      FASTAEntry(const FASTAEntry& rhs)
+        :
+        identifier(rhs.identifier),
+        description(rhs.description),
+        sequence(rhs.sequence)
+      {
+      }
+
+      FASTAEntry(FASTAEntry&& rhs) noexcept
+       :
+        identifier(::std::move(rhs.identifier)),
+        description(::std::move(rhs.description)),
+        sequence(::std::move(rhs.sequence)) 
+      {
+      }
+
+      FASTAEntry& operator=(const FASTAEntry& rhs)
+      {
+        if (*this == rhs) return *this;
+        identifier = rhs.identifier;
+        description = rhs.description;
+        sequence = rhs.sequence;
+        return *this;
+      }
 
       bool operator==(const FASTAEntry& rhs) const
       {
@@ -97,19 +123,19 @@ public:
                && sequence == rhs.sequence;
       }
     
-      bool headerMatches(const FASTAEntry rhs)
+      bool headerMatches(const FASTAEntry& rhs) const
       {
         return identifier == rhs.identifier && 
   	     description == rhs.description;
       }
  
-      bool sequenceMatches(const FASTAEntry rhs)
+      bool sequenceMatches(const FASTAEntry& rhs) const
       {
         return sequence == rhs.sequence;
       }
     };
 
-    /// Copy constructor
+    /// Default constructor
     FASTAFile();
 
     /// Destructor

--- a/src/openms/include/OpenMS/FORMAT/IdXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/IdXMLFile.h
@@ -35,6 +35,7 @@
 #ifndef OPENMS_FORMAT_IDXMLFILE_H
 #define OPENMS_FORMAT_IDXMLFILE_H
 
+#include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <OpenMS/FORMAT/HANDLERS/XMLHandler.h>
@@ -50,11 +51,11 @@ namespace OpenMS
     This class is used to load and store documents that implement
     the schema of idXML files.
 
-        A documented schema for this format can be found at http://open-ms.sourceforge.net/schemas/.
+    A documented schema for this format can be found at http://open-ms.sourceforge.net/schemas/.
 
-        One file can contain several ProteinIdentification runs. Each run consists of peptide hits stored in
-        PeptideIdentification and (optional) protein hits stored in Identification. Peptide and protein
-        hits are connected via a string identifier. We use the search engine and the date as identifier.
+    One file can contain several ProteinIdentification runs. Each run consists of peptide hits stored in
+    PeptideIdentification and (optional) protein hits stored in Identification. Peptide and protein
+    hits are connected via a string identifier. We use the search engine and the date as identifier.
 
     @note This format will eventually be replaced by the HUPO-PSI (mzIdentML and mzQuantML)) AnalysisXML formats!
 
@@ -62,7 +63,8 @@ namespace OpenMS
   */
   class OPENMS_DLLAPI IdXMLFile :
     protected Internal::XMLHandler,
-    public Internal::XMLFile
+    public Internal::XMLFile,
+    public ProgressLogger
   {
 public:
     // both ConsensusXMLFile and FeatureXMLFile use some protected IdXML helper functions to parse identifications without code duplication

--- a/src/openms/include/OpenMS/SYSTEM/SysInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/SysInfo.h
@@ -51,12 +51,21 @@ namespace OpenMS
 	{
 		public:
 			/// Get memory consumption in KiloBytes (KB)
-			/// This might be very unreliable, depending on operating system and kernel version
-			///
-			/// @param mem_virtual Total virtual memory allocated by the current process
+      /// On Windows, this is equivalent to 'Peak Working Set (Memory)' in Task Manager.
+      /// On other OS this might be very unreliable, depending on operating system and kernel version.
+      ///
+			/// @param mem_virtual Total virtual memory currently allocated by this process
 			/// @return True on success, false otherwise. If false is returned, then @p mem_virtual is set to 0.
 			static bool getProcessMemoryConsumption(size_t& mem_virtual);
-	};
+  
+      /// Get peak memory consumption in KiloBytes (KB)
+      /// On Windows, this is equivalent to 'Working Set (Memory)' in Task Manager.
+      /// On other OS this might be very unreliable, depending on operating system and kernel version.
+      ///
+      /// @param mem_virtual Total virtual memory allocated by this process
+      /// @return True on success, false otherwise. If false is returned, then @p mem_virtual is set to 0.
+      static bool getProcessPeakMemoryConsumption(size_t& mem_virtual);
+  };
 }
 
 #endif

--- a/src/openms/include/OpenMS/SYSTEM/SysInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/SysInfo.h
@@ -36,15 +36,15 @@
 #define OPENMS_SYSTEM_SYSINFO_H
 
 #include <OpenMS/config.h>
-#include <cstddef>
+#include <OpenMS/DATASTRUCTURES/String.h>
 
 namespace OpenMS
 {
 
 	/**
-	@brief Some static functions to get system information
+	@brief Some functions to get system information
 
-	Supports current memory consumption.
+	Supports current memory and peak memory consumption.
 
 	*/
 	class OPENMS_DLLAPI SysInfo
@@ -65,6 +65,48 @@ namespace OpenMS
       /// @param mem_virtual Total virtual memory allocated by this process
       /// @return True on success, false otherwise. If false is returned, then @p mem_virtual is set to 0.
       static bool getProcessPeakMemoryConsumption(size_t& mem_virtual);
+
+      /**
+        @brief A convenience class to report either absolute or delta (between two timepoints) RAM usage
+
+        Working RAM and Peak RAM usage are recorded at two time points ('before' and 'after').
+        @note Peak RAM is only supported on WindowsOS; other OS will only report Working RAM usage
+        
+        When constructed, MemUsage automatically queries the present RAM usage (first timepoint), i.e. calls @ref before().
+        Data for the second timepoint can be recorded using @ref after().
+
+        @ref delta() reports the difference between the timepoints (before -> after);
+        @ref usage() reports only the second timepoint's absolute value (after).
+
+        When @ref delta() or @ref usage() are called, and the second timepoint is not recorded yet, this will be done internally.
+
+      */
+      struct OPENMS_DLLAPI MemUsage
+      {
+        size_t mem_before, mem_before_peak, mem_after, mem_after_peak;
+
+        /// C'tor, calls @ref before() automatically
+        MemUsage();
+
+        /// forget all data (you need to call @ref before() again)
+        void reset();
+        /// record data for the first timepoint
+        void before();
+        /// record data for the second timepoint
+        void after();
+        /// get difference in memory usage between the two timepoints
+        /// @ref after() will be called unless it was called earlier
+        String delta(const String& event = "delta");
+
+        /// get current memory usage (i.e. 'after')
+        /// @ref after() will be called unless it was called earlier
+        String usage();
+
+      private:
+        // convert difference to string
+        String diff_str_(size_t mem_before, size_t mem_after);
+
+      };
   };
 }
 

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -36,6 +36,7 @@
 
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/SYSTEM/StopWatch.h>
+#include <OpenMS/SYSTEM/SysInfo.h>
 #include <OpenMS/SYSTEM/UpdateCheck.h>
 
 #include <OpenMS/DATASTRUCTURES/Date.h>
@@ -491,6 +492,14 @@ namespace OpenMS
     result = main_(argc, argv);
     sw.stop();
     LOG_INFO << this->tool_name_ << " took " << sw.toString() << "." << std::endl;
+
+    // useful for benchmarking
+    if (debug_level_ >= 1)
+    {
+      size_t mem_virtual(0);
+      writeLog_(String("Peak Memory Usage: ") + (SysInfo::getProcessPeakMemoryConsumption(mem_virtual) ? String(mem_virtual / 1024) + " MB" : "<unknown>"));
+    }
+
 
 #ifndef DEBUG_TOPP
   }

--- a/src/openms/source/CONCEPT/ProgressLogger.cpp
+++ b/src/openms/source/CONCEPT/ProgressLogger.cpp
@@ -102,18 +102,11 @@ public:
     void endProgress(const int current_recursion_depth) const
     {
       stop_watch_.stop();
-      if (begin_ == end_)
+      if (current_recursion_depth)
       {
-        if (current_recursion_depth)
-        {
-          cout << '\n';
-        }
-        cout << endl << string(2 * current_recursion_depth, ' ') << "-- done [took " << StopWatch::toString(stop_watch_.getCPUTime()) << " (CPU), " << StopWatch::toString(stop_watch_.getClockTime()) << " (Wall)] -- " << endl;
+        cout << '\n';
       }
-      else
-      {
-        cout << '\r' << string(2 * current_recursion_depth, ' ') << "-- done [took " << StopWatch::toString(stop_watch_.getCPUTime()) << " (CPU), " << StopWatch::toString(stop_watch_.getClockTime()) << " (Wall)] -- " << endl;
-      }
+      cout << '\r' << string(2 * current_recursion_depth, ' ') << "-- done [took " << StopWatch::toString(stop_watch_.getCPUTime()) << " (CPU), " << StopWatch::toString(stop_watch_.getClockTime()) << " (Wall)] -- " << endl;
     }
 
 private:

--- a/src/openms/source/FORMAT/FASTAFile.cpp
+++ b/src/openms/source/FORMAT/FASTAFile.cpp
@@ -112,7 +112,7 @@ namespace OpenMS
     String::size_type position = id.find_first_of(" \v\t");
     if (position == String::npos)
     {
-      protein.identifier = id;
+      protein.identifier = std::move(id);
       protein.description = "";
     }
     else
@@ -132,7 +132,7 @@ namespace OpenMS
     f.readStart(filename);
     while (f.readNext(p))
     {
-      data.push_back(p);
+      data.push_back(std::move(p));
     }
     return;
   }

--- a/src/openms/source/MATH/STATISTICS/CumulativeBinomial.cpp
+++ b/src/openms/source/MATH/STATISTICS/CumulativeBinomial.cpp
@@ -58,7 +58,7 @@ namespace OpenMS
         {
           coeff = boost::math::binomial_coefficient<double>(static_cast<unsigned int>(n), static_cast<unsigned int>(j));
         }
-        catch (std::overflow_error const& e)
+        catch (std::overflow_error const& /*e*/)
         {
           std::cout << "Warning: Binomial coefficient for match-odds score has overflowed! Setting value to the maximal double value." << std::endl;
           std::cout << "binomial_coefficient was called with N = " << n << " and k = " << j << std::endl;

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -411,13 +411,13 @@ protected:
 
       for (auto loopiter = entries.begin(); loopiter != entries.end(); ++loopiter)
       {
-        auto iter = find_if(entries.begin(), loopiter, [&loopiter](auto& entry) { return entry.headerMatches(*loopiter); });
+        auto iter = find_if(entries.begin(), loopiter, [&loopiter](const FASTAFile::FASTAEntry& entry) { return entry.headerMatches(*loopiter); });
         if (iter != loopiter)
         {
           os << "Warning: Duplicate header, Number: " << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " is same as Number: " << std::distance(entries.begin(), iter) << ", ID: " << iter->identifier << "\n";
         }
 
-        iter = find_if(entries.begin(), loopiter, [&loopiter](auto& entry) { return entry.sequenceMatches(*loopiter); });
+        iter = find_if(entries.begin(), loopiter, [&loopiter](const FASTAFile::FASTAEntry& entry) { return entry.sequenceMatches(*loopiter); });
         if (iter != loopiter && iter != entries.end())
         {
           os << "Warning: Duplicate sequence, Number: " << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " is same as Number: " << std::distance(entries.begin(), iter) << ", ID: " << iter->identifier << "\n";

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -105,56 +105,28 @@ using namespace std;
 
 namespace OpenMS
 {
-//helper struct for identification data
-struct IdData
-{
-  String identifier;
-  vector<ProteinIdentification> proteins;
-  vector<PeptideIdentification> peptides;
-};
-
-/// Write SomeStatistics to a stream.
-template <class T>
-static ostream &operator<<(ostream &os, const Math::SummaryStatistics<T> &rhs)
-{
-  return os << "  num. of values: " << rhs.count << "\n"
-            << "  mean:           " << rhs.mean << "\n"
-            << "  minimum:        " << rhs.min << "\n"
-            << "  lower quartile: " << rhs.lowerq << "\n"
-            << "  median:         " << rhs.median << "\n"
-            << "  upper quartile: " << rhs.upperq << "\n"
-            << "  maximum:        " << rhs.max << "\n"
-            << "  variance:       " << rhs.variance << "\n";
-}
-
-struct MemUsage
-{
-
-  size_t mem_before, mem_after;
-  MemUsage()
-      : mem_before(0), mem_after(0)
+  //helper struct for identification data
+  struct IdData
   {
-  }
+    String identifier;
+    vector<ProteinIdentification> proteins;
+    vector<PeptideIdentification> peptides;
+  };
 
-  void before()
+  /// Write SomeStatistics to a stream.
+  template <class T>
+  static ostream &operator<<(ostream &os, const Math::SummaryStatistics<T> &rhs)
   {
-    SysInfo::getProcessMemoryConsumption(mem_before);
+    return os << "  num. of values: " << rhs.count << "\n"
+              << "  mean:           " << rhs.mean << "\n"
+              << "  minimum:        " << rhs.min << "\n"
+              << "  lower quartile: " << rhs.lowerq << "\n"
+              << "  median:         " << rhs.median << "\n"
+              << "  upper quartile: " << rhs.upperq << "\n"
+              << "  maximum:        " << rhs.max << "\n"
+              << "  variance:       " << rhs.variance << "\n";
   }
-  void after()
-  {
-    SysInfo::getProcessMemoryConsumption(mem_after);
-  }
-};
-ostream &operator<<(ostream &os, const MemUsage &m)
-{
-  if (m.mem_after < m.mem_before)
-    os << "-" << (m.mem_before - m.mem_after) / 1024;
-  else
-    os << (m.mem_after - m.mem_before) / 1024;
-  os << " MB";
-  return os;
-}
-}
+} // namespace
 
 class TOPPFileInfo : public TOPPBase
 {
@@ -223,8 +195,6 @@ protected:
     // File type
     FileHandler fh;
     FileTypes::Type in_type = FileTypes::nameToType(getStringOption_("in_type"));
-
-    MemUsage mu;
 
     if (in_type == FileTypes::UNKNOWN)
     {
@@ -408,7 +378,7 @@ protected:
           OpenMS::Interfaces::ChromatogramPtr p = ifile.getChromatogramById(i);
         }
 
-        std::cout << "Found a valid indexedmzML XML File with " << ifile.getNrSpectra() << " spectra and " << ifile.getNrChromatograms() << " chromatograms." << std::endl
+        std::cout << "Found a valid indexed mzML XML File with " << ifile.getNrSpectra() << " spectra and " << ifile.getNrChromatograms() << " chromatograms." << std::endl
                   << std::endl;
       }
       else
@@ -427,34 +397,27 @@ protected:
     {
       vector<FASTAFile::FASTAEntry> entries;
       FASTAFile file;
-      vector<FASTAFile::FASTAEntry>::iterator loopiter;
-      vector<FASTAFile::FASTAEntry>::iterator iter;
 
       map<char, int> aacids;
-      std::map<char, int>::iterator it;
       int number_of_aacids = 0;
 
-      mu.before();
+      SysInfo::MemUsage mu;
       //loading input
       file.load(in, entries);
-
-      mu.after();
-      std::cout << "\n\nMemory usage while loading: " << mu << std::endl;
+      std::cout << "\n\n" << mu.delta("loading FASTA") << std::endl;
 
       os << "Number of sequences: " << entries.size() << "\n"
          << "\n";
 
-      for (loopiter = entries.begin(); loopiter != entries.end(); loopiter = std::next(loopiter))
+      for (auto loopiter = entries.begin(); loopiter != entries.end(); ++loopiter)
       {
-        iter = find_if(entries.begin(), loopiter, bind1st(mem_fun(&FASTAFile::FASTAEntry::headerMatches), &(*loopiter)));
-
+        auto iter = find_if(entries.begin(), loopiter, [&loopiter](auto& entry) { return entry.headerMatches(*loopiter); });
         if (iter != loopiter)
         {
           os << "Warning: Duplicate header, Number: " << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " is same as Number: " << std::distance(entries.begin(), iter) << ", ID: " << iter->identifier << "\n";
         }
 
-        iter = find_if(entries.begin(), loopiter, bind1st(mem_fun(&FASTAFile::FASTAEntry::sequenceMatches), &(*loopiter)));
-
+        iter = find_if(entries.begin(), loopiter, [&loopiter](auto& entry) { return entry.sequenceMatches(*loopiter); });
         if (iter != loopiter && iter != entries.end())
         {
           os << "Warning: Duplicate sequence, Number: " << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " is same as Number: " << std::distance(entries.begin(), iter) << ", ID: " << iter->identifier << "\n";
@@ -471,7 +434,7 @@ protected:
       os << "Amino acid counts: "
          << "\n";
 
-      for (it = aacids.begin(); it != aacids.end(); it = std::next(it))
+      for (auto it = aacids.begin(); it != aacids.end(); ++it)
       {
         os << it->first << '\t' << it->second << "\n";
       }
@@ -483,12 +446,11 @@ protected:
       ff.getOptions().setLoadConvexHull(false);   // CH's currently not needed here
       ff.getOptions().setLoadSubordinates(false); // SO's currently not needed here
 
-      mu.before();
+      SysInfo::MemUsage mu;
       // reading input
       ff.load(in, feat);
-      mu.after();
+      std::cout << "\n\n" << mu.delta("loading featureXML") << std::endl;
 
-      std::cout << "\n\nMemory usage while loading: " << mu << std::endl;
       feat.updateRanges();
 
       os << "Number of features: " << feat.size() << "\n"
@@ -530,11 +492,10 @@ protected:
     else if (in_type == FileTypes::CONSENSUSXML) //consensus features
     {
 
-      mu.before();
+      SysInfo::MemUsage mu;
       // reading input
       ConsensusXMLFile().load(in, cons);
-      mu.after();
-      std::cout << "\n\nMemory usage while loading: " << mu << std::endl;
+      std::cout << "\n\n" << mu.delta("loading consensusXML") << std::endl;
 
       cons.updateRanges();
 
@@ -598,7 +559,7 @@ protected:
       vector<uint16_t> peptide_length;
 
       // reading input
-      mu.before();
+      SysInfo::MemUsage mu;
       if (in_type == FileTypes::MZIDENTML)
       {
         MzIdentMLFile().load(in, id_data.proteins, id_data.peptides);
@@ -607,9 +568,7 @@ protected:
       {
         IdXMLFile().load(in, id_data.proteins, id_data.peptides, id_data.identifier);
       }
-
-      mu.after();
-      std::cout << "\n\nMemory usage while loading: " << mu << std::endl;
+      std::cout << "\n\n" << mu.delta("loading idXML") << std::endl;
 
       // export metadata to second output stream
       os_tsv << "database"
@@ -707,19 +666,15 @@ protected:
     else //peaks
     {
 
-      mu.before();
-
+      SysInfo::MemUsage mu;
       if (!fh.loadExperiment(in, exp, in_type, log_type_, false, false))
       {
         writeLog_("Unsupported or corrupt input file. Aborting!");
         printUsage_();
         return ILLEGAL_PARAMETERS;
       }
-
       // report memory consumption
-
-      mu.after();
-      std::cout << "\n\nMemory usage while loading: " << mu << std::endl;
+      std::cout << "\n\n" << mu.delta("loading MS data") << std::endl;
 
       //check if the meta data indicates that this is peak data
       UInt meta_type = SpectrumSettings::UNKNOWN;
@@ -1545,6 +1500,7 @@ protected:
     return ret;
   }
 };
+
 
 int main(int argc, const char **argv)
 {

--- a/src/topp/FileMerger.cpp
+++ b/src/topp/FileMerger.cpp
@@ -296,14 +296,14 @@ protected:
       for (loopiter = entries.begin(); loopiter != entries.end(); loopiter = std::next(loopiter))
       {
 
-        iter = find_if(entries.begin(), loopiter, bind1st(mem_fun(&FASTAFile::FASTAEntry::headerMatches), &(*loopiter)));
+        iter = find_if(entries.begin(), loopiter, [&loopiter](const FASTAFile::FASTAEntry& entry) { return entry.headerMatches(*loopiter); });
 
         if (iter != loopiter)
         {
           std::cout << "Warning: Duplicate header, Number: " << std::distance(entries.begin(), loopiter) + 1 << ", ID: " << loopiter->identifier << " is same as Number: " << std::distance(entries.begin(), iter) << ", ID: " << iter->identifier << "\n";
         }
 
-        iter = find_if(entries.begin(), loopiter, bind1st(mem_fun(&FASTAFile::FASTAEntry::sequenceMatches), &(*loopiter)));
+        iter = find_if(entries.begin(), loopiter, [&loopiter](const FASTAFile::FASTAEntry& entry) { return entry.sequenceMatches(*loopiter); });
 
         if (iter != loopiter && iter != entries.end())
         {


### PR DESCRIPTION
this PR introduces of some of new features which are required for the new Aho-Corasick PeptideIndexer.
Its a smaller, more digestable chunk, to make the review a bit easier. Another PR is coming up soon.

The changes introduced here are not dramatic:
[FEATURE] 10% faster writing of idXML 
[FEATURE] idXML can now report timings when loading/storing (via ProgressLogger)
[NOOP] minor formatting of Progresslogger output
[FEATURE] move semantics for FASTAEntries (potentially faster) when loading FASTA files
[FEATURE] TOPP tools report their peak memory usage when using -debug

