### PR TITLE
minor fixes to PeptideIndexer

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/FASTAFile.h
+++ b/src/openms/include/OpenMS/FORMAT/FASTAFile.h
@@ -153,7 +153,7 @@ public:
     void readStart(const String& filename);
 
     /**
-    @brief Prepares a FASTA file given by 'filename' for streamed reading using readNext().
+    @brief Reads the next FASTA entry from file.
 
     If you want to read all entries in one go, use load().
 


### PR DESCRIPTION
[FIX] fix PeptideIndexer crash (division by 0) if 0 peptides are mapped to the protein DB.

[FEATURE] parse protein sequences which contain modifications as AASequence (since otherwise hits in regions with modfied AA would not be found) and emit a warning to user to fix his Protein Database (fixes #2594)