### PR TITLE
[FEATURE] OpenSwathDecoyGenerator improvements 

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
@@ -107,14 +107,11 @@ public:
       mz_threshold is used for the matching of theoretical ion series to the observed one
 
     */
-    void generateDecoys(OpenMS::TargetedExperiment& exp,
-                        OpenMS::TargetedExperiment& dec, String method, String decoy_tag,
-                        double identity_threshold, int max_attempts, double mz_threshold,
-                        double mz_shift,
-                        double similarity_threshold,
-                        double precursor_mass_shift, std::vector<String> fragment_types,
-                        std::vector<size_t> fragment_charges, bool enable_specific_losses,
-                        bool enable_unspecific_losses, int round_decPow = -4);
+    void generateDecoys(OpenMS::TargetedExperiment& exp, OpenMS::TargetedExperiment& dec,
+                        String method, String decoy_tag, int max_attempts, double identity_threshold,
+                        double precursor_mz_shift, double product_mz_shift, double product_mz_threshold,
+                        std::vector<String> fragment_types, std::vector<size_t> fragment_charges,
+                        bool enable_specific_losses, bool enable_unspecific_losses, int round_decPow = -4);
 
     typedef std::vector<OpenMS::TargetedExperiment::Protein> ProteinVectorType;
     typedef std::vector<OpenMS::TargetedExperiment::Peptide> PeptideVectorType;

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
@@ -153,7 +153,7 @@ public:
     */
     OpenMS::TargetedExperiment::Peptide shufflePeptide(
       OpenMS::TargetedExperiment::Peptide peptide, double identity_threshold, int seed = -1,
-      int max_attempts = 10, bool replace_aa_instead_append = false);
+      int max_attempts = 100);
 
     /**
       @brief Pseudo-reverse a peptide sequence (with its modifications)

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
@@ -129,6 +129,12 @@ public:
       std::string sequence);
 
     /**
+      @brief Find all tryptic sites in a sequence and C- and N-terminus
+    */
+    std::vector<std::pair<std::string::size_type, std::string> > find_all_tryptic_and_term(
+      std::string sequence);
+
+    /**
       @brief Compute relative identity (relative number of matches of amino acids at the same position) between two sequences
     */
     float AASequenceIdentity(const String& sequence, const String& decoy);

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
@@ -123,26 +123,9 @@ public:
     typedef std::map<String, std::vector<const ReactionMonitoringTransition*> > PeptideTransitionMapType;
 
     /**
-      @brief Find all tryptic sites in a sequence
-    */
-    std::vector<std::pair<std::string::size_type, std::string> > find_all_tryptic(
-      std::string sequence);
-
-    /**
-      @brief Find all tryptic sites in a sequence and C- and N-terminus
-    */
-    std::vector<std::pair<std::string::size_type, std::string> > find_all_tryptic_and_term(
-      std::string sequence);
-
-    /**
       @brief Compute relative identity (relative number of matches of amino acids at the same position) between two sequences
     */
     float AASequenceIdentity(const String& sequence, const String& decoy);
-
-    /**
-      @brief Check if a peptide has C or N terminal modifications
-    */
-    bool has_CNterminal_mods(const OpenMS::TargetedExperiment::Peptide& peptide);
 
     /**
       @brief Shuffle a peptide (with its modifications) sequence
@@ -168,6 +151,28 @@ public:
     */
     OpenMS::TargetedExperiment::Peptide reversePeptide(
       OpenMS::TargetedExperiment::Peptide peptide);
+
+    /**
+      @brief Find all K, R, P sites in a sequence to be set as fixed
+
+      This method was adapted from the SpectraST decoy generator
+    */
+    std::vector<std::pair<std::string::size_type, std::string> > findFixedResidues(
+      std::string sequence);
+
+    /**
+      @brief Find all K, R, P and C-/N-terminal sites in a sequence to be set as fixed
+
+      This method was adapted from the SpectraST decoy generator
+    */
+    std::vector<std::pair<std::string::size_type, std::string> > findFixedAndTermResidues(
+      std::string sequence);
+
+    /**
+      @brief Check if a peptide has C or N terminal modifications
+    */
+    bool hasCNterminalMods(const OpenMS::TargetedExperiment::Peptide& peptide);
+
   };
 }
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h
@@ -110,12 +110,11 @@ public:
     void generateDecoys(OpenMS::TargetedExperiment& exp,
                         OpenMS::TargetedExperiment& dec, String method, String decoy_tag,
                         double identity_threshold, int max_attempts, double mz_threshold,
-                        double mz_shift, bool exclude_similar,
-                        double similarity_threshold, bool remove_CNterm_mods,
+                        double mz_shift,
+                        double similarity_threshold,
                         double precursor_mass_shift, std::vector<String> fragment_types,
                         std::vector<size_t> fragment_charges, bool enable_specific_losses,
-                        bool enable_unspecific_losses, bool remove_unannotated,
-                        int round_decPow = -4);
+                        bool enable_unspecific_losses, int round_decPow = -4);
 
     typedef std::vector<OpenMS::TargetedExperiment::Protein> ProteinVectorType;
     typedef std::vector<OpenMS::TargetedExperiment::Peptide> PeptideVectorType;

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -149,7 +149,7 @@ namespace OpenMS
     {
       // Block tryptic residues and N-/C-terminus from shuffling
       IndexType idx = MRMDecoy::find_all_tryptic_and_term(peptide.sequence);
-      
+
       shuffled = peptide;
       std::vector<Size> peptide_index;
       for (Size i = 0; i < peptide.sequence.size(); i++)
@@ -365,6 +365,8 @@ namespace OpenMS
     startProgress(0, exp.getPeptides().size(), "Generating decoy peptides");
     for (Size pep_idx = 0; pep_idx < exp.getPeptides().size(); ++pep_idx)
     {
+      setProgress(++progress);
+
       OpenMS::TargetedExperiment::Peptide peptide = exp.getPeptides()[pep_idx];
 
       peptide.id = decoy_tag + peptide.id;
@@ -415,7 +417,6 @@ namespace OpenMS
       }
 
       peptides.push_back(peptide);
-      setProgress(++progress);
     }
     endProgress();
     dec.setPeptides(peptides); // temporary set peptides, overwrite later again!
@@ -432,6 +433,8 @@ namespace OpenMS
     for (MRMDecoy::PeptideTransitionMapType::iterator pep_it = peptide_trans_map.begin();
          pep_it != peptide_trans_map.end(); ++pep_it)
     {
+      setProgress(++progress);
+
       String peptide_ref = pep_it->first;
       String decoy_peptide_ref = decoy_tag + pep_it->first; // see above, the decoy peptide id is computed deterministically from the target id
       const TargetedExperiment::Peptide target_peptide = exp.getPeptideByRef(peptide_ref);
@@ -497,7 +500,6 @@ namespace OpenMS
           LOG_DEBUG << "[peptide] Skipping " << decoy_tr.getPeptideRef() << " due to missing annotation" << std::endl;
         }
       } // end loop over transitions
