### PR TITLE
[FIX] Fixed SVMWrapper_test

### DIFF
--- a/src/tests/class_tests/openms/source/SVMWrapper_test.cpp
+++ b/src/tests/class_tests/openms/source/SVMWrapper_test.cpp
@@ -1041,8 +1041,9 @@ START_SECTION((void getSVCProbabilities(struct svm_problem *problem, std::vector
 							|| (predicted_labels[i] > 0 && probabilities[i] >= 0.5), true)
 	}
 	labels.clear();
-	labels.resize(4, -1);
-	labels.resize(8, 1);
+	// Start with -1 as "first" label
+	labels.resize(count / 2, -1);
+	labels.resize(count, 1);
 	problem = encoder.encodeLibSVMProblem(encoded_vectors, labels);
 	svm.train(problem);
 	svm.predict(problem, predicted_labels);
@@ -1051,8 +1052,10 @@ START_SECTION((void getSVCProbabilities(struct svm_problem *problem, std::vector
 	TEST_EQUAL(predicted_labels.size() == probabilities.size(), true)
 	for (Size i = 0; i < predicted_labels.size(); ++i)
 	{
-		TEST_EQUAL((predicted_labels[i] < 0 && probabilities[i] < 0.5)
-							|| (predicted_labels[i] > 0 && probabilities[i] >= 0.5), true)
+		// At probability 0.5, LibSVM will assign the first encountered label in the training data
+		// in this case "-1"
+		TEST_EQUAL((predicted_labels[i] < 0 && probabilities[i] <= 0.5)
+							|| (predicted_labels[i] > 0 && probabilities[i] > 0.5), true)
 	}
 
 END_SECTION


### PR DESCRIPTION
I don't know, why this only shows up on macOS and why only since some time but:
IMHO the test was designed wrongly. According to my short research, at a tie, LibSVM assigns the first encountered
label in the training data, which is a different one in the second test.
Let's see what other platforms say.