### PR TITLE
some performance optimizations (especially XML parsing)

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -781,31 +781,26 @@ public:
     return this_s;
   }
 
-  static String& removeWhitespaces(String & this_s)
+  static String& removeWhitespaces(String& this_s)
   {
-    bool contains_ws = false;
-    for (std::string::const_iterator it = this_s.begin(); it != this_s.end(); ++it)
+    int shift(0); // windowing number of removed whitespaces
+    std::string::iterator it_end = this_s.end();
+    for (std::string::iterator it = this_s.begin(); it != it_end; ++it)
     {
-      char c = *it;
+      const char c = *it;
       if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
       {
-        contains_ws = true;
-        break;
+        ++shift;
+        continue; // no need to shift this 
+      }
+      if (shift)
+      { // move current char to the left
+        *(it - shift) = c;
       }
     }
 
-    if (contains_ws)
-    {
-      std::string tmp;
-      tmp.reserve(this_s.size());
-      for (std::string::const_iterator it = this_s.begin(); it != this_s.end(); ++it)
-      {
-        char c = *it;
-        if (c != ' ' && c != '\t' && c != '\n' && c != '\r')
-          tmp += c;
-      }
-      this_s.swap(tmp);
-    }
+    // shorten result
+    if (shift) this_s.resize(this_s.size() - shift);
 
     return this_s;
   }

--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -783,24 +783,26 @@ public:
 
   static String& removeWhitespaces(String& this_s)
   {
-    int shift(0); // windowing number of removed whitespaces
+    std::string::iterator it = this_s.begin();
+    std::string::iterator dest = it;
     std::string::iterator it_end = this_s.end();
-    for (std::string::iterator it = this_s.begin(); it != it_end; ++it)
+    while (it != it_end)
     {
       const char c = *it;
       if (c == ' ' || c == '\t' || c == '\n' || c == '\r')
       {
-        ++shift;
-        continue; // no need to shift this 
+        ++it;
+        continue; // no need to copy a whitespace
       }
-      if (shift)
-      { // move current char to the left
-        *(it - shift) = c;
-      }
+      // copy to the left, if we had a whitespace before
+      if (dest != it) *dest = *it;
+      // advance both
+      ++dest;
+      ++it;
     }
 
     // shorten result
-    if (shift) this_s.resize(this_s.size() - shift);
+    if (dest != it) this_s.resize(dest - this_s.begin());
 
     return this_s;
   }

--- a/src/openms/include/OpenMS/FORMAT/Base64.h
+++ b/src/openms/include/OpenMS/FORMAT/Base64.h
@@ -67,10 +67,7 @@ namespace OpenMS
 public:
 
     /// default constructor
-    Base64();
-
-    /// Destructor
-    virtual ~Base64();
+    Base64() = default;
 
     /// Byte order type
     enum ByteOrder
@@ -87,7 +84,7 @@ public:
         @note @p in will be empty after this method
     */
     template <typename FromType>
-    void encode(std::vector<FromType> & in, ByteOrder to_byte_order, String & out, bool zlib_compression = false);
+    static void encode(std::vector<FromType> & in, ByteOrder to_byte_order, String & out, bool zlib_compression = false);
 
     /**
         @brief Decodes a Base64 string to a vector of floating point numbers
@@ -95,7 +92,7 @@ public:
         You have to specify the byte order of the input and if it is zlib-compressed.
     */
     template <typename ToType>
-    void decode(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out, bool zlib_compression = false);
+    static void decode(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out, bool zlib_compression = false);
 
     /**
         @brief Encodes a vector of integer point numbers to a Base64 string
@@ -105,7 +102,7 @@ public:
         @note @p in will be empty after this method
     */
     template <typename FromType>
-    void encodeIntegers(std::vector<FromType> & in, ByteOrder to_byte_order, String & out, bool zlib_compression = false);
+    static void encodeIntegers(std::vector<FromType> & in, ByteOrder to_byte_order, String & out, bool zlib_compression = false);
 
     /**
         @brief Decodes a Base64 string to a vector of integer numbers
@@ -113,7 +110,7 @@ public:
         You have to specify the byte order of the input and if it is zlib-compressed.
     */
     template <typename ToType>
