### PR TITLE
Fix class documentations

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AScore.h
@@ -193,11 +193,11 @@ namespace OpenMS
     virtual void updateMembers_();
 
     // variables:
-    double fragment_mass_tolerance_; //< Fragment mass tolerance for spectrum comparisons
-    bool fragment_tolerance_ppm_; //< Is fragment mass tolerance given in ppm (or Da)?
-    Size max_peptide_length_; //< Limit for peptide lengths that can be analyzed
-    Size max_permutations_; //< Limit for number of sequence permutations that can be handled
-    double unambiguous_score_; //< Score for unambiguous assignments (all sites phosphorylated)
+    double fragment_mass_tolerance_; ///< Fragment mass tolerance for spectrum comparisons
+    bool fragment_tolerance_ppm_; ///< Is fragment mass tolerance given in ppm (or Da)?
+    Size max_peptide_length_; ///< Limit for peptide lengths that can be analyzed
+    Size max_permutations_; ///< Limit for number of sequence permutations that can be handled
+    double unambiguous_score_; ///< Score for unambiguous assignments (all sites phosphorylated)
     
   };
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
@@ -97,11 +97,11 @@ namespace OpenMS
     AdductInfo();
 
     /// members
-    String name_; //< arbitrary name, only used for error reporting
-    EmpiricalFormula ef_; //< EF for the actual adduct e.g. 'H' in 2M+H;+1
-    double mass_; //< computed from ef_.getMonoWeight(), but stored explicitly for efficiency
-    int charge_;  //< negative or positive charge; must not be 0
-    UInt mol_multiplier_; //< Mol multiplier, e.g. 2 in 2M+H;+1
+    String name_; ///< arbitrary name, only used for error reporting
+    EmpiricalFormula ef_; ///< EF for the actual adduct e.g. 'H' in 2M+H;+1
+    double mass_; ///< computed from ef_.getMonoWeight(), but stored explicitly for efficiency
+    int charge_;  ///< negative or positive charge; must not be 0
+    UInt mol_multiplier_; ///< Mol multiplier, e.g. 2 in 2M+H;+1
   };
 
   class OPENMS_DLLAPI AccurateMassSearchResult
@@ -386,7 +386,7 @@ private:
 
     HMDBPropsMapping hmdb_properties_mapping_;
 
-    bool is_initialized_; //< true if init_() was called without any subsequent param changes
+    bool is_initialized_; ///< true if init_() was called without any subsequent param changes
 
     /// parameter stuff
     double mass_error_value_;

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
@@ -453,7 +453,6 @@ namespace seqan
     // Bfs Traversal
     typedef typename Iterator<TGraph, BfsIterator>::Type TBfsIterator;
     TBfsIterator it(me.data_graph, root);
-    //std::map<int, int> connectivity;
     typedef typename Size<AAcid>::Type TSize;
     TSize idxAAFirst, idxAALast; // range of unambiguous AAcids: AAcid(idx)
     _getSpawnRange('X', idxAAFirst, idxAALast);
@@ -464,12 +463,15 @@ namespace seqan
     }
 
     goNext(it); // skip root
+
+    // connectivity statistics
+    //std::map<int, int> connectivity;
+
     for (; !atEnd(it); goNext(it))
     {
       const typename GetValue<TBfsIterator>::Type itval = *it; // dereferencing *it will give an index into the property array!
 
-      //int edgecount = outDegree(me.data_graph, itval);
-      //++connectivity[edgecount];
+      //++connectivity[outDegree(me.data_graph, itval)];
 
       // set depth of current node using: depths(parent) + 1
       TVert parent = getProperty(parentMap, itval);
@@ -526,10 +528,10 @@ namespace seqan
     //sw.stop();
     //std::cout << OpenMS::String(" Trie build time: ") + sw.getClockTime() + " s (wall), " + sw.getCPUTime() + " s (CPU)).\n\n";
 
-    //for (std::map<int,int>::const_iterator it = connectivity.begin(); it != connectivity.end(); ++it)
-    //{
-    //  std::cout << "   conn: " << it->first << " : " << it->second << "x\n";
-    //}
+    /*for (std::map<int,int>::const_iterator it = connectivity.begin(); it != connectivity.end(); ++it)
+    {
+      std::cout << "   conn: " << it->first << " : " << it->second << "x\n";
+    }*/
 
   }
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AhoCorasickAmbiguous.h
@@ -303,7 +303,7 @@ namespace seqan
     String<KeyWordLengthType> data_node_depth;    // depths of each graph node
 
 #ifndef NDEBUG
-    String<TVert> parentMap;  //< allows to find parent of each node
+    String<TVert> parentMap;  ///< allows to find parent of each node
 #endif
 
     //____________________________________________________________________________
@@ -418,8 +418,8 @@ namespace seqan
     createTrie(me.data_graph, me.data_map_outputNodes, host(me));
 
     // Create parent map
-    String<TVert> parentMap;  //< allows to find parent of each node
-    String<TAlphabet> parentCharMap;      //< allows to find character that led us to current node
+    String<TVert> parentMap;  ///< allows to find parent of each node
+    String<TAlphabet> parentCharMap;      ///< allows to find character that led us to current node
     resizeVertexMap(me.data_graph, parentMap);
     resizeVertexMap(me.data_graph, parentCharMap);
     // init all nodes to Nil
@@ -437,7 +437,7 @@ namespace seqan
     }
     //std::cout << "\nassigned " << count_prop << " props to " << length(parentMap) << " values\n";
 #ifndef NDEBUG    
-    me.parentMap = parentMap;  //< allows to find parent of each node
+    me.parentMap = parentMap;  ///< allows to find parent of each node
 #endif
 
     // Build AC
@@ -997,9 +997,9 @@ namespace OpenMS
     typedef typename FuzzyACPattern::KeyWordLengthType KeyWordLengthType;
 
     // member
