### PR TITLE
[FIX] removed deprecated register storage class

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/Base64.h
+++ b/src/openms/include/OpenMS/FORMAT/Base64.h
@@ -429,8 +429,8 @@ private:
 
     src_size -= padding;
 
-    register UInt a;
-    register UInt b;
+    UInt a;
+    UInt b;
 
     UInt offset = 0;
     int inc = 1;
@@ -773,8 +773,8 @@ private:
 
     src_size -= padding;
 
-    register UInt a;
-    register UInt b;
+    UInt a;
+    UInt b;
 
     UInt offset = 0;
     int inc = 1;


### PR DESCRIPTION
removes some warning on modern compilers