### PR TITLE
[INTERNAL] correct column names in mzTab2tsv scripts

### DIFF
--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PEP.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PEP.R
@@ -62,7 +62,7 @@ readMzTabPEP <- function(file) {
   first.row <- startSection(file, "PEH")
   
   # read entire mzTab
-  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE)
+  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE, check.names=FALSE)
   
   # extract PEP data
   peptide.data <- data[which(data[,1]=="PEP"),]

--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PRT.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PRT.R
@@ -75,7 +75,7 @@ readMzTabPRT <-function(file) {
   first.row <- startSection(file, "PRH")
   
   # read entire mzTab
-  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE)
+  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE, check.names=FALSE)
   
   # extract PRT data
   protein.data <- data[which(data[,1]=="PRT"),]

--- a/share/OpenMS/SCRIPTS/mzTab2tsv_PSM.R
+++ b/share/OpenMS/SCRIPTS/mzTab2tsv_PSM.R
@@ -80,7 +80,7 @@ readMzTabPSM <- function(file) {
   first.row <- startSection(file, "PSH")
   
   # read entire mzTab
-  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE)
+  data <- read.table(file, sep="\t", skip=first.row-1, fill=TRUE, header=TRUE, quote="", na.strings=c("null","NA"), stringsAsFactors=FALSE, check.names=FALSE)
   
   # extract PSM data
   psm.data <- data[which(data[,1]=="PSM"),]


### PR DESCRIPTION
By default, square brackets in column names are substituted by dots. For example
```
best_search_engine_score[1]      -->      best_search_engine_score.1.
```
This PR corrects this behaviour.