-    ::seqan::Finder<seqan::AAString> finder_; //< locate the next peptide hit in protein
-    ::seqan::AAString protein_;               //< the protein sequence - we need to store it since the finder only keeps a pointer to protein when constructed
-    ::seqan::PatternAuxData<PeptideDB> dh_;   //< auxilliary data to hold a state after searching
+    ::seqan::Finder<seqan::AAString> finder_; ///< locate the next peptide hit in protein
+    ::seqan::AAString protein_;               ///< the protein sequence - we need to store it since the finder only keeps a pointer to protein when constructed
+    ::seqan::PatternAuxData<PeptideDB> dh_;   ///< auxilliary data to hold a state after searching
   }; // class FuzzyAC
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/IsobaricQuantifierStatistics.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/IsobaricQuantifierStatistics.h
@@ -58,15 +58,15 @@ namespace OpenMS
      */
     void reset();
 
-    Size channel_count; //< 4plex, 6plex, or 8 plex?!
-    Size iso_number_ms2_negative; //< number of MS2 spectra where one or more channels had negative solution
-    Size iso_number_reporter_negative; //< number of channels where naive solution was negative
-    Size iso_number_reporter_different; //< number of channels >0 where naive solution was different; happens when naive solution is negative in other channels
-    double iso_solution_different_intensity; //< absolute intensity difference between both solutions (for channels > 0)
-    double iso_total_intensity_negative; //< only for spectra where naive solution is negative
-    Size number_ms2_total; //< total number of MS2 spectra
-    Size number_ms2_empty; //< number of empty MS2 (no reporters at all)
-    std::map<String, Size> empty_channels; //< Channel_ID -> Missing; indicating the number of empty channels from all MS2 scans, i.e., numbers are between number_ms2_empty and number_ms2_total
+    Size channel_count; ///< 4plex, 6plex, or 8 plex?!
+    Size iso_number_ms2_negative; ///< number of MS2 spectra where one or more channels had negative solution
+    Size iso_number_reporter_negative; ///< number of channels where naive solution was negative
+    Size iso_number_reporter_different; ///< number of channels >0 where naive solution was different; happens when naive solution is negative in other channels
+    double iso_solution_different_intensity; ///< absolute intensity difference between both solutions (for channels > 0)
+    double iso_total_intensity_negative; ///< only for spectra where naive solution is negative
+    Size number_ms2_total; ///< total number of MS2 spectra
+    Size number_ms2_empty; ///< number of empty MS2 (no reporters at all)
+    std::map<String, Size> empty_channels; ///< Channel_ID -> Missing; indicating the number of empty channels from all MS2 scans, i.e., numbers are between number_ms2_empty and number_ms2_total
 
     /// Copy c'tor
     IsobaricQuantifierStatistics(const IsobaricQuantifierStatistics& other);

--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -75,10 +75,10 @@ namespace OpenMS
   */
   struct Citation
   {
-    std::string authors;    //< list of authors in AMA style, i.e. <surname> <initials>, ...
-    std::string title;      //< title of article
-    std::string when_where; //< suggested format: journal. year; volume, issue: pages
-    std::string doi;        //< plain DOI (no urls), e.g. 10.1021/pr100177k
+    std::string authors;    ///< list of authors in AMA style, i.e. <surname> <initials>, ...
+    std::string title;      ///< title of article
+    std::string when_where; ///< suggested format: journal. year; volume, issue: pages
+    std::string doi;        ///< plain DOI (no urls), e.g. 10.1021/pr100177k
 
                             /// mangle members to string
     std::string toString() const

--- a/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EnzymaticDigestion.h
@@ -64,9 +64,9 @@ public:
     /// when querying for valid digestion products, this determines if the specificity of the two peptide ends is considered important
     enum Specificity
     {
-      SPEC_FULL, //< fully enzyme specific, e.g., tryptic (ends with KR, AA-before is KR), or peptide is at protein terminal ends
-      SPEC_SEMI, //< semi specific, i.e., one of the two cleavage sites must fulfill requirements
-      SPEC_NONE, //< no requirements on start / end
+      SPEC_FULL, ///< fully enzyme specific, e.g., tryptic (ends with KR, AA-before is KR), or peptide is at protein terminal ends
+      SPEC_SEMI, ///< semi specific, i.e., one of the two cleavage sites must fulfill requirements
+      SPEC_NONE, ///< no requirements on start / end
       SIZE_OF_SPECIFICITY
     };
     /// Names of the Specificity

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -180,7 +180,7 @@ public:
     /// sets the unimod record id
     void setUniModRecordId(const Int& id);
 
-    /// sets the unimod record id
+    /// gets the unimod record id
     const Int& getUniModRecordId() const;
 
     /// returns the unimod accession if available

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Adduct.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Adduct.h
@@ -93,13 +93,13 @@ public:
     //}
 
 private:
-    Int charge_; //< usually +1
-    Int amount_; //< number of entities
-    double singleMass_; //< mass of a single entity
-    double log_prob_; //< log probability of observing a single entity of this adduct
-    String formula_; //< chemical formula (parsable by EmpiricalFormula)
-    double rt_shift_; //< RT shift induced by a single entity of this adduct (this is for adducts attached prior to ESI, e.g. labeling)
-    String label_; //< Label for this adduct (can be used to indicate heavy labels)
+    Int charge_; ///< usually +1
+    Int amount_; ///< number of entities
+    double singleMass_; ///< mass of a single entity
+    double log_prob_; ///< log probability of observing a single entity of this adduct
+    String formula_; ///< chemical formula (parsable by EmpiricalFormula)
+    double rt_shift_; ///< RT shift induced by a single entity of this adduct (this is for adducts attached prior to ESI, e.g. labeling)
+    String label_; ///< Label for this adduct (can be used to indicate heavy labels)
 
     String checkFormula_(const String& formula);
 

--- a/src/openms/include/OpenMS/DATASTRUCTURES/CalibrationData.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/CalibrationData.h
@@ -201,9 +201,9 @@ namespace OpenMS
 
 
     private:
-      std::vector<RichPeak2D> data_; //< calibration points
-      bool use_ppm_; //< return ppm values as y-values for the model instead of absolute delta in [Th]
-      std::set<int> groups_; //< peak groups present in this data
+      std::vector<RichPeak2D> data_; ///< calibration points
+      bool use_ppm_; ///< return ppm values as y-values for the model instead of absolute delta in [Th]
+      std::set<int> groups_; ///< peak groups present in this data
     };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Compomer.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Compomer.h
