### PR TITLE
[FEATURE] PosBegin() and PosEnd() for MSChromatogram and MSSpectrum

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -339,6 +339,86 @@ public:
     ConstIterator RTEnd(ConstIterator begin, CoordinateType rt, ConstIterator end) const;
 
     /**
+      @brief Binary search for peak range begin
+
+      Alias for RTBegin()
+
+      @note Make sure the chromatogram is sorted with respect to retention time! Otherwise the
+      result is undefined.
+    */
+    Iterator PosBegin(CoordinateType rt);
+
+    /**
+      @brief Binary search for peak range begin
+
+      Alias for RTBegin()
+
+      @note Make sure the chromatogram is sorted with respect to RT! Otherwise the result is
+      undefined.
+    */
+    Iterator PosBegin(Iterator begin, CoordinateType rt, Iterator end);
+
+    /**
+      @brief Binary search for peak range begin
+
+      Alias for RTBegin()
+
+      @note Make sure the chromatogram is sorted with respect to RT! Otherwise the result is
+      undefined.
+    */
+    ConstIterator PosBegin(CoordinateType rt) const;
+
+    /**
+      @brief Binary search for peak range begin
+
+      Alias for RTBegin()
+
+      @note Make sure the chromatogram is sorted with respect to RT! Otherwise the result is
+      undefined.
+    */
+    ConstIterator PosBegin(ConstIterator begin, CoordinateType rt, ConstIterator end) const;
+
+    /**
+      @brief Binary search for peak range end (returns the past-the-end iterator)
+
+      Alias for RTEnd()
+
+      @note Make sure the chromatogram is sorted with respect to RT. Otherwise the result is
+      undefined.
+    */
+    Iterator PosEnd(CoordinateType rt);
+
+    /**
+      @brief Binary search for peak range end (returns the past-the-end iterator)
+
+      Alias for RTEnd()
+
+      @note Make sure the chromatogram is sorted with respect to RT. Otherwise the result is
+      undefined.
+    */
+    Iterator PosEnd(Iterator begin, CoordinateType rt, Iterator end);
+
+    /**
+      @brief Binary search for peak range end (returns the past-the-end iterator)
+
+      Alias for RTEnd()
+
+      @note Make sure the chromatogram is sorted with respect to RT. Otherwise the result is
+      undefined.
+    */
+    ConstIterator PosEnd(CoordinateType rt) const;
+
+    /**
+      @brief Binary search for peak range end (returns the past-the-end iterator)
+
+      Alias for RTEnd()
+
+      @note Make sure the chromatogram is sorted with respect to RT. Otherwise the result is
+      undefined.
+    */
+    ConstIterator PosEnd(ConstIterator begin, CoordinateType rt, ConstIterator end) const;
+
+    /**
       @brief Clears all data and meta data
 
       @param clear_meta_data If @em true, all meta data is cleared in addition to the data.

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -413,6 +413,78 @@ public:
     */
     ConstIterator MZEnd(ConstIterator begin, CoordinateType mz, ConstIterator end) const;
 
