### PR TITLE
[Update] .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ OpenMS.includes
 src/.DS_Store
 src/openms/.DS_Store
 .vscode
+contrib-build
+openms-build


### PR DESCRIPTION
If the quickbuild script is used folders (contrib-build & openms-build) will be located in the OpenMS-folder.