@@ -162,13 +162,13 @@ public:
 
 private:
 
-    CompomerComponents cmp_; //< adducts of left and right side
-    Int net_charge_; //< net charge (right - left)
-    double mass_; //< net mass (right - left)
-    Int pos_charges_; //< net charges on the right
-    Int neg_charges_; //< net charges on the left
-    double log_p_; //< log probability of compomer
-    double rt_shift_; //< expected net RT shift of compomer (-shift_leftside + shift_rightside)
+    CompomerComponents cmp_; ///< adducts of left and right side
+    Int net_charge_; ///< net charge (right - left)
+    double mass_; ///< net mass (right - left)
+    Int pos_charges_; ///< net charges on the right
+    Int neg_charges_; ///< net charges on the left
+    double log_p_; ///< log probability of compomer
+    double rt_shift_; ///< expected net RT shift of compomer (-shift_leftside + shift_rightside)
     Size id_;
 
   }; // \Compomer

--- a/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
@@ -48,8 +48,8 @@
 namespace OpenMS
 {
 
-  struct TFI_File; //< template parameter for file-based FASTA access
-  struct TFI_Vector; //< template parameter for vector-based FASTA access
+  struct TFI_File; ///< template parameter for file-based FASTA access
+  struct TFI_Vector; ///< template parameter for vector-based FASTA access
 
   /**
   @brief This class allows for a chunk-wise single linear read over a (large) FASTA file, 
@@ -58,17 +58,17 @@ namespace OpenMS
   
   Internally uses FASTAFile class to read single sequences.
 
-  FASTAContainer supports two template specializations @em TFI_File and @em TFI_Vector.
+  FASTAContainer supports two template specializations FASTAContainer<TFI_File> and FASTAContainer<TFI_Vector>.
   
-  TFI_File will make FASTA entries available chunk-wise from start to end by loading it from a FASTA file.
+  FASTAContainer<TFI_File> will make FASTA entries available chunk-wise from start to end by loading it from a FASTA file.
   This avoids having to load the full file into memory. While loading, the container will
   memorize the file offsets of each entry, allowing to read an arbitrary i'th entry again from disk.
   If possible, only entries from the currently cached chunk should be queried, otherwise access will be slow.
   
-  TFI_Vector simply takes an existing vector of FASTAEntries and provides the same interface
-  (with a potentially huge speed benefit since it does not need disk access, but at the cost of memory).
+  FASTAContainer<TFI_Vector> simply takes an existing vector of FASTAEntries and provides the same interface
+  (with a potentially huge speed benefit over FASTAContainer<TFI_File> since it does not need disk access, but at the cost of memory).
 
-  If an algorithm searches through a FASTA file linearly, you can use TFI_File to pre-load a small chunk
+  If an algorithm searches through a FASTA file linearly, you can use FASTAContainer<TFI_File> to pre-load a small chunk
   and start working, while loading the next chunk in a background thread and swap it in when the active chunk 
   was processed.
 
@@ -76,6 +76,14 @@ namespace OpenMS
 template<typename TBackend>
 class FASTAContainer; // prototype
 
+/**
+  @brief FASTAContainer<TFI_File> will make FASTA entries available chunk-wise from start to end by loading it from a FASTA file.
+  This avoids having to load the full file into memory. While loading, the container will
+  memorize the file offsets of each entry, allowing to read an arbitrary i'th entry again from disk.
+  If possible, only entries from the currently cached chunk should be queried, otherwise access will be slow.
+
+  Internally uses FASTAFile class to read single sequences.
+*/
 template<>
 class FASTAContainer<TFI_File>
 {
@@ -99,10 +107,12 @@ public:
     return chunk_offset_;
   }
 
-  /// swaps in the background cache of entries, read previously via @p cacheChunk()
-  /// If you call this function without a prior call to @p cacheChunk(), the cache will be empty.
-  /// @return true if cache contains data; false if empty
-  /// @note Should be invoked by a single thread, followed by a barrier to sync access of subsequent chunkAt()
+  /** @brief Swaps in the background cache of entries, read previously via @p cacheChunk()
+      
+      If you call this function without a prior call to @p cacheChunk(), the cache will be empty.
+      @return true if cache contains data; false if empty
+      @note Should be invoked by a single thread, followed by a barrier to sync access of subsequent calls to chunkAt()
+  */
   bool activateCache()
   {
     chunk_offset_ += data_fg_.size();
@@ -111,9 +121,12 @@ public:
     return !data_fg_.empty();
   }
 
-  /// prefetched a new cache in the background, with up to @p suggestedSize entries (or fewer upon reaching EOF)
-  /// Call @p activateCache() afterwards to make the data available via @p chunkAt() or @p readAt().
-  /// @param suggested_size Number of FASTA entries to read from disk
+  /** @brief Prefetch a new cache in the background, with up to @p suggestedSize entries (or fewer upon reaching EOF)
+
+     Call @p activateCache() afterwards to make the data available via @p chunkAt() or @p readAt().
+     @param suggested_size Number of FASTA entries to read from disk
+     @return true if new data is available; false if background data is empty
+  */
   bool cacheChunk(int suggested_size)
   {
     data_bg_.clear();
@@ -135,18 +148,31 @@ public:
     return data_fg_.size();
   }
 
-  /// retrieve a FASTA entry at cache position @p pos (fast)
-  /// @note: can be used by multiple threads at a time (until activateCache() is called)
+  /** @brief Retrieve a FASTA entry at cache position @p pos (fast)
+      
+      Requires prior call to activateCache().
+      Index @p pos must be smaller than chunkSize().
+
+      @note: can be used by multiple threads at a time (until activateCache() is called)
+  */
   const FASTAFile::FASTAEntry& chunkAt(size_t pos) const
   {
     return data_fg_[pos];
   }
 
-  /// retrieve a FASTA entry at global position @pos (must not be behind the currently active chunk)
-  /// This query is fast, if @pos hits the currently active chunk, and slow (read from disk) for
-  /// earlier entries. Can be used before cacheChunk() and activateCache() reached the end of the file,
-  /// since it will reset the file position after its done reading (if reading from disk is required).
-  /// @note: not multi-threading safe (use chunkAt())!
+  /** @brief Retrieve a FASTA entry at global position @pos (must not be behind the currently active chunk, but can be smaller)
+
+    This query is fast, if @pos hits the currently active chunk, and slow (read from disk) for
+    earlier entries. Can be used before reaching the end of the file,
+    since it will reset the file position after its done reading (if reading from disk is required), but
+    must not be used for entries beyond the active chunk (unseen data).
+    
+    @param protein Return value
+    @param pos Absolute entry number in FASTA file
+    @return true if reading was successful; false otherwise (e.g. EOF)
+    @throw Exception::IndexOverflow if @p pos is beyond active chunk
+    @note: not multi-threading safe (use chunkAt())!
+  */
   bool readAt(FASTAFile::FASTAEntry& protein, size_t pos)
   {
     // check if position is currently cached...
@@ -173,30 +199,41 @@ public:
     return f_.atEnd() && offsets_.empty();
   }
 
-  /// NOT the size, but merely the number of already read entries (since we do not know how many are still to come)
-  /// @note Data in the background cache is included here, i.e. access to size()-1 using readAt() might be slow 
-  ///       if activateCache() was not called yet.
+  /** @brief NOT the number of entries in the FASTA file, but merely the number of already read entries (since we do not know how many are still to come)
+
+      @note Data in the background cache is included here, i.e. access to size()-1 using readAt() might be slow 
+            if activateCache() was not called yet.
+  */
   size_t size() const
   {
     return offsets_.size();
   }
 
 private:
-  FASTAFile f_;
-  std::vector<std::streampos> offsets_; /// internal byte offsets into FASTA file for random access reading of previous entries.
-  std::vector<FASTAFile::FASTAEntry> data_fg_; /// active (foreground) data
-  std::vector<FASTAFile::FASTAEntry> data_bg_; /// prefetched (background) data; will become the next active data
-  size_t chunk_offset_; /// number of entries before the current chunk
+  FASTAFile f_; ///< FASTA file connection
+  std::vector<std::streampos> offsets_; ///< internal byte offsets into FASTA file for random access reading of previous entries.
+  std::vector<FASTAFile::FASTAEntry> data_fg_; ///< active (foreground) data
+  std::vector<FASTAFile::FASTAEntry> data_bg_; ///< prefetched (background) data; will become the next active data
+  size_t chunk_offset_; ///< number of entries before the current chunk
 };
 
