### PR TITLE
[FIX] AbsoluteQuantitationMethod::getLLOD() getter correctly returns llod_

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
@@ -28,158 +28,84 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_ANALYSIS_QUANTITATION_ABSOLUTEQUANTITATIONMETHOD_H
 #define OPENMS_ANALYSIS_QUANTITATION_ABSOLUTEQUANTITATIONMETHOD_H
 
-#include <OpenMS/config.h>
-
-//Kernal classes
-#include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/KERNEL/FeatureMap.h>
-#include <OpenMS/KERNEL/MRMFeature.h>
-
-//Analysis classes
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>
-
-#include <cstddef> // for size_t & ptrdiff_t
-#include <vector>
-#include <string>
+#include <OpenMS/config.h> // OPENMS_DLLAPI
+#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>
 
 namespace OpenMS
 {
-
   /**
     @brief AbsoluteQuantitationMethod is a class to hold information about the
-      quantitation method and for applying and/or generating the quantitation method.
+    quantitation method and for applying and/or generating the quantitation method.
 
-    The quantitation method describes all parameters required to define the 
-      calibration curve used for absolute quantitation by Isotope Dilution Mass Spectrometry (IDMS).
-      The quantitation method also defines the statistics of the fitted calibration curve as well
-      as the lower and upper bounds of the calibration for later Quality Control.
-      
+    The quantitation method describes all parameters required to define the
+    calibration curve used for absolute quantitation by Isotope Dilution Mass Spectrometry (IDMS).
+    The quantitation method also defines the statistics of the fitted calibration curve as well
+    as the lower and upper bounds of the calibration for later Quality Control.
   */
   class OPENMS_DLLAPI AbsoluteQuantitationMethod
   {
+public:
+    AbsoluteQuantitationMethod() = default; ///< Constructor
+    ~AbsoluteQuantitationMethod() = default; ///< Destructor
 
-public:    
-  
-  //@{
-  /// Constructor
-  AbsoluteQuantitationMethod();
+    void setComponentName(const String& component_name); ///< Component name setter
+    String getComponentName() const; ///< Component name getter
 
-  /// Destructor
-  ~AbsoluteQuantitationMethod();
-  //@}
+    void setFeatureName(const String& feature_name); ///< Feature name setter
+    String getFeatureName() const; ///< Feature name getter
 
-  /// LLOD and ULOD setter
-  void setLLOD(const double& llod);
-  void setULOD(const double& ulod);
+    void setISName(const String& IS_name); ///< IS name setter
+    String getISName() const; ///< IS_name getter
 
-  /// LLOD and ULOD getter
-  double getLLOD();
-  double getULOD();
-  
-  /// LLOQ and ULOQ setter
-  void setLLOQ(const double& lloq);
-  void setULOQ(const double& uloq);
+    void setLLOD(const double llod); ///< LLOD setter
+    double getLLOD() const; ///< LLOD getter
+    void setULOD(const double ulod); ///< ULOD setter
+    double getULOD() const; ///< ULOD getter
+    bool checkLOD(const double value) const; ///< This function checks if the value is within the limits of detection (LOD)
 
-  /// LLOQ and ULOQ getter
-  double getLLOQ();
-  double getULOQ();
+    void setLLOQ(const double lloq); ///< LLOQ setter
+    double getLLOQ() const; ///< LLOQ getter
+    void setULOQ(const double uloq); ///< ULOQ setter
+    double getULOQ() const; ///< ULOQ getter
+    bool checkLOQ(const double value) const; ///< This function checks if the value is within the limits of quantitation (LOQ)
 
-  /**
-  @brief This function checks if the value is within the
-    limits of detection (LOD)
+    void setNPoints(const Int n_points); ///< Set the number of points
+    Int getNPoints() const; ///< Get the number of points
 
-  */ 
-  bool checkLOD(const double & value);
+    void setCorrelationCoefficient(const double correlation_coefficient); ///< Set the correlation coefficient
+    double getCorrelationCoefficient() const; ///< Get the correlation coefficient
 
-  /**
-  @brief This function checks if the value is within the
-    limits of quantitation (LOQ)
+    void setConcentrationUnits(const String& concentration_units); ///< Concentration units setter
+    String getConcentrationUnits() const; ///< Concentration units getter
 
-  */ 
-  bool checkLOQ(const double & value);
+    void setTransformationModel(const String& transformation_model); ///< Transformation model setter
+    String getTransformationModel() const; ///< Transformation model getter
 
-  /// component_name, IS_name, and feature_name setter
-  void setComponentName(const String& component_name);
-  void setISName(const String& IS_name);
-  void setFeatureName(const String& feature_name);
+    void setTransformationModelParams(const Param& transformation_model_params); ///< Transformation model parameters setter
+    Param getTransformationModelParams() const; ///< Transformation model parameters getter
 
-  /// component_name, IS_name, and feature_name getter
-  String getComponentName();
-  String getISName();
-  String getFeatureName();
-  
-  /// concentration_units setter
-  void setConcentrationUnits(const String& concentration_units);
-
-  /// concentration_units getter
-  String getConcentrationUnits();
-  
-  /// transformation_model and transformation_model_params setter
-  void setTransformationModel(const String& transformation_model);
-  void setTransformationModelParams(const Param& transformation_model_params);
-
-  /// transformation_model and transformation_model_params getter
-  String getTransformationModel();
-  Param getTransformationModelParams();
-  
-  /// statistics setter
-  void setNPoints(const int& n_points);
-  void setCorrelationCoefficient(const double& correlation_coefficient);
-  
-  /// statistics getter
-  int getNPoints();
-  double getCorrelationCoefficient();
-           
 private:
-  // members
-
-  /// id of the component
-  String component_name_;
-  
-  /// name of the feature (i.e., peak_apex_int or peak_area)
-  String feature_name_;
-
-  /// lower limit of detection (LLOD) of the transition
-  double llod_;
-
-  /// lower limit of quantitation (LLOQ) of the transition
-  double lloq_;
-
-  /// upper limit of detection (LLOD) of the transition
-  double ulod_;
-
-  /// upper limit of quantitation (LLOQ) of the transition
-  double uloq_;
-
-  /// number of points used in a calibration curve
-  int n_points_;
-
-  /// the Pearson R value for the correlation coefficient of the calibration curve
-  double correlation_coefficient_;
-
-  /// the internal standard (IS) name for the transition
-  String IS_name_;
-
-  /// the known concentration of the component
-  double actual_concentration_;
-
-  /// concentration units of the component's concentration
-  String concentration_units_;
-  
-  /// transformation model
-  String transformation_model_;
-
-  /// transformation model parameters
-  Param transformation_model_params_;  
+    String component_name_; ///< id of the component
+    String feature_name_; ///< name of the feature (i.e., peak_apex_int or peak_area)
+    String IS_name_; ///< the internal standard (IS) name for the transition
+    double llod_; ///< lower limit of detection (LLOD) of the transition
+    double ulod_; ///< upper limit of detection (ULOD) of the transition
+    double lloq_; ///< lower limit of quantitation (LLOQ) of the transition
+    double uloq_; ///< upper limit of quantitation (ULOQ) of the transition
+    Int n_points_; ///< number of points used in a calibration curve
+    double correlation_coefficient_; ///< the Pearson R value for the correlation coefficient of the calibration curve
+    String concentration_units_; ///< concentration units of the component's concentration
+    String transformation_model_; ///< transformation model
+    Param transformation_model_params_; ///< transformation model parameters
   };
-
 }
