### PR TITLE
PhosphoScoring: improve default score for unambiguous cases (solves #2051)

### DIFF
--- a/doc/doxygen/parameters/DefaultParamHandlerDocumenter.cpp
+++ b/doc/doxygen/parameters/DefaultParamHandlerDocumenter.cpp
@@ -32,6 +32,7 @@
 // $Authors: Marc Sturm $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/ANALYSIS/ID/AScore.h>
 #include <OpenMS/ANALYSIS/ID/IDMapper.h>
 #include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithm.h>
 #include <OpenMS/ANALYSIS/ID/ConsensusIDAlgorithmAverage.h>
@@ -342,6 +343,7 @@ int main(int argc, char** argv)
   // Simple cases
   //////////////////////////////////
 
+  DOCME(AScore);
   DOCME(BernNorm);
   DOCME(BiGaussFitter1D);
   DOCME(BiGaussModel);

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -36,6 +36,7 @@
 #define OPENMS_ANALYSIS_ID_ASCORE_H
 
 #include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
@@ -63,11 +64,14 @@ namespace OpenMS
       @brief Implementation of the Ascore
       For a given peptide sequence and its MS/MS spectrum it identifies the most probable phosphorylation-site(s).
       For each phosphorylation site a probability score is calculated.
-      The algorithm is implemented according to Beausoleil et al.
+      The algorithm is implemented according to Beausoleil et al. (Nat. Biotechnol. 2006).
+
+      @htmlinclude OpenMS_AScore.parameters
   */
-  class OPENMS_DLLAPI AScore
+  class OPENMS_DLLAPI AScore: public DefaultParamHandler
   {
     friend struct PScore;
+    
   public:
     ///Default constructor
     AScore();
@@ -85,23 +89,23 @@ namespace OpenMS
 
         @note the original sequence is saved in the PeptideHits as MetaValue Search_engine_sequence.
     */
-    PeptideHit compute(const PeptideHit& hit, PeakSpectrum& real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm, Size max_peptide_len = 60, Size max_num_perm = 16384);
+    PeptideHit compute(const PeptideHit& hit, PeakSpectrum& real_spectrum);
 
   protected:
-    int compareMZ_(double mz1, double mz2, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
+    int compareMZ_(double mz1, double mz2) const;
     
     /// getSpectrumDifference_ works similar as the method std::set_difference (http://en.cppreference.com/w/cpp/algorithm/set_difference). 
     /// set_difference was reimplemented, because it was necessary to overwrite the compare operator to be able to compare the m/z values.
     /// not implemented as "operator<", because using tolerances for comparison does not imply total ordering    
     template <class InputIterator1, class InputIterator2, class OutputIterator>
     OutputIterator getSpectrumDifference_(InputIterator1 first1, InputIterator1 last1,
-      InputIterator2 first2, InputIterator2 last2, OutputIterator result, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
+      InputIterator2 first2, InputIterator2 last2, OutputIterator result) const
     {
       while (first1 != last1 && first2 != last2)
       {
         double mz1 = first1->getMZ();
         double mz2 = first2->getMZ();
-        int val = compareMZ_(mz1, mz2, fragment_mass_tolerance, fragment_mass_unit_ppm);
+        int val = compareMZ_(mz1, mz2);
         
         if (val == -1)
         { 
@@ -119,11 +123,11 @@ namespace OpenMS
           ++first2;
           if (first2 != last2)
           {
-            int ret = compareMZ_(mz1, first2->getMZ(), fragment_mass_tolerance, fragment_mass_unit_ppm);
+            int ret = compareMZ_(mz1, first2->getMZ());
             while (ret == 0 && first2 != last2)
             {
               ++first2;
-              ret = compareMZ_(mz1, first2->getMZ(), fragment_mass_tolerance, fragment_mass_unit_ppm);
+              ret = compareMZ_(mz1, first2->getMZ());
             }
           }
           
@@ -131,11 +135,11 @@ namespace OpenMS
           ++first1;
           if (first1 != last1)
           {
-            int ret = compareMZ_(first1->getMZ(), mz2, fragment_mass_tolerance, fragment_mass_unit_ppm);
+            int ret = compareMZ_(first1->getMZ(), mz2);
             while (ret == 0 && first1 != last1)
             {
               ++first1;
-              ret = compareMZ_(first1->getMZ(), mz2, fragment_mass_tolerance, fragment_mass_unit_ppm);
+              ret = compareMZ_(first1->getMZ(), mz2);
             }
           }
         }
@@ -144,7 +148,7 @@ namespace OpenMS
     }
     
     ///Computes the site determining_ions for the given AS and sequences in candidates
-    void computeSiteDeterminingIons_(const std::vector<PeakSpectrum>& th_spectra, const ProbablePhosphoSites& candidates, std::vector<PeakSpectrum>& site_determining_ions, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
+    void computeSiteDeterminingIons_(const std::vector<PeakSpectrum>& th_spectra, const ProbablePhosphoSites& candidates, std::vector<PeakSpectrum>& site_determining_ions) const;
 
     /// return all phospho sites
     std::vector<Size> getSites_(const AASequence& without_phospho) const;
@@ -153,7 +157,7 @@ namespace OpenMS
     std::vector<std::vector<Size>> computePermutations_(const std::vector<Size>& sites, Int n_phosphorylation_events) const;
 
     /// Computes number of matched ions between windows and the given spectrum. All spectra have to be sorted by position!
-    Size numberOfMatchedIons_(const PeakSpectrum& th, const PeakSpectrum& windows, Size depth, double fragment_mass_tolerance, bool fragment_mass_tolerance_ppm = false) const;
+    Size numberOfMatchedIons_(const PeakSpectrum& th, const PeakSpectrum& windows, Size depth) const;
 
     /// Computes the peptide score according to Beausoleil et al. page 1291
     double peptideScore_(const std::vector<double>& scores) const;
@@ -180,10 +184,21 @@ namespace OpenMS
     std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrum_(PeakSpectrum& real_spectrum) const;
     
     /// Create 10 scores for each theoretical spectrum (permutation), according to Beausoleil et al. Figure 3 b
-    std::vector<std::vector<double>> calculatePermutationPeptideScores_(std::vector<PeakSpectrum>& th_spectra, const std::vector<PeakSpectrum>& windows_top10, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
+    std::vector<std::vector<double>> calculatePermutationPeptideScores_(std::vector<PeakSpectrum>& th_spectra, const std::vector<PeakSpectrum>& windows_top10) const;
     
     /// Rank weighted permutation scores ascending
     std::multimap<double, Size> rankWeightedPermutationPeptideScores_(const std::vector<std::vector<double>>& peptide_site_scores) const;
+
+    /// Reimplemented from @ref DefaultParamHandler
+    virtual void updateMembers_();
+
+    // variables:
+    double fragment_mass_tolerance_; //< Fragment mass tolerance for spectrum comparisons
+    bool fragment_tolerance_ppm_; //< Is fragment mass tolerance given in ppm (or Da)?
+    Size max_peptide_length_; //< Limit for peptide lengths that can be analyzed
+    Size max_permutations_; //< Limit for number of sequence permutations that can be handled
+    double unambiguous_score_; //< Score for unambiguous assignments (all sites phosphorylated)
+    
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -46,27 +46,28 @@
 
 namespace OpenMS
 {
-class PeptideHit;
-class AASequence;
-struct ProbablePhosphoSites
-{
+  class PeptideHit;
+  class AASequence;
+  
+  struct ProbablePhosphoSites
+  {
     Size first;
     Size second;
     Size seq_1; // index of best permutation with site in phosphorylated state
     Size seq_2; // index of permutation with site in unphosphorylated state
     Size peak_depth; // filtering level that gave rise to maximum discriminatory score
     Size AScore;
-};
-/**
+  };
+  
+  /**
       @brief Implementation of the Ascore
       For a given peptide sequence and its MS/MS spectrum it identifies the most probable phosphorylation-site(s).
       For each phosphorylation site a probability score is calculated.
       The algorithm is implemented according to Beausoleil et al.
-
   */
-class OPENMS_DLLAPI AScore
-{
-  friend struct PScore;
+  class OPENMS_DLLAPI AScore
+  {
+    friend struct PScore;
   public:
     ///Default constructor
     AScore();
@@ -84,7 +85,7 @@ class OPENMS_DLLAPI AScore
 
         @note the original sequence is saved in the PeptideHits as MetaValue Search_engine_sequence.
     */
-    PeptideHit compute(const PeptideHit & hit, PeakSpectrum &real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm, Size max_peptide_len = 60, Size max_num_perm = 16384);
+    PeptideHit compute(const PeptideHit& hit, PeakSpectrum& real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm, Size max_peptide_len = 60, Size max_num_perm = 16384);
 
   protected:
     int compareMZ_(double mz1, double mz2, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
@@ -143,25 +144,25 @@ class OPENMS_DLLAPI AScore
     }
     
     ///Computes the site determining_ions for the given AS and sequences in candidates
-    void computeSiteDeterminingIons_(const std::vector<PeakSpectrum> & th_spectra, const ProbablePhosphoSites & candidates, std::vector<PeakSpectrum> & site_determining_ions, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
+    void computeSiteDeterminingIons_(const std::vector<PeakSpectrum>& th_spectra, const ProbablePhosphoSites& candidates, std::vector<PeakSpectrum>& site_determining_ions, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
 
     /// return all phospho sites
-    std::vector<Size> getSites_(const AASequence & without_phospho) const;
+    std::vector<Size> getSites_(const AASequence& without_phospho) const;
 
     /// calculate all n_phosphorylation_events sized sets of phospho sites (all versions of the peptides with exactly n_phosphorylation_events)
-    std::vector<std::vector<Size> > computePermutations_(const std::vector<Size> & sites, Int n_phosphorylation_events) const;
+    std::vector<std::vector<Size>> computePermutations_(const std::vector<Size>& sites, Int n_phosphorylation_events) const;
 
     /// Computes number of matched ions between windows and the given spectrum. All spectra have to be sorted by position!
-    Size numberOfMatchedIons_(const PeakSpectrum & th, const PeakSpectrum & windows, Size depth, double fragment_mass_tolerance, bool fragment_mass_tolerance_ppm = false) const;
+    Size numberOfMatchedIons_(const PeakSpectrum& th, const PeakSpectrum& windows, Size depth, double fragment_mass_tolerance, bool fragment_mass_tolerance_ppm = false) const;
 
     /// Computes the peptide score according to Beausoleil et al. page 1291
-    double peptideScore_(const std::vector<double> & scores) const;
+    double peptideScore_(const std::vector<double>& scores) const;
 
     /**
         @brief Finds the peptides with the highest PeptideScores and outputs all information for computing the AScore
         @note This function assumes that there are more permutations than the assumed number of phosphorylations!
     */
-    void determineHighestScoringPermutations_(const std::vector<std::vector<double> > & peptide_site_scores, std::vector<ProbablePhosphoSites> & sites, const std::vector<std::vector<Size> > & permutations, std::multimap<double, Size>& ranking) const;
+    void determineHighestScoringPermutations_(const std::vector<std::vector<double>>& peptide_site_scores, std::vector<ProbablePhosphoSites>& sites, const std::vector<std::vector<Size>>& permutations, std::multimap<double, Size>& ranking) const;
 
     /// Computes the cumulative binomial probabilities.
     double computeCumulativeScore_(Size N, Size n, double p) const;
@@ -173,17 +174,17 @@ class OPENMS_DLLAPI AScore
     AASequence removePhosphositesFromSequence_(const String sequence) const;
     
     /// Create theoretical spectra with all combinations with the number of phosphorylation events
-    std::vector<PeakSpectrum> createTheoreticalSpectra_(const std::vector<std::vector<Size> > & permutations, const AASequence & seq_without_phospho) const;
+    std::vector<PeakSpectrum> createTheoreticalSpectra_(const std::vector<std::vector<Size>>& permutations, const AASequence& seq_without_phospho) const;
     
     /// Pick top 10 intensity peaks for each 100 Da windows
-    std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrum_(PeakSpectrum & real_spectrum) const;
+    std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrum_(PeakSpectrum& real_spectrum) const;
     
     /// Create 10 scores for each theoretical spectrum (permutation), according to Beausoleil et al. Figure 3 b
-    std::vector<std::vector<double> > calculatePermutationPeptideScores_(std::vector<PeakSpectrum> & th_spectra, const std::vector<PeakSpectrum> & windows_top10, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
+    std::vector<std::vector<double>> calculatePermutationPeptideScores_(std::vector<PeakSpectrum>& th_spectra, const std::vector<PeakSpectrum>& windows_top10, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
     
     /// Rank weighted permutation scores ascending
-    std::multimap<double, Size> rankWeightedPermutationPeptideScores_(const std::vector<std::vector<double> > & peptide_site_scores) const;
-};
+    std::multimap<double, Size> rankWeightedPermutationPeptideScores_(const std::vector<std::vector<double>>& peptide_site_scores) const;
+  };
 
 } // namespace OpenMS
 

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -49,15 +49,33 @@ using namespace std;
 namespace OpenMS
 {
 
-  AScore::AScore()
-  {    
+  AScore::AScore():
+    DefaultParamHandler("AScore")
+  {
+    defaults_.setValue("fragment_mass_tolerance", 0.05, "Fragment mass tolerance for spectrum comparisons");
+    defaults_.setMinFloat("fragment_mass_tolerance", 0.0);
+
+    defaults_.setValue("fragment_mass_unit", "Da", "Unit of fragment mass tolerance");
+    defaults_.setValidStrings("fragment_mass_unit", ListUtils::create<String>("Da,ppm"));
+
+    vector<String> advanced(1, "advanced"); // tag for advanced parameters
+
+    defaults_.setValue("max_peptide_length", 40, "Restrict scoring to peptides with a length no greater than this value ('0' for 'no restriction')", advanced);
+    defaults_.setMinInt("max_peptide_length", 0);
+
+    defaults_.setValue("max_num_perm", 16384, "Maximum number of permutations a sequence can have to be processed ('0' for 'no restriction')", advanced);
+    defaults_.setMinInt("max_num_perm", 0);
+
+    defaults_.setValue("unambiguous_score", 1000, "Score to use for unambiguous assignments, where all sites on a peptide are phosphorylated. (Note: If a peptide is not phosphorylated at all, its score is set to '-1'.)", advanced);
+
+    defaultsToParam_();
   }
 
   AScore::~AScore()
   {
   }
 
-  PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm, Size max_peptide_len, Size max_num_perm)
+  PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& real_spectrum)
   {
     PeptideHit phospho = hit;
     
@@ -72,64 +90,69 @@ namespace OpenMS
     
     Size number_of_phosphorylation_events = numberOfPhosphoEvents_(sequence_str);
     AASequence seq_without_phospho = removePhosphositesFromSequence_(sequence_str);
-    
-    if (seq_without_phospho.toUnmodifiedString().size() > max_peptide_len)
+
+    if ((max_peptide_length_ > 0) && (seq_without_phospho.toUnmodifiedString().size() > max_peptide_length_))
     {
       LOG_DEBUG << "\tcalculation aborted: peptide too long: " << seq_without_phospho.toString() << std::endl;
       return phospho;
     }
-    
+
     // determine all phospho sites
-    vector<Size> sites(getSites_(seq_without_phospho));
+    vector<Size> sites = getSites_(seq_without_phospho);
     Size number_of_STY = sites.size();
-    
-    if (number_of_phosphorylation_events == 0 || number_of_STY == 0 || number_of_STY == number_of_phosphorylation_events)
+
+    if (number_of_phosphorylation_events == 0 || number_of_STY == 0)
     {
       return phospho;
     }
-    
-    vector<vector<Size>> permutations(computePermutations_(sites, (Int)number_of_phosphorylation_events));
+    if (number_of_STY == number_of_phosphorylation_events)
+    {
+      phospho.setScore(unambiguous_score_);
+      return phospho;
+    } 
+
+    vector<vector<Size>> permutations = computePermutations_(sites, (Int)number_of_phosphorylation_events);
     LOG_DEBUG << "\tnumber of permutations: " << permutations.size() << std::endl;
-    
+
     // TODO: using a heuristic to calculate the best phospho sites if the number of permutations are exceeding the maximum.
     // A heuristic could be to calculate the best site for the first phosphorylation and based on this the best site for the second 
     // phosphorylation and so on until every site is determined
-    if (permutations.size() > max_num_perm) 
+    if ((max_permutations_ > 0) && (permutations.size() > max_permutations_))
     {
       LOG_DEBUG << "\tcalculation aborted: number of permutations exceeded" << std::endl;
       return phospho;
     }
-      
-    vector<PeakSpectrum> th_spectra(createTheoreticalSpectra_(permutations, seq_without_phospho));
-    
+
+    vector<PeakSpectrum> th_spectra = createTheoreticalSpectra_(permutations, seq_without_phospho);
+
     // prepare real spectrum windows
     if (!real_spectrum.isSorted())
     {
       real_spectrum.sortByPosition();
     }
-    vector<PeakSpectrum> windows_top10(peakPickingPerWindowsInSpectrum_(real_spectrum));
-    
+    vector<PeakSpectrum> windows_top10 = peakPickingPerWindowsInSpectrum_(real_spectrum);
+
     // calculate peptide score for each possible phospho site permutation
-    vector<vector<double>> peptide_site_scores(calculatePermutationPeptideScores_(th_spectra, windows_top10, fragment_mass_tolerance, fragment_mass_unit_ppm));
-    
+    vector<vector<double>> peptide_site_scores = calculatePermutationPeptideScores_(th_spectra, windows_top10);
+
     // rank peptide permutations ascending
-    multimap<double, Size> ranking(rankWeightedPermutationPeptideScores_(peptide_site_scores));
-    
+    multimap<double, Size> ranking = rankWeightedPermutationPeptideScores_(peptide_site_scores);
+
     multimap<double, Size>::reverse_iterator rev = ranking.rbegin();
     String seq1 = th_spectra[rev->second].getName();
     phospho.setSequence(AASequence::fromString(seq1));
     phospho.setMetaValue("search_engine_sequence", hit.getSequence().toString());
-    
+
     double peptide1_score = rev->first;
     phospho.setMetaValue("AScore_pep_score", peptide1_score); // initialize score with highest peptide score (aka highest weighted score)
-    
+
     ++rev;
     String seq2 = th_spectra[rev->second].getName();
     double peptide2_score = rev->first;
-    
+
     vector<ProbablePhosphoSites> phospho_sites;
     determineHighestScoringPermutations_(peptide_site_scores, phospho_sites, permutations, ranking);
-    
+
     Int rank = 1;
     double best_Ascore = std::numeric_limits<double>::max(); // the lower the better
     for (vector<ProbablePhosphoSites>::iterator s_it = phospho_sites.begin(); s_it != phospho_sites.end(); ++s_it)
@@ -142,33 +165,33 @@ namespace OpenMS
       else
       {
         vector<PeakSpectrum> site_determining_ions;
-        
-        computeSiteDeterminingIons_(th_spectra, *s_it, site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
+
+        computeSiteDeterminingIons_(th_spectra, *s_it, site_determining_ions);
         Size N = site_determining_ions[0].size(); // all possibilities have the same number so take the first one
         double p = static_cast<double>(s_it->peak_depth) / 100.0;
-        
+
         Size n_first = 0; // number of matching peaks for first peptide
         for (Size window_idx = 0; window_idx != windows_top10.size(); ++window_idx) // for each 100 m/z window
         {
-          n_first += numberOfMatchedIons_(site_determining_ions[0], windows_top10[window_idx], s_it->peak_depth, fragment_mass_tolerance, fragment_mass_unit_ppm);        
+          n_first += numberOfMatchedIons_(site_determining_ions[0], windows_top10[window_idx], s_it->peak_depth);        
         }
         double P_first = computeCumulativeScore_(N, n_first, p);
-        
+
         Size n_second = 0; // number of matching peaks for second peptide
         for (Size window_idx = 0; window_idx <  windows_top10.size(); ++window_idx) //each 100 m/z window
         {
-          n_second += numberOfMatchedIons_(site_determining_ions[1], windows_top10[window_idx], s_it->peak_depth, fragment_mass_tolerance, fragment_mass_unit_ppm);        
+          n_second += numberOfMatchedIons_(site_determining_ions[1], windows_top10[window_idx], s_it->peak_depth);        
         }
         Size N2 = site_determining_ions[1].size(); // all possibilities have the same number so take the first one
         double P_second = computeCumulativeScore_(N2, n_second, p);
-        
+
         //abs is used to avoid -0 score values
         double score_first = abs(-10 * log10(P_first));
         double score_second = abs(-10 * log10(P_second));
-        
+
         LOG_DEBUG << "\tfirst - N: " << N << ",p: " << p << ",n: " << n_first << ", score: " << score_first << std::endl;
         LOG_DEBUG << "\tsecond - N: " << N2 << ",p: " << p << ",n: " << n_second << ", score: " << score_second << std::endl;
-        
+
         Ascore = score_first - score_second;
         LOG_DEBUG << "\tAscore_" << rank << ": " << Ascore << std::endl;
       }
@@ -308,7 +331,7 @@ namespace OpenMS
   }
   
   // calculation of the number of different speaks between the theoretical spectra of the two best scoring peptide permutations, respectively
-  void AScore::computeSiteDeterminingIons_(const vector<PeakSpectrum>& th_spectra, const ProbablePhosphoSites& candidates, vector<PeakSpectrum>& site_determining_ions, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
+  void AScore::computeSiteDeterminingIons_(const vector<PeakSpectrum>& th_spectra, const ProbablePhosphoSites& candidates, vector<PeakSpectrum>& site_determining_ions) const
   {
     site_determining_ions.clear();
     site_determining_ions.resize(2);
@@ -320,13 +343,13 @@ namespace OpenMS
     AScore::getSpectrumDifference_(
       spectrum_first.begin(), spectrum_first.end(),
       spectrum_second.begin(), spectrum_second.end(),
-      std::inserter(spectrum_first_diff, spectrum_first_diff.begin()), fragment_mass_tolerance, fragment_mass_unit_ppm);
+      std::inserter(spectrum_first_diff, spectrum_first_diff.begin()));
       
     PeakSpectrum spectrum_second_diff;
     AScore::getSpectrumDifference_(
       spectrum_second.begin(), spectrum_second.end(),
       spectrum_first.begin(), spectrum_first.end(),
-      std::inserter(spectrum_second_diff, spectrum_second_diff.begin()), fragment_mass_tolerance, fragment_mass_unit_ppm);
+      std::inserter(spectrum_second_diff, spectrum_second_diff.begin()));
       
     LOG_DEBUG << spectrum_first_diff << std::endl;
     LOG_DEBUG << spectrum_second_diff << std::endl;
@@ -338,7 +361,7 @@ namespace OpenMS
     site_determining_ions[1].sortByPosition(); 
   }
 
-  Size AScore::numberOfMatchedIons_(const PeakSpectrum& th, const PeakSpectrum& window, Size depth, double fragment_mass_tolerance, bool fragment_mass_tolerance_ppm) const
+  Size AScore::numberOfMatchedIons_(const PeakSpectrum& th, const PeakSpectrum& window, Size depth) const
   {
     PeakSpectrum window_reduced = window;
     if (window_reduced.size() > depth)
@@ -362,11 +385,11 @@ namespace OpenMS
         double window_mz = window_reduced[nearest_peak].getMZ();
         double error = abs(window_mz - th[i].getMZ());
         
-        if (fragment_mass_tolerance_ppm)
+        if (fragment_tolerance_ppm_)
         {
           error = error / window_mz * 1e6;
         }
-        if (error < fragment_mass_tolerance)
+        if (error < fragment_mass_tolerance_)
         {
           ++n;
         }
@@ -545,7 +568,7 @@ namespace OpenMS
     return windows_top10;
   }
   
-  std::vector<std::vector<double>> AScore::calculatePermutationPeptideScores_(vector<PeakSpectrum>& th_spectra, const vector<PeakSpectrum>& windows_top10, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
+  std::vector<std::vector<double>> AScore::calculatePermutationPeptideScores_(vector<PeakSpectrum>& th_spectra, const vector<PeakSpectrum>& windows_top10) const
   {
     //prepare peak depth for all windows in the actual spectrum
     vector<vector<double>> permutation_peptide_scores(th_spectra.size());
@@ -562,7 +585,7 @@ namespace OpenMS
         Size n = 0;
         for (Size current_win = 0; current_win < windows_top10.size(); ++current_win) // count matched ions over all 100 Da windows
         {
-          n += numberOfMatchedIons_(*it, windows_top10[current_win], i, fragment_mass_tolerance, fragment_mass_unit_ppm);
+          n += numberOfMatchedIons_(*it, windows_top10[current_win], i);
         }
         double p = static_cast<double>(i) / 100.0;
         double cumulative_score = computeCumulativeScore_(N, n, p);
@@ -587,15 +610,15 @@ namespace OpenMS
     return ranking;
   }
   
-  int AScore::compareMZ_(double mz1, double mz2, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
+  int AScore::compareMZ_(double mz1, double mz2) const
   {
-    double tolerance = fragment_mass_tolerance;        
+    double tolerance = fragment_mass_tolerance_;        
     double error = mz1 - mz2;
     
-    if (fragment_mass_unit_ppm)
+    if (fragment_tolerance_ppm_)
     {
       double avg_mass = (mz1 + mz2) / 2;
-      tolerance = fragment_mass_tolerance * avg_mass / 1e6;
+      tolerance = tolerance * avg_mass / 1e6;
     }
     
     if (error < -tolerance)
@@ -611,4 +634,14 @@ namespace OpenMS
       return 0;
     }
   }
+
+  void AScore::updateMembers_()
+  {
+    fragment_mass_tolerance_ = param_.getValue("fragment_mass_tolerance");
+    fragment_tolerance_ppm_ = (param_.getValue("fragment_mass_unit") == "ppm");
+    max_peptide_length_ = param_.getValue("max_peptide_length");
+    max_permutations_ = param_.getValue("max_num_perm");
+    unambiguous_score_ = param_.getValue("unambiguous_score");
+  }
+  
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -57,7 +57,7 @@ namespace OpenMS
   {
   }
 
-  PeptideHit AScore::compute(const PeptideHit & hit, PeakSpectrum & real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm, Size max_peptide_len, Size max_num_perm)
+  PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm, Size max_peptide_len, Size max_num_perm)
   {
     PeptideHit phospho = hit;
     
@@ -88,7 +88,7 @@ namespace OpenMS
       return phospho;
     }
     
-    vector<vector<Size> > permutations(computePermutations_(sites, (Int)number_of_phosphorylation_events));
+    vector<vector<Size>> permutations(computePermutations_(sites, (Int)number_of_phosphorylation_events));
     LOG_DEBUG << "\tnumber of permutations: " << permutations.size() << std::endl;
     
     // TODO: using a heuristic to calculate the best phospho sites if the number of permutations are exceeding the maximum.
@@ -110,7 +110,7 @@ namespace OpenMS
     vector<PeakSpectrum> windows_top10(peakPickingPerWindowsInSpectrum_(real_spectrum));
     
     // calculate peptide score for each possible phospho site permutation
-    vector<vector<double> > peptide_site_scores(calculatePermutationPeptideScores_(th_spectra, windows_top10, fragment_mass_tolerance, fragment_mass_unit_ppm));
+    vector<vector<double>> peptide_site_scores(calculatePermutationPeptideScores_(th_spectra, windows_top10, fragment_mass_tolerance, fragment_mass_unit_ppm));
     
     // rank peptide permutations ascending
     multimap<double, Size> ranking(rankWeightedPermutationPeptideScores_(peptide_site_scores));
@@ -218,7 +218,7 @@ namespace OpenMS
     return score;
   }
 
-  void AScore::determineHighestScoringPermutations_(const std::vector<std::vector<double> >& peptide_site_scores, std::vector<ProbablePhosphoSites>& sites, const vector<vector<Size> >& permutations, std::multimap<double, Size>& ranking) const
+  void AScore::determineHighestScoringPermutations_(const std::vector<std::vector<double>>& peptide_site_scores, std::vector<ProbablePhosphoSites>& sites, const vector<vector<Size>>& permutations, std::multimap<double, Size>& ranking) const
   {
     // For every phospho site of the highest (weighted) scoring phospho site assignment:
     // 1. determine the next best (weighted) score assignment with this site in unphosporylated state.
@@ -308,7 +308,7 @@ namespace OpenMS
   }
   
   // calculation of the number of different speaks between the theoretical spectra of the two best scoring peptide permutations, respectively
-  void AScore::computeSiteDeterminingIons_(const vector<PeakSpectrum> & th_spectra, const ProbablePhosphoSites & candidates, vector<PeakSpectrum> & site_determining_ions, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
+  void AScore::computeSiteDeterminingIons_(const vector<PeakSpectrum>& th_spectra, const ProbablePhosphoSites& candidates, vector<PeakSpectrum>& site_determining_ions, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
   {
     site_determining_ions.clear();
     site_determining_ions.resize(2);
@@ -338,7 +338,7 @@ namespace OpenMS
     site_determining_ions[1].sortByPosition(); 
   }
 
-  Size AScore::numberOfMatchedIons_(const PeakSpectrum & th, const PeakSpectrum & window, Size depth, double fragment_mass_tolerance, bool fragment_mass_tolerance_ppm) const
+  Size AScore::numberOfMatchedIons_(const PeakSpectrum& th, const PeakSpectrum& window, Size depth, double fragment_mass_tolerance, bool fragment_mass_tolerance_ppm) const
   {
     PeakSpectrum window_reduced = window;
     if (window_reduced.size() > depth)
@@ -375,7 +375,7 @@ namespace OpenMS
     return n;
   }
 
-  double AScore::peptideScore_(const std::vector<double> & scores) const
+  double AScore::peptideScore_(const std::vector<double>& scores) const
   {
     OPENMS_PRECONDITION(scores.size() == 10, "Scores vector must contain a score for every peak level."); 
     return (scores[0] * 0.5
@@ -405,7 +405,7 @@ namespace OpenMS
     return tupel;
   }
 
-  vector<vector<Size> > AScore::computePermutations_(const vector<Size> & sites, Int n_phosphorylation_events) const
+  vector<vector<Size>> AScore::computePermutations_(const vector<Size>& sites, Int n_phosphorylation_events) const
   {
     vector<vector<Size>  > permutations;
     
@@ -433,7 +433,7 @@ namespace OpenMS
     // Generate all n_phosphorylation_events sized sets from sites
     {
       vector<Size> head;
-      vector<vector<Size> > tail;
+      vector<vector<Size>> tail;
       
       // all permutations with first site selected
       head.push_back(sites[0]);
@@ -442,7 +442,7 @@ namespace OpenMS
       
       tail = computePermutations_(tupel_left, tail_phospho_sites);
       
-      for (vector<vector<Size> >::iterator it = tail.begin(); it != tail.end(); ++it)
+      for (vector<vector<Size>>::iterator it = tail.begin(); it != tail.end(); ++it)
       {
         vector<Size> temp(head);
         temp.insert(temp.end(), it->begin(), it->end());
@@ -450,7 +450,7 @@ namespace OpenMS
       }
 
       // all permutations with first site not selected
-      vector<vector<Size> > other_possibilities(computePermutations_(tupel_left, n_phosphorylation_events));
+      vector<vector<Size>> other_possibilities(computePermutations_(tupel_left, n_phosphorylation_events));
       permutations.insert(permutations.end(), other_possibilities.begin(), other_possibilities.end());
       return permutations;
     }
@@ -480,7 +480,7 @@ namespace OpenMS
   }
   
   /// Create theoretical spectra
-  vector<PeakSpectrum> AScore::createTheoreticalSpectra_(const vector<vector<Size> > & permutations, const AASequence & seq_without_phospho) const
+  vector<PeakSpectrum> AScore::createTheoreticalSpectra_(const vector<vector<Size>>& permutations, const AASequence& seq_without_phospho) const
   {
     vector<PeakSpectrum> th_spectra;
     TheoreticalSpectrumGenerator spectrum_generator;
@@ -512,7 +512,7 @@ namespace OpenMS
     return th_spectra;
   }
     
-  std::vector<PeakSpectrum> AScore::peakPickingPerWindowsInSpectrum_(PeakSpectrum &real_spectrum) const
+  std::vector<PeakSpectrum> AScore::peakPickingPerWindowsInSpectrum_(PeakSpectrum& real_spectrum) const
   {
     vector<PeakSpectrum> windows_top10;
     
@@ -545,11 +545,11 @@ namespace OpenMS
     return windows_top10;
   }
   
-  std::vector<std::vector<double> > AScore::calculatePermutationPeptideScores_(vector<PeakSpectrum>& th_spectra, const vector<PeakSpectrum>& windows_top10, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
+  std::vector<std::vector<double>> AScore::calculatePermutationPeptideScores_(vector<PeakSpectrum>& th_spectra, const vector<PeakSpectrum>& windows_top10, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
   {
     //prepare peak depth for all windows in the actual spectrum
-    vector<vector<double> > permutation_peptide_scores(th_spectra.size());
-    vector<vector<double> >::iterator site_score = permutation_peptide_scores.begin();
+    vector<vector<double>> permutation_peptide_scores(th_spectra.size());
+    vector<vector<double>>::iterator site_score = permutation_peptide_scores.begin();
     
     // for each phospho site assignment
     for (vector<PeakSpectrum>::iterator it = th_spectra.begin(); it != th_spectra.end(); ++it, ++site_score)
@@ -574,7 +574,7 @@ namespace OpenMS
     return permutation_peptide_scores;
   }
   
-  std::multimap<double, Size> AScore::rankWeightedPermutationPeptideScores_(const vector<vector<double> > & peptide_site_scores) const
+  std::multimap<double, Size> AScore::rankWeightedPermutationPeptideScores_(const vector<vector<double>>& peptide_site_scores) const
   {
     multimap<double, Size> ranking;
     

--- a/src/pyOpenMS/pxds/AScore.pxd
+++ b/src/pyOpenMS/pxds/AScore.pxd
@@ -17,15 +17,14 @@ from ChromatogramPeak cimport *
 
 cdef extern from "<OpenMS/ANALYSIS/ID/AScore.h>" namespace "OpenMS":
 
-    cdef cppclass AScore:
-
+    cdef cppclass AScore(DefaultParamHandler):
+        # wrap-inherits:
+        #  DefaultParamHandler
         AScore() nogil except +
         AScore(AScore) nogil except + # wrap-ignore
 
         PeptideHit compute(PeptideHit & hit,
-                           MSSpectrum & real_spectrum,
-                           double fragment_mass_tolerance, 
-                           bool fragment_mass_unit_ppm) nogil except +
+                           MSSpectrum & real_spectrum) nogil except +
 
 
     cdef cppclass ProbablePhosphoSites:

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -1733,7 +1733,7 @@ def testAScore():
     hit = pyopenms.PeptideHit()
     spectrum = pyopenms.MSSpectrum()
 
-    ff.compute(hit, spectrum, 5.0, 1)
+    ff.compute(hit, spectrum)
     # ff.computeCumulativeScore(1,1,0.5)
 
 @report

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -404,9 +404,6 @@ START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum>& t
   PeakSpectrum temp1, temp2;
   vector<PeakSpectrum> site_determining_ions;
   
-  PeakSpectrum& real_spectrum = tmp;
-  std::vector<PeakSpectrum> windows_top10 = ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum);
-  
   AASequence seq = seq_without_phospho;
   vector<PeakSpectrum> th_s = ptr_test->createTheoreticalSpectraTest_(permutations, seq);
   

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -845,7 +845,13 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& re
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
   TEST_REAL_SIMILAR(static_cast<double>(hit6.getMetaValue("AScore_1")), 20.1669211754322);
-  TEST_EQUAL(hit6.getSequence().toString(), "ATPGNLGSSVLHS(Phospho)K");  
+  TEST_EQUAL(hit6.getSequence().toString(), "ATPGNLGSSVLHS(Phospho)K");
+
+  // ===========================================================================
+  // check if special score is used for unambiguous assignment:
+  PeptideHit hit7(1.0, 1, 1, AASequence::fromString("PEPT(Phospho)IDE"));
+  hit7 = ptr_test->compute(hit7, real_spectrum);
+  TEST_REAL_SIMILAR(hit7.getScore(), ptr_test->getParameters().getValue("unambiguous_score"));
 }
 END_SECTION 
 

--- a/src/tests/class_tests/openms/source/AScore_test.cpp
+++ b/src/tests/class_tests/openms/source/AScore_test.cpp
@@ -47,28 +47,28 @@ using namespace std;
 class AScoreTest : public AScore
 {
   public:
-    void computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum> & th_spectra, const ProbablePhosphoSites & candidates, std::vector<PeakSpectrum> & site_determining_ions, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const
+    void computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum>& th_spectra, const ProbablePhosphoSites& candidates, std::vector<PeakSpectrum>& site_determining_ions) const
     {
-      return computeSiteDeterminingIons_(th_spectra, candidates, site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
+      return computeSiteDeterminingIons_(th_spectra, candidates, site_determining_ions);
     }
 
-    std::vector<Size> getSitesTest_(const AASequence & without_phospho) const {
+    std::vector<Size> getSitesTest_(const AASequence& without_phospho) const {
       return getSites_(without_phospho);
     }
 
-    std::vector<std::vector<Size> > computePermutationsTest_(const std::vector<Size> & sites, Int n_phosphorylation_events) const
+    std::vector<std::vector<Size> > computePermutationsTest_(const std::vector<Size>& sites, Int n_phosphorylation_events) const
     {
       return computePermutations_(sites, n_phosphorylation_events);
     }
 
-    Size numberOfMatchedIonsTest_(const PeakSpectrum & th, const PeakSpectrum & windows, Size depth, double fragment_mass_tolerance, bool fragment_mass_tolerance_ppm = false) const
+    Size numberOfMatchedIonsTest_(const PeakSpectrum& th, const PeakSpectrum& windows, Size depth) const
     {
-      return numberOfMatchedIons_(th, windows, depth, fragment_mass_tolerance, fragment_mass_tolerance_ppm);
+      return numberOfMatchedIons_(th, windows, depth);
     }
 
-    //double peptideScoreTest_(const std::vector<double> & scores) const;
+    //double peptideScoreTest_(const std::vector<double>& scores) const;
 
-    void determineHighestScoringPermutationsTest_(const std::vector<std::vector<double> > & peptide_site_scores, std::vector<ProbablePhosphoSites> & sites, const std::vector<std::vector<Size> > & permutations, std::multimap<double, Size>& ranking) const
+    void determineHighestScoringPermutationsTest_(const std::vector<std::vector<double>>& peptide_site_scores, std::vector<ProbablePhosphoSites>& sites, const std::vector<std::vector<Size>>& permutations, std::multimap<double, Size>& ranking) const
     {
       return determineHighestScoringPermutations_(peptide_site_scores, sites, permutations, ranking);
     }
@@ -85,19 +85,19 @@ class AScoreTest : public AScore
       return removePhosphositesFromSequence_(sequence);
     }
     
-    std::vector<PeakSpectrum> createTheoreticalSpectraTest_(const std::vector<std::vector<Size> > & permutations, const AASequence & seq_without_phospho) const
+    std::vector<PeakSpectrum> createTheoreticalSpectraTest_(const std::vector<std::vector<Size>>& permutations, const AASequence& seq_without_phospho) const
     {
       return createTheoreticalSpectra_(permutations, seq_without_phospho);
     }
     
-    std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrumTest_(PeakSpectrum & real_spectrum) const
+    std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrumTest_(PeakSpectrum& real_spectrum) const
     {
       return peakPickingPerWindowsInSpectrum_(real_spectrum);
     }
     
-    //std::vector<std::vector<double> > calculatePermutationPeptideScoresTest_(std::vector<PeakSpectrum> & th_spectra, const std::vector<PeakSpectrum> & windows_top10, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const;
+    //std::vector<std::vector<double>> calculatePermutationPeptideScoresTest_(std::vector<PeakSpectrum>& th_spectra, const std::vector<PeakSpectrum>& windows_top10) const;
     
-    std::multimap<double, Size> rankWeightedPermutationPeptideScoresTest_(const std::vector<std::vector<double> > & peptide_site_scores) const
+    std::multimap<double, Size> rankWeightedPermutationPeptideScoresTest_(const std::vector<std::vector<double>>& peptide_site_scores) const
     {
       return rankWeightedPermutationPeptideScores_(peptide_site_scores);
     }
@@ -121,7 +121,7 @@ DTAFile().load(OPENMS_GET_TEST_DATA_PATH("Ascore_test_input3.dta"), tmp);
 //=============================================================================
 // create permutations based on sequence QSSVTQVTEQSPK
 //=============================================================================
-std::vector<std::vector<Size> > permutations;
+std::vector<std::vector<Size>> permutations;
 std::vector<Size> perm;
 
 perm.clear();
@@ -168,23 +168,23 @@ START_SECTION(double computeCumulativeScoreTest_(Size N, Size n, double p))
   Size n = 5;
   Size N = 1;
   double p = 0.1;
-  TEST_PRECONDITION_VIOLATED(ptr_test->computeCumulativeScoreTest_(N,n,p));
+  TEST_PRECONDITION_VIOLATED(ptr_test->computeCumulativeScoreTest_(N, n, p));
 
   n = 1;
-  double score = ptr_test->computeCumulativeScoreTest_(N,n,p);
-  TEST_REAL_SIMILAR(score,0.1);
+  double score = ptr_test->computeCumulativeScoreTest_(N, n, p);
+  TEST_REAL_SIMILAR(score, 0.1);
   N = 3;
-  score = ptr_test->computeCumulativeScoreTest_(N,n,p);
-  TEST_REAL_SIMILAR(score,0.271);
+  score = ptr_test->computeCumulativeScoreTest_(N, n, p);
+  TEST_REAL_SIMILAR(score, 0.271);
 }
 END_SECTION
 
-START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::vector<double> > & peptide_site_scores, std::vector<ProbablePhosphoSites> & sites, const std::vector<std::vector<Size> > & permutations))
+START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::vector<double>>& peptide_site_scores, std::vector<ProbablePhosphoSites>& sites, const std::vector<std::vector<Size>>& permutations))
 {
   std::multimap<double, Size> ranking;
-  std::vector< std::vector<double> > peptide_site_scores_1;
-  std::vector< std::vector<double> > peptide_site_scores_2;
-  std::vector< std::vector<double> > peptide_site_scores_3;
+  std::vector<std::vector<double>> peptide_site_scores_1;
+  std::vector<std::vector<double>> peptide_site_scores_2;
+  std::vector<std::vector<double>> peptide_site_scores_3;
   peptide_site_scores_1.resize(4);
   peptide_site_scores_2.resize(4);
   peptide_site_scores_3.resize(4);
@@ -226,7 +226,7 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
   peptide_site_scores_3[1] = temp;
 
 
-  vector<vector<Size> > permutations;
+  vector<vector<Size>> permutations;
   vector<Size> per;
   per.push_back(1);
   per.push_back(3);
@@ -251,60 +251,60 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
 
   vector<ProbablePhosphoSites> sites;
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_1);
-  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_1,sites,permutations,ranking);
-  TEST_EQUAL(sites.size(),3)
+  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_1, sites, permutations,ranking);
+  TEST_EQUAL(sites.size(), 3);
   TEST_EQUAL(sites[0].seq_1, 3);
-  TEST_EQUAL(sites[0].seq_2,1);
+  TEST_EQUAL(sites[0].seq_2, 1);
   TEST_EQUAL(sites[0].second, 3);
-  TEST_EQUAL(sites[0].first,1);
-  TEST_EQUAL(sites[0].peak_depth, 1)
-    TEST_EQUAL(sites[1].first,5);
-  TEST_EQUAL(sites[1].second,3);
+  TEST_EQUAL(sites[0].first, 1);
+  TEST_EQUAL(sites[0].peak_depth, 1);
+  TEST_EQUAL(sites[1].first, 5);
+  TEST_EQUAL(sites[1].second, 3);
   TEST_EQUAL(sites[1].seq_1, 3);
-  TEST_EQUAL(sites[1].seq_2,2);
-  TEST_EQUAL(sites[1].peak_depth, 1)
-    TEST_EQUAL(sites[2].first,6);
-  TEST_EQUAL(sites[2].second,3);
-    TEST_EQUAL(sites[2].seq_1, 3);
-  TEST_EQUAL(sites[2].seq_2,0);
-  TEST_EQUAL(sites[2].peak_depth, 1)
+  TEST_EQUAL(sites[1].seq_2, 2);
+  TEST_EQUAL(sites[1].peak_depth, 1);
+  TEST_EQUAL(sites[2].first, 6);
+  TEST_EQUAL(sites[2].second, 3);
+  TEST_EQUAL(sites[2].seq_1, 3);
+  TEST_EQUAL(sites[2].seq_2, 0);
+  TEST_EQUAL(sites[2].peak_depth, 1);
 
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_3);
-  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_3,sites,permutations,ranking);
-  TEST_EQUAL(sites.size(),3)
+  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_3, sites, permutations, ranking);
+  TEST_EQUAL(sites.size(), 3);
   TEST_EQUAL(sites[0].seq_1, 1);
-  TEST_EQUAL(sites[0].seq_2,3);
-  TEST_EQUAL(sites[0].second,1 );
-  TEST_EQUAL(sites[0].first,3);
-  TEST_EQUAL(sites[0].peak_depth, 1)
-    TEST_EQUAL(sites[1].first,5);
-  TEST_EQUAL(sites[1].second,1);
+  TEST_EQUAL(sites[0].seq_2, 3);
+  TEST_EQUAL(sites[0].second, 1);
+  TEST_EQUAL(sites[0].first, 3);
+  TEST_EQUAL(sites[0].peak_depth, 1);
+  TEST_EQUAL(sites[1].first, 5);
+  TEST_EQUAL(sites[1].second, 1);
   TEST_EQUAL(sites[1].seq_1, 1);
-  TEST_EQUAL(sites[1].seq_2,2);
-  TEST_EQUAL(sites[1].peak_depth, 1)
-    TEST_EQUAL(sites[2].first,6);
-  TEST_EQUAL(sites[2].second,1);
-    TEST_EQUAL(sites[2].seq_1, 1);
-  TEST_EQUAL(sites[2].seq_2,0);
-  TEST_EQUAL(sites[2].peak_depth, 1)
+  TEST_EQUAL(sites[1].seq_2, 2);
+  TEST_EQUAL(sites[1].peak_depth, 1);
+  TEST_EQUAL(sites[2].first, 6);
+  TEST_EQUAL(sites[2].second, 1);
+  TEST_EQUAL(sites[2].seq_1, 1);
+  TEST_EQUAL(sites[2].seq_2, 0);
+  TEST_EQUAL(sites[2].peak_depth, 1);
 
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_2);
-  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_2,sites,permutations,ranking);
-  TEST_EQUAL(sites.size(),3)
+  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_2, sites, permutations, ranking);
+  TEST_EQUAL(sites.size(), 3);
   TEST_EQUAL(sites[0].seq_1, 2);
-  TEST_EQUAL(sites[0].seq_2,1);
-  TEST_EQUAL(sites[0].second,5 );
-  TEST_EQUAL(sites[0].first,1);
-  TEST_EQUAL(sites[0].peak_depth, 1)
-    TEST_EQUAL(sites[1].first,3);
-  TEST_EQUAL(sites[1].second,5);
+  TEST_EQUAL(sites[0].seq_2, 1);
+  TEST_EQUAL(sites[0].second, 5);
+  TEST_EQUAL(sites[0].first, 1);
+  TEST_EQUAL(sites[0].peak_depth, 1);
+  TEST_EQUAL(sites[1].first, 3);
+  TEST_EQUAL(sites[1].second, 5);
   TEST_EQUAL(sites[1].seq_1, 2);
-  TEST_EQUAL(sites[1].seq_2,3);
-  TEST_EQUAL(sites[1].peak_depth, 1)
-    TEST_EQUAL(sites[2].first,6);
-  TEST_EQUAL(sites[2].second,5);
-    TEST_EQUAL(sites[2].seq_1, 2);
-  TEST_EQUAL(sites[2].seq_2,0);
+  TEST_EQUAL(sites[1].seq_2, 3);
+  TEST_EQUAL(sites[1].peak_depth, 1);
+  TEST_EQUAL(sites[2].first, 6);
+  TEST_EQUAL(sites[2].second, 5);
+  TEST_EQUAL(sites[2].seq_1, 2);
+  TEST_EQUAL(sites[2].seq_2, 0);
   TEST_EQUAL(sites[2].peak_depth, 1)
 
   peptide_site_scores_1.clear();
@@ -343,12 +343,12 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
   permutations.push_back(per);
 
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_1);
-  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_1,sites,permutations,ranking);
-  TEST_EQUAL(sites.size(),1)
-  TEST_EQUAL(sites[0].seq_1,0)
-  TEST_EQUAL(sites[0].seq_2,1)
-  TEST_EQUAL(sites[0].first,3);
-  TEST_EQUAL(sites[0].second,6);
+  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_1, sites, permutations, ranking);
+  TEST_EQUAL(sites.size(), 1)
+  TEST_EQUAL(sites[0].seq_1, 0)
+  TEST_EQUAL(sites[0].seq_2, 1)
+  TEST_EQUAL(sites[0].first, 3);
+  TEST_EQUAL(sites[0].second, 6);
   TEST_EQUAL(sites[0].peak_depth, 6)
 
   permutations.clear();
