### PR TITLE
fix #793 (metavalue check for PeptideIdentification)

### DIFF
--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -160,13 +160,6 @@ public:
     /// returns all peptide hits which reference to a given protein accession (i.e. filter by protein accession)
     static std::vector<PeptideHit> getReferencingHits(const std::vector<PeptideHit>&, const std::set<String>& accession);
 
-    /// remove the two helper functions below a some point, when we are sure that we did not miss or merge in deprecated code!
-    /// re-implemented from MetaValueInterface as a precaution against deprecated usage of "RT" and "MZ" values
-    const DataValue& getMetaValue(const String& name) const;
-    /// re-implemented from MetaValueInterface as a precaution against deprecated usage of "RT" and "MZ" values
-    void setMetaValue(const String& name, const DataValue& value);
-
-
 protected:
 
     String id_; ///< Identifier by which ProteinIdentification and PeptideIdentification are matched
@@ -174,6 +167,7 @@ protected:
     double significance_threshold_; ///< the peptide significance threshold
     String score_type_; ///< The score type (Mascot, Sequest, e-value, p-value)
     bool higher_score_better_; ///< The score orientation
+    // hint: here is an alignment gap of 7 bytes <-- here --> use it when introducing new members with sizeof(m)<=4
     String base_name_;
     double mz_;
     double rt_;

--- a/src/openms/source/METADATA/PeptideIdentification.cpp
+++ b/src/openms/source/METADATA/PeptideIdentification.cpp
@@ -305,27 +305,5 @@ namespace OpenMS
     }
     return filtered;
   }
-
-  /// re-implemented from MetaValueInterface as a precaution against deprecated usage of "RT" and "MZ" values
-  const DataValue& PeptideIdentification::getMetaValue(const String& name) const
-  {
-    if (name == "RT" || name == "MZ")
-    { // this line should never the triggered. Set a breakpoint, find out who called getMetaValue() and replace with PeptideIdentification.getRT()/.getMZ() !!!!
-      std::cerr << "\n\nUnsupported use of MetavalueInferface for 'RT' detected in " << __FILE__ << ":" << __LINE__ << ". Please notify the developers, so they can remove outdated code!\n\n";
-      exit(1);
-    }
-    return MetaInfoInterface::getMetaValue(name);
-  }
-
-  /// re-implemented from MetaValueInterface as a precaution against deprecated usage of "RT" and "MZ" values
-  void PeptideIdentification::setMetaValue(const String& name, const DataValue& value)
-  {
-    if (name == "RT" || name == "MZ")
-    { // this line should never the triggered. Set a breakpoint, find out who called getMetaValue() and replace with PeptideIdentification.getRT()/.getMZ() !!!!
-      std::cerr << "\n\nUnsupported use of MetavalueInferface for 'RT' detected in " << __FILE__ << ":" << __LINE__ << ". Please notify the developers, so they can remove outdated code!\n\n";
-      exit(1);
-    }
-    MetaInfoInterface::setMetaValue(name, value);
-  }
-
+  
 } // namespace OpenMS


### PR DESCRIPTION
the fix has been active for a few years now. Not needed any longer.