### PR TITLE
[FIX] TOPPView, simplified synchronizing of peak annotations (fixes #2956)

### DIFF
--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -870,8 +870,6 @@ namespace OpenMS
     MSSpectrum & spectrum = (*current_layer.getPeakData())[spectrum_index];
     int ms_level = spectrum.getMSLevel();
 
-    removeTemporaryAnnotations_(spectrum_index);
-
     if (ms_level == 2)
     {
       // synchronize PeptideHits with the annotations in the spectrum
@@ -886,6 +884,8 @@ namespace OpenMS
 
       removeTheoreticalSpectrumLayer_();
     }
+
+    removeTemporaryAnnotations_(spectrum_index);
 
     // reset selected id indices
     current_layer.peptide_id_index = -1;


### PR DESCRIPTION
Multiple annotation per peak are now possible.
Adding and editing peaks works as intended.
