### PR TITLE
[FIX, REFACTOR] SiriusAdapter 

### DIFF
--- a/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
@@ -68,13 +68,14 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
     {
       
       unsigned int rowcount = 0;   
-      unsigned int number_cor = 0;
       
       CsvFile compounds(pathtocsicsv, '\t');
       rowcount = compounds.rowCount();
     
       if (file && rowcount > 1)
       {
+        unsigned int number_cor = 0;
+        
         if (number > rowcount)
         {
           number_cor = rowcount; 

--- a/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
@@ -32,18 +32,10 @@
 // $Authors: Oliver Alka, Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/DATASTRUCTURES/ListUtils.h>
-#include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>
-#include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/MzTabFile.h>
-#include <OpenMS/FORMAT/MzTab.h>
-#include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/CsvFile.h>
-#include <OpenMS/FORMAT/FileTypes.h>
-#include <OpenMS/FORMAT/HANDLERS/MzMLHandler.h>
 
 #include <OpenMS/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.h>
 #include <OpenMS/FORMAT/DATAACCESS/SiriusMzTabWriter.h>
@@ -59,32 +51,18 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
   for (std::vector<String>::const_iterator it = paths.begin(); it != paths.end(); ++it)
   {
 
-    std::string pathtocsicsv = *it + "/summary_csi_fingerid.csv";
+    const std::string pathtocsicsv = *it + "/summary_csi_fingerid.csv";
 
     ifstream file(pathtocsicsv);
 
-
     if (file) 
     {
-      
-      unsigned int rowcount = 0;   
-      
       CsvFile compounds(pathtocsicsv, '\t');
-      rowcount = compounds.rowCount();
+      const UInt rowcount = compounds.rowCount();
     
-      if (file && rowcount > 1)
+      if (rowcount > 1)
       {
-        unsigned int number_cor = 0;
         
-        if (number > rowcount)
-        {
-          number_cor = rowcount; 
-        }
-        else
-        {
-          number_cor = number;
-        }
-
         // fill identification structure containing all candidate hits for a single spectrum
         CsiFingerIdMzTabWriter::CsiAdapterIdentification csi_id;
 
@@ -92,6 +70,7 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
         OpenMS::String str = File::path(pathtocsicsv);
         std::string scan_index = SiriusMzTabWriter::extract_scan_index(str);
 
+        const UInt number_cor = (number > rowcount) ? rowcount : number;
         for (Size j = 1; j < number_cor; ++j)
         {
           
@@ -130,10 +109,10 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
 
         // write results to mzTab file
         MzTabSmallMoleculeSectionRows smsd;
-        for (Size i = 0; i != csi_result.identifications.size(); ++i)
+        for (Size i = 0; i < csi_result.identifications.size(); ++i)
         {
           const CsiFingerIdMzTabWriter::CsiAdapterIdentification &id = csi_result.identifications[i];
-          for (Size j = 0; j != id.hits.size(); ++j)
+          for (Size j = 0; j < id.hits.size(); ++j)
           {
             const CsiFingerIdMzTabWriter::CsiAdapterHit &hit = id.hits[j];
             MzTabSmallMoleculeSectionRow smsr;
@@ -143,16 +122,16 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
 
             smsr.chemical_formula = MzTabString(hit.molecular_formula);
             smsr.description = MzTabString(hit.name);
-            vector <MzTabString> pubchemids;
-            for (Size k = 0; k != hit.pubchemids.size(); ++k)
+            std::vector <MzTabString> pubchemids;
+            for (Size k = 0; k < hit.pubchemids.size(); ++k)
             {
               pubchemids.push_back(MzTabString(hit.pubchemids[k]));
             }  
             smsr.identifier.set(pubchemids);
             smsr.inchi_key = MzTabString(hit.inchikey2D);
             smsr.smiles = MzTabString(hit.smiles);
-            vector < MzTabString > uri;
-            for (Size k = 0; k != hit.links.size(); ++k)
+            std::vector < MzTabString > uri;
+            for (Size k = 0; k < hit.links.size(); ++k)
             {
               uri.push_back(MzTabString(hit.links[k]));
             }  
@@ -170,9 +149,7 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
             smsd.push_back(smsr);
           } 
         }
-
         result.setSmallMoleculeSectionRows(smsd);
-     
       }
     }
   }

--- a/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
@@ -70,9 +70,15 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
         std::string line;
         while (std::getline(file, line))
         {
-            ++number_of_lines;   
+            ++number_of_lines;
+            if (number_of_lines > 2)
+            {
+                break;
+            }
         }    
     }
+
+    std::cout << "number_of_lines " << number_of_lines << std::endl;
 
     if (file && number_of_lines > 1)
     {
@@ -88,6 +94,9 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
 
       for (Size j = 1; j < number; ++j)
       {
+
+        std::cout << "line " << j << std::endl;
+
         StringList sl;
         compounds.getRow(j, sl);
         CsiFingerIdMzTabWriter::CsiAdapterHit csi_hit;

--- a/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
@@ -63,7 +63,18 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
 
     ifstream file(pathtocsicsv);
 
-    if (file)
+    int number_of_lines = 0;
+
+    if (file) 
+    {
+        std::string line;
+        while (std::getline(file, line))
+        {
+            ++number_of_lines;   
+        }    
+    }
+
+    if (file && number_of_lines > 1)
     {
       // read results from sirius output files
       CsvFile compounds(pathtocsicsv, '\t');

--- a/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
@@ -63,13 +63,13 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & paths, Size number
 
     ifstream file(pathtocsicsv);
 
-    unsigned int rowcount = 0;   
-    unsigned int number_cor = 0;
 
     if (file) 
     {
       
-      // read results from sirius output files
+      unsigned int rowcount = 0;   
+      unsigned int number_cor = 0;
+      
       CsvFile compounds(pathtocsicsv, '\t');
       rowcount = compounds.rowCount();
     

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
@@ -68,12 +68,12 @@ void SiriusMzTabWriter::read(const std::vector<String> & paths, Size number, MzT
 
     ifstream file(pathtosiriuscsv);
 
-    unsigned int rowcount = 0;   
-    unsigned int number_cor = 0;
-
     if (file) 
     {
       
+      unsigned int rowcount = 0;   
+      unsigned int number_cor = 0;
+    
       CsvFile compounds(pathtosiriuscsv, '\t');
       rowcount = compounds.rowCount();
 

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
@@ -43,7 +43,7 @@ using namespace OpenMS;
 using namespace std;
 
 
-inline String SiriusMzTabWriter::extract_scan_index(const String &path)
+String SiriusMzTabWriter::extract_scan_index(const String &path)
 {
   return path.substr(path.find_last_not_of("0123456789") + 1);
 }

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
@@ -68,111 +68,121 @@ void SiriusMzTabWriter::read(const std::vector<String> & paths, Size number, MzT
 
     ifstream file(pathtosiriuscsv);
 
-    //check if file is available and read input & write output
-    if (file)
+    unsigned int rowcount = 0;   
+    unsigned int number_cor = 0;
+
+    if (file) 
     {
-      // read results from sirius output files
+      
       CsvFile compounds(pathtosiriuscsv, '\t');
+      rowcount = compounds.rowCount();
 
-      // fill indentification structure containing all candidate hits for a single spectrum
-      SiriusMzTabWriter::SiriusAdapterIdentification sirius_id;
-
-      //Extract scan_index from path
-      OpenMS::String str = File::path(pathtosiriuscsv);
-      std::string scan_index = SiriusMzTabWriter::extract_scan_index(str);
-
-      //If there are less rows than output -> rowCount - 1 is used since the last row of the file is empty
-      if (number > compounds.rowCount())
+      if (file && rowcount > 1)
       {
-        number = compounds.rowCount() - 1;
-      }
-
-      for (Size j = 1; j < number; ++j)
-      {
-        StringList sl;
-        compounds.getRow(j, sl);
-        SiriusMzTabWriter::SiriusAdapterHit sirius_hit;
-
-        // parse single candidate hit
-        sirius_hit.formula = sl[0];
-        sirius_hit.adduct = sl[1];
-        sirius_hit.rank = sl[2].toInt();
-        sirius_hit.score = sl[3].toDouble();
-        sirius_hit.treescore = sl[4].toDouble();
-        sirius_hit.isoscore = sl[5].toDouble();
-        sirius_hit.explainedpeaks = sl[6].toInt();
-        sirius_hit.explainedintensity = sl[7].toDouble();
-
-        sirius_id.hits.push_back(sirius_hit);
-      }
-
-      sirius_id.scan_index = scan_index;
-      sirius_result.identifications.push_back(sirius_id);
-
-      // write metadata to mzTab file
-      MzTabMetaData md;
-      MzTabMSRunMetaData md_run;
-      md_run.location = MzTabString(str);
-      md.ms_run[1] = md_run;
-      md.description = MzTabString("Sirius-3.5");
-
-      //needed for header generation (score)
-      std::map<Size, MzTabParameter> smallmolecule_search_engine_score;
-      smallmolecule_search_engine_score[1].setName("score");
-      smallmolecule_search_engine_score[2].setName("treescore");
-      smallmolecule_search_engine_score[3].setName("isoscore");
-      md.smallmolecule_search_engine_score = smallmolecule_search_engine_score;
-      result.setMetaData(md);
-
-      // write results to mzTab file
-      MzTabSmallMoleculeSectionRows smsd;
-      for (Size i = 0; i != sirius_result.identifications.size(); ++i)
-      {
-        const SiriusMzTabWriter::SiriusAdapterIdentification &id = sirius_result.identifications[i];
-        for (Size j = 0; j != id.hits.size(); ++j)
+        if (number > rowcount)
         {
-          const SiriusMzTabWriter::SiriusAdapterHit &hit = id.hits[j];
-          MzTabSmallMoleculeSectionRow smsr;
-
-          map<Size, MzTabDouble> engine_score;
-          engine_score[1] = MzTabDouble(hit.score);
-          engine_score[2] = MzTabDouble(hit.treescore);
-          engine_score[3] = MzTabDouble(hit.isoscore);
-          smsr.best_search_engine_score = engine_score;
-
-          smsr.chemical_formula = MzTabString(hit.formula);
-
-          MzTabOptionalColumnEntry adduct;
-          adduct.first = "adduct";
-          adduct.second = MzTabString(hit.adduct);
-
-          MzTabOptionalColumnEntry rank;
-          rank.first = "rank";
-          rank.second = MzTabString(hit.rank);
-
-          MzTabOptionalColumnEntry explainedPeaks;
-          explainedPeaks.first = "explainedPeaks";
-          explainedPeaks.second = MzTabString(hit.explainedpeaks);
-
-          MzTabOptionalColumnEntry explainedIntensity;
-          explainedIntensity.first = "explainedIntensity";
-          explainedIntensity.second = MzTabString(hit.explainedintensity);
-
-          MzTabOptionalColumnEntry compoundId;
-          compoundId.first = "compoundId";
-          compoundId.second = MzTabString(id.scan_index);
-
-          smsr.opt_.push_back(adduct);
-          smsr.opt_.push_back(rank);
-          smsr.opt_.push_back(explainedPeaks);
-          smsr.opt_.push_back(explainedIntensity);
-          smsr.opt_.push_back(compoundId);
-          smsd.push_back(smsr);
+          number_cor = rowcount; 
         }
+        else
+        {
+          number_cor = number;
+        }
+
+        // fill indentification structure containing all candidate hits for a single spectrum
+        SiriusMzTabWriter::SiriusAdapterIdentification sirius_id;
+
+        //Extract scan_index from path
+        OpenMS::String str = File::path(pathtosiriuscsv);
+        std::string scan_index = SiriusMzTabWriter::extract_scan_index(str);
+
+        for (Size j = 1; j < number_cor; ++j)
+        {
+          
+          StringList sl;
+          compounds.getRow(j, sl);
+          SiriusMzTabWriter::SiriusAdapterHit sirius_hit;
+
+          // parse single candidate hit
+          sirius_hit.formula = sl[0];
+          sirius_hit.adduct = sl[1];
+          sirius_hit.rank = sl[2].toInt();
+          sirius_hit.score = sl[3].toDouble();
+          sirius_hit.treescore = sl[4].toDouble();
+          sirius_hit.isoscore = sl[5].toDouble();
+          sirius_hit.explainedpeaks = sl[6].toInt();
+          sirius_hit.explainedintensity = sl[7].toDouble();
+
+          sirius_id.hits.push_back(sirius_hit);
+        }
+
+        sirius_id.scan_index = scan_index;
+        sirius_result.identifications.push_back(sirius_id);
+
+        // write metadata to mzTab file
+        MzTabMetaData md;
+        MzTabMSRunMetaData md_run;
+        md_run.location = MzTabString(str);
+        md.ms_run[1] = md_run;
+        md.description = MzTabString("Sirius-3.5");
+
+        //needed for header generation (score)
+        std::map<Size, MzTabParameter> smallmolecule_search_engine_score;
+        smallmolecule_search_engine_score[1].setName("score");
+        smallmolecule_search_engine_score[2].setName("treescore");
+        smallmolecule_search_engine_score[3].setName("isoscore");
+        md.smallmolecule_search_engine_score = smallmolecule_search_engine_score;
+        result.setMetaData(md);
+
+        // write results to mzTab file
+        MzTabSmallMoleculeSectionRows smsd;
+        for (Size i = 0; i != sirius_result.identifications.size(); ++i)
+        {
+          const SiriusMzTabWriter::SiriusAdapterIdentification &id = sirius_result.identifications[i];
+          for (Size j = 0; j != id.hits.size(); ++j)
+          {
+            const SiriusMzTabWriter::SiriusAdapterHit &hit = id.hits[j];
+            MzTabSmallMoleculeSectionRow smsr;
+
+            map<Size, MzTabDouble> engine_score;
+            engine_score[1] = MzTabDouble(hit.score);
+            engine_score[2] = MzTabDouble(hit.treescore);
+            engine_score[3] = MzTabDouble(hit.isoscore);
+            smsr.best_search_engine_score = engine_score;
+
+            smsr.chemical_formula = MzTabString(hit.formula);
+
+            MzTabOptionalColumnEntry adduct;
+            adduct.first = "adduct";
+            adduct.second = MzTabString(hit.adduct);
+
+            MzTabOptionalColumnEntry rank;
+            rank.first = "rank";
+            rank.second = MzTabString(hit.rank);
+
+            MzTabOptionalColumnEntry explainedPeaks;
+            explainedPeaks.first = "explainedPeaks";
+            explainedPeaks.second = MzTabString(hit.explainedpeaks);
+
+            MzTabOptionalColumnEntry explainedIntensity;
+            explainedIntensity.first = "explainedIntensity";
+            explainedIntensity.second = MzTabString(hit.explainedintensity);
+
+            MzTabOptionalColumnEntry compoundId;
+            compoundId.first = "compoundId";
+            compoundId.second = MzTabString(id.scan_index);
+
+            smsr.opt_.push_back(adduct);
+            smsr.opt_.push_back(rank);
+            smsr.opt_.push_back(explainedPeaks);
+            smsr.opt_.push_back(explainedIntensity);
+            smsr.opt_.push_back(compoundId);
+            smsd.push_back(smsr);
+          }
+        }  
+
+        result.setSmallMoleculeSectionRows(smsd);
+
       }
-
-      result.setSmallMoleculeSectionRows(smsd);
-
     }
   }
 }

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
@@ -72,13 +72,14 @@ void SiriusMzTabWriter::read(const std::vector<String> & paths, Size number, MzT
     {
       
       unsigned int rowcount = 0;   
-      unsigned int number_cor = 0;
     
       CsvFile compounds(pathtosiriuscsv, '\t');
       rowcount = compounds.rowCount();
 
       if (file && rowcount > 1)
       {
+        unsigned int number_cor = 0;
+        
         if (number > rowcount)
         {
           number_cor = rowcount; 

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
@@ -32,18 +32,10 @@
 // $Authors: Oliver Alka, Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/DATASTRUCTURES/ListUtils.h>
-#include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>
-#include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/MzTabFile.h>
-#include <OpenMS/FORMAT/MzTab.h>
-#include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/FORMAT/CsvFile.h>
-#include <OpenMS/FORMAT/FileTypes.h>
-#include <OpenMS/FORMAT/HANDLERS/MzMLHandler.h>
 
 #include <OpenMS/FORMAT/DATAACCESS/SiriusMzTabWriter.h>
 
@@ -51,7 +43,7 @@ using namespace OpenMS;
 using namespace std;
 
 
-String SiriusMzTabWriter::extract_scan_index(const String &path)
+inline String SiriusMzTabWriter::extract_scan_index(const String &path)
 {
   return path.substr(path.find_last_not_of("0123456789") + 1);
 }
@@ -64,31 +56,20 @@ void SiriusMzTabWriter::read(const std::vector<String> & paths, Size number, MzT
   for (std::vector<String>::const_iterator it = paths.begin(); it != paths.end(); ++it)
   {
 
-    std::string pathtosiriuscsv = *it + "/summary_sirius.csv";
+    const std::string pathtosiriuscsv = *it + "/summary_sirius.csv";
 
     ifstream file(pathtosiriuscsv);
 
     if (file) 
     {
       
-      unsigned int rowcount = 0;   
-    
       CsvFile compounds(pathtosiriuscsv, '\t');
-      rowcount = compounds.rowCount();
+      const UInt rowcount = compounds.rowCount();
 
-      if (file && rowcount > 1)
+      if (rowcount > 1)
       {
-        unsigned int number_cor = 0;
+        const UInt number_cor = (number > rowcount) ? rowcount : number;
         
-        if (number > rowcount)
-        {
-          number_cor = rowcount; 
-        }
-        else
-        {
-          number_cor = number;
-        }
-
         // fill indentification structure containing all candidate hits for a single spectrum
         SiriusMzTabWriter::SiriusAdapterIdentification sirius_id;
 
@@ -136,10 +117,10 @@ void SiriusMzTabWriter::read(const std::vector<String> & paths, Size number, MzT
 
         // write results to mzTab file
         MzTabSmallMoleculeSectionRows smsd;
-        for (Size i = 0; i != sirius_result.identifications.size(); ++i)
+        for (Size i = 0; i < sirius_result.identifications.size(); ++i)
         {
           const SiriusMzTabWriter::SiriusAdapterIdentification &id = sirius_result.identifications[i];
-          for (Size j = 0; j != id.hits.size(); ++j)
+          for (Size j = 0; j < id.hits.size(); ++j)
           {
             const SiriusMzTabWriter::SiriusAdapterHit &hit = id.hits[j];
             MzTabSmallMoleculeSectionRow smsr;
@@ -180,12 +161,11 @@ void SiriusMzTabWriter::read(const std::vector<String> & paths, Size number, MzT
             smsd.push_back(smsr);
           }
         }  
-
         result.setSmallMoleculeSectionRows(smsd);
-
       }
     }
   }
 }
 
 /// @endcond
+

--- a/src/tests/topp/THIRDPARTY/SiriusAdapter_1_output.mzTab
+++ b/src/tests/topp/THIRDPARTY/SiriusAdapter_1_output.mzTab
@@ -5,26 +5,31 @@ MTD	description	Sirius-3.5
 MTD	smallmolecule_search_engine_score[1]	[, , score, ]
 MTD	smallmolecule_search_engine_score[2]	[, , treescore, ]
 MTD	smallmolecule_search_engine_score[3]	[, , isoscore, ]
-MTD	ms_run[1]-location	/var/folders/mz/8dz2f2mx0fl159nrypn6p4h40000gn/T/2017-07-17_101345_unicorn.Informatik.Uni-Tuebingen.De_83081_1/sirius_out/5_2017-07-17_101345_unicorn.Informatik.Uni-Tuebingen.De_83081_2_unknown5
+MTD	ms_run[1]-location	/home/alka/trash/OpenMS_Tmp/20170901_164107_abinode06_21638_1/sirius_out/5_20170901_164107_abinode06_21638_2_unknown5
 
 SMH	identifier	chemical_formula	smiles	inchi_key	description	exp_mass_to_charge	calc_mass_to_charge	charge	retention_time	taxid	species	database	database_version	spectra_ref	search_engine	best_search_engine_score[1]	best_search_engine_score[2]	best_search_engine_score[3]	modifications	adduct	rank	explainedPeaks	explainedIntensity	compoundId
 SML	null	C2H3NOP2	null	null	null	null	null	null	null	null	null	null	null	null	null	-3.68445966442255	-3.60517018598809	-0.0792894784344564	null	[M + Na]+	1	1	0	1
 SML	null	C2HNO3S	null	null	null	null	null	null	null	null	null	null	null	null	null	-4.33578659304687	-0.6094379124341	-3.72634868061277	null	[M + Na]+	2	1	0	1
 SML	null	CH3O4P2	null	null	null	null	null	null	null	null	null	null	null	null	null	-5.47259683461545	-5.21460809842219	-0.257988736193255	null	[M + H]+	3	1	0	1
 SML	null	CH2N3PS	null	null	null	null	null	null	null	null	null	null	null	null	null	-6.54211863986042	-5.21460809842219	-1.32751054143823	null	[M + Na]+	4	1	0	1
+SML	null	C3H4O2P	null	null	null	null	null	null	null	null	null	null	null	null	null	-9.2277291565995	-5.21460809842219	-4.01312105817731	null	[M + K]+	5	1	0	1
 SML	null	C8H18O5	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + Na]+	1	1	0	2
 SML	null	C6H12N6O3	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + H]+	2	1	0	2
 SML	null	C4H14N6O3	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.288414747721879	-0.288414747721879	0	null	[M + Na]+	3	1	0	2
 SML	null	C12H18S	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.6094379124341	-0.6094379124341	0	null	[M + Na]+	4	1	0	2
+SML	null	C14H16S	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.6094379124341	-0.6094379124341	0	null	[M + H]+	5	1	0	2
 SML	null	C3H5O4P	null	null	null	null	null	null	null	null	null	null	null	null	null	-1.82429048214559	-0.6094379124341	-1.21485256971149	null	[M + H]+	1	1	0	3
 SML	null	C2H4N2O3S	null	null	null	null	null	null	null	null	null	null	null	null	null	-3.38889852179499	-0.6094379124341	-2.77946060936089	null	[M + H]+	2	1	0	3
 SML	null	C2H6N2OP2	null	null	null	null	null	null	null	null	null	null	null	null	null	-4.97385377227592	-3.60517018598809	-1.36868358628783	null	[M + H]+	3	1	0	3
 SML	null	C5H6OS	null	null	null	null	null	null	null	null	null	null	null	null	null	-5.57319672071437	-0.609437912434101	-4.96375880828027	null	[M + Na]+	4	1	0	3
+SML	null	C4HN4P	null	null	null	null	null	null	null	null	null	null	null	null	null	-6.57362750622508	-3.60517018598809	-2.96845732023698	null	[M + H]+	5	1	0	3
 SML	null	C11H7NO5	null	null	null	null	null	null	null	null	null	null	null	null	null	5.36870872170094	5.36870872170094	0	null	[M + H]+	1	3	0.343859649122807	4
 SML	null	C7H9N5O2	null	null	null	null	null	null	null	null	null	null	null	null	null	1.11322446921037	1.11322446921037	0	null	[M + K]+	2	2	0.0456140350877193	4
 SML	null	C6H13NO6	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + K]+	3	1	0	4
 SML	null	C9H9NO5	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + Na]+	4	1	0	4
+SML	null	C10H5N5O	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + Na]+	5	1	0	4
 SML	null	C15H7NS	null	null	null	null	null	null	null	null	null	null	null	null	null	-1.37195285364449	-0.6094379124341	-0.762514941210389	null	[M + Na]+	1	1	0	5
 SML	null	C12H3N5O	null	null	null	null	null	null	null	null	null	null	null	null	null	-1.63153245080992	-2.1875534540406	0.556021003230673	null	[M + Na]+	2	1	0	5
 SML	null	C17H5NS	null	null	null	null	null	null	null	null	null	null	null	null	null	-1.82281844040714	-2.19065961434192	0.367841173934782	null	[M + H]+	3	1	0	5
 SML	null	C3H13N3O5P2	null	null	null	null	null	null	null	null	null	null	null	null	null	-2.16826989837334	-1.59323054205497	-0.575039356318372	null	[M + Na]+	4	1	0	5
+SML	null	C12H7N3P2	null	null	null	null	null	null	null	null	null	null	null	null	null	-5.58038812225914	-3.60517018598809	-1.97521793627104	null	[M + H]+	5	1	0	5

--- a/src/tests/topp/THIRDPARTY/SiriusAdapter_1_output.mzTab
+++ b/src/tests/topp/THIRDPARTY/SiriusAdapter_1_output.mzTab
@@ -5,24 +5,24 @@ MTD	description	Sirius-3.5
 MTD	smallmolecule_search_engine_score[1]	[, , score, ]
 MTD	smallmolecule_search_engine_score[2]	[, , treescore, ]
 MTD	smallmolecule_search_engine_score[3]	[, , isoscore, ]
-MTD	ms_run[1]-location
+MTD	ms_run[1]-location	/tmp/20170903_144402_leviathan_690_1/sirius_out/5_20170903_144402_leviathan_690_2_unknown5
 
 SMH	identifier	chemical_formula	smiles	inchi_key	description	exp_mass_to_charge	calc_mass_to_charge	charge	retention_time	taxid	species	database	database_version	spectra_ref	search_engine	best_search_engine_score[1]	best_search_engine_score[2]	best_search_engine_score[3]	modifications	adduct	rank	explainedPeaks	explainedIntensity	compoundId
-SML	null	C2H3NOP2	null	null	null	null	null	null	null	null	null	null	null	null	null	-3.68445966442255	-3.60517018598809	-0.0792894784344564	null	[M + Na]+	1	1	0	1
-SML	null	C2HNO3S	null	null	null	null	null	null	null	null	null	null	null	null	null	-4.33578659304687	-0.6094379124341	-3.72634868061277	null	[M + Na]+	2	1	0	1
-SML	null	CH3O4P2	null	null	null	null	null	null	null	null	null	null	null	null	null	-5.47259683461545	-5.21460809842219	-0.257988736193255	null	[M + H]+	3	1	0	1
-SML	null	CH2N3PS	null	null	null	null	null	null	null	null	null	null	null	null	null	-6.54211863986042	-5.21460809842219	-1.32751054143823	null	[M + Na]+	4	1	0	1
-SML	null	C3H4O2P	null	null	null	null	null	null	null	null	null	null	null	null	null	-9.2277291565995	-5.21460809842219	-4.01312105817731	null	[M + K]+	5	1	0	1
+SML	null	C2HNO3S	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.6094379124341	-0.6094379124341	0	null	[M + Na]+	1	1	0	1
+SML	null	HN5S	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.803949481017916	-0.803949481017916	0	null	[M + K]+	2	1	0	1
+SML	null	CH2N3OP	null	null	null	null	null	null	null	null	null	null	null	null	null	-3.60517018598809	-3.60517018598809	0	null	[M + K]+	3	1	0	1
+SML	null	C2H3NOP2	null	null	null	null	null	null	null	null	null	null	null	null	null	-3.60517018598809	-3.60517018598809	0	null	[M + Na]+	4	1	0	1
+SML	null	C3H4O2P	null	null	null	null	null	null	null	null	null	null	null	null	null	-5.21460809842219	-5.21460809842219	0	null	[M + K]+	5	1	0	1
 SML	null	C8H18O5	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + Na]+	1	1	0	2
 SML	null	C6H12N6O3	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + H]+	2	1	0	2
 SML	null	C4H14N6O3	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.288414747721879	-0.288414747721879	0	null	[M + Na]+	3	1	0	2
 SML	null	C12H18S	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.6094379124341	-0.6094379124341	0	null	[M + Na]+	4	1	0	2
 SML	null	C14H16S	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.6094379124341	-0.6094379124341	0	null	[M + H]+	5	1	0	2
-SML	null	C3H5O4P	null	null	null	null	null	null	null	null	null	null	null	null	null	-1.82429048214559	-0.6094379124341	-1.21485256971149	null	[M + H]+	1	1	0	3
-SML	null	C2H4N2O3S	null	null	null	null	null	null	null	null	null	null	null	null	null	-3.38889852179499	-0.6094379124341	-2.77946060936089	null	[M + H]+	2	1	0	3
-SML	null	C2H6N2OP2	null	null	null	null	null	null	null	null	null	null	null	null	null	-4.97385377227592	-3.60517018598809	-1.36868358628783	null	[M + H]+	3	1	0	3
-SML	null	C5H6OS	null	null	null	null	null	null	null	null	null	null	null	null	null	-5.57319672071437	-0.609437912434101	-4.96375880828027	null	[M + Na]+	4	1	0	3
-SML	null	C4HN4P	null	null	null	null	null	null	null	null	null	null	null	null	null	-6.57362750622508	-3.60517018598809	-2.96845732023698	null	[M + H]+	5	1	0	3
+SML	null	C8H2O	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + Na]+	1	1	0	3
+SML	null	C5H6O2	null	null	null	null	null	null	null	null	null	null	null	null	null	0	0	0	null	[M + K]+	2	1	0	3
+SML	null	C10O	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.212648657525802	-0.212648657525802	0	null	[M + H]+	3	1	0	3
+SML	null	C5H6OS	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.6094379124341	-0.6094379124341	0	null	[M + Na]+	4	1	0	3
+SML	null	C3H5O4P	null	null	null	null	null	null	null	null	null	null	null	null	null	-0.6094379124341	-0.6094379124341	0	null	[M + H]+	5	1	0	3
 SML	null	C11H7NO5	null	null	null	null	null	null	null	null	null	null	null	null	null	5.36870872170094	5.36870872170094	0	null	[M + H]+	1	3	0.343859649122807	4
 SML	null	C7H9N5O2	null	null	null	null	null	null	null	null	null	null	null	null	null	1.11322446921037	1.11322446921037	0	null	[M + K]+	2	2	0.0456140350877193	4
 SML	null	C6H13NO6	null	null	null	null	null	null	null	null	null	null	null	null	null	1	1	0	null	[M + K]+	3	1	0	4

--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -172,7 +172,7 @@ endif()
 
 #------------------------------------------------------------------------------
 if (NOT (${SIRIUS_BINARY} STREQUAL "SIRIUS_BINARY-NOTFOUND"))
-  add_test("TOPP_SiriusAdapter_1" ${TOPP_BIN_PATH}/SiriusAdapter -executable "${SIRIUS_BINARY}" -in ${DATA_DIR_TOPP}/THIRDPARTY/SiriusAdapter_1_input.mzML -out_sirius SiriusAdapter_1_output.tmp -auto_charge -profile qtof -database all)
+  add_test("TOPP_SiriusAdapter_1" ${TOPP_BIN_PATH}/SiriusAdapter -test -executable "${SIRIUS_BINARY}" -in ${DATA_DIR_TOPP}/THIRDPARTY/SiriusAdapter_1_input.mzML -out_sirius SiriusAdapter_1_output.tmp -auto_charge -profile qtof -database all)
   add_test("TOPP_SiriusAdapter_1_out" ${DIFF} -in1 SiriusAdapter_1_output.tmp -in2 ${DATA_DIR_TOPP}/THIRDPARTY/SiriusAdapter_1_output.mzTab -whitelist "MTD")
   set_tests_properties("TOPP_SiriusAdapter_1_out" PROPERTIES DEPENDS "TOPP_SiriusAdapter_1")
 endif()

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -111,7 +111,7 @@ protected:
     registerOutputFile_("out_sirius", "<file>", "", "MzTab Output file for SiriusAdapter results");
     setValidFormats_("out_sirius", ListUtils::create<String>("tsv"));
 
-    registerOutputFile_("out_fingerid","<file>", "", "MzTab ouput file for CSI:FingerID", false);
+    registerOutputFile_("out_fingerid","<file>", "", "MzTab ouput file for CSI:FingerID, if this parameter is given, SIRIUS will search for a molecular structure using CSI:FingerID after determining the sum formula", false);
     setValidFormats_("out_fingerid", ListUtils::create<String>("tsv"));
 
     registerStringOption_("profile", "<choice>", "qtof", "Specify the used analysis profile", false);
@@ -130,7 +130,6 @@ protected:
     registerFlag_("auto_charge", "Use this option if the charge of your compounds is unknown and you do not want to assume [M+H]+ as default. With the auto charge option SIRIUS will not care about charges and allow arbitrary adducts for the precursor peak.", false);
     registerFlag_("iontree", "Print molecular formulas and node labels with the ion formula instead of the neutral formula", false);
     registerFlag_("no_recalibration", "If this option is set, SIRIUS will not recalibrate the spectrum during the analysis.", false);
-    registerFlag_("fingerid", "If this option is set, SIRIUS will search for a molecular structure using CSI:FingerID after determining the sum formula", false);
   }
 
   ExitCodes main_(int, const char **)
@@ -144,7 +143,7 @@ protected:
     String out_csifingerid = getStringOption_("out_fingerid");
 
     // needed for counting
-    int number_compounds = getIntOption_("number") + 1;  // +1 needed to write the correct number of compounds
+    int number_compounds = getIntOption_("number"); 
 
     // Parameter for Sirius3
     QString executable = getStringOption_("executable").toQString();

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -111,8 +111,8 @@ protected:
     registerOutputFile_("out_sirius", "<file>", "", "MzTab Output file for SiriusAdapter results");
     setValidFormats_("out_sirius", ListUtils::create<String>("tsv"));
 
-    registerOutputFile_("out_CSIFingerID","<file>", "", "MzTab ouput file for CSI:FingerID", false);
-    setValidFormats_("out_CSIFingerID", ListUtils::create<String>("tsv"));
+    registerOutputFile_("out_fingerid","<file>", "", "MzTab ouput file for CSI:FingerID", false);
+    setValidFormats_("out_fingerid", ListUtils::create<String>("tsv"));
 
     registerStringOption_("profile", "<choice>", "qtof", "Specify the used analysis profile", false);
     setValidStrings_("profile", ListUtils::create<String>("qtof,orbitrap,fticr"));
@@ -141,7 +141,7 @@ protected:
 
     String in = getStringOption_("in");
     String out_sirius = getStringOption_("out_sirius");
-    String out_csifingerid = getStringOption_("out_CSIFingerID");
+    String out_csifingerid = getStringOption_("out_fingerid");
 
     // needed for counting
     int number_compounds = getIntOption_("number") + 1;  // +1 needed to write the correct number of compounds
@@ -160,7 +160,6 @@ protected:
 
     bool auto_charge = getFlag_("auto_charge");
     bool no_recalibration = getFlag_("no_recalibration");
-    bool fingerid = getFlag_("fingerid");
     bool iontree = getFlag_("iontree");
 
     //-------------------------------------------------------------
@@ -210,7 +209,7 @@ protected:
     {
       process_params << "--no-recalibration";
     }
-    if (fingerid)
+    if (!out_csifingerid.empty())
     {
       process_params << "--fingerid";
     }
@@ -258,7 +257,7 @@ protected:
     siriusfile.store(out_sirius, sirius_result);
 
     //Convert sirius_output to mztab and store file
-    if (out_csifingerid.empty() == false && fingerid)
+    if (!out_csifingerid.empty())
     {
       MzTab csi_result;
       MzTabFile csifile;

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -262,7 +262,7 @@ protected:
     siriusfile.store(out_sirius, sirius_result);
 
     //Convert sirius_output to mztab and store file
-    if (!out_csifingerid.empty())
+    if (out_csifingerid.empty() == false)
     {
       MzTab csi_result;
       MzTabFile csifile;


### PR DESCRIPTION
fix: 
Add number parameter (how many candidates should be written) > there was the issue that the number parameter was overwritten and then not set back to the original number. 
TOPP_Test

refactor:
-fingerid parameter is now used if -out_fingerid  (output folder) is set. 

