### PR TITLE
[Fix] xerces platform init win

### DIFF
--- a/src/tests/class_tests/openms/source/Bzip2InputStream_test.cpp
+++ b/src/tests/class_tests/openms/source/Bzip2InputStream_test.cpp
@@ -44,7 +44,7 @@ using namespace OpenMS;
 ///////////////////////////
 
 START_TEST(Bzip2InputStream, "$Id$")
-
+xercesc::XMLPlatformUtils::Initialize();
 Bzip2InputStream* ptr = nullptr;
 Bzip2InputStream* nullPointer = nullptr;
 START_SECTION(Bzip2InputStream(const   char* const     file_name))

--- a/src/tests/class_tests/openms/source/CompressedInputSource_test.cpp
+++ b/src/tests/class_tests/openms/source/CompressedInputSource_test.cpp
@@ -47,9 +47,11 @@ using namespace OpenMS;
 
 START_TEST(CompressedInputSource, "$Id$")
 
+xercesc::XMLPlatformUtils::Initialize();
 CompressedInputSource* ptr = nullptr;
 CompressedInputSource* nullPointer = nullptr;
-START_SECTION(CompressedInputSource(const String& file_path, const char * header,xercesc::MemoryManager* const manager = xercesc::XMLPlatformUtils::fgMemoryManager))
+
+START_SECTION(CompressedInputSource(const String& file_path, const char * header, xercesc::MemoryManager* const manager = xercesc::XMLPlatformUtils::fgMemoryManager))
   char header[3];
   header[0] = 'B';
   header[1] = 'Z';

--- a/src/tests/class_tests/openms/source/GzipInputStream_test.cpp
+++ b/src/tests/class_tests/openms/source/GzipInputStream_test.cpp
@@ -45,6 +45,7 @@ using namespace OpenMS;
 
 START_TEST(GzipInputStream, "$Id$")
 
+xercesc::XMLPlatformUtils::Initialize();
 GzipInputStream* ptr = nullptr;
 GzipInputStream* nullPointer = nullptr;
 START_SECTION(GzipInputStream(const char *const file_name))

--- a/src/tests/topp/THIRDPARTY/CruxAdapter_1_out.idXML
+++ b/src/tests/topp/THIRDPARTY/CruxAdapter_1_out.idXML
@@ -3,15 +3,15 @@
 <IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<SearchParameters id="SP_0" db="" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="unknown_enzyme" missed_cleavages="0" precursor_peak_tolerance="0" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
 	</SearchParameters>
-	<IdentificationRun date="2017-12-20T12:45:43" search_engine="" search_engine_version="" search_parameters_ref="SP_0" >
+	<IdentificationRun date="2018-02-06T18:26:26" search_engine="" search_engine_version="" search_parameters_ref="SP_0" >
 		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
 			<ProteinHit id="PH_0" accession="test2_rev" score="0" sequence="DFASSGGYVLHLHR" >
 				<UserParam type="string" name="isDecoy" value="false"/>
 			</ProteinHit>
-			<ProteinHit id="PH_1" accession="decoy_test2_rev" score="0" sequence="DHSLAVGHYFGLSR" >
+			<ProteinHit id="PH_1" accession="decoy_test2_rev" score="0" sequence="DHLHLVYGGSSAFR" >
 				<UserParam type="string" name="isDecoy" value="true"/>
 			</ProteinHit>
-			<ProteinHit id="PH_2" accession="decoy_BSA3" score="0" sequence="RADFLGQPDGFASDGGGGIFALR" >
+			<ProteinHit id="PH_2" accession="decoy_BSA3" score="0" sequence="RFGAQALDFLGGFGGIDSDAGPR" >
 				<UserParam type="string" name="isDecoy" value="true"/>
 			</ProteinHit>
 			<ProteinHit id="PH_3" accession="BSA3" score="0" sequence="RPGADSDIGGFGGLFDLAQAGFR" >
@@ -22,17 +22,17 @@
 		<PeptideIdentification score_type="SEQUEST:xcorr" higher_score_better="true" significance_threshold="0" MZ="520.262817382813" spectrum_reference="1-1" >
 			<PeptideHit score="3.42734361" sequence="DFASSGGYVLHLHR" charge="3" start="0" end="14" protein_refs="PH_0" >
 				<UserParam type="float" name="MS:1001155" value="3.42734361"/>
-				<UserParam type="float" name="MS:1001156" value="0.915512025"/>
+				<UserParam type="float" name="MS:1001156" value="0.966787994"/>
 				<UserParam type="float" name="calcMZ" value="520.263610839844"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="int" name="start" value="0"/>
 				<UserParam type="int" name="end" value="14"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</PeptideHit>