+/**
+@brief 
+FASTAContainer<TFI_Vector> simply takes an existing vector of FASTAEntries and provides the same interface
+with a potentially huge speed benefit over FASTAContainer<TFI_File> since it does not need disk access, but at the cost of memory.
+
+*/
 template<>
 class FASTAContainer<TFI_Vector>
 {
 public:
   FASTAContainer() = delete;
 
-  /// C'tor for already existing data. An internal reference will be kept
-  /// Make sure the data is not deleted during the lifetime of FASTAContainer
+  /** @brief C'tor for already existing data (by reference). 
+  
+   An internal reference will be kept. Make sure the data is not deleted during the lifetime of FASTAContainer
+
+  */
   FASTAContainer(const std::vector<FASTAFile::FASTAEntry>& data)
     : data_(data)
   {
@@ -208,8 +245,10 @@ public:
     return 0;
   }
 
-  /// no-op (since data is already fully available as vector)
-  /// @return true only on the first call; false on subsequent calls
+  /** @brief no-op (since data is already fully available as vector)
+
+     @return true only on the first call; false on subsequent calls
+  */
   bool activateCache()
   {
     static int count = 0;
@@ -217,8 +256,9 @@ public:
     return (count == 1); // only true on first call.
   }
 
-  /// no-op (since data is already fully available as vector)
-  /// @return true only on the first call; false on subsequent calls
+  /** @brief no-op (since data is already fully available as vector)
+     @return true only on the first call; false on subsequent calls
+  */
   bool cacheChunk(int /*suggested_size*/)
   {
     // NOOP, since we already have all the data...
@@ -227,14 +267,16 @@ public:
     return (count == 1); // only true on first call.
   }
 
-  /// active data spans the full range, i.e. size of container
-  /// @return the size of the underlying vector
+  /** @brief active data spans the full range, i.e. size of container
+      
+      @return the size of the underlying vector
+  */
   size_t chunkSize() const
   {
     return data_.size();
   }
 
-  /// fast access to chunked (here: all) entries
+  /// fast access to chunked (i.e. all) entries
   const FASTAFile::FASTAEntry& chunkAt(size_t pos) const
   {
     return data_[pos];
@@ -260,7 +302,7 @@ public:
   }
 
 private:
-  const std::vector<FASTAFile::FASTAEntry>& data_; //< reference to existing data
+  const std::vector<FASTAFile::FASTAEntry>& data_; ///< reference to existing data
 };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/DATASTRUCTURES/ToolDescription.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/ToolDescription.h
@@ -111,8 +111,8 @@ namespace OpenMS
       String text_finish;
       String category;
       String commandline;
-      String path; //< filename to external tool
-      String working_directory; //< folder where the command will be executed from
+      String path; ///< filename to external tool
+      String working_directory; ///< folder where the command will be executed from
       MappingParam tr_table;
       Param param;
     };

