### PR TITLE
[FIX] Patch for OpenSWATH PQP File Conversion

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -725,10 +725,16 @@ namespace OpenMS
 
       // Go through all transitions, for each transition get chromatogram and
       // the chromatogram and the assay to the MRMTransitionGroup
+      Size detection_assay_it = -1; // store index for the last detection transition
       for (Size i = 0; i < assay_it->second.size(); i++)
       {
         const TransitionType* transition = assay_it->second[i];
         precursor_mz = transition->getPrecursorMZ();
+
+        if (transition->isDetectingTransition())
+        {
+          detection_assay_it = i;
+        }
 
         // continue if we only have MS1 (we wont have any chromatograms for
         // the transitions)
@@ -786,11 +792,18 @@ namespace OpenMS
       trgroup_picker.pickTransitionGroup(transition_group);
       featureFinder.scorePeakgroups(transition_group, trafo, swath_maps, output, ms1only);
 
+      // Ensure that a detection transition is used to derive features for output
+      if (detection_assay_it < 0)
+      {
+          throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+              "Error, did not find any detection transition for feature " + id );
+      }
+
       // Add to the output tsv if given
       if (tsv_writer.isActive())
       {
         const OpenSwath::LightCompound pep = transition_exp.getCompounds()[ assay_peptide_map[id] ];
-        const TransitionType* transition = assay_it->second[0];
+        const TransitionType* transition = assay_it->second[detection_assay_it];
         to_tsv_output.push_back(tsv_writer.prepareLine(pep, transition, output, id));
       }
 
@@ -798,7 +811,7 @@ namespace OpenMS
       if (osw_writer.isActive())
       {
         const OpenSwath::LightCompound pep = transition_exp.getCompounds()[ assay_peptide_map[id] ];
-        const TransitionType* transition = assay_it->second[0];
+        const TransitionType* transition = assay_it->second[detection_assay_it];
         to_osw_output.push_back(osw_writer.prepareLine(pep, transition, output, id));
       }
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -725,7 +725,7 @@ namespace OpenMS
 
       // Go through all transitions, for each transition get chromatogram and
       // the chromatogram and the assay to the MRMTransitionGroup
-      Size detection_assay_it = -1; // store index for the last detection transition
+      int detection_assay_it = -1; // store index for the last detection transition
       for (Size i = 0; i < assay_it->second.size(); i++)
       {
         const TransitionType* transition = assay_it->second[i];
@@ -793,7 +793,7 @@ namespace OpenMS
       featureFinder.scorePeakgroups(transition_group, trafo, swath_maps, output, ms1only);
 
       // Ensure that a detection transition is used to derive features for output
-      if (detection_assay_it < 0)
+      if (detection_assay_it < 0 && output.size() > 0)
       {
           throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
               "Error, did not find any detection transition for feature " + id );

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
@@ -301,7 +301,7 @@ namespace OpenMS
       "CREATE TABLE PROTEIN(" \
       "ID INT PRIMARY KEY NOT NULL," \
       "PROTEIN_ACCESSION TEXT NOT NULL," \
-      "DECOY INT NOT NULL);" \
+      "DECOY INT NULL);" \
 
       // peptide_protein_mapping table
       // OpenSWATH proteomics workflows
@@ -482,15 +482,12 @@ namespace OpenMS
     endProgress();
 
     // OpenSWATH: Prepare protein inserts
-    std::stringstream insert_protein_sql;
-
     progress = 0;
-    startProgress(0, targeted_exp.getProteins().size(), String("Prepare ") + targeted_exp.getProteins().size() + " proteins");
+    startProgress(0, targeted_exp.getProteins().size(), "Prepare protein mapping");
     for (Size i = 0; i < targeted_exp.getProteins().size(); i++)
     {
       setProgress(progress++);
       OpenMS::TargetedExperiment::Protein protein = targeted_exp.getProteins()[i];
-      insert_protein_sql << "INSERT INTO PROTEIN (ID, PROTEIN_ACCESSION, DECOY) VALUES (" << i << ",'" << protein.id << "',0); ";
       protein_set.push_back(protein.id);
     }
     endProgress();
@@ -557,6 +554,17 @@ namespace OpenMS
     {
       setProgress(progress++);
       insert_peptide_protein_mapping << "INSERT INTO PEPTIDE_PROTEIN_MAPPING (PEPTIDE_ID, PROTEIN_ID) VALUES (" << it->first << "," << it->second << "); ";
+    }
+    endProgress();
+
+    // OpenSWATH: Prepare protein inserts
+    std::stringstream insert_protein_sql;
+    progress = 0;
+    startProgress(0, protein_set.size(), String("Prepare ") + protein_set.size() + " proteins");
+    for (Size i = 0; i < protein_set.size(); i++)
+    {
+      setProgress(progress++);
+      insert_protein_sql << "INSERT INTO PROTEIN (ID, PROTEIN_ACCESSION) VALUES (" << i << ",'" << protein_set[i] << "'); ";
     }
     endProgress();
 

--- a/src/tests/topp/TargetedFileConverter_1_output.TraML
+++ b/src/tests/topp/TargetedFileConverter_1_output.TraML
@@ -5,16 +5,16 @@
     <cv id="UO" fullName="Unit Ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
   </cvList>
   <ProteinList>
-    <Protein id="P0C0L5;P0C0L4">
+    <Protein id="P02768">
       <Sequence></Sequence>
     </Protein>
-    <Protein id="Q9HCU0">
+    <Protein id="P0C0L5;P0C0L4">
       <Sequence></Sequence>
     </Protein>
     <Protein id="Q9BX93">
       <Sequence></Sequence>
     </Protein>
-    <Protein id="P02768">
+    <Protein id="Q9HCU0">
       <Sequence></Sequence>
     </Protein>
   </ProteinList>
@@ -22,9 +22,9 @@
     <Peptide id="1" sequence="AACLLPK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)LLPK"/>
-      <ProteinRef ref="P0C0L5;P0C0L4"/>
+      <ProteinRef ref="P02768"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>
@@ -36,9 +36,9 @@
     <Peptide id="0" sequence="AACLLPKLDELRDEGK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)LLPKLDELRDEGK"/>
-      <ProteinRef ref="P0C0L5;P0C0L4"/>
+      <ProteinRef ref="P02768"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>
@@ -50,12 +50,12 @@
     <Peptide id="2" sequence="AACAQLNDFLQEYGTQGCQV">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)AQLNDFLQEYGTQGC(Carbamidomethyl)QV"/>
