### PR TITLE
TOPPView: better support for peak annotations in "Identification View"

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPViewIdentificationViewBehavior.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPViewIdentificationViewBehavior.h
@@ -108,6 +108,9 @@ private:
     /// Adds a theoretical spectrum as set from the preferences dialog for the peptide hit.
     void addTheoreticalSpectrumLayer_(const PeptideHit& ph);
 
+    /// Adds spectrum comprising annotated peaks
+    void addAnnotationsSpectrumLayer_(const std::vector<PeptideHit::PeakAnnotation>& annotations, const String& name);
+
     /// removes all layer with theoretical spectrum generated in identification view
     void removeTheoreticalSpectrumLayer_();
 

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPViewIdentificationViewBehavior.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPViewIdentificationViewBehavior.h
@@ -72,7 +72,7 @@ namespace OpenMS
 
 public:
     /// Construct the behaviour with its parent
-    TOPPViewIdentificationViewBehavior(TOPPViewBase * parent);
+    TOPPViewIdentificationViewBehavior(TOPPViewBase* parent);
 
 public slots:
     /// Behavior for showSpectrumAs1D
@@ -100,22 +100,22 @@ public slots:
 
 private:
     /// Adds labels for the provided precursors to the 1D spectrum
-    void addPrecursorLabels1D_(const std::vector<Precursor> & pcs);
+    void addPrecursorLabels1D_(const std::vector<Precursor>& pcs);
 
     /// Removes the precursor labels for from the specified 1D spectrum
     void removeTemporaryAnnotations_(Size spectrum_index);
 
     /// Adds a theoretical spectrum as set from the preferences dialog for the peptide hit.
-    void addTheoreticalSpectrumLayer_(const PeptideHit & ph);
+    void addTheoreticalSpectrumLayer_(const PeptideHit& ph);
 
     /// removes all layer with theoretical spectrum generated in identification view
     void removeTheoreticalSpectrumLayer_();
 
     /// Adds annotation (compound name, adducts, ppm error) to a peak in 1D spectra
-    void addPeakAnnotations_(const std::vector<PeptideIdentification> & ph);
+    void addPeakAnnotations_(const std::vector<PeptideIdentification>& ph);
 
     /// Adds fragment annotations to peaks in 1D spectra
-    void addFragmentAnnotations_(const PeptideHit & ph);
+    void addFragmentAnnotations_(const PeptideHit& ph);
 
   /// Helper function for text formatting
   String n_times(Size n, String input);
@@ -127,10 +127,10 @@ private:
   String collapseStringVector(std::vector<String> strings);
 
 private:
-    TOPPViewBase * tv_;
+    TOPPViewBase* tv_;
     /// Used to check which annotation handles have been added automatically by the identification view. Ownership
     /// of the AnnotationItems has the Annotation1DContainer
-    std::vector<Annotation1DItem *> temporary_annotations_;
+    std::vector<Annotation1DItem*> temporary_annotations_;
   };
 }
 

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPViewIdentificationViewBehavior.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPViewIdentificationViewBehavior.h
@@ -109,16 +109,13 @@ private:
     void addTheoreticalSpectrumLayer_(const PeptideHit& ph);
 
     /// Adds spectrum comprising annotated peaks
-    void addAnnotationsSpectrumLayer_(const std::vector<PeptideHit::PeakAnnotation>& annotations, const String& name);
+    void addAnnotationsSpectrumLayer_(const PeptideHit& hit, bool align = false);
 
     /// removes all layer with theoretical spectrum generated in identification view
     void removeTheoreticalSpectrumLayer_();
 
     /// Adds annotation (compound name, adducts, ppm error) to a peak in 1D spectra
     void addPeakAnnotations_(const std::vector<PeptideIdentification>& ph);
-
-    /// Adds fragment annotations to peaks in 1D spectra
-    void addFragmentAnnotations_(const PeptideHit& ph);
 
   /// Helper function for text formatting
   String n_times(Size n, String input);