-#endif // OPENMS_ANALYSIS_QUANTITATION_ABSOLUTEQUANTITATIONMETHOD_H
 
+#endif // OPENMS_ANALYSIS_QUANTITATION_ABSOLUTEQUANTITATIONMETHOD_H

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
@@ -158,11 +158,11 @@ namespace OpenMS
 
   bool AbsoluteQuantitationMethod::checkLOD(const double value) const
   {
-    return value >= llod_ && value <= ulod_ ? true : false; // is it bracketed or not
+    return value >= llod_ && value <= ulod_; // is it bracketed or not
   }
 
   bool AbsoluteQuantitationMethod::checkLOQ(const double value) const
   {
-    return value >= lloq_ && value <= uloq_ ? true : false; // is it bracketed or not
+    return value >= lloq_ && value <= uloq_; // is it bracketed or not
   }
 } // namespace

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
@@ -28,180 +28,141 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>
 
-//Kernal classes
-#include <OpenMS/KERNEL/StandardTypes.h>
-
-//Analysis classes
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelBSpline.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
-
-#include <cstddef> // for size_t & ptrdiff_t
-#include <vector>
-#include <string>
-
 namespace OpenMS
 {
-    
-  AbsoluteQuantitationMethod::AbsoluteQuantitationMethod()
-  {
-  }
-  
-  AbsoluteQuantitationMethod::~AbsoluteQuantitationMethod()
-  {
-  }
-  
-  //LOD getters and setters
-  void AbsoluteQuantitationMethod::setLLOD(const double& llod)
+  void AbsoluteQuantitationMethod::setLLOD(const double llod)
   {
     llod_ = llod;
   }
-  
-  void AbsoluteQuantitationMethod::setULOD(const double& ulod)
+
+  void AbsoluteQuantitationMethod::setULOD(const double ulod)
   {
     ulod_ = ulod;
   }
-    
-  double AbsoluteQuantitationMethod::getLLOD()
+
+  double AbsoluteQuantitationMethod::getLLOD() const
   {
     return llod_;
   }
-  
-  double AbsoluteQuantitationMethod::getULOD()
+
+  double AbsoluteQuantitationMethod::getULOD() const
   {
     return ulod_;
   }
-  
-  void AbsoluteQuantitationMethod::setLLOQ(const double& lloq)
+
+  void AbsoluteQuantitationMethod::setLLOQ(const double lloq)
   {
     lloq_ = lloq;
   }
-  
-  void AbsoluteQuantitationMethod::setULOQ(const double& uloq)
+
+  void AbsoluteQuantitationMethod::setULOQ(const double uloq)
   {
     uloq_ = uloq;
   }
-  
-  double AbsoluteQuantitationMethod::getLLOQ()
+
+  double AbsoluteQuantitationMethod::getLLOQ() const
   {
     return lloq_;
   }
-  
-  double AbsoluteQuantitationMethod::getULOQ()
+
+  double AbsoluteQuantitationMethod::getULOQ() const
   {
     return uloq_;
   }
-  
-  //Component, IS, and Feature name setters  
+
   void AbsoluteQuantitationMethod::setFeatureName(const String& feature_name)
   {
     feature_name_ = feature_name;
   }
-  
-  String AbsoluteQuantitationMethod::getFeatureName()
+
+  String AbsoluteQuantitationMethod::getFeatureName() const
   {
     return feature_name_;
   } 
-  
+
   void AbsoluteQuantitationMethod::setISName(const String& IS_name)
   {
     IS_name_ = IS_name;
   }
-  
-  String AbsoluteQuantitationMethod::getISName()
+
+  String AbsoluteQuantitationMethod::getISName() const
   {
     return IS_name_;
   }
-  
+
   void AbsoluteQuantitationMethod::setComponentName(const String& component_name)
   {
     component_name_ = component_name;
   }
-  
-  String AbsoluteQuantitationMethod::getComponentName()
+
+  String AbsoluteQuantitationMethod::getComponentName() const
   {
     return component_name_;
   }
-  
-  //Concentration unit getter and setter
+
   void AbsoluteQuantitationMethod::setConcentrationUnits(const String& concentration_units)
   {
     concentration_units_ = concentration_units;
   }
 
-  String AbsoluteQuantitationMethod::getConcentrationUnits()
+  String AbsoluteQuantitationMethod::getConcentrationUnits() const
   {
     return concentration_units_;
   }
-  
-  //Transformation model getters and setters
+
   void AbsoluteQuantitationMethod::setTransformationModel(const String& transformation_model)
   {
     transformation_model_ = transformation_model;
   }
+
   void AbsoluteQuantitationMethod::setTransformationModelParams(const Param& transformation_model_params)
   {
     transformation_model_params_ = transformation_model_params;
   }
 
-  String AbsoluteQuantitationMethod::getTransformationModel()
+  String AbsoluteQuantitationMethod::getTransformationModel() const
   {
     return transformation_model_;
   }
 
-  Param AbsoluteQuantitationMethod::getTransformationModelParams()
+  Param AbsoluteQuantitationMethod::getTransformationModelParams() const
   {
     return transformation_model_params_;
   }
-  
-  //Statistics getters and setters
-  void AbsoluteQuantitationMethod::setNPoints(const int& n_points)
+
+  void AbsoluteQuantitationMethod::setNPoints(const Int n_points)
   {
     n_points_ = n_points;
   }
-  void AbsoluteQuantitationMethod::setCorrelationCoefficient(const double& correlation_coefficient)
+
+  void AbsoluteQuantitationMethod::setCorrelationCoefficient(const double correlation_coefficient)
   {
     correlation_coefficient_ = correlation_coefficient;
   }
-  
-  int AbsoluteQuantitationMethod::getNPoints()
+
+  Int AbsoluteQuantitationMethod::getNPoints() const
   {
     return n_points_;
   }
-  double AbsoluteQuantitationMethod::getCorrelationCoefficient()
+
+  double AbsoluteQuantitationMethod::getCorrelationCoefficient() const
   {
     return correlation_coefficient_;
   }
 
-  //Non getter/setter methods
-  bool AbsoluteQuantitationMethod::checkLOD(const double & value)
+  bool AbsoluteQuantitationMethod::checkLOD(const double value) const
   {
-    bool bracketted = false;
-    if (value <= ulod_ && value >= llod_)
-    {
-      bracketted = true;
-    }
-    return bracketted;
+    return value >= llod_ && value <= ulod_ ? true : false; // is it bracketed or not
   }
 
-  bool AbsoluteQuantitationMethod::checkLOQ(const double & value)
+  bool AbsoluteQuantitationMethod::checkLOQ(const double value) const
   {
-    bool bracketted = false;
-    if (value <= uloq_ && value >= lloq_)
-    {
-      bracketted = true;
-    }
-    return bracketted;
+    return value >= lloq_ && value <= uloq_ ? true : false; // is it bracketed or not
   }
-
 } // namespace