+    /**
+      @brief Binary search for peak range begin
+
+      Alias for MZBegin()
+
+      @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
+    */
+    Iterator PosBegin(CoordinateType mz);
+
+    /**
+      @brief Binary search for peak range begin
+
+      Alias for MZBegin()
+
+      @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
+    */
+    Iterator PosBegin(Iterator begin, CoordinateType mz, Iterator end);
+
+    /**
+      @brief Binary search for peak range begin
+
+      Alias for MZBegin()
+
+      @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
+    */
+    ConstIterator PosBegin(CoordinateType mz) const;
+
+    /**
+      @brief Binary search for peak range begin
+
+      Alias for MZBegin()
+
+      @note Make sure the spectrum is sorted with respect to m/z! Otherwise the result is undefined.
+    */
+    ConstIterator PosBegin(ConstIterator begin, CoordinateType mz, ConstIterator end) const;
+
+    /**
+      @brief Binary search for peak range end (returns the past-the-end iterator)
+
+      Alias for MZEnd()
+
+      @note Make sure the spectrum is sorted with respect to m/z. Otherwise the result is undefined.
+    */
+    Iterator PosEnd(CoordinateType mz);
+
+    /**
+      @brief Binary search for peak range end (returns the past-the-end iterator)
+
+      Alias for MZEnd()
+
+      @note Make sure the spectrum is sorted with respect to m/z. Otherwise the result is undefined.
+    */
+    Iterator PosEnd(Iterator begin, CoordinateType mz, Iterator end);
+
+    /**
+      @brief Binary search for peak range end (returns the past-the-end iterator)
+
+      Alias for MZEnd()
+
+      @note Make sure the spectrum is sorted with respect to m/z. Otherwise the result is undefined.
+    */
+    ConstIterator PosEnd(CoordinateType mz) const;
+
+    /**
+      @brief Binary search for peak range end (returns the past-the-end iterator)
+
+      Alias for MZEnd()
+
+      @note Make sure the spectrum is sorted with respect to m/z. Otherwise the result is undefined.
+    */
+    ConstIterator PosEnd(ConstIterator begin, CoordinateType mz, ConstIterator end) const;
+
     //@}
 
 

--- a/src/openms/source/KERNEL/MSChromatogram.cpp
+++ b/src/openms/source/KERNEL/MSChromatogram.cpp
@@ -355,6 +355,50 @@ MSChromatogram::RTEnd(MSChromatogram::ConstIterator begin, MSChromatogram::Coord
   return upper_bound(begin, end, p, PeakType::PositionLess());
 }
 
+MSChromatogram::Iterator MSChromatogram::PosBegin(MSChromatogram::CoordinateType rt)
+{
+  return RTBegin(rt);
+}
+
+MSChromatogram::Iterator
+MSChromatogram::PosBegin(MSChromatogram::Iterator begin, MSChromatogram::CoordinateType rt, MSChromatogram::Iterator end)
+{
+  return RTBegin(begin, rt, end);
+}
+
+MSChromatogram::Iterator MSChromatogram::PosEnd(MSChromatogram::CoordinateType rt)
+{
+  return RTEnd(rt);
+}
+
+MSChromatogram::Iterator
+MSChromatogram::PosEnd(MSChromatogram::Iterator begin, MSChromatogram::CoordinateType rt, MSChromatogram::Iterator end)
+{
+  return RTEnd(begin, rt, end);
+}
+
+MSChromatogram::ConstIterator MSChromatogram::PosBegin(MSChromatogram::CoordinateType rt) const
+{
+  return RTBegin(rt);
+}
+
+MSChromatogram::ConstIterator
+MSChromatogram::PosBegin(MSChromatogram::ConstIterator begin, MSChromatogram::CoordinateType rt, MSChromatogram::ConstIterator end) const
+{
+  return RTBegin(begin, rt, end);
+}
+
+MSChromatogram::ConstIterator MSChromatogram::PosEnd(MSChromatogram::CoordinateType rt) const
+{
+  return RTEnd(rt);
+}
+
+MSChromatogram::ConstIterator
+MSChromatogram::PosEnd(MSChromatogram::ConstIterator begin, MSChromatogram::CoordinateType rt, MSChromatogram::ConstIterator end) const
+{
+  return RTEnd(begin, rt, end);
+}
+
 MSChromatogram::ConstIterator MSChromatogram::MZEnd(MSChromatogram::CoordinateType rt) const {return RTEnd(rt);}
 
 void MSChromatogram::clear(bool clear_meta_data)

--- a/src/openms/source/KERNEL/MSSpectrum.cpp
+++ b/src/openms/source/KERNEL/MSSpectrum.cpp
@@ -503,6 +503,50 @@ namespace OpenMS
     return lower_bound(ContainerType::begin(), ContainerType::end(), p, PeakType::PositionLess());
   }
 
