### PR TITLE
[FEATURE] Improvements for PQP conversion / Renaming of classes

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
@@ -36,7 +36,7 @@
 #define OPENMS_ANALYSIS_OPENSWATH_TARGETEDSPECTRAEXTRACTOR_H
 
 #include <OpenMS/config.h> // OPENMS_DLLAPI
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h
@@ -32,10 +32,10 @@
 // $Authors: George Rosenberger, Hannes Roest $
 // --------------------------------------------------------------------------
 
-#ifndef OPENMS_ANALYSIS_OPENSWATH_TRANSITIONPQPREADER_H
-#define OPENMS_ANALYSIS_OPENSWATH_TRANSITIONPQPREADER_H
+#ifndef OPENMS_ANALYSIS_OPENSWATH_TRANSITIONPQPFILE_H
+#define OPENMS_ANALYSIS_OPENSWATH_TRANSITIONPQPFILE_H
 
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
 
 #include <boost/range/algorithm.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
@@ -50,11 +50,11 @@ namespace OpenMS
 
       The PQP files are SQLite databases consisting of several tables representing the data contained in TraML files.
 
-  @htmlinclude OpenMS_TransitionPQPReader.parameters
+  @htmlinclude OpenMS_TransitionPQPFile.parameters
 
   */
-  class OPENMS_DLLAPI TransitionPQPReader :
-    public TransitionTSVReader
+  class OPENMS_DLLAPI TransitionPQPFile :
+    public TransitionTSVFile
   {
 
 private:
@@ -78,10 +78,10 @@ public:
 
     //@{
     /// Constructor
-    TransitionPQPReader();
+    TransitionPQPFile();
 
     /// Destructor
-    ~TransitionPQPReader() override;
+    ~TransitionPQPFile() override;
     //@}
 
     /** @brief Write out a targeted experiment (TraML structure) into a PQP file

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h
@@ -32,8 +32,8 @@
 // $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
 
-#ifndef OPENMS_ANALYSIS_OPENSWATH_TRANSITIONTSVREADER_H
-#define OPENMS_ANALYSIS_OPENSWATH_TRANSITIONTSVREADER_H
+#ifndef OPENMS_ANALYSIS_OPENSWATH_TRANSITIONTSVFILE_H
+#define OPENMS_ANALYSIS_OPENSWATH_TRANSITIONTSVFILE_H
 
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h>
@@ -75,10 +75,10 @@ namespace OpenMS
       identifying_transition (bool, should this transition be used for UIS identification together with the detecting transitions?)
       quantifying_transition (bool, should this transition be used for quantification?)
 
-  @htmlinclude OpenMS_TransitionTSVReader.parameters
+  @htmlinclude OpenMS_TransitionTSVFile.parameters
 
   */
-  class OPENMS_DLLAPI TransitionTSVReader :
+  class OPENMS_DLLAPI TransitionTSVFile :
     public ProgressLogger,
     public DefaultParamHandler
   {
@@ -172,7 +172,7 @@ protected:
    */
     //@{
 
-    TransitionTSVReader::TSVTransition convertTransition_(const ReactionMonitoringTransition* it, OpenMS::TargetedExperiment& targeted_exp);
+    TransitionTSVFile::TSVTransition convertTransition_(const ReactionMonitoringTransition* it, OpenMS::TargetedExperiment& targeted_exp);
 
     /// Synchronize members with param class
     void updateMembers_() override;
@@ -263,10 +263,10 @@ public:
 
     //@{
     /// Constructor
-    TransitionTSVReader();
+    TransitionTSVFile();
 
     /// Destructor
-    ~TransitionTSVReader() override;
+    ~TransitionTSVFile() override;
     //@}
 
     /** @brief Write out a targeted experiment (TraML structure) into a tsv file

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/sources.cmake
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/sources.cmake
@@ -28,8 +28,8 @@ set(sources_list_h
   TargetedSpectraExtractor.h
   SwathMapMassCorrection.h
   SwathWindowLoader.h
-  TransitionTSVReader.h
-  TransitionPQPReader.h
+  TransitionTSVFile.h
+  TransitionPQPFile.h
   MRMFeatureQC.h
   MRMFeatureFilter.h
 )

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -32,17 +32,17 @@
 // $Authors: George Rosenberger, Hannes Roest $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>
 
 namespace OpenMS
 {
 
-  TransitionPQPReader::TransitionPQPReader() :
-    TransitionTSVReader()
+  TransitionPQPFile::TransitionPQPFile() :
+    TransitionTSVFile()
   {
   }
 
-  TransitionPQPReader::~TransitionPQPReader()
+  TransitionPQPFile::~TransitionPQPFile()
   {
   }
 
@@ -56,7 +56,7 @@ namespace OpenMS
     return(0);
   }
 
-  void TransitionPQPReader::readPQPInput_(const char* filename, std::vector<TSVTransition>& transition_list, bool legacy_traml_id)
+  void TransitionPQPFile::readPQPInput_(const char* filename, std::vector<TSVTransition>& transition_list, bool legacy_traml_id)
   {
     sqlite3 *db;
     char *zErrMsg = nullptr;
@@ -290,7 +290,7 @@ namespace OpenMS
 
   }
 
-  void TransitionPQPReader::writePQPOutput_(const char* filename, OpenMS::TargetedExperiment& targeted_exp)
+  void TransitionPQPFile::writePQPOutput_(const char* filename, OpenMS::TargetedExperiment& targeted_exp)
   {
     sqlite3 *db;
     char *zErrMsg = nullptr;
@@ -429,10 +429,10 @@ namespace OpenMS
     for (auto const & x : group_vec) { group_map[x] = group_map_idx; group_map_idx++; }
 
     // IPF: Loop through all transitions and generate peptidoform data structures
-    std::vector<TransitionPQPReader::TSVTransition > transitions;
+    std::vector<TransitionPQPFile::TSVTransition > transitions;
     for (Size i = 0; i < targeted_exp.getTransitions().size(); i++)
     {
-      TransitionPQPReader::TSVTransition transition = convertTransition_(&targeted_exp.getTransitions()[i], targeted_exp);
+      TransitionPQPFile::TSVTransition transition = convertTransition_(&targeted_exp.getTransitions()[i], targeted_exp);
       transitions.push_back(transition);
 
       std::copy( transition.peptidoforms.begin(), transition.peptidoforms.end(), std::inserter( peptide_vec, peptide_vec.end() ) );
@@ -476,7 +476,7 @@ namespace OpenMS
     // OpenSWATH: Prepare transition inserts
     for (Size i = 0; i < transitions.size(); i++)
     {
-      TransitionPQPReader::TSVTransition transition = transitions[i];
+      TransitionPQPFile::TSVTransition transition = transitions[i];
 
       // IPF: Generate transition-peptide mapping tables (one identification transition can map to multiple peptidoforms)
       for (Size j = 0; j < transition.peptidoforms.size(); j++)
@@ -697,7 +697,7 @@ namespace OpenMS
   }
 
   // public methods
-  void TransitionPQPReader::convertTargetedExperimentToPQP(const char* filename, OpenMS::TargetedExperiment& targeted_exp)
+  void TransitionPQPFile::convertTargetedExperimentToPQP(const char* filename, OpenMS::TargetedExperiment& targeted_exp)
   {
     if (targeted_exp.containsInvalidReferences())
     {
@@ -707,14 +707,14 @@ namespace OpenMS
     writePQPOutput_(filename, targeted_exp);
   }
 
-  void TransitionPQPReader::convertPQPToTargetedExperiment(const char* filename, OpenMS::TargetedExperiment& targeted_exp, bool legacy_traml_id)
+  void TransitionPQPFile::convertPQPToTargetedExperiment(const char* filename, OpenMS::TargetedExperiment& targeted_exp, bool legacy_traml_id)
   {
     std::vector<TSVTransition> transition_list;
     readPQPInput_(filename, transition_list, legacy_traml_id);
     TSVToTargetedExperiment_(transition_list, targeted_exp);
   }
 
-  void TransitionPQPReader::convertPQPToTargetedExperiment(const char* filename, OpenSwath::LightTargetedExperiment& targeted_exp, bool legacy_traml_id)
+  void TransitionPQPFile::convertPQPToTargetedExperiment(const char* filename, OpenSwath::LightTargetedExperiment& targeted_exp, bool legacy_traml_id)
   {
     std::vector<TSVTransition> transition_list;
     readPQPInput_(filename, transition_list, legacy_traml_id);

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPFile.cpp
@@ -59,7 +59,6 @@ namespace OpenMS
   void TransitionPQPFile::readPQPInput_(const char* filename, std::vector<TSVTransition>& transition_list, bool legacy_traml_id)
   {
     sqlite3 *db;
-    char *zErrMsg = nullptr;
     sqlite3_stmt * cntstmt;
     sqlite3_stmt * stmt;
     int rc;

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionPQPReader.cpp
@@ -58,8 +58,9 @@ namespace OpenMS
 
   void TransitionPQPReader::readPQPInput_(const char* filename, std::vector<TSVTransition>& transition_list, bool legacy_traml_id)
   {
-    std::cout << "Reading PQP file" << std::endl;
     sqlite3 *db;
+    char *zErrMsg = nullptr;
+    sqlite3_stmt * cntstmt;
     sqlite3_stmt * stmt;
     int rc;
     std::string select_sql;
@@ -78,7 +79,13 @@ namespace OpenMS
       fprintf(stderr, "Can't open database: %s\n", sqlite3_errmsg(db));
     }
 
-    // Get Peptides
+    // Count transitions
+    sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM TRANSITION;", -1, &cntstmt, nullptr);
+    sqlite3_step( cntstmt );
+    int num_transitions = sqlite3_column_int( cntstmt, 0 );
+    sqlite3_finalize(cntstmt);
+
+    // Get peptides
     select_sql = "SELECT " \
                   "PRECURSOR.PRECURSOR_MZ AS precursor, " \
                   "TRANSITION.PRODUCT_MZ AS product, " \
@@ -116,7 +123,7 @@ namespace OpenMS
                   "INNER JOIN " \
                   "(SELECT PEPTIDE_ID, GROUP_CONCAT(PROTEIN_ACCESSION,';') AS PROTEIN_ACCESSION FROM PROTEIN INNER JOIN PEPTIDE_PROTEIN_MAPPING ON PROTEIN.ID = PEPTIDE_PROTEIN_MAPPING.PROTEIN_ID GROUP BY PEPTIDE_ID) AS PROTEIN_AGGREGATED ON PEPTIDE.ID = PROTEIN_AGGREGATED.PEPTIDE_ID ";
 
-    // Get Compounds
+    // Get compounds
     select_sql += "UNION SELECT " \
                   "PRECURSOR.PRECURSOR_MZ AS precursor, " \
                   "TRANSITION.PRODUCT_MZ AS product, " \
@@ -153,12 +160,15 @@ namespace OpenMS
                   "INNER JOIN COMPOUND ON PRECURSOR_COMPOUND_MAPPING.COMPOUND_ID = COMPOUND.ID; ";
 
     // Execute SQL select statement
-    sqlite3_prepare(db, select_sql.c_str(), -1, &stmt, nullptr);
+    sqlite3_prepare_v2(db, select_sql.c_str(), -1, &stmt, nullptr);
     sqlite3_step( stmt );
 
+    Size progress = 0;
+    startProgress(0, num_transitions, "reading PQP file");
     // Convert SQLite data to TSVTransition data structure
     while (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
     {
+      setProgress(progress++);
       TSVTransition mytransition;
 
       if (sqlite3_column_type( stmt, 0 ) != SQLITE_NULL)
@@ -273,6 +283,7 @@ namespace OpenMS
       transition_list.push_back(mytransition);
       sqlite3_step( stmt );
     }
+    endProgress();
 
     sqlite3_finalize(stmt);
     sqlite3_close(db);
@@ -302,7 +313,7 @@ namespace OpenMS
       "CREATE TABLE PROTEIN(" \
       "ID INT PRIMARY KEY NOT NULL," \
       "PROTEIN_ACCESSION TEXT NOT NULL," \
-      "DECOY INT NULL);" \
+      "DECOY INT NOT NULL);" \
 
       // peptide_protein_mapping table
       // OpenSWATH proteomics workflows
@@ -396,29 +407,21 @@ namespace OpenMS
     insert_transition_sql.precision(11);
 
     // OpenSWATH: Loop through TargetedExperiment to generate index maps for peptides
-    Size progress = 0;
-    startProgress(0, targeted_exp.getPeptides().size(), "Convert peptides");
     for (Size i = 0; i < targeted_exp.getPeptides().size(); i++)
     {
-      setProgress(progress++);
       OpenMS::TargetedExperiment::Peptide peptide = targeted_exp.getPeptides()[i];
       std::string peptide_sequence = TargetedExperimentHelper::getAASequence(peptide).toUniModString();
       peptide_vec.push_back(peptide_sequence);
       group_vec.push_back(peptide.id);
     }
-    endProgress();
 
     // OpenSWATH: Loop through TargetedExperiment to generate index maps for compounds
-    progress = 0;
-    startProgress(0, targeted_exp.getCompounds().size(), "Convert compounds");
     for (Size i = 0; i < targeted_exp.getCompounds().size(); i++)
     {
-      setProgress(progress++);
       OpenMS::TargetedExperiment::Compound compound = targeted_exp.getCompounds()[i];
       compound_vec.push_back(compound.id);
       group_vec.push_back(compound.id);
     }
-    endProgress();
 
     // OpenSWATH: Group set must be unique
     boost::erase(group_vec, boost::unique<boost::return_found_end>(boost::sort(group_vec)));
@@ -426,12 +429,9 @@ namespace OpenMS
     for (auto const & x : group_vec) { group_map[x] = group_map_idx; group_map_idx++; }
 
     // IPF: Loop through all transitions and generate peptidoform data structures
-    progress = 0;
     std::vector<TransitionPQPReader::TSVTransition > transitions;
-    startProgress(0, targeted_exp.getTransitions().size(), "Convert peptidoforms");
     for (Size i = 0; i < targeted_exp.getTransitions().size(); i++)
     {
-      setProgress(progress++);
       TransitionPQPReader::TSVTransition transition = convertTransition_(&targeted_exp.getTransitions()[i], targeted_exp);
       transitions.push_back(transition);
 
@@ -451,7 +451,6 @@ namespace OpenMS
         }
       }
     }
-    endProgress();
 
     // OpenSWATH: Peptide and compound sets must be unique
     boost::erase(peptide_vec, boost::unique<boost::return_found_end>(boost::sort(peptide_vec)));
@@ -463,15 +462,11 @@ namespace OpenMS
     for (auto const & x : compound_vec) { compound_map[x] = compound_map_idx; compound_map_idx++; }
 
     // OpenSWATH: Loop through TargetedExperiment to generate index maps for proteins
-    progress = 0;
-    startProgress(0, targeted_exp.getProteins().size(), "Prepare protein mapping");
     for (Size i = 0; i < targeted_exp.getProteins().size(); i++)
     {
-      setProgress(progress++);
       OpenMS::TargetedExperiment::Protein protein = targeted_exp.getProteins()[i];
       protein_vec.push_back(protein.id);
     }
-    endProgress();
 
     // OpenSWATH: Protein set must be unique
     boost::erase(protein_vec, boost::unique<boost::return_found_end>(boost::sort(protein_vec)));
@@ -479,11 +474,8 @@ namespace OpenMS
     for (auto const & x : protein_vec) { protein_map[x] = protein_map_idx; protein_map_idx++; }
 
     // OpenSWATH: Prepare transition inserts
-    progress = 0;
-    startProgress(0, transitions.size(), String("Prepare ") +  transitions.size() + " transitions and mapping");
     for (Size i = 0; i < transitions.size(); i++)
     {
-      setProgress(progress++);
       TransitionPQPReader::TSVTransition transition = transitions[i];
 
       // IPF: Generate transition-peptide mapping tables (one identification transition can map to multiple peptidoforms)
@@ -504,18 +496,14 @@ namespace OpenMS
       // OpenSWATH: Insert transition data
       insert_transition_sql << "INSERT INTO TRANSITION (ID, TRAML_ID, PRODUCT_MZ, CHARGE, TYPE, ORDINAL, DETECTING, IDENTIFYING, QUANTIFYING, LIBRARY_INTENSITY, DECOY) VALUES (" << i << ",'" << transition.transition_name << "'," << transition.product << "," << transition_charge << ",'" << transition.fragment_type<< "'," << transition.fragment_nr << "," << transition.detecting_transition << "," << transition.identifying_transition << "," << transition.quantifying_transition << "," << transition.library_intensity << "," << transition.decoy << "); ";
     }
-    endProgress();
 
     std::stringstream insert_precursor_sql, insert_precursor_peptide_mapping, insert_precursor_compound_mapping;
     insert_precursor_sql.precision(11);
     std::vector<std::pair<int, int> > peptide_protein_map;
 
     // OpenSWATH: Prepare peptide precursor inserts
-    progress = 0;
-    startProgress(0, targeted_exp.getPeptides().size(), "Prepare peptide precursors and mapping");
     for (Size i = 0; i < targeted_exp.getPeptides().size(); i++)
     {
-      setProgress(progress++);
       OpenMS::TargetedExperiment::Peptide peptide = targeted_exp.getPeptides()[i];
       std::string peptide_sequence = TargetedExperimentHelper::getAASequence(peptide).toUniModString();
       int group_set_index = group_map[peptide.id];
@@ -531,14 +519,10 @@ namespace OpenMS
       insert_precursor_peptide_mapping << "INSERT INTO PRECURSOR_PEPTIDE_MAPPING (PRECURSOR_ID, PEPTIDE_ID) VALUES (" << group_set_index << "," << peptide_set_index << "); ";
 
     }
-    endProgress();
 
     // OpenSWATH: Prepare compound precursor inserts
-    progress = 0;
-    startProgress(0, targeted_exp.getCompounds().size(), "Prepare compound precursors and mapping");
     for (Size i = 0; i < targeted_exp.getCompounds().size(); i++)
     {
-      setProgress(progress++);
       OpenMS::TargetedExperiment::Compound compound = targeted_exp.getCompounds()[i];
       int group_set_index = group_map[compound.id];
       int compound_set_index = compound_map[compound.id];
@@ -554,55 +538,45 @@ namespace OpenMS
       insert_precursor_compound_mapping << "INSERT INTO PRECURSOR_COMPOUND_MAPPING (PRECURSOR_ID, COMPOUND_ID) VALUES (" << group_set_index << "," << compound_set_index << "); ";
 
     }
-    endProgress();
 
     boost::erase(peptide_protein_map, boost::unique<boost::return_found_end>(boost::sort(peptide_protein_map)));
     // OpenSWATH: Prepare peptide-protein mapping inserts
     std::stringstream insert_peptide_protein_mapping;
-    progress = 0;
-    startProgress(0, peptide_protein_map.size(), "Prepare peptide - protein mapping");
     for (std::vector<std::pair<int, int> >::iterator it = peptide_protein_map.begin(); it != peptide_protein_map.end(); ++it)
     {
-      setProgress(progress++);
       insert_peptide_protein_mapping << "INSERT INTO PEPTIDE_PROTEIN_MAPPING (PEPTIDE_ID, PROTEIN_ID) VALUES (" << it->first << "," << it->second << "); ";
     }
-    endProgress();
 
     // OpenSWATH: Prepare protein inserts
     std::stringstream insert_protein_sql;
-    progress = 0;
-    startProgress(0, protein_map.size(), String("Prepare ") + protein_map.size() + " proteins");
     for (std::map<std::string, int >::iterator it = protein_map.begin(); it != protein_map.end(); ++it)
     {
-      setProgress(progress++);
-      insert_protein_sql << "INSERT INTO PROTEIN (ID, PROTEIN_ACCESSION) VALUES (" << it->second << ",'" << it->first << "'); ";
+      insert_protein_sql << "INSERT INTO PROTEIN (ID, PROTEIN_ACCESSION, DECOY) VALUES (" << it->second << ",'" << it->first << "'," << 0 << "); ";
     }
-    endProgress();
 
     // OpenSWATH: Prepare peptide inserts
     std::stringstream insert_peptide_sql;
-    progress = 0;
-    startProgress(0, peptide_map.size(), String("Prepare ") + peptide_map.size() + " peptides");
     for (std::map<std::string, int >::iterator it = peptide_map.begin(); it != peptide_map.end(); ++it)
     {
-      setProgress(progress++);
-      insert_peptide_sql << "INSERT INTO PEPTIDE (ID, UNMODIFIED_SEQUENCE, MODIFIED_SEQUENCE, DECOY) VALUES (" << it->second << ",'" << AASequence::fromString(it->first).toUnmodifiedString() << "','" << it->first << "'," << 0 <<"); ";
+      insert_peptide_sql << "INSERT INTO PEPTIDE (ID, UNMODIFIED_SEQUENCE, MODIFIED_SEQUENCE, DECOY) VALUES (" << it->second << ",'" << AASequence::fromString(it->first).toUnmodifiedString() << "','" << it->first << "'," << 0 << "); ";
     }
-    endProgress();
 
     // OpenSWATH: Prepare compound inserts
     std::stringstream insert_compound_sql;
-    progress = 0;
-    startProgress(0, compound_map.size(), String("Prepare ") + compound_map.size() + " compounds");
     for (std::map<std::string, int >::iterator it = compound_map.begin(); it != compound_map.end(); ++it)
     {
-      setProgress(progress++);
       OpenMS::TargetedExperiment::Compound compound = targeted_exp.getCompoundByRef(it->first);
-      insert_compound_sql << "INSERT INTO COMPOUND (ID, COMPOUND_NAME, SUM_FORMULA, SMILES, DECOY) VALUES (" << it->second << ",'" << compound.id << "','" << compound.molecular_formula << "','" << compound.smiles_string << "'," << 0 <<"); ";
+      insert_compound_sql << "INSERT INTO COMPOUND (ID, COMPOUND_NAME, SUM_FORMULA, SMILES, DECOY) VALUES (" << it->second << ",'" << compound.id << "','" << compound.molecular_formula << "','" << compound.smiles_string << "'," << 0 << "); ";
     }
-    endProgress();
 
-    std::cout << "Writing PQP file" << std::endl;
+    // OpenSWATH: Prepare decoy updates
+    std::stringstream update_decoys_sql;
+    // Peptides
+    update_decoys_sql << "UPDATE PEPTIDE SET DECOY = 1 WHERE ID IN (SELECT PEPTIDE.ID FROM PRECURSOR JOIN PRECURSOR_PEPTIDE_MAPPING ON PRECURSOR.ID =  PRECURSOR_PEPTIDE_MAPPING.PRECURSOR_ID JOIN PEPTIDE ON PRECURSOR_PEPTIDE_MAPPING.PEPTIDE_ID = PEPTIDE.ID WHERE PRECURSOR.DECOY = 1); ";
+    // Compounds
+    update_decoys_sql << "UPDATE COMPOUND SET DECOY = 1 WHERE ID IN (SELECT COMPOUND.ID FROM PRECURSOR JOIN PRECURSOR_COMPOUND_MAPPING ON PRECURSOR.ID =  PRECURSOR_COMPOUND_MAPPING.PRECURSOR_ID JOIN COMPOUND ON PRECURSOR_COMPOUND_MAPPING.COMPOUND_ID = COMPOUND.ID WHERE PRECURSOR.DECOY = 1); ";
+    // Proteins
+    update_decoys_sql << "UPDATE PROTEIN SET DECOY = 1 WHERE ID IN (SELECT PROTEIN.ID FROM PEPTIDE JOIN PEPTIDE_PROTEIN_MAPPING ON PEPTIDE.ID =  PEPTIDE_PROTEIN_MAPPING.PEPTIDE_ID JOIN PROTEIN ON PEPTIDE_PROTEIN_MAPPING.PROTEIN_ID = PROTEIN.ID WHERE PEPTIDE.DECOY = 1); ";
 
     sqlite3_exec(db, "BEGIN TRANSACTION", nullptr, nullptr, &zErrMsg);
 
@@ -699,6 +673,16 @@ namespace OpenMS
     // Execute SQL insert statement
     std::string insert_transition_precursor_mapping_sql_str = insert_transition_precursor_mapping_sql.str();
     rc = sqlite3_exec(db, insert_transition_precursor_mapping_sql_str.c_str(), callback, nullptr, &zErrMsg);
+    if ( rc != SQLITE_OK )
+    {
+      sqlite3_free(zErrMsg);
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          zErrMsg);
+    }
+
+    // Execute SQL update statement
+    std::string update_decoys_sql_str = update_decoys_sql.str();
+    rc = sqlite3_exec(db, update_decoys_sql_str.c_str(), callback, nullptr, &zErrMsg);
     if ( rc != SQLITE_OK )
     {
       sqlite3_free(zErrMsg);

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVFile.cpp
@@ -32,7 +32,7 @@
 // $Authors: Hannes Roest $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
 
 #include <OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
@@ -109,8 +109,8 @@ namespace OpenMS
     return false;
   }
 
-  TransitionTSVReader::TransitionTSVReader() :
-    DefaultParamHandler("TransitionTSVReader")
+  TransitionTSVFile::TransitionTSVFile() :
+    DefaultParamHandler("TransitionTSVFile")
   {
     defaults_.setValue("retentionTimeInterpretation", "iRT", "How to interpret the provided retention time (the retention time column can either be interpreted to be in iRT, minutes or seconds)", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("retentionTimeInterpretation", ListUtils::create<String>("iRT,seconds,minutes"));
@@ -124,18 +124,18 @@ namespace OpenMS
     updateMembers_();
   }
 
-  TransitionTSVReader::~TransitionTSVReader()
+  TransitionTSVFile::~TransitionTSVFile()
   {
   }
 
-  void TransitionTSVReader::updateMembers_()
+  void TransitionTSVFile::updateMembers_()
   {
     retentionTimeInterpretation_ = param_.getValue("retentionTimeInterpretation");
     override_group_label_check_ = param_.getValue("override_group_label_check").toBool();
     force_invalid_mods_ = param_.getValue("force_invalid_mods").toBool();
   }
 
-  const char* TransitionTSVReader::strarray_[] =
+  const char* TransitionTSVFile::strarray_[] =
   {
     "PrecursorMz",
     "ProductMz",
@@ -164,9 +164,9 @@ namespace OpenMS
     "QuantifyingTransition"
   };
 
-  const std::vector<std::string> TransitionTSVReader::header_names_(strarray_, strarray_ + 25);
+  const std::vector<std::string> TransitionTSVFile::header_names_(strarray_, strarray_ + 25);
 
-  void TransitionTSVReader::getTSVHeader_(const std::string& line, char& delimiter,
+  void TransitionTSVFile::getTSVHeader_(const std::string& line, char& delimiter,
                                           std::vector<std::string> header, std::map<std::string, int>& header_dict)
   {
     std::string tmp;
@@ -239,7 +239,7 @@ namespace OpenMS
     }
   }
 
-  void TransitionTSVReader::readUnstructuredTSVInput_(const char* filename, FileTypes::Type filetype, std::vector<TSVTransition>& transition_list)
+  void TransitionTSVFile::readUnstructuredTSVInput_(const char* filename, FileTypes::Type filetype, std::vector<TSVTransition>& transition_list)
   {
     std::ifstream data(filename);
     std::string   line;
@@ -497,7 +497,7 @@ namespace OpenMS
     }
   }
 
-  void TransitionTSVReader::spectrastRTExtract(const String str_inp, double & value, bool & spectrast_legacy)
+  void TransitionTSVFile::spectrastRTExtract(const String str_inp, double & value, bool & spectrast_legacy)
   {
     // If SpectraST was run in RT normalization mode, the retention time is annotated as following: "3887.50(57.30)"
     // 3887.50 refers to the non-normalized RT of the individual or consensus run, and 57.30 refers to the normalized
@@ -520,7 +520,7 @@ namespace OpenMS
     }
   }
 
-  bool TransitionTSVReader::spectrastAnnotationExtract(const String str_inp, TSVTransition & mytransition)
+  bool TransitionTSVFile::spectrastAnnotationExtract(const String str_inp, TSVTransition & mytransition)
   {
     // Parses SpectraST fragment ion annotations
     // Example: y13^2/0.000,b16-18^2/-0.013,y7-45/0.000
@@ -591,7 +591,7 @@ namespace OpenMS
     return false;
   }
 
-  void TransitionTSVReader::cleanupTransitions_(TSVTransition& mytransition)
+  void TransitionTSVFile::cleanupTransitions_(TSVTransition& mytransition)
   {
     // deal with FullPeptideNames like PEPTIDE/2
     std::vector<String> substrings;
@@ -603,7 +603,7 @@ namespace OpenMS
     }
   }
 
-  void TransitionTSVReader::TSVToTargetedExperiment_(std::vector<TSVTransition>& transition_list, OpenMS::TargetedExperiment& exp)
+  void TransitionTSVFile::TSVToTargetedExperiment_(std::vector<TSVTransition>& transition_list, OpenMS::TargetedExperiment& exp)
   {
     // For the CV terms, see
     // http://psidev.cvs.sourceforge.net/viewvc/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo
@@ -668,7 +668,7 @@ namespace OpenMS
     exp.setProteins(proteins);
   }
 
-  void TransitionTSVReader::TSVToTargetedExperiment_(std::vector<TSVTransition>& transition_list, OpenSwath::LightTargetedExperiment& exp)
+  void TransitionTSVFile::TSVToTargetedExperiment_(std::vector<TSVTransition>& transition_list, OpenSwath::LightTargetedExperiment& exp)
   {
     std::map<String, int> compound_map;
     std::map<String, int> protein_map;
@@ -732,7 +732,7 @@ namespace OpenMS
     endProgress();
   }
 
-  void TransitionTSVReader::resolveMixedSequenceGroups_(std::vector<TransitionTSVReader::TSVTransition>& transition_list)
+  void TransitionTSVFile::resolveMixedSequenceGroups_(std::vector<TransitionTSVFile::TSVTransition>& transition_list)
   {
     // Create temporary map by group label
     std::map< String, std::vector<TSVTransition*> > label_transition_map;
@@ -782,7 +782,7 @@ namespace OpenMS
 
   }
 
-  void TransitionTSVReader::createTransition_(std::vector<TSVTransition>::iterator& tr_it, OpenMS::ReactionMonitoringTransition& rm_trans)
+  void TransitionTSVFile::createTransition_(std::vector<TSVTransition>::iterator& tr_it, OpenMS::ReactionMonitoringTransition& rm_trans)
   {
     // the following attributes will be stored as meta values (userParam):
     // - annotation (as by SpectraST)
@@ -971,7 +971,7 @@ namespace OpenMS
     else if (!tr_it->quantifying_transition) {rm_trans.setQuantifyingTransition(false);}
   }
 
-  void TransitionTSVReader::createProtein_(std::vector<TSVTransition>::iterator& tr_it, OpenMS::TargetedExperiment::Protein& protein)
+  void TransitionTSVFile::createProtein_(std::vector<TSVTransition>::iterator& tr_it, OpenMS::TargetedExperiment::Protein& protein)
   {
     // the following attributes will be stored as CV values (CV):
     // - uniprot accession number (if available)
@@ -992,7 +992,7 @@ namespace OpenMS
     }
   }
 
-  void TransitionTSVReader::interpretRetentionTime_(std::vector<TargetedExperiment::RetentionTime>& retention_times, const OpenMS::DataValue rt_value)
+  void TransitionTSVFile::interpretRetentionTime_(std::vector<TargetedExperiment::RetentionTime>& retention_times, const OpenMS::DataValue rt_value)
   {
     TargetedExperiment::RetentionTime retention_time;
     retention_time.setRT(rt_value);
@@ -1016,7 +1016,7 @@ namespace OpenMS
     retention_times.push_back(retention_time);
   }
 
-  void TransitionTSVReader::createPeptide_(std::vector<TSVTransition>::iterator& tr_it, OpenMS::TargetedExperiment::Peptide& peptide)
+  void TransitionTSVFile::createPeptide_(std::vector<TSVTransition>::iterator& tr_it, OpenMS::TargetedExperiment::Peptide& peptide)
   {
 
     // the following attributes will be stored as meta values (userParam):
@@ -1130,7 +1130,7 @@ namespace OpenMS
                           + aa_sequence.toUnmodifiedString() + " != " + peptide.sequence).c_str())
   }
 
-  void TransitionTSVReader::createCompound_(std::vector<TSVTransition>::iterator& tr_it, OpenMS::TargetedExperiment::Compound& compound)
+  void TransitionTSVFile::createCompound_(std::vector<TSVTransition>::iterator& tr_it, OpenMS::TargetedExperiment::Compound& compound)
   {
 
     // the following attributes will be stored as meta values (userParam):
@@ -1167,7 +1167,7 @@ namespace OpenMS
     compound.rts = retention_times;
   }
 
-  void TransitionTSVReader::addModification_(std::vector<TargetedExperiment::Peptide::Modification>& mods,
+  void TransitionTSVFile::addModification_(std::vector<TargetedExperiment::Peptide::Modification>& mods,
                                              int location, const ResidueModification& rmod)
   {
     TargetedExperiment::Peptide::Modification mod;
@@ -1178,7 +1178,7 @@ namespace OpenMS
     mods.push_back(mod);
   }
 
-  TransitionTSVReader::TSVTransition TransitionTSVReader::convertTransition_(const ReactionMonitoringTransition* it, OpenMS::TargetedExperiment& targeted_exp)
+  TransitionTSVFile::TSVTransition TransitionTSVFile::convertTransition_(const ReactionMonitoringTransition* it, OpenMS::TargetedExperiment& targeted_exp)
   {
     TSVTransition mytransition;
     mytransition.precursor = it->getPrecursorMZ();
@@ -1366,7 +1366,7 @@ namespace OpenMS
     return(mytransition);
   }
 
-  void TransitionTSVReader::writeTSVOutput_(const char* filename, OpenMS::TargetedExperiment& targeted_exp)
+  void TransitionTSVFile::writeTSVOutput_(const char* filename, OpenMS::TargetedExperiment& targeted_exp)
   {
     std::vector<TSVTransition> mytransitions;
 
@@ -1374,7 +1374,7 @@ namespace OpenMS
     startProgress(0, targeted_exp.getTransitions().size(), "writing OpenSWATH Transition List TSV file");
     for (Size i = 0; i < targeted_exp.getTransitions().size(); i++)
     {
-      TransitionTSVReader::TSVTransition mytransition = convertTransition_(&targeted_exp.getTransitions()[i],targeted_exp);
+      TransitionTSVFile::TSVTransition mytransition = convertTransition_(&targeted_exp.getTransitions()[i],targeted_exp);
       mytransitions.push_back(mytransition);
       setProgress(progress++);
     }
@@ -1431,7 +1431,7 @@ namespace OpenMS
   }
 
   // public methods
-  void TransitionTSVReader::convertTargetedExperimentToTSV(const char* filename, OpenMS::TargetedExperiment& targeted_exp)
+  void TransitionTSVFile::convertTargetedExperimentToTSV(const char* filename, OpenMS::TargetedExperiment& targeted_exp)
   {
     if (targeted_exp.containsInvalidReferences())
     {
@@ -1441,21 +1441,21 @@ namespace OpenMS
     writeTSVOutput_(filename, targeted_exp);
   }
 
-  void TransitionTSVReader::convertTSVToTargetedExperiment(const char* filename, FileTypes::Type filetype, OpenMS::TargetedExperiment& targeted_exp)
+  void TransitionTSVFile::convertTSVToTargetedExperiment(const char* filename, FileTypes::Type filetype, OpenMS::TargetedExperiment& targeted_exp)
   {
     std::vector<TSVTransition> transition_list;
     readUnstructuredTSVInput_(filename, filetype, transition_list);
     TSVToTargetedExperiment_(transition_list, targeted_exp);
   }
 
-  void TransitionTSVReader::convertTSVToTargetedExperiment(const char* filename, FileTypes::Type filetype, OpenSwath::LightTargetedExperiment& targeted_exp)
+  void TransitionTSVFile::convertTSVToTargetedExperiment(const char* filename, FileTypes::Type filetype, OpenSwath::LightTargetedExperiment& targeted_exp)
   {
     std::vector<TSVTransition> transition_list;
     readUnstructuredTSVInput_(filename, filetype, transition_list);
     TSVToTargetedExperiment_(transition_list, targeted_exp);
   }
 
-  void TransitionTSVReader::validateTargetedExperiment(OpenMS::TargetedExperiment& targeted_exp)
+  void TransitionTSVFile::validateTargetedExperiment(OpenMS::TargetedExperiment& targeted_exp)
   {
     if (targeted_exp.containsInvalidReferences())
     {

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVReader.cpp
@@ -621,7 +621,7 @@ namespace OpenMS
     resolveMixedSequenceGroups_(transition_list);
 
     Size progress = 0;
-    startProgress(0, transition_list.size(), "converting to TraML format");
+    startProgress(0, transition_list.size(), "conversion to internal data representation");
     for (std::vector<TSVTransition>::iterator tr_it = transition_list.begin(); tr_it != transition_list.end(); ++tr_it)
     {
 
@@ -676,7 +676,7 @@ namespace OpenMS
     resolveMixedSequenceGroups_(transition_list);
 
     Size progress = 0;
-    startProgress(0, transition_list.size(), "converting to Transition List Format");
+    startProgress(0, transition_list.size(), "conversion to internal data representation");
     for (std::vector<TSVTransition>::iterator tr_it = transition_list.begin(); tr_it != transition_list.end(); ++tr_it)
     {
       OpenSwath::LightTransition transition;
@@ -1371,7 +1371,7 @@ namespace OpenMS
     std::vector<TSVTransition> mytransitions;
 
     Size progress = 0;
-    startProgress(0, targeted_exp.getTransitions().size(), "converting to OpenSWATH transition TSV format");
+    startProgress(0, targeted_exp.getTransitions().size(), "writing OpenSWATH Transition List TSV file");
     for (Size i = 0; i < targeted_exp.getTransitions().size(); i++)
     {
       TransitionTSVReader::TSVTransition mytransition = convertTransition_(&targeted_exp.getTransitions()[i],targeted_exp);

--- a/src/openms/source/ANALYSIS/OPENSWATH/sources.cmake
+++ b/src/openms/source/ANALYSIS/OPENSWATH/sources.cmake
@@ -7,8 +7,8 @@ MRMIonSeries.cpp
 MRMAssay.cpp
 MRMDecoy.cpp
 MRMRTNormalizer.cpp
-TransitionTSVReader.cpp
-TransitionPQPReader.cpp
+TransitionTSVFile.cpp
+TransitionPQPFile.cpp
 SwathMapMassCorrection.cpp
 OpenSwathHelper.cpp
 OpenSwathScoring.cpp

--- a/src/openswathalgo/include/OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/UTILS/sources.cmake
+++ b/src/openswathalgo/include/OpenMS/ANALYSIS/OPENSWATH/OPENSWATHALGO/UTILS/sources.cmake
@@ -6,8 +6,8 @@ set(sources_list_h
 MRMIonSeries.h
 MRMAssay.h
 MRMDecoy.h
-TransitionTSVReader.h
-TransitionPQPReader.h
+TransitionTSVFile.h
+TransitionPQPFile.h
 OpenSwathHelper.h
 ChromatogramExtractor.h
 )

--- a/src/pyOpenMS/pxds/TargetedSpectraExtractor.pxd
+++ b/src/pyOpenMS/pxds/TargetedSpectraExtractor.pxd
@@ -1,4 +1,4 @@
-from TransitionTSVReader cimport *
+from TransitionTSVFile cimport *
 from TargetedExperiment cimport *
 from DefaultParamHandler cimport *
 from GaussFilter cimport *

--- a/src/pyOpenMS/pxds/TransitionPQPFile.pxd
+++ b/src/pyOpenMS/pxds/TransitionPQPFile.pxd
@@ -1,21 +1,21 @@
 from Types cimport *
 from libcpp cimport bool
-from TransitionTSVReader cimport *
+from TransitionTSVFile cimport *
 from TargetedExperiment cimport *
 from LightTargetedExperiment cimport *
 
-cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>" namespace "OpenMS":
+cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>" namespace "OpenMS":
 
-    cdef cppclass TransitionPQPReader:
+    cdef cppclass TransitionPQPFile:
 
-        TransitionPQPReader() nogil except +
-        TransitionPQPReader(TransitionPQPReader) nogil except + #wrap-ignore
+        TransitionPQPFile() nogil except +
+        TransitionPQPFile(TransitionPQPFile) nogil except + #wrap-ignore
 
         void convertTargetedExperimentToPQP(char * filename, TargetedExperiment & targeted_exp) nogil except +
         void convertPQPToTargetedExperiment(char * filename, TargetedExperiment & targeted_exp, bool legacy_traml_id) nogil except +
         void convertPQPToTargetedExperiment(char * filename, LightTargetedExperiment & targeted_exp, bool legacy_traml_id) nogil except +
 
-        # inherited from TransitionTSVReader
+        # inherited from TransitionTSVFile
         # due to issues with Cython and overloaded inheritance
         void convertTargetedExperimentToTSV(char * filename, TargetedExperiment& targeted_exp) nogil except +
 

--- a/src/pyOpenMS/pxds/TransitionTSVFile.pxd
+++ b/src/pyOpenMS/pxds/TransitionTSVFile.pxd
@@ -7,14 +7,14 @@ from FileTypes cimport *
 from TargetedExperiment cimport *
 from LightTargetedExperiment cimport *
 
-cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>" namespace "OpenMS":
+cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>" namespace "OpenMS":
 
-    cdef cppclass TransitionTSVReader(ProgressLogger):
+    cdef cppclass TransitionTSVFile(ProgressLogger):
         # wrap-inherits:
         #    ProgressLogger
 
-        TransitionTSVReader()                       nogil except +
-        TransitionTSVReader(TransitionTSVReader)    nogil except + # wrap-ignore
+        TransitionTSVFile()                       nogil except +
+        TransitionTSVFile(TransitionTSVFile)    nogil except + # wrap-ignore
 
         void convertTargetedExperimentToTSV(char * filename, TargetedExperiment& targeted_exp) nogil except +
     

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -1784,18 +1784,18 @@ def testInternalCalibration():
     assert pyopenms.InternalCalibration().calibrate is not None
 
 @report
-def testTransitionTSVReader():
+def testTransitionTSVFile():
     """
     @tests:
-     TransitionTSVReader.__init__
-     TransitionTSVReader.calibrateMapGlobally
-     TransitionTSVReader.calibrateMapSpectrumwise
+     TransitionTSVFile.__init__
+     TransitionTSVFile.calibrateMapGlobally
+     TransitionTSVFile.calibrateMapSpectrumwise
     """
-    ff = pyopenms.TransitionTSVReader()
+    ff = pyopenms.TransitionTSVFile()
 
-    assert pyopenms.TransitionTSVReader().convertTargetedExperimentToTSV is not None
-    assert pyopenms.TransitionTSVReader().convertTSVToTargetedExperiment is not None
-    assert pyopenms.TransitionTSVReader().validateTargetedExperiment is not None
+    assert pyopenms.TransitionTSVFile().convertTargetedExperimentToTSV is not None
+    assert pyopenms.TransitionTSVFile().convertTSVToTargetedExperiment is not None
+    assert pyopenms.TransitionTSVFile().validateTargetedExperiment is not None
 
 @report
 def testProteaseDigestion():

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -595,8 +595,8 @@ if(NOT DISABLE_OPENSWATH)
     MRMDecoy_test
     MRMIonSeries_test
     MRMRTNormalizer_test
-    TransitionTSVReader_test
-    TransitionPQPReader_test
+    TransitionTSVFile_test
+    TransitionPQPFile_test
     ChromatogramExtractor_test
     ChromatogramExtractorAlgorithm_test
     OpenSwathHelper_test
@@ -636,8 +636,8 @@ set(Boost_dependent_tests
   PeakPickerMRM_test
   StatisticFunctions_test
   String_test
-  TransitionTSVReader_test
-  TransitionPQPReader_test
+  TransitionTSVFile_test
+  TransitionPQPFile_test
 )
 
 ### collect test executables

--- a/src/tests/class_tests/openms/source/TargetedSpectraExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/TargetedSpectraExtractor_test.cpp
@@ -106,7 +106,7 @@ const String experiment_path = OPENMS_GET_TEST_DATA_PATH("TargetedSpectraExtract
 const String target_list_path = OPENMS_GET_TEST_DATA_PATH("TargetedSpectraExtractor_13CFlux_TraML.csv");
 MzMLFile mzml;
 MSExperiment experiment;
-TransitionTSVReader tsv_reader;
+TransitionTSVFile tsv_reader;
 TargetedExperiment targeted_exp;
 mzml.load(experiment_path, experiment);
 Param tsv_params = tsv_reader.getParameters();

--- a/src/tests/class_tests/openms/source/TransitionPQPFile_test.cpp
+++ b/src/tests/class_tests/openms/source/TransitionPQPFile_test.cpp
@@ -40,28 +40,28 @@
 #include <boost/assign/list_of.hpp>
 
 ///////////////////////////
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>
 ///////////////////////////
 
 using namespace OpenMS;
 using namespace std;
 
-START_TEST(TransitionPQPReader, "$Id$")
+START_TEST(TransitionPQPFile, "$Id$")
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
-TransitionPQPReader* ptr = nullptr;
-TransitionPQPReader* nullPointer = nullptr;
+TransitionPQPFile* ptr = nullptr;
+TransitionPQPFile* nullPointer = nullptr;
 
-START_SECTION(TransitionPQPReader())
+START_SECTION(TransitionPQPFile())
 {
-  ptr = new TransitionPQPReader();
+  ptr = new TransitionPQPFile();
   TEST_NOT_EQUAL(ptr, nullPointer)
 }
 END_SECTION
 
-START_SECTION(~TransitionPQPReader())
+START_SECTION(~TransitionPQPFile())
 {
   delete ptr;
 }

--- a/src/tests/class_tests/openms/source/TransitionTSVFile_test.cpp
+++ b/src/tests/class_tests/openms/source/TransitionTSVFile_test.cpp
@@ -40,28 +40,28 @@
 #include <boost/assign/list_of.hpp>
 
 ///////////////////////////
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
 ///////////////////////////
 
 using namespace OpenMS;
 using namespace std;
 
-START_TEST(TransitionTSVReader, "$Id$")
+START_TEST(TransitionTSVFile, "$Id$")
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
-TransitionTSVReader* ptr = nullptr;
-TransitionTSVReader* nullPointer = nullptr;
+TransitionTSVFile* ptr = nullptr;
+TransitionTSVFile* nullPointer = nullptr;
 
-START_SECTION(TransitionTSVReader())
+START_SECTION(TransitionTSVFile())
 {
-  ptr = new TransitionTSVReader();
+  ptr = new TransitionTSVFile();
   TEST_NOT_EQUAL(ptr, nullPointer)
 }
 END_SECTION
 
-START_SECTION(~TransitionTSVReader())
+START_SECTION(~TransitionTSVFile())
 {
   delete ptr;
 }

--- a/src/topp/OpenSwathAssayGenerator.cpp
+++ b/src/topp/OpenSwathAssayGenerator.cpp
@@ -33,8 +33,8 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMAssay.h>
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
@@ -275,7 +275,7 @@ protected:
     {
       const char* tr_file = in.c_str();
       Param reader_parameters = getParam_().copy("algorithm:", true);
-      TransitionTSVReader tsv_reader = TransitionTSVReader();
+      TransitionTSVFile tsv_reader = TransitionTSVFile();
       tsv_reader.setLogType(log_type_);
       tsv_reader.setParameters(reader_parameters);
       tsv_reader.convertTSVToTargetedExperiment(tr_file, in_type, targeted_exp);
@@ -284,7 +284,7 @@ protected:
     else if (in_type == FileTypes::PQP)
     {
       const char* tr_file = in.c_str();
-      TransitionPQPReader pqp_reader = TransitionPQPReader();
+      TransitionPQPFile pqp_reader = TransitionPQPFile();
       Param reader_parameters = getParam_().copy("algorithm:", true);
       pqp_reader.setLogType(log_type_);
       pqp_reader.setParameters(reader_parameters);
@@ -331,14 +331,14 @@ protected:
     if (out_type == FileTypes::TSV)
     {
       const char* tr_file = out.c_str();
-      TransitionTSVReader tsv_reader = TransitionTSVReader();
+      TransitionTSVFile tsv_reader = TransitionTSVFile();
       tsv_reader.setLogType(log_type_);
       tsv_reader.convertTargetedExperimentToTSV(tr_file, targeted_exp);
     }
     if (out_type == FileTypes::PQP)
     {
       const char * tr_file = out.c_str();
-      TransitionPQPReader pqp_reader = TransitionPQPReader();
+      TransitionPQPFile pqp_reader = TransitionPQPFile();
       pqp_reader.setLogType(log_type_);
       pqp_reader.convertTargetedExperimentToPQP(tr_file, targeted_exp);
     }

--- a/src/topp/OpenSwathDecoyGenerator.cpp
+++ b/src/topp/OpenSwathDecoyGenerator.cpp
@@ -33,8 +33,8 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMDecoy.h>
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
 #include <OpenMS/CONCEPT/Exception.h>
@@ -220,7 +220,7 @@ protected:
     {
       const char* tr_file = in.c_str();
       Param reader_parameters = getParam_().copy("algorithm:", true);
-      TransitionTSVReader tsv_reader = TransitionTSVReader();
+      TransitionTSVFile tsv_reader = TransitionTSVFile();
       tsv_reader.setLogType(log_type_);
       tsv_reader.setParameters(reader_parameters);
       tsv_reader.convertTSVToTargetedExperiment(tr_file, in_type, targeted_exp);
@@ -229,7 +229,7 @@ protected:
     else if (in_type == FileTypes::PQP)
     {
       const char* tr_file = in.c_str();
-      TransitionPQPReader pqp_reader = TransitionPQPReader();
+      TransitionPQPFile pqp_reader = TransitionPQPFile();
       Param reader_parameters = getParam_().copy("algorithm:", true);
       pqp_reader.setLogType(log_type_);
       pqp_reader.setParameters(reader_parameters);
@@ -274,14 +274,14 @@ protected:
     if (out_type == FileTypes::TSV)
     {
       const char* tr_file = out.c_str();
-      TransitionTSVReader tsv_reader = TransitionTSVReader();
+      TransitionTSVFile tsv_reader = TransitionTSVFile();
       tsv_reader.setLogType(log_type_);
       tsv_reader.convertTargetedExperimentToTSV(tr_file, targeted_merged);
     }
     if (out_type == FileTypes::PQP)
     {
       const char * tr_file = out.c_str();
-      TransitionPQPReader pqp_reader = TransitionPQPReader();
+      TransitionPQPFile pqp_reader = TransitionPQPFile();
       pqp_reader.setLogType(log_type_);
       pqp_reader.convertTargetedExperimentToPQP(tr_file, targeted_merged);
     }

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -45,8 +45,8 @@
 #include <OpenMS/FORMAT/TransformationXMLFile.h>
 #include <OpenMS/FORMAT/SwathFile.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h>
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathTSVWriter.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h>
 
@@ -563,7 +563,7 @@ protected:
     }
     else if (name == "Library")
     {
-      return TransitionTSVReader().getDefaults();
+      return TransitionTSVFile().getDefaults();
     }
     else
     {
@@ -837,7 +837,7 @@ protected:
     else if (tr_type == FileTypes::PQP || tr_file.suffix(3).toLower() == "pqp"  )
     {
       progresslogger.startProgress(0, 1, "Load PQP file");
-      TransitionPQPReader().convertPQPToTargetedExperiment(tr_file.c_str(), transition_exp);
+      TransitionPQPFile().convertPQPToTargetedExperiment(tr_file.c_str(), transition_exp);
       progresslogger.endProgress();
 
       remove(out_osw.c_str());
@@ -852,7 +852,7 @@ protected:
     else if (tr_type == FileTypes::TSV || tr_file.suffix(3).toLower() == "tsv"  )
     {
       progresslogger.startProgress(0, 1, "Load TSV file");
-      TransitionTSVReader tsv_reader;
+      TransitionTSVFile tsv_reader;
       tsv_reader.setParameters(tsv_reader_param);
       tsv_reader.convertTSVToTargetedExperiment(tr_file.c_str(), tr_type, transition_exp);
       progresslogger.endProgress();

--- a/src/utils/TargetedFileConverter.cpp
+++ b/src/utils/TargetedFileConverter.cpp
@@ -32,8 +32,8 @@
 // $Authors: George Rosenberger, Hannes Roest $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVReader.h>
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPReader.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionPQPFile.h>
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/CONCEPT/Exception.h>
@@ -182,7 +182,7 @@ protected:
 
   Param getSubsectionDefaults_(const String&) const override
   {
-    return TransitionTSVReader().getDefaults();
+    return TransitionTSVFile().getDefaults();
   }
 
   ExitCodes main_(int, const char**) override
@@ -230,7 +230,7 @@ protected:
     {
       const char* tr_file = in.c_str();
       Param reader_parameters = getParam_().copy("algorithm:", true);
-      TransitionTSVReader tsv_reader = TransitionTSVReader();
+      TransitionTSVFile tsv_reader = TransitionTSVFile();
       tsv_reader.setLogType(log_type_);
       tsv_reader.setParameters(reader_parameters);
       tsv_reader.convertTSVToTargetedExperiment(tr_file, in_type, targeted_exp);
@@ -239,7 +239,7 @@ protected:
     else if (in_type == FileTypes::PQP)
     {
       const char* tr_file = in.c_str();
-      TransitionPQPReader pqp_reader = TransitionPQPReader();
+      TransitionPQPFile pqp_reader = TransitionPQPFile();
       Param reader_parameters = getParam_().copy("algorithm:", true);
       pqp_reader.setLogType(log_type_);
       pqp_reader.setParameters(reader_parameters);
@@ -255,14 +255,14 @@ protected:
     if (out_type == FileTypes::TSV)
     {
       const char* tr_file = out.c_str();
-      TransitionTSVReader tsv_reader = TransitionTSVReader();
+      TransitionTSVFile tsv_reader = TransitionTSVFile();
       tsv_reader.setLogType(log_type_);
       tsv_reader.convertTargetedExperimentToTSV(tr_file, targeted_exp);
     }
     if (out_type == FileTypes::PQP)
     {
       const char * tr_file = out.c_str();
-      TransitionPQPReader pqp_reader = TransitionPQPReader();
+      TransitionPQPFile pqp_reader = TransitionPQPFile();
       pqp_reader.setLogType(log_type_);
       pqp_reader.convertTargetedExperimentToPQP(tr_file, targeted_exp);
     }


### PR DESCRIPTION
This PR improves the conversion from TSV or TraML to PQP. Instead of ~20min (PHL), this takes now <2min. To achieve this, the necessary PQP indexes during conversion are based on different data structures.

Additionally, the classes TransitionTSVReader and TransitionPQPReader are renamed to TransitionTSVFile and TransitionPQPFile according to the request of @timosachsenberg.
