### PR TITLE
[FIX] database parameter used by CSIFingerID

### DIFF
--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -172,7 +172,7 @@ endif()
 
 #------------------------------------------------------------------------------
 if (NOT (${SIRIUS_BINARY} STREQUAL "SIRIUS_BINARY-NOTFOUND"))
-  add_test("TOPP_SiriusAdapter_1" ${TOPP_BIN_PATH}/SiriusAdapter -executable "${SIRIUS_BINARY}" -in ${DATA_DIR_TOPP}/THIRDPARTY/SiriusAdapter_1_input.mzML -out_sirius SiriusAdapter_1_output.tmp -auto_charge -profile qtof)
+  add_test("TOPP_SiriusAdapter_1" ${TOPP_BIN_PATH}/SiriusAdapter -executable "${SIRIUS_BINARY}" -in ${DATA_DIR_TOPP}/THIRDPARTY/SiriusAdapter_1_input.mzML -out_sirius SiriusAdapter_1_output.tmp -auto_charge -profile qtof -database all)
   add_test("TOPP_SiriusAdapter_1_out" ${DIFF} -in1 SiriusAdapter_1_output.tmp -in2 ${DATA_DIR_TOPP}/THIRDPARTY/SiriusAdapter_1_output.mzTab -whitelist "MTD")
   set_tests_properties("TOPP_SiriusAdapter_1_out" PROPERTIES DEPENDS "TOPP_SiriusAdapter_1")
 endif()

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -117,6 +117,8 @@ protected:
     registerStringOption_("profile", "<choice>", "qtof", "Specify the used analysis profile", false);
     setValidStrings_("profile", ListUtils::create<String>("qtof,orbitrap,fticr"));
     registerIntOption_("candidates", "<num>", 5, "The number of candidates in the output. Default 5 best candidates", false);
+    registerStringOption_("database", "<choice>", "all", "search formulas in given database", false);
+    setValidStrings_("database", ListUtils::create<String>("all,chebi,custom,kegg,bio,natural products,pubmed,hmdb,biocyc,hsdb,knapsack,biological,zinc bio,gnps,pubchem,mesh,maconda"));    
     registerIntOption_("noise", "<num>", 0, "median intensity of noise peaks", false);
     registerIntOption_("ppm_max", "<num>", 10, "allowed ppm for decomposing masses", false);
     registerStringOption_("isotope", "<choice>", "both", "how to handle isotope pattern data. Use 'score' to use them for ranking or 'filter' if you just want to remove candidates with bad isotope pattern. With 'both' you can use isotopes for filtering and scoring (default). Use 'omit' to ignore isotope pattern.", false);
@@ -148,6 +150,7 @@ protected:
     QString executable = getStringOption_("executable").toQString();
     QString profile = getStringOption_("profile").toQString();
     QString elements = getStringOption_("elements").toQString();
+    QString database = getStringOption_("database").toQString();    
     QString isotope = getStringOption_("isotope").toQString();
     QString noise = QString::number(getIntOption_("noise"));
     QString ppm_max = QString::number(getIntOption_("ppm_max"));
@@ -195,6 +198,7 @@ protected:
     QStringList process_params; // the actual process
     process_params << "-p" << profile
                    << "-e" << elements
+                   << "-d" << database
                    << "-s" << isotope
                    << "--noise" << noise
                    << "--candidates" << candidates


### PR DESCRIPTION
Error was introduced by wrong Sirius version without FingerID.
The Version with FingerID uses the database parameter. 

This right version can be found in THIRDPARTY. 