### PR TITLE
[FIX] In SysInfo.cpp, change c header stdlib.h to cpp header cstdlib

### DIFF
--- a/src/openms/source/SYSTEM/SysInfo.cpp
+++ b/src/openms/source/SYSTEM/SysInfo.cpp
@@ -40,10 +40,11 @@
 #elif __APPLE__
 #include <mach/mach.h>
 #include <mach/mach_init.h>
+#include <cstdlib>
 #else
 #include <cstdio>
 #include <unistd.h>
-#include <stdlib.h>
+#include <cstdlib>
 #define OMS_USELINUXMEMORYPLATFORM
 #endif
 


### PR DESCRIPTION
Changes the c header `stdlib.h `in `SysInfo.cpp` to the c++ header `cstdlib`. This fixes the error that I encountered on ElCapitan that abs is not a member of the std namespace. Also, I think the cpp header  `cstdlib` is preferred over the `stdlib.h` c header.

https://stackoverflow.com/questions/2900785/whats-the-difference-between-cstdlib-and-stdlib-h