### PR TITLE
Feature/crux enzymes

### DIFF
--- a/share/OpenMS/CHEMISTRY/Enzymes.xml
+++ b/share/OpenMS/CHEMISTRY/Enzymes.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-
 <PARAMETERS>
   <NODE name="Enzymes">
     <NODE name="Trypsin">

--- a/share/OpenMS/CHEMISTRY/Enzymes.xml
+++ b/share/OpenMS/CHEMISTRY/Enzymes.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
+
 <PARAMETERS>
   <NODE name="Enzymes">
     <NODE name="Trypsin">
@@ -11,6 +12,7 @@
       <ITEM name="XTandemID" value="[KR]|{P}" type="string" />
       <ITEM name="OMSSAID" value="0" type="int" />
       <ITEM name="CometID" value="1" type="int" />
+      <ITEM name="CruxID" value="trypsin" type="string" />
     </NODE>
     <NODE name="Arg-C">
       <ITEM name="Name" value="Arg-C" type="string" />
@@ -22,6 +24,7 @@
       <ITEM name="XTandemID" value="[R]|{P}" type="string" />
       <ITEM name="OMSSAID" value="1" type="int" />
       <ITEM name="CometID" value="5" type="int" />
+      <ITEM name="CruxID" value="arg-c" type="string" />
       <NODE name="Synonyms">
         <ITEM name="Clostripain" value="Clostripain" type="string" />
         <ITEM name="argc" value="argc" type="string" />
@@ -46,6 +49,7 @@
       <ITEM name="XTandemID" value="[X]|[BD]" type="string" />
       <ITEM name="OMSSAID" value="12" type="int" />
       <ITEM name="CometID" value="6" type="int" />
+      <ITEM name="CruxID" value="asp-n" type="string" />
     </NODE>
     <NODE name="Asp-N/B">
       <ITEM name="Name" value="Asp-N/B" type="string" />
@@ -76,6 +80,7 @@
       <ITEM name="XTandemID" value="[FYWL]|{P}" type="string" />
       <ITEM name="OMSSAID" value="3" type="int" />
       <ITEM name="CometID" value="10" type="int" />
+      <ITEM name="CruxID" value="chymotrypsin" type="string" />
     </NODE>
     <NODE name="Chymotrypsin/P">
       <ITEM name="Name" value="Chymotrypsin/P" type="string" />
@@ -117,6 +122,7 @@
       <ITEM name="XTandemID" value="[K]|{P}" type="string" />
       <ITEM name="OMSSAID" value="5" type="int" />
       <ITEM name="CometID" value="3" type="int" />
+      <ITEM name="CruxID" value="lys-c" type="string" />
     </NODE>
     <NODE name="Lys-N">
       <ITEM name="Name" value="Lys-N" type="string" />
@@ -128,6 +134,7 @@
       <ITEM name="XTandemID" value="[X]|[K]" type="string" />
       <ITEM name="CometID" value="4" type="int" />
       <ITEM name="MSGFID" value="4" type="int" />
+      <ITEM name="CruxID" value="lys-n" type="string" />
     </NODE>
     <NODE name="Lys-C/P">
       <ITEM name="Name" value="Lys-C/P" type="string" />
@@ -172,6 +179,7 @@
       <ITEM name="OMSSAID" value="10" type="int" />
       <ITEM name="CometID" value="2" type="int" />
       <ITEM name="MSGFID" value="1" type="int" />
+      <ITEM name="CruxID" value="trypsin/p" type="string" />
     </NODE>
     <NODE name="V8-DE">
       <ITEM name="Name" value="V8-DE" type="string" />
@@ -198,6 +206,7 @@
       <ITEM name="NTermGain" value="H" type="string" />
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001915" type="string" />
+      <ITEM name="CruxID" value="elastase" type="string" />
       <ITEM name="XTandemID" value="[ALIV]|{P}" type="string" />
     </NODE>
     <NODE name="proline endopeptidase">
@@ -242,6 +251,54 @@
       <ITEM name="PSIID" value="MS:1001918" type="string" />
       <ITEM name="XTandemID" value="[W]|[X]" type="string" />
     </NODE>
