### PR TITLE
[FIX] Remove database parameter (SiriusAdapter)

### DIFF
--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -198,7 +198,6 @@ protected:
     QStringList process_params; // the actual process
     process_params << "-p" << profile
                    << "-e" << elements
-                   << "-d" << database
                    << "-s" << isotope
                    << "--noise" << noise
                    << "--candidates" << candidates


### PR DESCRIPTION
Sirius 3.5 parameter update - SiriusAdapter was failing. 