### PR TITLE
[FIX?] LogStream_test parallel for

### DIFF
--- a/src/tests/class_tests/openms/source/LogStream_test.cpp
+++ b/src/tests/class_tests/openms/source/LogStream_test.cpp
@@ -87,11 +87,12 @@ START_SECTION(([EXTRA] OpenMP - test))
   Log_info.insert(stream_by_logger);
   Log_info.remove(cout);
 
-#ifdef _OPENMP
-omp_set_num_threads(8);
-#pragma omp parallel
-#endif
+
   {
+    #ifdef _OPENMP
+	omp_set_num_threads(8);
+    #pragma omp parallel for
+    #endif
     for (int i=0;i<10000;++i)
     {
       LOG_DEBUG << "1\n";


### PR DESCRIPTION
Indeed this test gave random errors in around 1 in 5 executions with OpenMP on Win10 VS2015.
I don't know the exact reason and probably big parts of the class are not really threadsafe (as found by @timosachsenberg ) but changing the pragma to parallel for gets rid of the random errors (at least there were 0 in 500 executions).
See #2275