@@ -360,19 +360,19 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
   per.push_back(5);
   per.push_back(6);
   permutations.push_back(per);
-    per.clear();
+  per.clear();
   per.push_back(3);
   per.push_back(7);
   permutations.push_back(per);
-    per.clear();
+  per.clear();
   per.push_back(3);
   per.push_back(6);
   permutations.push_back(per);
-    per.clear();
+  per.clear();
   per.push_back(5);
   per.push_back(7);
   permutations.push_back(per);
-    per.clear();
+  per.clear();
   per.push_back(6);
   per.push_back(7);
   permutations.push_back(per);
@@ -383,45 +383,41 @@ START_SECTION(determineHighestScoringPermutationsTest_(const std::vector<std::ve
   peptide_site_scores_1.push_back(temp);
   
   ranking = ptr_test->rankWeightedPermutationPeptideScoresTest_(peptide_site_scores_1);
-  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_1,sites,permutations,ranking);
-  TEST_EQUAL(sites.size(),2)
-  TEST_EQUAL(sites[0].seq_1,0)
-  TEST_EQUAL(sites[0].seq_2,4)
-  TEST_EQUAL(sites[0].first,3);
-  TEST_EQUAL(sites[0].second,7);
-  TEST_EQUAL(sites[0].peak_depth, 6)
-  TEST_EQUAL(sites[1].seq_1,0)
-  TEST_EQUAL(sites[1].seq_2,3)
-  TEST_EQUAL(sites[1].first,5);
-  TEST_EQUAL(sites[1].second,6);
-  TEST_EQUAL(sites[1].peak_depth, 6)
-
+  ptr_test->determineHighestScoringPermutationsTest_(peptide_site_scores_1, sites, permutations, ranking);
+  TEST_EQUAL(sites.size(), 2);
+  TEST_EQUAL(sites[0].seq_1, 0);
+  TEST_EQUAL(sites[0].seq_2, 4);
+  TEST_EQUAL(sites[0].first, 3);
+  TEST_EQUAL(sites[0].second, 7);
+  TEST_EQUAL(sites[0].peak_depth, 6);
+  TEST_EQUAL(sites[1].seq_1, 0);
+  TEST_EQUAL(sites[1].seq_2, 3);
+  TEST_EQUAL(sites[1].first, 5);
+  TEST_EQUAL(sites[1].second, 6);
+  TEST_EQUAL(sites[1].peak_depth, 6);
 }
 END_SECTION
 
