### PR TITLE
Fix/travis split

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,15 +83,19 @@ matrix:
       compiler: clang
 
 ## clang tests class and TOPP tests: without gui and without address sanitizer (debug build)
-    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Debug CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
+    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=OFF ADDRESS_SANITIZER=Off BUILD_TYPE=Debug CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
+      os: linux
+      compiler: clang
+## clang tests class and TOPP tests: without gui and without address sanitizer (debug build)
+    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=OFF ENABLE_CLASS_TESTING=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Debug CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
       os: linux
       compiler: clang
 
-## clang tests class and TOPP tests: without gui and without address sanitizer (release build)
-    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=ON ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Release CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
-      os: linux
-      compiler: clang
-
+# ## clang tests class and TOPP tests: without gui and without address sanitizer (release build)
+#     - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=ON ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Release CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
+#       os: linux
+#       compiler: clang
+#
 ### OS X tests
 #    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=OFF ADDRESS_SANITIZER=Off BUILD_TYPE=Release
 #      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,15 +82,15 @@ matrix:
       os: linux
       compiler: clang
 
-## clang tests class and TOPP tests: without gui and without address sanitizer (debug build)
-    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=OFF ADDRESS_SANITIZER=Off BUILD_TYPE=Debug CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
-      os: linux
-      compiler: clang
-## clang tests class and TOPP tests: without gui and without address sanitizer (debug build)
-    - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=OFF ENABLE_CLASS_TESTING=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Debug CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
-      os: linux
-      compiler: clang
-
+# ## clang tests class and TOPP tests: without gui and without address sanitizer (debug build)
+#     - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=OFF ADDRESS_SANITIZER=Off BUILD_TYPE=Debug CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
+#       os: linux
+#       compiler: clang
+# ## clang tests class and TOPP tests: without gui and without address sanitizer (debug build)
+#     - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=OFF ENABLE_TOPP_TESTING=OFF ENABLE_CLASS_TESTING=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Debug CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
+#       os: linux
+#       compiler: clang
+# 
 # ## clang tests class and TOPP tests: without gui and without address sanitizer (release build)
 #     - env: ENABLE_STYLE_TESTING=OFF WITH_GUI=ON ENABLE_TOPP_TESTING=ON ENABLE_CLASS_TESTING=ON ADDRESS_SANITIZER=Off BUILD_TYPE=Release CXX_FLAGS="-Qunused-arguments" CFLAGS="-Qunused-arguments" CCACHE_CPP2=1 OPENMP=Off
 #       os: linux


### PR DESCRIPTION
there isnt much point having the clang travis tests around if they always time out. I guess there are two options

- use jenkins and our own build infrastructure for CI
- (temporarily) remove clang builds

I guess we should try to move away from travis in the medium to long run or just use it for quick evaluations as the gcc release build. We anyways dont really need Debug/Release builds across multiple compilers for each PR. Its enough to see if everything builds (including pyopenms) and the tests work in one configuration.