### PR TITLE
[FEATURE] CsvFile::addRow() and CsvFile::clearBuffer()

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/CsvFile.h
+++ b/src/openms/include/OpenMS/FORMAT/CsvFile.h
@@ -82,7 +82,26 @@ public:
     */
     void fload(const String& filename, char is = ',', bool ie = false, Int first_n = -1);
 
+    /**
+      @brief Stores the buffer's content into a file.
+
+      @param filename The output filename.
+    */
     void fstore(const String& filename);
+
+    /**
+      @brief Add a row to the buffer.
+
+      @param list StringList which will contain all items of the row to add
+    */
+    void addRow(const StringList& list);
+
+    /**
+      @brief Clears the buffer
+
+      Clears TextFile::buffer_
+    */
+    void clearBuffer();
 
     /**
       @brief writes all items from a row to list

--- a/src/openms/include/OpenMS/FORMAT/CsvFile.h
+++ b/src/openms/include/OpenMS/FORMAT/CsvFile.h
@@ -80,14 +80,14 @@ public:
 
       @exception Exception::FileNotFound is thrown if the file could not be opened.
     */
-    void fload(const String& filename, char is = ',', bool ie = false, Int first_n = -1);
+    void load(const String& filename, char is = ',', bool ie = false, Int first_n = -1);
 
     /**
       @brief Stores the buffer's content into a file.
 
       @param filename The output filename.
     */
-    void fstore(const String& filename);
+    void store(const String& filename);
 
     /**
       @brief Add a row to the buffer.
@@ -101,7 +101,7 @@ public:
 
       Clears TextFile::buffer_
     */