-START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum> & th_spectra, const ProbablePhosphoSites & candidates, std::vector<PeakSpectrum> & site_determining_ions, double fragment_mass_tolerance, bool fragment_mass_unit_ppm))
+START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum>& th_spectra, const ProbablePhosphoSites& candidates, std::vector<PeakSpectrum>& site_determining_ions))
 {
-  double fragment_mass_tolerance = 0.05;
-  bool fragment_mass_unit_ppm = false;
-
   ProbablePhosphoSites candidates;
-  PeakSpectrum temp1,temp2;
+  PeakSpectrum temp1, temp2;
   vector<PeakSpectrum> site_determining_ions;
   
-  PeakSpectrum &real_spectrum = tmp;
-  std::vector<PeakSpectrum> windows_top10(ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum));
+  PeakSpectrum& real_spectrum = tmp;
+  std::vector<PeakSpectrum> windows_top10 = ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum);
   
   AASequence seq = seq_without_phospho;
-  vector<PeakSpectrum> th_s(ptr_test->createTheoreticalSpectraTest_(permutations, seq));
+  vector<PeakSpectrum> th_s = ptr_test->createTheoreticalSpectraTest_(permutations, seq);
   
   candidates.seq_1 = 3;
   candidates.seq_2 = 4;
   candidates.first = 10;
   candidates.second = 7;
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),6)
-  TEST_EQUAL(site_determining_ions[1].size(),6)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 6);
+  TEST_EQUAL(site_determining_ions[1].size(), 6);
   
   //=============================================================================
   
