### PR TITLE
[FIX] #3179 

### DIFF
--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -177,7 +177,7 @@ namespace OpenMS
       if (!File::exists(old_ini_file))
       {
         String msg = String("Could not open old INI file '") + old_ini_file + "'! File does not exist!";
-        if (getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
+        if (getScene_() && getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
         else LOG_ERROR << msg << std::endl;
         tool_ready_ = false;
         return false;
@@ -195,7 +195,7 @@ namespace OpenMS
           " returned with exit code (" + String(p.exitCode()) + "), exit status (" + String(p.exitStatus()) + ")." +
           "\noutput:\n" + String(QString(p.readAll())) +
           "\n";
-      if (getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
+      if (getScene_() && getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
       else LOG_ERROR << msg << std::endl;
       tool_ready_ = false;
       return false;
@@ -203,7 +203,7 @@ namespace OpenMS
     if (!File::exists(ini_file))
     { // it would be weird to get here, since the TOPP tool ran successfully above, so INI file should exist, but nevertheless:
       String msg = String("Could not open '") + ini_file + "'! It does not exist!";
-      if (getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
+      if (getScene_() && getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
       else LOG_ERROR << msg << std::endl;
       tool_ready_ = false;
       return false;


### PR DESCRIPTION
scene() will return nullptr, since the TOPPASToolVertex is not registered as an object the scene yet (we're still constructing it.

Fixes #3179.