### PR TITLE
[NOP] remove compile warning GCC7

### DIFF
--- a/src/openms/source/ANALYSIS/MAPMATCHING/LabeledPairFinder.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/LabeledPairFinder.cpp
@@ -214,7 +214,7 @@ namespace OpenMS
         for (Size i = 0; i < hist.size(); ++i)
         {
           points[i][0] = hist.centerOfBin(i);
-          points[i][1] = max(0u, hist[i]);
+          points[i][1] = hist[i];
         }
         GaussFitter fitter;
         fitter.setInitialParameters(result);


### PR DESCRIPTION
taking the max of unsigned zero and a value is always equal to the other value