--- a/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
+++ b/src/openms/include/OpenMS/FILTERING/CALIBRATION/InternalCalibration.h
@@ -73,9 +73,9 @@ namespace OpenMS
     /// helper class, describing a lock mass
     struct LockMass
     {
-      double mz; //< m/z of the lock mass (incl. adducts)
-      unsigned int ms_level;   //< MS level where it occurs
-      int charge;     //< charge of the ion (to find isotopes)
+      double mz; ///< m/z of the lock mass (incl. adducts)
+      unsigned int ms_level;   ///< MS level where it occurs
+      int charge;     ///< charge of the ion (to find isotopes)
 
       LockMass(double mz_, int lvl_, int charge_)
         : mz(mz_),

--- a/src/openms/include/OpenMS/FILTERING/CALIBRATION/MZTrafoModel.h
+++ b/src/openms/include/OpenMS/FILTERING/CALIBRATION/MZTrafoModel.h
@@ -68,14 +68,14 @@ namespace OpenMS
   {
   
   private:
-    std::vector<double> coeff_;  //< Model coefficients (for both linear and quadratic models), estimated from the data
-    bool use_ppm_; //< during training, model is build on absolute or relative(ppm) predictions. predict(), i.e. applying the model, requires this information too
-    double rt_; //< retention time associated to the model (i.e. where the calibrant data was taken from)
+    std::vector<double> coeff_;  ///< Model coefficients (for both linear and quadratic models), estimated from the data
+    bool use_ppm_; ///< during training, model is build on absolute or relative(ppm) predictions. predict(), i.e. applying the model, requires this information too
+    double rt_; ///< retention time associated to the model (i.e. where the calibrant data was taken from)
 
-    static Math::RANSACParam* ransac_params_; //< global pointer, init to NULL at startup; set class-global RANSAC params
-    static double limit_offset_; //< acceptable boundary for the estimated offset; if estimated offset is larger (absolute) the model does not validate (isValidModel())
-    static double limit_scale_; //< acceptable boundary for the estimated scale; if estimated scale is larger (absolute) the model does not validate (isValidModel())
-    static double limit_power_; //< acceptable boundary for the estimated power; if estimated power is larger (absolute) the model does not validate (isValidModel())
+    static Math::RANSACParam* ransac_params_; ///< global pointer, init to NULL at startup; set class-global RANSAC params
+    static double limit_offset_; ///< acceptable boundary for the estimated offset; if estimated offset is larger (absolute) the model does not validate (isValidModel())
+    static double limit_scale_; ///< acceptable boundary for the estimated scale; if estimated scale is larger (absolute) the model does not validate (isValidModel())
+    static double limit_power_; ///< acceptable boundary for the estimated power; if estimated power is larger (absolute) the model does not validate (isValidModel())
 
   public:
 
@@ -97,7 +97,7 @@ namespace OpenMS
     MZTrafoModel(bool ppm_model);
 
     enum MODELTYPE { LINEAR, LINEAR_WEIGHTED, QUADRATIC, QUADRATIC_WEIGHTED, SIZE_OF_MODELTYPE };
-    static const std::string names_of_modeltype[]; //< strings corresponding to enum MODELTYPE
+    static const std::string names_of_modeltype[]; ///< strings corresponding to enum MODELTYPE
     /**
       @brief Convert string to enum
 

--- a/src/openms/include/OpenMS/FORMAT/FASTAFile.h
+++ b/src/openms/include/OpenMS/FORMAT/FASTAFile.h
@@ -215,10 +215,10 @@ public:
     void static store(const String& filename, const std::vector<FASTAEntry>& data);
 
 protected:
-    std::fstream infile_;   //< filestream for reading; init using FastaFile::readStart()
-    std::ofstream outfile_; //< filestream for writing; init using FastaFile::writeStart()
-    std::unique_ptr<void, std::function<void(void*) > > reader_; //< filestream for reading; init using FastaFile::readStart(); needs to be a pointer, since its not copy-constructable; we use void* here, to avoid pulling in seqan includes
-    Size entries_read_; //< some internal book-keeping during reading
+    std::fstream infile_;   ///< filestream for reading; init using FastaFile::readStart()
+    std::ofstream outfile_; ///< filestream for writing; init using FastaFile::writeStart()
+    std::unique_ptr<void, std::function<void(void*) > > reader_; ///< filestream for reading; init using FastaFile::readStart(); needs to be a pointer, since its not copy-constructable; we use void* here, to avoid pulling in seqan includes
+    Size entries_read_; ///< some internal book-keeping during reading
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FORMAT/OPTIONS/PeakFileOptions.h
+++ b/src/openms/include/OpenMS/FORMAT/OPTIONS/PeakFileOptions.h
@@ -224,8 +224,8 @@ public:
 
 private:
     bool metadata_only_;
-    bool force_maxquant_compatibility_; //< for mzXML-writing only: set a fixed vendor (Thermo Scientific), mass analyzer (FTMS)
-    bool force_tpp_compatibility_; //< for mzML-writing only: work around some bugs in TPP file parsers
+    bool force_maxquant_compatibility_; ///< for mzXML-writing only: set a fixed vendor (Thermo Scientific), mass analyzer (FTMS)
+    bool force_tpp_compatibility_; ///< for mzML-writing only: work around some bugs in TPP file parsers
     bool write_supplemental_data_;
     bool has_rt_range_;
     bool has_mz_range_;

--- a/src/openms/include/OpenMS/KERNEL/FeatureMap.h
+++ b/src/openms/include/OpenMS/KERNEL/FeatureMap.h
@@ -60,7 +60,7 @@ namespace OpenMS
   /// Each feature contributes one vote (=state)
   struct OPENMS_DLLAPI AnnotationStatistics
   {
-    std::vector<Size> states; //< count each state, indexing by BaseFeature::AnnotationState
+    std::vector<Size> states; ///< count each state, indexing by BaseFeature::AnnotationState
 
     AnnotationStatistics();
 

--- a/src/openms/include/OpenMS/KERNEL/MassTrace.h
+++ b/src/openms/include/OpenMS/KERNEL/MassTrace.h
@@ -65,8 +65,8 @@ public:
 
     // must match to names_of_quantmethod[]
     enum MT_QUANTMETHOD {
-      MT_QUANT_AREA = 0,  //< quantify by area
-      MT_QUANT_MEDIAN,    //< quantify by median of intensities
+      MT_QUANT_AREA = 0,  ///< quantify by area
+      MT_QUANT_MEDIAN,    ///< quantify by median of intensities
       SIZE_OF_MT_QUANTMETHOD
     };
     static const std::string names_of_quantmethod[SIZE_OF_MT_QUANTMETHOD];
@@ -340,9 +340,9 @@ private:
     /// Container for smoothed intensities. Smoothing must be done externally.
     std::vector<double> smoothed_intensities_;
 
-    double fwhm_; //< FWHM of RT peak
-    Size fwhm_start_idx_; //< index into 'trace_peaks_' vector (inclusive)
-    Size fwhm_end_idx_; //< index into 'trace_peaks_' vector (inclusive)
+    double fwhm_; ///< FWHM of RT peak
+    Size fwhm_start_idx_; ///< index into 'trace_peaks_' vector (inclusive)
+    Size fwhm_end_idx_; ///< index into 'trace_peaks_' vector (inclusive)
 
     /// use area under mass trace or the median of intensities
     MT_QUANTMETHOD quant_method_;

--- a/src/openms/include/OpenMS/MATH/MISC/RANSAC.h
+++ b/src/openms/include/OpenMS/MATH/MISC/RANSAC.h
@@ -80,12 +80,12 @@ namespace OpenMS
         return r.str();
       }
 
-      size_t n; //< data points: The minimum number of data points required to fit the model
-      size_t k; //< iterations: The maximum number of iterations allowed in the algorithm 
-      double t; //< Threshold value: for determining when a data point fits a model. Corresponds to the maximal squared deviation in units of the _second_ dimension (dim2).
-      size_t d; //< The number of close data values (according to 't') required to assert that a model fits well to data
-      bool relative_d; //< Should 'd' be interpreted as percentages (0-100) of data input size.
-      int (*rng)(int); //< Optional RNG function (useful for testing with fixed seeds)
+      size_t n; ///< data points: The minimum number of data points required to fit the model
+      size_t k; ///< iterations: The maximum number of iterations allowed in the algorithm 
+      double t; ///< Threshold value: for determining when a data point fits a model. Corresponds to the maximal squared deviation in units of the _second_ dimension (dim2).
+      size_t d; ///< The number of close data values (according to 't') required to assert that a model fits well to data
+      bool relative_d; ///< Should 'd' be interpreted as percentages (0-100) of data input size.
+      int (*rng)(int); ///< Optional RNG function (useful for testing with fixed seeds)
     };
 
     /**

--- a/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
@@ -74,11 +74,11 @@ namespace OpenMS
         technical_replicate(1) 
       {
       }
-      std::string file; //< file name, mandatory
-      unsigned fraction; //< fraction 1..m, mandatory, 1 if not set
-      unsigned technical_replicate; //< technical replicate 1..k of a fraction, 1 if not set
+      std::string file; ///< file name, mandatory
+      unsigned fraction; ///< fraction 1..m, mandatory, 1 if not set
+      unsigned technical_replicate; ///< technical replicate 1..k of a fraction, 1 if not set
     };
-    std::vector<MSRun> runs;  //< run 1..n (index + 1 determines run id of the first column)
+    std::vector<MSRun> runs;  ///< run 1..n (index + 1 determines run id of the first column)
 
     /// return fraction index to MSRuns (e.g., Fraction 1 maps to MSRun 1 and 2 in the example above)
     std::map<unsigned int, std::set<unsigned int> > getFractionToRunsMapping() const;

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/IsotopeWaveletTransform.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/IsotopeWaveletTransform.h
@@ -75,15 +75,15 @@ public:
     /** @brief Internally used data structure. */
     struct BoxElement
     {
-      double mz; //<The monoisotopic position
-      UInt c; //<Note, this is not the charge (it is charge-1!!!)
-      double score; //<The associated score
-      double intens; //<The transformed intensity at the monoisotopic mass
+      double mz; ///<The monoisotopic position
+      UInt c; ///<Note, this is not the charge (it is charge-1!!!)
+      double score; ///<The associated score
+      double intens; ///<The transformed intensity at the monoisotopic mass
       double ref_intens;
-      double RT; //<The elution time (not the scan index)
-      UInt RT_index; //<The elution time (map) index
-      UInt MZ_begin; //<Index
-      UInt MZ_end; //<Index
+      double RT; ///<The elution time (not the scan index)
+      UInt RT_index; ///<The elution time (map) index
+      UInt MZ_begin; ///<Index
+      UInt MZ_end; ///<Index
     };
 
     typedef std::multimap<UInt, BoxElement> Box; ///<Key: RT index, value: BoxElement
@@ -203,8 +203,8 @@ public:
 
 protected:
 
-      const MSSpectrum* reference_; //<The reference spectrum
-      std::vector<float>* trans_intens_; //<The intensities of the transform
+      const MSSpectrum* reference_; ///<The reference spectrum
+      std::vector<float>* trans_intens_; ///<The intensities of the transform
 
     };
 

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerCWT.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerCWT.h
@@ -171,10 +171,10 @@ protected:
     struct OPENMS_DLLAPI PeakArea_
     {
       typedef MSSpectrum::iterator PeakIterator;
-      PeakIterator left;  //< iterator to the leftmost valid point
-      PeakIterator max;   //< iterator to the maximum position
-      PeakIterator right; //< iterator to the rightmost valid point (inclusive)
-      DPosition<1> centroid_position; //< The estimated centroid position in m/z
+      PeakIterator left;  ///< iterator to the leftmost valid point
+      PeakIterator max;   ///< iterator to the maximum position
+      PeakIterator right; ///< iterator to the rightmost valid point (inclusive)
+      DPosition<1> centroid_position; ///< The estimated centroid position in m/z
     };
 
     /// Computes the peak's left and right area

--- a/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
@@ -70,9 +70,9 @@ namespace OpenMS
   */
   struct FeatureDeconvolution::CmpInfo_
   {
-    String s_comp; //< formula as String
-    Size idx_cp; //< index into compomer vector
-    UInt side_cp; //< side of parent compomer (LEFT or RIGHT)
+    String s_comp; ///< formula as String
+    Size idx_cp; ///< index into compomer vector
+    UInt side_cp; ///< side of parent compomer (LEFT or RIGHT)
 
     // C'tor
     CmpInfo_() :

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -70,9 +70,9 @@ namespace OpenMS
   */
   struct MetaboliteFeatureDeconvolution::CmpInfo_
   {
-    String s_comp; //< formula as String
-    Size idx_cp; //< index into compomer vector
-    UInt side_cp; //< side of parent compomer (LEFT or RIGHT)
+    String s_comp; ///< formula as String
+    Size idx_cp; ///< index into compomer vector
+    UInt side_cp; ///< side of parent compomer (LEFT or RIGHT)
 
     // C'tor
     CmpInfo_() :

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
@@ -65,8 +65,8 @@ namespace OpenMS
       signal_not_unique(0)
     {}
 
-    std::vector<double> mz_deltas; //< m/z distance between expected and observed reporter ion closest to expected position
-    int signal_not_unique;  //< counts if more than one peak was found within the search window of each reporter position
+    std::vector<double> mz_deltas; ///< m/z distance between expected and observed reporter ion closest to expected position
+    int signal_not_unique;  ///< counts if more than one peak was found within the search window of each reporter position
   };
 
 

--- a/src/openms/source/ANALYSIS/TARGETED/PSLPFormulation.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/PSLPFormulation.cpp
@@ -595,7 +595,7 @@ namespace OpenMS
           std::cout << "protein " << map_iter->first << " peptide " << p
 
                     << " scan " << curr_rt_index << " weight "
-            //<< curr_rt_weight * map_iter->second[p] * mz_weight
+            ///<< curr_rt_weight * map_iter->second[p] * mz_weight
             // << " = " << curr_rt_weight << " * " << map_iter->second[p]
                     << std::endl;
           //                            << " * "<<mz_weight<<std::endl;
@@ -1175,7 +1175,7 @@ namespace OpenMS
       std::vector<double> entries(stop - start);
       std::vector<Int> indices(stop - start);
 #ifdef DEBUG_OPS
-      std::cout << "feature " << i << " "; //<<features[i].getMZ() <<" "<<features[i].getRT()<<" ";
+      std::cout << "feature " << i << " "; ///<<features[i].getMZ() <<" "<<features[i].getRT()<<" ";
       std::cout << stop - start << "variables in equation\n";
 #endif
       Size c = 0;

--- a/src/openms/source/ANALYSIS/TARGETED/PrecursorIonSelectionPreprocessing.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/PrecursorIonSelectionPreprocessing.cpp
@@ -293,7 +293,7 @@ namespace OpenMS
     std::cout << "Parameters: " << param_.getValue("preprocessed_db_path")
               << "\t" << param_.getValue("precursor_mass_tolerance")
               << " " << param_.getValue("precursor_mass_tolerance_unit")
-      //<< "\t"<<param_.getValue("rt_tolerance")
+      ///<< "\t"<<param_.getValue("rt_tolerance")
               << "\t" << param_.getValue("missed_cleavages")
               << "\t" << param_.getValue("taxonomy")
               << "\t" << param_.getValue("tmp_dir") << "---"

--- a/src/openms/source/FORMAT/OMSSAXMLFile.cpp
+++ b/src/openms/source/FORMAT/OMSSAXMLFile.cpp
@@ -327,14 +327,14 @@ namespace OpenMS
     }
 
     // modifications
-    //<MSHits_mods>
+    ///<MSHits_mods>
     // <MSModHit>
     //  <MSModHit_site>4</MSModHit_site>
     //  <MSModHit_modtype>
     //   <MSMod>2</MSMod>
     //  </MSModHit_modtype>
     // </MSModHit>
-    //</MSHits_mods>
+    ///</MSHits_mods>
 
 
     if (tag_ == "MSHits_mods")

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -1361,7 +1361,7 @@ namespace OpenMS
     }
     else if (element == "enzymatic_search_constraint") // parent: "search_summary"
     {
-      //<enzymatic_search_constraint enzyme="nonspecific" max_num_internal_cleavages="1" min_number_termini="2"/>
+      ///<enzymatic_search_constraint enzyme="nonspecific" max_num_internal_cleavages="1" min_number_termini="2"/>
       enzyme_ = attributeAsString_(attributes, "enzyme");
       if (enzyme_ == "nonspecific") enzyme_ = "unspecific cleavage";
       if (ProteaseDB::getInstance()->hasEnzyme(enzyme_))

--- a/src/openms/source/FORMAT/QcMLFile.cpp
+++ b/src/openms/source/FORMAT/QcMLFile.cpp
@@ -1158,7 +1158,7 @@ namespace OpenMS
                 qp.cvAcc = "QC:0000005";
                 for (std::vector<QualityParameter>::const_iterator qit = rq->second.begin(); qit != rq->second.end(); ++qit)
                 {
-                  //<qualityParameter name="mzML file" ID="OTT0650-S44-A-Leber_1_run_name" cvRef="MS" accession="MS:1000577" value="OTT0650-S44-A-Leber_1"/>
+                  ///<qualityParameter name="mzML file" ID="OTT0650-S44-A-Leber_1_run_name" cvRef="MS" accession="MS:1000577" value="OTT0650-S44-A-Leber_1"/>
                   if (qit->cvAcc == "MS:1000577")
                     qp.value = qit->value;
                 }

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraViewWidget.h
@@ -76,11 +76,11 @@ private:
     /// cache to store mapping of chromatogram precursors to chromatogram indices
     std::map<size_t, std::map<Precursor, std::vector<Size>, Precursor::MZLess> > map_precursor_to_chrom_idx_cache_;
 private slots:
-    void spectrumSearchText_(); //< searches for rows containing a search text (from spectra_search_box_); called when text search box is used
+    void spectrumSearchText_(); ///< searches for rows containing a search text (from spectra_search_box_); called when text search box is used
     void spectrumBrowserHeaderContextMenu_(const QPoint &);
     void spectrumSelectionChange_(QTreeWidgetItem *, QTreeWidgetItem *);
-    void searchAndShow_(); //< searches using text box and plots the spectrum
-    void spectrumDoubleClicked_(QTreeWidgetItem *); //< called upon double click; emits spectrumDoubleClicked() after some checking (opens a new Tab)
+    void searchAndShow_(); ///< searches using text box and plots the spectrum
+    void spectrumDoubleClicked_(QTreeWidgetItem *); ///< called upon double click; emits spectrumDoubleClicked() after some checking (opens a new Tab)
     void spectrumContextMenu_(const QPoint &);
   };
 }

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
@@ -88,8 +88,8 @@ public:
     ///Enumerate all available paint styles
     enum DrawModes
     {
-      DM_PEAKS,                                 //< draw data as peak
-      DM_CONNECTEDLINES                 //< draw as connected lines
+      DM_PEAKS,                                 ///< draw data as peak
+      DM_CONNECTEDLINES                 ///< draw as connected lines
     };
 
     /// Returns the draw mode of the current layer

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum2DCanvas.h
@@ -389,9 +389,9 @@ protected:
     /// stores the linear color gradient for non-log modes
     MultiGradient linear_gradient_;
     
