### PR TITLE
[FEATURE] deleting selections of peak annotations in TOPPView

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotations1DContainer.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/ANNOTATION/Annotations1DContainer.h
@@ -101,6 +101,9 @@ public:
     /// Removes the selected items
     void removeSelectedItems();
 
+    /// Returns the selected items
+    std::vector<Annotation1DItem*> getSelectedItems();
+
     /// Sets the pen_
     void setPen(const QPen & pen);
 

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -276,7 +276,7 @@ public:
     void synchronizePeakAnnotations();
 
     /// remove peak annotations in the given list from the currently active PeptideHit
-    void removePeakAnnotationsFromPeptideHit(std::vector<Annotation1DItem*>);
+    void removePeakAnnotationsFromPeptideHit(const std::vector<Annotation1DItem*>& selected_annotations);
 
     /// if this layer is visible
     bool visible;

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -275,6 +275,9 @@ public:
     /// if no PeptideIdentification or PeptideHit for the spectrum exist, it is generated
     void synchronizePeakAnnotations();
 
+    /// remove peak annotations in the given list from the currently active PeptideHit
+    void removePeakAnnotationsFromPeptideHit(std::vector<Annotation1DItem*>);
+
     /// if this layer is visible
     bool visible;
 

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotations1DContainer.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotations1DContainer.cpp
@@ -195,4 +195,17 @@ namespace OpenMS
     }
   }
 
+  std::vector<Annotation1DItem*> Annotations1DContainer::getSelectedItems()
+  {
+    std::vector<Annotation1DItem*> annotation_items;
+    for (Iterator it = begin(); it != end(); ++it)
+    {
+      if ((*it)->isSelected())
+      {
+        annotation_items.push_back(*it);
+      }
+    }
+    return annotation_items;
+  }
+
 } //Namespace

--- a/src/openms_gui/source/VISUAL/ANNOTATION/Annotations1DContainer.cpp
+++ b/src/openms_gui/source/VISUAL/ANNOTATION/Annotations1DContainer.cpp
@@ -197,14 +197,13 @@ namespace OpenMS
 
   std::vector<Annotation1DItem*> Annotations1DContainer::getSelectedItems()
   {
-    std::vector<Annotation1DItem*> annotation_items;
-    for (Iterator it = begin(); it != end(); ++it)
-    {
-      if ((*it)->isSelected())
-      {
-        annotation_items.push_back(*it);
-      }
-    }
+    // initialize with maximal possible size
+    std::vector<Annotation1DItem*> annotation_items(size());
+    // copy if is selected
+    auto it = std::copy_if(begin(), end(), annotation_items.begin(), [](Annotation1DItem* anno){return anno->isSelected();});
+    // resize to number of actually copied items
+    annotation_items.resize(std::distance(annotation_items.begin(), it));
+
     return annotation_items;
   }
 

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -249,11 +249,13 @@ namespace OpenMS
     bool annotations_changed(false);
 
     // collect annotations, that have to be removed
-    for (const auto tmp_a : fas)
+    for (const auto& tmp_a : fas)
     {
-      for (const auto it : selected_annotations)
+      for (const auto& it : selected_annotations)
       {
         Annotation1DPeakItem* pa = dynamic_cast<Annotation1DPeakItem*>(it);
+        // only search for peak annotations
+        if (pa == nullptr) { continue; }
         if (fabs(tmp_a.mz - pa->getPeakPosition()[0]) < 1e-6)
         {
           if (String(pa->getText()).hasPrefix(tmp_a.annotation))
@@ -265,11 +267,10 @@ namespace OpenMS
       }
     }
     // remove the collected annotations from the PeptideHit annotations
-    for (const auto tmp_a : to_remove)
+    for (const auto& tmp_a : to_remove)
     {
       fas.erase(std::remove(fas.begin(), fas.end(), tmp_a), fas.end());
     }
     if (annotations_changed) { hit.setPeakAnnotations(fas); }
   }
-
 } //Namespace

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -249,9 +249,9 @@ namespace OpenMS
     bool annotations_changed(false);
 
     // collect annotations, that have to be removed
-    for (const auto& tmp_a : fas)
+    for (auto const& tmp_a : fas)
     {
-      for (const auto& it : selected_annotations)
+      for (auto const& it : selected_annotations)
       {
         Annotation1DPeakItem* pa = dynamic_cast<Annotation1DPeakItem*>(it);
         // only search for peak annotations
@@ -267,7 +267,7 @@ namespace OpenMS
       }
     }
     // remove the collected annotations from the PeptideHit annotations