+    <NODE name="iodosobenzoate">
+      <ITEM name="Name" value="iodosobenzoate" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=W)" type="string" />
+      <ITEM name="CruxID" value="iodosobenzoate" type="string" />
+    </NODE>
+    <NODE name="staphylococcal protease/D">
+      <ITEM name="Name" value="staphylococcal protease/D" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=E)" type="string" />
+      <ITEM name="CruxID" value="staph-protease" type="string" />
+      <NODE name="Synonyms">
+        <ITEM name="Glu-C/D" value="Glu-C/D" type="string" />
+        <ITEM name="staphylococcal protease/D" value="staphylococcal protease/D" type="string" />
+      </NODE>
+    </NODE>
+    <NODE name="proline-endopeptidase/HKR">
+      <ITEM name="Name" value="proline-endopeptidase/HKR" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=P)" type="string" />
+      <ITEM name="CruxID" value="proline-endopeptidase" type="string" />
+    </NODE>
+    <NODE name="Glu-C+P">
+      <ITEM name="Name" value="Glu-C+P" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[DE])(?!P)" type="string" />
+      <ITEM name="CruxID" value="glu-c" type="string" />
+      <NODE name="Synonyms">
+        <ITEM name="Glu-C+P" value="Glu-C+P" type="string" />
+        <ITEM name="staphylococcal protease+P" value="staphylococcal protease+P" type="string" />
+      </NODE>
+    </NODE>
+    <NODE name="PepsinA + P">
+      <ITEM name="Name" value="PepsinA + P" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[FL])(?!P)" type="string" />
+      <ITEM name="CruxID" value="pepsin-a" type="string" />
+    </NODE>
+    <NODE name="cyanogen-bromide">
+      <ITEM name="Name" value="cyanogen-bromide" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=M)" type="string" />
+      <ITEM name="CruxID" value="cyanogen-bromide" type="string" />
+    </NODE>
+    <NODE name="Clostripain/P">
+      <ITEM name="Name" value="Clostripain/P" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=R)" type="string" />
+      <ITEM name="CruxID" value="clostripain" type="string" />
+    </NODE>
+    <NODE name="elastase-trypsin-chymotrypsin">
+      <ITEM name="Name" value="elastase-trypsin-chymotrypsin" type="string" />
+      <ITEM name="CruxID" value="elastase-trypsin-chymotrypsin" type="string" />
+      <ITEM name="RegEx" value="(?&lt;=[ALIVKRWFY])(?!P)" type="string" />
+    </NODE>
     <NODE name="no cleavage">
       <ITEM name="Name" value="no cleavage" type="string" />
       <ITEM name="RegEx" value="()" type="string" />
@@ -250,6 +307,7 @@
       <ITEM name="CTermGain" value="OH" type="string" />
       <ITEM name="PSIID" value="MS:1001955" type="string" />
       <ITEM name="XTandemID" value="" type="string" />
+      <ITEM name="CruxID" value="no-enzyme" type="string" />
       <ITEM name="OMSSAID" value="11" type="int" />
       <ITEM name="MSGFID" value="9" type="int" />
     </NODE>

--- a/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeProtein.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeProtein.h
@@ -69,6 +69,7 @@ namespace OpenMS
                                     String psi_id = "",
                                     String xtandem_id = "",
                                     UInt comet_id = 0,
+                                    String crux_id = "",
                                     Int msgf_id = -1,
                                     UInt omssa_id = 0);
 
@@ -115,6 +116,12 @@ namespace OpenMS
 
     /// sets the Comet enzyme ID
     void setCometID(UInt value);
+
+    /// returns the Crux enzyme ID
+    String getCruxID() const;
+
+    /// sets the Crux enzyme ID
+    void setCruxID(const String& value);
 
     /// sets the MSGFPlus enzyme id
     void setMSGFID(Int value);
@@ -169,6 +176,8 @@ namespace OpenMS
     String xtandem_id_;
 
     UInt comet_id_;
+
+    String crux_id_;
 
     Int msgf_id_;
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ProteaseDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ProteaseDB.h
@@ -66,6 +66,9 @@ namespace OpenMS
     /// returns all the enzyme names available for Comet
     void getAllCometNames(std::vector<String>& all_names) const;
 
+    /// returns all the enzyme names available for Crux
+    void getAllCruxNames(std::vector<String>& all_names) const;
+
     /// returns all the enzyme names available for OMSSA
     void getAllOMSSANames(std::vector<String>& all_names) const;
 
@@ -74,4 +77,5 @@ namespace OpenMS
   };
 }
 
-#endif
+#endif // OPENMS_CHEMISTRY_PROTEASEDB_H
+

