### PR TITLE
Fix/shaker scores, fixes #2921

### DIFF
--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -2051,7 +2051,14 @@ namespace OpenMS
         {
           for (vector<CVTerm>::const_iterator cv = cvs->second.begin(); cv != cvs->second.end(); ++cv)
           {
-            hit.setMetaValue(cvs->first, cv->getValue().toString().toDouble());
+            if (cvs->first == "MS:1002540")
+            {
+              hit.setMetaValue(cvs->first, cv->getValue().toString());
+            }
+            else
+            {
+              hit.setMetaValue(cvs->first, cv->getValue().toString().toDouble());
+            }
           }
         }
         for (map<String, DataValue>::const_iterator up = params.second.begin(); up != params.second.end(); ++up)

--- a/src/tests/topp/IDFileConverter_8_input.mzid
+++ b/src/tests/topp/IDFileConverter_8_input.mzid
@@ -127,11 +127,13 @@
 					<PeptideEvidenceRef peptideEvidence_ref="16970929867631067734"/> 
 					<PeptideEvidenceRef peptideEvidence_ref="10918478775903385808"/> 
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="0.9"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Confident"/>
 				</SpectrumIdentificationItem>
 				<SpectrumIdentificationItem passThreshold="0" rank="0" peptide_ref="354584743404697772" calculatedMassToCharge="1112.56946892307" experimentalMassToCharge="675.9" chargeState="1" id="3236576916011203184"> 
 					<PeptideEvidenceRef peptideEvidence_ref="11064349190525804944"/> 
 					<PeptideEvidenceRef peptideEvidence_ref="8047898833664078744"/> 
 					<cvParam accession="MS:1002354" cvRef="PSI-MS" name="PSM-level q-value" value="1.4"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Confident"/>
 				</SpectrumIdentificationItem>
 				<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="1234.5"/>
 			</SpectrumIdentificationResult>
@@ -139,10 +141,12 @@
 				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="4943767272410482976" calculatedMassToCharge="634.838928386321" experimentalMassToCharge="0.7" chargeState="2" id="4272689534495877804"> 
 					<PeptideEvidenceRef peptideEvidence_ref="8460469863535845399"/> 
 					<cvParam accession="MS:1001331" cvRef="PSI-MS" name="X\!Tandem:hyperscore" value="44.4"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Doubtful"/>
 				</SpectrumIdentificationItem>
 				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="7485621129914001920" calculatedMassToCharge="712.889484077721" experimentalMassToCharge="0.7" chargeState="2" id="16267378008351021065"> 
 					<PeptideEvidenceRef peptideEvidence_ref="9078722222385889961"/> 
 					<cvParam accession="MS:1001331" cvRef="PSI-MS" name="X\!Tandem:hyperscore" value="33.3"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Doubtful"/>
 				</SpectrumIdentificationItem>
 				<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="1.6"/>
 			</SpectrumIdentificationResult>
@@ -150,10 +154,12 @@
 				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="4943767272410482976" calculatedMassToCharge="634.838928386321" experimentalMassToCharge="987.6" chargeState="2" id="10278086369066574741"> 
 					<PeptideEvidenceRef peptideEvidence_ref="8460469863535845399"/> 
 					<cvParam accession="MS:1001171" cvRef="PSI-MS" name="Mascot:score" value="99.4"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Not Validated"/>
 				</SpectrumIdentificationItem>
 				<SpectrumIdentificationItem passThreshold="1" rank="0" peptide_ref="7485621129914001920" calculatedMassToCharge="1424.77169168867" experimentalMassToCharge="987.6" chargeState="1" id="5481200184408979228"> 
 					<PeptideEvidenceRef peptideEvidence_ref="9078722222385889961"/> 
 					<cvParam accession="MS:1001171" cvRef="PSI-MS" name="Mascot:score" value="33.3"/>
+                    <cvParam cvRef="PSI-MS" accession="MS:1002540" name="PeptideShaker PSM confidence type" value="Not Validated"/>
 				</SpectrumIdentificationItem>
 				<cvParam accession="MS:1000894" cvRef="PSI-MS" name="retention time" value="5432.1"/>
 			</SpectrumIdentificationResult>

--- a/src/tests/topp/IDFileConverter_8_output.idXML
+++ b/src/tests/topp/IDFileConverter_8_output.idXML
@@ -18,12 +18,14 @@
 		<PeptideIdentification score_type="q-value" higher_score_better="false" significance_threshold="0" MZ="675.9" RT="1234.5" spectrum_reference="17" >
 			<PeptideHit score="0.9" sequence="PEPTIDER" charge="1" aa_before="A A" aa_after="B B" protein_refs="PH_0 PH_1" >
 				<UserParam type="float" name="MS:1002354" value="0.9"/>
+				<UserParam type="string" name="MS:1002540" value="Confident"/>
 				<UserParam type="float" name="calcMZ" value="956.468357540271"/>
 				<UserParam type="int" name="pass_threshold" value="0"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</PeptideHit>
 			<PeptideHit score="1.4" sequence="PEPTIDERR" charge="1" aa_before="A A" aa_after="B B" protein_refs="PH_1 PH_0" >
 				<UserParam type="float" name="MS:1002354" value="1.4"/>
+				<UserParam type="string" name="MS:1002540" value="Confident"/>
 				<UserParam type="float" name="calcMZ" value="1112.56946892307"/>
 				<UserParam type="int" name="pass_threshold" value="0"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
@@ -31,12 +33,14 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="X\!Tandem:hyperscore" higher_score_better="true" significance_threshold="0" MZ="0.7" RT="1.6" spectrum_reference="45" >
 			<PeptideHit score="44.4" sequence="PEPTIDEC(Carbamidomethyl)K" charge="2" aa_before="A" aa_after="B" protein_refs="PH_1" >
+				<UserParam type="string" name="MS:1002540" value="Doubtful"/>
 				<UserParam type="float" name="calcMZ" value="634.838928386321"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="MS:1001331" value="44.4"/>
 			</PeptideHit>
 			<PeptideHit score="33.3" sequence="N[+3785.30710]PEPTIDEK" charge="2" aa_before="A" aa_after="B" protein_refs="PH_0" >
+				<UserParam type="string" name="MS:1002540" value="Doubtful"/>
 				<UserParam type="float" name="calcMZ" value="712.889484077721"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>
@@ -45,12 +49,14 @@
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Mascot:score" higher_score_better="true" significance_threshold="0" MZ="987.6" RT="5432.1" spectrum_reference="99" >
 			<PeptideHit score="99.4" sequence="PEPTIDEC(Carbamidomethyl)K" charge="2" aa_before="A" aa_after="B" protein_refs="PH_1" >
+				<UserParam type="string" name="MS:1002540" value="Not Validated"/>
 				<UserParam type="float" name="calcMZ" value="634.838928386321"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 				<UserParam type="float" name="MS:1001171" value="99.4"/>
 			</PeptideHit>
 			<PeptideHit score="33.3" sequence="N[+3785.30710]PEPTIDEK" charge="1" aa_before="A" aa_after="B" protein_refs="PH_0" >
+				<UserParam type="string" name="MS:1002540" value="Not Validated"/>
 				<UserParam type="float" name="calcMZ" value="1424.77169168867"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="string" name="target_decoy" value="decoy"/>


### PR DESCRIPTION
Reading in string type score for PeptideShaker mzid output.
Should fix #2921