### PR TITLE
[FEATURE] Add ChromatogramPeak constructor with position and intensity args

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/ChromatogramPeak.h
+++ b/src/openms/include/OpenMS/KERNEL/ChromatogramPeak.h
@@ -85,6 +85,12 @@ public:
       intensity_(p.intensity_)
     {}
 
+    /// Constructor with position and intensity
+    inline ChromatogramPeak(const PositionType position, const IntensityType intensity) :
+      position_(position),
+      intensity_(intensity)
+    {}
+
     /**
       @brief Destructor
 

--- a/src/openms/include/OpenMS/KERNEL/ChromatogramPeak.h
+++ b/src/openms/include/OpenMS/KERNEL/ChromatogramPeak.h
@@ -86,8 +86,8 @@ public:
     {}
 
     /// Constructor with position and intensity
-    inline ChromatogramPeak(const PositionType position, const IntensityType intensity) :
-      position_(position),
+    inline ChromatogramPeak(const PositionType retention_time, const IntensityType intensity) :
+      position_(retention_time),
       intensity_(intensity)
     {}
 

--- a/src/pyOpenMS/pxds/ChromatogramPeak.pxd
+++ b/src/pyOpenMS/pxds/ChromatogramPeak.pxd
@@ -13,6 +13,7 @@ cdef extern from "<OpenMS/KERNEL/ChromatogramPeak.h>" namespace "OpenMS":
 
         ChromatogramPeak() nogil except +
         ChromatogramPeak(ChromatogramPeak &) nogil except +
+        ChromatogramPeak(PositionType, IntensityType) nogil except +
         bool operator==(ChromatogramPeak) nogil except +
         bool operator!=(ChromatogramPeak) nogil except +
 

--- a/src/pyOpenMS/pxds/ChromatogramPeak.pxd
+++ b/src/pyOpenMS/pxds/ChromatogramPeak.pxd
@@ -6,6 +6,7 @@ cdef extern from "<OpenMS/KERNEL/ChromatogramPeak.h>" namespace "OpenMS::Chromat
 
     ctypedef double IntensityType
     ctypedef double CoordinateType
+    ctypedef DPosition1 PositionType
 
 cdef extern from "<OpenMS/KERNEL/ChromatogramPeak.h>" namespace "OpenMS":
 
@@ -13,7 +14,7 @@ cdef extern from "<OpenMS/KERNEL/ChromatogramPeak.h>" namespace "OpenMS":
 
         ChromatogramPeak() nogil except +
         ChromatogramPeak(ChromatogramPeak &) nogil except +
-        ChromatogramPeak(CoordinateType retention_time, IntensityType intensity) nogil except +
+        ChromatogramPeak(PositionType retention_time, IntensityType intensity) nogil except +
         bool operator==(ChromatogramPeak) nogil except +
         bool operator!=(ChromatogramPeak) nogil except +
 

--- a/src/pyOpenMS/pxds/ChromatogramPeak.pxd
+++ b/src/pyOpenMS/pxds/ChromatogramPeak.pxd
@@ -13,7 +13,7 @@ cdef extern from "<OpenMS/KERNEL/ChromatogramPeak.h>" namespace "OpenMS":
 
         ChromatogramPeak() nogil except +
         ChromatogramPeak(ChromatogramPeak &) nogil except +
-        ChromatogramPeak(PositionType, IntensityType) nogil except +
+        ChromatogramPeak(DPosition1, CoordinateType) nogil except +
         bool operator==(ChromatogramPeak) nogil except +
         bool operator!=(ChromatogramPeak) nogil except +
 

--- a/src/pyOpenMS/pxds/ChromatogramPeak.pxd
+++ b/src/pyOpenMS/pxds/ChromatogramPeak.pxd
@@ -13,7 +13,7 @@ cdef extern from "<OpenMS/KERNEL/ChromatogramPeak.h>" namespace "OpenMS":
 
         ChromatogramPeak() nogil except +
         ChromatogramPeak(ChromatogramPeak &) nogil except +
-        ChromatogramPeak(DPosition1, CoordinateType) nogil except +
+        ChromatogramPeak(CoordinateType retention_time, IntensityType intensity) nogil except +
         bool operator==(ChromatogramPeak) nogil except +
         bool operator!=(ChromatogramPeak) nogil except +
 

--- a/src/tests/class_tests/openms/source/ChromatogramPeak_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromatogramPeak_test.cpp
@@ -130,16 +130,16 @@ START_SECTION((ChromatogramPeak(const ChromatogramPeak& p)))
   TEST_REAL_SIMILAR(pos2[0], 21.21)
 END_SECTION
 
-START_SECTION((ChromatogramPeak(const PositionType position, const IntensityType intensity)))
+START_SECTION((ChromatogramPeak(const PositionType retention_time, const IntensityType intensity)))
   ChromatogramPeak p1(3.0, 5.0);
-  TEST_REAL_SIMILAR(p1.getPos(), 3.0)
+  TEST_REAL_SIMILAR(p1.getRT(), 3.0)
   TEST_REAL_SIMILAR(p1.getIntensity(), 5.0)
 
-  ChromatogramPeak::PositionType position;
-  position[0] = 2.0;
+  ChromatogramPeak::PositionType retention_time;
+  retention_time[0] = 2.0;
   ChromatogramPeak::IntensityType intensity = 4.0;
-  ChromatogramPeak p2(position, intensity);
-  TEST_REAL_SIMILAR(p2.getPos(), 2.0)
+  ChromatogramPeak p2(retention_time, intensity);
+  TEST_REAL_SIMILAR(p2.getRT(), 2.0)
   TEST_REAL_SIMILAR(p2.getIntensity(), 4.0)
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ChromatogramPeak_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromatogramPeak_test.cpp
@@ -130,6 +130,19 @@ START_SECTION((ChromatogramPeak(const ChromatogramPeak& p)))
   TEST_REAL_SIMILAR(pos2[0], 21.21)
 END_SECTION
 
+START_SECTION((ChromatogramPeak(const PositionType position, const IntensityType intensity)))
+  ChromatogramPeak p1(3.0, 5.0);
+  TEST_REAL_SIMILAR(p1.getPos(), 3.0)
+  TEST_REAL_SIMILAR(p1.getIntensity(), 5.0)
+
+  ChromatogramPeak::PositionType position;
+  position[0] = 2.0;
+  ChromatogramPeak::IntensityType intensity = 4.0;
+  ChromatogramPeak p2(position, intensity);
+  TEST_REAL_SIMILAR(p2.getPos(), 2.0)
+  TEST_REAL_SIMILAR(p2.getIntensity(), 4.0)
+END_SECTION
+
 START_SECTION((ChromatogramPeak& operator = (const ChromatogramPeak& rhs)))
   ChromatogramPeak::PositionType pos;
   pos[0] = 21.21;


### PR DESCRIPTION
Allows the user to instantiate a `ChromatogramPeak` by passing a position and an intensity as arguments, as in:
`ChromatogramPeak p(3.0, 5.0);`