-

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
@@ -73,7 +73,7 @@ namespace OpenMS
     
   double AbsoluteQuantitationMethod::getLLOD()
   {
-    return ulod_;
+    return llod_;
   }
   
   double AbsoluteQuantitationMethod::getULOD()

--- a/src/pyOpenMS/pxds/AbsoluteQuantitationMethod.pxd
+++ b/src/pyOpenMS/pxds/AbsoluteQuantitationMethod.pxd
@@ -23,23 +23,22 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>" n
         void checkLOD(double value) nogil except +
         void checkLOQ(double value) nogil except +
         
-        void setComponentName(String component_name) nogil except +
-        void setISName(String IS_name) nogil except +
-        void setFeatureName(String feature_name) nogil except +
+        void setComponentName(String& component_name) nogil except +
+        void setISName(String& IS_name) nogil except +
+        void setFeatureName(String& feature_name) nogil except +
         String getComponentName() nogil except +
         String getISName() nogil except +
         String getFeatureName() nogil except +
 
-        void setConcentrationUnits(String concentration_units) nogil except +
+        void setConcentrationUnits(String& concentration_units) nogil except +
         String getConcentrationUnits() nogil except +
 
-        void setTransformationModel(String transformation_model) nogil except +
+        void setTransformationModel(String& transformation_model) nogil except +
         void setTransformationModelParams(Param transformation_model_param) nogil except +
         String getTransformationModel() nogil except +
         Param getTransformationModelParams() nogil except +
 