-    void clearBuffer();
+    void clear();
 
     /**
       @brief writes all items from a row to list

--- a/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
+++ b/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
@@ -55,7 +55,7 @@ namespace OpenMS
     char is = ',';
     bool ie = false; 
     Int first_n = -1;
-    fload(filename, is, ie, first_n);
+    CsvFile::load(filename, is, ie, first_n);
 
     // parse the file
     std::map<String,int> headers;

--- a/src/openms/source/FORMAT/CsvFile.cpp
+++ b/src/openms/source/FORMAT/CsvFile.cpp
@@ -69,6 +69,26 @@ namespace OpenMS
     store(filename);
   }
 
+  void CsvFile::addRow(const StringList& list)
+  {
+    StringList elements = list;
+    if (itemenclosed_)
+    {
+      for (Size i = 0; i < elements.size(); ++i)
+      {
+        elements[i].quote('"', String::NONE);
+      }
+    }
+    String line;
+    line.concatenate(elements.begin(), elements.end(), itemseperator_);
+    addLine(line);
+  }
+
+  void CsvFile::clearBuffer()
+  {
+    buffer_.clear();
+  }
+
   bool CsvFile::getRow(Size row, StringList& list)
   {
     if (row > TextFile::buffer_.size())

--- a/src/openms/source/FORMAT/CsvFile.cpp
+++ b/src/openms/source/FORMAT/CsvFile.cpp
@@ -91,7 +91,8 @@ namespace OpenMS
 
   bool CsvFile::getRow(Size row, StringList& list)
   {
-    if (row > TextFile::buffer_.size())
+    // it is assumed that the value to be casted won't be so large to overflow an int
+    if (static_cast<int>(row) > static_cast<int>(TextFile::buffer_.size()) - 1)
     {
       throw Exception::InvalidIterator(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }

--- a/src/openms/source/FORMAT/CsvFile.cpp
+++ b/src/openms/source/FORMAT/CsvFile.cpp
@@ -54,19 +54,19 @@ namespace OpenMS
   CsvFile::CsvFile(const String& filename, char is, bool ie, Int first_n) :
     TextFile(), itemseperator_(is), itemenclosed_(ie)
   {
-    load(filename, false, first_n);
+    TextFile::load(filename, false, first_n);
   }
 
-  void CsvFile::fload(const String& filename, char is, bool ie, Int first_n)
+  void CsvFile::load(const String& filename, char is, bool ie, Int first_n)
   {
     itemseperator_ = is;
     itemenclosed_ = ie;
-    load(filename, true, first_n);
+    TextFile::load(filename, true, first_n);
   }
 
-  void CsvFile::fstore(const String& filename)
+  void CsvFile::store(const String& filename)
   {
-    store(filename);
+    TextFile::store(filename);
   }
 
   void CsvFile::addRow(const StringList& list)
@@ -84,7 +84,7 @@ namespace OpenMS
     addLine(line);
   }
 
-  void CsvFile::clearBuffer()
+  void CsvFile::clear()
   {
     buffer_.clear();
   }
@@ -96,7 +96,7 @@ namespace OpenMS
     {
       throw Exception::InvalidIterator(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }
-    bool splitted = TextFile::buffer_.operator[](row).split(itemseperator_, list);
+    bool splitted = buffer_[row].split(itemseperator_, list);
     if (!splitted)
     {
       return splitted;

--- a/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
+++ b/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
@@ -56,7 +56,7 @@ namespace OpenMS
     char is = ',';
     bool ie = false; 
     Int first_n = -1;
-    fload(filename, is, ie, first_n);
+    CsvFile::load(filename, is, ie, first_n);
 
     // parse the file
     std::map<String,int> headers;

--- a/src/tests/class_tests/openms/source/CsvFile_test.cpp
+++ b/src/tests/class_tests/openms/source/CsvFile_test.cpp
@@ -126,6 +126,32 @@ START_SECTION(void fstore(const String& filename))
 	TEST_EQUAL(list,ListUtils::create<String>("spectral,search"))
 END_SECTION
 
+START_SECTION(void addRow(const StringList& list))
+	CsvFile f1, f2;
+	StringList list;
+
+	f1.addRow(ListUtils::create<String>("first,second,third"));
+	f1.addRow(ListUtils::create<String>("4,5,6"));
+
+	f1.fstore(OPENMS_GET_TEST_DATA_PATH("CsvFile_4.csv"));
+	f2.fload(OPENMS_GET_TEST_DATA_PATH("CsvFile_4.csv"), ',', false);
+	f2.getRow(0,list);
+	TEST_EQUAL(list, ListUtils::create<String>("first,second,third"))
+	f2.getRow(1,list);
+	TEST_EQUAL(list, ListUtils::create<String>("4,5,6"))
+END_SECTION
+
+START_SECTION(void clearBuffer())
+	CsvFile f1;
+	StringList list;
+
+	f1.addRow(ListUtils::create<String>("hello,world"));
+	f1.getRow(0, list);
+	TEST_EQUAL(list, ListUtils::create<String>("hello,world"))
+	f1.clearBuffer();
+	TEST_EXCEPTION(Exception::InvalidIterator, f1.getRow(0, list))
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/CsvFile_test.cpp
+++ b/src/tests/class_tests/openms/source/CsvFile_test.cpp
@@ -70,9 +70,9 @@ START_SECTION(CsvFile(const String& filename, char is = ',',bool ie = false, Int
 TEST_EXCEPTION(Exception::FileNotFound, CsvFile("CsvFile_1.csv"))
 END_SECTION
 
-START_SECTION(void fload(const String& filename, char is = ',', bool ie = false, Int first_n = -1))
+START_SECTION(void load(const String& filename, char is = ',', bool ie = false, Int first_n = -1))
 //tested in getRow
-TEST_EXCEPTION(Exception::FileNotFound, f1.fload("CsvFile_1.csv"))
+TEST_EXCEPTION(Exception::FileNotFound, f1.load("CsvFile_1.csv"))
 
 
 END_SECTION
@@ -83,7 +83,6 @@ START_SECTION(bool getRow(Size row,StringList &list))
 	TOLERANCE_ABSOLUTE(0.01)
 	CsvFile f1,f3,f4;
 
-
 	CsvFile f2(OPENMS_GET_TEST_DATA_PATH("CsvFile_1.csv"), '\t');
 	StringList list;
 	f2.getRow(0,list);
@@ -93,7 +92,7 @@ START_SECTION(bool getRow(Size row,StringList &list))
 	f2.getRow(2,list);
 	TEST_EQUAL(list,ListUtils::create<String>("spectral,search"))
 
-	f3.fload(OPENMS_GET_TEST_DATA_PATH("CsvFile_1.csv"),'\t');
+	f3.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_1.csv"),'\t');
 	f3.getRow(0,list);
 	TEST_EQUAL(list,ListUtils::create<String>("hello,world"))
 	f3.getRow(1,list);
@@ -101,7 +100,7 @@ START_SECTION(bool getRow(Size row,StringList &list))
 	f3.getRow(2,list);
 	TEST_EQUAL(list,ListUtils::create<String>("spectral,search"))
 
-	f4.fload(OPENMS_GET_TEST_DATA_PATH("CsvFile_2.csv"),'\t',true);
+	f4.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_2.csv"),'\t',true);
 	f4.getRow(0,list);
 	TEST_EQUAL(list,ListUtils::create<String>("hello,world"))
 	f4.getRow(1,list);
@@ -111,13 +110,13 @@ START_SECTION(bool getRow(Size row,StringList &list))
 
 END_SECTION
 
-START_SECTION(void fstore(const String& filename))
+START_SECTION(void store(const String& filename))
 	CsvFile f1,f2;
 	StringList list;
 
-	f1.fload(OPENMS_GET_TEST_DATA_PATH("CsvFile_2.csv"),'\t',true); // load from a file
-	f1.fstore(OPENMS_GET_TEST_DATA_PATH("CsvFile_3.csv"));          // store into a new one
-	f2.fload(OPENMS_GET_TEST_DATA_PATH("CsvFile_3.csv"),'\t',true); // load the new one
+	f1.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_2.csv"),'\t',true); // load from a file
+	f1.store(OPENMS_GET_TEST_DATA_PATH("CsvFile_3.csv"));          // store into a new one
+	f2.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_3.csv"),'\t',true); // load the new one
 	f2.getRow(0,list);
 	TEST_EQUAL(list,ListUtils::create<String>("hello,world"))
 	f2.getRow(1,list);
@@ -133,22 +132,22 @@ START_SECTION(void addRow(const StringList& list))
 	f1.addRow(ListUtils::create<String>("first,second,third"));
 	f1.addRow(ListUtils::create<String>("4,5,6"));
 
-	f1.fstore(OPENMS_GET_TEST_DATA_PATH("CsvFile_4.csv"));
-	f2.fload(OPENMS_GET_TEST_DATA_PATH("CsvFile_4.csv"), ',', false);
+	f1.store(OPENMS_GET_TEST_DATA_PATH("CsvFile_4.csv"));
+	f2.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_4.csv"), ',', false);
 	f2.getRow(0,list);
 	TEST_EQUAL(list, ListUtils::create<String>("first,second,third"))
 	f2.getRow(1,list);
 	TEST_EQUAL(list, ListUtils::create<String>("4,5,6"))
 END_SECTION
 
-START_SECTION(void clearBuffer())
+START_SECTION(void clear())
 	CsvFile f1;
 	StringList list;
 
 	f1.addRow(ListUtils::create<String>("hello,world"));
 	f1.getRow(0, list);
 	TEST_EQUAL(list, ListUtils::create<String>("hello,world"))
-	f1.clearBuffer();
+	f1.clear();
 	TEST_EXCEPTION(Exception::InvalidIterator, f1.getRow(0, list))
 END_SECTION
 


### PR DESCRIPTION
This PR adds two methods to the CsvFile class.

`addRow()` adds a row to the `buffer_` inherited from _TextFile_. It takes into account the values of `itemenclosed_` and `itemseperator_`.

`clearBuffer()` simply calls `buffer_.clear()`.