+  MSSpectrum::Iterator MSSpectrum::PosBegin(MSSpectrum::CoordinateType mz)
+  {
+    return MZBegin(mz);
+  }
+
+  MSSpectrum::Iterator
+  MSSpectrum::PosBegin(MSSpectrum::Iterator begin, MSSpectrum::CoordinateType mz, MSSpectrum::Iterator end)
+  {
+    return MZBegin(begin, mz, end);
+  }
+
+  MSSpectrum::Iterator MSSpectrum::PosEnd(MSSpectrum::CoordinateType mz)
+  {
+    return MZEnd(mz);
+  }
+
+  MSSpectrum::Iterator
+  MSSpectrum::PosEnd(MSSpectrum::Iterator begin, MSSpectrum::CoordinateType mz, MSSpectrum::Iterator end)
+  {
+    return MZEnd(begin, mz, end);
+  }
+
+  MSSpectrum::ConstIterator MSSpectrum::PosBegin(MSSpectrum::CoordinateType mz) const
+  {
+    return MZBegin(mz);
+  }
+
+  MSSpectrum::ConstIterator
+  MSSpectrum::PosBegin(MSSpectrum::ConstIterator begin, MSSpectrum::CoordinateType mz, MSSpectrum::ConstIterator end) const
+  {
+    return MZBegin(begin, mz, end);
+  }
+
+  MSSpectrum::ConstIterator MSSpectrum::PosEnd(MSSpectrum::CoordinateType mz) const
+  {
+    return MZEnd(mz);
+  }
+
+  MSSpectrum::ConstIterator
+  MSSpectrum::PosEnd(MSSpectrum::ConstIterator begin, MSSpectrum::CoordinateType mz, MSSpectrum::ConstIterator end) const
+  {
+    return MZEnd(begin, mz, end);
+  }
+
   bool MSSpectrum::RTLess::operator()(const MSSpectrum &a, const MSSpectrum &b) const {
     return a.getRT() < b.getRT();
   }

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -478,11 +478,11 @@ START_SECTION((Iterator RTEnd(CoordinateType rt)))
 
   MSChromatogram::Iterator it;
 
-  it = tmp.RTBegin(4.5);
+  it = tmp.RTEnd(4.5);
   TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.RTBegin(5.0);
-  TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.RTBegin(5.5);
+  it = tmp.RTEnd(5.0);
+  TEST_EQUAL(it->getPosition()[0],6.0)
+  it = tmp.RTEnd(5.5);
   TEST_EQUAL(it->getPosition()[0],6.0)
 }
 END_SECTION
@@ -508,11 +508,11 @@ START_SECTION((Iterator RTEnd(Iterator begin, CoordinateType rt, Iterator end)))
 
   MSChromatogram::Iterator it;
 
-  it = tmp.RTBegin(tmp.begin(), 4.5, tmp.end());
-  TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.RTBegin(tmp.begin(), 4.5, tmp.end());
-  TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.RTBegin(tmp.begin(), 4.5, tmp.begin());
+  it = tmp.RTEnd(tmp.begin(), 3.5, tmp.end());
+  TEST_EQUAL(it->getPosition()[0],4.0)
+  it = tmp.RTEnd(tmp.begin(), 5.0, tmp.end());
+  TEST_EQUAL(it->getPosition()[0],6.0)
+  it = tmp.RTEnd(tmp.begin(), 4.5, tmp.begin());
   TEST_EQUAL(it->getPosition()[0],tmp.begin()->getPosition()[0])
 }
 END_SECTION
@@ -538,11 +538,11 @@ START_SECTION((ConstIterator RTBegin(CoordinateType rt) const ))
 
   MSChromatogram::ConstIterator it;
 
