### PR TITLE
[FIX] OpenSWATH: Store UniMod sequence in PQP files

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -414,6 +414,16 @@ protected:
     String toUnmodifiedString() const;
 
     /**
+        @brief returns the peptide as string with UniMod-style modifications embedded in brackets
+
+        Uses round brackets when possible (id is known) or square brackets for
+        unknown modifications where only the mass is known.
+
+        i.e.: n[43]PEPC(UniMod:4)PEPM[147]PEPRc[16]
+    */
+    String toUniModString() const;
+
+    /**
         @brief create a TPP compatible string of the modified sequence using bracket notation.
 
         Instead of using the modification names, it writes the modification masses in brackets

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -406,7 +406,7 @@ protected:
         Uses round brackets when possible (id is known) or square brackets for
         unknown modifications where only the mass is known.
 
-        i.e.: n[43]PEPC(Carbamidomethyl)PEPM[147]PEPRc[16]
+        i.e.: .n[43]PEPC(Carbamidomethyl)PEPM[147]PEPR.[16]
     */
     String toString() const;
 
@@ -419,7 +419,7 @@ protected:
         Uses round brackets when possible (id is known) or square brackets for
         unknown modifications where only the mass is known.
 
-        i.e.: n[43]PEPC(UniMod:4)PEPM[147]PEPRc[16]
+        i.e.: .n[43]PEPC(UniMod:4)PEPM[147]PEPR.[16]
     */
     String toUniModString() const;
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
@@ -400,7 +400,7 @@ namespace OpenMS
     {
       setProgress(progress++);
       OpenMS::TargetedExperiment::Peptide peptide = targeted_exp.getPeptides()[i];
-      std::string peptide_sequence = TargetedExperimentHelper::getAASequence(peptide).toString();
+      std::string peptide_sequence = TargetedExperimentHelper::getAASequence(peptide).toUniModString();
       peptide_set.push_back(peptide_sequence);
       group_set.push_back(peptide.id);
     }
@@ -505,7 +505,7 @@ namespace OpenMS
     {
       setProgress(progress++);
       OpenMS::TargetedExperiment::Peptide peptide = targeted_exp.getPeptides()[i];
-      std::string peptide_sequence = TargetedExperimentHelper::getAASequence(peptide).toString();
+      std::string peptide_sequence = TargetedExperimentHelper::getAASequence(peptide).toUniModString();
       int group_set_index = std::distance(group_set.begin(),std::find(group_set.begin(), group_set.end(), peptide.id));
       int peptide_set_index = std::distance(peptide_set.begin(), std::find(peptide_set.begin(), peptide_set.end(), peptide_sequence));
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
@@ -1398,27 +1398,8 @@ namespace OpenMS
         }
       }
 
-      mytransition.FullPeptideName = "";
-      {
-        // Instead of relying on the full_peptide_name, rather look at the actual modifications!
-        OpenSwath::LightCompound lightpep;
-        OpenSwathDataAccessHelper::convertTargetedCompound(pep, lightpep);
-        for (int loc = -1; loc <= (int)lightpep.sequence.size(); loc++)
-        {
-          if (loc > -1 && loc < (int)lightpep.sequence.size())
-          {
-            mytransition.FullPeptideName += lightpep.sequence[loc];
-          }
-          // C-terminal and N-terminal modifications may be at positions -1 or lightpep.sequence
-          for (Size modloc = 0; modloc < lightpep.modifications.size(); modloc++)
-          {
-            if (lightpep.modifications[modloc].location == loc)
-            {
-              mytransition.FullPeptideName += "(UniMod:" + String(lightpep.modifications[modloc].unimod_id) + ")";
-            }
-          }
-        }
-      }
+      mytransition.FullPeptideName = TargetedExperimentHelper::getAASequence(pep).toUniModString();;
+
       mytransition.precursor_charge = "NA";
       if (pep.hasCharge())
       {

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
@@ -1398,7 +1398,7 @@ namespace OpenMS
         }
       }
 
-      mytransition.FullPeptideName = TargetedExperimentHelper::getAASequence(pep).toUniModString();;
+      mytransition.FullPeptideName = TargetedExperimentHelper::getAASequence(pep).toUniModString();
 
       mytransition.precursor_charge = "NA";
       if (pep.hasCharge())

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -107,6 +107,68 @@ namespace OpenMS
     return tmp;
   }
 
