### PR TITLE
[BUILD] remove double promotion warnings

### DIFF
--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -131,6 +131,7 @@ elseif ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
                   # These are warnings of moderate severity, which are disabled
                   # for now until we are down to a reasonable size of warnings.
                   -Wno-double-promotion
+                  -Wno-unused-template
                   -Wno-conversion
                   -Wno-float-equal
                   -Wno-switch-enum

--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -130,6 +130,7 @@ elseif ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
                   -Wno-c++98-compat-pedantic
                   # These are warnings of moderate severity, which are disabled
                   # for now until we are down to a reasonable size of warnings.
+                  -Wno-double-promotion
                   -Wno-conversion
                   -Wno-float-equal
                   -Wno-switch-enum


### PR DESCRIPTION
a small fix to reduce clang warnings, see  #757