@@ -432,7 +428,7 @@ START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum> & 
   candidates.first = 1;
   candidates.second = 4;
   
-  vector<vector<Size> > p;
+  vector<vector<Size>> p;
   perm.clear();
   perm.push_back(candidates.first);
   p.push_back(perm);
@@ -443,29 +439,29 @@ START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum> & 
   
   th_s = ptr_test->createTheoreticalSpectraTest_(p, seq);
   
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),6)
-  TEST_EQUAL(site_determining_ions[1].size(),6)
-  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),203.102)
-  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),538.19)
-  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),201.123)
-  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),540.17)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 6);
+  TEST_EQUAL(site_determining_ions[1].size(), 6);
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(), 203.102);
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size() - 1].getMZ(), 538.19);
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(), 201.123);
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size() - 1].getMZ(), 540.17);
   
   candidates.first = 4;
   candidates.second = 1;
   candidates.seq_1 = 1;
   candidates.seq_2 = 0;
   
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),6)
-  TEST_EQUAL(site_determining_ions[1].size(),6)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 6);
+  TEST_EQUAL(site_determining_ions[1].size(), 6);
 
-  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),203.102)
-  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),538.19)
-  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),201.123)
-  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),540.17)
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(), 203.102);
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size() - 1].getMZ(), 538.19);
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(), 201.123);
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size() - 1].getMZ(), 540.17);
   
   //=============================================================================
   