+  String AASequence::toUniModString() const
+  {
+    const AASequence & seq = *this;
+
+    String bs;
+    int unimod = -1;
+
+    if (seq.empty()) return bs;
+
+    if (seq.hasNTerminalModification())
+    {
+      const ResidueModification& mod = *(seq.getNTerminalModification());
+      unimod = mod.getUniModRecordId();
+      if (unimod > -1)
+      {
+        bs += ".(UniMod:" + String(unimod) + ")";
+      }
+      else
+      {
+        bs += ".[" + String(mod.getDiffMonoMass()) + "]";
+      }
+    }
+
+    for (Size i = 0; i != seq.size(); ++i)
+    {
+      const Residue& r = seq[i];
+      const String aa = r.getOneLetterCode() != "" ? r.getOneLetterCode() : "X";
+      if (r.isModified())
+      {
+        const ResidueModification& mod = *(r.getModification());
+        unimod = mod.getUniModRecordId();
+        if (unimod > -1)
+        {
+          bs += aa + "(UniMod:" + String(unimod) + ")";
+        }
+        else
+        {
+          bs += aa + "[" + String(r.getMonoWeight(Residue::Internal)) + "]";
+        }
+      }
+      else  // amino acid not modified
+      {
+        bs += aa;
+      }
+    }
+
+    if (seq.hasCTerminalModification())
+    {
+      const ResidueModification& mod = *(seq.getCTerminalModification());
+      unimod = mod.getUniModRecordId();
+      if (unimod > -1)
+      {
+        bs += ".(UniMod:" + String(unimod) + ")";
+      }
+      else
+      {
+        bs += ".[" + String(mod.getDiffMonoMass()) + "]";
+      }
+    }
+    return bs;
+  }
+
   String AASequence::toBracketString(bool integer_mass, const vector<String> & fixed_modifications) const
   {
     const AASequence & seq = *this;

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -120,9 +120,9 @@ namespace OpenMS
     {
       const ResidueModification& mod = *(seq.getNTerminalModification());
       unimod = mod.getUniModRecordId();
-      if (unimod > -1)
+      if (mod.getUniModRecordId() > -1)
       {
-        bs += ".(UniMod:" + String(unimod) + ")";
+        bs += ".(" + mod.getUniModAccession() + ")";
       }
       else
       {
@@ -133,14 +133,13 @@ namespace OpenMS
     for (Size i = 0; i != seq.size(); ++i)
     {
       const Residue& r = seq[i];
-      const String aa = r.getOneLetterCode() != "" ? r.getOneLetterCode() : "X";
+      const String aa = r.getOneLetterCode();
       if (r.isModified())
       {
         const ResidueModification& mod = *(r.getModification());
-        unimod = mod.getUniModRecordId();
-        if (unimod > -1)
+        if (mod.getUniModRecordId() > -1)
         {
-          bs += aa + "(UniMod:" + String(unimod) + ")";
+          bs += aa + "(" + mod.getUniModAccession() + ")";
         }
         else
         {
@@ -156,10 +155,9 @@ namespace OpenMS
     if (seq.hasCTerminalModification())
     {
       const ResidueModification& mod = *(seq.getCTerminalModification());
-      unimod = mod.getUniModRecordId();
-      if (unimod > -1)
+      if (mod.getUniModRecordId() > -1)
       {
-        bs += ".(UniMod:" + String(unimod) + ")";
+        bs += ".(" + mod.getUniModAccession() + ")";
       }
       else
       {

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -112,14 +112,11 @@ namespace OpenMS
     const AASequence & seq = *this;
 
     String bs;
-    int unimod = -1;
-
     if (seq.empty()) return bs;
 
     if (seq.hasNTerminalModification())
     {
       const ResidueModification& mod = *(seq.getNTerminalModification());
-      unimod = mod.getUniModRecordId();
       if (mod.getUniModRecordId() > -1)
       {
         bs += ".(" + mod.getUniModAccession() + ")";

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -472,6 +472,14 @@ START_SECTION(String toUnmodifiedString() const)
   TEST_STRING_EQUAL(seq3.toUnmodifiedString(), "DFPIANGER")
 END_SECTION
 
+START_SECTION(String toUniModString() const)
+  AASequence s = AASequence::fromString("PEPC(Carbamidomethyl)PEPM(Oxidation)PEPR");
+  TEST_STRING_EQUAL(s.toUniModString(), "PEPC(UniMod:4)PEPM(UniMod:35)PEPR");
+  s.setNTerminalModification("Acetyl (N-term)");
+  s.setCTerminalModification("Amidated (C-term)");
+  TEST_STRING_EQUAL(s.toUniModString(), ".(UniMod:1)PEPC(UniMod:4)PEPM(UniMod:35)PEPR.(UniMod:2)");
+END_SECTION
+
 START_SECTION(String toBracketString(const std::vector<String> & fixed_modifications = std::vector<String>()) const)
   AASequence s = AASequence::fromString("PEPC(Carbamidomethyl)PEPM(Oxidation)PEPR");
   TEST_STRING_EQUAL(s.toBracketString(), "PEPC[160]PEPM[147]PEPR");
@@ -804,6 +812,7 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
   AASequence test6 = AASequence::fromString("PEPTX[1600.230654]IDE");
   TEST_EQUAL(test6.size(), 8)
   TEST_EQUAL(test6.toString(), "PEPTX[1600.230654]IDE")
+  TEST_EQUAL(test6.toUniModString(), "PEPTX[1600.230654]IDE")
   TEST_EQUAL(test6.toBracketString(), "PEPTX[1600]IDE")
   TEST_EQUAL(test6.toBracketString(false), "PEPTX[1600.230654]IDE")
   TEST_EQUAL(test6.toUnmodifiedString(), "PEPTXIDE")
@@ -817,6 +826,7 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
   AASequence test7 = AASequence::fromString(test6.toString());
   TEST_EQUAL(test7.size(), 8)
   TEST_EQUAL(test7.toString(), "PEPTX[1600.230654]IDE")
+  TEST_EQUAL(test7.toUniModString(), "PEPTX[1600.230654]IDE")
   TEST_EQUAL(test7.toBracketString(), "PEPTX[1600]IDE")
   TEST_EQUAL(test7.toBracketString(false), "PEPTX[1600.230654]IDE")
   TEST_EQUAL(test7.toUnmodifiedString(), "PEPTXIDE")
@@ -827,6 +837,7 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
     AASequence test_seq = AASequence::fromString("PEPTN[1600.230654]IDE");
     TEST_EQUAL(test_seq.size(), 8)
     TEST_EQUAL(test_seq.toString(), "PEPTN[1600.230654]IDE")
+    TEST_EQUAL(test_seq.toUniModString(), "PEPTN[1600.230654]IDE")
     TEST_EQUAL(test_seq.toBracketString(false), "PEPTN[1600.230654]IDE")
     TEST_EQUAL(test_seq.toUnmodifiedString(), "PEPTNIDE")
     TEST_REAL_SIMILAR(test_seq.getMonoWeight(), aa_original.getMonoWeight() + 1600.230654)
@@ -835,6 +846,7 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
     AASequence test_other = AASequence::fromString(test_seq.toString());
     TEST_EQUAL(test_other.size(), 8)
     TEST_EQUAL(test_other.toString(), "PEPTN[1600.230654]IDE")
+    TEST_EQUAL(test_other.toUniModString(), "PEPTN[1600.230654]IDE")
     TEST_EQUAL(test_other.toBracketString(false), "PEPTN[1600.230654]IDE")
     TEST_EQUAL(test_other.toUnmodifiedString(), "PEPTNIDE")
 
@@ -844,6 +856,7 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
     test_other = AASequence::fromString(test_seq.toBracketString(false));
     TEST_EQUAL(test_other.size(), 8)
     TEST_EQUAL(test_other.toString(), "PEPTN[1600.230654]IDE")
+    TEST_EQUAL(test_other.toUniModString(), "PEPTN[1600.230654]IDE")
     TEST_EQUAL(test_other.toBracketString(false), "PEPTN[1600.230654]IDE")
     TEST_EQUAL(test_other.toUnmodifiedString(), "PEPTNIDE")
 
@@ -855,12 +868,20 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
     AASequence test_seq = AASequence::fromString("[1600.230654]IDE");
     TEST_EQUAL(test_seq.size(), 3)
     TEST_EQUAL(test_seq.toString(), ".[1600.230654]IDE")
+    TEST_EQUAL(test_seq.toUniModString(), ".[1600.230654]IDE")
     TEST_EQUAL(test_seq.toBracketString(false), "n[1600.230654]IDE")
     TEST_EQUAL(test_seq.toUnmodifiedString(), "IDE")
     TEST_REAL_SIMILAR(test_seq.getMonoWeight(), aa_half.getMonoWeight() + 1600.230654)
 
     // test that we can re-read the string
     AASequence test_other = AASequence::fromString(test_seq.toString());
+    TEST_EQUAL(test_other.size(), 3)
+    TEST_EQUAL(test_other.toString(), ".[1600.230654]IDE")
+
+    TEST_EQUAL(test_seq, test_other) // the peptides should be equal
+
+    // test that we can re-read the string from UniModString
+    test_other = AASequence::fromString(test_seq.toUniModString());
     TEST_EQUAL(test_other.size(), 3)
     TEST_EQUAL(test_other.toString(), ".[1600.230654]IDE")
 
@@ -879,12 +900,20 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
     AASequence test_seq = AASequence::fromString("IDE.[1600.230654]");
     TEST_EQUAL(test_seq.size(), 3)
     TEST_EQUAL(test_seq.toString(), "IDE.[1600.230654]")
+    TEST_EQUAL(test_seq.toUniModString(), "IDE.[1600.230654]")
     TEST_EQUAL(test_seq.toBracketString(false), "IDEc[1600.230654]")
     TEST_EQUAL(test_seq.toUnmodifiedString(), "IDE")
     TEST_REAL_SIMILAR(test_seq.getMonoWeight(), aa_half.getMonoWeight() + 1600.230654)
 
     // test that we can re-read the string
     AASequence test_other = AASequence::fromString(test_seq.toString());
+    TEST_EQUAL(test_other.size(), 3)
+    TEST_EQUAL(test_other.toString(), "IDE.[1600.230654]")
+
+    TEST_EQUAL(test_seq, test_other) // the peptides should be equal
+
+    // test that we can re-read the UniModString
+    test_other = AASequence::fromString(test_seq.toUniModString());
     TEST_EQUAL(test_other.size(), 3)
     TEST_EQUAL(test_other.toString(), "IDE.[1600.230654]")
 
@@ -909,6 +938,7 @@ START_SECTION([EXTRA] Arbitrary tag in peptides using square brackets)
     AASequence test_seq = AASequence::fromString("DFPANGERX[113.0840643509]");
     TEST_EQUAL(test_seq.size(), 9)
     TEST_EQUAL(test_seq.toString(), "DFPANGERX[113.0840643509]")
+    TEST_EQUAL(test_seq.toUniModString(), "DFPANGERX[113.0840643509]")
     TEST_EQUAL(test_seq.toBracketString(true), "DFPANGERX[113]")
     TEST_EQUAL(test_seq.toBracketString(false), "DFPANGERX[113.0840643509]")
     TEST_EQUAL(test_seq.toUnmodifiedString(), "DFPANGERX")

--- a/src/tests/topp/ConvertTraMLToTSV_output.tsv
+++ b/src/tests/topp/ConvertTraMLToTSV_output.tsv
@@ -4,7 +4,7 @@ PrecursorMz	ProductMz	PrecursorCharge	ProductCharge	LibraryIntensity	NormalizedR
 501	618.31	2	2	10000	0.2	PEPTIDECEK	PEPT(UniMod:21)IDEC(UniMod:4)EK	tr_gr2	light				ProteinA	uniprot_nr_1	y	3	y4	1	tr_gr2	tr3	0	1	0	1
 501	628.435	2	2	2000	0.2	PEPTIDECEK	PEPT(UniMod:21)IDEC(UniMod:4)EK	tr_gr2	light				ProteinA	uniprot_nr_1	y	4	y5	1	tr_gr2	tr4	0	1	0	1
 501	651.3	2	3	4300	0.2	PEPTIDECEK	PEPT(UniMod:21)IDEC(UniMod:4)EK	tr_gr2	light				ProteinA	uniprot_nr_1	y	5	y6	1	tr_gr2	tr5	0	1	0	1
-722.685	358.179	3	2	2714	52.2	QVFIGCPASVADQDAFERM	(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERM(UniMod:11)	78	light				ProteinC	uniprot_nr_2	a	6	b3	-1	78	454	0	1	0	1
+722.685	358.179	3	2	2714	52.2	QVFIGCPASVADQDAFERM	.(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERM(UniMod:11)	78	light				ProteinC	uniprot_nr_2	a	6	b3	-1	78	454	0	1	0	1
 510.008269	628.435	2	2	1	0.44	PEPTIDEAR	PEPTIDEAR(UniMod:267)	tr_gr1	heavy				ProteinA	uniprot_nr_1	b	1	y5	1	tr_gr1_heavy	tr1_heavy	0	1	0	1
 510.008269	654.38	2	2	2	0.44	PEPTIDEAR	PEPTIDEAR(UniMod:267)	tr_gr1	heavy				ProteinA	uniprot_nr_1	b	2	y6	1	tr_gr1_heavy	tr2_heavy	0	1	0	1
 509.014199	618.31	2	2	10000	0.2	PEPTIDECEK	PEPT(UniMod:21)IDEC(UniMod:4)EK(UniMod:259)	tr_gr2	silac				ProteinA	uniprot_nr_1	y	3	y4	1	tr_gr2_heavy	tr3_heavy	0	1	0	1

--- a/src/tests/topp/ConvertTraMLToTSV_output.tsv
+++ b/src/tests/topp/ConvertTraMLToTSV_output.tsv
@@ -4,7 +4,7 @@ PrecursorMz	ProductMz	PrecursorCharge	ProductCharge	LibraryIntensity	NormalizedR
 501	618.31	2	2	10000	0.2	PEPTIDECEK	PEPT(UniMod:21)IDEC(UniMod:4)EK	tr_gr2	light				ProteinA	uniprot_nr_1	y	3	y4	1	tr_gr2	tr3	0	1	0	1
 501	628.435	2	2	2000	0.2	PEPTIDECEK	PEPT(UniMod:21)IDEC(UniMod:4)EK	tr_gr2	light				ProteinA	uniprot_nr_1	y	4	y5	1	tr_gr2	tr4	0	1	0	1
 501	651.3	2	3	4300	0.2	PEPTIDECEK	PEPT(UniMod:21)IDEC(UniMod:4)EK	tr_gr2	light				ProteinA	uniprot_nr_1	y	5	y6	1	tr_gr2	tr5	0	1	0	1
-722.685	358.179	3	2	2714	52.2	QVFIGCPASVADQDAFERM	.(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERM(UniMod:11)	78	light				ProteinC	uniprot_nr_2	a	6	b3	-1	78	454	0	1	0	1
+722.685	358.179	3	2	2714	52.2	QVFIGCPASVADQDAFERM	.(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERM.(UniMod:11)	78	light				ProteinC	uniprot_nr_2	a	6	b3	-1	78	454	0	1	0	1
 510.008269	628.435	2	2	1	0.44	PEPTIDEAR	PEPTIDEAR(UniMod:267)	tr_gr1	heavy				ProteinA	uniprot_nr_1	b	1	y5	1	tr_gr1_heavy	tr1_heavy	0	1	0	1
 510.008269	654.38	2	2	2	0.44	PEPTIDEAR	PEPTIDEAR(UniMod:267)	tr_gr1	heavy				ProteinA	uniprot_nr_1	b	2	y6	1	tr_gr1_heavy	tr2_heavy	0	1	0	1
 509.014199	618.31	2	2	10000	0.2	PEPTIDECEK	PEPT(UniMod:21)IDEC(UniMod:4)EK(UniMod:259)	tr_gr2	silac				ProteinA	uniprot_nr_1	y	3	y4	1	tr_gr2_heavy	tr3_heavy	0	1	0	1

--- a/src/tests/topp/TargetedFileConverter_1_output.TraML
+++ b/src/tests/topp/TargetedFileConverter_1_output.TraML
@@ -21,7 +21,7 @@
   <CompoundList>
     <Peptide id="1" sequence="AACLLPK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)LLPK"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)LLPK"/>
       <ProteinRef ref="P02768"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
@@ -34,7 +34,7 @@
     </Peptide>
     <Peptide id="0" sequence="AACLLPKLDELRDEGK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)LLPKLDELRDEGK"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)LLPKLDELRDEGK"/>
       <ProteinRef ref="P02768"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
@@ -47,7 +47,7 @@
     </Peptide>
     <Peptide id="2" sequence="AACAQLNDFLQEYGTQGCQV">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)AQLNDFLQEYGTQGC(Carbamidomethyl)QV"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)AQLNDFLQEYGTQGC(UniMod:4)QV"/>
       <ProteinRef ref="P0C0L5;P0C0L4"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
@@ -63,7 +63,7 @@
     </Peptide>
     <Peptide id="3" sequence="AACICAEEEKEEL">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)IC(Carbamidomethyl)AEEEKEEL"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)IC(UniMod:4)AEEEKEEL"/>
       <ProteinRef ref="Q9BX93"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
@@ -79,7 +79,7 @@
     </Peptide>
     <Peptide id="4" sequence="AACGPSSCYALFPR">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)GPSSC(Carbamidomethyl)YALFPR"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)GPSSC(UniMod:4)YALFPR"/>
       <ProteinRef ref="Q9HCU0"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>

--- a/src/tests/topp/TargetedFileConverter_2_output.TraML
+++ b/src/tests/topp/TargetedFileConverter_2_output.TraML
@@ -21,7 +21,7 @@
   <CompoundList>
     <Peptide id="P02768_AAC(Carbamidomethyl)LLPK_2" sequence="AACLLPK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)LLPK"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)LLPK"/>
       <ProteinRef ref="P02768"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
@@ -34,7 +34,7 @@
     </Peptide>
     <Peptide id="P02768_AAC(Carbamidomethyl)LLPKLDELRDEGK_3" sequence="AACLLPKLDELRDEGK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)LLPKLDELRDEGK"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)LLPKLDELRDEGK"/>
       <ProteinRef ref="P02768"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
@@ -47,7 +47,7 @@
     </Peptide>
     <Peptide id="P0C0L5;P0C0L4_AAC(Carbamidomethyl)AQLNDFLQEYGTQGC(Carbamidomethyl)QV_3" sequence="AACAQLNDFLQEYGTQGCQV">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)AQLNDFLQEYGTQGC(Carbamidomethyl)QV"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)AQLNDFLQEYGTQGC(UniMod:4)QV"/>
       <ProteinRef ref="P0C0L5;P0C0L4"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
@@ -63,7 +63,7 @@
     </Peptide>
     <Peptide id="Q9BX93_AAC(Carbamidomethyl)IC(Carbamidomethyl)AEEEKEEL_2" sequence="AACICAEEEKEEL">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)IC(Carbamidomethyl)AEEEKEEL"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)IC(UniMod:4)AEEEKEEL"/>
       <ProteinRef ref="Q9BX93"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
@@ -79,7 +79,7 @@
     </Peptide>
     <Peptide id="Q9HCU0_AAC(Carbamidomethyl)GPSSC(Carbamidomethyl)YALFPR_2" sequence="AACGPSSCYALFPR">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="AAC(Carbamidomethyl)GPSSC(Carbamidomethyl)YALFPR"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="AAC(UniMod:4)GPSSC(UniMod:4)YALFPR"/>
       <ProteinRef ref="Q9HCU0"/>
       <Modification location="3" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
            <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>


### PR DESCRIPTION
This PR addresses issue https://github.com/OpenMS/OpenMS/issues/3042 reported by @bretttully. TargetedFileConverter now always stores modifications in UniMod format in PQP files, which improves compatibility with TraML.

This is implemented by the new function AASequence::toUniModString(), which works analogously to AASequence::toString(), except that known modifications are reported in UniMod format rather than the internal nomenclature.