--- a/src/openms/source/CHEMISTRY/DigestionEnzymeProtein.cpp
+++ b/src/openms/source/CHEMISTRY/DigestionEnzymeProtein.cpp
@@ -47,6 +47,7 @@ namespace OpenMS
     psi_id_(""),
     xtandem_id_(""),
     comet_id_(),
+    crux_id_(),
     msgf_id_(-1),
     omssa_id_()
   {
@@ -59,6 +60,7 @@ namespace OpenMS
     psi_id_(enzyme.psi_id_),
     xtandem_id_(enzyme.xtandem_id_),
     comet_id_(enzyme.comet_id_),
+    crux_id_(enzyme.crux_id_),
     msgf_id_(enzyme.msgf_id_),
     omssa_id_(enzyme.omssa_id_)
   {
@@ -73,6 +75,7 @@ namespace OpenMS
                                                  String psi_id,
                                                  String xtandem_id,
                                                  UInt comet_id,
+                                                 String crux_id,
                                                  Int msgf_id,
                                                  UInt omssa_id) :
     DigestionEnzyme(name, cleavage_regex, synonyms, regex_description),
@@ -81,6 +84,7 @@ namespace OpenMS
     psi_id_(psi_id),
     xtandem_id_(xtandem_id),
     comet_id_(comet_id),
+    crux_id_(crux_id),
     msgf_id_(msgf_id),
     omssa_id_(omssa_id)
   {
@@ -100,6 +104,7 @@ namespace OpenMS
       psi_id_ = enzyme.psi_id_;
       xtandem_id_ = enzyme.xtandem_id_;
       comet_id_ = enzyme.comet_id_;
+      crux_id_ = enzyme.crux_id_;
       omssa_id_ = enzyme.omssa_id_;
       msgf_id_ = enzyme.msgf_id_;
     }
@@ -156,6 +161,16 @@ namespace OpenMS
     return comet_id_;
   }
 
+  void DigestionEnzymeProtein::setCruxID(const String& value)
+  {
+    crux_id_ = value;
+  }
+
+  String DigestionEnzymeProtein::getCruxID() const
+  {
+    return crux_id_;
+  }
+
   void DigestionEnzymeProtein::setOMSSAID(UInt value)
   {
     omssa_id_ = value;
@@ -184,6 +199,7 @@ namespace OpenMS
            psi_id_ == enzyme.psi_id_ &&
            xtandem_id_ == enzyme.xtandem_id_ &&
            comet_id_ == enzyme.comet_id_ &&
+           crux_id_ == enzyme.crux_id_ &&
            msgf_id_ == enzyme.msgf_id_ &&
            omssa_id_ == enzyme.omssa_id_;
   }
@@ -237,6 +253,11 @@ namespace OpenMS
     if (key.hasSuffix(":CometID"))
     {
       setCometID(value.toInt());
+      return true;
+    }
+    if (key.hasSuffix(":CruxID"))
+    {
+      setCruxID(value);
       return true;
     }
     if (key.hasSuffix(":OMSSAID"))

--- a/src/openms/source/CHEMISTRY/ProteaseDB.cpp
+++ b/src/openms/source/CHEMISTRY/ProteaseDB.cpp
@@ -56,6 +56,19 @@ namespace OpenMS
     }
   }
 
+  void ProteaseDB::getAllCruxNames(vector<String>& all_names) const
+  {
+    all_names.clear();
+    all_names.push_back("custom-enzyme");
+    for (ConstEnzymeIterator it = const_enzymes_.begin(); it != const_enzymes_.end(); ++it)
+    {
+      if ((*it)->getCruxID() != "")
+      {
+        all_names.push_back((*it)->getCruxID());
+      }
+    }
+  }
+
   void ProteaseDB::getAllCometNames(vector<String>& all_names) const
   {
     all_names.clear();

--- a/src/tests/class_tests/openms/source/ProteaseDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDB_test.cpp
@@ -125,6 +125,33 @@ START_SECTION((void getAllXTandemNames(std::vector<String>& all_names) const))
     TEST_EQUAL(names.size(), old_size)
 END_SECTION
 
+START_SECTION((void getAllCruxNames(std::vector<String>& all_names) const))
+    vector<String> names;
+    ptr->getAllCruxNames(names);
+    TEST_EQUAL(find(names.begin(), names.end(), "no-enzyme") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "trypsin") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "trypsin/p") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "chymotrypsin") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "elastase") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "clostripain") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "cyanogen-bromide") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "iodosobenzoate") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "proline-endopeptidase") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "staph-protease") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "asp-n") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "lys-c") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "lys-n") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "arg-c") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "glu-c") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "pepsin-a") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "elastase-trypsin-chymotrypsin") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "custom-enzyme") != names.end(), true)
+    TEST_EQUAL(find(names.begin(), names.end(), "dummy false protease") != names.end(), false)
+    Size old_size=names.size();
+    ptr->getAllCruxNames(names);
+    TEST_EQUAL(names.size(), old_size)
+END_SECTION
+
 START_SECTION((void getAllOMSSANames(std::vector<String>& all_names) const))
     vector<String> names;
     ptr->getAllOMSSANames(names);

