### PR TITLE
improvements of mzTab2tsv scripts

### DIFF
--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PEP.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PEP.R
@@ -1,10 +1,25 @@
-## This is an R script for the conversion of mzTab to a better readable tsv format
+## This is an R script for the conversion of mzTab to a better readable tsv format.
 
-# options
-options(digits=10)
+# clear entire workspace
+rm(list = ls())
 
 input.file <- commandArgs(TRUE)[1]
 output.file <- commandArgs(TRUE)[2]
+
+# find start of the section
+startSection <- function(file, section.identifier) {
+  data <- file(file, "r")
+  row = 0
+  while (TRUE) {
+    row = row + 1
+    line = readLines(data, n=1)
+    if (substr(line, 1, 3)==section.identifier) {
+      break
+    }
+  }
+  close(data)
+  return (row)
+}
 
 # count the occurences of character c in string s
 countOccurrences <- function(char,s) {
@@ -12,32 +27,51 @@ countOccurrences <- function(char,s) {
 	return (nchar(s) - nchar(s2))
 }
 
-# check that all protein accessions are of the format *|*|*
-checkAccessionFormat <- function(accessions) {
-	n <- length(accessions)
-	count <- countOccurrences("[|]",accessions)
-	m <- length(which(count==2))
-	return (n==m)
+# check that the protein accession is of the format *|*|*
+# Note that NA returns TRUE.
+checkAccessionFormat <- function(accession) {
+  if (is.na(accession)) {
+    return (TRUE)
+  }
+  n <- length(accession)
+  count <- countOccurrences("[|]",accession)
+  m <- length(which(count==2))
+  return (n==m)
+}
+
+# Extracts the second entry from a string of the form *|*|*.
+getAccession <- function(string) {
+  if (is.na(string)) {
+    return (NA)
+  }
+  return (unlist(strsplit(string, "[|]"))[2])
+}
+
+# Extracts the third entry from a string of the form *|*|*.
+getGene <- function(string) {
+  if (is.na(string)) {
+    return (NA)
+  }
+  return (unlist(strsplit(string, "[|]"))[3])
 }
 
 # read the PEP section of an mzTab file
 readMzTabPEP <- function(file) {
   
+  # find start of the PEP section
+  first.row <- startSection(file, "PEH")
+  
   # read entire mzTab
-  no.col <- max(count.fields(file, sep = "\t", quote=""))
-  data <- read.table(file,sep="\t",fill=TRUE, quote="", col.names=1:no.col)
+  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE)
   
   # extract PEP data
   peptide.data <- data[which(data[,1]=="PEP"),]
-  colnames(peptide.data) <- unlist(data[which(data[,1]=="PEH")[1],])
   peptide.data$PEH <- NULL
   
-  # simplify accession (in case it is of the format *|*|* )
-  peptide.data$accession <- as.character(peptide.data$accession)
-  if (checkAccessionFormat(peptide.data$accession)) {
-    list <- strsplit(peptide.data$accession,"[|]")
-    peptide.data$accession <- unlist(lapply(list, '[[', 2))
-    peptide.data$gene <- unlist(lapply(list, '[[', 3))
+  # In case the accession column is of the format *|*|*, we split this column into an accession and a gene column.
+  if (all(sapply(peptide.data$accession, checkAccessionFormat))) {
+    peptide.data$gene <- sapply(peptide.data$accession, getGene)
+    peptide.data$accession <- sapply(peptide.data$accession, getAccession)
   }
   
   return (peptide.data)

--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PRT.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PRT.R
@@ -1,10 +1,25 @@
-## This is an R script for the conversion of mzTab to a better readable tsv format
+## This is an R script for the conversion of mzTab to a better readable tsv format.
 
-# options
-options(digits=10)
+# clear entire workspace
+rm(list = ls())
 
 input.file <- commandArgs(TRUE)[1]
 output.file <- commandArgs(TRUE)[2]
+
+# find start of the section
+startSection <- function(file, section.identifier) {
+  data <- file(file, "r")
+  row = 0
+  while (TRUE) {
+    row = row + 1
+    line = readLines(data, n=1)
+    if (substr(line, 1, 3)==section.identifier) {
+      break
+    }
+  }
+  close(data)
+  return (row)
+}
 
 # get index in protein groups list containing protein x
 getIndex <- function(x, members) {
@@ -25,80 +40,80 @@ countOccurrences <- function(char,s) {
 	return (nchar(s) - nchar(s2))
 }
 
-# check that all protein accessions are of the format *|*|*
-checkAccessionFormat <- function(accessions) {
-	n <- length(accessions)
-	count <- countOccurrences("[|]",accessions)
-	m <- length(which(count>=2))
-	return (n==m)
+# check that the protein accession is of the format *|*|*
+# Note that NA returns TRUE.
+checkAccessionFormat <- function(accession) {
+  if (is.na(accession)) {
+    return (TRUE)
+  }
+  n <- length(accession)
+  count <- countOccurrences("[|]",accession)
+  m <- length(which(count==2))
+  return (n==m)
 }
 
-getAccessions <- function(string) {
-	accessions <- strsplit(string,",")
-	accessions <- lapply(accessions,strsplit,"[|]")
-	accessions <- data.frame(matrix(unlist(accessions),ncol=3,byrow=TRUE))
-	return (paste(as.character(accessions[,2]), collapse=","))
+# Extracts the second entry from a string of the form *|*|*.
+getAccession <- function(string) {
+  if (is.na(string)) {
+    return (NA)
+  }
+  return (unlist(strsplit(string, "[|]"))[2])
 }
 
-getGenes <- function(string) {
-	accessions <- strsplit(string,",")
-	accessions <- lapply(accessions,strsplit,"[|]")
-	accessions <- data.frame(matrix(unlist(accessions),ncol=3,byrow=TRUE))
-	return (paste(as.character(accessions[,3]), collapse=","))
+# Extracts the third entry from a string of the form *|*|*.
+getGene <- function(string) {
+  if (is.na(string)) {
+    return (NA)
+  }
+  return (unlist(strsplit(string, "[|]"))[3])
 }
 
 # read the PRT section of an mzTab file
-readMzTabPRT <- function(file) {
+readMzTabPRT <-function(file) {
+  
+  # find start of the PRT section
+  first.row <- startSection(file, "PRH")
   
   # read entire mzTab
-  no.col <- max(count.fields(file, sep = "\t", quote=""))
-  data <- read.table(file, sep="\t", fill=TRUE, quote="", col.names=1:no.col)
+  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE)
   
-  # extract protein data
+  # extract PRT data
   protein.data <- data[which(data[,1]=="PRT"),]
-  colnames(protein.data) <- unlist(data[which(data[,1]=="PRH")[1],])
   protein.data$PRH <- NULL
-  columns.to.keep <- which(colnames(protein.data)!="")
-  protein.data <- protein.data[,columns.to.keep]
   
+  # In case the accession column is of the format *|*|*, we split this column into an accession and a gene column.
+  if (all(sapply(protein.data$accession, checkAccessionFormat))) {
+    protein.data$gene <- sapply(protein.data$accession, getGene)
+    protein.data$accession <- sapply(protein.data$accession, getAccession)
+  }
+  
+  # split into different types
   proteins <- protein.data[which(protein.data$opt_global_protein_group_type=="single_protein"),]
   protein.groups <- protein.data[which(protein.data$opt_global_protein_group_type=="protein_group"),]
   indistinguishable.groups <- protein.data[which(protein.data$opt_global_protein_group_type=="indistinguishable_group"),]
-
-  protein.groups.members <- as.character(protein.groups$ambiguity_members)
-  
-  indistinguishable.groups.members <- as.character(indistinguishable.groups$ambiguity_members)
   
   if ((dim(protein.groups)[1] > 0) && (dim(indistinguishable.groups)[1] > 0)) {
     # match indistinguishable groups to protein groups
     group.index <- as.vector(sapply(firstEntry(indistinguishable.groups.members), getIndex, members=protein.groups.members))
     table <- data.frame(cbind(group.index, indistinguishable.groups.members))
-    
+
     # merge information from the protein list
     colnames(table) <- c("protein group","accessions")
     table$accession <- firstEntry(table$accessions)
     table <- merge(table, proteins, by="accession")
     table$accession <- NULL
-    
+
     # order table by protein.group
     table$"protein group" <- as.integer(table$"protein group")
     table <- table[order(table$"protein group"),]
-  } else {
+  }
+  else {
     table <- proteins
     colnames(table) <- gsub("accession","accessions", colnames(table))
   }
   
-  # simplify accessions (in case they are of the format *|*|* )
-  table$accessions <- as.character(table$accessions)
-  if (checkAccessionFormat(table$accessions)) {
-    x <- unlist(lapply(table$accessions,getAccessions))
-    y <- unlist(lapply(table$accessions,getGenes))
-    table$accessions <- x
-    table$gene <- y
-  }
-
-  return (protein.groups)
+  return (table)
 }
 
-table <- readMzTabPRT(input.file)
-write.table(table, output.file, sep="\t", row.names=FALSE, col.names=TRUE, quote=FALSE)
+protein.data <- readMzTabPRT(input.file)
+write.table(protein.data, output.file, sep="\t", row.names=FALSE, col.names=TRUE, quote=FALSE)

--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PSM.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PSM.R
@@ -1,10 +1,43 @@
-## This is an R script for the conversion of mzTab to a better readable tsv format
+## This is an R script for the conversion of mzTab to a better readable tsv format.
 
-# options
-options(digits=10)
+# clear entire workspace
+rm(list = ls())
 
 input.file <- commandArgs(TRUE)[1]
 output.file <- commandArgs(TRUE)[2]
+
+# find start of the section
+startSection <- function(file, section.identifier) {
+  data <- file(file, "r")
+  row = 0
+  while (TRUE) {
+    row = row + 1
+    line = readLines(data, n=1)
+    if (substr(line, 1, 3)==section.identifier) {
+      break
+    }
+  }
+  close(data)
+  return (row)
+}
+
+# function describing how to collapse rows
+# In the case of string columns (e.g. accessions), the row entries are first made unique and then written to a comma-separated string.
+# In all other cases, the entry of the first row is returned.
+collapseRows <- function(x) {
+  if (is.character(x)) {
+    x <- paste(unique(x[!is.na(x)]), collapse=",")
+    if (x=="") {
+      return(NA)
+    }
+    else {
+      return (x)
+    }
+  }
+  else {
+    return (x[1])
+  }
+}
 
 # count the occurences of character c in string s
 countOccurrences <- function(c,s) {
@@ -12,66 +45,57 @@ countOccurrences <- function(c,s) {
   return (nchar(s) - nchar(s2))
 }
 
-# check that all protein accessions are of the format *|*|* 
-checkAccessionFormat <- function(accessions) {
-  n <- length(accessions)
-  count <- countOccurrences("[|]",accessions)
+# check that the protein accession is of the format *|*|*
+# Note that NA returns TRUE.
+checkAccessionFormat <- function(accession) {
+  if (is.na(accession)) {
+    return (TRUE)
+  }
+  n <- length(accession)
+  count <- countOccurrences("[|]",accession)
   m <- length(which(count==2))
   return (n==m)
 }
 
-# collapse rows
-# (In mzTab, PSMs with multiple protein accessions are reported in multiple rows. This function collapses them to a single row.)
-collapseRows <- function(psm.data) {
-  
-  # generate index vector idx
-  tmp.psm.id <- 0
-  idx <- c()
-  accessions.tmp <- c()
-  accessions.strings <- c()
-  for (i in 1:length(psm.data$PSM_ID)) {
-    
-    if (psm.data$PSM_ID[i] == tmp.psm.id) {
-      if (length(accessions.tmp) > 0) {
-        accessions.strings <- c(accessions.strings, toString(accessions.tmp, sep=','))
-        accessions.tmp <- c()
-      }
-      
-      idx <- c(idx,i)
-      tmp.psm.id <- tmp.psm.id + 1
-    }
-    
-    accessions.tmp <- c(accessions.tmp, psm.data$accession[i])
+# Extracts the second entry from a string of the form *|*|*.
+getAccession <- function(string) {
+  if (is.na(string)) {
+    return (NA)
   }
-  accessions.strings <- c(accessions.strings, toString(accessions.tmp, sep=','))
-  
-  psm.data <- psm.data[idx,]
-  psm.data$accession <- accessions.strings
-  
-  return (psm.data)
+  return (unlist(strsplit(string, "[|]"))[2])
+}
+
+# Extracts the third entry from a string of the form *|*|*.
+getGene <- function(string) {
+  if (is.na(string)) {
+    return (NA)
+  }
+  return (unlist(strsplit(string, "[|]"))[3])
 }
 
 # read the PSM section of an mzTab file
 readMzTabPSM <- function(file) {
   
+  # find start of the PSM section
+  first.row <- startSection(file, "PSH")
+  
   # read entire mzTab
-  no.col <- max(count.fields(file, sep = "\t", quote=""))
-  data <- read.table(file, sep="\t", fill=TRUE, quote="", col.names=1:no.col)
+  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE)
   
   # extract PSM data
   psm.data <- data[which(data[,1]=="PSM"),]
-  colnames(psm.data) <- unlist(data[which(data[,1]=="PSH")[1],])
   psm.data$PSH <- NULL
   
-  # simplify accession (in case it is of the format *|*|* )
-  psm.data$accession <- as.character(psm.data$accession)
-  if (checkAccessionFormat(psm.data$accession)) {
-    list <- strsplit(psm.data$accession, "[|]")
-    psm.data$accession <- unlist(lapply(list, '[[', 2))
-    psm.data$gene <- unlist(lapply(list, '[[', 3))
+  # In case the accession column is of the format *|*|*, we split this column into an accession and a gene column.
+  if (all(sapply(psm.data$accession, checkAccessionFormat))) {
+    psm.data$gene <- sapply(psm.data$accession, getGene)
+    psm.data$accession <- sapply(psm.data$accession, getAccession)
   }
   
-  psm.data <- collapseRows(psm.data)
+  # In the mzTab format, PSMs with multiple protein accessions are written to multiple rows.
+  # Here we collapse these rows and separate multiple accessions/genes by comma.
+  psm.data <- aggregate(psm.data, by=list(temp = psm.data$PSM_ID), FUN=collapseRows)
+  psm.data$temp <- NULL
   
   return (psm.data)
 }


### PR DESCRIPTION
This PR combines three improvements for the `mzTab2tsv` scripts.
- all columns now have automatically the correct types
- `readMzTabPSM` is faster
- when splitting `accession` and `gene` columns, `NA` entries are now allowed