@@ -487,28 +483,28 @@ START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum> & 
   
   th_s = ptr_test->createTheoreticalSpectraTest_(p, seq);
   
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),7)
-  TEST_EQUAL(site_determining_ions[1].size(),7)
-  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),106.05)
-  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),636.206)
-  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),186.016)
-  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),640.201)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 7);
+  TEST_EQUAL(site_determining_ions[1].size(), 7);
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(), 106.05);
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size() - 1].getMZ(), 636.206);
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(), 186.016);
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size() - 1].getMZ(), 640.201);
   
   candidates.first = 4;
   candidates.second = 0;
   candidates.seq_1 = 1;
   candidates.seq_2 = 0;
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),7)
-  TEST_EQUAL(site_determining_ions[1].size(),7)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 7);
+  TEST_EQUAL(site_determining_ions[1].size(), 7);
 
-  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),106.05)
-  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),636.206)
-  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),186.016)
-  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),640.201)
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(), 106.05);
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size() - 1].getMZ(), 636.206);
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(), 186.016);
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size() - 1].getMZ(), 640.201);
   
   //=============================================================================
   
@@ -530,29 +526,29 @@ START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum> & 
   
   th_s = ptr_test->createTheoreticalSpectraTest_(p, seq);
   
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),8)
-  TEST_EQUAL(site_determining_ions[1].size(),8)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 8);
+  TEST_EQUAL(site_determining_ions[1].size(), 8);
 