--- a/src/topp/CruxAdapter.cpp
+++ b/src/topp/CruxAdapter.cpp
@@ -128,10 +128,6 @@ protected:
     registerStringOption_("extra_search_args", "<choice>", "", "Extra arguments to be passed to tide-search", false, false);
     registerStringOption_("extra_percolator_args", "<choice>", "", "Extra arguments to be passed to percolator", false, false);
 
-    //Files
-    registerOutputFile_("pin_out", "<file>", "", "Output file - for Percolator input", false);
-    setValidFormats_("pin_out", ListUtils::create<String>("csv"));
-
     //Masses
     registerDoubleOption_("precursor_mass_tolerance", "<tolerance>", 10.0, "Precursor monoisotopic mass tolerance (Crux parameter: peptide_mass_tolerance)", false, false);
     registerStringOption_("precursor_mass_units", "<choice>", "ppm", "Unit of precursor mass tolerance (amu, m/z or ppm)", false, false);
@@ -144,8 +140,10 @@ protected:
     setValidStrings_("run_percolator", ListUtils::create<String>("true,false"));
 
     //Search Enzyme
+    vector<String> all_enzymes;
+    ProteaseDB::getInstance()->getAllCruxNames(all_enzymes);
     registerStringOption_("enzyme", "<cleavage site>", "trypsin", "The enzyme used for peptide digestion.", false, false);
-    setValidStrings_("enzyme", ListUtils::create<String>("no-enzyme,trypsin,trypsin/p,chymotrypsin,elastase,clostripain,cyanogen-bromide,iodosobenzoate,proline-endopeptidase,staph-protease,asp-n,lys-c,lys-n,arg-c,glu-c,pepsin-a,elastase-trypsin-chymotrypsin,custom-enzyme"));
+    setValidStrings_("enzyme", all_enzymes);
     registerStringOption_("digestion", "<choice>", "full-digest", "Full, partial or non specific digestion", false, false);
     setValidStrings_("digestion", ListUtils::create<String>("full-digest,partial-digest,non-specific-digest"));
     registerIntOption_("allowed_missed_cleavages", "<num>", 0, "Number of possible cleavage sites missed by the enzyme, maximum value is 5; for enzyme search", false, false);


### PR DESCRIPTION
As discussed in #3114 this PR adds the Crux names and regexes of enzymes to Enzymes.xml. Unfortunately many of them do not map 1:1 to the Enzymes we already have so we need to create several new ones. For reference

```
$ crux tide-index
...
  [--enzyme no-enzyme|trypsin|trypsin/p|chymotrypsin|elastase|clostripain|cyanogen-bromide|iodosobenzoate|proline-endopeptidase|staph-protease|asp-n|lys-c|lys-n|arg-c|glu-c|pepsin-a|elastase-trypsin-chymotrypsin|custom-enzyme]
     Specify the enzyme used to digest the proteins in silico. Available enzymes
     (with the corresponding digestion rules indicated in parentheses) include
     no-enzyme ([X]|[X]), trypsin ([RK]|{P}), trypsin/p ([RK]|[]), chymotrypsin
     ([FWYL]|{P}), elastase ([ALIV]|{P}), clostripain ([R]|[]), cyanogen-bromide
     ([M]|[]), iodosobenzoate ([W]|[]), proline-endopeptidase ([P]|[]),
     staph-protease ([E]|[]), asp-n ([]|[D]), lys-c ([K]|{P}), lys-n ([]|[K]),
     arg-c ([R]|{P}), glu-c ([DE]|{P}), pepsin-a ([FL]|{P}),
     elastase-trypsin-chymotrypsin ([ALIVKRWFY]|{P}). Specifying --enzyme
     no-enzyme yields a non-enzymatic digest. Warning: the resulting index may
     be quite large. Default = trypsin.

...
```