-        void setNPoints(int n_points) nogil except +
+        void setNPoints(Int n_points) nogil except +
         void setCorrelationCoefficient(double correlation_coefficient) nogil except +
-        int getNPoints() nogil except +
+        Int getNPoints() nogil except +
         double getCorrelationCoefficient() nogil except +
-

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitationMethod_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitationMethod_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 //
 
@@ -39,14 +39,6 @@
 ///////////////////////////
 
 #include <OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>
-
-//Analysis classes
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationDescription.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLinear.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelBSpline.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelInterpolated.h>
-#include <OpenMS/ANALYSIS/MAPMATCHING/TransformationModelLowess.h>
 
 using namespace OpenMS;
 using namespace std;
@@ -59,47 +51,83 @@ START_TEST(AbsoluteQuantitationMethod, "$Id$")
 
 AbsoluteQuantitationMethod* ptr = nullptr;
 AbsoluteQuantitationMethod* nullPointer = nullptr;
-START_SECTION((AbsoluteQuantitationMethod()))
-	ptr = new AbsoluteQuantitationMethod();
-	TEST_NOT_EQUAL(ptr, nullPointer);
+
+START_SECTION(AbsoluteQuantitationMethod())
+{
+  ptr = new AbsoluteQuantitationMethod();
+  TEST_NOT_EQUAL(ptr, nullPointer);
+}
 END_SECTION
 
