### PR TITLE
[FIX] sort peptide hits in idXML files

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/IdXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/IdXMLFile.h
@@ -99,7 +99,7 @@ public:
     /**
         @brief Stores the data in an idXML file
 
-        The data is read in and stored in the file 'filename'.
+        The data is read in and stored in the file 'filename'. PeptideHits are sorted by score.
 
         @exception Exception::UnableToCreateFile is thrown if the file could not be created
     */

--- a/src/tests/class_tests/openms/source/IdXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/IdXMLFile_test.cpp
@@ -205,20 +205,21 @@ END_SECTION
 
 START_SECTION(void store(String filename, const std::vector<ProteinIdentification>& protein_ids, const std::vector<PeptideIdentification>& peptide_ids, const String& document_id="") )
 
-  //store and load data
+  // load, store, and reload data
   std::vector<ProteinIdentification> protein_ids, protein_ids2;
   std::vector<PeptideIdentification> peptide_ids, peptide_ids2;
   String document_id, document_id2;
-  String input_path = OPENMS_GET_TEST_DATA_PATH("IdXMLFile_whole.idXML");
-  IdXMLFile().load(input_path, protein_ids2, peptide_ids2, document_id2);
-  String filename;
-  NEW_TMP_FILE(filename)
-  IdXMLFile().store(filename, protein_ids2, peptide_ids2, document_id2);
+  String target_file = OPENMS_GET_TEST_DATA_PATH("IdXMLFile_whole.idXML");
+  IdXMLFile().load(target_file, protein_ids2, peptide_ids2, document_id2);
+
+  String actual_file;
+  NEW_TMP_FILE(actual_file)
+  IdXMLFile().store(actual_file, protein_ids2, peptide_ids2, document_id2);
 
   FuzzyStringComparator fuzzy;
   fuzzy.setWhitelist(ListUtils::create<String>("<?xml-stylesheet"));
   fuzzy.setAcceptableAbsolute(0.0001);