--- a/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
@@ -139,10 +139,10 @@ namespace OpenMS
     create_rows_for_commmon_metavalue_ = new QCheckBox("Show advanced\nannotations", this);
     connect(create_rows_for_commmon_metavalue_, SIGNAL(toggled(bool)), this, SLOT(updateEntries()));
 
-    QPushButton* save_IDs = new QPushButton("save IDs", this);
+    QPushButton* save_IDs = new QPushButton("Save IDs", this);
     connect(save_IDs, SIGNAL(clicked()), this, SLOT(saveIDs_()));
 
-    QPushButton* export_table = new QPushButton("export table", this);
+    QPushButton* export_table = new QPushButton("Export table", this);
     connect(export_table, SIGNAL(clicked()), this, SLOT(exportEntries_()));
 
     tmp_hbox_layout->addWidget(hide_no_identification_);
@@ -549,7 +549,9 @@ namespace OpenMS
             addDoubleItemToBottomRow_(ph.getCharge(), 9, c);
 
             //sequence
-            addTextItemToBottomRow_(ph.getSequence().toString().toQString(), 10, c);
+            String seq = ph.getSequence().toString();
+            if (seq.empty()) seq = ph.getMetaValue("label");
+            addTextItemToBottomRow_(seq.toQString(), 10, c);
 
             //Accession
             item = table_widget_->itemPrototype()->clone();
@@ -591,7 +593,7 @@ namespace OpenMS
               {
                 ppm_error = fabs((double)pi[pi_idx].getHits()[0].getMetaValue(Constants::PRECURSOR_ERROR_PPM_USERPARAM));
               }
-              else // works for normal linear fragments with the correct modifications included in the AASequence
+              else if (!ph.getSequence().empty()) // works for normal linear fragments with the correct modifications included in the AASequence
               {
                 double exp_precursor = (*layer_->getPeakData())[i].getPrecursors()[0].getMZ();
                 int charge = (*layer_->getPeakData())[i].getPrecursors()[0].getCharge();

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1917,7 +1917,7 @@ namespace OpenMS
         painter.drawLine(begin_p.x(), height() / 2 - 5, end_p.x(), height() / 2 + 5);
       }
     }
-    else if (!mirror_mode_)
+    else
     {
       painter.setPen(Qt::red);
       QPoint begin_p, end_p;

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -475,7 +475,7 @@ namespace OpenMS
     return result;
   }
 
-  // Helper function, that collapses a vector of Strings into one String
+  // Helper function that collapses a vector of strings into one string
   String TOPPViewIdentificationViewBehavior::collapseStringVector(vector<String> strings)
   {
     String result;
@@ -486,7 +486,7 @@ namespace OpenMS
     return result;
   }
 
