### PR TITLE
Feature/sm memory management

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -35,8 +35,6 @@
 #ifndef OPENMS_FORMAT_HANDLERS_XMLHANDLER_H
 #define OPENMS_FORMAT_HANDLERS_XMLHANDLER_H
 
-#include <iosfwd>
-
 #include <OpenMS/CONCEPT/Types.h>
 #include <OpenMS/CONCEPT/Macros.h>
 
@@ -45,11 +43,16 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
 
+#include <boost/scoped_array.hpp>
+
+#include <xercesc/util/XMLString.hpp>
 #include <xercesc/sax2/DefaultHandler.hpp>
 #include <xercesc/sax/Locator.hpp>
 #include <xercesc/sax2/Attributes.hpp>
 
 #include <algorithm>
+#include <iosfwd>
+#include <string>
 
 namespace OpenMS
 {
@@ -69,6 +72,36 @@ namespace OpenMS
     */
     class OPENMS_DLLAPI StringManager
     {
+
+      typedef std::basic_string<XMLCh> XercesString;
+
+      // Converts from a narrow-character string to a wide-character string.
+      inline XercesString fromNative(const char* str) const
+      {
+          boost::scoped_array<XMLCh> ptr(xercesc::XMLString::transcode(str));
+          return XercesString(ptr.get( ));
+      }
+
+      // Converts from a narrow-character string to a wide-charactr string.
+      inline XercesString fromNative(const std::string& str) const
+      {
+          return fromNative(str.c_str( ));
+      }
+
+      // Converts from a wide-character string to a narrow-character string.
+      inline std::string toNative(const XMLCh* str) const
+      {
+          boost::scoped_array<char> ptr(xercesc::XMLString::transcode(str));
+          return std::string(ptr.get( ));
+      }
+
+      // Converts from a wide-character string to a narrow-character string.
+      inline std::string toNative(const XercesString& str) const
+      {
+          return toNative(str.c_str( ));
+      }
+
+
 public:
       /// Constructor
       StringManager();
@@ -79,17 +112,29 @@ public:
       /// Frees memory of all owned strings
       void clear();
 
-      /// Transcode the supplied C string to XMLCh* and take ownership of the XMLCh*
-      XMLCh * convert(const char * str) const;
+      /// Transcode the supplied C string to XMLCh*
+      XercesString convert(const char * str) const
+      {
+        return fromNative(str);
+      }
 
-      /// Transcode the supplied C++ string to XMLCh* and take ownership of the XMLCh*
-      XMLCh * convert(const std::string & str) const;
+      /// Transcode the supplied C++ string to XMLCh*
+      XercesString convert(const std::string & str) const
+      {
+        return fromNative(str.c_str( ));
+      }
 
-      /// Transcode the supplied OpenMS string to XMLCh* and take ownership of the XMLCh*
-      XMLCh * convert(const String & str) const;
+      /// Transcode the supplied OpenMS string to XMLCh*
+      XercesString convert(const String & str) const
+      {
+        return fromNative(str.c_str( ));
+      }
 
-      /// Transcode the supplied XMLCh* to a C string and take ownership of the C string
-      char * convert(const XMLCh * str) const;
+      /// Transcode the supplied XMLCh* to a String
+      String convert(const XMLCh * str) const
+      {
+        return toNative(str);
+      }
 
       /**
        * @brief Transcodes the supplied XMLCh* and appends it to the OpenMS String
@@ -100,6 +145,7 @@ public:
       static void appendASCII(const XMLCh * str, const XMLSize_t length, String & result);
 
 private:
+
       mutable std::vector<XMLCh *> xml_strings_;
       mutable std::vector<char *> c_strings_;
     };
@@ -376,9 +422,9 @@ protected:
       //@{
 
       /// Converts an attribute to a String
-      inline char * attributeAsString_(const xercesc::Attributes & a, const char * name) const
+      inline String attributeAsString_(const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val == 0) fatalError(LOAD, String("Required attribute '") + name + "' not present!");
         return sm_.convert(val);
       }
@@ -386,7 +432,7 @@ protected:
       /// Converts an attribute to a Int
       inline Int attributeAsInt_(const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val == 0) fatalError(LOAD, String("Required attribute '") + name + "' not present!");
         return xercesc::XMLString::parseInt(val);
       }
@@ -394,7 +440,7 @@ protected:
       /// Converts an attribute to a double
       inline double attributeAsDouble_(const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val == 0) fatalError(LOAD, String("Required attribute '") + name + "' not present!");
         return String(sm_.convert(val)).toDouble();
       }
@@ -427,7 +473,7 @@ protected:
       */
       inline bool optionalAttributeAsString_(String & value, const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val != 0)
         {
           value = sm_.convert(val);
@@ -443,7 +489,7 @@ protected:
       */
       inline bool optionalAttributeAsInt_(Int & value, const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val != 0)
         {
           value = xercesc::XMLString::parseInt(val);
@@ -459,7 +505,7 @@ protected:
       */
       inline bool optionalAttributeAsUInt_(UInt & value, const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val != 0)
         {
           value = xercesc::XMLString::parseInt(val);
@@ -475,7 +521,7 @@ protected:
       */
       inline bool optionalAttributeAsDouble_(double & value, const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val != 0)
         {
           value = String(sm_.convert(val)).toDouble();
@@ -491,7 +537,7 @@ protected:
       */
       inline bool optionalAttributeAsDoubleList_(DoubleList & value, const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val != 0)
         {
           value = attributeAsDoubleList_(a, name);
@@ -507,7 +553,7 @@ protected:
       */
       inline bool optionalAttributeAsStringList_(StringList & value, const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val != 0)
         {
           value = attributeAsStringList_(a, name);
@@ -523,7 +569,7 @@ protected:
       */
       inline bool optionalAttributeAsIntList_(IntList & value, const xercesc::Attributes & a, const char * name) const
       {
-        const XMLCh * val = a.getValue(sm_.convert(name));
+        const XMLCh * val = a.getValue(sm_.convert(name).c_str());
         if (val != 0)
         {
           value = attributeAsIntList_(a, name);
@@ -533,7 +579,7 @@ protected:
       }
 
       /// Converts an attribute to a String
-      inline char * attributeAsString_(const xercesc::Attributes & a, const XMLCh * name) const
+      inline String attributeAsString_(const xercesc::Attributes & a, const XMLCh * name) const
       {
         const XMLCh * val = a.getValue(name);
         if (val == 0) fatalError(LOAD, String("Required attribute '") + sm_.convert(name) + "' not present!");
@@ -583,8 +629,8 @@ protected:
         const XMLCh * val = a.getValue(name);
         if (val != 0)
         {
-          char * tmp2 = sm_.convert(val);
-          if (String(tmp2) != "")
+          String tmp2 = sm_.convert(val);
+          if (tmp2 != "")
           {
             value = tmp2;
             return true;
@@ -683,7 +729,7 @@ private:
       /// Not implemented
       XMLHandler();
 
-      inline String expectList_(const char * str) const
+      inline String expectList_(const String& str) const
       {
         String tmp(str);
         if (!(tmp.hasPrefix('[') && tmp.hasSuffix(']')))

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -78,27 +78,27 @@ namespace OpenMS
       // Converts from a narrow-character string to a wide-character string.
       inline XercesString fromNative(const char* str) const
       {
-          boost::scoped_array<XMLCh> ptr(xercesc::XMLString::transcode(str));
-          return XercesString(ptr.get( ));
+        boost::scoped_array<XMLCh> ptr(xercesc::XMLString::transcode(str));
+        return XercesString(ptr.get( ));
       }
 
       // Converts from a narrow-character string to a wide-charactr string.
       inline XercesString fromNative(const std::string& str) const
       {
-          return fromNative(str.c_str( ));
+        return fromNative(str.c_str( ));
       }
 
       // Converts from a wide-character string to a narrow-character string.
       inline std::string toNative(const XMLCh* str) const
       {
-          boost::scoped_array<char> ptr(xercesc::XMLString::transcode(str));
-          return std::string(ptr.get( ));
+        boost::scoped_array<char> ptr(xercesc::XMLString::transcode(str));
+        return std::string(ptr.get( ));
       }
 
       // Converts from a wide-character string to a narrow-character string.
       inline std::string toNative(const XercesString& str) const
       {
-          return toNative(str.c_str( ));
+        return toNative(str.c_str( ));
       }
 
 
@@ -106,32 +106,32 @@ public:
       /// Constructor
       StringManager();
 
-      /// Destructor. Destroys the strings in the various lists
+      /// Destructor
       ~StringManager();
 
-      /// Frees memory of all owned strings
+      /// NOP
       void clear();
 
-      /// Transcode the supplied C string to XMLCh*
-      XercesString convert(const char * str) const
+      /// Transcode the supplied C string to a xerces string
+      inline XercesString convert(const char * str) const
       {
         return fromNative(str);
       }
 
-      /// Transcode the supplied C++ string to XMLCh*
-      XercesString convert(const std::string & str) const
+      /// Transcode the supplied C++ string to a xerces string
+      inline XercesString convert(const std::string & str) const
       {
         return fromNative(str.c_str( ));
       }
 
-      /// Transcode the supplied OpenMS string to XMLCh*
-      XercesString convert(const String & str) const
+      /// Transcode the supplied OpenMS string to a xerces string
+      inline XercesString convert(const String & str) const
       {
         return fromNative(str.c_str( ));
       }
 
       /// Transcode the supplied XMLCh* to a String
-      String convert(const XMLCh * str) const
+      inline String convert(const XMLCh * str) const
       {
         return toNative(str);
       }
@@ -144,10 +144,6 @@ public:
       */
       static void appendASCII(const XMLCh * str, const XMLSize_t length, String & result);
 
-private:
-
-      mutable std::vector<XMLCh *> xml_strings_;
-      mutable std::vector<char *> c_strings_;
     };
 
     /**

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -78,27 +78,31 @@ namespace OpenMS
       // Converts from a narrow-character string to a wide-character string.
       inline XercesString fromNative(const char* str) const
       {
-        boost::scoped_array<XMLCh> ptr(xercesc::XMLString::transcode(str));
-        return XercesString(ptr.get( ));
+        XMLCh* ptr(xercesc::XMLString::transcode(str));
+        XercesString result(ptr);
+        xercesc::XMLString::release(&ptr);
+        return result;
       }
 
       // Converts from a narrow-character string to a wide-charactr string.
       inline XercesString fromNative(const std::string& str) const
       {
-        return fromNative(str.c_str( ));
+        return fromNative(str.c_str());
       }
 
       // Converts from a wide-character string to a narrow-character string.
       inline std::string toNative(const XMLCh* str) const
       {
-        boost::scoped_array<char> ptr(xercesc::XMLString::transcode(str));
-        return std::string(ptr.get( ));
+        char* ptr(xercesc::XMLString::transcode(str));
+        std::string result(ptr);
+        xercesc::XMLString::release(&ptr);
+        return result;
       }
 
       // Converts from a wide-character string to a narrow-character string.
       inline std::string toNative(const XercesString& str) const
       {
-        return toNative(str.c_str( ));
+        return toNative(str.c_str());
       }
 
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -60,14 +60,12 @@ namespace OpenMS
   {
 
     /*
-     * @brief Helper class for XML parsing that handles the memory management for conversions of Xerces strings
+     * @brief Helper class for XML parsing that handles the conversions of Xerces strings
      *
      * It provides the convert() function which internally calls
      * XMLString::transcode and ensures that the memory is released properly
-     * through XMLString::release in a transparent and object oriented manner. 
-     *
-     * Releasing the memory can be done manually through clear() or will be done
-     * automatically in the destructor. 
+     * through XMLString::release internally. It returns a std::string or
+     * std::basic_string<XMLCh> to the caller who takes ownership of the data.
      *
     */
     class OPENMS_DLLAPI StringManager
@@ -112,9 +110,6 @@ public:
 
       /// Destructor
       ~StringManager();
-
-      /// NOP
-      void clear();
 
       /// Transcode the supplied C string to a xerces string
       inline XercesString convert(const char * str) const

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -81,22 +81,22 @@ namespace OpenMS
       }
 
       // Converts from a narrow-character string to a wide-charactr string.
-      inline XercesString fromNative_(const std::string& str) const
+      inline XercesString fromNative_(const String& str) const
       {
         return fromNative(str.c_str());
       }
 
       // Converts from a wide-character string to a narrow-character string.
-      inline std::string toNative_(const XMLCh* str) const
+      inline String toNative_(const XMLCh* str) const
       {
         char* ptr(xercesc::XMLString::transcode(str));
-        std::string result(ptr);
+        String result(ptr);
         xercesc::XMLString::release(&ptr);
         return result;
       }
 
       // Converts from a wide-character string to a narrow-character string.
-      inline std::string toNative_(const XercesString& str) const
+      inline String toNative_(const XercesString& str) const
       {
         return toNative(str.c_str());
       }

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -83,7 +83,7 @@ namespace OpenMS
       // Converts from a narrow-character string to a wide-charactr string.
       inline XercesString fromNative_(const String& str) const
       {
-        return fromNative(str.c_str());
+        return fromNative_(str.c_str());
       }
 
       // Converts from a wide-character string to a narrow-character string.
@@ -98,7 +98,7 @@ namespace OpenMS
       // Converts from a wide-character string to a narrow-character string.
       inline String toNative_(const XercesString& str) const
       {
-        return toNative(str.c_str());
+        return toNative_(str.c_str());
       }
 
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -43,8 +43,6 @@
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/METADATA/MetaInfoInterface.h>
 
-#include <boost/scoped_array.hpp>
-
 #include <xercesc/util/XMLString.hpp>
 #include <xercesc/sax2/DefaultHandler.hpp>
 #include <xercesc/sax/Locator.hpp>

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/XMLHandler.h
@@ -72,7 +72,7 @@ namespace OpenMS
       typedef std::basic_string<XMLCh> XercesString;
 
       // Converts from a narrow-character string to a wide-character string.
-      inline XercesString fromNative(const char* str) const
+      inline XercesString fromNative_(const char* str) const
       {
         XMLCh* ptr(xercesc::XMLString::transcode(str));
         XercesString result(ptr);
@@ -81,13 +81,13 @@ namespace OpenMS
       }
 
       // Converts from a narrow-character string to a wide-charactr string.
-      inline XercesString fromNative(const std::string& str) const
+      inline XercesString fromNative_(const std::string& str) const
       {
         return fromNative(str.c_str());
       }
 
       // Converts from a wide-character string to a narrow-character string.
-      inline std::string toNative(const XMLCh* str) const
+      inline std::string toNative_(const XMLCh* str) const
       {
         char* ptr(xercesc::XMLString::transcode(str));
         std::string result(ptr);
@@ -96,7 +96,7 @@ namespace OpenMS
       }
 
       // Converts from a wide-character string to a narrow-character string.
-      inline std::string toNative(const XercesString& str) const
+      inline std::string toNative_(const XercesString& str) const
       {
         return toNative(str.c_str());
       }
@@ -112,25 +112,25 @@ public:
       /// Transcode the supplied C string to a xerces string
       inline XercesString convert(const char * str) const
       {
-        return fromNative(str);
+        return fromNative_(str);
       }
 
       /// Transcode the supplied C++ string to a xerces string
       inline XercesString convert(const std::string & str) const
       {
-        return fromNative(str.c_str( ));
+        return fromNative_(str.c_str());
       }
 
       /// Transcode the supplied OpenMS string to a xerces string
       inline XercesString convert(const String & str) const
       {
-        return fromNative(str.c_str( ));
+        return fromNative_(str.c_str());
       }
 
       /// Transcode the supplied XMLCh* to a String
       inline String convert(const XMLCh * str) const
       {
-        return toNative(str);
+        return toNative_(str);
       }
 
       /**

--- a/src/openms/source/FORMAT/CompressedInputSource.cpp
+++ b/src/openms/source/FORMAT/CompressedInputSource.cpp
@@ -60,13 +60,13 @@ namespace OpenMS
     //  it as is.
     //
     Internal::StringManager strman;
-    XMLCh * file = strman.convert(file_path.c_str());
-    if (xercesc::XMLPlatformUtils::isRelative(file, manager))
+    auto file = strman.convert(file_path.c_str());
+    if (xercesc::XMLPlatformUtils::isRelative(file.c_str(), manager))
     {
       XMLCh * curDir = xercesc::XMLPlatformUtils::getCurrentDirectory(manager);
 
       XMLSize_t curDirLen = XMLString::stringLen(curDir);
-      XMLSize_t filePathLen = XMLString::stringLen(file);
+      XMLSize_t filePathLen = XMLString::stringLen(file.c_str());
       XMLCh * fullDir = (XMLCh *) manager->allocate
                         (
         (curDirLen + filePathLen + 2) * sizeof(XMLCh)
@@ -74,7 +74,7 @@ namespace OpenMS
 
       XMLString::copyString(fullDir, curDir);
       fullDir[curDirLen] = chForwardSlash;
-      XMLString::copyString(&fullDir[curDirLen + 1], file);
+      XMLString::copyString(&fullDir[curDirLen + 1], file.c_str());
 
       XMLPlatformUtils::removeDotSlash(fullDir, manager);
       XMLPlatformUtils::removeDotDotSlash(fullDir, manager);
@@ -86,7 +86,7 @@ namespace OpenMS
     }
     else
     {
-      XMLCh * tmpBuf = XMLString::replicate(file, manager);
+      XMLCh * tmpBuf = XMLString::replicate(file.c_str(), manager);
       XMLPlatformUtils::removeDotSlash(tmpBuf, manager);
       setSystemId(tmpBuf);
       manager->deallocate(tmpBuf);  //delete [] tmpBuf;

--- a/src/openms/source/FORMAT/ConsensusXMLFile.cpp
+++ b/src/openms/source/FORMAT/ConsensusXMLFile.cpp
@@ -508,7 +508,7 @@ namespace OpenMS
       pep_hit_.setSequence(AASequence::fromString(String(attributeAsString_(attributes, "sequence"))));
 
       //parse optional protein ids to determine accessions
-      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs"));
+      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs").c_str());
       if (refs != 0)
       {
         String accession_string = sm_.convert(refs);

--- a/src/openms/source/FORMAT/FeatureXMLFile.cpp
+++ b/src/openms/source/FORMAT/FeatureXMLFile.cpp
@@ -687,7 +687,7 @@ namespace OpenMS
       pep_hit_.setSequence(AASequence::fromString(String(attributeAsString_(attributes, "sequence"))));
 
       //parse optional protein ids to determine accessions
-      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs"));
+      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs").c_str());
       if (refs != 0)
       {
         String accession_string = sm_.convert(refs);

--- a/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
@@ -115,7 +115,7 @@ namespace OpenMS
       if (skip_spectrum_)
         return;
 
-      char * transcoded_chars = sm_.convert(chars);
+      String transcoded_chars = sm_.convert(chars);
 
       //current tag
       const String & current_tag = open_tags_.back();
@@ -264,9 +264,9 @@ namespace OpenMS
       else if (tag == "software")
       {
         data_processing_ = DataProcessingPtr(new DataProcessing);
-        if (attributes.getIndex(sm_.convert("completionTime")) != -1)
+        if (attributes.getIndex(sm_.convert("completionTime").c_str()) != -1)
         {
-          data_processing_->setCompletionTime(asDateTime_(sm_.convert(attributes.getValue(sm_.convert("completionTime")))));
+          data_processing_->setCompletionTime(asDateTime_(sm_.convert(attributes.getValue(sm_.convert("completionTime").c_str())).c_str()));
         }
       }
       else if (tag == "precursor")

--- a/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzDataHandler.cpp
@@ -486,8 +486,6 @@ namespace OpenMS
         logger_.endProgress();
         scan_count = 0;
       }
-
-      sm_.clear();
     }
 
     void MzDataHandler::fillData_()

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -1202,8 +1202,6 @@ namespace OpenMS
         populateSpectraWithData();
         populateChromatogramsWithData();
       }
-
-      sm_.clear();
     }
 
     void MzMLHandler::handleCVParam_(const String& parent_parent_tag, const String& parent_tag, /* const String & cvref,  */ const String& accession, const String& name, const String& value, const String& unit_accession)

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -631,11 +631,13 @@ namespace OpenMS
       }
       else
       {
-        char* transcoded_chars = sm_.convert(chars);
-        String transcoded_chars2 = transcoded_chars;
+        String transcoded_chars2 = sm_.convert(chars);
         transcoded_chars2.trim();
         if (transcoded_chars2 != "")
-          warning(LOAD, String("Unhandled character content in tag '") + current_tag + "': " + transcoded_chars2);
+        {
+          warning(LOAD, String("Unhandled character content in tag '") + current_tag + "': " +
+              transcoded_chars2);
+        }
       }
     }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -561,7 +561,7 @@ namespace OpenMS
       }
       else if (open_tags_.back() == "precursorMz")
       {
-        char* transcoded_chars = sm_.convert(chars);
+        String transcoded_chars = sm_.convert(chars);
         double mz_pos = asDouble_(transcoded_chars);
         //precursor m/z
         spectrum_data_.back().spectrum.getPrecursors().back().setMZ(mz_pos);
@@ -575,13 +575,13 @@ namespace OpenMS
       }
       else if (open_tags_.back() == "comment")
       {
-        char* transcoded_chars = sm_.convert(chars);
+        String transcoded_chars = sm_.convert(chars);
         String parent_tag = *(open_tags_.end() - 2);
         //std::cout << "- Comment of parent " << parent_tag << "\n";
 
         if (parent_tag == "msInstrument")
         {
-          exp_->getInstrument().setMetaValue("#comment", String(transcoded_chars));
+          exp_->getInstrument().setMetaValue("#comment", transcoded_chars);
         }
         else if (parent_tag == "dataProcessing")
         {
@@ -591,15 +591,15 @@ namespace OpenMS
         {
           spectrum_data_.back().spectrum.setComment(transcoded_chars);
         }
-        else if (String(transcoded_chars).trim() != "")
+        else if (transcoded_chars.trim() != "")
         {
           warning(LOAD, String("Unhandled comment '") + transcoded_chars + "' in element '" + open_tags_.back() + "'");
         }
       }
       else
       {
-        char* transcoded_chars = sm_.convert(chars);
-        if (String(transcoded_chars).trim() != "")
+        String transcoded_chars = sm_.convert(chars);
+        if (transcoded_chars.trim() != "")
         {
           warning(LOAD, String("Unhandled character content '") + transcoded_chars + "' in element '" + open_tags_.back() + "'");
         }

--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -537,7 +537,6 @@ namespace OpenMS
           }
       }
       //std::cout << " -- End -- " << "\n";
-      sm_.clear();
     }
 
     void MzXMLHandler::characters(const XMLCh* const chars, const XMLSize_t length)

--- a/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
@@ -69,13 +69,6 @@ namespace OpenMS
 
     void TraMLHandler::startElement(const XMLCh* const /*uri*/, const XMLCh* const /*local_name*/, const XMLCh* const qname, const xercesc::Attributes& attributes)
     {
-
-      // We should not need any previous dynamically allocated strings any more
-      // once we start processing a new element. Further optimization may move this
-      // statement down so that we dont call it too often.
-      // This results in substantial memory efficiency gains.
-      sm_.clear();
-
       static const XMLCh* s_type = xercesc::XMLString::transcode("type");
       static const XMLCh* s_value = xercesc::XMLString::transcode("value");
       static const XMLCh* s_name = xercesc::XMLString::transcode("name");

--- a/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/UnimodXMLHandler.cpp
@@ -149,16 +149,16 @@ namespace OpenMS
       if (tag_ == "umod:delta" || tag_ == "delta")
       {
         // avge_mass="-0.9848" mono_mass="-0.984016" composition="H N O(-1)" >
-        avge_mass_ = String(sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("avge_mass"))))).toDouble();
-        mono_mass_ = String(sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("mono_mass"))))).toDouble();
+        avge_mass_ = String(sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("avge_mass").c_str())))).toDouble();
+        mono_mass_ = String(sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("mono_mass").c_str())))).toDouble();
         return;
       }
 
       // <umod:element symbol="H" number="1"/>
       if (tag_ == "umod:element")
       {
-        String symbol = sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("symbol"))));
-        String num = sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("number"))));
+        String symbol = sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("symbol").c_str())));
+        String num = sm_.convert(attributes.getValue(attributes.getIndex(sm_.convert("number").c_str())));
         String isotope, tmp_symbol;
         for (Size i = 0; i != symbol.size(); ++i)
         {

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -227,18 +227,12 @@ namespace OpenMS
     }
 
     //*******************************************************************************************************************