-  it = tmp.RTEnd(4.5);
+  it = tmp.RTBegin(4.5);
   TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.RTEnd(5.0);
-  TEST_EQUAL(it->getPosition()[0],6.0)
-  it = tmp.RTEnd(5.5);
+  it = tmp.RTBegin(5.0);
+  TEST_EQUAL(it->getPosition()[0],5.0)
+  it = tmp.RTBegin(5.5);
   TEST_EQUAL(it->getPosition()[0],6.0)
 
 }
@@ -599,11 +599,11 @@ START_SECTION((ConstIterator RTEnd(CoordinateType rt) const ))
 
   MSChromatogram::ConstIterator it;
 
-  it = tmp.RTBegin(4.5);
+  it = tmp.RTEnd(4.5);
   TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.RTBegin(5.0);
-  TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.RTBegin(5.5);
+  it = tmp.RTEnd(5.0);
+  TEST_EQUAL(it->getPosition()[0],6.0)
+  it = tmp.RTEnd(5.5);
   TEST_EQUAL(it->getPosition()[0],6.0)
 
 }

--- a/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
+++ b/src/tests/class_tests/openms/source/MSChromatogram_test.cpp
@@ -639,6 +639,119 @@ START_SECTION((ConstIterator RTEnd(ConstIterator begin, CoordinateType rt, Const
 }
 END_SECTION
 
+MSChromatogram tmp;
+vector<double> position = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0};
+for (Size i=0; i<position.size(); ++i)
+{
+  ChromatogramPeak cp;
+  cp.setPos(position[i]);
+  tmp.push_back(cp);
+}
+
+START_SECTION((Iterator PosBegin(CoordinateType rt)))
+{
+  MSChromatogram::Iterator it;
+  it = tmp.PosBegin(4.5);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(5.0);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(5.5);
+  TEST_EQUAL(it->getPos(), 6.0)
+}
+END_SECTION
+
+START_SECTION((Iterator PosBegin(Iterator begin, CoordinateType rt, Iterator end)))
+{
+  MSChromatogram::Iterator it;
+  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(tmp.begin(), 5.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 6.0)
+  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.begin());
+  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
+  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
+  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
+}
+END_SECTION
+
+START_SECTION((ConstIterator PosBegin(CoordinateType rt) const ))
+{
+  MSChromatogram::ConstIterator it;
+  it = tmp.PosBegin(4.5);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(5.0);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(5.5);
+  TEST_EQUAL(it->getPos(), 6.0)
+}
+END_SECTION
+
+START_SECTION((ConstIterator PosBegin(ConstIterator begin, CoordinateType rt, ConstIterator end) const ))
+{
+  MSChromatogram::ConstIterator it;
+  it = tmp.PosBegin(tmp.begin(), 3.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 4.0)
+  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.begin());
+  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
+  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
+  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
+}
+END_SECTION
+
+START_SECTION((Iterator PosEnd(CoordinateType rt)))
+{
+  MSChromatogram::Iterator it;
+  it = tmp.PosEnd(4.5);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosEnd(5.0);
+  TEST_EQUAL(it->getPos(), 6.0)
+  it = tmp.PosEnd(5.5);
+  TEST_EQUAL(it->getPos(), 6.0)
+}
+END_SECTION
+
+START_SECTION((Iterator PosEnd(Iterator begin, CoordinateType rt, Iterator end)))
+{
+  MSChromatogram::Iterator it;
+  it = tmp.PosEnd(tmp.begin(), 3.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 4.0)
+  it = tmp.PosEnd(tmp.begin(), 4.0, tmp.end());
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosEnd(tmp.begin(), 4.5, tmp.begin());
+  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
+  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
+  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
+}
+END_SECTION
+
+START_SECTION((ConstIterator PosEnd(CoordinateType rt) const ))
+{
+  MSChromatogram::ConstIterator it;
+  it = tmp.PosEnd(4.5);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosEnd(5.0);
+  TEST_EQUAL(it->getPos(), 6.0)
+  it = tmp.PosEnd(5.5);
+  TEST_EQUAL(it->getPos(), 6.0)
+}
+END_SECTION
+
+START_SECTION((ConstIterator PosEnd(ConstIterator begin, CoordinateType rt, ConstIterator end) const ))
+{
+  MSChromatogram::ConstIterator it;
+  it = tmp.PosEnd(tmp.begin(), 4.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosEnd(tmp.begin(), 5.0, tmp.end());
+  TEST_EQUAL(it->getPos(), 6.0)
+  it = tmp.PosEnd(tmp.begin(), 4.5, tmp.begin());
+  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
+  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
+  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
+}
+END_SECTION
+
 START_SECTION((MSChromatogram(const MSChromatogram &source)))
 {
   MSChromatogram tmp;

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -682,11 +682,11 @@ START_SECTION((Iterator MZEnd(CoordinateType mz)))
 
   MSSpectrum::Iterator it;
 
-  it = tmp.MZBegin(4.5);
+  it = tmp.MZEnd(4.5);
   TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.MZBegin(5.0);
-  TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.MZBegin(5.5);
+  it = tmp.MZEnd(5.0);
+  TEST_EQUAL(it->getPosition()[0],6.0)
+  it = tmp.MZEnd(5.5);
   TEST_EQUAL(it->getPosition()[0],6.0)
 END_SECTION
 
@@ -710,11 +710,11 @@ START_SECTION((Iterator MZBegin(CoordinateType mz)))
 
   MSSpectrum::Iterator it;
 
-  it = tmp.MZEnd(4.5);
+  it = tmp.MZBegin(4.5);
   TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.MZEnd(5.0);
-  TEST_EQUAL(it->getPosition()[0],6.0)
-  it = tmp.MZEnd(5.5);
+  it = tmp.MZBegin(5.0);
+  TEST_EQUAL(it->getPosition()[0],5.0)
+  it = tmp.MZBegin(5.5);
   TEST_EQUAL(it->getPosition()[0],6.0)
 END_SECTION
 
@@ -850,11 +850,11 @@ START_SECTION((ConstIterator MZEnd(CoordinateType mz) const))
 
   MSSpectrum::ConstIterator it;
 
-  it = tmp.MZBegin(4.5);
+  it = tmp.MZEnd(4.5);
   TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.MZBegin(5.0);
-  TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.MZBegin(5.5);
+  it = tmp.MZEnd(5.0);
+  TEST_EQUAL(it->getPosition()[0],6.0)
+  it = tmp.MZEnd(5.5);
   TEST_EQUAL(it->getPosition()[0],6.0)
 END_SECTION
 
@@ -878,11 +878,11 @@ START_SECTION((ConstIterator MZBegin(CoordinateType mz) const))
 
   MSSpectrum::ConstIterator it;
 
-  it = tmp.MZEnd(4.5);
+  it = tmp.MZBegin(4.5);
   TEST_EQUAL(it->getPosition()[0],5.0)
-  it = tmp.MZEnd(5.0);
-  TEST_EQUAL(it->getPosition()[0],6.0)
-  it = tmp.MZEnd(5.5);
+  it = tmp.MZBegin(5.0);
+  TEST_EQUAL(it->getPosition()[0],5.0)
+  it = tmp.MZBegin(5.5);
   TEST_EQUAL(it->getPosition()[0],6.0)
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -886,6 +886,117 @@ START_SECTION((ConstIterator MZBegin(CoordinateType mz) const))
   TEST_EQUAL(it->getPosition()[0],6.0)
 END_SECTION
 
+MSSpectrum tmp;
+vector<double> position = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0};
+for (Size i=0; i<position.size(); ++i)
+{
+  tmp.push_back(Peak1D(position[i], 0.0));
+}
+
+START_SECTION((Iterator PosBegin(CoordinateType mz)))
+{
+  MSSpectrum::Iterator it;
+  it = tmp.PosBegin(4.5);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(5.0);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(5.5);
+  TEST_EQUAL(it->getPos(), 6.0)
+}
+END_SECTION
+
+START_SECTION((Iterator PosBegin(Iterator begin, CoordinateType mz, Iterator end)))
+{
+  MSSpectrum::Iterator it;
+  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(tmp.begin(), 5.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 6.0)
+  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.begin());
+  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
+  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
+  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
+}
+END_SECTION
+
+START_SECTION((ConstIterator PosBegin(CoordinateType mz) const ))
+{
+  MSSpectrum::ConstIterator it;
+  it = tmp.PosBegin(4.5);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(5.0);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(5.5);
+  TEST_EQUAL(it->getPos(), 6.0)
+}
+END_SECTION
+
+START_SECTION((ConstIterator PosBegin(ConstIterator begin, CoordinateType mz, ConstIterator end) const ))
+{
+  MSSpectrum::ConstIterator it;
+  it = tmp.PosBegin(tmp.begin(), 3.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 4.0)
+  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosBegin(tmp.begin(), 4.5, tmp.begin());
+  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
+  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
+  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
+}
+END_SECTION
+
+START_SECTION((Iterator PosEnd(CoordinateType mz)))
+{
+  MSSpectrum::Iterator it;
+  it = tmp.PosEnd(4.5);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosEnd(5.0);
+  TEST_EQUAL(it->getPos(), 6.0)
+  it = tmp.PosEnd(5.5);
+  TEST_EQUAL(it->getPos(), 6.0)
+}
+END_SECTION
+
+START_SECTION((Iterator PosEnd(Iterator begin, CoordinateType mz, Iterator end)))
+{
+  MSSpectrum::Iterator it;
+  it = tmp.PosEnd(tmp.begin(), 3.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 4.0)
+  it = tmp.PosEnd(tmp.begin(), 4.0, tmp.end());
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosEnd(tmp.begin(), 4.5, tmp.begin());
+  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
+  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
+  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
+}
+END_SECTION
+
+START_SECTION((ConstIterator PosEnd(CoordinateType mz) const ))
+{
+  MSSpectrum::ConstIterator it;
+  it = tmp.PosEnd(4.5);
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosEnd(5.0);
+  TEST_EQUAL(it->getPos(), 6.0)
+  it = tmp.PosEnd(5.5);
+  TEST_EQUAL(it->getPos(), 6.0)
+}
+END_SECTION
+
+START_SECTION((ConstIterator PosEnd(ConstIterator begin, CoordinateType mz, ConstIterator end) const ))
+{
+  MSSpectrum::ConstIterator it;
+  it = tmp.PosEnd(tmp.begin(), 4.5, tmp.end());
+  TEST_EQUAL(it->getPos(), 5.0)
+  it = tmp.PosEnd(tmp.begin(), 5.0, tmp.end());
+  TEST_EQUAL(it->getPos(), 6.0)
+  it = tmp.PosEnd(tmp.begin(), 4.5, tmp.begin());
+  TEST_EQUAL(it->getPos(), tmp.begin()->getPos())
+  it = tmp.PosBegin(tmp.begin(), 8.0, tmp.end());
+  TEST_EQUAL((it-1)->getPos(), (tmp.end()-1)->getPos())
+}
+END_SECTION
+
 START_SECTION((Size findNearest(CoordinateType mz) const))
   MSSpectrum tmp;
   Peak1D p;


### PR DESCRIPTION
@timosachsenberg 
As discussed, I implemented methods `PosBegin()` and `PosEnd()`.
These are basically aliases for `RTBegin()` and `RTEnd()` (in `MSChromatogram`) and for `MZBegin()` and `MZEnd()` (in `MSSpectrum`).

This way it should be easier to build algorithms that use range methods and support both container classes.