-  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),370.101)
-  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),917.403)
-  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),290.135)
-  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),997.37)
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(), 370.101);
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size() - 1].getMZ(), 917.403);
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(), 290.135);
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size() - 1].getMZ(), 997.37);
   
   candidates.seq_1 = 1;
   candidates.seq_2 = 0;
   candidates.first = 6;
   candidates.second = 2;
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),8)
-  TEST_EQUAL(site_determining_ions[1].size(),8)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 8);
+  TEST_EQUAL(site_determining_ions[1].size(), 8);
 
-  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),370.101)
-  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),917.403)
-  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),290.135)
-  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),997.37)
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(), 370.101);
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size() - 1].getMZ(), 917.403);
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(), 290.135);
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size() - 1].getMZ(), 997.37);
   
   //=============================================================================
   
@@ -575,29 +571,29 @@ START_SECTION(computeSiteDeterminingIonsTest_(const std::vector<PeakSpectrum> & 
   
   th_s = ptr_test->createTheoreticalSpectraTest_(p, seq);
   
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),8)
-  TEST_EQUAL(site_determining_ions[1].size(),4)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 8);
+  TEST_EQUAL(site_determining_ions[1].size(), 4);
   
-  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),390.142)
-  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),1128.57 )
-  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),310.176)
-  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),1208.54)
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(), 390.142);
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size() - 1].getMZ(), 1128.57);
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(), 310.176);
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size() - 1].getMZ(), 1208.54);
     
   candidates.seq_1 = 1;
   candidates.seq_2 = 0;
   candidates.first = 8;
   candidates.second = 12;
-  ptr_test->computeSiteDeterminingIonsTest_(th_s,candidates,site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
-  TEST_EQUAL(site_determining_ions.size(),2)
-  TEST_EQUAL(site_determining_ions[0].size(),4)
-  TEST_EQUAL(site_determining_ions[1].size(),8)
+  ptr_test->computeSiteDeterminingIonsTest_(th_s, candidates, site_determining_ions);
+  TEST_EQUAL(site_determining_ions.size(), 2);
+  TEST_EQUAL(site_determining_ions[0].size(), 4);
+  TEST_EQUAL(site_determining_ions[1].size(), 8);
 
-  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(),390.142)
-  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size()-1].getMZ(),1128.57 )
-  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(),310.176)
-  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size()-1].getMZ(),1208.54)
+  TEST_REAL_SIMILAR(site_determining_ions[1][0].getMZ(), 390.142);
+  TEST_REAL_SIMILAR(site_determining_ions[1][site_determining_ions[1].size() - 1].getMZ(), 1128.57);
+  TEST_REAL_SIMILAR(site_determining_ions[0][0].getMZ(), 310.176);
+  TEST_REAL_SIMILAR(site_determining_ions[0][site_determining_ions[0].size() - 1].getMZ(), 1208.54);
 }
 END_SECTION
 
@@ -607,13 +603,13 @@ START_SECTION(std::vector<Size> getSitesTest_(const AASequence& without_phospho)
   vector<Size> tupel(ptr_test->getSitesTest_(phospho));
   TEST_EQUAL(4, tupel.size())
   TEST_EQUAL(1, tupel[0])
-  TEST_EQUAL(3,tupel[1])
-  TEST_EQUAL(5,tupel[2])
-  TEST_EQUAL(6,tupel[3])
+  TEST_EQUAL(3, tupel[1])
+  TEST_EQUAL(5, tupel[2])
+  TEST_EQUAL(6, tupel[3])
 }
 END_SECTION
 