-
     
     StringManager::StringManager()
     {
     }
 
     StringManager::~StringManager()
-    {
-      clear();
-    }
-
-    void StringManager::clear()
     {
     }
 

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -62,9 +62,8 @@ namespace OpenMS
     {
     }
 
-    void XMLHandler::reset() // reset Xerces XML strings (memleak otherwise)
+    void XMLHandler::reset()
     {
-      sm_.clear();
     }
 
     void XMLHandler::fatalError(const SAXParseException & exception)

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -255,34 +255,6 @@ namespace OpenMS
       c_strings_.clear();
     }
 
-    XMLCh * StringManager::convert(const char * str) const
-    {
-      XMLCh * result = XMLString::transcode(str);
-      xml_strings_.push_back(result);
-      return result;
-    }
-
-    XMLCh * StringManager::convert(const std::string & str) const
-    {
-      XMLCh * result = XMLString::transcode(str.c_str());
-      xml_strings_.push_back(result);
-      return result;
-    }
-
-    XMLCh * StringManager::convert(const String & str) const
-    {
-      XMLCh * result = XMLString::transcode(str.c_str());
-      xml_strings_.push_back(result);
-      return result;
-    }
-
-    char * StringManager::convert(const XMLCh * str) const
-    {
-      char * result = XMLString::transcode(str);
-      c_strings_.push_back(result);
-      return result;
-    }
-
     void StringManager::appendASCII(const XMLCh * chars, const XMLSize_t length, String & result)
     {
       // XMLCh are characters in UTF16 (usually stored as 16bit unsigned

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -229,9 +229,7 @@ namespace OpenMS
     //*******************************************************************************************************************
 
     
-    StringManager::StringManager() :
-      xml_strings_(0),
-      c_strings_(0)
+    StringManager::StringManager()
     {
     }
 
@@ -242,17 +240,6 @@ namespace OpenMS
 
     void StringManager::clear()
     {
-      for (Size i = 0; i < xml_strings_.size(); ++i)
-      {
-        XMLString::release(&xml_strings_[i]);
-      }
-      xml_strings_.clear();
-
-      for (Size i = 0; i < c_strings_.size(); ++i)
-      {
-        XMLString::release(&c_strings_[i]);
-      }
-      c_strings_.clear();
     }
 
     void StringManager::appendASCII(const XMLCh * chars, const XMLSize_t length, String & result)

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -606,7 +606,7 @@ namespace OpenMS
       pep_hit_.setSequence(AASequence::fromString(String(attributeAsString_(attributes, "sequence"))));
 
       //parse optional protein ids to determine accessions
-      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs"));
+      const XMLCh* refs = attributes.getValue(sm_.convert("protein_refs").c_str());
       if (refs != 0)
       {
         String accession_string = sm_.convert(refs);

--- a/src/openms/source/FORMAT/VALIDATORS/XMLValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/XMLValidator.cpp
@@ -86,12 +86,12 @@ namespace OpenMS
     parser->setEntityResolver(NULL);
 
     //load schema
-    LocalFileInputSource schema_file(Internal::StringManager().convert(schema));
+    LocalFileInputSource schema_file(Internal::StringManager().convert(schema).c_str());
     parser->loadGrammar(schema_file, Grammar::SchemaGrammarType, true);
     parser->setFeature(XMLUni::fgXercesUseCachedGrammarInParse, true);
 
     // try to parse file
-    LocalFileInputSource source(Internal::StringManager().convert(filename.c_str()));
+    LocalFileInputSource source(Internal::StringManager().convert(filename.c_str()).c_str());
 
     try
     {

--- a/src/openms/source/FORMAT/XMLFile.cpp
+++ b/src/openms/source/FORMAT/XMLFile.cpp
@@ -149,11 +149,11 @@ private:
       //g2 = static_cast<char>(0x8b); // can make troubles if it is casted to 0x7F which is the biggest number signed char can save
       if ((bz[0] == 'B' && bz[1] == 'Z') || (bz[0] == g1 && bz[1] == g2))
       {
-        source.reset(new CompressedInputSource(StringManager().convert(filename.c_str()), bz));
+        source.reset(new CompressedInputSource(Internal::StringManager().convert(filename.c_str()).c_str(), bz));
       }
       else
       {
-        source.reset(new xercesc::LocalFileInputSource(StringManager().convert(filename.c_str())));
+        source.reset(new xercesc::LocalFileInputSource(Internal::StringManager().convert(filename.c_str()).c_str()));
       }
       // what if no encoding given http://xerces.apache.org/xerces-c/apiDocs-3/classInputSource.html
       if (!enforced_encoding_.empty())

--- a/src/openms/source/FORMAT/XTandemXMLFile.cpp
+++ b/src/openms/source/FORMAT/XTandemXMLFile.cpp
@@ -284,7 +284,7 @@ namespace OpenMS
 
     if (tag_ == "group")
     {
-      Int index = attributes.getIndex(sm_.convert("z"));
+      Int index = attributes.getIndex(sm_.convert("z").c_str());
       if (index >= 0)
       {
         current_charge_ = String(sm_.convert(attributes.getValue(index))).toInt();

--- a/src/tests/class_tests/openms/source/CompressedInputSource_test.cpp
+++ b/src/tests/class_tests/openms/source/CompressedInputSource_test.cpp
@@ -70,7 +70,7 @@ START_SECTION(CompressedInputSource(const XMLCh *const file_path, const char *he
   header[2] = '\0';
   String bz = String(header);
   String filename(OPENMS_GET_TEST_DATA_PATH("Bzip2IfStream_1.bz2"));
-  ptr = new CompressedInputSource(Internal::StringManager().convert(filename.c_str()),bz);
+  ptr = new CompressedInputSource(Internal::StringManager().convert(filename.c_str()).c_str(),bz);
   TEST_NOT_EQUAL(ptr, nullPointer)
   delete ptr;
 END_SECTION

--- a/src/tests/class_tests/openms/source/CompressedInputSource_test.cpp
+++ b/src/tests/class_tests/openms/source/CompressedInputSource_test.cpp
@@ -49,13 +49,13 @@ START_TEST(CompressedInputSource, "$Id$")
 
 CompressedInputSource* ptr = 0;
 CompressedInputSource* nullPointer = 0;
-START_SECTION(CompressedInputSource(const   String& file_path, const char * header,xercesc::MemoryManager* const manager = xercesc::XMLPlatformUtils::fgMemoryManager))
+START_SECTION(CompressedInputSource(const String& file_path, const char * header,xercesc::MemoryManager* const manager = xercesc::XMLPlatformUtils::fgMemoryManager))
   char header[3];
   header[0] = 'B';
   header[1] = 'Z';
   header[2] = '\0';
   String bz = String(header);
-  ptr = new CompressedInputSource(OPENMS_GET_TEST_DATA_PATH("Bzip2IfStream_1.bz2"),bz);
+  ptr = new CompressedInputSource(OPENMS_GET_TEST_DATA_PATH("Bzip2IfStream_1.bz2"), bz);
   TEST_NOT_EQUAL(ptr, nullPointer)
 END_SECTION
 
@@ -70,7 +70,7 @@ START_SECTION(CompressedInputSource(const XMLCh *const file_path, const char *he
   header[2] = '\0';
   String bz = String(header);
   String filename(OPENMS_GET_TEST_DATA_PATH("Bzip2IfStream_1.bz2"));
-  ptr = new CompressedInputSource(Internal::StringManager().convert(filename.c_str()).c_str(),bz);
+  ptr = new CompressedInputSource(Internal::StringManager().convert(filename.c_str()).c_str(), bz);
   TEST_NOT_EQUAL(ptr, nullPointer)
   delete ptr;
 END_SECTION
@@ -82,7 +82,7 @@ START_SECTION(virtual xercesc::BinInputStream* makeStream() const)
   header[1] = 'Z';
   header[2] = '\0';
   String bz = String(header);
-  CompressedInputSource source(OPENMS_GET_TEST_DATA_PATH("ThisFileDoesNotExist"),bz);
+  CompressedInputSource source(OPENMS_GET_TEST_DATA_PATH("ThisFileDoesNotExist"), bz);
   TEST_EXCEPTION(Exception::FileNotFound,source.makeStream())
 END_SECTION
 


### PR DESCRIPTION
change StringManager memory management

- take ownership away from StringManager
- only use safe containers, either `std::string` or `std::basic_string<XMLChar>`

see also C++ cookbook https://resources.oreilly.com/examples/9780596007614/blob/master/14-4.h

replaces #2901