### PR TITLE
Easy indication if Absolute Quantitation found an optimal calibration or not

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitation.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitation.h
@@ -190,9 +190,11 @@ public:
       @param transformation_model_params parameters used by the transformation_model
       @param optimized_params optimized parameters
 
+      @returns true if a a fit was found, false otherwise
+
       @exception Exception::UnableToFit
     */ 
-    void optimizeCalibrationCurveIterative(
+    bool optimizeCalibrationCurveIterative(
       std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
       const String & feature_name,
       const String & transformation_model,

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -409,7 +409,6 @@ namespace OpenMS
     Param & optimized_params)
   {
 
-    bool optimal_calibration_found = false; 
     // sort from min to max concentration
     std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations_sorted = component_concentrations;
     std::sort(component_concentrations_sorted.begin(), component_concentrations_sorted.end(),

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -441,7 +441,7 @@ namespace OpenMS
       if (component_concentrations_sorted_indices.size() < min_points_)
       {
         LOG_INFO << "No optimal calibration found for " << component_concentrations_sub[0].feature.getMetaValue("native_id") << " .";
-        break;
+        return optimal_calibration_found;
       }
 
       // fit the model
@@ -477,7 +477,7 @@ namespace OpenMS
         // copy over the final optimized points before exiting
         component_concentrations = component_concentrations_sub;
         optimal_calibration_found = true;
-        break;
+        return optimal_calibration_found;
       }
 
       // R2 and biases check failed, determine potential outlier
@@ -514,7 +514,7 @@ namespace OpenMS
       }
       else
       {
-        break;
+        return optimal_calibration_found;
       }
     }
   }

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -441,7 +441,7 @@ namespace OpenMS
       if (component_concentrations_sorted_indices.size() < min_points_)
       {
         LOG_INFO << "No optimal calibration found for " << component_concentrations_sub[0].feature.getMetaValue("native_id") << " .";
-        return optimal_calibration_found;
+        return false;  //no optimal calibration found
       }
 
       // fit the model
@@ -476,8 +476,7 @@ namespace OpenMS
 
         // copy over the final optimized points before exiting
         component_concentrations = component_concentrations_sub;
-        optimal_calibration_found = true;
-        return optimal_calibration_found;
+        return true;  //optimal calibration found
       }
 
       // R2 and biases check failed, determine potential outlier
@@ -514,10 +513,10 @@ namespace OpenMS
       }
       else
       {
-        return optimal_calibration_found;
+        return false;  //no optimal calibration found
       }
     }
-    return optimal_calibration_found;
+    return false;  //no optimal calibration found
   }
 
   std::vector<AbsoluteQuantitationStandards::featureConcentration> AbsoluteQuantitation::extractComponents_(

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -621,6 +621,27 @@ namespace OpenMS
           component_aqm.getTransformationModelParams(),
           optimized_params);
 
+        // order component concentrations and update the lloq and uloq
+        std::vector<AbsoluteQuantitationStandards::featureConcentration>::const_iterator it;
+        it = std::min_element(cc[component_name].begin(), cc[component_name].end(), [](
+            const AbsoluteQuantitationStandards::featureConcentration& lhs,
+            const AbsoluteQuantitationStandards::featureConcentration& rhs
+          )
+          {
+            return lhs.actual_concentration < rhs.actual_concentration;
+          }
+        );
+        component_aqm.setLLOQ(it->actual_concentration);
+        it = std::max_element(cc[component_name].begin(), cc[component_name].end(), [](
+            const AbsoluteQuantitationStandards::featureConcentration& lhs,
+            const AbsoluteQuantitationStandards::featureConcentration& rhs
+          )
+          {
+            return lhs.actual_concentration < rhs.actual_concentration;
+          }
+        );
+        component_aqm.setULOQ(it->actual_concentration);
+
         if (optimal_calibration_found)
         {
           // calculate the R2 and bias
@@ -643,27 +664,9 @@ namespace OpenMS
         {
           component_aqm.setCorrelationCoefficient(0.0);
           component_aqm.setNPoints(0);
+          component_aqm.setLLOQ(0.0);
+          component_aqm.setULOQ(0.0);
         }
-
-        std::vector<AbsoluteQuantitationStandards::featureConcentration>::const_iterator it;
-        it = std::min_element(cc[component_name].begin(), cc[component_name].end(), [](
-            const AbsoluteQuantitationStandards::featureConcentration& lhs,
-            const AbsoluteQuantitationStandards::featureConcentration& rhs
-          )
-          {
-            return lhs.actual_concentration < rhs.actual_concentration;
-          }
-        );
-        component_aqm.setLLOQ(it->actual_concentration);
-        it = std::max_element(cc[component_name].begin(), cc[component_name].end(), [](
-            const AbsoluteQuantitationStandards::featureConcentration& lhs,
-            const AbsoluteQuantitationStandards::featureConcentration& rhs
-          )
-          {
-            return lhs.actual_concentration < rhs.actual_concentration;
-          }
-        );
-        component_aqm.setULOQ(it->actual_concentration);
       }
       else if (optimization_method_ != "iterative")
       {

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -517,6 +517,7 @@ namespace OpenMS
         return optimal_calibration_found;
       }
     }
+    return optimal_calibration_found;
   }
 
   std::vector<AbsoluteQuantitationStandards::featureConcentration> AbsoluteQuantitation::extractComponents_(

--- a/src/pyOpenMS/pxds/AbsoluteQuantitation.pxd
+++ b/src/pyOpenMS/pxds/AbsoluteQuantitation.pxd
@@ -24,7 +24,7 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitation.h>" namespa
                                 String & transformation_model, Param & transformation_model_params) nogil except +
         void quantifyComponents(FeatureMap& unknowns) nogil except +
 