-      setProgress(++progress);
     } // end loop over peptides
     endProgress();
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -45,7 +45,7 @@
 
 namespace OpenMS
 {
-  std::vector<std::pair<std::string::size_type, std::string> > MRMDecoy::find_all_tryptic(std::string sequence)
+  std::vector<std::pair<std::string::size_type, std::string> > MRMDecoy::findFixedResidues(std::string sequence)
   {
     std::vector<std::pair<std::string::size_type, std::string> > idx;
     std::vector<std::string> pattern;
@@ -67,7 +67,7 @@ namespace OpenMS
     return idx;
   }
 
-  std::vector<std::pair<std::string::size_type, std::string> > MRMDecoy::find_all_tryptic_and_term(std::string sequence)
+  std::vector<std::pair<std::string::size_type, std::string> > MRMDecoy::findFixedAndTermResidues(std::string sequence)
   {
     // also blocks both N- and C-terminus from shuffling
     std::vector<std::pair<std::string::size_type, std::string> > idx;
@@ -148,7 +148,7 @@ namespace OpenMS
            attempts < max_attempts)
     {
       // Block tryptic residues and N-/C-terminus from shuffling
-      IndexType idx = MRMDecoy::find_all_tryptic_and_term(peptide.sequence);
+      IndexType idx = MRMDecoy::findFixedAndTermResidues(peptide.sequence);
 
       shuffled = peptide;
       std::vector<Size> peptide_index;
@@ -315,7 +315,7 @@ namespace OpenMS
     return peptide;
   }
 
-  bool MRMDecoy::has_CNterminal_mods(const OpenMS::TargetedExperiment::Peptide& peptide)
+  bool MRMDecoy::hasCNterminalMods(const OpenMS::TargetedExperiment::Peptide& peptide)
   {
     for (Size j = 0; j < peptide.mods.size(); j++)
     {
@@ -367,7 +367,7 @@ namespace OpenMS
       if (method == "pseudo-reverse")
       {
         // exclude peptide if it has C/N terminal modifications because we can't do a (partial) reverse
-        if (MRMDecoy::has_CNterminal_mods(peptide))
+        if (MRMDecoy::hasCNterminalMods(peptide))
         {
           LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
           exclusion_peptides.push_back(peptide.id);
@@ -380,7 +380,7 @@ namespace OpenMS
       else if (method == "reverse")
       {
         // exclude peptide if it has C/N terminal modifications because we can't do a (partial) reverse
-        if (MRMDecoy::has_CNterminal_mods(peptide))
+        if (MRMDecoy::hasCNterminalMods(peptide))
         {
           LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
           exclusion_peptides.push_back(peptide.id);

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -328,9 +328,8 @@ namespace OpenMS
   }
 
   void MRMDecoy::generateDecoys(OpenMS::TargetedExperiment& exp, OpenMS::TargetedExperiment& dec,
-                                String method, String decoy_tag, double identity_threshold, int max_attempts,
-                                double mz_threshold, double mz_shift,
-                                double similarity_threshold, double precursor_mass_shift,
+                                String method, String decoy_tag, int max_attempts, double identity_threshold,
+                                double precursor_mz_shift, double product_mz_shift, double product_mz_threshold,
                                 std::vector<String> fragment_types, std::vector<size_t> fragment_charges,
                                 bool enable_specific_losses, bool enable_unspecific_losses, int round_decPow)
   {
@@ -448,16 +447,16 @@ namespace OpenMS
 
         decoy_tr.setNativeID(decoy_tag + tr.getNativeID());
         decoy_tr.setDecoyTransitionType(ReactionMonitoringTransition::DECOY);
-        decoy_tr.setPrecursorMZ(tr.getPrecursorMZ() + precursor_mass_shift); // fix for TOPPView: Duplicate precursor MZ is not displayed.
+        decoy_tr.setPrecursorMZ(tr.getPrecursorMZ() + precursor_mz_shift); // fix for TOPPView: Duplicate precursor MZ is not displayed.
 
         // determine the current annotation for the target ion and then select
         // the appropriate decoy ion for this target transition
-        std::pair<String, double> targetion = mrmis.annotateIon(target_ionseries, tr.getProductMZ(), mz_threshold);
+        std::pair<String, double> targetion = mrmis.annotateIon(target_ionseries, tr.getProductMZ(), product_mz_threshold);
         std::pair<String, double> decoyion = mrmis.getIon(decoy_ionseries, targetion.first);
 
         if (method == "shift")
         {
-          decoy_tr.setProductMZ(decoyion.second + mz_shift);
+          decoy_tr.setProductMZ(decoyion.second + product_mz_shift);
         }
         else
         {
@@ -467,14 +466,6 @@ namespace OpenMS
 
         if (decoyion.second > 0)
         {
-          if (similarity_threshold >= 0)
-          {
-            if (std::fabs(tr.getProductMZ() - decoy_tr.getProductMZ()) < similarity_threshold)
-            {
-              exclusion_peptides.push_back(decoy_tr.getPeptideRef());
-              LOG_DEBUG << "[peptide] Skipping " << decoy_tr.getPeptideRef() << " due to reaching fragment ion similarity threshold" << std::endl;
-           }
-          }
           decoy_transitions.push_back(decoy_tr);
         }
         else

--- a/src/pyOpenMS/pxds/MRMDecoy.pxd
+++ b/src/pyOpenMS/pxds/MRMDecoy.pxd
@@ -14,10 +14,8 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h>" namespace "OpenMS":
         MRMDecoy()                       nogil except +
         MRMDecoy(MRMDecoy)               nogil except + # wrap-ignore
 
-        void generateDecoys(TargetedExperiment & exp,
-                            TargetedExperiment & dec, String method, String decoy_tag,
-                            double identity_threshold, int max_attempts, double mz_threshold,
-                            double mz_shift, double similarity_threshold,
-                            double precursor_mass_shift, libcpp_vector[String] fragment_types,
-                            libcpp_vector[size_t] fragment_charges, bool enable_specific_losses,
-                            bool enable_unspecific_losses, int round_decPow) nogil except +
+        void generateDecoys(TargetedExperiment& exp, TargetedExperiment& dec,
+                            String method, String decoy_tag, int max_attempts, double identity_threshold,
+                            double precursor_mz_shift, double product_mz_shift, double product_mz_threshold,
+                            libcpp_vector[String] fragment_types, libcpp_vector[size_t] fragment_charges,
+                            bool enable_specific_losses, bool enable_unspecific_losses, int round_decPow) nogil except +

--- a/src/pyOpenMS/pxds/MRMDecoy.pxd
+++ b/src/pyOpenMS/pxds/MRMDecoy.pxd
@@ -16,11 +16,8 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h>" namespace "OpenMS":
 
         void generateDecoys(TargetedExperiment & exp,
                             TargetedExperiment & dec, String method, String decoy_tag,
-                            double identity_threshold, int max_attempts, double mz_threshold, 
-                            double mz_shift, bool exclude_similar, 
-                            double similarity_threshold, bool remove_CNterm_mods,
+                            double identity_threshold, int max_attempts, double mz_threshold,
+                            double mz_shift, double similarity_threshold,
                             double precursor_mass_shift, libcpp_vector[String] fragment_types,
                             libcpp_vector[size_t] fragment_charges, bool enable_specific_losses,
-                            bool enable_unspecific_losses, bool remove_unannotated,
-                            int round_decPow) nogil except +
-
+                            bool enable_unspecific_losses, int round_decPow) nogil except +

--- a/src/tests/class_tests/openms/data/MRMDecoyGenerator_output.TraML
+++ b/src/tests/class_tests/openms/data/MRMDecoyGenerator_output.TraML
@@ -10,6 +10,16 @@
     </Protein>
   </ProteinList>
   <CompoundList>
+    <Peptide id="DECOY_AAAAAK" sequence="AAAAAK">
+      <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
+      <cvParam cvRef="" accession="" name="full_peptide_name" value="AAAAAK"/>
+      <ProteinRef ref="DECOY_AQRT"/>
+      <RetentionTimeList>
+        <RetentionTime>
+          <cvParam cvRef="MS" accession="MS:1000896" name="normalized retention time" value="54.97"/>
+        </RetentionTime>
+      </RetentionTimeList>
+    </Peptide>
     <Peptide id="DECOY_ADVTPADFSEWSK" sequence="SWESFDAPTVDAK">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="2"/>
       <cvParam cvRef="" accession="" name="full_peptide_name" value="ADVTPADFSEWSK"/>
@@ -194,6 +204,32 @@
       <cvParam cvRef="MS" accession="MS:1001226" name="product ion intensity" value="3987.2"/>
       <cvParam cvRef="MS" accession="MS:1002008" name="decoy SRM transition"/>
       <userParam name="annotation" type="xsd:string" value="0"/>
+    </Transition>
+    <Transition id="DECOY_AAAAAK.exclude_similar_test1" peptideRef="DECOY_AAAAAK">
+      <Precursor>
+        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="251.75" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+      </Precursor>
+      <Product>
+        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="180.6157" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+      </Product>
+      <cvParam cvRef="" accession="" name="annotation" value="AAAAAK0"/>
+      <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.48"/>
+      <cvParam cvRef="MS" accession="decoy" name="decoy" value="0"/>
+      <cvParam cvRef="MS" accession="MS:1001226" name="product ion intensity" value="100"/>
+      <cvParam cvRef="MS" accession="MS:1002008" name="decoy SRM transition"/>
+    </Transition>
+    <Transition id="DECOY_AAAAAK.exclude_similar_test2" peptideRef="DECOY_AAAAAK">
+      <Precursor>
+        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="251.75" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+      </Precursor>
+      <Product>
+        <cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="144.4253" unitCvRef="MS" unitAccession="MS:1000040" unitName="m/z"/>
+      </Product>
+      <cvParam cvRef="" accession="" name="annotation" value="AAAAAK0"/>
+      <cvParam cvRef="MS" accession="MS:1000045" name="collision energy" value="37.48"/>
+      <cvParam cvRef="MS" accession="decoy" name="decoy" value="0"/>
+      <cvParam cvRef="MS" accession="MS:1001226" name="product ion intensity" value="100"/>
+      <cvParam cvRef="MS" accession="MS:1002008" name="decoy SRM transition"/>
     </Transition>
     <Transition id="DECOY_AQRT.ADVTPADFSEWSK.2_y9_1.light" peptideRef="DECOY_ADVTPADFSEWSK">
       <Precursor>

--- a/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
@@ -93,6 +93,25 @@ START_SECTION((std::vector<std::pair<std::string::size_type, std::string> > find
 
 END_SECTION
 
+START_SECTION((std::vector<std::pair<std::string::size_type, std::string> > find_all_tryptic_and_term(std::string sequence)))
+{
+  MRMDecoy gen;
+
+  String sequence = "TRESTPEPTIKDE";
+  std::vector<pair<std::string::size_type, std::string> > tryptic_results = gen.find_all_tryptic_and_term(sequence);
+  std::vector<pair<std::string::size_type, std::string> > tryptic_control = boost::assign::list_of(std::make_pair(0, "T")) (std::make_pair(1, "R")) (std::make_pair(5, "P")) (std::make_pair(7, "P")) (std::make_pair(10, "K")) (std::make_pair(12, "E"));
+
+  for (Size i = 0; i < tryptic_results.size(); i++)
+  {
+    pair<std::string::size_type, std::string> result = tryptic_results[i];
+    pair<std::string::size_type, std::string> control = tryptic_control[i];
+    TEST_EQUAL(result.first, control.first)
+    TEST_EQUAL(result.second, control.second)
+  }
+}
+
+END_SECTION
+
 START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::TargetedExperiment::Peptide peptide, double identity_threshold, int seed = -1, int max_attempts = 10))
 {
   MRMDecoy gen;
@@ -104,8 +123,8 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   modification.mono_mass_delta = 79.966331;
   peptide.mods.push_back(modification);
 
-  OpenMS::String expected_sequence = "TETTPEPESID";
-  OpenMS::Size expected_location = 8;
+  OpenMS::String expected_sequence = "TIDEPEPSTTE";
+  OpenMS::Size expected_location = 7;
 
   OpenMS::TargetedExperiment::Peptide shuffled = gen.shufflePeptide(peptide, 0.7, 43);
 
@@ -124,7 +143,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_07;
   shuffleAASequence_target_sequence_07.sequence = "TESTPEPTIDE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_07;
-  shuffleAASequence_expected_07.sequence = "ETSTPDPEETI";
+  shuffleAASequence_expected_07.sequence = "TTETPEPIDSE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_07;
   shuffleAASequence_result_07 = gen.shufflePeptide(shuffleAASequence_target_sequence_07, 0.7, 42);
   TEST_EQUAL(shuffleAASequence_result_07.sequence, shuffleAASequence_expected_07.sequence)
@@ -132,7 +151,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_09;
   shuffleAASequence_target_sequence_09.sequence = "TESTPEPTIDE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_09;
-  shuffleAASequence_expected_09.sequence = "ETSTPDPEETI";
+  shuffleAASequence_expected_09.sequence = "TTETPEPIDSE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_09;
   shuffleAASequence_result_09 = gen.shufflePeptide(shuffleAASequence_target_sequence_09, 0.9, 42);
   TEST_EQUAL(shuffleAASequence_result_09.sequence, shuffleAASequence_expected_09.sequence)
@@ -140,7 +159,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_01;
   shuffleAASequence_target_sequence_01.sequence = "TESTPEPTIDE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_01;
-  shuffleAASequence_expected_01.sequence = "SIECPAPDEETTT";
+  shuffleAASequence_expected_01.sequence = "TQLNPCPAETSCCEIDTAHQE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_01;
   shuffleAASequence_result_01 = gen.shufflePeptide(shuffleAASequence_target_sequence_01, 0.2, 42, 10000);
   TEST_EQUAL(shuffleAASequence_result_01.sequence, shuffleAASequence_expected_01.sequence)
@@ -148,7 +167,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_00;
   shuffleAASequence_target_sequence_00.sequence = "TESTPEPTIDE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_00;
-  shuffleAASequence_expected_00.sequence = "TEEDPTPDGATECIS";
+  shuffleAASequence_expected_00.sequence = "TAQDPEPTTSEIALE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00;
   shuffleAASequence_result_00 = gen.shufflePeptide(shuffleAASequence_target_sequence_00, 0.0, 42, 20);
   TEST_EQUAL(shuffleAASequence_result_00.sequence, shuffleAASequence_expected_00.sequence)
@@ -156,7 +175,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_01b;
   shuffleAASequence_target_sequence_01b.sequence = "TESTPEPTIDE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_01b;
-  shuffleAASequence_expected_01b.sequence = "TETTPDPICEE";
+  shuffleAASequence_expected_01b.sequence = "TNGCADQQEAE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_01b;
   shuffleAASequence_result_01b = gen.shufflePeptide(shuffleAASequence_target_sequence_01b, 0.2, 42, 10000, true);
   TEST_EQUAL(shuffleAASequence_result_01b.sequence, shuffleAASequence_expected_01b.sequence)
@@ -164,7 +183,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_00b;
   shuffleAASequence_target_sequence_00b.sequence = "TESTPEPTIDE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_00b;
-  shuffleAASequence_expected_00b.sequence = "QDCHGLGGEEC";
+  shuffleAASequence_expected_00b.sequence = "TNDQIADNNEE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00b;
   shuffleAASequence_result_00b = gen.shufflePeptide(shuffleAASequence_target_sequence_00b, 0.0, 42, 2000, true);
   TEST_EQUAL(shuffleAASequence_result_00b.sequence, shuffleAASequence_expected_00b.sequence)
@@ -172,7 +191,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   {
     OpenMS::TargetedExperiment::Peptide original_input;
     original_input.sequence = "TESTPEPTIDEK";
-    expected_sequence = "ETSTPDPEETIK";
+    expected_sequence = "TTETPEPEDSIK";
     OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00;
     shuffled = gen.shufflePeptide(original_input, 0.7, 42, 20);
     TEST_EQUAL(shuffled.sequence[shuffled.sequence.size() - 1], 'K')
@@ -183,7 +202,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   {
     OpenMS::TargetedExperiment::Peptide original_input;
     original_input.sequence = "TESTPEPTIDER";
-    expected_sequence = "ETSTPDPEETIR";
+    expected_sequence = "TTETPEPEDSIR";
     OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00;
     shuffled = gen.shufflePeptide(original_input, 0.7, 42, 20);
     TEST_EQUAL(shuffled.sequence[shuffled.sequence.size() - 1], 'R')
@@ -201,13 +220,13 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
     mod.unimod_id = 35;
     mods.push_back(mod);
     original_input.mods = mods;
-    expected_sequence = "MPGHLMGASLEKPF";
+    expected_sequence = "EPSALMGGHLFKPM";
     OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00;
     shuffled = gen.shufflePeptide(original_input, 0.7, 42, 20);
-    TEST_EQUAL(shuffled.sequence[shuffled.sequence.size() - 1], 'F')
+    TEST_EQUAL(shuffled.sequence[shuffled.sequence.size() - 1], 'M')
     TEST_EQUAL(shuffled.sequence, expected_sequence)
     TEST_EQUAL(shuffled.mods.size(), 1)
-    TEST_EQUAL(shuffled.mods[0].location, 5) // the second M moved to position 5
+    TEST_EQUAL(shuffled.mods[0].location, 13) // the second M remained at position 13
   }
 
   {
@@ -221,10 +240,10 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
     mod.unimod_id = 35;
     mods.push_back(mod);
     original_input.mods = mods;
-    expected_sequence = "MPGHLMGASLEKPF";
+    expected_sequence = "EPSALMGGHLFKPM";
     OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00;
     shuffled = gen.shufflePeptide(original_input, 0.7, 42, 20);
-    TEST_EQUAL(shuffled.sequence[shuffled.sequence.size() - 1], 'F')
+    TEST_EQUAL(shuffled.sequence[shuffled.sequence.size() - 1], 'M')
     TEST_EQUAL(shuffled.sequence, expected_sequence)
     TEST_EQUAL(shuffled.mods.size(), 1)
     TEST_EQUAL(shuffled.mods[0].location, 14) // Problem: this modification cannot be C terminal any more for F!
@@ -257,9 +276,9 @@ START_SECTION([EXTRA] shuffle_peptide_with_modifications_and2attempts)
   modification.mono_mass_delta = 79.966331;
   peptide.mods.push_back(modification);
 
-  OpenMS::String expected_sequence = "GPPEVSGPGSPPPDPR";
-  OpenMS::Size expected_location_1 = 5;
-  OpenMS::Size expected_location_2 = 9;
+  OpenMS::String expected_sequence = "GPPGDSEPGSPPPVPR";
+  OpenMS::Size expected_location_1 = 9;
+  OpenMS::Size expected_location_2 = 5;
 
   OpenMS::TargetedExperiment::Peptide shuffled = gen.shufflePeptide(peptide, 0.7, 130);
 
@@ -296,7 +315,7 @@ START_SECTION([EXTRA] shuffle_peptide_with_terminal_modifications)
   modification.mono_mass_delta = 4.008491;
   peptide.mods.push_back(modification);
 
-  OpenMS::String expected_sequence = "TETTPEPESID";
+  OpenMS::String expected_sequence = "TIDEPEPSTTE";
 
   OpenMS::TargetedExperiment::Peptide shuffled = gen.shufflePeptide(peptide, 0.7, 43);
 
@@ -313,7 +332,7 @@ START_SECTION([EXTRA] shuffle_peptide_with_KPR)
   MRMDecoy gen;
   OpenMS::TargetedExperiment::Peptide peptide;
   peptide.sequence = "KPRKPRPK";
-  OpenMS::String expected_sequence = "KPRKPRPKNL";
+  OpenMS::String expected_sequence = "KPRKPNLRPK";
   OpenMS::TargetedExperiment::Peptide shuffled = gen.shufflePeptide(peptide, 0.7, 130, 17);
   TEST_EQUAL(shuffled.sequence, expected_sequence)
 }
@@ -399,10 +418,9 @@ END_SECTION
 START_SECTION((void generateDecoys(OpenMS::TargetedExperiment & exp,
                                    OpenMS::TargetedExperiment & dec, String method, String decoy_tag,
                                    double identity_threshold, int max_attempts, double mz_threshold,
-                                   bool theoretical, double mz_shift, bool exclude_similar,
-                                   double similarity_threshold, bool remove_CNterm_mods, double precursor_mass_shift,
+                                   double mz_shift, double similarity_threshold, double precursor_mass_shift,
                                    std::vector<String> fragment_types, std::vector<size_t> fragment_charges,
-                                   bool enable_specific_losses, bool enable_unspecific_losses, bool skip_unannotated); ))
+                                   bool enable_specific_losses, bool enable_unspecific_losses); ))
 {
   String method = "pseudo-reverse";
   double identity_threshold = 0.7;
@@ -410,8 +428,6 @@ START_SECTION((void generateDecoys(OpenMS::TargetedExperiment & exp,
   double mz_threshold = 0.8;
   double mz_shift = 20;
   String decoy_tag = "DECOY_";
-  bool exclude_similar = true;
-  bool remove_CNterminal_mods = false;
   double similarity_threshold = 0.1;
   std::vector<String> fragment_types;
   fragment_types.push_back(String("b"));
@@ -425,7 +441,6 @@ START_SECTION((void generateDecoys(OpenMS::TargetedExperiment & exp,
   fragment_charges.push_back(5);
   bool enable_unspecific_losses = false;
   bool enable_specific_losses = true;
-  bool skip_unannotated = true;
 
   String in = "MRMDecoyGenerator_input.TraML";
   String out = "MRMDecoyGenerator_output.TraML";

--- a/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
@@ -415,20 +415,22 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide reversePeptide(OpenMS::Targete
 END_SECTION
 
 /// Public methods
-START_SECTION((void generateDecoys(OpenMS::TargetedExperiment & exp,
-                                   OpenMS::TargetedExperiment & dec, String method, String decoy_tag,
-                                   double identity_threshold, int max_attempts, double mz_threshold,
-                                   double mz_shift, double similarity_threshold, double precursor_mass_shift,
+
+
+
+START_SECTION((void generateDecoys(OpenMS::TargetedExperiment& exp, OpenMS::TargetedExperiment& dec,
+                                   String method, String decoy_tag, int max_attempts, double identity_threshold,
+                                   double precursor_mz_shift, double product_mz_shift, double product_mz_threshold,
                                    std::vector<String> fragment_types, std::vector<size_t> fragment_charges,
-                                   bool enable_specific_losses, bool enable_unspecific_losses); ))
+                                   bool enable_specific_losses, bool enable_unspecific_losses, int round_decPow); ))
 {
   String method = "pseudo-reverse";
   double identity_threshold = 0.7;
   Int max_attempts = 5;
-  double mz_threshold = 0.8;
-  double mz_shift = 20;
+  double product_mz_threshold = 0.8;
+  double precursor_mz_shift = 0.1;
+  double product_mz_shift = 20;
   String decoy_tag = "DECOY_";
-  double similarity_threshold = 0.1;
   std::vector<String> fragment_types;
   fragment_types.push_back(String("b"));
   fragment_types.push_back(String("y"));
@@ -460,12 +462,11 @@ START_SECTION((void generateDecoys(OpenMS::TargetedExperiment & exp,
                         targeted_decoy,
                         method,
                         decoy_tag,
-                        identity_threshold,
                         max_attempts,
-                        mz_threshold,
-                        mz_shift, 
-                        similarity_threshold,
-                        0.1,
+                        identity_threshold,
+                        precursor_mz_shift, 
+                        product_mz_shift, 
+                        product_mz_threshold,
                         fragment_types, 
                         fragment_charges,
                         enable_specific_losses, 

--- a/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
@@ -74,12 +74,12 @@ START_SECTION(~MRMDecoy())
 
 END_SECTION
 
-START_SECTION((std::vector<std::pair<std::string::size_type, std::string> > find_all_tryptic(std::string sequence)))
+START_SECTION((std::vector<std::pair<std::string::size_type, std::string> > findFixedResidues(std::string sequence)))
 {
   MRMDecoy gen;
 
   String sequence = "TRESTPEPTIKDE";
-  std::vector<pair<std::string::size_type, std::string> > tryptic_results = gen.find_all_tryptic(sequence);
+  std::vector<pair<std::string::size_type, std::string> > tryptic_results = gen.findFixedResidues(sequence);
   std::vector<pair<std::string::size_type, std::string> > tryptic_control = boost::assign::list_of(std::make_pair(1, "R")) (std::make_pair(5, "P")) (std::make_pair(7, "P")) (std::make_pair(10, "K"));
 
   for (Size i = 0; i < tryptic_results.size(); i++)
@@ -93,12 +93,12 @@ START_SECTION((std::vector<std::pair<std::string::size_type, std::string> > find
 
 END_SECTION
 
-START_SECTION((std::vector<std::pair<std::string::size_type, std::string> > find_all_tryptic_and_term(std::string sequence)))
+START_SECTION((std::vector<std::pair<std::string::size_type, std::string> > findFixedAndTermResidues(std::string sequence)))
 {
   MRMDecoy gen;
 
   String sequence = "TRESTPEPTIKDE";
-  std::vector<pair<std::string::size_type, std::string> > tryptic_results = gen.find_all_tryptic_and_term(sequence);
+  std::vector<pair<std::string::size_type, std::string> > tryptic_results = gen.findFixedAndTermResidues(sequence);
   std::vector<pair<std::string::size_type, std::string> > tryptic_control = boost::assign::list_of(std::make_pair(0, "T")) (std::make_pair(1, "R")) (std::make_pair(5, "P")) (std::make_pair(7, "P")) (std::make_pair(10, "K")) (std::make_pair(12, "E"));
 
   for (Size i = 0; i < tryptic_results.size(); i++)

--- a/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
@@ -159,7 +159,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_01;
   shuffleAASequence_target_sequence_01.sequence = "TESTPEPTIDE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_01;
-  shuffleAASequence_expected_01.sequence = "TQLNPCPAETSCCEIDTAHQE";
+  shuffleAASequence_expected_01.sequence = "TNGCADQQEAE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_01;
   shuffleAASequence_result_01 = gen.shufflePeptide(shuffleAASequence_target_sequence_01, 0.2, 42, 10000);
   TEST_EQUAL(shuffleAASequence_result_01.sequence, shuffleAASequence_expected_01.sequence)
@@ -167,7 +167,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_00;
   shuffleAASequence_target_sequence_00.sequence = "TESTPEPTIDE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_00;
-  shuffleAASequence_expected_00.sequence = "TAQDPEPTTSEIALE";
+  shuffleAASequence_expected_00.sequence = "TEIEPAPTQTE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00;
   shuffleAASequence_result_00 = gen.shufflePeptide(shuffleAASequence_target_sequence_00, 0.0, 42, 20);
   TEST_EQUAL(shuffleAASequence_result_00.sequence, shuffleAASequence_expected_00.sequence)
@@ -177,7 +177,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_01b;
   shuffleAASequence_expected_01b.sequence = "TNGCADQQEAE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_01b;
-  shuffleAASequence_result_01b = gen.shufflePeptide(shuffleAASequence_target_sequence_01b, 0.2, 42, 10000, true);
+  shuffleAASequence_result_01b = gen.shufflePeptide(shuffleAASequence_target_sequence_01b, 0.2, 42, 10000);
   TEST_EQUAL(shuffleAASequence_result_01b.sequence, shuffleAASequence_expected_01b.sequence)
 
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_target_sequence_00b;
@@ -185,7 +185,7 @@ START_SECTION(OpenMS::TargetedExperiment::Peptide shufflePeptide(OpenMS::Targete
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_expected_00b;
   shuffleAASequence_expected_00b.sequence = "TNDQIADNNEE";
   OpenMS::TargetedExperiment::Peptide shuffleAASequence_result_00b;
-  shuffleAASequence_result_00b = gen.shufflePeptide(shuffleAASequence_target_sequence_00b, 0.0, 42, 2000, true);
+  shuffleAASequence_result_00b = gen.shufflePeptide(shuffleAASequence_target_sequence_00b, 0.0, 42, 2000);
   TEST_EQUAL(shuffleAASequence_result_00b.sequence, shuffleAASequence_expected_00b.sequence)
   // ensure that C-terminal K and R are preserved
   {
@@ -332,7 +332,7 @@ START_SECTION([EXTRA] shuffle_peptide_with_KPR)
   MRMDecoy gen;
   OpenMS::TargetedExperiment::Peptide peptide;
   peptide.sequence = "KPRKPRPK";
-  OpenMS::String expected_sequence = "KPRKPNLRPK";
+  OpenMS::String expected_sequence = "KNRKPRPK";
   OpenMS::TargetedExperiment::Peptide shuffled = gen.shufflePeptide(peptide, 0.7, 130, 17);
   TEST_EQUAL(shuffled.sequence, expected_sequence)
 }

--- a/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMDecoy_test.cpp
@@ -449,15 +449,12 @@ START_SECTION((void generateDecoys(OpenMS::TargetedExperiment & exp,
                         max_attempts,
                         mz_threshold,
                         mz_shift, 
-                        exclude_similar,
                         similarity_threshold,
-                        remove_CNterminal_mods, 
                         0.1,
                         fragment_types, 
                         fragment_charges,
                         enable_specific_losses, 
-                        enable_unspecific_losses,
-                        skip_unannotated); 
+                        enable_unspecific_losses); 
   traml.store(test, targeted_decoy);
 
   TEST_FILE_EQUAL(test.c_str(), OPENMS_GET_TEST_DATA_PATH(out))

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1055,7 +1055,7 @@ ${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDec
   add_test("TOPP_OpenSwathDecoyGenerator_test_1_out1" ${DIFF} -whitelist "id=" -in1 OpenSwathDecoyGenerator.TraML.tmp -in2 ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_output.TraML)
   set_tests_properties("TOPP_OpenSwathDecoyGenerator_test_1_out1" PROPERTIES DEPENDS "TOPP_OpenSwathDecoyGenerator_test_1")
   add_test("TOPP_OpenSwathDecoyGenerator_test_2"
-${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_input_2.TraML -out OpenSwathDecoyGenerator_2.TraML.tmp -out_type TraML -method pseudo-reverse -mz_threshold 0.8)
+${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_input_2.TraML -out OpenSwathDecoyGenerator_2.TraML.tmp -out_type TraML -method pseudo-reverse -product_mz_threshold 0.8)
   add_test("TOPP_OpenSwathDecoyGenerator_test_2_out1" ${DIFF} -in1 OpenSwathDecoyGenerator_2.TraML.tmp -in2 ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_output_2.TraML)
   set_tests_properties("TOPP_OpenSwathDecoyGenerator_test_2_out1" PROPERTIES DEPENDS "TOPP_OpenSwathDecoyGenerator_test_2")
   add_test("TOPP_OpenSwathDecoyGenerator_test_3"

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1051,15 +1051,15 @@ ${TOPP_BIN_PATH}/OpenSwathAssayGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathAss
   set_tests_properties("TOPP_OpenSwathAssayGenerator_test_1_out1" PROPERTIES DEPENDS "TOPP_OpenSwathAssayGenerator_test_1")
   
   add_test("TOPP_OpenSwathDecoyGenerator_test_1"
-${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_input.TraML -out OpenSwathDecoyGenerator.TraML.tmp -method pseudo-reverse -remove_CNterm_mods)
+${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_input.TraML -out OpenSwathDecoyGenerator.TraML.tmp -out_type TraML -method pseudo-reverse -separate)
   add_test("TOPP_OpenSwathDecoyGenerator_test_1_out1" ${DIFF} -whitelist "id=" -in1 OpenSwathDecoyGenerator.TraML.tmp -in2 ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_output.TraML)
   set_tests_properties("TOPP_OpenSwathDecoyGenerator_test_1_out1" PROPERTIES DEPENDS "TOPP_OpenSwathDecoyGenerator_test_1")
   add_test("TOPP_OpenSwathDecoyGenerator_test_2"
-${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_input_2.TraML -out OpenSwathDecoyGenerator_2.TraML.tmp -append -method pseudo-reverse -remove_CNterm_mods -remove_unannotated -mz_threshold 0.8)
+${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_input_2.TraML -out OpenSwathDecoyGenerator_2.TraML.tmp -out_type TraML -method pseudo-reverse -mz_threshold 0.8)
   add_test("TOPP_OpenSwathDecoyGenerator_test_2_out1" ${DIFF} -in1 OpenSwathDecoyGenerator_2.TraML.tmp -in2 ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_output_2.TraML)
   set_tests_properties("TOPP_OpenSwathDecoyGenerator_test_2_out1" PROPERTIES DEPENDS "TOPP_OpenSwathDecoyGenerator_test_2")
   add_test("TOPP_OpenSwathDecoyGenerator_test_3"
-${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_input_3.TraML -out OpenSwathDecoyGenerator_3.TraML.tmp -method pseudo-reverse -remove_CNterm_mods)
+${TOPP_BIN_PATH}/OpenSwathDecoyGenerator -test -in ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_input_3.TraML -out OpenSwathDecoyGenerator_3.TraML.tmp -out_type TraML -method pseudo-reverse -separate)
   add_test("TOPP_OpenSwathDecoyGenerator_test_3_out1" ${DIFF} -in1 OpenSwathDecoyGenerator_3.TraML.tmp -in2 ${DATA_DIR_TOPP}/OpenSwathDecoyGenerator_output_3.TraML)
   set_tests_properties("TOPP_OpenSwathDecoyGenerator_test_3_out1" PROPERTIES DEPENDS "TOPP_OpenSwathDecoyGenerator_test_3")
 

--- a/src/tests/topp/OpenSwathDecoyGenerator_input.TraML
+++ b/src/tests/topp/OpenSwathDecoyGenerator_input.TraML
@@ -13,13 +13,13 @@
     <Peptide id="78" sequence="QVFIGCPASVADQDAFERR">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
       <cvParam cvRef="MS" accession="MS:1000893" name="peptide group label" value="QVFIGCPASVADQDAFERR"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERR(UniMod:11)"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERR(UniMod:193)"/>
       <ProteinRef ref="ProteinC"/>
       <Modification location="0" monoisotopicMassDelta="43.005814" averageMassDelta="43.0247">
         <cvParam cvRef="UNIMOD" accession="UNIMOD:5" name="Carbamyl"/>
       </Modification>
-      <Modification location="20" monoisotopicMassDelta="-48.003371" averageMassDelta="-48.1075">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:11" name="Met->Hsl"/>
+      <Modification location="20" monoisotopicMassDelta="4.008491" averageMassDelta="3.9995">
+        <cvParam cvRef="UNIMOD" accession="UNIMOD:193" name="Label:18O(2)"/>
       </Modification>
       <Modification location="6" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
         <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>

--- a/src/tests/topp/OpenSwathDecoyGenerator_input_3.TraML
+++ b/src/tests/topp/OpenSwathDecoyGenerator_input_3.TraML
@@ -13,13 +13,13 @@
     <Peptide id="78" sequence="QVFIGCPASVADQDAFERR">
       <cvParam cvRef="MS" accession="MS:1000041" name="charge state" value="3"/>
       <cvParam cvRef="MS" accession="MS:1000893" name="peptide group label" value="QVFIGCPASVADQDAFERR"/>
-      <userParam name="full_peptide_name" type="xsd:string" value="(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERR(UniMod:11)"/>
+      <userParam name="full_peptide_name" type="xsd:string" value="(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERR(UniMod:193)"/>
       <ProteinRef ref="ProteinC"/>
       <Modification location="0" monoisotopicMassDelta="43.005814" averageMassDelta="43.0247">
         <cvParam cvRef="UNIMOD" accession="UNIMOD:5" name="Carbamyl"/>
       </Modification>
-      <Modification location="20" monoisotopicMassDelta="-48.003371" averageMassDelta="-48.1075">
-        <cvParam cvRef="UNIMOD" accession="UNIMOD:11" name="Met->Hsl"/>
+      <Modification location="20" monoisotopicMassDelta="4.008491" averageMassDelta="3.9995">
+        <cvParam cvRef="UNIMOD" accession="UNIMOD:193" name="Label:18O(2)"/>
       </Modification>
       <Modification location="6" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
         <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>

--- a/src/tests/topp/OpenSwathDecoyGenerator_output_2.TraML
+++ b/src/tests/topp/OpenSwathDecoyGenerator_output_2.TraML
@@ -19,13 +19,13 @@
       <userParam name="full_peptide_name" type="xsd:string" value="(UniMod:5)QVFIGC(UniMod:4)PASVADQDAFERM(UniMod:11)"/>
       <ProteinRef ref="ProteinC"/>
       <Modification location="0" monoisotopicMassDelta="43.005814" averageMassDelta="43.0247">
-           <cvParam cvRef="UNIMOD" accession="UNIMOD:5" name="Carbamyl"/>
+        <cvParam cvRef="UNIMOD" accession="UNIMOD:5" name="Carbamyl"/>
       </Modification>
       <Modification location="20" monoisotopicMassDelta="-48.003371" averageMassDelta="-48.1075">
-           <cvParam cvRef="UNIMOD" accession="UNIMOD:11" name="Met->Hsl"/>
+        <cvParam cvRef="UNIMOD" accession="UNIMOD:11" name="Met->Hsl"/>
       </Modification>
       <Modification location="6" monoisotopicMassDelta="57.021464" averageMassDelta="57.0513">
-           <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
+        <cvParam cvRef="UNIMOD" accession="UNIMOD:4" name="Carbamidomethyl"/>
       </Modification>
       <RetentionTimeList>
         <RetentionTime>

--- a/src/topp/OpenSwathDecoyGenerator.cpp
+++ b/src/topp/OpenSwathDecoyGenerator.cpp
@@ -36,6 +36,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
+#include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
@@ -129,7 +130,7 @@ protected:
     registerDoubleOption_("min_decoy_fraction", "<double>", 0.8, "Minimum fraction of decoy / target peptides and proteins", false, true);
 
     registerIntOption_("shuffle_max_attempts", "<int>", 100, "shuffle: maximum attempts to lower the amino acid sequence identity between target and decoy for the shuffle algorithm", false, true);
-    registerDoubleOption_("shuffle_sequence_identity_threshold", "<double>", 0.3, "shuffle: target-decoy amino acid sequence identity threshold for the shuffle algorithm", false, true);
+    registerDoubleOption_("shuffle_sequence_identity_threshold", "<double>", 0.1, "shuffle: target-decoy amino acid sequence identity threshold for the shuffle algorithm", false, true);
     registerDoubleOption_("shift_precursor_mz_shift", "<double>", 0.0, "shift: precursor ion MZ shift in Thomson for shift decoy method", false, true);
     registerDoubleOption_("shift_product_mz_shift", "<double>", 20, "shift: fragment ion MZ shift in Thomson for shift decoy method", false, true);
 
@@ -212,7 +213,7 @@ protected:
     TargetedExperiment targeted_decoy;
 
     // Load data
-    LOG_INFO << "Loading " << in << std::endl;
+    LOG_INFO << "Loading targets from file: " << in << std::endl;
     if (in_type == FileTypes::TSV || in_type == FileTypes::MRM)
     {
       const char* tr_file = in.c_str();
@@ -240,6 +241,7 @@ protected:
     }
 
     MRMDecoy decoys = MRMDecoy();
+    decoys.setLogType(ProgressLogger::CMD);
 
     LOG_INFO << "Generate decoys" << std::endl;
     decoys.generateDecoys(targeted_exp, targeted_decoy, method, decoy_tag, identity_threshold, max_attempts, product_mz_threshold, product_mz_shift, similarity_threshold, precursor_mz_shift, allowed_fragment_types, allowed_fragment_charges, enable_detection_specific_losses, enable_detection_unspecific_losses);
@@ -258,14 +260,15 @@ protected:
     TargetedExperiment targeted_merged;
     if (separate)
     {
+      LOG_INFO << "Writing only decoys to file: " << out << std::endl;
       targeted_merged = targeted_decoy;
     }
     else
     {
+      LOG_INFO << "Writing targets and decoys to file: " << out << std::endl;
       targeted_merged = targeted_exp + targeted_decoy;
     }
 
-    LOG_INFO << "Writing decoys" << out << std::endl;
     if (out_type == FileTypes::TSV)
     {
       const char* tr_file = out.c_str();

--- a/src/topp/OpenSwathDecoyGenerator.cpp
+++ b/src/topp/OpenSwathDecoyGenerator.cpp
@@ -80,8 +80,10 @@ using namespace OpenMS;
   to the one described in Lam, Henry, et al. (2010). "Artificial decoy spectral
   libraries for false discovery rate estimation in spectral library searching in
   proteomics".  Journal of Proteome Research 9, 605-610. It shuffles the amino
-  acid sequence and shuffles the fragment ion intensities accordingly, however
-  for this to work the fragment ions need to be matched to annotated before.
+  acid sequence (excluding N-/C-terminal and K/R/P) and shuffles the fragment 
+  ion intensities accordingly. If the new sequence does not reach a threshold of
+  identity within a set number of trials, a random amino acid (not N-/C-terminal
+  or modified) is "mutated" to a random other amino acid.
 
   <B>The command line parameters of this tool are:</B>
   @verbinclude TOPP_OpenSwathDecoyGenerator.cli
@@ -121,8 +123,8 @@ protected:
     registerStringOption_("out_type", "<type>", "", "Output file type -- default: determined from file extension or content\n", false);
     setValidStrings_("out_type", ListUtils::create<String>(formats));
 
-    registerStringOption_("method", "<type>", "shuffle", "decoy generation method ('shuffle','shuffle-mutated','pseudo-reverse','reverse','shift')", false);
-    setValidStrings_("method", ListUtils::create<String>(String("shuffle,shuffle-mutated,pseudo-reverse,reverse,shift")));
+    registerStringOption_("method", "<type>", "shuffle", "decoy generation method ('shuffle','pseudo-reverse','reverse','shift')", false);
+    setValidStrings_("method", ListUtils::create<String>(String("shuffle,pseudo-reverse,reverse,shift")));
 
     registerStringOption_("decoy_tag", "<type>", "DECOY_", "decoy tag", false);
 

--- a/src/topp/OpenSwathDecoyGenerator.cpp
+++ b/src/topp/OpenSwathDecoyGenerator.cpp
@@ -128,11 +128,11 @@ protected:
 
     registerStringOption_("decoy_tag", "<type>", "DECOY_", "decoy tag", false);
 
-    registerDoubleOption_("product_mz_similarity_threshold", "<double>", 0.05, "Similarity threshold for absolute difference of the product mz of target and decoy assays for exclusion in Dalton. Suggested value: 0.05", false, true);
     registerDoubleOption_("min_decoy_fraction", "<double>", 0.8, "Minimum fraction of decoy / target peptides and proteins", false, true);
 
-    registerIntOption_("shuffle_max_attempts", "<int>", 100, "shuffle: maximum attempts to lower the amino acid sequence identity between target and decoy for the shuffle algorithm", false, true);
-    registerDoubleOption_("shuffle_sequence_identity_threshold", "<double>", 0.1, "shuffle: target-decoy amino acid sequence identity threshold for the shuffle algorithm", false, true);
+    registerIntOption_("shuffle_max_attempts", "<int>", 30, "shuffle: maximum attempts to lower the amino acid sequence identity between target and decoy for the shuffle algorithm", false, true);
+    registerDoubleOption_("shuffle_sequence_identity_threshold", "<double>", 0.5, "shuffle: target-decoy amino acid sequence identity threshold for the shuffle algorithm", false, true);
+
     registerDoubleOption_("shift_precursor_mz_shift", "<double>", 0.0, "shift: precursor ion MZ shift in Thomson for shift decoy method", false, true);
     registerDoubleOption_("shift_product_mz_shift", "<double>", 20, "shift: fragment ion MZ shift in Thomson for shift decoy method", false, true);
 
@@ -183,11 +183,11 @@ protected:
     String method = getStringOption_("method");
     String decoy_tag = getStringOption_("decoy_tag");
 
-    double similarity_threshold = getDoubleOption_("product_mz_similarity_threshold");
     double min_decoy_fraction = getDoubleOption_("min_decoy_fraction");
 
     Int max_attempts = getIntOption_("shuffle_max_attempts");
     double identity_threshold = getDoubleOption_("shuffle_sequence_identity_threshold");
+
     double precursor_mz_shift = getDoubleOption_("shift_precursor_mz_shift");
     double product_mz_shift = getDoubleOption_("shift_product_mz_shift");
 
@@ -246,7 +246,7 @@ protected:
     decoys.setLogType(ProgressLogger::CMD);
 
     LOG_INFO << "Generate decoys" << std::endl;
-    decoys.generateDecoys(targeted_exp, targeted_decoy, method, decoy_tag, identity_threshold, max_attempts, product_mz_threshold, product_mz_shift, similarity_threshold, precursor_mz_shift, allowed_fragment_types, allowed_fragment_charges, enable_detection_specific_losses, enable_detection_unspecific_losses);
+    decoys.generateDecoys(targeted_exp, targeted_decoy, method, decoy_tag, max_attempts, identity_threshold, precursor_mz_shift, product_mz_shift, product_mz_threshold, allowed_fragment_types, allowed_fragment_charges, enable_detection_specific_losses, enable_detection_unspecific_losses);
 
     // Check if we have enough peptides left
     LOG_INFO << "Number of target peptides: " << targeted_exp.getPeptides().size() << std::endl;
@@ -256,7 +256,7 @@ protected:
 
     if ((float)targeted_decoy.getPeptides().size() / (float)targeted_exp.getPeptides().size() < min_decoy_fraction || (float)targeted_decoy.getProteins().size() / (float)targeted_exp.getProteins().size() < min_decoy_fraction)
     {
-       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The number of decoys for peptides or proteins is below the threshold of " + String(min_decoy_fraction * 100) + "% of the number of targets. If you used the 'shuffle' method, consider increasing the number of attempts.");
+       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The number of decoys for peptides or proteins is below the threshold of " + String(min_decoy_fraction * 100) + "% of the number of targets.");
     }
 
     TargetedExperiment targeted_merged;

--- a/src/topp/OpenSwathDecoyGenerator.cpp
+++ b/src/topp/OpenSwathDecoyGenerator.cpp
@@ -33,10 +33,14 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/FORMAT/TraMLFile.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/FORMAT/FileTypes.h>
 
 using namespace OpenMS;
 
@@ -104,47 +108,81 @@ protected:
 
   void registerOptionsAndFlags_()
   {
-    registerInputFile_("in", "<file>", "", "input file ('traML')");
-    setValidFormats_("in", ListUtils::create<String>("traML"));
-    
-    registerOutputFile_("out", "<file>", "", "output file");
-    setValidFormats_("out", ListUtils::create<String>("traML"));
+    registerInputFile_("in", "<file>", "", "Input file");
+    registerStringOption_("in_type", "<type>", "", "Input file type -- default: determined from file extension or content\n", false);
+    String formats("tsv,mrm,pqp,TraML");
+    setValidFormats_("in", ListUtils::create<String>(formats));
+    setValidStrings_("in_type", ListUtils::create<String>(formats));
+
+    formats = "tsv,pqp,TraML";
+    registerOutputFile_("out", "<file>", "", "Output file");
+    setValidFormats_("out", ListUtils::create<String>(formats));
+    registerStringOption_("out_type", "<type>", "", "Output file type -- default: determined from file extension or content\n", false);
+    setValidStrings_("out_type", ListUtils::create<String>(formats));
 
     registerStringOption_("method", "<type>", "shuffle", "decoy generation method ('shuffle','pseudo-reverse','reverse','shift')", false);
     registerStringOption_("decoy_tag", "<type>", "DECOY_", "decoy tag", false);
-    registerDoubleOption_("mz_threshold", "<double>", 0.05, "MZ threshold in Thomson for fragment ion annotation", false);
-    registerFlag_("exclude_similar", "set this flag if decoy assays with similarity of the peptide sequence to the target assays higher than the identity_threshold should be excluded. If similarity_threshold is over 0, decoy assays with an absolute difference of the decoy and target product mz smaller than similarity_threshold are further excluded.");
-    registerDoubleOption_("similarity_threshold", "<double>", -1, "Similarity threshold for absolute difference of the product mz of target and decoy assays for exclusion in Dalton. Suggested value: 0.05", false);
-    registerFlag_("append", "set this flag if non-decoy TraML should be appended to the output.");
-    registerFlag_("remove_CNterm_mods", "set this flag to remove decoy peptides with C/N terminal modifications (may be necessary depending on the decoy generation method).");
-    registerFlag_("remove_unannotated", "set this flag if target assays with unannotated ions should be ignored from decoy generation.");
-    registerDoubleOption_("identity_threshold", "<double>", 0.7, "shuffle: identity threshold for the shuffle algorithm", false);
-    registerIntOption_("max_attempts", "<int>", 10, "shuffle: maximum attempts to lower the sequence identity between target and decoy for the shuffle algorithm", false);
-    registerDoubleOption_("mz_shift", "<double>", 20, "shift: MZ shift in Thomson for shift decoy method", false);
-    registerDoubleOption_("precursor_mass_shift", "<double>", 0.0, "Mass shift to apply to the precursor ion", false);
-    registerStringOption_("allowed_fragment_types", "<type>", "b,y", "allowed fragment types", false);
-    registerStringOption_("allowed_fragment_charges", "<type>", "1,2,3,4", "allowed fragment charge states", false);
-    registerFlag_("enable_detection_specific_losses", "set this flag if specific neutral losses for detection fragment ions should be allowed");
-    registerFlag_("enable_detection_unspecific_losses", "set this flag if unspecific neutral losses (H2O1, H3N1, C1H2N2, C1H2N1O1) for detection fragment ions should be allowed");
 
+    registerDoubleOption_("product_mz_similarity_threshold", "<double>", 0.05, "Similarity threshold for absolute difference of the product mz of target and decoy assays for exclusion in Dalton. Suggested value: 0.05", false, true);
+
+    registerIntOption_("shuffle_max_attempts", "<int>", 100, "shuffle: maximum attempts to lower the amino acid sequence identity between target and decoy for the shuffle algorithm", false, true);
+    registerDoubleOption_("shuffle_sequence_identity_threshold", "<double>", 0.3, "shuffle: target-decoy amino acid sequence identity threshold for the shuffle algorithm", false, true);
+    registerDoubleOption_("shift_precursor_mz_shift", "<double>", 0.0, "shift: precursor ion MZ shift in Thomson for shift decoy method", false, true);
+    registerDoubleOption_("shift_product_mz_shift", "<double>", 20, "shift: fragment ion MZ shift in Thomson for shift decoy method", false, true);
+
+    registerDoubleOption_("product_mz_threshold", "<double>", 0.025, "MZ threshold in Thomson for fragment ion annotation", false, true);
+    registerStringOption_("allowed_fragment_types", "<type>", "b,y", "allowed fragment types", false, true);
+    registerStringOption_("allowed_fragment_charges", "<type>", "1,2,3,4", "allowed fragment charge states", false, true);
+    registerFlag_("enable_detection_specific_losses", "set this flag if specific neutral losses for detection fragment ions should be allowed", true);
+    registerFlag_("enable_detection_unspecific_losses", "set this flag if unspecific neutral losses (H2O1, H3N1, C1H2N2, C1H2N1O1) for detection fragment ions should be allowed", true);
+
+    registerFlag_("separate", "set this flag if decoys should not be appended to targets.", true);
   }
 
   ExitCodes main_(int, const char **)
   {
+    FileHandler fh;
+
+    //input file type
     String in = getStringOption_("in");
+    FileTypes::Type in_type = FileTypes::nameToType(getStringOption_("in_type"));
+
+    if (in_type == FileTypes::UNKNOWN)
+    {
+      in_type = fh.getType(in);
+      writeDebug_(String("Input file type: ") + FileTypes::typeToName(in_type), 2);
+    }
+
+    if (in_type == FileTypes::UNKNOWN)
+    {
+      writeLog_("Error: Could not determine input file type!");
+      return PARSE_ERROR;
+    }
+
+    //output file names and types
     String out = getStringOption_("out");
+    FileTypes::Type out_type = FileTypes::nameToType(getStringOption_("out_type"));
+
+    if (out_type == FileTypes::UNKNOWN)
+    {
+      out_type = fh.getTypeByFileName(out);
+    }
+
+    if (out_type == FileTypes::UNKNOWN)
+    {
+      writeLog_("Error: Could not determine output file type!");
+      return PARSE_ERROR;
+    }
+
     String method = getStringOption_("method");
     String decoy_tag = getStringOption_("decoy_tag");
-    double mz_threshold = getDoubleOption_("mz_threshold");
-    bool exclude_similar = getFlag_("exclude_similar");
-    double similarity_threshold = getDoubleOption_("similarity_threshold");
-    bool append = getFlag_("append");
-    bool remove_CNterm_mods = getFlag_("remove_CNterm_mods");
-    bool remove_unannotated = getFlag_("remove_unannotated");
-    double identity_threshold = getDoubleOption_("identity_threshold");
-    Int max_attempts = getIntOption_("max_attempts");
-    double mz_shift = getDoubleOption_("mz_shift");
-    double precursor_mass_shift = getDoubleOption_("precursor_mass_shift");
+    double product_mz_threshold = getDoubleOption_("product_mz_threshold");
+    double similarity_threshold = getDoubleOption_("product_mz_similarity_threshold");
+    bool separate = getFlag_("separate");
+    double identity_threshold = getDoubleOption_("shuffle_sequence_identity_threshold");
+    Int max_attempts = getIntOption_("shuffle_max_attempts");
+    double precursor_mz_shift = getDoubleOption_("shift_precursor_mz_shift");
+    double product_mz_shift = getDoubleOption_("shift_product_mz_shift");
     String allowed_fragment_types_string = getStringOption_("allowed_fragment_types");
     String allowed_fragment_charges_string = getStringOption_("allowed_fragment_charges");
     bool enable_detection_specific_losses = getFlag_("enable_detection_specific_losses");
@@ -167,28 +205,84 @@ protected:
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "No valid decoy generation method selected!");
     }
 
-    TraMLFile traml;
     TargetedExperiment targeted_exp;
     TargetedExperiment targeted_decoy;
 
-    std::cout << "Loading " << in << std::endl;
-    traml.load(in, targeted_exp);
+    // Load data
+    LOG_INFO << "Loading " << in << std::endl;
+    if (in_type == FileTypes::TSV || in_type == FileTypes::MRM)
+    {
+      const char* tr_file = in.c_str();
+      Param reader_parameters = getParam_().copy("algorithm:", true);
+      TransitionTSVReader tsv_reader = TransitionTSVReader();
+      tsv_reader.setLogType(log_type_);
+      tsv_reader.setParameters(reader_parameters);
+      tsv_reader.convertTSVToTargetedExperiment(tr_file, in_type, targeted_exp);
+      tsv_reader.validateTargetedExperiment(targeted_exp);
+    }
+    else if (in_type == FileTypes::PQP)
+    {
+      const char* tr_file = in.c_str();
+      TransitionPQPReader pqp_reader = TransitionPQPReader();
+      Param reader_parameters = getParam_().copy("algorithm:", true);
+      pqp_reader.setLogType(log_type_);
+      pqp_reader.setParameters(reader_parameters);
+      pqp_reader.convertPQPToTargetedExperiment(tr_file, targeted_exp);
+      pqp_reader.validateTargetedExperiment(targeted_exp);
+    }
+    else if (in_type == FileTypes::TRAML)
+    {
+      TraMLFile traml;
+      traml.load(in, targeted_exp);
+    }
 
     MRMDecoy decoys = MRMDecoy();
 
-    std::cout << "Generate decoys" << std::endl;
-    decoys.generateDecoys(targeted_exp, targeted_decoy, method, decoy_tag, identity_threshold, max_attempts, mz_threshold, mz_shift, exclude_similar, similarity_threshold, remove_CNterm_mods, precursor_mass_shift, allowed_fragment_types, allowed_fragment_charges, enable_detection_specific_losses, enable_detection_unspecific_losses, remove_unannotated);
+    LOG_INFO << "Generate decoys" << std::endl;
+    decoys.generateDecoys(targeted_exp, targeted_decoy, method, decoy_tag, identity_threshold, max_attempts, product_mz_threshold, product_mz_shift, similarity_threshold, precursor_mz_shift, allowed_fragment_types, allowed_fragment_charges, enable_detection_specific_losses, enable_detection_unspecific_losses);
 
-    if (append)
+    // Check if we have enough peptides left
+    LOG_INFO << "Number of target peptides: " << targeted_exp.getPeptides().size() << std::endl;
+    LOG_INFO << "Number of decoy peptides: " << targeted_decoy.getPeptides().size() << std::endl;
+    LOG_INFO << "Number of target proteins: " << targeted_exp.getProteins().size() << std::endl;
+    LOG_INFO << "Number of decoy proteins: " << targeted_decoy.getProteins().size() << std::endl;
+
+    if ((float)targeted_decoy.getPeptides().size() / (float)targeted_exp.getPeptides().size() < 0.8 || (float)targeted_decoy.getProteins().size() / (float)targeted_exp.getProteins().size() < 0.8)
     {
-      TargetedExperiment targeted_merged;
-      targeted_merged += targeted_exp + targeted_decoy;
-      traml.store(out, targeted_merged);
+       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The number of decoys for peptides or proteins is below the recommended threshold of 80% of the number of targets. If you used the 'shuffle' method, consider increasing the number of attempts.");
+    }
+
+    TargetedExperiment targeted_merged;
+    if (separate)
+    {
+      targeted_merged = targeted_decoy;
     }
     else
     {
-      traml.store(out, targeted_decoy);
+      targeted_merged = targeted_exp + targeted_decoy;
     }
+
+    LOG_INFO << "Writing decoys" << out << std::endl;
+    if (out_type == FileTypes::TSV)
+    {
+      const char* tr_file = out.c_str();
+      TransitionTSVReader tsv_reader = TransitionTSVReader();
+      tsv_reader.setLogType(log_type_);
+      tsv_reader.convertTargetedExperimentToTSV(tr_file, targeted_exp);
+    }
+    if (out_type == FileTypes::PQP)
+    {
+      const char * tr_file = out.c_str();
+      TransitionPQPReader pqp_reader = TransitionPQPReader();
+      pqp_reader.setLogType(log_type_);
+      pqp_reader.convertTargetedExperimentToPQP(tr_file, targeted_exp);
+    }
+    else if (out_type == FileTypes::TRAML)
+    {
+      TraMLFile traml;
+      traml.store(out, targeted_exp);
+    }
+
     return EXECUTION_OK;
   }
 


### PR DESCRIPTION
Over the past years, we have made several adjustments to ``OpenSwathDecoyGenerator`` to deal with more complex spectral libraries. One particular problem was non-canonical PTMs, particularly at the C-/N-term. We introduced several new parameters for the TOPP tool, which were used in combination to exclude some of the difficult peptides when they failed checks. Finding the right combination was sometimes frustrating for users.

This PR attempts to remove most of these parameters and to enable only sensible combinations. Further, some changes to the algorithm ensure that for the vast majority of applications, the default parameters work reliably out of the box, without the need for tweaking.

Further, ``OpenSwathDecoyGenerator`` now supports all other formats for spectral libraries as well. Generating decoys for the PHL takes only 3-5min depending on the format.

Since the algorithmic changes are substantial and the default parameters are modified, we should do further testing to ensure that all challenges are covered. I will test with SWATH-MS Gold Standard, PTM-SWATH-MS Gold Standard and the SWATH-MS interlab study / PHL data sets within the next days and report back.