-START_SECTION(std::vector<std::vector<Size> > computePermutationsTest_(const std::vector<Size>& tupel,Int number_of_phospho_sites))
+START_SECTION(std::vector<std::vector<Size>> computePermutationsTest_(const std::vector<Size>& tupel, Int number_of_phospho_sites))
 {
   vector<Size> tupel;
   tupel.push_back(1);
@@ -622,98 +618,96 @@ START_SECTION(std::vector<std::vector<Size> > computePermutationsTest_(const std
   tupel.push_back(4);
   vector<vector<Size> > permutations;
   
-  permutations = ptr_test->computePermutationsTest_(tupel,1);
-  TEST_EQUAL(4,permutations.size())
-  TEST_EQUAL(1,permutations[0][0])
-  TEST_EQUAL(2,permutations[1][0])
-  TEST_EQUAL(3,permutations[2][0])
-  TEST_EQUAL(4,permutations[3][0])
+  permutations = ptr_test->computePermutationsTest_(tupel, 1);
+  TEST_EQUAL(4, permutations.size());
+  TEST_EQUAL(1, permutations[0][0]);
+  TEST_EQUAL(2, permutations[1][0]);
+  TEST_EQUAL(3, permutations[2][0]);
+  TEST_EQUAL(4, permutations[3][0]);
 
-  permutations = ptr_test->computePermutationsTest_(tupel,2);
-  TEST_EQUAL(6,permutations.size())
-  TEST_EQUAL(1,permutations[0][0])
-  TEST_EQUAL(2,permutations[0][1])
-  TEST_EQUAL(1,permutations[1][0])
-  TEST_EQUAL(3,permutations[1][1])
-  TEST_EQUAL(1,permutations[2][0])
-  TEST_EQUAL(4,permutations[2][1])
-  TEST_EQUAL(2,permutations[3][0])
-  TEST_EQUAL(3,permutations[3][1])
-  TEST_EQUAL(2,permutations[4][0])
-  TEST_EQUAL(4,permutations[4][1])
-  TEST_EQUAL(3,permutations[5][0])
-  TEST_EQUAL(4,permutations[5][1])
+  permutations = ptr_test->computePermutationsTest_(tupel, 2);
+  TEST_EQUAL(6, permutations.size());
+  TEST_EQUAL(1, permutations[0][0]);
+  TEST_EQUAL(2, permutations[0][1]);
+  TEST_EQUAL(1, permutations[1][0]);
+  TEST_EQUAL(3, permutations[1][1]);
+  TEST_EQUAL(1, permutations[2][0]);
+  TEST_EQUAL(4, permutations[2][1]);
+  TEST_EQUAL(2, permutations[3][0]);
+  TEST_EQUAL(3, permutations[3][1]);
+  TEST_EQUAL(2, permutations[4][0]);
+  TEST_EQUAL(4, permutations[4][1]);
+  TEST_EQUAL(3, permutations[5][0]);
+  TEST_EQUAL(4, permutations[5][1]);
 
-  permutations = ptr_test->computePermutationsTest_(tupel,3);
-  TEST_EQUAL(4,permutations.size())
-  TEST_EQUAL(1,permutations[0][0])
-  TEST_EQUAL(2,permutations[0][1])
-  TEST_EQUAL(3,permutations[0][2])
-  TEST_EQUAL(1,permutations[1][0])
-  TEST_EQUAL(2,permutations[1][1])
-  TEST_EQUAL(4,permutations[1][2])
-  TEST_EQUAL(1,permutations[2][0])
-  TEST_EQUAL(3,permutations[2][1])
-  TEST_EQUAL(4,permutations[2][2])
-  TEST_EQUAL(2,permutations[3][0])
-  TEST_EQUAL(3,permutations[3][1])
-  TEST_EQUAL(4,permutations[3][2])
+  permutations = ptr_test->computePermutationsTest_(tupel, 3);
+  TEST_EQUAL(4, permutations.size());
+  TEST_EQUAL(1, permutations[0][0]);
+  TEST_EQUAL(2, permutations[0][1]);
+  TEST_EQUAL(3, permutations[0][2]);
+  TEST_EQUAL(1, permutations[1][0]);
+  TEST_EQUAL(2, permutations[1][1]);
+  TEST_EQUAL(4, permutations[1][2]);
+  TEST_EQUAL(1, permutations[2][0]);
+  TEST_EQUAL(3, permutations[2][1]);
+  TEST_EQUAL(4, permutations[2][2]);
+  TEST_EQUAL(2, permutations[3][0]);
+  TEST_EQUAL(3, permutations[3][1]);
+  TEST_EQUAL(4, permutations[3][2]);
 
-  permutations = ptr_test->computePermutationsTest_(tupel,4);
-  TEST_EQUAL(1,permutations.size())
-  TEST_EQUAL(1,permutations[0][0])
-  TEST_EQUAL(2,permutations[0][1])
-  TEST_EQUAL(3,permutations[0][2])
-  TEST_EQUAL(4,permutations[0][3])
+  permutations = ptr_test->computePermutationsTest_(tupel, 4);
+  TEST_EQUAL(1, permutations.size());
+  TEST_EQUAL(1, permutations[0][0]);
+  TEST_EQUAL(2, permutations[0][1]);
+  TEST_EQUAL(3, permutations[0][2]);
+  TEST_EQUAL(4, permutations[0][3]);
   
   tupel.clear();
-  permutations = ptr_test->computePermutationsTest_(tupel,0);
-  TEST_EQUAL(0,permutations.size())
+  permutations = ptr_test->computePermutationsTest_(tupel, 0);
+  TEST_EQUAL(0, permutations.size());
 }
 END_SECTION
 
 START_SECTION(AASequence removePhosphositesFromSequenceTest_(const String sequence))
 {
   String sequence = "QSSVTQVTEQS(Phospho)PK";
-  TEST_EQUAL(ptr_test->removePhosphositesFromSequenceTest_(sequence).toString(),"QSSVTQVTEQSPK");
+  TEST_EQUAL(ptr_test->removePhosphositesFromSequenceTest_(sequence).toString(), "QSSVTQVTEQSPK");
 }
 END_SECTION
 
-START_SECTION(std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrumTest_(PeakSpectrum & real_spectrum))
+START_SECTION(std::vector<PeakSpectrum> peakPickingPerWindowsInSpectrumTest_(PeakSpectrum& real_spectrum))
 {
-  PeakSpectrum &real_spectrum = tmp;
+  PeakSpectrum& real_spectrum = tmp;
   
-  std::vector<PeakSpectrum> windows_top10(ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum));
-  TEST_EQUAL(windows_top10.size(),8);
-  TEST_EQUAL(windows_top10[0].size(),1);
-  TEST_EQUAL(windows_top10[1].size(),1);
-  TEST_EQUAL(windows_top10[4].size(),0);
-  TEST_EQUAL(windows_top10[7].size(),1);
+  std::vector<PeakSpectrum> windows_top10 = ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum);
+  TEST_EQUAL(windows_top10.size(), 8);
+  TEST_EQUAL(windows_top10[0].size(), 1);
+  TEST_EQUAL(windows_top10[1].size(), 1);
+  TEST_EQUAL(windows_top10[4].size(), 0);
+  TEST_EQUAL(windows_top10[7].size(), 1);
 }
 END_SECTION
 
-START_SECTION(Size numberOfMatchedIonsTest_(const PeakSpectrum & th, const PeakSpectrum & windows, Size depth, double fragment_mass_tolerance, bool fragment_mass_tolerance_ppm = false))
+START_SECTION(Size numberOfMatchedIonsTest_(const PeakSpectrum& th, const PeakSpectrum& windows, Size depth))
 {
-  PeakSpectrum &real_spectrum = tmp;
-  double fragment_mass_tolerance = 0.5;
-  bool fragment_mass_tolerance_ppm = false;
-  
-  vector<PeakSpectrum> th_spectra(ptr_test->createTheoreticalSpectraTest_(permutations, seq_without_phospho));
-  std::vector<PeakSpectrum> windows_top10(ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum));
+  PeakSpectrum& real_spectrum = tmp;
+  Param params;
+  params.setValue("fragment_mass_tolerance", 0.5);
+  ptr_test->setParameters(params);
+ 
+  vector<PeakSpectrum> th_spectra = ptr_test->createTheoreticalSpectraTest_(permutations, seq_without_phospho);
+  std::vector<PeakSpectrum> windows_top10 = ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum);
   
   //QSSVTQVTEQS(phospho)PK
   vector<PeakSpectrum>::iterator it = th_spectra.end() - 1;
-  TEST_EQUAL(ptr_test->numberOfMatchedIonsTest_(*it, windows_top10[0], 1, fragment_mass_tolerance, fragment_mass_tolerance_ppm), 1);
-  TEST_EQUAL(ptr_test->numberOfMatchedIonsTest_(*it, windows_top10[1], 1, fragment_mass_tolerance, fragment_mass_tolerance_ppm), 1);
+  TEST_EQUAL(ptr_test->numberOfMatchedIonsTest_(*it, windows_top10[0], 1), 1);
+  TEST_EQUAL(ptr_test->numberOfMatchedIonsTest_(*it, windows_top10[1], 1), 1);
 }
 END_SECTION
 
 // of best peptide
 START_SECTION(calculateCumulativeBinominalProbabilityScore)
 {
-  double fragment_mass_tolerance = 0.5;
-  bool fragment_mass_unit_ppm = false;
-  
   vector<ProbablePhosphoSites> phospho_sites;
   phospho_sites.clear();
   phospho_sites.resize(1);
@@ -725,14 +719,14 @@ START_SECTION(calculateCumulativeBinominalProbabilityScore)
   phospho_sites[0].second = 7;
   
   
-  PeakSpectrum &real_spectrum = tmp;
-  std::vector<PeakSpectrum> windows_top10(ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum));
-  vector<PeakSpectrum> th_spectra(ptr_test->createTheoreticalSpectraTest_(permutations, seq_without_phospho));
+  PeakSpectrum& real_spectrum = tmp;
+  std::vector<PeakSpectrum> windows_top10 = ptr_test->peakPickingPerWindowsInSpectrumTest_(real_spectrum);
+  vector<PeakSpectrum> th_spectra = ptr_test->createTheoreticalSpectraTest_(permutations, seq_without_phospho);
   
   for (vector<ProbablePhosphoSites>::iterator s_it = phospho_sites.begin(); s_it < phospho_sites.end(); ++s_it)
   {
     vector<PeakSpectrum> site_determining_ions;
-    ptr_test->computeSiteDeterminingIonsTest_(th_spectra, *s_it, site_determining_ions, fragment_mass_tolerance, fragment_mass_unit_ppm);
+    ptr_test->computeSiteDeterminingIonsTest_(th_spectra, *s_it, site_determining_ions);
     
     Size N = site_determining_ions[0].size(); // all possibilities have the same number so take the first one
     double p = static_cast<double>(s_it->peak_depth) / 100.0;
@@ -740,7 +734,7 @@ START_SECTION(calculateCumulativeBinominalProbabilityScore)
     Size n_first = 0;
     for (Size depth = 0; depth != windows_top10.size(); ++depth) // for each 100 m/z window
     {
-      n_first += ptr_test->numberOfMatchedIonsTest_(site_determining_ions[0], windows_top10[depth], s_it->peak_depth, fragment_mass_tolerance, fragment_mass_unit_ppm);
+      n_first += ptr_test->numberOfMatchedIonsTest_(site_determining_ions[0], windows_top10[depth], s_it->peak_depth);
     }
     
     double P_first = ptr_test->computeCumulativeScoreTest_(N, n_first, p);
@@ -750,13 +744,13 @@ START_SECTION(calculateCumulativeBinominalProbabilityScore)
 }
 END_SECTION
 