-    void decodeIntegers(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out, bool zlib_compression = false);
+    static void decodeIntegers(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out, bool zlib_compression = false);
 
     /**
         @brief Encodes a vector of strings to a Base64 string
@@ -127,7 +124,7 @@ public:
       
         @note Unless append_null_byte is false, will add a null byte ("\0") at the end of each input
     */
-    void encodeStrings(const std::vector<String> & in, String & out, bool zlib_compression = false, bool append_null_byte = true);
+    static void encodeStrings(const std::vector<String> & in, String & out, bool zlib_compression = false, bool append_null_byte = true);
 
     /**
         @brief Decodes a Base64 string to a vector of (null-terminated) strings
@@ -138,7 +135,7 @@ public:
         @param out A vector containing the decoded data (split at null "\0") bytes
         @param zlib_compression Whether the data should be decompressed with zlib after decoding in Base64
     */
-    void decodeStrings(const String & in, std::vector<String> & out, bool zlib_compression = false);
+    static void decodeStrings(const String & in, std::vector<String> & out, bool zlib_compression = false);
 
     /**
         @brief Decodes a Base64 string to a QByteArray
@@ -147,7 +144,7 @@ public:
         @param out A ByteArray containing the decoded data
         @param zlib_compression Whether the data should be decompressed with zlib after decoding in Base64
     */
-    void decodeSingleString(const String & in, QByteArray & base64_uncompressed, bool zlib_compression);
+    static void decodeSingleString(const String & in, QByteArray & base64_uncompressed, bool zlib_compression);
 
 private:
 
@@ -169,19 +166,19 @@ private:
     static const char decoder_[];
     /// Decodes a Base64 string to a vector of floating point numbers
     template <typename ToType>
-    void decodeUncompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out);
+    static void decodeUncompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out);
 
     ///Decodes a compressed Base64 string to a vector of floating point numbers
     template <typename ToType>
-    void decodeCompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out);
+    static void decodeCompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out);
 
     /// Decodes a Base64 string to a vector of integer numbers
     template <typename ToType>
-    void decodeIntegersUncompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out);
+    static void decodeIntegersUncompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out);
 
     ///Decodes a compressed Base64 string to a vector of integer numbers
     template <typename ToType>