-  // Helper function, that turns fragment annotations into coverage Strings for visuaization with the sequence
+  // Helper function that turns fragment annotations into coverage strings for visualization with the sequence
   void TOPPViewIdentificationViewBehavior::extractCoverageStrings(vector<PeptideHit::PeakAnnotation> frag_annotations, String& alpha_string, String& beta_string, Size alpha_size, Size beta_size)
   {
     vector<String> alpha_strings(alpha_size, " ");

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -183,42 +183,38 @@ namespace OpenMS
       const double peak_int = current_layer.getCurrentSpectrum()[peak_idx].getIntensity();
       DPosition<2> position = DPosition<2>(it->mz, peak_int);
       String annotation = it->annotation;
-      // write out positive and negative charges with the correct sign, at the end of the annotation string
-      if (it->charge != 0)
+      // XL-MS specific coloring of the labels, green for linear fragments and red for cross-linked fragments
+      QColor color;
+      if ((annotation.hasSubstring(String("[alpha|")) || annotation.hasSubstring(String("[beta|"))) && annotation.hasSubstring(String("|ci$")))
+      {
+        color = Qt::darkGreen;
+      }
+      else if ((annotation.hasSubstring(String("[alpha|")) || annotation.hasSubstring(String("[beta|"))) &&  annotation.hasSubstring(String("|xi$")))
+      {
+        color = Qt::darkRed;
+      }
+      else
+      {
+        continue; // handled by "addAnnotationsSpectrumLayer_"
+      }
+
+      // write out positive and negative charges with the correct sign at the end of the annotation string
+      switch (it->charge)
       {
         annotation = it->charge > 0 ? annotation + "+" + String(it->charge): annotation + String(it->charge);
       }
 
-      Annotation1DItem * item;
-
-      // XL-MS specific coloring of the labels, green for linear fragments and red for cross-linked fragments
-      // for now red is the standard color of labels
-      if ((annotation.hasSubstring(String("[alpha|")) || annotation.hasSubstring(String("[beta|"))) && annotation.hasSubstring(String("|ci$")))
-      {
-        item = new Annotation1DPeakItem(position, annotation.toQString(), Qt::darkGreen);
-      }
-      else if ((annotation.hasSubstring(String("[alpha|")) || annotation.hasSubstring(String("[beta|"))) &&  annotation.hasSubstring(String("|xi$")))
-      {
-        item = new Annotation1DPeakItem(position, annotation.toQString(), Qt::darkRed);
-      }
-      else // use peak color as default annotation color
-      {
-        QColor color = (annotation[0] < 'n') ? Qt::darkRed : Qt::darkGreen;
-        item = new Annotation1DPeakItem(position, annotation.toQString(), color);
-        // add peak (code from "Spectrum1DCanvas::drawAlignment"):
-        QPainter painter(current_canvas);
-        painter.setPen(color);
-        QPoint begin_p, end_p;
-        // updatePercentageFactor_(current_layer); // @TODO: needed?
-        current_canvas->dataToWidget(it->mz, 0, begin_p, false, true);
-        current_canvas->dataToWidget(it->mz, it->intensity, end_p, false, true);
-        painter.drawLine(begin_p.x(), begin_p.y(), end_p.x(), end_p.y());
-      }
+      Annotation1DItem* item = new Annotation1DPeakItem(position, annotation.toQString(), color);
       item->setSelected(false);
       temporary_annotations_.push_back(item); // for removal (no ownership)
       current_layer.getCurrentAnnotations().push_front(item); // for visualization (ownership)
     }
+
+    String name = ph.getSequence().toString();
+    if (name.empty()) name = ph.getMetaValue("label");
+    addAnnotationsSpectrumLayer_(fa, name);
   }
+
 
   void TOPPViewIdentificationViewBehavior::addPeakAnnotations_(const std::vector<PeptideIdentification>& ph)
   {
@@ -906,6 +902,77 @@ namespace OpenMS
 
     widget_1D->canvas()->setTextBox(QString());
   }
