### PR TITLE
calculateRatio fails when feature_name = intensity and there is no IS

### DIFF
--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
@@ -388,7 +388,7 @@ namespace OpenMS
     // metaValue feature_name access
     else
     {
-      else if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
+      if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
       {
         const double feature_1 = component_1.getMetaValue(feature_name);
         const double feature_2 = component_2.getMetaValue(feature_name);

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
@@ -368,35 +368,42 @@ namespace OpenMS
   
   double MRMFeatureFilter::calculateIonRatio(const Feature & component_1, const Feature & component_2, const String & feature_name)
   {
-    
     double ratio = 0.0;
-    if (feature_name == "intensity" && component_1.metaValueExists("native_id") && component_2.metaValueExists("native_id"))
+    // member feature_name access
+    if (feature_name == "intensity")
     {
-      const double feature_1 = component_1.getIntensity();
-      const double feature_2 = component_2.getIntensity();
-      ratio = feature_1 / feature_2;
+      if (component_1.metaValueExists("native_id") && component_2.metaValueExists("native_id"))
+      {
+        const double feature_1 = component_1.getIntensity();
+        const double feature_2 = component_2.getIntensity();
+        ratio = feature_1 / feature_2;
+      }
+      else if (component_1.metaValueExists("native_id"))
+      {
+        LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
+        const double feature_1 = component_1.getIntensity();
+        ratio = feature_1;
+      }
     }
-    else if (feature_name == "intensity" && component_1.metaValueExists("native_id"))
-    {
-      LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
-      const double feature_1 = component_1.getIntensity();
-      ratio = feature_1;
-    }
-    else if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
-    {
-      double feature_1 = component_1.getMetaValue(feature_name);
-      double feature_2 = component_2.getMetaValue(feature_name);
-      ratio = feature_1/feature_2;
-    }
-    else if (component_1.metaValueExists(feature_name))
-    {
-      LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
-      double feature_1 = component_1.getMetaValue(feature_name);
-      ratio = feature_1;
-    }
+    // metaValue feature_name access
     else
     {
-      LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
+      else if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
+      {
+        const double feature_1 = component_1.getMetaValue(feature_name);
+        const double feature_2 = component_2.getMetaValue(feature_name);
+        ratio = feature_1/feature_2;
+      }
+      else if (component_1.metaValueExists(feature_name))
+      {
+        LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
+        const double feature_1 = component_1.getMetaValue(feature_name);
+        ratio = feature_1;
+      }
+      else
+      {
+        LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
+      }
     }
 
     return ratio;

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
@@ -370,28 +370,33 @@ namespace OpenMS
   {
     
     double ratio = 0.0;
-    if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
-    {
-      double feature_1 = component_1.getMetaValue(feature_name);
-      double feature_2 = component_2.getMetaValue(feature_name);
-      ratio = feature_1/feature_2;
-      
-    }
-    else if (feature_name == "intensity")
+    if (feature_name == "intensity" && component_1.metaValueExists("native_id") && component_2.metaValueExists("native_id"))
     {
       const double feature_1 = component_1.getIntensity();
       const double feature_2 = component_2.getIntensity();
       ratio = feature_1 / feature_2;
     }
+    else if (feature_name == "intensity" && component_1.metaValueExists("native_id"))
+    {
+      LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
+      const double feature_1 = component_1.getIntensity();
+      ratio = feature_1;
+    }
+    else if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
+    {
+      double feature_1 = component_1.getMetaValue(feature_name);
+      double feature_2 = component_2.getMetaValue(feature_name);
+      ratio = feature_1/feature_2;
+    }
     else if (component_1.metaValueExists(feature_name))
     {
-      LOG_INFO << "Warning: no ion pair found for transition_id " << component_1.getMetaValue("native_id") << ".";
+      LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
       double feature_1 = component_1.getMetaValue(feature_name);
       ratio = feature_1;
-    } 
+    }
     else
     {
-      LOG_INFO << "Feature metaValue " << feature_name << " not found for transition_ids " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
+      LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
     }
 
     return ratio;

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -155,7 +155,7 @@ namespace OpenMS
     // metaValue feature_name access
     else
     {
-      else if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
+      if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
       {
         const double feature_1 = component_1.getMetaValue(feature_name);
         const double feature_2 = component_2.getMetaValue(feature_name);

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -136,17 +136,23 @@ namespace OpenMS
   double AbsoluteQuantitation::calculateRatio(const Feature & component_1, const Feature & component_2, const String & feature_name)
   {
     double ratio = 0.0;
-    if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
-    {
-      double feature_1 = component_1.getMetaValue(feature_name);
-      double feature_2 = component_2.getMetaValue(feature_name);
-      ratio = feature_1/feature_2;
-    }
-    else if (feature_name == "intensity")
+    if (feature_name == "intensity" && component_1.metaValueExists("native_id") && component_2.metaValueExists("native_id"))
     {
       const double feature_1 = component_1.getIntensity();
       const double feature_2 = component_2.getIntensity();
       ratio = feature_1 / feature_2;
+    }
+    else if (feature_name == "intensity" && component_1.metaValueExists("native_id"))
+    {
+      LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
+      const double feature_1 = component_1.getIntensity();
+      ratio = feature_1;
+    }
+    else if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
+    {
+      double feature_1 = component_1.getMetaValue(feature_name);
+      double feature_2 = component_2.getMetaValue(feature_name);
+      ratio = feature_1/feature_2;
     }
     else if (component_1.metaValueExists(feature_name))
     {

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -136,33 +136,41 @@ namespace OpenMS
   double AbsoluteQuantitation::calculateRatio(const Feature & component_1, const Feature & component_2, const String & feature_name)
   {
     double ratio = 0.0;
-    if (feature_name == "intensity" && component_1.metaValueExists("native_id") && component_2.metaValueExists("native_id"))
+    // member feature_name access
+    if (feature_name == "intensity")
     {
-      const double feature_1 = component_1.getIntensity();
-      const double feature_2 = component_2.getIntensity();
-      ratio = feature_1 / feature_2;
+      if (component_1.metaValueExists("native_id") && component_2.metaValueExists("native_id"))
+      {
+        const double feature_1 = component_1.getIntensity();
+        const double feature_2 = component_2.getIntensity();
+        ratio = feature_1 / feature_2;
+      }
+      else if (component_1.metaValueExists("native_id"))
+      {
+        LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
+        const double feature_1 = component_1.getIntensity();
+        ratio = feature_1;
+      }
     }
-    else if (feature_name == "intensity" && component_1.metaValueExists("native_id"))
-    {
-      LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
-      const double feature_1 = component_1.getIntensity();
-      ratio = feature_1;
-    }
-    else if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
-    {
-      double feature_1 = component_1.getMetaValue(feature_name);
-      double feature_2 = component_2.getMetaValue(feature_name);
-      ratio = feature_1/feature_2;
-    }
-    else if (component_1.metaValueExists(feature_name))
-    {
-      LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
-      double feature_1 = component_1.getMetaValue(feature_name);
-      ratio = feature_1;
-    }
+    // metaValue feature_name access
     else
     {
-      LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
+      else if (component_1.metaValueExists(feature_name) && component_2.metaValueExists(feature_name))
+      {
+        const double feature_1 = component_1.getMetaValue(feature_name);
+        const double feature_2 = component_2.getMetaValue(feature_name);
+        ratio = feature_1/feature_2;
+      }
+      else if (component_1.metaValueExists(feature_name))
+      {
+        LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
+        const double feature_1 = component_1.getMetaValue(feature_name);
+        ratio = feature_1;
+      }
+      else
+      {
+        LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
+      }
     }
 
     return ratio;

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -226,7 +226,7 @@ START_SECTION((double calculateRatio(const Feature & component_1, const Feature 
   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_4,feature_name),5.0);
   TEST_REAL_SIMILAR(absquant.calculateRatio(component_3,component_4,feature_name),0.0);
   // feature_name == "intensity"
-  Feature component_5, component_6, component_7;
+  Feature component_5, component_6, component_7, component_8;
   feature_name = "intensity";
   component_5.setMetaValue("native_id", "component5");
   component_6.setMetaValue("native_id", "component6");
@@ -236,6 +236,7 @@ START_SECTION((double calculateRatio(const Feature & component_1, const Feature 
   TEST_REAL_SIMILAR(absquant.calculateRatio(component_6, component_5, feature_name), 1.33333333333333);
   component_7.setMetaValue("native_id", "component7");
   TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_7, feature_name), inf);
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_8, feature_name), 3.0);
 END_SECTION
 
 START_SECTION((double calculateBias(const double & actual_concentration, const double & calculated_concentration)))

--- a/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
@@ -119,7 +119,8 @@ START_SECTION(double calculateIonRatio(const Feature & component_1, const Featur
   TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_1,component_4,feature_name),5.0);
   TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_3,component_4,feature_name),0.0);
   // feature_name == "intensity"
-  Feature component_5, component_6, component_7;
+  // feature_name == "intensity"
+  Feature component_5, component_6, component_7, component_8;
   feature_name = "intensity";
   component_5.setMetaValue("native_id", "component5");
   component_6.setMetaValue("native_id", "component6");
@@ -129,6 +130,7 @@ START_SECTION(double calculateIonRatio(const Feature & component_1, const Featur
   TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_6, component_5, feature_name), 1.33333333333333);
   component_7.setMetaValue("native_id", "component7");
   TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_5, component_7, feature_name), inf);
+  TEST_REAL_SIMILAR(mrmff.calculateIonRatio(component_5, component_8, feature_name), 3.0);
 }
 END_SECTION
 


### PR DESCRIPTION
### Fix
- added additional conditionals to calculateRatio and calculateIonRatio methods
- added tests to test for the case of feature_name = intensity and no IS