### PR TITLE
PyOpenMS packaging in Qt5

### DIFF
--- a/src/pyOpenMS/pyopenms/__init__.py
+++ b/src/pyOpenMS/pyopenms/__init__.py
@@ -8,16 +8,6 @@ import os
 here = os.path.abspath(os.path.dirname(__file__))
 os.environ["OPENMS_DATA_PATH"] = os.path.join(here, "share/OpenMS")
 
-import sys
-if sys.platform.startswith("linux"):
-    # load local shared libries before we import pyopenms.so, else
-    # those are not found. setting LD_LIBRARY_PATH does not work,
-    # see: http://stackoverflow.com/questions/1178094
-    import ctypes
-    ctypes.cdll.LoadLibrary(os.path.join(here, "libOpenSwathAlgo.so"))
-    ctypes.cdll.LoadLibrary(os.path.join(here, "libOpenMS.so"))
-    ctypes.cdll.LoadLibrary(os.path.join(here, "libSuperHirn.so"))
-
 try:
     from .all_modules import *
     from .python_extras import *

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -133,6 +133,9 @@ include_dirs.extend(LIBRARIES_EXTEND)
 libraries.extend(LIBRARIES_EXTEND)
 library_dirs.extend(LIBRARY_DIRS_EXTEND)
 
+# Ensure we do not have any empty entries
+library_dirs = [l for l in library_dirs if len(l) > 0]
+
 extra_link_args = []
 extra_compile_args = []
 

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -93,11 +93,11 @@ for OPEN_MS_CONTRIB_BUILD_DIR in OPEN_MS_CONTRIB_BUILD_DIRS.split(";"):
 #
 if iswin:
     if IS_DEBUG:
-        libraries = ["OpenMSd", "OpenSwathAlgod", "SuperHirnd", "xerces-c_3D", "QtCored4"]
+        libraries = ["OpenMSd", "OpenSwathAlgod", "SuperHirnd", "xerces-c_3D", "QtCored5"]
     else:
-        libraries = ["OpenMS", "OpenSwathAlgo", "SuperHirn", "xerces-c_3", "QtCore4"]
+        libraries = ["OpenMS", "OpenSwathAlgo", "SuperHirn", "xerces-c_3", "QtCore5"]
 elif sys.platform.startswith("linux"):
-    libraries = ["OpenMS", "OpenSwathAlgo", "SuperHirn", "xerces-c", "QtCore"]
+    libraries = ["OpenMS", "OpenSwathAlgo", "SuperHirn", "xerces-c", "Qt5Core"]
 elif sys.platform == "darwin":
     libraries = ["OpenMS", "OpenSwathAlgo", "SuperHirn"]
 else:

--- a/tools/create-manylinux.sh
+++ b/tools/create-manylinux.sh
@@ -6,7 +6,7 @@
 #
 # Execute as:
 # 
-#   sudo docker run --net=host -v `pwd`:/data manylinux_qt_contrib /bin/bash /data/create-manylinux.sh
+#   sudo docker run --net=host -v `pwd`:/data hroest/manylinux_qt59_contrib:latest /bin/bash /data/create-manylinux.sh
 #
 
 ## For a release, change to the following:
@@ -35,7 +35,8 @@ for PYBIN in /opt/python/cp27* /opt/python/cp3[4-9]*; do
   cd /openms-build-$PYVER
 
   # configure and build
-  cmake -DCMAKE_PREFIX_PATH="/contrib-build/" -DPYOPENMS=On -DPYTHON_EXECUTABLE:FILEPATH=$PYBIN/bin/python -DPY_NUM_THREADS=2 -DPY_NUM_MODULES=4 -DQT_QMAKE_EXECUTABLE=/qt/bin/qmake ../OpenMS
+  cmake -DCMAKE_PREFIX_PATH="/qt/;/contrib-build/" -DPYOPENMS=On -DPYTHON_EXECUTABLE:FILEPATH=$PYBIN/bin/python \
+    -DPY_NUM_THREADS=2 -DPY_NUM_MODULES=4 -DQT_QMAKE_EXECUTABLE=/qt/bin/qmake ../OpenMS
   make -j6 pyopenms
 
   # create final wheel ready for bundling (and make sure we find the OpenMS libs)
