### PR TITLE
[FIX] Quantify and calculate ion ration by intensity

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
@@ -376,7 +376,13 @@ namespace OpenMS
       double feature_2 = component_2.getMetaValue(feature_name);
       ratio = feature_1/feature_2;
       
-    } 
+    }
+    else if (feature_name == "intensity")
+    {
+      const double feature_1 = component_1.getIntensity();
+      const double feature_2 = component_2.getIntensity();
+      ratio = feature_1 / feature_2;
+    }
     else if (component_1.metaValueExists(feature_name))
     {
       LOG_INFO << "Warning: no ion pair found for transition_id " << component_1.getMetaValue("native_id") << ".";

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -142,6 +142,12 @@ namespace OpenMS
       double feature_2 = component_2.getMetaValue(feature_name);
       ratio = feature_1/feature_2;
     }
+    else if (feature_name == "intensity")
+    {
+      const double feature_1 = component_1.getIntensity();
+      const double feature_2 = component_2.getIntensity();
+      ratio = feature_1 / feature_2;
+    }
     else if (component_1.metaValueExists(feature_name))
     {
       LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -225,6 +225,17 @@ START_SECTION((double calculateRatio(const Feature & component_1, const Feature 
   component_4.setMetaValue("native_id","component4");
   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_4,feature_name),5.0);
   TEST_REAL_SIMILAR(absquant.calculateRatio(component_3,component_4,feature_name),0.0);
+  // feature_name == "intensity"
+  Feature component_5, component_6, component_7;
+  feature_name = "intensity";
+  component_5.setMetaValue("native_id", "component5");
+  component_6.setMetaValue("native_id", "component6");
+  component_5.setIntensity(3.0);
+  component_6.setIntensity(4.0);
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_6, feature_name), 0.75);
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_6, component_5, feature_name), 1.33333333333333);
+  component_7.setMetaValue("native_id", "component7");
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_7, feature_name), inf);
 END_SECTION
 
 START_SECTION((double calculateBias(const double & actual_concentration, const double & calculated_concentration)))

--- a/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
@@ -118,7 +118,17 @@ START_SECTION(double calculateIonRatio(const Feature & component_1, const Featur
   component_4.setMetaValue("native_id","component4");
   TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_1,component_4,feature_name),5.0);
   TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_3,component_4,feature_name),0.0);
-
+  // feature_name == "intensity"
+  Feature component_5, component_6, component_7;
+  feature_name = "intensity";
+  component_5.setMetaValue("native_id", "component5");
+  component_6.setMetaValue("native_id", "component6");
+  component_5.setIntensity(3.0);
+  component_6.setIntensity(4.0);
+  TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_5, component_6, feature_name), 0.75);
+  TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_6, component_5, feature_name), 1.33333333333333);
+  component_7.setMetaValue("native_id", "component7");
+  TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_5, component_7, feature_name), inf);
 }
 END_SECTION
 


### PR DESCRIPTION
_MRMFeatureFilter_ and _AbsoluteQuantitation_ methods to calculate the ratio between two components (i.e., subfeatures) is only supported for `metaValue`s. 
However, there should be an option to calculate the ratio by intensity.  The intensity (i.e., peak area) is given a dedicated attribute in the `Feature` class, and can only be accessed by `getIntensity()`.
This PR implements the functionality for intensity.