-  bool result = fuzzy.compareFiles(input_path, filename);
+  bool result = fuzzy.compareFiles(actual_file, target_file);
   TEST_EQUAL(result, true);
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MascotXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MascotXMLFile_test.cpp
@@ -251,7 +251,7 @@ START_SECTION((void load(const String& filename, ProteinIdentification& protein_
     FuzzyStringComparator fuzzy;
     fuzzy.setWhitelist(ListUtils::create<String>("<?xml-stylesheet"));
     fuzzy.setAcceptableAbsolute(0.0001);
-    bool result = fuzzy.compareFiles(OPENMS_GET_TEST_DATA_PATH("MascotXMLFile_test_out_3.idXML"), filename);
+    bool result = fuzzy.compareFiles(filename, OPENMS_GET_TEST_DATA_PATH("MascotXMLFile_test_out_3.idXML"));
     TEST_EQUAL(result, true);
   }
 }

--- a/src/tests/topp/CompNovoCID_1_output.idXML
+++ b/src/tests/topp/CompNovoCID_1_output.idXML
@@ -3,11 +3,11 @@
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="+2-+3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="0.3" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
 	</SearchParameters>
-	<IdentificationRun date="2015-10-28T13:52:42" search_engine="CompNovo" search_engine_version="0.9beta" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:40:16" search_engine="CompNovo" search_engine_version="0.9beta" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 		</ProteinIdentification>
 		<PeptideIdentification score_type="" higher_score_better="true" significance_threshold="0" MZ="509.751" RT="-1" >
-			<PeptideHit score="1.0658213328619" sequence="DFPLANGER" charge="2" >
+			<PeptideHit score="1.0659004538858" sequence="DFPLANGER" charge="2" >
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/CompNovo_1_output.idXML
+++ b/src/tests/topp/CompNovo_1_output.idXML
@@ -3,11 +3,11 @@
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="+2-+3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="0.3" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
 	</SearchParameters>
-	<IdentificationRun date="2015-10-28T13:52:40" search_engine="CompNovo" search_engine_version="0.9beta" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:40:04" search_engine="CompNovo" search_engine_version="0.9beta" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 		</ProteinIdentification>
 		<PeptideIdentification score_type="" higher_score_better="true" significance_threshold="0" MZ="509.751" RT="-1" >
-			<PeptideHit score="1.77919503181063" sequence="DFPLANGER" charge="2" >
+			<PeptideHit score="1.77968758332555" sequence="DFPLANGER" charge="2" >
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/ConsensusID_1_output.idXML
+++ b/src/tests/topp/ConsensusID_1_output.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2015-10-28T13:52:37" search_engine="OpenMS/ConsensusID_PEPMatrix" search_engine_version="2.0.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:39:44" search_engine="OpenMS/ConsensusID_PEPMatrix" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="695.3646" RT="2233.105" >

--- a/src/tests/topp/ConsensusID_4_output.idXML
+++ b/src/tests/topp/ConsensusID_4_output.idXML
@@ -2,9 +2,9 @@
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
-    <VariableModification name="Oxidation (M)" />
+		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2015-10-28T13:52:37" search_engine="OpenMS/ConsensusID_PEPMatrix" search_engine_version="2.0.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:39:45" search_engine="OpenMS/ConsensusID_PEPMatrix" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="695.3646" RT="2233.105" >

--- a/src/tests/topp/ConsensusID_5_output.idXML
+++ b/src/tests/topp/ConsensusID_5_output.idXML
@@ -2,9 +2,9 @@
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
-    <VariableModification name="Oxidation (M)" />
+		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2015-10-28T13:52:38" search_engine="OpenMS/ConsensusID_PEPIons" search_engine_version="2.0.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:39:46" search_engine="OpenMS/ConsensusID_PEPIons" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="695.3646" RT="2233.105" >

--- a/src/tests/topp/ConsensusID_6_output.idXML
+++ b/src/tests/topp/ConsensusID_6_output.idXML
@@ -2,9 +2,9 @@
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
-    <VariableModification name="Oxidation (M)" />
+		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2015-10-28T13:52:38" search_engine="OpenMS/ConsensusID_best" search_engine_version="2.0.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:39:47" search_engine="OpenMS/ConsensusID_best" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="695.3646" RT="2233.105" >

--- a/src/tests/topp/IDFileConverter_12_output.idXML
+++ b/src/tests/topp/IDFileConverter_12_output.idXML
@@ -2,13 +2,13 @@
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
-        <VariableModification name="Acetyl (N-term)" />
-        <VariableModification name="Carbamidomethyl (N-term)" />
-        <VariableModification name="Deamidated (N)" />
-        <VariableModification name="Deamidated (Q)" />
-        <VariableModification name="Oxidation (M)" />
+		<VariableModification name="Acetyl (N-term)" />
+		<VariableModification name="Carbamidomethyl (N-term)" />
+		<VariableModification name="Deamidated (N)" />
+		<VariableModification name="Deamidated (Q)" />
+		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-  <IdentificationRun date="2015-10-28T13:51:28" search_engine="Percolator" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:35:15" search_engine="Percolator" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Augustus2_AUGUSTUS00000009543_5_25910749-25909503_1" score="0" sequence="" >
 			</ProteinHit>

--- a/src/tests/topp/IDFileConverter_13_output.idXML
+++ b/src/tests/topp/IDFileConverter_13_output.idXML
@@ -8,7 +8,7 @@
 		<VariableModification name="Deamidated (Q)" />
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2016-12-20T16:43:35" search_engine="Percolator" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:35:16" search_engine="Percolator" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Augustus2_AUGUSTUS00000009543_5_25910749-25909503_1" score="0" sequence="" >
 			</ProteinHit>

--- a/src/tests/topp/IDFileConverter_14_output.idXML
+++ b/src/tests/topp/IDFileConverter_14_output.idXML
@@ -8,7 +8,7 @@
 		<VariableModification name="Deamidated (Q)" />
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2016-12-20T16:43:55" search_engine="Percolator" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:35:17" search_engine="Percolator" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Augustus2_AUGUSTUS00000009543_5_25910749-25909503_1" score="0" sequence="" >
 			</ProteinHit>

--- a/src/tests/topp/IDFileConverter_15_output.idXML
+++ b/src/tests/topp/IDFileConverter_15_output.idXML
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<SearchParameters id="SP_0" db="/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+	<SearchParameters id="SP_0" db="/Users/pfeuffer/git/OpenMS/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 				<UserParam type="string" name="MS:1001211" value=""/>
 				<UserParam type="string" name="MS:1001256" value=""/>
@@ -20,7 +20,7 @@
 				<UserParam type="string" name="Protocol" value="Standard"/>
 				<UserParam type="string" name="TargetDecoyApproach" value="false"/>
 	</SearchParameters>
-	<IdentificationRun date="2016-10-18T08:03:17" search_engine="MS-GF+" search_engine_version="Release (v2016.10.14)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:35:18" search_engine="MS-GF+" search_engine_version="Release (v2017.01.13)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="BSA3" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
@@ -31,7 +31,7 @@
 			<ProteinHit id="PH_2" accession="" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
 			</ProteinHit>
-			<UserParam type="stringList" name="spectra_data" value="[/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/spectra.mzML]"/>
+			<UserParam type="stringList" name="spectra_data" value="[/Users/pfeuffer/git/OpenMS/src/tests/topp/THIRDPARTY/spectra.mzML]"/>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="MS-GF:RawScore" higher_score_better="true" significance_threshold="0" MZ="1063.20983886719" RT="4587.669" spectrum_reference="spectrum=1" >
 			<PeptideHit score="163" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="-" aa_after="E" start="1" end="28" protein_refs="PH_1" >

--- a/src/tests/topp/IDFileConverter_22_output.idXML
+++ b/src/tests/topp/IDFileConverter_22_output.idXML
@@ -20,7 +20,7 @@
 				<UserParam type="string" name="Protocol" value="Standard"/>
 				<UserParam type="string" name="TargetDecoyApproach" value="false"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-05-12T16:31:40" search_engine="MS-GF+" search_engine_version="Release (v2017.01.13)" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:35:25" search_engine="MS-GF+" search_engine_version="Release (v2017.01.13)" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="BSA3" score="0" sequence="" >
 				<UserParam type="string" name="isDecoy" value="false"/>
@@ -53,15 +53,15 @@
 				<UserParam type="float" name="sum_intensity" value="159149.309085846"/>
 				<UserParam type="float" name="NTermIonCurrentRatio" value="0.562074811965916"/>
 				<UserParam type="float" name="CTermIonCurrentRatio" value="0.244423888669089"/>
-				<UserParam type="float" name="median_fragment_error" value="0.00186384639619064"/>
-				<UserParam type="float" name="IQR_fragment_error" value="0.00426560995003911"/>
-				<UserParam type="float" name="topN_meanfragmenterror" value="0.00127883276817491"/>
-				<UserParam type="float" name="topN_MSEfragmenterror" value="2.21576052025374e-06"/>
-				<UserParam type="float" name="topN_stddevfragmenterror" value="0.00148854308646197"/>
+				<UserParam type="float" name="median_fragment_error" value="0.00186384643893689"/>
+				<UserParam type="float" name="IQR_fragment_error" value="0.00426561001222581"/>
+				<UserParam type="float" name="topN_meanfragmenterror" value="0.00127883278115145"/>
+				<UserParam type="float" name="topN_MSEfragmenterror" value="3.85117387676815e-06"/>
+				<UserParam type="float" name="topN_stddevfragmenterror" value="0.00160781032060917"/>
 				<UserParam type="string" name="max_series_type" value="y"/>
 				<UserParam type="int" name="max_series_size" value="15"/>
 				<UserParam type="float" name="sn_by_matched_intensity" value="3.30483269691467"/>
-				<UserParam type="float" name="sn_by_median_intensity" value="8.00933933258057"/>
+				<UserParam type="float" name="sn_by_median_intensity" value="8.0093355178833"/>
 				<UserParam type="int" name="precursor_in_ms2" value="0"/>
 			</PeptideHit>
 			<UserParam type="float" name="fragment_match_tolerance" value="0.01"/>
@@ -86,15 +86,15 @@
 				<UserParam type="float" name="sum_intensity" value="36257.1194534302"/>
 				<UserParam type="float" name="NTermIonCurrentRatio" value="0.409870897464539"/>
 				<UserParam type="float" name="CTermIonCurrentRatio" value="0.441169616232408"/>
-				<UserParam type="float" name="median_fragment_error" value="0.00118083569157079"/>
-				<UserParam type="float" name="IQR_fragment_error" value="0.00399363754345927"/>
-				<UserParam type="float" name="topN_meanfragmenterror" value="0.000688030630637318"/>
-				<UserParam type="float" name="topN_MSEfragmenterror" value="3.11506635456216e-07"/>
-				<UserParam type="float" name="topN_stddevfragmenterror" value="0.000558127794914584"/>
+				<UserParam type="float" name="median_fragment_error" value="0.00118083570851013"/>
+				<UserParam type="float" name="IQR_fragment_error" value="0.00399363759788685"/>
+				<UserParam type="float" name="topN_meanfragmenterror" value="0.000688030638100047"/>
+				<UserParam type="float" name="topN_MSEfragmenterror" value="7.84892791971883e-07"/>
+				<UserParam type="float" name="topN_stddevfragmenterror" value="0.000602846916866501"/>
 				<UserParam type="string" name="max_series_type" value="y"/>
 				<UserParam type="int" name="max_series_size" value="12"/>
 				<UserParam type="float" name="sn_by_matched_intensity" value="3.04820585250854"/>
-				<UserParam type="float" name="sn_by_median_intensity" value="6.62783718109131"/>
+				<UserParam type="float" name="sn_by_median_intensity" value="6.62783670425415"/>
 				<UserParam type="int" name="precursor_in_ms2" value="1"/>
 			</PeptideHit>
 			<UserParam type="float" name="fragment_match_tolerance" value="0.01"/>
@@ -119,15 +119,15 @@
 				<UserParam type="float" name="sum_intensity" value="209432.387580872"/>
 				<UserParam type="float" name="NTermIonCurrentRatio" value="0.320391346980731"/>
 				<UserParam type="float" name="CTermIonCurrentRatio" value="0.510163289435426"/>
-				<UserParam type="float" name="median_fragment_error" value="0.000935632878963588"/>
-				<UserParam type="float" name="IQR_fragment_error" value="0.000915520260207359"/>
-				<UserParam type="float" name="topN_meanfragmenterror" value="0.000776723732412522"/>
-				<UserParam type="float" name="topN_MSEfragmenterror" value="1.36927722407586e-07"/>
-				<UserParam type="float" name="topN_stddevfragmenterror" value="0.000370037460816585"/>
+				<UserParam type="float" name="median_fragment_error" value="0.000935632851906121"/>
+				<UserParam type="float" name="IQR_fragment_error" value="0.000915520213311538"/>
+				<UserParam type="float" name="topN_meanfragmenterror" value="0.00077672371740586"/>
+				<UserParam type="float" name="topN_MSEfragmenterror" value="7.40227443741563e-07"/>
+				<UserParam type="float" name="topN_stddevfragmenterror" value="0.000399686121418106"/>
 				<UserParam type="string" name="max_series_type" value="y"/>
 				<UserParam type="int" name="max_series_size" value="12"/>
 				<UserParam type="float" name="sn_by_matched_intensity" value="6.87547922134399"/>
-				<UserParam type="float" name="sn_by_median_intensity" value="8.91692352294922"/>
+				<UserParam type="float" name="sn_by_median_intensity" value="8.9169225692749"/>
 				<UserParam type="int" name="precursor_in_ms2" value="0"/>
 			</PeptideHit>
 			<UserParam type="float" name="fragment_match_tolerance" value="0.01"/>

--- a/src/tests/topp/IDFileConverter_3_output.idXML
+++ b/src/tests/topp/IDFileConverter_3_output.idXML
@@ -47,23 +47,19 @@
 				<UserParam type="int" name="is_unique" value="1"/>
 				<UserParam type="int" name="is_contributing" value="1"/>
 			</PeptideHit>
-			<PeptideHit score="0.7701" sequence="TAGWNIPMGLLYNK" charge="2" protein_refs="PH_0" >
-				<UserParam type="int" name="is_unique" value="1"/>
-				<UserParam type="int" name="is_contributing" value="1"/>
-			</PeptideHit>
-			<PeptideHit score="0.6859" sequence="IMNGEADAMSLDGGFVYIAGK" charge="2" protein_refs="PH_0" >
-				<UserParam type="int" name="is_unique" value="1"/>
-				<UserParam type="int" name="is_contributing" value="1"/>
-			</PeptideHit>
-			<PeptideHit score="0.3973" sequence="TAGWNIPMGLLYNK" charge="2" protein_refs="PH_0" >
-				<UserParam type="int" name="is_unique" value="1"/>
-				<UserParam type="int" name="is_contributing" value="1"/>
-			</PeptideHit>
 			<PeptideHit score="0.778" sequence="AVMDDFAAFVEK" charge="2" protein_refs="PH_1" >
 				<UserParam type="int" name="is_unique" value="1"/>
 				<UserParam type="int" name="is_contributing" value="1"/>
 			</PeptideHit>
+			<PeptideHit score="0.7701" sequence="TAGWNIPMGLLYNK" charge="2" protein_refs="PH_0" >
+				<UserParam type="int" name="is_unique" value="1"/>
+				<UserParam type="int" name="is_contributing" value="1"/>
+			</PeptideHit>
 			<PeptideHit score="0.7534" sequence="RHPDYSVVLLLR" charge="3" protein_refs="PH_1" >
+				<UserParam type="int" name="is_unique" value="1"/>
+				<UserParam type="int" name="is_contributing" value="1"/>
+			</PeptideHit>
+			<PeptideHit score="0.7504" sequence="ITPNLAEFAFSLYR" charge="2" protein_refs="PH_2" >
 				<UserParam type="int" name="is_unique" value="1"/>
 				<UserParam type="int" name="is_contributing" value="1"/>
 			</PeptideHit>
@@ -75,11 +71,7 @@
 				<UserParam type="int" name="is_unique" value="1"/>
 				<UserParam type="int" name="is_contributing" value="1"/>
 			</PeptideHit>
-			<PeptideHit score="0.3025" sequence="RMPCAEDYLSVVLNQLCVLHEK" charge="3" protein_refs="PH_1" >
-				<UserParam type="int" name="is_unique" value="1"/>
-				<UserParam type="int" name="is_contributing" value="1"/>
-			</PeptideHit>
-			<PeptideHit score="0.7504" sequence="ITPNLAEFAFSLYR" charge="2" protein_refs="PH_2" >
+			<PeptideHit score="0.6859" sequence="IMNGEADAMSLDGGFVYIAGK" charge="2" protein_refs="PH_0" >
 				<UserParam type="int" name="is_unique" value="1"/>
 				<UserParam type="int" name="is_contributing" value="1"/>
 			</PeptideHit>
@@ -88,6 +80,14 @@
 				<UserParam type="int" name="is_contributing" value="1"/>
 			</PeptideHit>
 			<PeptideHit score="0.4788" sequence="QEPSQGTTTFAVTSILR" charge="2" protein_refs="PH_3 PH_4" >
+				<UserParam type="int" name="is_unique" value="1"/>
+				<UserParam type="int" name="is_contributing" value="1"/>
+			</PeptideHit>
+			<PeptideHit score="0.3973" sequence="TAGWNIPMGLLYNK" charge="2" protein_refs="PH_0" >
+				<UserParam type="int" name="is_unique" value="1"/>
+				<UserParam type="int" name="is_contributing" value="1"/>
+			</PeptideHit>
+			<PeptideHit score="0.3025" sequence="RMPCAEDYLSVVLNQLCVLHEK" charge="3" protein_refs="PH_1" >
 				<UserParam type="int" name="is_unique" value="1"/>
 				<UserParam type="int" name="is_contributing" value="1"/>
 			</PeptideHit>

--- a/src/tests/topp/IDFileConverter_7_output.idXML
+++ b/src/tests/topp/IDFileConverter_7_output.idXML
@@ -3,7 +3,7 @@
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 	</SearchParameters>
-	<IdentificationRun date="2015-10-28T13:51:26" search_engine="XTandem" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:35:11" search_engine="XTandem" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="XTandem" higher_score_better="false" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="BSA3 ##3" score="-15" sequence="" >
 			</ProteinHit>
@@ -13,7 +13,7 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="XTandem" higher_score_better="true" significance_threshold="0" spectrum_reference="_tandem_input_file.mzData scan 1 (charge 3)" >
-			<PeptideHit score="56.5" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0"  end="13" protein_refs="PH_2" >
+			<PeptideHit score="56.5" sequence="DFASSGGYVLHLHR" charge="3" aa_before="[" aa_after="E" start="0" end="13" protein_refs="PH_2" >
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="float" name="delta" value="-0.0022"/>
 				<UserParam type="float" name="mass" value="1558.7761"/>
@@ -26,7 +26,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="XTandem" higher_score_better="true" significance_threshold="0" spectrum_reference="_tandem_input_file.mzData scan 2 (charge 3)" >
-			<PeptideHit score="77.9" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0"  end="27" protein_refs="PH_1" >
+			<PeptideHit score="77.9" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="[" aa_after="E" start="0" end="27" protein_refs="PH_1" >
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="float" name="delta" value="0.0017"/>
 				<UserParam type="float" name="mass" value="3187.6132"/>
@@ -39,7 +39,7 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="XTandem" higher_score_better="true" significance_threshold="0" spectrum_reference="_tandem_input_file.mzData scan 3 (charge 3)" >
-			<PeptideHit score="86.6" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0"  end="22" protein_refs="PH_0" >
+			<PeptideHit score="86.6" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" aa_before="[" aa_after="A" start="0" end="22" protein_refs="PH_0" >
 				<UserParam type="float" name="nextscore" value="8"/>
 				<UserParam type="float" name="delta" value="0.0053"/>
 				<UserParam type="float" name="mass" value="2324.1418"/>

--- a/src/tests/topp/IDFilter_12_output.idXML
+++ b/src/tests/topp/IDFilter_12_output.idXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />

--- a/src/tests/topp/IDFilter_13_output.idXML
+++ b/src/tests/topp/IDFilter_13_output.idXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />

--- a/src/tests/topp/IDFilter_14_output.idXML
+++ b/src/tests/topp/IDFilter_14_output.idXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />

--- a/src/tests/topp/IDFilter_15_output.idXML
+++ b/src/tests/topp/IDFilter_15_output.idXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />

--- a/src/tests/topp/IDFilter_16_output.idXML
+++ b/src/tests/topp/IDFilter_16_output.idXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="http://open-ms.sourceforge.net/XSL/IdXML.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />

--- a/src/tests/topp/IDMerger_1_output.idXML
+++ b/src/tests/topp/IDMerger_1_output.idXML
@@ -14,9 +14,9 @@
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0" MZ="623.58" RT="-1" >
 			<PeptideHit score="40.5" sequence="APRTPEPTIDER" charge="2" protein_refs="PH_0" >
 			</PeptideHit>
-			<PeptideHit score="30.5" sequence="APRTPEPTIDERR" charge="2" protein_refs="PH_0" >
-			</PeptideHit>
 			<PeptideHit score="40.5" sequence="APRTTPEPTIDER" charge="2" protein_refs="PH_1" >
+			</PeptideHit>
+			<PeptideHit score="30.5" sequence="APRTPEPTIDERR" charge="2" protein_refs="PH_0" >
 			</PeptideHit>
 			<PeptideHit score="30.5" sequence="APEPTIDER" charge="2" >
 			</PeptideHit>

--- a/src/tests/topp/IDMerger_3_output.idXML
+++ b/src/tests/topp/IDMerger_3_output.idXML
@@ -13,9 +13,9 @@
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0" MZ="623.58" RT="-1" >
 			<PeptideHit score="40.5" sequence="APRTPEPTIDER" charge="2" protein_refs="PH_0" >
 			</PeptideHit>
-			<PeptideHit score="30.5" sequence="APRTPEPTIDERR" charge="2" protein_refs="PH_0" >
-			</PeptideHit>
 			<PeptideHit score="40.5" sequence="APRTTPEPTIDER" charge="2" protein_refs="PH_1" >
+			</PeptideHit>
+			<PeptideHit score="30.5" sequence="APRTPEPTIDERR" charge="2" protein_refs="PH_0" >
 			</PeptideHit>
 			<PeptideHit score="30.5" sequence="APEPTIDER" charge="2" >
 			</PeptideHit>
@@ -33,9 +33,9 @@
 		<PeptideIdentification score_type="Mascot" higher_score_better="true" significance_threshold="0" MZ="623.58" RT="-1" >
 			<PeptideHit score="40.5" sequence="APRTPEPTIDER" charge="2" protein_refs="PH_2" >
 			</PeptideHit>
-			<PeptideHit score="30.5" sequence="APRTPEPTIDERR" charge="2" protein_refs="PH_2" >
-			</PeptideHit>
 			<PeptideHit score="40.5" sequence="APRTTPEPTIDER" charge="2" protein_refs="PH_3" >
+			</PeptideHit>
+			<PeptideHit score="30.5" sequence="APRTPEPTIDERR" charge="2" protein_refs="PH_2" >
 			</PeptideHit>
 			<PeptideHit score="30.5" sequence="APEPTIDER" charge="2" >
 			</PeptideHit>

--- a/src/tests/topp/IDPosteriorErrorProbability_Mascot_output.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_Mascot_output.idXML
@@ -33,11 +33,11 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="15" MZ="300.164093" RT="1437.53" >
-			<PeptideHit score="0.999999703800026" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3" >
+			<PeptideHit score="0.999996682184601" sequence="GPFAHELK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
-				<UserParam type="float" name="EValue" value="0.79432823472"/>
-				<UserParam type="float" name="Mascot_score" value="14.45"/>
+				<UserParam type="float" name="EValue" value="0.30199517204"/>
+				<UserParam type="float" name="Mascot_score" value="0.43"/>
 			</PeptideHit>
 			<PeptideHit score="0.999997619610497" sequence="WSDLHLK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
@@ -45,37 +45,19 @@
 				<UserParam type="float" name="EValue" value="0.34673685045"/>
 				<UserParam type="float" name="Mascot_score" value="1.64"/>
 			</PeptideHit>
-			<PeptideHit score="0.999996682184601" sequence="GPFAHELK" charge="3" >
+			<PeptideHit score="0.999999703800026" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
-				<UserParam type="float" name="EValue" value="0.30199517204"/>
-				<UserParam type="float" name="Mascot_score" value="0.43"/>
+				<UserParam type="float" name="EValue" value="0.79432823472"/>
+				<UserParam type="float" name="Mascot_score" value="14.45"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="19" MZ="300.678009" RT="1575.38" >
-			<PeptideHit score="0.999977806014592" sequence="VSAAPR" charge="2" >
+			<PeptideHit score="0.993318846453717" sequence="LTGGPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.13182567386"/>
-				<UserParam type="float" name="Mascot_score" value="11.41"/>
-			</PeptideHit>
-			<PeptideHit score="0.999799808981541" sequence="LSGAPR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.0457088189615"/>
-				<UserParam type="float" name="Mascot_score" value="5.92"/>
-			</PeptideHit>
-			<PeptideHit score="0.99972646822851" sequence="LSQPR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.0389045144994"/>
-				<UserParam type="float" name="Mascot_score" value="5.83"/>
-			</PeptideHit>
-			<PeptideHit score="0.995387619683354" sequence="GSAIPR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.00851138038202"/>
-				<UserParam type="float" name="Mascot_score" value="1.17"/>
+				<UserParam type="float" name="EValue" value="0.00691830970919"/>
+				<UserParam type="float" name="Mascot_score" value="0.91"/>
 			</PeptideHit>
 			<PeptideHit score="0.99519248174031" sequence="GSAPLR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
@@ -83,11 +65,29 @@
 				<UserParam type="float" name="EValue" value="0.00831763771103"/>
 				<UserParam type="float" name="Mascot_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.993318846453717" sequence="LTGGPR" charge="2" >
+			<PeptideHit score="0.995387619683354" sequence="GSAIPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.00691830970919"/>
-				<UserParam type="float" name="Mascot_score" value="0.91"/>
+				<UserParam type="float" name="EValue" value="0.00851138038202"/>
+				<UserParam type="float" name="Mascot_score" value="1.17"/>
+			</PeptideHit>
+			<PeptideHit score="0.99972646822851" sequence="LSQPR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.0389045144994"/>
+				<UserParam type="float" name="Mascot_score" value="5.83"/>
+			</PeptideHit>
+			<PeptideHit score="0.999799808981541" sequence="LSGAPR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.0457088189615"/>
+				<UserParam type="float" name="Mascot_score" value="5.92"/>
+			</PeptideHit>
+			<PeptideHit score="0.999977806014592" sequence="VSAAPR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.13182567386"/>
+				<UserParam type="float" name="Mascot_score" value="11.41"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="301.8590088" RT="1754.8" >
@@ -115,11 +115,11 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="19" MZ="307.4929504" RT="1417.29" >
-			<PeptideHit score="0.205898136317334" sequence="RM(Oxidation)EALER" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="0"/>
+			<PeptideHit score="0.0829167864461242" sequence="TMLASGNAR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
-				<UserParam type="float" name="Mascot_score" value="2.16"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
+				<UserParam type="float" name="Mascot_score" value="0.46"/>
 			</PeptideHit>
 			<PeptideHit score="0.105295709433451" sequence="RMELESR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
@@ -127,19 +127,19 @@
 				<UserParam type="float" name="EValue" value="3.0199517204e-05"/>
 				<UserParam type="float" name="Mascot_score" value="1.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.0829167864461242" sequence="TMLASGNAR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
+			<PeptideHit score="0.205898136317334" sequence="RM(Oxidation)EALER" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
-				<UserParam type="float" name="Mascot_score" value="0.46"/>
+				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
+				<UserParam type="float" name="Mascot_score" value="2.16"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="308.5265198" RT="1374.39" >
-			<PeptideHit score="0.0552026346076845" sequence="IIAPPERK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_9" >
-				<UserParam type="float" name="homology_threshold" value="0"/>
+			<PeptideHit score="0.0265340096810519" sequence="ISPPAALVR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="1e-05"/>
-				<UserParam type="float" name="Mascot_score" value="21.2"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
+				<UserParam type="float" name="Mascot_score" value="5.25"/>
 			</PeptideHit>
 			<PeptideHit score="0.039216373494282" sequence="LPSAPLAVR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
@@ -147,25 +147,25 @@
 				<UserParam type="float" name="EValue" value="4.78630092323e-06"/>
 				<UserParam type="float" name="Mascot_score" value="5.7"/>
 			</PeptideHit>
-			<PeptideHit score="0.0265340096810519" sequence="ISPPAALVR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="13"/>
+			<PeptideHit score="0.0552026346076845" sequence="IIAPPERK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_9" >
+				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
-				<UserParam type="float" name="Mascot_score" value="5.25"/>
+				<UserParam type="float" name="EValue" value="1e-05"/>
+				<UserParam type="float" name="Mascot_score" value="21.2"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="15" MZ="309.1685791" RT="3449.33" >
-			<PeptideHit score="0.0201592377248982" sequence="LHQSDVAR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="15"/>
-				<UserParam type="float" name="identity_threshold" value="26"/>
-				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
-				<UserParam type="float" name="Mascot_score" value="17.01"/>
-			</PeptideHit>
 			<PeptideHit score="0.00935505970276241" sequence="AAGHAKGSAR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="26"/>
 				<UserParam type="float" name="EValue" value="2.39883291902e-07"/>
 				<UserParam type="float" name="Mascot_score" value="1.93"/>
+			</PeptideHit>
+			<PeptideHit score="0.0201592377248982" sequence="LHQSDVAR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="15"/>
+				<UserParam type="float" name="identity_threshold" value="26"/>
+				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
+				<UserParam type="float" name="Mascot_score" value="17.01"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="417.1908" RT="2289.66040039063" >

--- a/src/tests/topp/IDPosteriorErrorProbability_Mascot_output2.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_Mascot_output2.idXML
@@ -33,17 +33,17 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="15" MZ="300.164093" RT="1437.53" >
-			<PeptideHit score="0.999999703800026" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_3" >
+			<PeptideHit score="0.999996682184601" sequence="GPFAHELK" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
-				<UserParam type="float" name="EValue" value="0.79432823472"/>
-				<UserParam type="float" name="Mascot_score" value="14.45"/>
+				<UserParam type="float" name="EValue" value="0.30199517204"/>
+				<UserParam type="float" name="Mascot_score" value="0.43"/>
 			</PeptideHit>
-			<PeptideHit score="0.999999703800026" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3" >
+			<PeptideHit score="0.999996682184601" sequence="GPFAHELK" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
-				<UserParam type="float" name="EValue" value="0.79432823472"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="14.45"/>
+				<UserParam type="float" name="EValue" value="0.30199517204"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.43"/>
 			</PeptideHit>
 			<PeptideHit score="0.999997619610497" sequence="WSDLHLK" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
@@ -57,67 +57,31 @@
 				<UserParam type="float" name="EValue" value="0.34673685045"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.64"/>
 			</PeptideHit>
-			<PeptideHit score="0.999996682184601" sequence="GPFAHELK" charge="2" >
+			<PeptideHit score="0.999999703800026" sequence="LC(Carbamidomethyl)VLHEK" charge="2" aa_before="R" aa_after="T" protein_refs="PH_3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
-				<UserParam type="float" name="EValue" value="0.30199517204"/>
-				<UserParam type="float" name="Mascot_score" value="0.43"/>
+				<UserParam type="float" name="EValue" value="0.79432823472"/>
+				<UserParam type="float" name="Mascot_score" value="14.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.999996682184601" sequence="GPFAHELK" charge="3" >
+			<PeptideHit score="0.999999703800026" sequence="LC(Carbamidomethyl)VLHEK" charge="3" aa_before="R" aa_after="T" protein_refs="PH_3" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="22"/>
-				<UserParam type="float" name="EValue" value="0.30199517204"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.43"/>
+				<UserParam type="float" name="EValue" value="0.79432823472"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="14.45"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="19" MZ="300.678009" RT="1575.38" >
-			<PeptideHit score="0.999977806014592" sequence="VSAAPR" charge="2" >
+			<PeptideHit score="0.993318846453717" sequence="LTGGPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.13182567386"/>
-				<UserParam type="float" name="Mascot_score" value="11.41"/>
+				<UserParam type="float" name="EValue" value="0.00691830970919"/>
+				<UserParam type="float" name="Mascot_score" value="0.91"/>
 			</PeptideHit>
-			<PeptideHit score="0.999977806014592" sequence="VSAAPR" charge="3" >
+			<PeptideHit score="0.993318846453717" sequence="LTGGPR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.13182567386"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="11.41"/>
-			</PeptideHit>
-			<PeptideHit score="0.999799808981541" sequence="LSGAPR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.0457088189615"/>
-				<UserParam type="float" name="Mascot_score" value="5.92"/>
-			</PeptideHit>
-			<PeptideHit score="0.999799808981541" sequence="LSGAPR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.0457088189615"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="5.92"/>
-			</PeptideHit>
-			<PeptideHit score="0.99972646822851" sequence="LSQPR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.0389045144994"/>
-				<UserParam type="float" name="Mascot_score" value="5.83"/>
-			</PeptideHit>
-			<PeptideHit score="0.99972646822851" sequence="LSQPR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.0389045144994"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="5.83"/>
-			</PeptideHit>
-			<PeptideHit score="0.995387619683354" sequence="GSAIPR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.00851138038202"/>
-				<UserParam type="float" name="Mascot_score" value="1.17"/>
-			</PeptideHit>
-			<PeptideHit score="0.995387619683354" sequence="GSAIPR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
-				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.00851138038202"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="1.17"/>
+				<UserParam type="float" name="EValue" value="0.00691830970919"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.91"/>
 			</PeptideHit>
 			<PeptideHit score="0.99519248174031" sequence="GSAPLR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
@@ -131,17 +95,53 @@
 				<UserParam type="float" name="EValue" value="0.00831763771103"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.993318846453717" sequence="LTGGPR" charge="2" >
+			<PeptideHit score="0.995387619683354" sequence="GSAIPR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.00691830970919"/>
-				<UserParam type="float" name="Mascot_score" value="0.91"/>
+				<UserParam type="float" name="EValue" value="0.00851138038202"/>
+				<UserParam type="float" name="Mascot_score" value="1.17"/>
 			</PeptideHit>
-			<PeptideHit score="0.993318846453717" sequence="LTGGPR" charge="3" >
+			<PeptideHit score="0.995387619683354" sequence="GSAIPR" charge="3" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="20"/>
-				<UserParam type="float" name="EValue" value="0.00691830970919"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.91"/>
+				<UserParam type="float" name="EValue" value="0.00851138038202"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="1.17"/>
+			</PeptideHit>
+			<PeptideHit score="0.99972646822851" sequence="LSQPR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.0389045144994"/>
+				<UserParam type="float" name="Mascot_score" value="5.83"/>
+			</PeptideHit>
+			<PeptideHit score="0.99972646822851" sequence="LSQPR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.0389045144994"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="5.83"/>
+			</PeptideHit>
+			<PeptideHit score="0.999799808981541" sequence="LSGAPR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.0457088189615"/>
+				<UserParam type="float" name="Mascot_score" value="5.92"/>
+			</PeptideHit>
+			<PeptideHit score="0.999799808981541" sequence="LSGAPR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.0457088189615"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="5.92"/>
+			</PeptideHit>
+			<PeptideHit score="0.999977806014592" sequence="VSAAPR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.13182567386"/>
+				<UserParam type="float" name="Mascot_score" value="11.41"/>
+			</PeptideHit>
+			<PeptideHit score="0.999977806014592" sequence="VSAAPR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
+				<UserParam type="float" name="identity_threshold" value="20"/>
+				<UserParam type="float" name="EValue" value="0.13182567386"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="11.41"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="301.8590088" RT="1754.8" >
@@ -187,17 +187,17 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="19" MZ="307.4929504" RT="1417.29" >
-			<PeptideHit score="0.205898136317334" sequence="RM(Oxidation)EALER" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="0"/>
+			<PeptideHit score="0.0829167864461242" sequence="TMLASGNAR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
-				<UserParam type="float" name="Mascot_score" value="2.16"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
+				<UserParam type="float" name="Mascot_score" value="0.46"/>
 			</PeptideHit>
-			<PeptideHit score="0.205898136317334" sequence="RM(Oxidation)EALER" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="0"/>
+			<PeptideHit score="0.0829167864461242" sequence="TMLASGNAR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="19"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="2.16"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.46"/>
 			</PeptideHit>
 			<PeptideHit score="0.105295709433451" sequence="RMELESR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="19"/>
@@ -211,31 +211,31 @@
 				<UserParam type="float" name="EValue" value="3.0199517204e-05"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.45"/>
 			</PeptideHit>
-			<PeptideHit score="0.0829167864461242" sequence="TMLASGNAR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
+			<PeptideHit score="0.205898136317334" sequence="RM(Oxidation)EALER" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
-				<UserParam type="float" name="Mascot_score" value="0.46"/>
+				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
+				<UserParam type="float" name="Mascot_score" value="2.16"/>
 			</PeptideHit>
-			<PeptideHit score="0.0829167864461242" sequence="TMLASGNAR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="19"/>
+			<PeptideHit score="0.205898136317334" sequence="RM(Oxidation)EALER" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="19"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-05"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.46"/>
+				<UserParam type="float" name="EValue" value="7.58577575029e-05"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="2.16"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="308.5265198" RT="1374.39" >
-			<PeptideHit score="0.0552026346076845" sequence="IIAPPERK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_9" >
-				<UserParam type="float" name="homology_threshold" value="0"/>
+			<PeptideHit score="0.0265340096810519" sequence="ISPPAALVR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="1e-05"/>
-				<UserParam type="float" name="Mascot_score" value="21.2"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
+				<UserParam type="float" name="Mascot_score" value="5.25"/>
 			</PeptideHit>
-			<PeptideHit score="0.0552026346076845" sequence="IIAPPERK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_9" >
-				<UserParam type="float" name="homology_threshold" value="0"/>
+			<PeptideHit score="0.0265340096810519" sequence="ISPPAALVR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="13"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="1e-05"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="21.2"/>
+				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="5.25"/>
 			</PeptideHit>
 			<PeptideHit score="0.039216373494282" sequence="LPSAPLAVR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="13"/>
@@ -249,32 +249,20 @@
 				<UserParam type="float" name="EValue" value="4.78630092323e-06"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="5.7"/>
 			</PeptideHit>
-			<PeptideHit score="0.0265340096810519" sequence="ISPPAALVR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="13"/>
+			<PeptideHit score="0.0552026346076845" sequence="IIAPPERK" charge="2" aa_before="K" aa_after="Y" protein_refs="PH_9" >
+				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
-				<UserParam type="float" name="Mascot_score" value="5.25"/>
+				<UserParam type="float" name="EValue" value="1e-05"/>
+				<UserParam type="float" name="Mascot_score" value="21.2"/>
 			</PeptideHit>
-			<PeptideHit score="0.0265340096810519" sequence="ISPPAALVR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="13"/>
+			<PeptideHit score="0.0552026346076845" sequence="IIAPPERK" charge="3" aa_before="K" aa_after="Y" protein_refs="PH_9" >
+				<UserParam type="float" name="homology_threshold" value="0"/>
 				<UserParam type="float" name="identity_threshold" value="13"/>
-				<UserParam type="float" name="EValue" value="2.08929613085e-06"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="5.25"/>
+				<UserParam type="float" name="EValue" value="1e-05"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="21.2"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="15" MZ="309.1685791" RT="3449.33" >
-			<PeptideHit score="0.0201592377248982" sequence="LHQSDVAR" charge="2" >
-				<UserParam type="float" name="homology_threshold" value="15"/>
-				<UserParam type="float" name="identity_threshold" value="26"/>
-				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
-				<UserParam type="float" name="Mascot_score" value="17.01"/>
-			</PeptideHit>
-			<PeptideHit score="0.0201592377248982" sequence="LHQSDVAR" charge="3" >
-				<UserParam type="float" name="homology_threshold" value="15"/>
-				<UserParam type="float" name="identity_threshold" value="26"/>
-				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
-				<UserParam type="float" name="Posterior Error Probability_score" value="17.01"/>
-			</PeptideHit>
 			<PeptideHit score="0.00935505970276241" sequence="AAGHAKGSAR" charge="2" >
 				<UserParam type="float" name="homology_threshold" value="15"/>
 				<UserParam type="float" name="identity_threshold" value="26"/>
@@ -286,6 +274,18 @@
 				<UserParam type="float" name="identity_threshold" value="26"/>
 				<UserParam type="float" name="EValue" value="2.39883291902e-07"/>
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.93"/>
+			</PeptideHit>
+			<PeptideHit score="0.0201592377248982" sequence="LHQSDVAR" charge="2" >
+				<UserParam type="float" name="homology_threshold" value="15"/>
+				<UserParam type="float" name="identity_threshold" value="26"/>
+				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
+				<UserParam type="float" name="Mascot_score" value="17.01"/>
+			</PeptideHit>
+			<PeptideHit score="0.0201592377248982" sequence="LHQSDVAR" charge="3" >
+				<UserParam type="float" name="homology_threshold" value="15"/>
+				<UserParam type="float" name="identity_threshold" value="26"/>
+				<UserParam type="float" name="EValue" value="1.17489755494e-06"/>
+				<UserParam type="float" name="Posterior Error Probability_score" value="17.01"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="13" MZ="417.1908" RT="2289.66040039063" >

--- a/src/tests/topp/IDPosteriorErrorProbability_OMSSA_output.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_OMSSA_output.idXML
@@ -15,35 +15,35 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="380.6954346" RT="778.61" >
-			<PeptideHit score="0.999999703800026" sequence="AEDAKAR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.79432823472"/>
-			</PeptideHit>
-			<PeptideHit score="0.999997619610497" sequence="TVDGVNR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_0" >
-				<UserParam type="float" name="OMSSA_score" value="0.34673685045"/>
-			</PeptideHit>
-			<PeptideHit score="0.999996682184601" sequence="TVDGPSGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.30199517204"/>
-			</PeptideHit>
-			<PeptideHit score="0.999977806014592" sequence="AEQAVSR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="0.13182567386"/>
-			</PeptideHit>
-			<PeptideHit score="0.999799808981541" sequence="EAAAVGSR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_0" >
-				<UserParam type="float" name="OMSSA_score" value="0.0457088189615"/>
-			</PeptideHit>
-			<PeptideHit score="0.99972646822851" sequence="EAEGRAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.0389045144994"/>
-			</PeptideHit>
-			<PeptideHit score="0.995387619683354" sequence="EAEGARK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.00851138038202"/>
-			</PeptideHit>
-			<PeptideHit score="0.99519248174031" sequence="LSNEAAR" charge="2" aa_before="R" aa_after="R" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.00831763771103"/>
+			<PeptideHit score="0.992137188268975" sequence="GDRADAR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.0063095734448"/>
 			</PeptideHit>
 			<PeptideHit score="0.993318846453717" sequence="AEASVAGR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
 				<UserParam type="float" name="OMSSA_score" value="0.00691830970919"/>
 			</PeptideHit>
-			<PeptideHit score="0.992137188268975" sequence="GDRADAR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.0063095734448"/>
+			<PeptideHit score="0.99519248174031" sequence="LSNEAAR" charge="2" aa_before="R" aa_after="R" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.00831763771103"/>
+			</PeptideHit>
+			<PeptideHit score="0.995387619683354" sequence="EAEGARK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.00851138038202"/>
+			</PeptideHit>
+			<PeptideHit score="0.99972646822851" sequence="EAEGRAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.0389045144994"/>
+			</PeptideHit>
+			<PeptideHit score="0.999799808981541" sequence="EAAAVGSR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0457088189615"/>
+			</PeptideHit>
+			<PeptideHit score="0.999977806014592" sequence="AEQAVSR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="0.13182567386"/>
+			</PeptideHit>
+			<PeptideHit score="0.999996682184601" sequence="TVDGPSGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.30199517204"/>
+			</PeptideHit>
+			<PeptideHit score="0.999997619610497" sequence="TVDGVNR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.34673685045"/>
+			</PeptideHit>
+			<PeptideHit score="0.999999703800026" sequence="AEDAKAR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.79432823472"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="309.2268982" RT="958.267" >
@@ -52,32 +52,32 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="375.6966248" RT="998.481" >
-			<PeptideHit score="0.453250508471886" sequence="VANYQR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.000223872113857"/>
-			</PeptideHit>
-			<PeptideHit score="0.205898136317334" sequence="RQYQR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="7.58577575029e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.105295709433451" sequence="QGVYQR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="3.0199517204e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.0829167864461242" sequence="VYEPSR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.0552026346076845" sequence="MQATTAK" charge="2" aa_after="R" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="1e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.039216373494282" sequence="DFEAIR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="4.78630092323e-06"/>
-			</PeptideHit>
-			<PeptideHit score="0.0265340096810519" sequence="FDELAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-06"/>
+			<PeptideHit score="0.00935505970276241" sequence="VEFFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="2.39883291902e-07"/>
 			</PeptideHit>
 			<PeptideHit score="0.0201592377248982" sequence="VEEFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
 				<UserParam type="float" name="OMSSA_score" value="1.17489755494e-06"/>
 			</PeptideHit>
-			<PeptideHit score="0.00935505970276241" sequence="VEFFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="2.39883291902e-07"/>
+			<PeptideHit score="0.0265340096810519" sequence="FDELAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-06"/>
+			</PeptideHit>
+			<PeptideHit score="0.039216373494282" sequence="DFEAIR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="4.78630092323e-06"/>
+			</PeptideHit>
+			<PeptideHit score="0.0552026346076845" sequence="MQATTAK" charge="2" aa_after="R" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="1e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.0829167864461242" sequence="VYEPSR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.105295709433451" sequence="QGVYQR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="3.0199517204e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.205898136317334" sequence="RQYQR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="7.58577575029e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.453250508471886" sequence="VANYQR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.000223872113857"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/IDPosteriorErrorProbability_OMSSA_output2.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_OMSSA_output2.idXML
@@ -15,53 +15,11 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="380.6954346" RT="778.61" >
-			<PeptideHit score="0.999999703800026" sequence="AEDAKAR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.79432823472"/>
+			<PeptideHit score="0.992137188268975" sequence="GDRADAR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.0063095734448"/>
 			</PeptideHit>
-			<PeptideHit score="0.999999703800026" sequence="AEDAKAR" charge="3" aa_before="R" aa_after="V" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.79432823472"/>
-			</PeptideHit>
-			<PeptideHit score="0.999997619610497" sequence="TVDGVNR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_0" >
-				<UserParam type="float" name="OMSSA_score" value="0.34673685045"/>
-			</PeptideHit>
-			<PeptideHit score="0.999997619610497" sequence="TVDGVNR" charge="3" aa_before="R" aa_after="E" protein_refs="PH_0" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.34673685045"/>
-			</PeptideHit>
-			<PeptideHit score="0.999996682184601" sequence="TVDGPSGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.30199517204"/>
-			</PeptideHit>
-			<PeptideHit score="0.999996682184601" sequence="TVDGPSGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.30199517204"/>
-			</PeptideHit>
-			<PeptideHit score="0.999977806014592" sequence="AEQAVSR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="0.13182567386"/>
-			</PeptideHit>
-			<PeptideHit score="0.999977806014592" sequence="AEQAVSR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_2" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.13182567386"/>
-			</PeptideHit>
-			<PeptideHit score="0.999799808981541" sequence="EAAAVGSR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_0" >
-				<UserParam type="float" name="OMSSA_score" value="0.0457088189615"/>
-			</PeptideHit>
-			<PeptideHit score="0.999799808981541" sequence="EAAAVGSR" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.0457088189615"/>
-			</PeptideHit>
-			<PeptideHit score="0.99972646822851" sequence="EAEGRAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.0389045144994"/>
-			</PeptideHit>
-			<PeptideHit score="0.99972646822851" sequence="EAEGRAK" charge="3" aa_before="R" aa_after="E" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.0389045144994"/>
-			</PeptideHit>
-			<PeptideHit score="0.995387619683354" sequence="EAEGARK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.00851138038202"/>
-			</PeptideHit>
-			<PeptideHit score="0.995387619683354" sequence="EAEGARK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.00851138038202"/>
-			</PeptideHit>
-			<PeptideHit score="0.99519248174031" sequence="LSNEAAR" charge="2" aa_before="R" aa_after="R" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.00831763771103"/>
-			</PeptideHit>
-			<PeptideHit score="0.99519248174031" sequence="LSNEAAR" charge="3" aa_before="R" aa_after="R" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.00831763771103"/>
+			<PeptideHit score="0.992137188268975" sequence="GDRADAR" charge="3" aa_before="R" aa_after="S" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.0063095734448"/>
 			</PeptideHit>
 			<PeptideHit score="0.993318846453717" sequence="AEASVAGR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
 				<UserParam type="float" name="OMSSA_score" value="0.00691830970919"/>
@@ -69,11 +27,53 @@
 			<PeptideHit score="0.993318846453717" sequence="AEASVAGR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_1" >
 				<UserParam type="float" name="Posterior Error Probability_score" value="0.00691830970919"/>
 			</PeptideHit>
-			<PeptideHit score="0.992137188268975" sequence="GDRADAR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.0063095734448"/>
+			<PeptideHit score="0.99519248174031" sequence="LSNEAAR" charge="2" aa_before="R" aa_after="R" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.00831763771103"/>
 			</PeptideHit>
-			<PeptideHit score="0.992137188268975" sequence="GDRADAR" charge="3" aa_before="R" aa_after="S" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.0063095734448"/>
+			<PeptideHit score="0.99519248174031" sequence="LSNEAAR" charge="3" aa_before="R" aa_after="R" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.00831763771103"/>
+			</PeptideHit>
+			<PeptideHit score="0.995387619683354" sequence="EAEGARK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.00851138038202"/>
+			</PeptideHit>
+			<PeptideHit score="0.995387619683354" sequence="EAEGARK" charge="3" aa_before="K" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.00851138038202"/>
+			</PeptideHit>
+			<PeptideHit score="0.99972646822851" sequence="EAEGRAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.0389045144994"/>
+			</PeptideHit>
+			<PeptideHit score="0.99972646822851" sequence="EAEGRAK" charge="3" aa_before="R" aa_after="E" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.0389045144994"/>
+			</PeptideHit>
+			<PeptideHit score="0.999799808981541" sequence="EAAAVGSR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0457088189615"/>
+			</PeptideHit>
+			<PeptideHit score="0.999799808981541" sequence="EAAAVGSR" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.0457088189615"/>
+			</PeptideHit>
+			<PeptideHit score="0.999977806014592" sequence="AEQAVSR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="0.13182567386"/>
+			</PeptideHit>
+			<PeptideHit score="0.999977806014592" sequence="AEQAVSR" charge="3" aa_before="R" aa_after="L" protein_refs="PH_2" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.13182567386"/>
+			</PeptideHit>
+			<PeptideHit score="0.999996682184601" sequence="TVDGPSGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.30199517204"/>
+			</PeptideHit>
+			<PeptideHit score="0.999996682184601" sequence="TVDGPSGK" charge="3" aa_before="K" aa_after="L" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.30199517204"/>
+			</PeptideHit>
+			<PeptideHit score="0.999997619610497" sequence="TVDGVNR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.34673685045"/>
+			</PeptideHit>
+			<PeptideHit score="0.999997619610497" sequence="TVDGVNR" charge="3" aa_before="R" aa_after="E" protein_refs="PH_0" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.34673685045"/>
+			</PeptideHit>
+			<PeptideHit score="0.999999703800026" sequence="AEDAKAR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.79432823472"/>
+			</PeptideHit>
+			<PeptideHit score="0.999999703800026" sequence="AEDAKAR" charge="3" aa_before="R" aa_after="V" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.79432823472"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="309.2268982" RT="958.267" >
@@ -85,47 +85,11 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Error Probability" higher_score_better="false" significance_threshold="0" MZ="375.6966248" RT="998.481" >
-			<PeptideHit score="0.453250508471886" sequence="VANYQR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.000223872113857"/>
+			<PeptideHit score="0.00935505970276241" sequence="VEFFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="2.39883291902e-07"/>
 			</PeptideHit>
-			<PeptideHit score="0.453250508471886" sequence="VANYQR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="0.000223872113857"/>
-			</PeptideHit>
-			<PeptideHit score="0.205898136317334" sequence="RQYQR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="7.58577575029e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.205898136317334" sequence="RQYQR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_2" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="7.58577575029e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.105295709433451" sequence="QGVYQR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="3.0199517204e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.105295709433451" sequence="QGVYQR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_2" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="3.0199517204e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.0829167864461242" sequence="VYEPSR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.0829167864461242" sequence="VYEPSR" charge="3" aa_before="R" aa_after="F" protein_refs="PH_2" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="2.08929613085e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.0552026346076845" sequence="MQATTAK" charge="2" aa_after="R" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="1e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.0552026346076845" sequence="MQATTAK" charge="3" aa_after="R" protein_refs="PH_2" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="1e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.039216373494282" sequence="DFEAIR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="4.78630092323e-06"/>
-			</PeptideHit>
-			<PeptideHit score="0.039216373494282" sequence="DFEAIR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="4.78630092323e-06"/>
-			</PeptideHit>
-			<PeptideHit score="0.0265340096810519" sequence="FDELAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-06"/>
-			</PeptideHit>
-			<PeptideHit score="0.0265340096810519" sequence="FDELAR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_2" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="2.08929613085e-06"/>
+			<PeptideHit score="0.00935505970276241" sequence="VEFFAR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="2.39883291902e-07"/>
 			</PeptideHit>
 			<PeptideHit score="0.0201592377248982" sequence="VEEFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
 				<UserParam type="float" name="OMSSA_score" value="1.17489755494e-06"/>
@@ -133,11 +97,47 @@
 			<PeptideHit score="0.0201592377248982" sequence="VEEFAR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_1" >
 				<UserParam type="float" name="Posterior Error Probability_score" value="1.17489755494e-06"/>
 			</PeptideHit>
-			<PeptideHit score="0.00935505970276241" sequence="VEFFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="2.39883291902e-07"/>
+			<PeptideHit score="0.0265340096810519" sequence="FDELAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-06"/>
 			</PeptideHit>
-			<PeptideHit score="0.00935505970276241" sequence="VEFFAR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="Posterior Error Probability_score" value="2.39883291902e-07"/>
+			<PeptideHit score="0.0265340096810519" sequence="FDELAR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="2.08929613085e-06"/>
+			</PeptideHit>
+			<PeptideHit score="0.039216373494282" sequence="DFEAIR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="4.78630092323e-06"/>
+			</PeptideHit>
+			<PeptideHit score="0.039216373494282" sequence="DFEAIR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="4.78630092323e-06"/>
+			</PeptideHit>
+			<PeptideHit score="0.0552026346076845" sequence="MQATTAK" charge="2" aa_after="R" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="1e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.0552026346076845" sequence="MQATTAK" charge="3" aa_after="R" protein_refs="PH_2" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="1e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.0829167864461242" sequence="VYEPSR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.0829167864461242" sequence="VYEPSR" charge="3" aa_before="R" aa_after="F" protein_refs="PH_2" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="2.08929613085e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.105295709433451" sequence="QGVYQR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="3.0199517204e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.105295709433451" sequence="QGVYQR" charge="3" aa_before="K" aa_after="V" protein_refs="PH_2" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="3.0199517204e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.205898136317334" sequence="RQYQR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="7.58577575029e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.205898136317334" sequence="RQYQR" charge="3" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="7.58577575029e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.453250508471886" sequence="VANYQR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.000223872113857"/>
+			</PeptideHit>
+			<PeptideHit score="0.453250508471886" sequence="VANYQR" charge="3" aa_before="R" aa_after="D" protein_refs="PH_1" >
+				<UserParam type="float" name="Posterior Error Probability_score" value="0.000223872113857"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/IDPosteriorErrorProbability_prob_correct_output.idXML
+++ b/src/tests/topp/IDPosteriorErrorProbability_prob_correct_output.idXML
@@ -15,35 +15,35 @@
 			</ProteinHit>
 		</ProteinIdentification>
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="380.6954346" RT="778.61" >
-			<PeptideHit score="2.96199974214595e-07" sequence="AEDAKAR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.79432823472"/>
-			</PeptideHit>
-			<PeptideHit score="2.38038950273189e-06" sequence="TVDGVNR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_0" >
-				<UserParam type="float" name="OMSSA_score" value="0.34673685045"/>
-			</PeptideHit>
-			<PeptideHit score="3.31781539897325e-06" sequence="TVDGPSGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.30199517204"/>
-			</PeptideHit>
-			<PeptideHit score="2.21939854082587e-05" sequence="AEQAVSR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="0.13182567386"/>
-			</PeptideHit>
-			<PeptideHit score="0.000200191018458806" sequence="EAAAVGSR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_0" >
-				<UserParam type="float" name="OMSSA_score" value="0.0457088189615"/>
-			</PeptideHit>
-			<PeptideHit score="0.000273531771489921" sequence="EAEGRAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.0389045144994"/>
-			</PeptideHit>
-			<PeptideHit score="0.00461238031664557" sequence="EAEGARK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.00851138038202"/>
-			</PeptideHit>
-			<PeptideHit score="0.00480751825969028" sequence="LSNEAAR" charge="2" aa_before="R" aa_after="R" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.00831763771103"/>
+			<PeptideHit score="0.00786281173102454" sequence="GDRADAR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.0063095734448"/>
 			</PeptideHit>
 			<PeptideHit score="0.00668115354628251" sequence="AEASVAGR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
 				<UserParam type="float" name="OMSSA_score" value="0.00691830970919"/>
 			</PeptideHit>
-			<PeptideHit score="0.00786281173102454" sequence="GDRADAR" charge="2" aa_before="R" aa_after="S" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.0063095734448"/>
+			<PeptideHit score="0.00480751825969028" sequence="LSNEAAR" charge="2" aa_before="R" aa_after="R" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.00831763771103"/>
+			</PeptideHit>
+			<PeptideHit score="0.00461238031664557" sequence="EAEGARK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.00851138038202"/>
+			</PeptideHit>
+			<PeptideHit score="0.000273531771489921" sequence="EAEGRAK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.0389045144994"/>
+			</PeptideHit>
+			<PeptideHit score="0.000200191018458806" sequence="EAAAVGSR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.0457088189615"/>
+			</PeptideHit>
+			<PeptideHit score="2.21939854082587e-05" sequence="AEQAVSR" charge="2" aa_before="R" aa_after="L" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="0.13182567386"/>
+			</PeptideHit>
+			<PeptideHit score="3.31781539897325e-06" sequence="TVDGPSGK" charge="2" aa_before="K" aa_after="L" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.30199517204"/>
+			</PeptideHit>
+			<PeptideHit score="2.38038950273189e-06" sequence="TVDGVNR" charge="2" aa_before="R" aa_after="E" protein_refs="PH_0" >
+				<UserParam type="float" name="OMSSA_score" value="0.34673685045"/>
+			</PeptideHit>
+			<PeptideHit score="2.96199974214595e-07" sequence="AEDAKAR" charge="2" aa_before="R" aa_after="V" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.79432823472"/>
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="309.2268982" RT="958.267" >
@@ -52,32 +52,32 @@
 			</PeptideHit>
 		</PeptideIdentification>
 		<PeptideIdentification score_type="Posterior Probability" higher_score_better="true" significance_threshold="0" MZ="375.6966248" RT="998.481" >
-			<PeptideHit score="0.546749491528114" sequence="VANYQR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="0.000223872113857"/>
-			</PeptideHit>
-			<PeptideHit score="0.794101863682666" sequence="RQYQR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="7.58577575029e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.894704290566549" sequence="QGVYQR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="3.0199517204e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.917083213553876" sequence="VYEPSR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.944797365392316" sequence="MQATTAK" charge="2" aa_after="R" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="1e-05"/>
-			</PeptideHit>
-			<PeptideHit score="0.960783626505718" sequence="DFEAIR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="4.78630092323e-06"/>
-			</PeptideHit>
-			<PeptideHit score="0.973465990318948" sequence="FDELAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
-				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-06"/>
+			<PeptideHit score="0.990644940297238" sequence="VEFFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="2.39883291902e-07"/>
 			</PeptideHit>
 			<PeptideHit score="0.979840762275102" sequence="VEEFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
 				<UserParam type="float" name="OMSSA_score" value="1.17489755494e-06"/>
 			</PeptideHit>
-			<PeptideHit score="0.990644940297238" sequence="VEFFAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
-				<UserParam type="float" name="OMSSA_score" value="2.39883291902e-07"/>
+			<PeptideHit score="0.973465990318948" sequence="FDELAR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-06"/>
+			</PeptideHit>
+			<PeptideHit score="0.960783626505718" sequence="DFEAIR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="4.78630092323e-06"/>
+			</PeptideHit>
+			<PeptideHit score="0.944797365392316" sequence="MQATTAK" charge="2" aa_after="R" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="1e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.917083213553876" sequence="VYEPSR" charge="2" aa_before="R" aa_after="F" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="2.08929613085e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.894704290566549" sequence="QGVYQR" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="3.0199517204e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.794101863682666" sequence="RQYQR" charge="2" aa_before="R" aa_after="A" protein_refs="PH_2" >
+				<UserParam type="float" name="OMSSA_score" value="7.58577575029e-05"/>
+			</PeptideHit>
+			<PeptideHit score="0.546749491528114" sequence="VANYQR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_1" >
+				<UserParam type="float" name="OMSSA_score" value="0.000223872113857"/>
 			</PeptideHit>
 		</PeptideIdentification>
 	</IdentificationRun>

--- a/src/tests/topp/MascotAdapter_2_output.idXML
+++ b/src/tests/topp/MascotAdapter_2_output.idXML
@@ -71,13 +71,13 @@
 			</PeptideHit>
 			<PeptideHit score="6.66" sequence="SISVEDKTDVR" charge="2" aa_before="R R R R R R" aa_after="K K K K K K" protein_refs="PH_15 PH_16 PH_17 PH_18 PH_19 PH_20" >
 			</PeptideHit>
+			<PeptideHit score="5.61" sequence="AQQRMSGTLEK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_24" >
+			</PeptideHit>
 			<PeptideHit score="5.57" sequence="EQMATSGNEPGK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_21" >
 			</PeptideHit>
 			<PeptideHit score="5.24" sequence="VVEVFSEYFK" charge="2" aa_before="K" aa_after="E" protein_refs="PH_22" >
 			</PeptideHit>
 			<PeptideHit score="4.59" sequence="TPQADKTEEVK" charge="2" aa_before="R" aa_after="E" protein_refs="PH_23" >
-			</PeptideHit>
-			<PeptideHit score="5.61" sequence="AQQRMSGTLEK" charge="2" aa_before="R" aa_after="V" protein_refs="PH_24" >
 			</PeptideHit>
 			<PeptideHit score="4.24" sequence="LSSEDKEAIEK" charge="2" aa_before="K K" aa_after="A A" protein_refs="PH_25 PH_26" >
 			</PeptideHit>

--- a/src/tests/topp/OpenPepXLLF_output.idXML
+++ b/src/tests/topp/OpenPepXLLF_output.idXML
@@ -17,7 +17,7 @@
 				<UserParam type="int" name="modifications:variable_max_per_peptide" value="2"/>
 				<UserParam type="int" name="MS:1001029" value="397"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-08-07T12:39:18" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:41:33" search_engine="OpenXQuest" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Protein1" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/OpenPepXL_output.idXML
+++ b/src/tests/topp/OpenPepXL_output.idXML
@@ -19,7 +19,7 @@
 				<UserParam type="int" name="modifications:variable_max_per_peptide" value="2"/>
 				<UserParam type="int" name="MS:1001029" value="329"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-08-07T12:43:53" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:41:28" search_engine="OpenXQuest" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Protein1" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/RNPxlSearch_1_output.idXML
+++ b/src/tests/topp/RNPxlSearch_1_output.idXML
@@ -3,7 +3,7 @@
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/RNPxlSearch_1_input.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="2:5" enzyme="unknown_enzyme" missed_cleavages="1" precursor_peak_tolerance="20" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="20" peak_mass_tolerance_ppm="false" >
 	</SearchParameters>
-	<IdentificationRun date="2017-08-11T18:51:17" search_engine="RNPxlSearch" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:38:58" search_engine="RNPxlSearch" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Cse1" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/SimpleSearchEngine_1_out.idXML
+++ b/src/tests/topp/SimpleSearchEngine_1_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/SimpleSearchEngine_1.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="+2-+5" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2016-08-02T12:07:39" search_engine="SimpleSearchEngine" search_engine_version="2.0.1" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:41:17" search_engine="SimpleSearchEngine" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<UserParam type="stringList" name="spectra_data" value="[file://./KKramer_150612_yeastTAP_4_120min.raw]"/>
 		</ProteinIdentification>

--- a/src/tests/topp/THIRDPARTY/OMSSAAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/OMSSAAdapter_1_out.idXML
@@ -4,7 +4,7 @@
 	<SearchParameters id="SP_0" db="/nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="0" mass_type="monoisotopic" charges="+1-+3" enzyme="trypsin" missed_cleavages="1" precursor_peak_tolerance="5" precursor_peak_tolerance_ppm="true" peak_mass_tolerance="0.3" peak_mass_tolerance_ppm="false" >
 		<VariableModification name="Oxidation (M)" />
 	</SearchParameters>
-	<IdentificationRun date="2016-12-20T17:14:00" search_engine="OMSSA" search_engine_version="2.1.8" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:40:56" search_engine="OMSSA" search_engine_version="2.1.8" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="OMSSA" higher_score_better="false" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="BSA2" score="0" sequence="" >
 			</ProteinHit>

--- a/src/tests/topp/THIRDPARTY/PercolatorAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/PercolatorAdapter_1_out.idXML
@@ -41,7 +41,7 @@
 				<UserParam type="string" name="Percolator:decoy-pattern" value="random"/>
 				<UserParam type="int" name="Percolator:post-processing-tdc" value="0"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-10-09T18:33:43" search_engine="Comet" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-11-28T11:40:58" search_engine="Comet" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q02952|AKA12_HUMAN" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/XFDR_test_out1.idXML
+++ b/src/tests/topp/XFDR_test_out1.idXML
@@ -9,7 +9,7 @@
 				<UserParam type="float" name="cross_link:mass" value="138.068"/>
 				<UserParam type="floatList" name="cross_link:mass_monolink" value="[]"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-03-19T10:18:40" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-03-19T10:18:40" search_engine="OpenXQuest" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q00610|CLH1_HUMAN" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/XFDR_test_out2.idXML
+++ b/src/tests/topp/XFDR_test_out2.idXML
@@ -9,7 +9,7 @@
 				<UserParam type="float" name="cross_link:mass" value="138.068"/>
 				<UserParam type="floatList" name="cross_link:mass_monolink" value="[]"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-03-19T10:18:40" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-03-19T10:18:40" search_engine="OpenXQuest" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="sp|Q00610|CLH1_HUMAN" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/XFDR_test_out3.idXML
+++ b/src/tests/topp/XFDR_test_out3.idXML
@@ -9,7 +9,7 @@
 				<UserParam type="float" name="cross_link:mass" value="138.068"/>
 				<UserParam type="floatList" name="cross_link:mass_monolink" value="[0, 156.079]"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-05-12T15:34:13" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-05-12T15:34:13" search_engine="OpenXQuest" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Protein3" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>

--- a/src/tests/topp/XFDR_test_out4.idXML
+++ b/src/tests/topp/XFDR_test_out4.idXML
@@ -9,7 +9,7 @@
 				<UserParam type="float" name="cross_link:mass" value="138.068"/>
 				<UserParam type="floatList" name="cross_link:mass_monolink" value="[0, 156.079]"/>
 	</SearchParameters>
-	<IdentificationRun date="2017-05-12T15:34:13" search_engine="OpenXQuest" search_engine_version="2.2.0" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2017-05-12T15:34:13" search_engine="OpenXQuest" search_engine_version="2.3.0" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="Protein3" score="0" sequence="" >
 				<UserParam type="string" name="target_decoy" value="target"/>


### PR DESCRIPTION
sort hits according to score before storing to idXML file.