-    double pen_size_min_; //< minimum number of pixels for one data point
-    double pen_size_max_; //< maximum number of pixels for one data point
-    double canvas_coverage_min_; //< minimum coverage of the canvas required; if lower, points are upscaled in size
+    double pen_size_min_; ///< minimum number of pixels for one data point
+    double pen_size_max_; ///< maximum number of pixels for one data point
+    double canvas_coverage_min_; ///< minimum coverage of the canvas required; if lower, points are upscaled in size
 
   private:
     /// Default C'tor hidden

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASOutputFileListVertex.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASOutputFileListVertex.h
@@ -107,10 +107,10 @@ protected:
     // custom output folder name
     QString output_folder_name_;
 
-    static bool copy_(const QString & from, const QString & to); //< STATIC(!) function which calls QFile::copy(); needs to be static, since we need to pass a function pointer (which does not work on member functions)
+    static bool copy_(const QString & from, const QString & to); ///< STATIC(!) function which calls QFile::copy(); needs to be static, since we need to pass a function pointer (which does not work on member functions)
     // convenience members, not required for operation, but for progress during copying
-    int files_written_;       //< files that were already written
-    int files_total_;     //< total number of files from upstream
+    int files_written_;       ///< files that were already written
+    int files_total_;     ///< total number of files from upstream
   };
 }
 

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASScene.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASScene.h
@@ -123,10 +123,10 @@ public:
     /// Pipeline status after refreshParameters() was called
     enum RefreshStatus
     {
-      ST_REFRESH_NOCHANGE,        //< no updates required
-      ST_REFRESH_CHANGED,         //< some parameters were updated, but pipeline is ok
-      ST_REFRESH_CHANGEINVALID,   //< updating made pipeline invalid
-      ST_REFRESH_REMAINSINVALID   //< pipeline was not valid before and is invalid afterwards
+      ST_REFRESH_NOCHANGE,        ///< no updates required
+      ST_REFRESH_CHANGED,         ///< some parameters were updated, but pipeline is ok
+      ST_REFRESH_CHANGEINVALID,   ///< updating made pipeline invalid
+      ST_REFRESH_REMAINSINVALID   ///< pipeline was not valid before and is invalid afterwards
     };
 
 