-START_SECTION(std::vector<PeakSpectrum> createTheoreticalSpectraTest_(const std::vector<std::vector<Size> > & permutations, const AASequence & seq_without_phospho))
+START_SECTION(std::vector<PeakSpectrum> createTheoreticalSpectraTest_(const std::vector<std::vector<Size>>& permutations, const AASequence& seq_without_phospho))
 {
   // create theoretical based on permutations
   vector<PeakSpectrum> th_spectra(ptr_test->createTheoreticalSpectraTest_(permutations, seq_without_phospho));
-  TEST_EQUAL(th_spectra.size(),5);
-  TEST_EQUAL(th_spectra[0].getName(),"QS(Phospho)SVTQVTEQSPK");
-  TEST_EQUAL(th_spectra[4].getName(),"QSSVTQVTEQS(Phospho)PK");
+  TEST_EQUAL(th_spectra.size(), 5);
+  TEST_EQUAL(th_spectra[0].getName(), "QS(Phospho)SVTQVTEQSPK");
+  TEST_EQUAL(th_spectra[4].getName(), "QSSVTQVTEQS(Phospho)PK");
   TEST_REAL_SIMILAR(th_spectra[4][0].getMZ(), 147.11340);
   TEST_REAL_SIMILAR(th_spectra[4][2].getMZ(), 244.166);
   TEST_REAL_SIMILAR(th_spectra[4][21].getMZ(), 1352.57723);
@@ -765,7 +759,7 @@ START_SECTION(std::vector<PeakSpectrum> createTheoreticalSpectraTest_(const std:
 }
 END_SECTION 
 
-START_SECTION(PeptideHit AScore::compute(const PeptideHit & hit, PeakSpectrum & real_spectrum, double fragment_mass_tolerance, bool fragment_mass_unit_ppm) const)
+START_SECTION(PeptideHit AScore::compute(const PeptideHit& hit, PeakSpectrum& real_spectrum) const)
 {
   // ====================================================================================================================================
   // The Ascore results differ to the results of the Ascore tool provided on the website http://ascore.med.harvard.edu/ascore.html
@@ -779,77 +773,79 @@ START_SECTION(PeptideHit AScore::compute(const PeptideHit & hit, PeakSpectrum & 
   // ====================================================================================================================================
   
   PeakSpectrum real_spectrum;
-  double fragment_mass_tolerance = 0.6;
-  bool fragment_mass_unit_ppm = false;
+  Param params;
+  params.setValue("fragment_mass_tolerance", 0.6);
+  ptr_test->setParameters(params);
   
   DTAFile().load(OPENMS_GET_TEST_DATA_PATH("Ascore_test_input1.dta"), real_spectrum);
   PeptideHit hit1(1.0, 1, 1, AASequence::fromString("QSSVT(Phospho)QSK"));
-  hit1 = ptr_test->compute(hit1, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
+  hit1 = ptr_test->compute(hit1, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=3.51, sequence=QSSVT*QSK
   TEST_REAL_SIMILAR(static_cast<double>(hit1.getMetaValue("AScore_1")), 9.40409359086883);
-  TEST_EQUAL(hit1.getSequence().toString(),"QSS(Phospho)VTQSK");
+  TEST_EQUAL(hit1.getSequence().toString(), "QSS(Phospho)VTQSK");
   
   // ===========================================================================
   
   DTAFile().load(OPENMS_GET_TEST_DATA_PATH("Ascore_test_input2.dta"), real_spectrum);
   PeptideHit hit2(1.0, 1, 1, AASequence::fromString("RIRLT(Phospho)ATTR"));
-  hit2 = ptr_test->compute(hit2, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
+  hit2 = ptr_test->compute(hit2, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=21.3
   TEST_REAL_SIMILAR(static_cast<double>(hit2.getMetaValue("AScore_1")), 20.4116482719882);
-  TEST_EQUAL(hit2.getSequence().toString(),"RIRLT(Phospho)ATTR");
+  TEST_EQUAL(hit2.getSequence().toString(), "RIRLT(Phospho)ATTR");
   
   // ===========================================================================
   
   DTAFile().load(OPENMS_GET_TEST_DATA_PATH("Ascore_test_input3.dta"), real_spectrum);
   PeptideHit hit3(1.0, 1, 1, AASequence::fromString("QSSVTQVTEQS(Phospho)PK"));
-  hit3 = ptr_test->compute(hit3, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
+  hit3 = ptr_test->compute(hit3, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
   TEST_REAL_SIMILAR(static_cast<double>(hit3.getMetaValue("AScore_1")), 92.2548303427145);
-  TEST_EQUAL(hit3.getSequence().toString(),"QSSVTQVTEQS(Phospho)PK"); 
+  TEST_EQUAL(hit3.getSequence().toString(), "QSSVTQVTEQS(Phospho)PK"); 
   
   // ===========================================================================
   
-  fragment_mass_tolerance = 0.05;
-  fragment_mass_unit_ppm = false; 
+  params.setValue("fragment_mass_tolerance", 0.05);
+  ptr_test->setParameters(params);
   
   DTAFile().load(OPENMS_GET_TEST_DATA_PATH("Ascore_test_input4.dta"), real_spectrum);
   PeptideHit hit4(1.0, 1, 1, AASequence::fromString("ATPGNLGSSVLHS(Phospho)K"));
   
-  hit4 = ptr_test->compute(hit4, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
+  hit4 = ptr_test->compute(hit4, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
   TEST_REAL_SIMILAR(static_cast<double>(hit4.getMetaValue("AScore_1")), 20.1669211754322);
-  TEST_EQUAL(hit4.getSequence().toString(),"ATPGNLGSSVLHS(Phospho)K");
+  TEST_EQUAL(hit4.getSequence().toString(), "ATPGNLGSSVLHS(Phospho)K");
   
   // ===========================================================================
   // PPM UNIT TEST
   // ===========================================================================
   
-  fragment_mass_tolerance = 700; // 0.6 Da were converted to ppm based on a small peptide 
-  fragment_mass_unit_ppm = true; 
+  params.setValue("fragment_mass_tolerance", 700.0); // 0.6 Da were converted to ppm based on a small peptide 
+  params.setValue("fragment_mass_unit", "ppm");
+  ptr_test->setParameters(params);
   
   DTAFile().load(OPENMS_GET_TEST_DATA_PATH("Ascore_test_input1.dta"), real_spectrum);
   PeptideHit hit5(1.0, 1, 1, AASequence::fromString("QSSVT(Phospho)QSK"));
-  hit5 = ptr_test->compute(hit5, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
+  hit5 = ptr_test->compute(hit5, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=3.51, sequence=QSSVT*QSK
   TEST_REAL_SIMILAR(static_cast<double>(hit5.getMetaValue("AScore_1")), 9.40409359086883);
-  TEST_EQUAL(hit5.getSequence().toString(),"QSS(Phospho)VTQSK");
+  TEST_EQUAL(hit5.getSequence().toString(), "QSS(Phospho)VTQSK");
   
-  fragment_mass_tolerance = 70; // 0.05 Da were converted to ppm based on a small peptide
-  fragment_mass_unit_ppm = true; 
+  params.setValue("fragment_mass_tolerance", 70.0); // 0.05 Da were converted to ppm based on a small peptide
+  ptr_test->setParameters(params);
   
   DTAFile().load(OPENMS_GET_TEST_DATA_PATH("Ascore_test_input4.dta"), real_spectrum);
   PeptideHit hit6(1.0, 1, 1, AASequence::fromString("ATPGNLGSSVLHS(Phospho)K"));
   
-  hit6 = ptr_test->compute(hit6, real_spectrum, fragment_mass_tolerance, fragment_mass_unit_ppm);
+  hit6 = ptr_test->compute(hit6, real_spectrum);
   
   // http://ascore.med.harvard.edu/ascore.html result=88.3
   TEST_REAL_SIMILAR(static_cast<double>(hit6.getMetaValue("AScore_1")), 20.1669211754322);
-  TEST_EQUAL(hit6.getSequence().toString(),"ATPGNLGSSVLHS(Phospho)K");  
+  TEST_EQUAL(hit6.getSequence().toString(), "ATPGNLGSSVLHS(Phospho)K");  
 }
 END_SECTION 
 

--- a/src/topp/PhosphoScoring.cpp
+++ b/src/topp/PhosphoScoring.cpp
@@ -286,10 +286,9 @@ protected:
     String out(getStringOption_("out"));
 
     AScore ascore;
-    ascore.setParameters(getParam_());
-    // Param ascore_params = ascore.getDefaults();
-    // ascore_params.update(param_);
-    // ascore.setParameters(ascore_params);
+    Param ascore_params = ascore.getDefaults();
+    ascore_params.update(getParam_(), false, false, false, false, Log_debug);
+    ascore.setParameters(ascore_params);
 
     //-------------------------------------------------------------
     // loading input

--- a/src/topp/PhosphoScoring.cpp
+++ b/src/topp/PhosphoScoring.cpp
@@ -251,20 +251,9 @@ protected:
     registerInputFile_("id", "<file>", "", "Identification input file which contains a search against a concatenated sequence database");
     setValidFormats_("id", ListUtils::create<String>("idXML"));
     registerOutputFile_("out", "<file>", "", "Identification output annotated with phosphorylation scores");
-    setValidFormats_("out", ListUtils::create<String>("idXML"));
-    registerDoubleOption_("fragment_mass_tolerance", "<tolerance>", 0.05, "Fragment mass error", false);
 
-    StringList fragment_mass_tolerance_unit_valid_strings;
-    fragment_mass_tolerance_unit_valid_strings.push_back("Da");
-    fragment_mass_tolerance_unit_valid_strings.push_back("ppm");
-    registerStringOption_("fragment_mass_unit", "<unit>", "Da", "Unit of fragment mass error", false, false);
-    setValidStrings_("fragment_mass_unit", fragment_mass_tolerance_unit_valid_strings);  
-
-    registerIntOption_("max_peptide_length", "<num>", 40, "Restrict scoring to peptides with a length shorter than this value", false);
-    setMinInt_("max_peptide_length", 1);
-    
-    registerIntOption_("max_num_perm", "<num>", 16384, "Maximum number of permutations a sequence can have", false);
-    setMinInt_("max_num_perm", 1);
+    // Ascore algorithm parameters:
+    registerFullParam_(AScore().getDefaults());
   }
   
   // If the score_type has a different name in the meta_values, it is not possible to find it.
@@ -295,12 +284,12 @@ protected:
     String in(getStringOption_("in"));
     String id(getStringOption_("id"));
     String out(getStringOption_("out"));
-    double fragment_mass_tolerance(getDoubleOption_("fragment_mass_tolerance"));
-    bool fragment_mass_unit_ppm = getStringOption_("fragment_mass_unit") == "Da" ? false : true;
-    Size max_peptide_len = getIntOption_("max_peptide_length");
-    Size max_num_perm = getIntOption_("max_num_perm");
-    
+
     AScore ascore;
+    ascore.setParameters(getParam_());
+    // Param ascore_params = ascore.getDefaults();
+    // ascore_params.update(param_);
+    // ascore.setParameters(ascore_params);
 
     //-------------------------------------------------------------
     // loading input
@@ -338,7 +327,7 @@ protected:
         
         LOG_DEBUG << "starting to compute AScore RT=" << pep_id->getRT() << " SEQUENCE: " << scored_hit.getSequence().toString() << std::endl;
         
-        PeptideHit phospho_sites = ascore.compute(scored_hit, temp, fragment_mass_tolerance, fragment_mass_unit_ppm, max_peptide_len, max_num_perm);
+        PeptideHit phospho_sites = ascore.compute(scored_hit, temp);
         scored_peptides.push_back(phospho_sites);
       }
 


### PR DESCRIPTION
Apart from some coding style adaptations, the main change is to use DefaultParamHandler for general AScore parameters (rather than passing them in every function) and the addition of the new "unambiguous_score" (advanced) parameter.