-START_SECTION((~AbsoluteQuantitationMethod()))
-	delete ptr;
+START_SECTION(~AbsoluteQuantitationMethod())
+{
+  delete ptr;
+}
 END_SECTION
 
-START_SECTION((bool checkLOD(const double & value)))
-
+START_SECTION(all setters and getters)
+{
   AbsoluteQuantitationMethod aqm;
-  double value = 2.0;
 
-  // tests
+  aqm.setComponentName("component");
+  aqm.setFeatureName("feature");
+  aqm.setISName("IS");
+  aqm.setLLOD(1.2);
+  aqm.setULOD(3.4);
+  aqm.setLLOQ(5.6);
+  aqm.setULOQ(7.8);
+  aqm.setNPoints(9);
+  aqm.setCorrelationCoefficient(0.44);
+  aqm.setConcentrationUnits("uM");
+  aqm.setTransformationModel("TransformationModelLinear");
+  Param params1;
+  params1.setValue("slope", 1);
+  aqm.setTransformationModelParams(params1);
+
+  TEST_EQUAL(aqm.getComponentName(), "component")
+  TEST_EQUAL(aqm.getFeatureName(), "feature")
+  TEST_EQUAL(aqm.getISName(), "IS")
+  TEST_REAL_SIMILAR(aqm.getLLOD(), 1.2)
+  TEST_REAL_SIMILAR(aqm.getULOD(), 3.4)
+  TEST_REAL_SIMILAR(aqm.getLLOQ(), 5.6)
+  TEST_REAL_SIMILAR(aqm.getULOQ(), 7.8)
+  TEST_EQUAL(aqm.getNPoints(), 9)
+  TEST_REAL_SIMILAR(aqm.getCorrelationCoefficient(), 0.44)
+  TEST_EQUAL(aqm.getConcentrationUnits(), "uM")
+  TEST_EQUAL(aqm.getTransformationModel(), "TransformationModelLinear")
+  Param params2 = aqm.getTransformationModelParams();
+  TEST_EQUAL(params2.getValue("slope"), 1)
+}
+END_SECTION
+
+START_SECTION(bool checkLOD(const double value) const)
+{
+  AbsoluteQuantitationMethod aqm;
+  const double value = 2.0;
   aqm.setLLOD(0.0);
   aqm.setULOD(4.0);
-  TEST_EQUAL(aqm.checkLOD(value),true);
-  aqm.setLLOD(0.0);
+  TEST_EQUAL(aqm.checkLOD(value), true);
   aqm.setULOD(1.0);
-  TEST_EQUAL(aqm.checkLOD(value),false);
+  TEST_EQUAL(aqm.checkLOD(value), false);
   aqm.setLLOD(3.0);
   aqm.setULOD(4.0);
-  TEST_EQUAL(aqm.checkLOD(value),false);
+  TEST_EQUAL(aqm.checkLOD(value), false);
+}
 END_SECTION
 
-START_SECTION((bool checkLOQ(const double & value)))
-
+START_SECTION(bool checkLOQ(const double value) const)
+{
   AbsoluteQuantitationMethod aqm;
-  double value = 2.0;
-
-  // tests
+  const double value = 2.0;
   aqm.setLLOQ(0.0);
   aqm.setULOQ(4.0);
-  TEST_EQUAL(aqm.checkLOQ(value),true);
-  aqm.setLLOQ(0.0);
+  TEST_EQUAL(aqm.checkLOQ(value), true);
   aqm.setULOQ(1.0);
-  TEST_EQUAL(aqm.checkLOQ(value),false);
+  TEST_EQUAL(aqm.checkLOQ(value), false);
   aqm.setLLOQ(3.0);
   aqm.setULOQ(4.0);
-  TEST_EQUAL(aqm.checkLOQ(value),false);
+  TEST_EQUAL(aqm.checkLOQ(value), false);
+}
 END_SECTION
 
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
I'm working on a class named _AbsoluteQuantitationMethodFile_ and I found this bug.
For now I'm only correcting this line, since I guess it is high priority.
I will also add tests that would catch this kind of bugs once I'm done with my other classes.