@@ -51,5 +52,4 @@ for PYBIN in /opt/python/cp27* /opt/python/cp3[4-9]*; do
   # retrieve data
   mv wheelhouse/* /data/wheelhouse/
 done
-
 

--- a/tools/create-manylinux.sh
+++ b/tools/create-manylinux.sh
@@ -5,7 +5,7 @@
 # based on https://github.com/pypa/python-manylinux-demo/blob/master/travis/build-wheels.sh
 #
 # Execute as:
-# 
+#
 #   sudo docker run --net=host -v `pwd`:/data hroest/manylinux_qt59_contrib:v1.2 /bin/bash /data/create-manylinux.sh
 #
 
@@ -17,7 +17,7 @@ git clone -b feature/qt5 https://github.com/hroest/OpenMS.git
 # make sure that we can find the link library
 ln -s /contrib-build/lib64/libxerces-c-3.2.a /contrib-build/lib/libxerces-c.a
 
-yum install -y zip 
+yum install -y zip
 
 # install Python deps
 for PYBIN in /opt/python/cp27* /opt/python/cp3[4-9]*; do
@@ -63,7 +63,8 @@ for PYBIN in /opt/python/cp27* /opt/python/cp3[4-9]*; do
     bn=`basename $whl .whl`
     cd wheelhouse_fixed
     mv $bn.whl $bn.zip
-    unzip $bn.zip 
+    unzip $bn.zip
+    rm -rf $bn.zip
     /bin/cp /qt/lib/libQt5Core.so pyopenms/.libs/libQt5Core-*
     rm -rf pyopenms/lib*
     # this does not always work, see https://github.com/pypa/manylinux/issues/119

--- a/tools/create-manylinux.sh
+++ b/tools/create-manylinux.sh
@@ -11,8 +11,8 @@
 
 ## For a release, change to the following:
 ## git clone -b Release2.3.0 https://github.com/OpenMS/OpenMS.git
-git clone -b feature/qt5 https://github.com/hroest/OpenMS.git
-
+git clone https://github.com/OpenMS/OpenMS.git 
+ 
 # Bugfix 1:
 # make sure that we can find the link library
 ln -s /contrib-build/lib64/libxerces-c-3.2.a /contrib-build/lib/libxerces-c.a

--- a/tools/create-manylinux.sh
+++ b/tools/create-manylinux.sh
@@ -11,9 +11,15 @@
 
 ## For a release, change to the following:
 ## git clone -b Release2.3.0 https://github.com/OpenMS/OpenMS.git
-## sed -i 's/@CF_OPENMS_PACKAGE_VERSION@/2.3.0.3/' OpenMS/src/pyOpenMS/env.py.in
+git clone -b feature/qt5 https://github.com/hroest/OpenMS.git
 
-git clone https://github.com/OpenMS/OpenMS.git
+# Bugfix 1:
+# our QT library does not support SSL
+sed -i 's/connectToHostEncrypted/connectToHost/' OpenMS/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+
+# Bugfix 2:
+# make sure that we can find the link library
+ln -s /contrib-build/lib64/libxerces-c-3.2.a /contrib-build/lib/libxerces-c.a
 
 # install Python deps
 for PYBIN in /opt/python/cp27* /opt/python/cp3[4-9]*; do

--- a/tools/create-manylinux.sh
+++ b/tools/create-manylinux.sh
@@ -6,7 +6,7 @@
 #
 # Execute as:
 # 
-#   sudo docker run --net=host -v `pwd`:/data hroest/manylinux_qt59_contrib:latest /bin/bash /data/create-manylinux.sh
+#   sudo docker run --net=host -v `pwd`:/data hroest/manylinux_qt59_contrib:v1.2 /bin/bash /data/create-manylinux.sh
 #
 
 ## For a release, change to the following:
@@ -14,10 +14,6 @@
 git clone -b feature/qt5 https://github.com/hroest/OpenMS.git
 
 # Bugfix 1:
-# our QT library does not support SSL
-sed -i 's/connectToHostEncrypted/connectToHost/' OpenMS/src/openms/source/FORMAT/MascotRemoteQuery.cpp
-
-# Bugfix 2:
 # make sure that we can find the link library
 ln -s /contrib-build/lib64/libxerces-c-3.2.a /contrib-build/lib/libxerces-c.a
 

--- a/tools/create-manylinux.sh
+++ b/tools/create-manylinux.sh
@@ -17,6 +17,8 @@ git clone -b feature/qt5 https://github.com/hroest/OpenMS.git
 # make sure that we can find the link library
 ln -s /contrib-build/lib64/libxerces-c-3.2.a /contrib-build/lib/libxerces-c.a
 
+yum install -y zip 
+
 # install Python deps
 for PYBIN in /opt/python/cp27* /opt/python/cp3[4-9]*; do
   "$PYBIN/bin/pip" install -U Cython
@@ -62,10 +64,10 @@ for PYBIN in /opt/python/cp27* /opt/python/cp3[4-9]*; do
     cd wheelhouse_fixed
     mv $bn.whl $bn.zip
     unzip $bn.zip 
-    rm -rf pyopenms/.libs/libQt5Core-82077f0c.so.5.9.4 
-    cp /qt/lib/libQt5Core.so.5.9.4 pyopenms/.libs/libQt5Core-82077f0c.so.5.9.4 
+    /bin/cp /qt/lib/libQt5Core.so pyopenms/.libs/libQt5Core-*
     rm -rf pyopenms/lib*
-    strip --strip-unneeded pyopenms/.libs/libOpenMS-efc15f4d.so
+    # this does not always work, see https://github.com/pypa/manylinux/issues/119
+    # strip --strip-unneeded pyopenms/.libs/libOpenMS-*.so
     zip -r $bn.zip pyopenms pyopenms-*.dist-info
     rm -rf pyopenms pyopenms-*.dist-info
     mv $bn.zip $bn.whl


### PR DESCRIPTION
make some changes to deploy pyOpenMS with Qt5 - so far only Linux is tested. Some observations:

- there is an incompatibility in contrib regarding xerces
- it used to be sufficient to provide `-DQT_QMAKE_EXECUTABLE=` to find Qt4, now that wont work any more with Qt5 and I also have to provide `-DCMAKE_PREFIX_PATH="/qt/"`
- somehow `patchelf` is broken when used with `auditwheel repair` to fix the Qt5Core library in this case and when we try to change the soname of our `libQt5Core` then everything breaks and Python segfaults. I tried to work around this for a long time, wasting many hours until the only solution I found was to undo what  `auditwheel repair` does and just copy back the original libQt. I am not sure what is happening here but I can very clearly see that Python packages with the original `libQt5Core` work and as soon as you run `patchelf --set-soname libQt5Core-82077f0c.so.5.9.4 pyopenms/.libs/libQt5Core-82077f0c.so.5.9.4` (which is what auditwheel essentially does) then the whole library will not work any more and will segfault. This does not happen for any other libraries and it worked for libQt4 so I dont really know why this is. So far I have been able to narrow it down to that `patchelf` call which somehow trashes the Qt5Core library.