### PR TITLE
[FIX]!!! huge speed and memory improvement by not storing all xerces …

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -102,6 +102,8 @@ public:
 private:
       mutable std::vector<XMLCh *> xml_strings_;
       mutable std::vector<char *> c_strings_;
+      mutable size_t idx_xml_, idx_c_;
+
     };
 
     /**


### PR DESCRIPTION
…transcoded strings but using a ringbuffer instead.

For speed & RAM improvements, see #2899.

Not thouroughly tested yet.
Assumes that during loading, the format-specific xml-handlers to not store pointers to transcoded strings while at the same time keep on calling convert() more than 99x (the ringbuffer will free the data pointed to).

