### PR TITLE
[FIX] changed names in AbsoluteQuantitationStandards to match

### DIFF
--- a/src/openms/include/OpenMS/METADATA/AbsoluteQuantitationStandards.h
+++ b/src/openms/include/OpenMS/METADATA/AbsoluteQuantitationStandards.h
@@ -71,9 +71,9 @@ public:
     */ 
     struct runConcentration
     {
-      String run_id;
-      String component_id;
-      String IS_component_id;
+      String sample_name;
+      String component_name;
+      String IS_component_name;
       double actual_concentration;
       double IS_actual_concentration;
       String concentration_units;
@@ -98,7 +98,7 @@ public:
        @brief Method to map runs to components to known concentrations
 
        Note that for the method to work, the features must be annotated with
-         a metaValue for "run_id"
+         a metaValue for "sample_name"
 
       @param run_concentrations a list of runConcentration structs (e.g., from file upload).
       @param features a list of corresponding features for each of the unique runs in run_concentrations

--- a/src/pyOpenMS/pxds/AbsoluteQuantitationStandards.pxd
+++ b/src/pyOpenMS/pxds/AbsoluteQuantitationStandards.pxd
@@ -8,9 +8,9 @@ cdef extern from "<OpenMS/METADATA/AbsoluteQuantitationStandards.h>" namespace "
         AQS_runConcentration()
         AQS_runConcentration(AQS_runConcentration &) # no-wrap
 
-        String run_id
-        String component_id
-        String IS_component_id
+        String sample_name
+        String component_name
+        String IS_component_name
         double actual_concentration
         double IS_actual_concentration
         String concentration_units


### PR DESCRIPTION
Changed the names of run_id and component_/IS_id to match the names in the other AbsoluteQuantitation classes (i.e., _id to _name).  This should make things more clear for developers and users alike.