### PR TITLE
[UPDATE] UTILS/TOPP doxygen

### DIFF
--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -124,6 +124,8 @@
   - @subpage TOPP_PepNovoAdapter - Identifies MS/MS spectra using PepNovo (external).
   - @subpage TOPP_XTandemAdapter - Identifies MS/MS spectra using XTandem (external).
   - @subpage TOPP_SpecLibSearcher - Identifies peptide MS/MS spectra by spectral matching with a searchable spectral library.
+  - @subpage TOPP_CruxAdapter -Identifies peptides in MS/MS spectra via Crux and tide-search.
+
 
   <b>Protein/Peptide Processing</b>
   - @subpage TOPP_ConsensusID - Computes a consensus identification from peptide identifications of several identification engines.

--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -124,8 +124,7 @@
   - @subpage TOPP_PepNovoAdapter - Identifies MS/MS spectra using PepNovo (external).
   - @subpage TOPP_XTandemAdapter - Identifies MS/MS spectra using XTandem (external).
   - @subpage TOPP_SpecLibSearcher - Identifies peptide MS/MS spectra by spectral matching with a searchable spectral library.
-  - @subpage TOPP_CruxAdapter -Identifies peptides in MS/MS spectra via Crux and tide-search.
-
+  - @subpage TOPP_CruxAdapter - Identifies peptides in MS/MS spectra via Crux and tide-search.
 
   <b>Protein/Peptide Processing</b>
   - @subpage TOPP_ConsensusID - Computes a consensus identification from peptide identifications of several identification engines.

--- a/doc/doxygen/public/UTILS.doxygen
+++ b/doc/doxygen/public/UTILS.doxygen
@@ -63,7 +63,6 @@
   - @subpage UTILS_FFEval - Evaluation tool for feature detection algorithms.
   - @subpage UTILS_IDEvaluator - Evaluation tool, comparing peptide recovery at different q-value thresholds for multiple search engines (e.g., after ConsensusID). For interactive version use the @subpage UTILS_IDEvaluatorGUI tool.
   - @subpage UTILS_LabeledEval - Evaluation tool for isotope-labeled quantitation experiments.
-  - @subpage UTILS_MapAlignmentEvaluation - Evaluates alignment results against a ground truth.
   - @subpage UTILS_RTEvaluation - Application that evaluates TPs (true positives), TNs, FPs, and FNs for an idXML file with predicted RTs.
   - @subpage UTILS_TransformationEvaluation - Simple evaluation of transformations (e.g. RT transformations produced by a MapAligner tool).
 
@@ -79,7 +78,13 @@
   - @subpage UTILS_SpecLibCreator - Creates an MSP-formatted spectral library.
   - @subpage UTILS_SpectraSTSearchAdapter - An interface to the 'SEARCH' mode of the SpectraST program (external, beta).
   - @subpage UTILS_PSMFeatureExtractor - Creates search engine specific features for PercolatorAdapter input.
-  
+  - @subpage TOPP_MSFraggerAdapter - Peptide Identification with MSFragger.
+  - @subpage UTILS_NovorAdapter - De novo sequencing from tandem mass spectrometry data.
+
+  <b>Cross-linking</b>
+  - @subpage UTILS_OpenPepXL - Search for peptide pairs linked with a labeled cross-linker.
+  - @subpage UTILS_OpenPepXLLF - Search for cross-linked peptide pairs in tandem MS spectra.
+  - @subpage UTILS_XFDR - Calculates false discovery rate estimates on crosslink identifications.
 
   <b>Quantitation</b>
   - @subpage UTILS_ERPairFinder - Evaluate pair ratios on enhanced resolution (zoom) scans.
@@ -91,6 +96,7 @@
   <b>Metabolite Identification</b>
   - @subpage UTILS_AccurateMassSearch - Find potential HMDB IDs within the given mass error window.
   - @subpage UTILS_MetaboliteSpectralMatcher - Identify small molecules from tandem MS spectra.  
+  - @subpage UTILS_SiriusAdapter - De novo metabolite identification.
 
   <b>Quality Control</b>
   - @subpage UTILS_QCCalculator - Calculates basic quality parameters from MS experiments and compiles data for subsequent QC into a qcML file.
@@ -112,23 +118,23 @@
   - @subpage UTILS_SvmTheoreticalSpectrumGeneratorTrainer - A trainer for SVM models as input for SvmTheoreticalSpectrumGenerator.
   - @subpage UTILS_PeakPickerIterative A tool for peak detection in profile data.
   - @subpage UTILS_DatabaseFilter - Filters a protein database in FASTA format according to one or multiple filtering criteria.
-  - @subpage UTILS_SpectraSTSearchAdapter - This tool provides an interface to the 'SEARCH' mode of the SpectraST program.
   - @subpage UTILS_TICCalculator - Calculates the TIC of a raw mass spectrometric file. 
   - @subpage UTILS_MultiplexResolver - Resolves conflicts between identifications and quantifications in multiplex data.
   - @subpage UTILS_LowMemPeakPickerHiRes - A tool for peak detection on streamed profile data 