--- a/src/openms_gui/include/OpenMS/VISUAL/TOPPASVertex.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/TOPPASVertex.h
@@ -143,7 +143,7 @@ public:
 		@throw Exception::FileNotWritable() if too long (>=255 chars)
 		*/
 		void check_(const QString& filename);
-		QStringList filenames_;   //< filenames passed from upstream node in this round
+		QStringList filenames_;   ///< filenames passed from upstream node in this round
 	};
 	/// Info for one edge and round, to be passed to next node
     struct VertexRoundPackage
@@ -154,8 +154,8 @@ public:
       {
       }
 
-	  TOPPASFilenames filenames; //< filenames passed from upstream node in this round
-      TOPPASEdge* edge;  //< edge that connects the upstream node to the current one
+	  TOPPASFilenames filenames; ///< filenames passed from upstream node in this round
+      TOPPASEdge* edge;  ///< edge that connects the upstream node to the current one
     };
 
 	

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/IDEvaluatorGUI.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/IDEvaluatorGUI.cpp
@@ -94,7 +94,7 @@ public:
   }
 
 protected:
-  StringList out_formats_; //< valid output formats for image
+  StringList out_formats_; ///< valid output formats for image
 
   void registerOptionsAndFlags_()
   {

--- a/src/tests/class_tests/openms_gui/source/GUI/TOPPView_test.cpp
+++ b/src/tests/class_tests/openms_gui/source/GUI/TOPPView_test.cpp
@@ -81,9 +81,9 @@ class TestTOPPView: public QObject
 			delay(p_delay)
 		{}
 
-		QString keys; //< key sequence
+		QString keys; ///< key sequence
 		QString title;//< expected window title
-		int delay;    //< delay in ms when event is fired off
+		int delay;    ///< delay in ms when event is fired off
 	};
 
 public slots:

--- a/src/utils/IDEvaluator.cpp
+++ b/src/utils/IDEvaluator.cpp
@@ -97,7 +97,7 @@ public:
   }
 
 protected:
-  StringList out_formats_; //< valid output formats for image
+  StringList out_formats_; ///< valid output formats for image
 
   Param getSubsectionDefaults_(const String& /*section*/) const
   {

--- a/src/utils/ImageCreator.cpp
+++ b/src/utils/ImageCreator.cpp
@@ -87,7 +87,7 @@ public:
   }
 
 protected:
-  StringList out_formats_; //< valid output formats for image
+  StringList out_formats_; ///< valid output formats for image
 
   void addPoint_(int x, int y, QImage & image, QColor color = Qt::black,
                  Size size = 2)


### PR DESCRIPTION
some classes used `//<` to annotate members in a single line (which does not work with Doxygen).
Fixed using `///<`.

[DOC] fix wrong/missing docs (doxygen formatting mostly) 
[DOC] more fixes using ' git grep -l " //<" | xargs sed -i 's/ \/\/</ \/\/\/</g' '