### PR TITLE
[FEATURE] TOPPView: peaks colored by label content

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -308,6 +308,9 @@ public:
     /// Annotations of all spectra of the experiment (1D view)
     std::vector<Annotations1DContainer> annotations_1d;
 
+    /// Peak colors of the currently shown spectrum
+    std::vector<QColor> peak_colors_1d;
+
     /// Flag that indicates if the layer data can be modified (so far used for features only)
     bool modifiable;
 

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -138,6 +138,7 @@ public:
       gradient(),
       filters(),
       annotations_1d(),
+      peak_colors_1d(),
       modifiable(false),
       modified(false),
       label(L_NONE),

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -748,6 +748,32 @@ namespace OpenMS
           {
             if (layer.filters.passes(spectrum, it - spectrum.begin()))
             {
+              // TODO THIS IS WHERE PEAKS ARE DRAWN
+              // LayerData accessible in "layer"
+              // vector<PeptideIdentification> pep_ids = layer.getPeakData()[layer.getCurrentSpectrumIndex()].getPeptideIdentifications();
+
+              if (layer.peptide_hit_index == -1)
+              {
+                // cout << "TEST NO ID | " << layer.peptide_id_index << " | " << layer.peptide_hit_index << endl;
+              }
+              else
+              {
+                // cout << "TEST ID AVAILABLE | " << layer.peptide_id_index << " | " << layer.peptide_hit_index << endl;
+              }
+              // cout << "TEST " << layer.getCurrentSpectrumIndex() << endl;
+              // cout << "TEST2 " << spectrum.getIntegerDataArrays().size() << endl;
+
+              // DataArrays accessible from spectrum
+              // DataArrays::IntegerDataArray test_array = spectrum.getIntegerDataArrays()[0];
+
+              // layer.param.setValue("peak_color", "blue");
+
+              QPen pen(QColor(QString("#00ff00")), 1);
+              pen.setStyle(peak_penstyle_[i]);
+              painter->setPen(pen);
+
+
+
               dataToWidget(*it, end, layer.flipped);
               dataToWidget(it->getMZ(), 0.0f, begin, layer.flipped);
 

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -748,31 +748,15 @@ namespace OpenMS
           {
             if (layer.filters.passes(spectrum, it - spectrum.begin()))
             {
-              // TODO THIS IS WHERE PEAKS ARE DRAWN
-              // LayerData accessible in "layer"
-              // vector<PeptideIdentification> pep_ids = layer.getPeakData()[layer.getCurrentSpectrumIndex()].getPeptideIdentifications();
 
-              if (layer.peptide_hit_index == -1)
+              // use peak colors stored in the layer, if available
+              if (layer.peak_colors_1d.size() == spectrum.size())
               {
-                // cout << "TEST NO ID | " << layer.peptide_id_index << " | " << layer.peptide_hit_index << endl;
+                // find correct peak index
+                Size peak_index = std::distance(spectrum.begin(), it);
+                pen.setColor(layer.peak_colors_1d[peak_index]);
+                painter->setPen(pen);
               }
-              else
-              {
-                // cout << "TEST ID AVAILABLE | " << layer.peptide_id_index << " | " << layer.peptide_hit_index << endl;
-              }
-              // cout << "TEST " << layer.getCurrentSpectrumIndex() << endl;
-              // cout << "TEST2 " << spectrum.getIntegerDataArrays().size() << endl;
-
-              // DataArrays accessible from spectrum
-              // DataArrays::IntegerDataArray test_array = spectrum.getIntegerDataArrays()[0];
-
-              // layer.param.setValue("peak_color", "blue");
-
-              QPen pen(QColor(QString("#00ff00")), 1);
-              pen.setStyle(peak_penstyle_[i]);
-              painter->setPen(pen);
-
-
 
               dataToWidget(*it, end, layer.flipped);
               dataToWidget(it->getMZ(), 0.0f, begin, layer.flipped);

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -935,24 +935,30 @@ namespace OpenMS
                               ann_spectrum[i].getIntensity());
         const String& label = labels[i];
         QColor color;
+        QColor peak_color;
+        LayerData& annotated_layer = current_canvas->getCurrentLayer();
         // XL-MS specific coloring of the labels, green for linear fragments and red for cross-linked fragments
         if (label.hasSubstring("[alpha|") || label.hasSubstring("[beta|"))
         {
           if (label.hasSubstring("|ci$"))
           {
             color = Qt::darkGreen;
+            peak_color = Qt::green;
           }
           else if (label.hasSubstring("|xi$"))
           {
             color = Qt::darkRed;
+            peak_color = Qt::red;
           }
         }
         else // different colors for left/right fragments (e.g. b/y ions)
         {
           color = (label.at(0) < 'n') ? Qt::darkRed : Qt::darkGreen;
+          peak_color = (label.at(0) < 'n') ? Qt::red : Qt::green;
         }
 
         Annotation1DItem* item = new Annotation1DPeakItem(position, label.toQString(), color);
+        annotated_layer.peak_colors_1d.push_back(peak_color);
         item->setSelected(false);
         tv_->getActive1DWidget()->canvas()->getCurrentLayer().getCurrentAnnotations().push_front(item);
       }


### PR DESCRIPTION
Extension of #3007 by @hendrikweisser .

A new vector for peak colors has been added to LayerData.
Peaks are colored by the colors stored in there, if its length equals the length of the spectrum.
Currently it is filled by label content, in the same way the colors for the labels were determined.
In the future we can also use information in DataArrays or other sources to set colors for different kinds of data.

Screenshot (for Cross-Linking MS data):
![peak_colors](https://user-images.githubusercontent.com/15832022/36840221-83982622-1d44-11e8-85d0-c67eba9f0121.png)
