### PR TITLE
[FIX] change order in restriction to make featureXML the default output format

### DIFF
--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -118,7 +118,7 @@ public:
 protected:
   void registerOptionsAndFlags_()
   {
-    TOPPMapAlignerBase::registerOptionsAndFlags_("mzML,featureXML",
+    TOPPMapAlignerBase::registerOptionsAndFlags_("featureXML,mzML",
                                                  REF_RESTRICTED);
     registerSubsection_("algorithm", "Algorithm parameters section");
   }


### PR DESCRIPTION
that way it is not necessary to change output file type in KNIME