-        void optimizeCalibrationCurveIterative(
+        bool optimizeCalibrationCurveIterative(
             libcpp_vector[ AQS_featureConcentration ] & component_concentrations,
             String & feature_name,
             String & transformation_model,

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -753,8 +753,8 @@ START_SECTION((void optimizeCalibrationCurves(AbsoluteQuantitationStandards::com
   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);  // previous supplied
   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);  // previous supplied
   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.0);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.01);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.0);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 0.0);
   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 0.0);
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -646,8 +646,8 @@ START_SECTION((bool optimizeCalibrationCurveIterative(
     transformation_model_params,
     optimized_params);
 
-  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 1.0);
-  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 0.0);
+  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.482400123016735);
+  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 0.305125368008987);
   TEST_EQUAL(optimal_fit_found, false);
 
 END_SECTION
@@ -750,8 +750,8 @@ START_SECTION((void optimizeCalibrationCurves(AbsoluteQuantitationStandards::com
 
   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.01);
   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 4.0);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 1.0);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 0.0);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);  // previous supplied
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);  // previous supplied
   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.0);
   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.01);
   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -547,7 +547,7 @@ START_SECTION((Param AbsoluteQuantitation::fitCalibration(
 
 END_SECTION
 
-START_SECTION((void optimizeCalibrationCurveIterative(
+START_SECTION((bool optimizeCalibrationCurveIterative(
   std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
   const String & feature_name,
   const String & transformation_model,
@@ -575,13 +575,15 @@ START_SECTION((void optimizeCalibrationCurveIterative(
   Param transformation_model_params;
   transformation_model_params.setValue("x_weight", "ln(x)");
   transformation_model_params.setValue("y_weight", "ln(y)");
+  transformation_model_params.setValue("slope", "1.0");
+  transformation_model_params.setValue("intercept", "0.0");
   transformation_model_params.setValue("x_datum_min", -1e12);
   transformation_model_params.setValue("x_datum_max", 1e12);
   transformation_model_params.setValue("y_datum_min", -1e12);
   transformation_model_params.setValue("y_datum_max", 1e12);
   Param optimized_params;
 
-  absquant.optimizeCalibrationCurveIterative(
+  bool optimal_fit_found = absquant.optimizeCalibrationCurveIterative(
     component_concentrations,
     feature_name,
     transformation_model,
@@ -592,11 +594,12 @@ START_SECTION((void optimizeCalibrationCurveIterative(
   TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 40.0);
   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.9011392589);
   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 1.870185076);
+  TEST_EQUAL(optimal_fit_found, true);
 
   // TEST 2: amp
   component_concentrations = make_amp_standards();
 
-  absquant.optimizeCalibrationCurveIterative(
+  optimal_fit_found = absquant.optimizeCalibrationCurveIterative(
     component_concentrations,
     feature_name,
     transformation_model,
@@ -607,11 +610,12 @@ START_SECTION((void optimizeCalibrationCurveIterative(
   TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 8.0);
   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.95799683);
   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), -1.047543387);
+  TEST_EQUAL(optimal_fit_found, true);
 
   // TEST 3: atp
   component_concentrations = make_atp_standards();
 
-  absquant.optimizeCalibrationCurveIterative(
+  optimal_fit_found = absquant.optimizeCalibrationCurveIterative(
     component_concentrations,
     feature_name,
     transformation_model,
@@ -622,6 +626,29 @@ START_SECTION((void optimizeCalibrationCurveIterative(
   TEST_REAL_SIMILAR(component_concentrations[3].actual_concentration, 8.0);
   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.623040824);
   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 0.36130172586);
+  TEST_EQUAL(optimal_fit_found, true);
+
+  // TEST 4: atp with too stringent of a criteria (should fail)
+  component_concentrations = make_atp_standards();
+  
+  absquant_params.setValue("min_points", 12);
+  absquant_params.setValue("max_bias", 5.0);
+  absquant_params.setValue("min_correlation_coefficient", 0.99);
+  absquant_params.setValue("max_iters", 100);
+  absquant_params.setValue("outlier_detection_method", "iter_jackknife");
+  absquant_params.setValue("use_chauvenet", "false");
+  absquant.setParameters(absquant_params);
+
+  optimal_fit_found = absquant.optimizeCalibrationCurveIterative(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params,
+    optimized_params);
+
+  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 1.0);
+  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 0.0);
+  TEST_EQUAL(optimal_fit_found, false);
 
 END_SECTION
 
@@ -723,12 +750,12 @@ START_SECTION((void optimizeCalibrationCurves(AbsoluteQuantitationStandards::com
 
   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.01);
   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 4.0);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.997143769417099);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 1.0);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 0.0);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.0);
   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.01);
   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 14);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 0.0);
 END_SECTION
 
 START_SECTION(void optimizeSingleCalibrationCurve(


### PR DESCRIPTION
### Description
It not straight forward to determine based on the output of Absolute Quantitation if an optimal calibration curve was found.

### Fix
- Added a boolean output to `OptimizeCalibrationCurvesIterative` to indicate if an optimal fit was found or not
- Set the `n_points` and `correlation_coefficient` to default values of 0 if an optimal fit was not found to clearly indicate that an optimal was not found
- Updated the transformation model params only if an optimal fit was found.  Otherwise, the user provided params (if any) are returned)