+
+  void TOPPViewIdentificationViewBehavior::addAnnotationsSpectrumLayer_(const vector<PeptideHit::PeakAnnotation>& annotations, const String& name)
+  {
+    SpectrumCanvas* current_canvas = tv_->getActive1DWidget()->canvas();
+    LayerData& current_layer = current_canvas->getCurrentLayer();
+    Size current_spectrum_layer_index = current_canvas->activeLayerIndex();
+    Size current_spectrum_index = current_layer.getCurrentSpectrumIndex();
+
+    PeakSpectrum spectrum;
+    vector<String> labels;
+    for (const auto& ann : annotations)
+    {
+      Peak1D peak(ann.mz, ann.intensity);
+      spectrum.push_back(peak);
+      String label = ann.annotation;
+      // write out positive and negative charges with the correct sign at the end of the annotation string
+      switch (ann.charge)
+      {
+      case 0: break;
+      case 1: label += "+"; break;
+      case 2: label += "++"; break;
+      case -1: label += "-"; break;
+      case -2: label += "--"; break;
+      default: label += ((ann.charge > 0) ? "+" : "") + String(ann.charge);
+      }
+      labels.push_back(label);
+    }
+    spectrum.sortByPosition();
+
+    PeakMap new_exp;
+    new_exp.addSpectrum(spectrum);
+    ExperimentSharedPtrType new_exp_sptr(new PeakMap(new_exp));
+    FeatureMapSharedPtrType f_dummy(new FeatureMapType());
+    ConsensusMapSharedPtrType c_dummy(new ConsensusMapType());
+    vector<PeptideIdentification> p_dummy;
+
+    // Block update events for identification widget
+    tv_->getSpectraIdentificationViewWidget()->ignore_update = true;
+
+    String layer_caption = name + " (identification view)";
+    tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, LayerData::DT_PEAK, true, false, false, "", layer_caption);
+
+    // get layer index of new layer
+    Size theoretical_spectrum_layer_index = tv_->getActive1DWidget()->canvas()->activeLayerIndex();
+
+    // kind of a hack to check whether adding the layer was successful
+    if (current_spectrum_layer_index != theoretical_spectrum_layer_index)
+    {
+      // Ensure theoretical spectrum is drawn as dashed sticks
+      tv_->setDrawMode1D(Spectrum1DCanvas::DM_PEAKS);
+      // tv_->getActive1DWidget()->canvas()->setCurrentLayerPeakPenStyle(Qt::DashLine);
+
+      // Add ion names as annotations to the theoretical spectrum
+      for (Size i = 0; i != spectrum.size(); ++i)
+      {
+        DPosition<2> position = DPosition<2>(spectrum[i].getMZ(), spectrum[i].getIntensity());
+        const String& label = labels[i];
+        QColor color = (label.at(0) < 'n') ? Qt::darkRed : Qt::darkGreen;
+        Annotation1DItem* item = new Annotation1DPeakItem(position, label.toQString(), color);
+        item->setSelected(false);
+        tv_->getActive1DWidget()->canvas()->getCurrentLayer().getCurrentAnnotations().push_front(item);
+      }
+
+      tv_->getActive1DWidget()->canvas()->activateLayer(current_spectrum_layer_index);
+      tv_->getActive1DWidget()->canvas()->getCurrentLayer().setCurrentSpectrumIndex(current_spectrum_index);
+
+      tv_->updateLayerBar();
+      tv_->getSpectraIdentificationViewWidget()->ignore_update = false;
+    }
+  }
+
 
   void TOPPViewIdentificationViewBehavior::removeTheoreticalSpectrumLayer_()
   {

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -56,7 +56,7 @@ using namespace std;
 
 namespace OpenMS
 {
-  TOPPViewIdentificationViewBehavior::TOPPViewIdentificationViewBehavior(TOPPViewBase * parent) :
+  TOPPViewIdentificationViewBehavior::TOPPViewIdentificationViewBehavior(TOPPViewBase* parent) :
     tv_(parent)
   {
   }
@@ -70,13 +70,13 @@ namespace OpenMS
   void TOPPViewIdentificationViewBehavior::showSpectrumAs1D(int spectrum_index, int peptide_id_index, int peptide_hit_index)
   {
     // basic behavior 1
-    const LayerData & layer = tv_->getActiveCanvas()->getCurrentLayer();
+    const LayerData& layer = tv_->getActiveCanvas()->getCurrentLayer();
     ExperimentSharedPtrType exp_sptr = layer.getPeakData();
 
     if (layer.type == LayerData::DT_PEAK)
     {
       // open new 1D widget with the current default parameters
-      Spectrum1DWidget* w = new Spectrum1DWidget(tv_->getSpectrumParameters(1), (QWidget *)tv_->getWorkspace());
+      Spectrum1DWidget* w = new Spectrum1DWidget(tv_->getSpectrumParameters(1), (QWidget*)tv_->getWorkspace());
       // add data
       if (!w->canvas()->addLayer(exp_sptr, layer.filename) || (Size)spectrum_index >= w->canvas()->getCurrentLayer().getPeakData()->size())
       {
@@ -271,13 +271,13 @@ namespace OpenMS
 
   void TOPPViewIdentificationViewBehavior::activate1DSpectrum(int spectrum_index, int peptide_id_index, int peptide_hit_index)
   {
-    Spectrum1DWidget * widget_1D = tv_->getActive1DWidget();
+    Spectrum1DWidget* widget_1D = tv_->getActive1DWidget();
 
     // return if no active 1D widget is present
     if (widget_1D == 0) return;
 
     widget_1D->canvas()->activateSpectrum(spectrum_index);
-    LayerData & current_layer = widget_1D->canvas()->getCurrentLayer();
+    LayerData& current_layer = widget_1D->canvas()->getCurrentLayer();
     current_layer.peptide_id_index = peptide_id_index;
     current_layer.peptide_hit_index = peptide_hit_index;
 
@@ -285,7 +285,7 @@ namespace OpenMS
     {
       UInt ms_level = current_layer.getCurrentSpectrum().getMSLevel();
 
-      const vector<PeptideIdentification> & pis = current_layer.getCurrentSpectrum().getPeptideIdentifications();
+      const vector<PeptideIdentification>& pis = current_layer.getCurrentSpectrum().getPeptideIdentifications();
       switch (ms_level)
       {
         case 1: // mass fingerprint annotation of name etc and precursor labels
@@ -537,9 +537,9 @@ namespace OpenMS
     beta_string = collapseStringVector(beta_strings);
   }
 
-  void TOPPViewIdentificationViewBehavior::addPrecursorLabels1D_(const vector<Precursor> & pcs)
+  void TOPPViewIdentificationViewBehavior::addPrecursorLabels1D_(const vector<Precursor>& pcs)
   {
-    LayerData & current_layer = tv_->getActive1DWidget()->canvas()->getCurrentLayer();
+    LayerData& current_layer = tv_->getActive1DWidget()->canvas()->getCurrentLayer();
 
     if (current_layer.type == LayerData::DT_PEAK)
     {
@@ -568,7 +568,7 @@ namespace OpenMS
         DPosition<2> lower_position = DPosition<2>(isolation_window_lower_mz, max_intensity);
         DPosition<2> upper_position = DPosition<2>(isolation_window_upper_mz, max_intensity);
 
-        Annotation1DDistanceItem * item = new Annotation1DDistanceItem(QString::number(it->getCharge()), lower_position, upper_position);
+        Annotation1DDistanceItem* item = new Annotation1DDistanceItem(QString::number(it->getCharge()), lower_position, upper_position);
         // add additional tick at precursor target position (e.g. to show if isolation window is asymmetric)
         vector<double> ticks;
         ticks.push_back(it->getMZ());
@@ -591,10 +591,10 @@ namespace OpenMS
     cout << "removePrecursorLabels1D_ " << spectrum_index << endl;
 #endif
     // Delete annotations added by IdentificationView (but not user added annotations)
-    LayerData & current_layer = tv_->getActive1DWidget()->canvas()->getCurrentLayer();
-    const vector<Annotation1DItem *> & cas = temporary_annotations_;
-    Annotations1DContainer & las = current_layer.getAnnotations(spectrum_index);
-    for (vector<Annotation1DItem *>::const_iterator it = cas.begin(); it != cas.end(); ++it)
+    LayerData& current_layer = tv_->getActive1DWidget()->canvas()->getCurrentLayer();
+    const vector<Annotation1DItem*>& cas = temporary_annotations_;
+    Annotations1DContainer& las = current_layer.getAnnotations(spectrum_index);
+    for (vector<Annotation1DItem*>::const_iterator it = cas.begin(); it != cas.end(); ++it)
     {
       Annotations1DContainer::iterator i = find(las.begin(), las.end(), *it);
       if (i != las.end())
@@ -606,11 +606,11 @@ namespace OpenMS
     temporary_annotations_.clear();
   }
 
-  void TOPPViewIdentificationViewBehavior::addTheoreticalSpectrumLayer_(const PeptideHit & ph)
+  void TOPPViewIdentificationViewBehavior::addTheoreticalSpectrumLayer_(const PeptideHit& ph)
   {
-    SpectrumCanvas * current_canvas = tv_->getActive1DWidget()->canvas();
-    LayerData & current_layer = current_canvas->getCurrentLayer();
-    SpectrumType & current_spectrum = current_layer.getCurrentSpectrum();
+    SpectrumCanvas* current_canvas = tv_->getActive1DWidget()->canvas();
+    LayerData& current_layer = current_canvas->getCurrentLayer();
+    SpectrumType& current_spectrum = current_layer.getCurrentSpectrum();
 
     AASequence aa_sequence = ph.getSequence();
 
@@ -618,7 +618,7 @@ namespace OpenMS
     Size current_spectrum_layer_index = current_canvas->activeLayerIndex();
     Size current_spectrum_index = current_layer.getCurrentSpectrumIndex();
 
-    const Param & tv_params = tv_->getParameters();
+    const Param& tv_params = tv_->getParameters();
 
     PeakSpectrum spectrum;
     TheoreticalSpectrumGenerator generator;
@@ -659,7 +659,7 @@ namespace OpenMS
       generator.getSpectrum(spectrum, aa_sequence, 1, max_charge);
 
     }
-    catch (Exception::BaseException & e)
+    catch (Exception::BaseException& e)
     {
       QMessageBox::warning(tv_, "Error", QString("Spectrum generation failed! (") + e.what() + "). Please report this to the developers (specify what input you used)!");
       return;
@@ -698,13 +698,13 @@ namespace OpenMS
 
         if (s.at(0) == 'y')
         {
-          Annotation1DItem * item = new Annotation1DPeakItem(position, s, Qt::darkRed);
+          Annotation1DItem* item = new Annotation1DPeakItem(position, s, Qt::darkRed);
           item->setSelected(false);
           tv_->getActive1DWidget()->canvas()->getCurrentLayer().getCurrentAnnotations().push_front(item);
         }
         else if (s.at(0) == 'b')
         {
-          Annotation1DItem * item = new Annotation1DPeakItem(position, s, Qt::darkGreen);
+          Annotation1DItem* item = new Annotation1DPeakItem(position, s, Qt::darkGreen);
           item->setSelected(false);
           tv_->getActive1DWidget()->canvas()->getCurrentLayer().getCurrentAnnotations().push_front(item);
         }
@@ -760,7 +760,7 @@ namespace OpenMS
             }
           }
           s.append(aa_ss);
-          Annotation1DItem * item = tv_->getActive1DWidget()->canvas()->addPeakAnnotation(pi, s, Qt::darkRed);
+          Annotation1DItem* item = tv_->getActive1DWidget()->canvas()->addPeakAnnotation(pi, s, Qt::darkRed);
           temporary_annotations_.push_back(item);
         }
         else if (s.at(0) == 'b')
@@ -776,14 +776,14 @@ namespace OpenMS
           aa_ss.replace(QRegExp("[(].*[)]"), "*");
           // append to label
           s.append(aa_ss);
-          Annotation1DItem * item = tv_->getActive1DWidget()->canvas()->addPeakAnnotation(pi, s, Qt::darkGreen);
+          Annotation1DItem* item = tv_->getActive1DWidget()->canvas()->addPeakAnnotation(pi, s, Qt::darkGreen);
           // save label for later removal
           temporary_annotations_.push_back(item);
         }
         else
         {
           s.append("\n");
-          Annotation1DItem * item = tv_->getActive1DWidget()->canvas()->addPeakAnnotation(pi, s, Qt::black);
+          Annotation1DItem* item = tv_->getActive1DWidget()->canvas()->addPeakAnnotation(pi, s, Qt::black);
           // save label for later removal
           temporary_annotations_.push_back(item);
         }
@@ -797,17 +797,17 @@ namespace OpenMS
   void TOPPViewIdentificationViewBehavior::deactivate1DSpectrum(int spectrum_index)
   {
     // Retrieve active 1D widget
-    Spectrum1DWidget * widget_1D = tv_->getActive1DWidget();
+    Spectrum1DWidget* widget_1D = tv_->getActive1DWidget();
 
     // Return if none present
     if (widget_1D == 0) return;
 
-    LayerData & current_layer = widget_1D->canvas()->getCurrentLayer();
+    LayerData& current_layer = widget_1D->canvas()->getCurrentLayer();
 
     // Return if no valid peak layer attached
     if (current_layer.getPeakData()->size() == 0 || current_layer.type != LayerData::DT_PEAK) { return; }
 
-    MSSpectrum & spectrum = (*current_layer.getPeakData())[spectrum_index];
+    MSSpectrum& spectrum = (*current_layer.getPeakData())[spectrum_index];
     int ms_level = spectrum.getMSLevel();
 
     if (ms_level == 2)
@@ -816,7 +816,7 @@ namespace OpenMS
       current_layer.synchronizePeakAnnotations();
 
       // remove all graphical peak annotations as these will be recreated from the stored peak annotations
-      Annotations1DContainer & las = current_layer.getAnnotations(spectrum_index);
+      Annotations1DContainer& las = current_layer.getAnnotations(spectrum_index);
       auto new_end = std::remove_if(las.begin(), las.end(),
                               [](const Annotation1DItem* a)
                               { return dynamic_cast<const Annotation1DPeakItem*>(a) != nullptr; });
@@ -967,10 +967,10 @@ namespace OpenMS
 
   void TOPPViewIdentificationViewBehavior::removeTheoreticalSpectrumLayer_()
   {
-    Spectrum1DWidget * spectrum_widget_1D = tv_->getActive1DWidget();
+    Spectrum1DWidget* spectrum_widget_1D = tv_->getActive1DWidget();
     if (spectrum_widget_1D)
     {
-      Spectrum1DCanvas * canvas_1D = spectrum_widget_1D->canvas();
+      Spectrum1DCanvas* canvas_1D = spectrum_widget_1D->canvas();
 
       // Find the automatically generated layer with theoretical spectrum and remove it and the associated alignment.
       // before activating the next normal spectrum
@@ -994,9 +994,9 @@ namespace OpenMS
     Spectrum1DWidget* w = tv_->getActive1DWidget();
     if (w == 0) return;
 
-    SpectrumCanvas * current_canvas = w->canvas();
-    LayerData & current_layer = current_canvas->getCurrentLayer();
-    SpectrumType & current_spectrum = current_layer.getCurrentSpectrum();
+    SpectrumCanvas* current_canvas = w->canvas();
+    LayerData& current_layer = current_canvas->getCurrentLayer();
+    SpectrumType& current_spectrum = current_layer.getCurrentSpectrum();
 
     // find first MS2 spectrum with peptide identification and set current spectrum to it
     if (current_spectrum.getMSLevel() == 1)  // no fragment spectrum
@@ -1019,7 +1019,7 @@ namespace OpenMS
 
   void TOPPViewIdentificationViewBehavior::deactivateBehavior()
   {
-    Spectrum1DWidget * widget_1D = tv_->getActive1DWidget();
+    Spectrum1DWidget* widget_1D = tv_->getActive1DWidget();
 
     // return if no active 1D widget is present
     if (widget_1D == 0) return;
@@ -1038,7 +1038,7 @@ namespace OpenMS
 
   void TOPPViewIdentificationViewBehavior::setVisibleArea1D(double l, double h)
   {
-    Spectrum1DWidget * widget_1D = tv_->getActive1DWidget();
+    Spectrum1DWidget* widget_1D = tv_->getActive1DWidget();
 
     // return if no active 1D widget is present
     if (widget_1D == 0) return;

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -145,68 +145,6 @@ namespace OpenMS
     // else if (layer.type == LayerData::DT_CHROMATOGRAM)
   }
 
-  void TOPPViewIdentificationViewBehavior::addFragmentAnnotations_(const PeptideHit& ph)
-  {
-    // called anew for every click on a spectrum
-    LayerData& current_layer = tv_->getActive1DWidget()->canvas()->getCurrentLayer();
-
-    if (current_layer.getCurrentSpectrum().empty())
-    {
-      LOG_WARN << "Spectrum is empty! Nothing to annotate!" << std::endl;
-    }
-
-    if (!current_layer.getCurrentSpectrum().isSorted())
-    {
-      QMessageBox::warning(tv_, "Error", "The spectrum is not sorted! Aborting!");
-      return;
-    }
-
-    typedef std::vector<PeptideHit::PeakAnnotation> FragmentAnnotations;
-
-    const FragmentAnnotations& fa = ph.getPeakAnnotations();
-
-    for (FragmentAnnotations::const_iterator it = fa.begin(); it!= fa.end(); ++it)
-    {
-      // query closest peak to expected position
-      int peak_idx = current_layer.getCurrentSpectrum().findNearest(it->mz, 1e-2);
-
-      // check if m/z fits
-      if (peak_idx == -1)
-      {
-        LOG_WARN << "Annotation present for missing peak.  m/z: " << it->mz << std::endl;
-        continue;
-      }
-
-      const double peak_int = current_layer.getCurrentSpectrum()[peak_idx].getIntensity();
-      DPosition<2> position = DPosition<2>(it->mz, peak_int);
-      String annotation = it->annotation;
-      // write out positive and negative charges with the correct sign, at the end of the annotation string
-      if (it->charge != 0)
-      {
-        annotation = it->charge > 0 ? annotation + "+" + String(it->charge): annotation + String(it->charge);
-      }
-
-      Annotation1DItem* item;
-
-      // XL-MS specific coloring of the labels, green for linear fragments and red for cross-linked fragments
-      // for now red is the standard color of labels
-      if ((annotation.hasSubstring(String("[alpha|")) || annotation.hasSubstring(String("[beta|"))) && annotation.hasSubstring(String("|ci$")))
-      {
-        item = new Annotation1DPeakItem(position, annotation.toQString(), Qt::darkGreen);
-      }
-      else if ((annotation.hasSubstring(String("[alpha|")) || annotation.hasSubstring(String("[beta|"))) &&  annotation.hasSubstring(String("|xi$")))
-      {
-        item = new Annotation1DPeakItem(position, annotation.toQString(), Qt::darkRed);
-      }
-      else // use peak color as default annotation color
-      {
-        item = new Annotation1DPeakItem(position, annotation.toQString(), QColor(current_layer.param.getValue("peak_color").toQString()));
-      }
-      item->setSelected(false);
-      temporary_annotations_.push_back(item); // for removal (no ownership)
-      current_layer.getCurrentAnnotations().push_front(item); // for visualization (ownership)
-    }
-  }
 
   void TOPPViewIdentificationViewBehavior::addPeakAnnotations_(const std::vector<PeptideIdentification>& ph)
   {

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -931,6 +931,15 @@ namespace OpenMS
     }
     spectrum.sortByPosition();
 
+    if (spectrum.getMaxInt() <= 1.0) // undo scaling of intensities
+    {
+      double max_int = current_layer.getCurrentSpectrum().getMaxInt();
+      for (auto& peak : spectrum)
+      {
+        peak.setIntensity(peak.getIntensity() * max_int);
+      }
+    }
+
     PeakMap new_exp;
     new_exp.addSpectrum(spectrum);
     ExperimentSharedPtrType new_exp_sptr(new PeakMap(new_exp));

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -49,7 +49,6 @@
 
 #include <QtCore/QString>
 #include <QtGui/QMessageBox>
-#include <QtGui/QPainter>
 
 using namespace OpenMS;
 using namespace std;


### PR DESCRIPTION
In TOPPView's "Identification View", peak annotations stored for peptide hits can be visualized (as an alternative to generating a theoretical spectrum). Previously only labels with the annotations were added to peaks in the measured spectrum. With this change, a second spectrum containing the peaks from the annotations as well as the labels is generated (analogous to a theoretical spectrum). This highlights the actual peaks that are annotated.

(It would be really nice if different peaks could be shown in different colours, but currently that's only possible for the labels.)

@enetz: Can you please check if this still works for showing the special annotations for cross-linked peptides?