-    void decodeIntegersCompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out);
+    static void decodeIntegersCompressed_(const String & in, ByteOrder from_byte_order, std::vector<ToType> & out);
   };
 
   /// Endianizes a 32 bit type from big endian to little endian and vice versa

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
@@ -57,33 +57,34 @@ namespace OpenMS
       /// Binary data representation
       struct BinaryData
       {
-        String base64;
+        // ordered by size (alignment) and cache hotness in 'decode'
         enum {PRE_NONE, PRE_32, PRE_64} precision;
-        Size size;
+        enum { DT_NONE, DT_FLOAT, DT_INT, DT_STRING } data_type;
+        MSNumpressCoder::NumpressCompression np_compression;
         bool compression; // zlib compression
-        enum {DT_NONE, DT_FLOAT, DT_INT, DT_STRING} data_type;
+        String base64;
+        Size size;
         std::vector<float> floats_32;
         std::vector<double> floats_64;
         std::vector<Int32> ints_32;
         std::vector<Int64> ints_64;
         std::vector<String> decoded_char;
         MetaInfoDescription meta;
-        MSNumpressCoder::NumpressCompression np_compression;
 
         /// Constructor
         BinaryData() :
-          base64(),
           precision(PRE_NONE),
-          size(0),
-          compression(false),
           data_type(DT_NONE),
+          np_compression(),
+          compression(false),
+          base64(),
+          size(0),
           floats_32(),
           floats_64(),
           ints_32(),
           ints_64(),
           decoded_char(),
-          meta(),
-          np_compression()
+          meta()
         {
         }
 
@@ -110,7 +111,7 @@ namespace OpenMS
       */
       static void decodeBase64Arrays(std::vector<BinaryData> & data_, bool skipXMLCheck = false);
 
-      static void computeDataProperties_(std::vector<BinaryData>& data_, bool& precision_64, SignedSize& index, String index_name);
+      static void computeDataProperties_(std::vector<BinaryData>& data_, bool& precision_64, SignedSize& index, const String& index_name);
 
       static bool handleBinaryDataArrayCVParam(std::vector<BinaryData>& data_,
         const String& accession, const String& value, const String& name);

--- a/src/openms/source/ANALYSIS/XLMS/XQuestScores.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/XQuestScores.cpp
@@ -57,13 +57,13 @@ namespace OpenMS
     if (matched_alpha <= 0)
     {
 //      matched_alpha_float = std::numeric_limits<float>::min();
-      matched_alpha_float = 0.1;
+      matched_alpha_float = 0.1f;
     }
     float matched_beta_float = matched_beta;
     if (matched_beta <= 0)
     {
 //      matched_beta_float = std::numeric_limits<float>::min();
-      matched_beta_float = 0.1;
+      matched_beta_float = 0.1f;
     }
 
       float result = sqrt((static_cast<float>(matched_alpha_float) / static_cast<float>(ions_alpha)) * (static_cast<float>(matched_beta_float) / static_cast<float>(ions_beta)));

--- a/src/openms/source/FORMAT/Base64.cpp
+++ b/src/openms/source/FORMAT/Base64.cpp
@@ -126,14 +126,6 @@ print s
   const char Base64::encoder_[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   const char Base64::decoder_[] = "|$$$}rstuvwxyz{$$$$$$$>?@ABCDEFGHIJKLMNOPQRSTUVW$$$$$$XYZ[\\]^_`abcdefghijklmnopq";
 
-  Base64::Base64()
-  {
-  }
-
-  Base64::~Base64()
-  {
-  }
-
   void Base64::encodeStrings(const std::vector<String>& in, String& out, bool zlib_compression, bool append_null_byte)
   {
     out.clear();

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -155,19 +155,14 @@ namespace OpenMS
 
   void MzMLHandlerHelper::decodeBase64Arrays(std::vector<BinaryData> & data_, bool skipXMLCheck)
   {
-    // Decoder/Encoder for Base64-data in MzML
-    Base64 decoder_;
-
     // decode all base64 arrays
-    for (Size i = 0; i < data_.size(); i++)
+    for (auto& bindata : data_)
     {
       // remove whitespaces from binary data
       // this should not be necessary, but linebreaks inside the base64 data are unfortunately no exception
-      // NOTE: this may take up to 10% of reading time with a single thread,
-      //       either omit it or make it more efficient
       if (!skipXMLCheck)
       {
-        data_[i].base64.removeWhitespaces();
+        bindata.base64.removeWhitespaces();
       }
 
       // Catch proteowizard invalid conversion where 
@@ -177,109 +172,112 @@ namespace OpenMS
       // Since numpress arrays are always 64 bit and decode to double arrays,
       // this should be safe. However, we cannot generally assume that DT_NONE
       // means that we are dealing with a 64 bit float type. 
-      if (data_[i].np_compression != MSNumpressCoder::NONE && 
-          data_[i].data_type == BinaryData::DT_NONE)
+      if (bindata.np_compression != MSNumpressCoder::NONE && 
+          bindata.data_type == BinaryData::DT_NONE)
       {
         MzMLHandlerHelper::warning(0, String("Invalid mzML format: Numpress-compressed binary data array '") + 
-            data_[i].meta.getName() + "' has no child term of MS:1000518 (binary data type) set. Assuming 64 bit float data type.");
-        data_[i].data_type = BinaryData::DT_FLOAT;
-        data_[i].precision = BinaryData::PRE_64;
+            bindata.meta.getName() + "' has no child term of MS:1000518 (binary data type) set. Assuming 64 bit float data type.");
+        bindata.data_type = BinaryData::DT_FLOAT;
+        bindata.precision = BinaryData::PRE_64;
       }
-      if (data_[i].np_compression == MSNumpressCoder::PIC && 
-          data_[i].data_type == BinaryData::DT_INT)
+      if (bindata.np_compression == MSNumpressCoder::PIC && 
+          bindata.data_type == BinaryData::DT_INT)
       {
-        data_[i].data_type = BinaryData::DT_FLOAT;
-        data_[i].precision = BinaryData::PRE_64;
+        bindata.data_type = BinaryData::DT_FLOAT;
+        bindata.precision = BinaryData::PRE_64;
       }
 
       // decode data and check if the length of the decoded data matches the expected length
-      if (data_[i].data_type == BinaryData::DT_FLOAT)
+      if (bindata.data_type == BinaryData::DT_FLOAT)
       {
-        if (data_[i].np_compression != MSNumpressCoder::NONE)
+        if (bindata.np_compression != MSNumpressCoder::NONE)
         {
           // If its numpress, we don't distinguish 32 / 64 bit as the numpress
           // decoder always works with 64 bit (takes std::vector<double>)
           MSNumpressCoder::NumpressConfig config;
-          config.np_compression = data_[i].np_compression;
-          MSNumpressCoder().decodeNP(data_[i].base64, data_[i].floats_64,  data_[i].compression, config);
+          config.np_compression = bindata.np_compression;
+          MSNumpressCoder().decodeNP(bindata.base64, bindata.floats_64,  bindata.compression, config);
 
           // Next, ensure that we only look at the float array even if the
           // mzML tags say 32 bit data (I am looking at you, proteowizard)
-          data_[i].precision = BinaryData::PRE_64;
+          bindata.precision = BinaryData::PRE_64;
         }
-        else if (data_[i].precision == BinaryData::PRE_64)
+        else if (bindata.precision == BinaryData::PRE_64)
         {
-          decoder_.decode(data_[i].base64, Base64::BYTEORDER_LITTLEENDIAN, data_[i].floats_64, data_[i].compression);
-          if (data_[i].size != data_[i].floats_64.size())
+          Base64::decode(bindata.base64, Base64::BYTEORDER_LITTLEENDIAN, bindata.floats_64, bindata.compression);
+          if (bindata.size != bindata.floats_64.size())
           {
-            MzMLHandlerHelper::warning(0, String("Float binary data array '") + data_[i].meta.getName() + 
-                "' has length " + data_[i].floats_64.size() + ", but should have length " + data_[i].size + ".");
-            data_[i].size = data_[i].floats_64.size();
+            MzMLHandlerHelper::warning(0, String("Float binary data array '") + bindata.meta.getName() + 
+                "' has length " + bindata.floats_64.size() + ", but should have length " + bindata.size + ".");
+            bindata.size = bindata.floats_64.size();
           }
         }
-        else if (data_[i].precision == BinaryData::PRE_32)
+        else if (bindata.precision == BinaryData::PRE_32)
         {
-          decoder_.decode(data_[i].base64, Base64::BYTEORDER_LITTLEENDIAN, data_[i].floats_32, data_[i].compression);
-          if (data_[i].size != data_[i].floats_32.size())
+          Base64::decode(bindata.base64, Base64::BYTEORDER_LITTLEENDIAN, bindata.floats_32, bindata.compression);
+          if (bindata.size != bindata.floats_32.size())
           {
-            MzMLHandlerHelper::warning(0, String("Float binary data array '") + data_[i].meta.getName() + 
-                "' has length " + data_[i].floats_32.size() + ", but should have length " + data_[i].size + ".");
-            data_[i].size = data_[i].floats_32.size();
-          }
-        }
-      }
-      else if (data_[i].data_type == BinaryData::DT_INT)
-      {
-        if (data_[i].precision == BinaryData::PRE_64)
-        {
-          decoder_.decodeIntegers(data_[i].base64, Base64::BYTEORDER_LITTLEENDIAN, data_[i].ints_64, data_[i].compression);
-          if (data_[i].size != data_[i].ints_64.size())
-          {
-            MzMLHandlerHelper::warning(0, String("Integer binary data array '") + data_[i].meta.getName() + 
-                "' has length " + data_[i].ints_64.size() + ", but should have length " + data_[i].size + ".");
-            data_[i].size = data_[i].ints_64.size();
-          }
-        }
-        else if (data_[i].precision == BinaryData::PRE_32)
-        {
-          decoder_.decodeIntegers(data_[i].base64, Base64::BYTEORDER_LITTLEENDIAN, data_[i].ints_32, data_[i].compression);
-          if (data_[i].size != data_[i].ints_32.size())
-          {
-            MzMLHandlerHelper::warning(0, String("Integer binary data array '") + data_[i].meta.getName() + 
-                "' has length " + data_[i].ints_32.size() + ", but should have length " + data_[i].size + ".");
-            data_[i].size = data_[i].ints_32.size();
+            MzMLHandlerHelper::warning(0, String("Float binary data array '") + bindata.meta.getName() + 
+                "' has length " + bindata.floats_32.size() + ", but should have length " + bindata.size + ".");
+            bindata.size = bindata.floats_32.size();
           }
         }
       }
-      else if (data_[i].data_type == BinaryData::DT_STRING)
+      else if (bindata.data_type == BinaryData::DT_INT)
       {
-        decoder_.decodeStrings(data_[i].base64, data_[i].decoded_char, data_[i].compression);
-        if (data_[i].size != data_[i].decoded_char.size())
+        if (bindata.precision == BinaryData::PRE_64)
         {
-          MzMLHandlerHelper::warning(0, String("String binary data array '") + data_[i].meta.getName() + 
-              "' has length " + data_[i].decoded_char.size() + ", but should have length " + data_[i].size + ".");
-          data_[i].size = data_[i].decoded_char.size();
+          Base64::decodeIntegers(bindata.base64, Base64::BYTEORDER_LITTLEENDIAN, bindata.ints_64, bindata.compression);
+          if (bindata.size != bindata.ints_64.size())
+          {
+            MzMLHandlerHelper::warning(0, String("Integer binary data array '") + bindata.meta.getName() + 
+                "' has length " + bindata.ints_64.size() + ", but should have length " + bindata.size + ".");
+            bindata.size = bindata.ints_64.size();
+          }
+        }
+        else if (bindata.precision == BinaryData::PRE_32)
+        {
+          Base64::decodeIntegers(bindata.base64, Base64::BYTEORDER_LITTLEENDIAN, bindata.ints_32, bindata.compression);
+          if (bindata.size != bindata.ints_32.size())
+          {
+            MzMLHandlerHelper::warning(0, String("Integer binary data array '") + bindata.meta.getName() + 
+                "' has length " + bindata.ints_32.size() + ", but should have length " + bindata.size + ".");
+            bindata.size = bindata.ints_32.size();
+          }
+        }
+      }
+      else if (bindata.data_type == BinaryData::DT_STRING)
+      {
+        Base64::decodeStrings(bindata.base64, bindata.decoded_char, bindata.compression);
+        if (bindata.size != bindata.decoded_char.size())
+        {
+          MzMLHandlerHelper::warning(0, String("String binary data array '") + bindata.meta.getName() + 
+              "' has length " + bindata.decoded_char.size() + ", but should have length " + bindata.size + ".");
+          bindata.size = bindata.decoded_char.size();
         }
       }
       else 
       {
         // TODO throw error?
-        MzMLHandlerHelper::warning(0, String("Invalid mzML format: Binary data array '") + data_[i].meta.getName() + 
+        MzMLHandlerHelper::warning(0, String("Invalid mzML format: Binary data array '") + bindata.meta.getName() + 
             "' has no child term of MS:1000518 (binary data type) set. Cannot automatically deduce data type.");
       }
     }
 
   }
 
-  void MzMLHandlerHelper::computeDataProperties_(std::vector<BinaryData>& data_, bool& precision_64, SignedSize& index, String index_name)
+  void MzMLHandlerHelper::computeDataProperties_(std::vector<BinaryData>& data_, bool& precision_64, SignedSize& index, const String& index_name)
   {
-    for (Size i = 0; i < data_.size(); i++)
+    SignedSize i(0);
+    for (const auto& bindata : data_)
     {
-      if (data_[i].meta.getName() == index_name)
+      if (bindata.meta.getName() == index_name)
       {
         index = i;
-        precision_64 = (data_[i].precision == BinaryData::PRE_64);
+        precision_64 = (bindata.precision == BinaryData::PRE_64);
+        return;
       }
+      ++i;
     }
   }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -269,7 +269,7 @@ namespace OpenMS
   void MzMLHandlerHelper::computeDataProperties_(std::vector<BinaryData>& data_, bool& precision_64, SignedSize& index, const String& index_name)
   {
     SignedSize i(0);
-    for (const auto& bindata : data_)
+    for (auto const&  bindata : data_)
     {
       if (bindata.meta.getName() == index_name)
       {

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -806,6 +806,10 @@ START_SECTION((String& removeWhitespaces()))
 
 	s.removeWhitespaces();
 	TEST_EQUAL(s,"");
+  
+  s = " \t \n ";
+  s.removeWhitespaces();
+  TEST_EQUAL(s, "");
 
 	s = "test";
 	s.removeWhitespaces();

--- a/src/tests/class_tests/openms/source/SysInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/SysInfo_test.cpp
@@ -66,12 +66,11 @@ START_SECTION(static bool getProcessMemoryConsumption(size_t& mem_virtual))
     TEST_EQUAL(after - first > 10000, true)
   }
 
+  TEST_EQUAL(SysInfo::getProcessMemoryConsumption(final), true);
+  std::cout << "Memory consumed after release of MSExperiment: " << final << " KB" << std::endl;
   // just for fun. There is probably no guarantee that we get the whole mem back by the memory manager
   // (and indeed, it does not work on all OS's; e.g. on Linux, the page tables will remain in RAM, unless mem pressure is high)
-  //TEST_EQUAL(SysInfo::getProcessMemoryConsumption(final), true);
-  std::cout << "Memory consumed after release of MSExperiment: " << final << " KB" << std::endl;
-
-  TEST_EQUAL(after > final, true)
+  //TEST_EQUAL(after > final, true)
 
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/SysInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/SysInfo_test.cpp
@@ -67,7 +67,8 @@ START_SECTION(static bool getProcessMemoryConsumption(size_t& mem_virtual))
   }
 
   // just for fun. There is probably no guarantee that we get the whole mem back by the memory manager
-  TEST_EQUAL(SysInfo::getProcessMemoryConsumption(final), true);
+  // (and indeed, it does not work on all OS's; e.g. on Linux, the page tables will remain in RAM, unless mem pressure is high)
+  //TEST_EQUAL(SysInfo::getProcessMemoryConsumption(final), true);
   std::cout << "Memory consumed after release of MSExperiment: " << final << " KB" << std::endl;
 
   TEST_EQUAL(after > final, true)


### PR DESCRIPTION
[FEATURE] faster whitespace removal function (2x - 6x faster than before)

On string with no whitespaces (stringlen 3000, 1e5 iterations):
old: 4.46 s (wall), 4.46 s (CPU), 0.00 s (system), 4.46 s (user)
new: 2.68 s (wall), 2.68 s (CPU), 0.00 s (system), 2.68 s (user)

On string with whitespaces: (stringlen 3000, 1e5 iterations):
old: 25.03 s (wall), 25.02 s (CPU), 0.00 s (system), 25.02 s (user)
new: 3.37 s (wall), 3.37 s (CPU), 0.00 s (system), 3.37 s (user)

[FIX] some cleaning up in XML parsing code, e.g. Base64 uses static functions only, so we can remove instanciation

In total, mzML parsing (FileInfo -in ...) is about 6% faster (~60 vs 63 MB/sec) on my machine.
There is a lot more potential IMHO, but I take what I can get :)