-    for (const auto& tmp_a : to_remove)
+    for (auto const& tmp_a : to_remove)
     {
       fas.erase(std::remove(fas.begin(), fas.end(), tmp_a), fas.end());
     }

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -228,8 +228,6 @@ namespace OpenMS
     MSSpectrum & spectrum = (*getPeakData())[spectrum_index];
     int ms_level = spectrum.getMSLevel();
 
-    bool annotations_changed(false);
-
     if (ms_level != 2)
     {
       return;
@@ -268,6 +266,7 @@ namespace OpenMS
 
           // all requirements fulfilled, PH in hit and annotations in anno items
           vector<PeptideHit::PeakAnnotation> to_remove;
+          bool annotations_changed(false);
 
           for (auto tmp_a : fas)
           {

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -278,10 +278,7 @@ namespace OpenMS
               {
                 if (String(pa->getText()).hasPrefix(tmp_a.annotation))
                 {
-                  // erase(tmp_a);
-                  // std::remove(fas.begin(), fas.end(), tmp_a);
                   to_remove.push_back(tmp_a);
-                  // fas.erase(std::remove(fas.begin(), fas.end(), tmp_a), fas.end());
                   annotations_changed = true;
                 }
               }

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1337,6 +1337,7 @@ namespace OpenMS
         else if (result->text() == "Edit")
         {
           annot_item->editText();
+          getCurrentLayer_().synchronizePeakAnnotations();
         }
         update_(OPENMS_PRETTY_FUNCTION);
       }

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -509,6 +509,7 @@ namespace OpenMS
     if (e->key() == Qt::Key_Delete)
     {
       e->accept();
+      getCurrentLayer_().removePeakAnnotationsFromPeptideHit(getCurrentLayer_().getCurrentAnnotations().getSelectedItems());
       getCurrentLayer_().getCurrentAnnotations().removeSelectedItems();
       update_(OPENMS_PRETTY_FUNCTION);
     }

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -499,7 +499,7 @@ namespace OpenMS
       bool has_beta = frag_annotations[i].annotation.hasSubstring(String("beta|"));
       // if it has both, it is a complex fragment and more difficult to parse
       // those are ignored for the coverage indicator for now
-      if ( has_alpha ^ has_beta )
+      if ( has_alpha != has_beta )
       {
         vector<String> dol_split;
         frag_annotations[i].annotation.split("$", dol_split);

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -495,7 +495,11 @@ namespace OpenMS
 
     for (Size i = 0; i < frag_annotations.size(); ++i)
     {
-      if (frag_annotations[i].annotation.hasSubstring(String("[alpha|")) || frag_annotations[i].annotation.hasSubstring(String("[beta|")))
+      bool has_alpha = frag_annotations[i].annotation.hasSubstring(String("alpha|"));
+      bool has_beta = frag_annotations[i].annotation.hasSubstring(String("beta|"));
+      // if it has both, it is a complex fragment and more difficult to parse
+      // those are ignored for the coverage indicator for now
+      if ( has_alpha ^ has_beta )
       {
         vector<String> dol_split;
         frag_annotations[i].annotation.split("$", dol_split);
@@ -506,7 +510,19 @@ namespace OpenMS
         bool alpha = bar_split[0] == "[alpha";
         bool ci = bar_split[1] == "ci";
 
-        int pos = dol_split[1].suffix(dol_split[1].size()-1).prefix(dol_split[1].size()-2).toInt()-1;
+        vector<String> loss_split;
+        dol_split[1].split("-", loss_split);
+        String pos_string = loss_split[0].suffix(loss_split[0].size()-1);
+        int pos;
+        if (pos_string.hasSubstring("]"))
+        {
+          pos = pos_string.prefix(pos_string.size()-1).toInt()-1;
+        }
+        else
+        {
+          pos = pos_string.toInt()-1;
+        }
+
         String frag_type = dol_split[1][0];
         //bool left = (frag_type == "a" || frag_type == "b" || frag_type == "c");
         int direction;


### PR DESCRIPTION
A selection of peak annotations deleted from the TOPPView spectrum canvas
using the DEL key
will now also be removed from the peak annotations of
the current PeptideHit.