-  - @subpage UTILS_LowMemPeakPickerHiRes_RandomAccess - A tool for peak detection on streamed profile data 
+  - @subpage UTILS_LowMemPeakPickerHiResRandomAccess - A tool for peak detection on streamed profile data 
   - @subpage UTILS_MRMTransitionGroupPicker - Picks peaks in MRM chromatograms.
+  - @subpage TOPP_ClusterMassTraces - Cluster mass traces occuring in the same map together.
+  - @subpage TOPP_CorrelateMassTraces - Identifies precursor mass traces and tries to correlate them with fragment ion mass traces in SWATH maps.
+  - @subpage UTILS_IDDecoyProbability - Estimate probability of peptide hits.
+  - @subpage UTILS_RNADigestor - Digests an RNA sequence database in-silico.
 
   <!--
   - TODO we need descriptions for all of these
   - @subpage UTILS_MetaProSIP - xxx
-  - @subpage UTILS_MultiplexResolver - xxx
-  - @subpage UTILS_OpenMSInfo
-  - @subpage UTILS_SimpleSearchEngine
-  - @subpage UTILS_TopPerc
+  - @subpage UTILS_OpenMSInfo - xxx
   - @subpage UTILS_RNPxlSearch - Tool for RNP 
+  - @subpage UTILS_SimpleSearchEngine - xxx
   -->
-
 
   <b>Deprecated</b>
   - @subpage UTILS_IDDecoyProbability - Estimates peptide probabilities using a decoy search strategy. <br> WARNING: This utility is deprecated.

--- a/doc/doxygen/public/UTILS.doxygen
+++ b/doc/doxygen/public/UTILS.doxygen
@@ -128,13 +128,13 @@
   - @subpage UTILS_IDDecoyProbability - Estimate probability of peptide hits.
   - @subpage UTILS_RNADigestor - Digests an RNA sequence database in-silico.
 
-  <!--
+<!--
   - TODO we need descriptions for all of these
-  - @subpage UTILS_MetaProSIP - xxx
-  - @subpage UTILS_OpenMSInfo - xxx
-  - @subpage UTILS_RNPxlSearch - Tool for RNP 
-  - @subpage UTILS_SimpleSearchEngine - xxx
-  -->
+  - @subpage UTILS_OpenMSInfo - Print build system information.
+  - @subpage UTILS_RNPxlSearch - Annotate RNA to peptide crosslinks in MS/MS spectra.
+  - @subpage UTILS_MetaProSIP - Performs proteinSIP on peptide features for elemental flux analysis.
+  - @subpage UTILS_SimpleSearchEngine - Annotates MS/MS spectra using SimpleSearchEngine.
+-->
 
   <b>Deprecated</b>
   - @subpage UTILS_IDDecoyProbability - Estimates peptide probabilities using a decoy search strategy. <br> WARNING: This utility is deprecated.

--- a/src/utils/NovorAdapter.cpp
+++ b/src/utils/NovorAdapter.cpp
@@ -67,8 +67,13 @@ using namespace std;
 <CENTER>
     <table>
         <tr>
-            <td ALIGN = "center" BGCOLOR="#EBEBEB"> MS2-Filtering with @ref TOPP_FileFilter</td>
-            <td VALIGN = "middle" ROWSPAN=2> \f$ \longrightarrow \f$ NovorAdapter \f$</td>
+            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. predecessor tools </td>
+            <td VALIGN="middle" ROWSPAN=2> \f$ \longrightarrow \f$ NovorAdapter \f$ \longrightarrow \f$</td>
+            <td ALIGN = "center" BGCOLOR="#EBEBEB"> pot. successor tools </td>
+        </tr>
+        <tr>
+            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> signal-/preprocessing e.g. @ref TOPP_FileFilter  @n (in mzML format)</td>
+            <td VALIGN="middle" ALIGN = "center" ROWSPAN=1> @ref TOPP_IDFilter or @n any protein/peptide processing tool</td>
         </tr>
     </table>
 </CENTER>

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -53,7 +53,7 @@ using namespace std;
 //Doxygen docu
 //----------------------------------------------------------
 /**
-  @page UTILS_SiriusAdapter
+  @page UTILS_SiriusAdapter SiriusAdapter
 
   @brief De novo metabolite identification.
 


### PR DESCRIPTION
[UPDATE] UTILS.doxygen
[UPDATE] TOPP.doxygen

had to do some smaller fixes (documentation related) in 
[FIX] SiriusAdapter
[FIX] NovorAdapter

#3186 

Documentation is missing in 
UTILS_RNPxlSearch
UTILS_MetaProSip
UTILS_OpenMSInfo
UTILS_SimpleSearchEngine