-			<PeptideHit score="0.289570749" sequence="DHSLAVGHYFGLSR" charge="3" start="0" end="14" protein_refs="PH_1" >
-				<UserParam type="float" name="MS:1001155" value="0.289570749"/>
+			<PeptideHit score="0.113829076" sequence="DHLHLVYGGSSAFR" charge="3" start="0" end="14" protein_refs="PH_1" >
+				<UserParam type="float" name="MS:1001155" value="0.113829076"/>
 				<UserParam type="float" name="MS:1001156" value="0"/>
-				<UserParam type="float" name="calcMZ" value="520.263610839844"/>
+				<UserParam type="float" name="calcMZ" value="520.263549804688"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="int" name="start" value="0"/>
 				<UserParam type="int" name="end" value="14"/>
@@ -42,17 +42,17 @@
 		<PeptideIdentification score_type="SEQUEST:xcorr" higher_score_better="true" significance_threshold="0" MZ="775.387268066406" spectrum_reference="3-3" >
 			<PeptideHit score="4.30930567" sequence="RPGADSDIGGFGGLFDLAQAGFR" charge="3" start="0" end="23" protein_refs="PH_3" >
 				<UserParam type="float" name="MS:1001155" value="4.30930567"/>
-				<UserParam type="float" name="MS:1001156" value="0.978120983"/>
+				<UserParam type="float" name="MS:1001156" value="0.897529006"/>
 				<UserParam type="float" name="calcMZ" value="775.385437011719"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="int" name="start" value="0"/>
 				<UserParam type="int" name="end" value="23"/>
 				<UserParam type="string" name="target_decoy" value="target"/>
 			</PeptideHit>
-			<PeptideHit score="0.094281137" sequence="RADFLGQPDGFASDGGGGIFALR" charge="3" start="0" end="23" protein_refs="PH_2" >
-				<UserParam type="float" name="MS:1001155" value="0.094281137"/>
+			<PeptideHit score="0.441580683" sequence="RFGAQALDFLGGFGGIDSDAGPR" charge="3" start="0" end="23" protein_refs="PH_2" >
+				<UserParam type="float" name="MS:1001155" value="0.441580683"/>
 				<UserParam type="float" name="MS:1001156" value="0"/>
-				<UserParam type="float" name="calcMZ" value="775.385375976563"/>
+				<UserParam type="float" name="calcMZ" value="775.385437011719"/>
 				<UserParam type="int" name="pass_threshold" value="1"/>
 				<UserParam type="int" name="start" value="0"/>
 				<UserParam type="int" name="end" value="23"/>

--- a/src/tests/topp/THIRDPARTY/third_party_tests.cmake
+++ b/src/tests/topp/THIRDPARTY/third_party_tests.cmake
@@ -136,7 +136,7 @@ endif()
 #------------------------------------------------------------------------------
 if (NOT (${CRUX_BINARY} STREQUAL "CRUX_BINARY-NOTFOUND"))
   ### NOT needs to be added after the binarys have been included
-  add_test("TOPP_CruxAdapter_1" ${TOPP_BIN_PATH}/CruxAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/CruxAdapter_1.ini -database ${DATA_DIR_TOPP}/THIRDPARTY/proteins.fasta -in ${DATA_DIR_TOPP}/THIRDPARTY/spectra_comet.mzML -out CruxAdapter_1_out1.tmp -crux_executable "${CRUX_BINARY}" -run_percolator false)
+  add_test("TOPP_CruxAdapter_1" ${TOPP_BIN_PATH}/CruxAdapter -test -ini ${DATA_DIR_TOPP}/THIRDPARTY/CruxAdapter_1.ini -database ${DATA_DIR_TOPP}/THIRDPARTY/proteins.fasta -in ${DATA_DIR_TOPP}/THIRDPARTY/spectra_comet.mzML -out CruxAdapter_1_out1.tmp -crux_executable "${CRUX_BINARY}" -run_percolator false -extra_index_args "\\--decoy-format peptide-reverse")
   add_test("TOPP_CruxAdapter_1_out1" ${DIFF} -in1 CruxAdapter_1_out1.tmp -in2 ${DATA_DIR_TOPP}/THIRDPARTY/CruxAdapter_1_out.idXML -whitelist "IdentificationRun date" "SearchParameters id=\"SP_0\" db=" "UserParam type=\"stringList\" name=\"spectra_data\" value=")
   set_tests_properties("TOPP_CruxAdapter_1_out1" PROPERTIES DEPENDS "TOPP_CruxAdapter_1")
 endif()


### PR DESCRIPTION
Don't know why this showed up only when linking to static Xerces. Or the newer version?
But I think this here is the correct way.
One could discuss of course where to correctly put the initialization. In the class?

This here solves it on win for me.

And oops. Since I tested this on the Crux test fix PR, it includes its commits, too.