-      <ProteinRef ref="Q9HCU0"/>
+      <ProteinRef ref="P0C0L5;P0C0L4"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <Modification location="18" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>
@@ -69,10 +69,10 @@
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)IC(Carbamidomethyl)AEEEKEEL"/>
       <ProteinRef ref="Q9BX93"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <Modification location="5" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>
@@ -84,12 +84,12 @@
     <Peptide id="4" sequence="AACGPSSCYALFPR">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)GPSSC(Carbamidomethyl)YALFPR"/>
-      <ProteinRef ref="P02768"/>
+      <ProteinRef ref="Q9HCU0"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <Modification location="8" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>

--- a/src/tests/topp/TargetedFileConverter_2_output.TraML
+++ b/src/tests/topp/TargetedFileConverter_2_output.TraML
@@ -5,16 +5,16 @@
     <cv id="UO" fullName="Unit Ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
   </cvList>
   <ProteinList>
-    <Protein id="P0C0L5;P0C0L4">
+    <Protein id="P02768">
       <Sequence></Sequence>
     </Protein>
-    <Protein id="Q9HCU0">
+    <Protein id="P0C0L5;P0C0L4">
       <Sequence></Sequence>
     </Protein>
     <Protein id="Q9BX93">
       <Sequence></Sequence>
     </Protein>
-    <Protein id="P02768">
+    <Protein id="Q9HCU0">
       <Sequence></Sequence>
     </Protein>
   </ProteinList>
@@ -22,9 +22,9 @@
     <Peptide id="P02768_AAC(Carbamidomethyl)LLPK_2" sequence="AACLLPK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)LLPK"/>
-      <ProteinRef ref="P0C0L5;P0C0L4"/>
+      <ProteinRef ref="P02768"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>
@@ -36,9 +36,9 @@
     <Peptide id="P02768_AAC(Carbamidomethyl)LLPKLDELRDEGK_3" sequence="AACLLPKLDELRDEGK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)LLPKLDELRDEGK"/>
-      <ProteinRef ref="P0C0L5;P0C0L4"/>
+      <ProteinRef ref="P02768"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>
@@ -50,12 +50,12 @@
     <Peptide id="P0C0L5;P0C0L4_AAC(Carbamidomethyl)AQLNDFLQEYGTQGC(Carbamidomethyl)QV_3" sequence="AACAQLNDFLQEYGTQGCQV">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)AQLNDFLQEYGTQGC(Carbamidomethyl)QV"/>
-      <ProteinRef ref="Q9HCU0"/>
+      <ProteinRef ref="P0C0L5;P0C0L4"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <Modification location="18" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>
@@ -69,10 +69,10 @@
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)IC(Carbamidomethyl)AEEEKEEL"/>
       <ProteinRef ref="Q9BX93"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <Modification location="5" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>
@@ -84,12 +84,12 @@
     <Peptide id="Q9HCU0_AAC(Carbamidomethyl)GPSSC(Carbamidomethyl)YALFPR_2" sequence="AACGPSSCYALFPR">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
       <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)GPSSC(Carbamidomethyl)YALFPR"/>
-      <ProteinRef ref="P02768"/>
+      <ProteinRef ref="Q9HCU0"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <Modification location="8" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>


### PR DESCRIPTION
This PR fixes two issues with PQP files generated by TargetedFileConverter and used by OpenSwathWorkflow.

1. To do transition-level scoring, OpenSwathWorkflow commonly reads a sorted TraML or TSV file, where "detection transitions" are parsed first and "identification transitions" are added later. When writing an OpenSWATH TSV report, the ``decoy`` flag is set correctly because the first transitions of a peak group are used to set this flag. This is not always the case when a PQP input is used in combination with a OpenSWATH TSV report. The patch below ensures that this is always the case.
2. A bug led to wrong peptide-protein associations when converting TraML to PQP files.