### PR TITLE
Missing IS feature causes some sort of memory fault

### DIFF
--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -207,8 +207,6 @@ namespace OpenMS
     // reset biases
     biases.clear();
 
-    std::cout<<"biases.clear();"<<std::endl;
-
     // extract out the calibration points
     std::vector<double> concentration_ratios, feature_amounts_ratios;
     TransformationModel::DataPoints data;
@@ -222,7 +220,6 @@ namespace OpenMS
         feature_name,
         transformation_model,
         transformation_model_params);
-      std::cout<<"applyCalibration"<<std::endl;
 
       double actual_concentration_ratio = component_concentrations[i].actual_concentration/
         component_concentrations[i].IS_actual_concentration;
@@ -233,19 +230,20 @@ namespace OpenMS
         component_concentrations[i].IS_feature,
         feature_name)/component_concentrations[i].dilution_factor;
       feature_amounts_ratios.push_back(feature_amount_ratio);
-      std::cout<<"calculateRatio"<<std::endl;
 
       // calculate the bias
       double bias = calculateBias(actual_concentration_ratio, calculated_concentration_ratio);
       biases.push_back(bias);
-      std::cout<<"calculateBias"<<std::endl;
 
       point.first = actual_concentration_ratio;
       point.second = feature_amount_ratio;
       data.push_back(point);
     }
     
-
+    if (data.size() == 0)
+    {
+      return; // an "InvalidRange" error will be thrown by Math::pearsonCorrelationCoefficient
+    }
     // apply weighting to the feature amounts and actual concentration ratios
     TransformationModel tm(data, transformation_model_params);
     tm.weightData(data);
@@ -255,7 +253,6 @@ namespace OpenMS
       concentration_ratios_weighted.push_back(data[i].first);
       feature_amounts_ratios_weighted.push_back(data[i].second);
     }
-    std::cout<<"weightData"<<std::endl;
 
     // calculate the R2 (R2 = Pearson_R^2)
     correlation_coefficient = Math::pearsonCorrelationCoefficient(

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -213,7 +213,7 @@ namespace OpenMS
     TransformationModel::DataPoint point;
     for (size_t i = 0; i < component_concentrations.size(); ++i)
     {
-
+      
       // calculate the actual and calculated concentration ratios
       double calculated_concentration_ratio = applyCalibration(component_concentrations[i].feature,
         component_concentrations[i].IS_feature,
@@ -401,7 +401,7 @@ namespace OpenMS
     // }
   }
 
-  bool AbsoluteQuantitation::optimizeCalibrationCurveIterative(
+  void AbsoluteQuantitation::optimizeCalibrationCurveIterative(
     std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
     const String & feature_name,
     const String & transformation_model,
@@ -409,7 +409,6 @@ namespace OpenMS
     Param & optimized_params)
   {
 
-    bool optimal_calibration_found = false; 
     // sort from min to max concentration
     std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations_sorted = component_concentrations;
     std::sort(component_concentrations_sorted.begin(), component_concentrations_sorted.end(),
@@ -441,7 +440,7 @@ namespace OpenMS
       if (component_concentrations_sorted_indices.size() < min_points_)
       {
         LOG_INFO << "No optimal calibration found for " << component_concentrations_sub[0].feature.getMetaValue("native_id") << " .";
-        return optimal_calibration_found;
+        break;
       }
 
       // fit the model
@@ -476,8 +475,7 @@ namespace OpenMS
 
         // copy over the final optimized points before exiting
         component_concentrations = component_concentrations_sub;
-        optimal_calibration_found = true;
-        return optimal_calibration_found;
+        break;
       }
 
       // R2 and biases check failed, determine potential outlier
@@ -514,10 +512,9 @@ namespace OpenMS
       }
       else
       {
-        return optimal_calibration_found;
+        break;
       }
     }
-    return optimal_calibration_found;
   }
 
   std::vector<AbsoluteQuantitationStandards::featureConcentration> AbsoluteQuantitation::extractComponents_(
@@ -615,14 +612,26 @@ namespace OpenMS
       {
         // optimize the calibraiton curve for the component
         Param optimized_params;
-        bool optimal_calibration_found = optimizeCalibrationCurveIterative(
+        optimizeCalibrationCurveIterative(
           cc[component_name],
           component_aqm.getFeatureName(),
           component_aqm.getTransformationModel(),
           component_aqm.getTransformationModelParams(),
           optimized_params);
 
-        // order component concentrations and update the lloq and uloq
+        // calculate the R2 and bias
+        std::vector<double> biases;
+        double correlation_coefficient = 0.0;
+        calculateBiasAndR(
+          cc[component_name],
+          component_aqm.getFeatureName(),
+          component_aqm.getTransformationModel(),
+          optimized_params,
+          biases,
+          correlation_coefficient);
+
+        // record the updated information
+        component_aqm.setCorrelationCoefficient(correlation_coefficient);
         std::vector<AbsoluteQuantitationStandards::featureConcentration>::const_iterator it;
         it = std::min_element(cc[component_name].begin(), cc[component_name].end(), [](
             const AbsoluteQuantitationStandards::featureConcentration& lhs,
@@ -642,32 +651,8 @@ namespace OpenMS
           }
         );
         component_aqm.setULOQ(it->actual_concentration);
-
-        if (optimal_calibration_found)
-        {
-          // calculate the R2 and bias
-          std::vector<double> biases;
-          double correlation_coefficient = 0.0;
-          calculateBiasAndR(
-            cc[component_name],
-            component_aqm.getFeatureName(),
-            component_aqm.getTransformationModel(),
-            optimized_params,
-            biases,
-            correlation_coefficient);
-
-          // record the updated information
-          component_aqm.setCorrelationCoefficient(correlation_coefficient);
-          component_aqm.setTransformationModelParams(optimized_params);
-          component_aqm.setNPoints(cc[component_name].size());
-        }
-        else 
-        {
-          component_aqm.setCorrelationCoefficient(0.0);
-          component_aqm.setNPoints(0);
-          component_aqm.setLLOQ(0.0);
-          component_aqm.setULOQ(0.0);
-        }
+        component_aqm.setTransformationModelParams(optimized_params);
+        component_aqm.setNPoints(cc[component_name].size());
       }
       else if (optimization_method_ != "iterative")
       {

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -461,12 +461,12 @@ namespace OpenMS
         correlation_coefficient);
 
       // check R2 and biases
-      bool bias_check = true;
+      bool bias_check = false;
       for (size_t bias_it = 0; bias_it < biases.size(); ++bias_it)
       {
-        if (biases[bias_it] > max_bias_)
+        if (biases[bias_it] <= max_bias_)
         {
-          bias_check = false;
+          bias_check = true;
         }
       }
       if (bias_check && correlation_coefficient > min_correlation_coefficient_)

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -461,12 +461,12 @@ namespace OpenMS
         correlation_coefficient);
 
       // check R2 and biases
-      bool bias_check = false;
+      bool bias_check = true;
       for (size_t bias_it = 0; bias_it < biases.size(); ++bias_it)
       {
-        if (biases[bias_it] <= max_bias_)
+        if (biases[bias_it] > max_bias_)
         {
-          bias_check = true;
+          bias_check = false;
         }
       }
       if (bias_check && correlation_coefficient > min_correlation_coefficient_)

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -207,6 +207,8 @@ namespace OpenMS
     // reset biases
     biases.clear();
 
+    std::cout<<"biases.clear();"<<std::endl;
+
     // extract out the calibration points
     std::vector<double> concentration_ratios, feature_amounts_ratios;
     TransformationModel::DataPoints data;
@@ -220,6 +222,7 @@ namespace OpenMS
         feature_name,
         transformation_model,
         transformation_model_params);
+      std::cout<<"applyCalibration"<<std::endl;
 
       double actual_concentration_ratio = component_concentrations[i].actual_concentration/
         component_concentrations[i].IS_actual_concentration;
@@ -230,15 +233,18 @@ namespace OpenMS
         component_concentrations[i].IS_feature,
         feature_name)/component_concentrations[i].dilution_factor;
       feature_amounts_ratios.push_back(feature_amount_ratio);
+      std::cout<<"calculateRatio"<<std::endl;
 
       // calculate the bias
       double bias = calculateBias(actual_concentration_ratio, calculated_concentration_ratio);
       biases.push_back(bias);
+      std::cout<<"calculateBias"<<std::endl;
 
       point.first = actual_concentration_ratio;
       point.second = feature_amount_ratio;
       data.push_back(point);
     }
+    
 
     // apply weighting to the feature amounts and actual concentration ratios
     TransformationModel tm(data, transformation_model_params);
@@ -249,6 +255,7 @@ namespace OpenMS
       concentration_ratios_weighted.push_back(data[i].first);
       feature_amounts_ratios_weighted.push_back(data[i].second);
     }
+    std::cout<<"weightData"<<std::endl;
 
     // calculate the R2 (R2 = Pearson_R^2)
     correlation_coefficient = Math::pearsonCorrelationCoefficient(

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -401,7 +401,7 @@ namespace OpenMS
     // }
   }
 
-  void AbsoluteQuantitation::optimizeCalibrationCurveIterative(
+  bool AbsoluteQuantitation::optimizeCalibrationCurveIterative(
     std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
     const String & feature_name,
     const String & transformation_model,
@@ -409,6 +409,7 @@ namespace OpenMS
     Param & optimized_params)
   {
 
+    bool optimal_calibration_found = false; 
     // sort from min to max concentration
     std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations_sorted = component_concentrations;
     std::sort(component_concentrations_sorted.begin(), component_concentrations_sorted.end(),
@@ -440,7 +441,7 @@ namespace OpenMS
       if (component_concentrations_sorted_indices.size() < min_points_)
       {
         LOG_INFO << "No optimal calibration found for " << component_concentrations_sub[0].feature.getMetaValue("native_id") << " .";
-        break;
+        return optimal_calibration_found;
       }
 
       // fit the model
@@ -475,7 +476,8 @@ namespace OpenMS
 
         // copy over the final optimized points before exiting
         component_concentrations = component_concentrations_sub;
-        break;
+        optimal_calibration_found = true;
+        return optimal_calibration_found;
       }
 
       // R2 and biases check failed, determine potential outlier
@@ -512,9 +514,10 @@ namespace OpenMS
       }
       else
       {
-        break;
+        return optimal_calibration_found;
       }
     }
+    return optimal_calibration_found;
   }
 
   std::vector<AbsoluteQuantitationStandards::featureConcentration> AbsoluteQuantitation::extractComponents_(
@@ -612,26 +615,14 @@ namespace OpenMS
       {
         // optimize the calibraiton curve for the component
         Param optimized_params;
-        optimizeCalibrationCurveIterative(
+        bool optimal_calibration_found = optimizeCalibrationCurveIterative(
           cc[component_name],
           component_aqm.getFeatureName(),
           component_aqm.getTransformationModel(),
           component_aqm.getTransformationModelParams(),
           optimized_params);
 
-        // calculate the R2 and bias
-        std::vector<double> biases;
-        double correlation_coefficient = 0.0;
-        calculateBiasAndR(
-          cc[component_name],
-          component_aqm.getFeatureName(),
-          component_aqm.getTransformationModel(),
-          optimized_params,
-          biases,
-          correlation_coefficient);
-
-        // record the updated information
-        component_aqm.setCorrelationCoefficient(correlation_coefficient);
+        // order component concentrations and update the lloq and uloq
         std::vector<AbsoluteQuantitationStandards::featureConcentration>::const_iterator it;
         it = std::min_element(cc[component_name].begin(), cc[component_name].end(), [](
             const AbsoluteQuantitationStandards::featureConcentration& lhs,
@@ -651,8 +642,32 @@ namespace OpenMS
           }
         );
         component_aqm.setULOQ(it->actual_concentration);
-        component_aqm.setTransformationModelParams(optimized_params);
-        component_aqm.setNPoints(cc[component_name].size());
+
+        if (optimal_calibration_found)
+        {
+          // calculate the R2 and bias
+          std::vector<double> biases;
+          double correlation_coefficient = 0.0;
+          calculateBiasAndR(
+            cc[component_name],
+            component_aqm.getFeatureName(),
+            component_aqm.getTransformationModel(),
+            optimized_params,
+            biases,
+            correlation_coefficient);
+
+          // record the updated information
+          component_aqm.setCorrelationCoefficient(correlation_coefficient);
+          component_aqm.setTransformationModelParams(optimized_params);
+          component_aqm.setNPoints(cc[component_name].size());
+        }
+        else 
+        {
+          component_aqm.setCorrelationCoefficient(0.0);
+          component_aqm.setNPoints(0);
+          component_aqm.setLLOQ(0.0);
+          component_aqm.setULOQ(0.0);
+        }
       }
       else if (optimization_method_ != "iterative")
       {

--- a/src/openms/source/METADATA/AbsoluteQuantitationStandards.cpp
+++ b/src/openms/source/METADATA/AbsoluteQuantitationStandards.cpp
@@ -84,7 +84,7 @@ namespace OpenMS
         }
         if (run.IS_component_name != "")
         {
-          if (!findComponentFeature_(fmap, run.IS_component_name, fc.IS_feature)
+          if (!findComponentFeature_(fmap, run.IS_component_name, fc.IS_feature))
           { // down stream methods will expect to find an IS
             continue;
           } 

--- a/src/openms/source/METADATA/AbsoluteQuantitationStandards.cpp
+++ b/src/openms/source/METADATA/AbsoluteQuantitationStandards.cpp
@@ -84,7 +84,10 @@ namespace OpenMS
         }
         if (run.IS_component_name != "")
         {
-          findComponentFeature_(fmap, run.IS_component_name, fc.IS_feature);
+          if (!findComponentFeature_(fmap, run.IS_component_name, fc.IS_feature)
+          { // down stream methods will expect to find an IS
+            continue;
+          } 
         }
         // fill the rest of the information from the current runConcentration
         fc.actual_concentration = run.actual_concentration;

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -416,17 +416,17 @@ START_SECTION((void (
   std::vector<double> biases = {0.0};
   double correlation_coefficient = 0.0;
 
-  // will cause an "InvalidRange" exception
-  absquant.calculateBiasAndR(
-    component_concentrations,
-    feature_name,
-    transformation_model,
-    param,
-    biases,
-    correlation_coefficient);
+  // // will cause an "InvalidRange" exception
+  // absquant.calculateBiasAndR(
+  //   component_concentrations,
+  //   feature_name,
+  //   transformation_model,
+  //   param,
+  //   biases,
+  //   correlation_coefficient);
 
-  TEST_EQUAL(biases.size(), 0);
-  TEST_REAL_SIMILAR(correlation_coefficient, 0.0);
+  // TEST_EQUAL(biases.size(), 0);
+  // TEST_REAL_SIMILAR(correlation_coefficient, 0.0);
 
   // point #1
   component.setMetaValue("native_id","component");

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -416,17 +416,17 @@ START_SECTION((void (
   std::vector<double> biases = {0.0};
   double correlation_coefficient = 0.0;
 
-  // // will cause an "InvalidRange" exception
-  // absquant.calculateBiasAndR(
-  //   component_concentrations,
-  //   feature_name,
-  //   transformation_model,
-  //   param,
-  //   biases,
-  //   correlation_coefficient);
+  // will cause an "InvalidRange" exception
+  absquant.calculateBiasAndR(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    param,
+    biases,
+    correlation_coefficient);
 
-  // TEST_EQUAL(biases.size(), 0);
-  // TEST_REAL_SIMILAR(correlation_coefficient, 0.0);
+  TEST_EQUAL(biases.size(), 0);
+  TEST_REAL_SIMILAR(correlation_coefficient, 0.0);
 
   // point #1
   component.setMetaValue("native_id","component");

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -203,189 +203,189 @@ START_SECTION((~AbsoluteQuantitation()))
   delete ptr;
 END_SECTION
 
-// START_SECTION((double calculateRatio(const Feature & component_1, const Feature & component_2, const String feature_name)))
-//   AbsoluteQuantitation absquant;
-//   String feature_name = "peak_apex_int";
-//   double inf = std::numeric_limits<double>::infinity();
-//   // dummy features
-//   OpenMS::Feature component_1, component_2;
+START_SECTION((double calculateRatio(const Feature & component_1, const Feature & component_2, const String feature_name)))
+  AbsoluteQuantitation absquant;
+  String feature_name = "peak_apex_int";
+  double inf = std::numeric_limits<double>::infinity();
+  // dummy features
+  OpenMS::Feature component_1, component_2;
 
-//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),0.0);
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),0.0);
 
-//   component_1.setMetaValue(feature_name, 5.0);
-//   component_1.setMetaValue("native_id","component1");
-//   component_2.setMetaValue(feature_name, 5.0);
-//   component_2.setMetaValue("native_id","component2");
-//   // tests
-//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),1.0);
-//   component_2.setMetaValue(feature_name, 0.0);
-//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),inf);
-//   // dummy features
-//   OpenMS::Feature component_3, component_4;
-//   component_3.setMetaValue("peak_area", 5.0);
-//   component_3.setMetaValue("native_id","component3");
-//   component_4.setMetaValue("peak_area", 5.0);
-//   component_4.setMetaValue("native_id","component4");
-//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_4,feature_name),5.0);
-//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_3,component_4,feature_name),0.0);
-//   // feature_name == "intensity"
-//   Feature component_5, component_6, component_7;
-//   feature_name = "intensity";
-//   component_5.setMetaValue("native_id", "component5");
-//   component_6.setMetaValue("native_id", "component6");
-//   component_5.setIntensity(3.0);
-//   component_6.setIntensity(4.0);
-//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_6, feature_name), 0.75);
-//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_6, component_5, feature_name), 1.33333333333333);
-//   component_7.setMetaValue("native_id", "component7");
-//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_7, feature_name), inf);
-// END_SECTION
+  component_1.setMetaValue(feature_name, 5.0);
+  component_1.setMetaValue("native_id","component1");
+  component_2.setMetaValue(feature_name, 5.0);
+  component_2.setMetaValue("native_id","component2");
+  // tests
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),1.0);
+  component_2.setMetaValue(feature_name, 0.0);
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),inf);
+  // dummy features
+  OpenMS::Feature component_3, component_4;
+  component_3.setMetaValue("peak_area", 5.0);
+  component_3.setMetaValue("native_id","component3");
+  component_4.setMetaValue("peak_area", 5.0);
+  component_4.setMetaValue("native_id","component4");
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_4,feature_name),5.0);
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_3,component_4,feature_name),0.0);
+  // feature_name == "intensity"
+  Feature component_5, component_6, component_7;
+  feature_name = "intensity";
+  component_5.setMetaValue("native_id", "component5");
+  component_6.setMetaValue("native_id", "component6");
+  component_5.setIntensity(3.0);
+  component_6.setIntensity(4.0);
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_6, feature_name), 0.75);
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_6, component_5, feature_name), 1.33333333333333);
+  component_7.setMetaValue("native_id", "component7");
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_7, feature_name), inf);
+END_SECTION
 
-// START_SECTION((double calculateBias(const double & actual_concentration, const double & calculated_concentration)))
-//   AbsoluteQuantitation absquant;
-//   double actual_concentration = 5.0;
-//   double calculated_concentration = 5.0;
-//   TEST_REAL_SIMILAR(absquant.calculateBias(actual_concentration,calculated_concentration),0.0);
-//   calculated_concentration = 4.0;
-//   TEST_REAL_SIMILAR(absquant.calculateBias(actual_concentration,calculated_concentration),20.0);
-// END_SECTION
+START_SECTION((double calculateBias(const double & actual_concentration, const double & calculated_concentration)))
+  AbsoluteQuantitation absquant;
+  double actual_concentration = 5.0;
+  double calculated_concentration = 5.0;
+  TEST_REAL_SIMILAR(absquant.calculateBias(actual_concentration,calculated_concentration),0.0);
+  calculated_concentration = 4.0;
+  TEST_REAL_SIMILAR(absquant.calculateBias(actual_concentration,calculated_concentration),20.0);
+END_SECTION
 
-// START_SECTION((double applyCalibration(const Feature & component,
-//   const Feature & IS_component,
-//   const String & feature_name,
-//   const String & transformation_model,
-//   const Param & transformation_model_params)))
+START_SECTION((double applyCalibration(const Feature & component,
+  const Feature & IS_component,
+  const String & feature_name,
+  const String & transformation_model,
+  const Param & transformation_model_params)))
 
-//   AbsoluteQuantitation absquant;
+  AbsoluteQuantitation absquant;
 
-//   // set-up the features
-//   Feature component, IS_component;
-//   component.setMetaValue("native_id","component");
-//   component.setMetaValue("peak_apex_int",2.0);
-//   IS_component.setMetaValue("native_id","IS");
-//   IS_component.setMetaValue("peak_apex_int",1.0);
-//   String feature_name = "peak_apex_int";
+  // set-up the features
+  Feature component, IS_component;
+  component.setMetaValue("native_id","component");
+  component.setMetaValue("peak_apex_int",2.0);
+  IS_component.setMetaValue("native_id","IS");
+  IS_component.setMetaValue("peak_apex_int",1.0);
+  String feature_name = "peak_apex_int";
 
-//   // set-up the model and params
-//   // y = m*x + b
-//   // x = (y - b)/m
-//   String transformation_model;
-//   Param param;
-//   // transformation_model = "TransformationModelLinear";
-//   transformation_model = "linear";
-//   param.setValue("slope",2.0);
-//   param.setValue("intercept",1.0);
+  // set-up the model and params
+  // y = m*x + b
+  // x = (y - b)/m
+  String transformation_model;
+  Param param;
+  // transformation_model = "TransformationModelLinear";
+  transformation_model = "linear";
+  param.setValue("slope",2.0);
+  param.setValue("intercept",1.0);
 
-//   TEST_REAL_SIMILAR(absquant.applyCalibration(component,
-//     IS_component,
-//     feature_name,
-//     transformation_model,
-//     param),0.5);
-// END_SECTION
+  TEST_REAL_SIMILAR(absquant.applyCalibration(component,
+    IS_component,
+    feature_name,
+    transformation_model,
+    param),0.5);
+END_SECTION
 
-// START_SECTION((void quantifyComponents(std::vector<FeatureMap>& unknowns)))
+START_SECTION((void quantifyComponents(std::vector<FeatureMap>& unknowns)))
 
-//   AbsoluteQuantitation absquant;
+  AbsoluteQuantitation absquant;
 
-//   // set-up the unknown FeatureMap
-//   FeatureMap unknown_feature_map;
-//   // set-up the features and sub-features
-//   std::vector<Feature> unknown_feature_subordinates;
-//   Feature unknown_feature, component, IS_component;
-//   String feature_name = "peak_apex_int";
-//   // component 1
-//   unknown_feature.setMetaValue("PeptideRef","component_group1");
-//   component.setMetaValue("native_id","component1");
-//   component.setMetaValue(feature_name,2.0);
-//   IS_component.setMetaValue("native_id","IS1");
-//   IS_component.setMetaValue(feature_name,2.0);
-//   unknown_feature_subordinates.push_back(IS_component);
-//   unknown_feature_subordinates.push_back(component);
-//   unknown_feature.setSubordinates(unknown_feature_subordinates);
-//   unknown_feature_map.push_back(unknown_feature);
-//   unknown_feature_subordinates.clear();
-//   // component 2
-//   unknown_feature.setMetaValue("PeptideRef","component_group2");
-//   component.setMetaValue("native_id","component2");
-//   component.setMetaValue(feature_name,4.0);
-//   IS_component.setMetaValue("native_id","IS2");
-//   IS_component.setMetaValue(feature_name,4.0);
-//   unknown_feature_subordinates.push_back(IS_component);
-//   unknown_feature_subordinates.push_back(component);
-//   unknown_feature.setSubordinates(unknown_feature_subordinates);
-//   unknown_feature_map.push_back(unknown_feature);
-//   unknown_feature_subordinates.clear();
-//   // component 3
-//   unknown_feature.setMetaValue("PeptideRef","component_group3");
-//   component.setMetaValue("native_id","component3");
-//   component.setMetaValue(feature_name,6.0);
-//   IS_component.setMetaValue("native_id","IS3");
-//   IS_component.setMetaValue(feature_name,6.0);
-//   unknown_feature_subordinates.push_back(component);  // test order change
-//   unknown_feature_subordinates.push_back(IS_component);
-//   unknown_feature.setSubordinates(unknown_feature_subordinates);
-//   unknown_feature_map.push_back(unknown_feature);
-//   unknown_feature_subordinates.clear();
-//   // // set-up the unknowns
-//   // std::vector<FeatureMap> unknowns;
-//   // unknowns.push_back(unknown_feature_map);
+  // set-up the unknown FeatureMap
+  FeatureMap unknown_feature_map;
+  // set-up the features and sub-features
+  std::vector<Feature> unknown_feature_subordinates;
+  Feature unknown_feature, component, IS_component;
+  String feature_name = "peak_apex_int";
+  // component 1
+  unknown_feature.setMetaValue("PeptideRef","component_group1");
+  component.setMetaValue("native_id","component1");
+  component.setMetaValue(feature_name,2.0);
+  IS_component.setMetaValue("native_id","IS1");
+  IS_component.setMetaValue(feature_name,2.0);
+  unknown_feature_subordinates.push_back(IS_component);
+  unknown_feature_subordinates.push_back(component);
+  unknown_feature.setSubordinates(unknown_feature_subordinates);
+  unknown_feature_map.push_back(unknown_feature);
+  unknown_feature_subordinates.clear();
+  // component 2
+  unknown_feature.setMetaValue("PeptideRef","component_group2");
+  component.setMetaValue("native_id","component2");
+  component.setMetaValue(feature_name,4.0);
+  IS_component.setMetaValue("native_id","IS2");
+  IS_component.setMetaValue(feature_name,4.0);
+  unknown_feature_subordinates.push_back(IS_component);
+  unknown_feature_subordinates.push_back(component);
+  unknown_feature.setSubordinates(unknown_feature_subordinates);
+  unknown_feature_map.push_back(unknown_feature);
+  unknown_feature_subordinates.clear();
+  // component 3
+  unknown_feature.setMetaValue("PeptideRef","component_group3");
+  component.setMetaValue("native_id","component3");
+  component.setMetaValue(feature_name,6.0);
+  IS_component.setMetaValue("native_id","IS3");
+  IS_component.setMetaValue(feature_name,6.0);
+  unknown_feature_subordinates.push_back(component);  // test order change
+  unknown_feature_subordinates.push_back(IS_component);
+  unknown_feature.setSubordinates(unknown_feature_subordinates);
+  unknown_feature_map.push_back(unknown_feature);
+  unknown_feature_subordinates.clear();
+  // // set-up the unknowns
+  // std::vector<FeatureMap> unknowns;
+  // unknowns.push_back(unknown_feature_map);
 
-//   // set-up the model and params
-//   AbsoluteQuantitationMethod aqm;
-//   String transformation_model;
-//   Param param;
-//   // transformation_model = "TransformationModelLinear";
-//   transformation_model = "linear";
-//   param.setValue("slope",1.0);
-//   param.setValue("intercept",0.0);
-//   aqm.setTransformationModel(transformation_model);
-//   aqm.setTransformationModelParams(param);
-//   // set-up the quant_method map
-//   std::vector<AbsoluteQuantitationMethod> quant_methods;
-//   // component_1
-//   aqm.setComponentName("component1");
-//   aqm.setISName("IS1");
-//   aqm.setFeatureName(feature_name);
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
-//   // component_2
-//   aqm.setComponentName("component2");
-//   aqm.setISName("IS1");
-//   aqm.setFeatureName(feature_name); // test IS outside component_group
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
-//   // component_3
-//   aqm.setComponentName("component3");
-//   aqm.setISName("IS3");
-//   aqm.setFeatureName(feature_name);
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
+  // set-up the model and params
+  AbsoluteQuantitationMethod aqm;
+  String transformation_model;
+  Param param;
+  // transformation_model = "TransformationModelLinear";
+  transformation_model = "linear";
+  param.setValue("slope",1.0);
+  param.setValue("intercept",0.0);
+  aqm.setTransformationModel(transformation_model);
+  aqm.setTransformationModelParams(param);
+  // set-up the quant_method map
+  std::vector<AbsoluteQuantitationMethod> quant_methods;
+  // component_1
+  aqm.setComponentName("component1");
+  aqm.setISName("IS1");
+  aqm.setFeatureName(feature_name);
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
+  // component_2
+  aqm.setComponentName("component2");
+  aqm.setISName("IS1");
+  aqm.setFeatureName(feature_name); // test IS outside component_group
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
+  // component_3
+  aqm.setComponentName("component3");
+  aqm.setISName("IS3");
+  aqm.setFeatureName(feature_name);
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
 
-//   absquant.setQuantMethods(quant_methods);
-//   absquant.quantifyComponents(unknown_feature_map);
+  absquant.setQuantMethods(quant_methods);
+  absquant.quantifyComponents(unknown_feature_map);
 
-//   // DEBUGGING:
-//   // for (size_t i = 0; i < unknowns.size(); ++i)
-//   // {
-//   //   for (size_t j = 0; j < unknowns[i].size(); ++j)
-//   //   {
-//   //     for (size_t k = 0; k < unknowns[i][j].getSubordinates().size(); ++k)
-//   //     {
-//   //       std::cout << "component = " << unknowns[i][j].getSubordinates()[k].getMetaValue("native_id") << std::endl;
-//   //       std::cout << "calculated_concentration = " << unknowns[i][j].getSubordinates()[k].getMetaValue("calculated_concentration") << std::endl;
-//   //     }
-//   //   }
-//   // }
+  // DEBUGGING:
+  // for (size_t i = 0; i < unknowns.size(); ++i)
+  // {
+  //   for (size_t j = 0; j < unknowns[i].size(); ++j)
+  //   {
+  //     for (size_t k = 0; k < unknowns[i][j].getSubordinates().size(); ++k)
+  //     {
+  //       std::cout << "component = " << unknowns[i][j].getSubordinates()[k].getMetaValue("native_id") << std::endl;
+  //       std::cout << "calculated_concentration = " << unknowns[i][j].getSubordinates()[k].getMetaValue("calculated_concentration") << std::endl;
+  //     }
+  //   }
+  // }
 
-//   TEST_EQUAL(unknown_feature_map[0].getSubordinates()[0].getMetaValue("calculated_concentration"),"");
-//   TEST_STRING_EQUAL(unknown_feature_map[0].getSubordinates()[0].getMetaValue("concentration_units"),"");
-//   TEST_REAL_SIMILAR(unknown_feature_map[0].getSubordinates()[1].getMetaValue("calculated_concentration"),1.0);
-//   TEST_STRING_EQUAL(unknown_feature_map[0].getSubordinates()[1].getMetaValue("concentration_units"),"uM");
-//   TEST_REAL_SIMILAR(unknown_feature_map[1].getSubordinates()[1].getMetaValue("calculated_concentration"),2.0);
-//   TEST_STRING_EQUAL(unknown_feature_map[1].getSubordinates()[1].getMetaValue("concentration_units"),"uM");
-//   TEST_REAL_SIMILAR(unknown_feature_map[2].getSubordinates()[0].getMetaValue("calculated_concentration"),1.0);
-//   TEST_STRING_EQUAL(unknown_feature_map[2].getSubordinates()[0].getMetaValue("concentration_units"),"uM");
-// END_SECTION
+  TEST_EQUAL(unknown_feature_map[0].getSubordinates()[0].getMetaValue("calculated_concentration"),"");
+  TEST_STRING_EQUAL(unknown_feature_map[0].getSubordinates()[0].getMetaValue("concentration_units"),"");
+  TEST_REAL_SIMILAR(unknown_feature_map[0].getSubordinates()[1].getMetaValue("calculated_concentration"),1.0);
+  TEST_STRING_EQUAL(unknown_feature_map[0].getSubordinates()[1].getMetaValue("concentration_units"),"uM");
+  TEST_REAL_SIMILAR(unknown_feature_map[1].getSubordinates()[1].getMetaValue("calculated_concentration"),2.0);
+  TEST_STRING_EQUAL(unknown_feature_map[1].getSubordinates()[1].getMetaValue("concentration_units"),"uM");
+  TEST_REAL_SIMILAR(unknown_feature_map[2].getSubordinates()[0].getMetaValue("calculated_concentration"),1.0);
+  TEST_STRING_EQUAL(unknown_feature_map[2].getSubordinates()[0].getMetaValue("concentration_units"),"uM");
+END_SECTION
 
 START_SECTION((void (
   const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
@@ -475,569 +475,569 @@ START_SECTION((void (
 
 END_SECTION
 
-// START_SECTION((Param AbsoluteQuantitation::fitCalibration(
-//     const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
-//     const String & feature_name,
-//     const String & transformation_model,
-//     const Param & transformation_model_params)))
-
-//   AbsoluteQuantitation absquant;
-
-//   // TEST 1:
-//   static const double arrx1[] = {-1, -2, -3, 1, 2, 3};
-//   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
-//   static const double arry1[] = {1, 1, 1, 1, 1, 1};
-//   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-//   static const double arrz1[] = {-2, -4, -6, 2, 4, 6};
-//   std::vector<double> z1 (arrz1, arrz1 + sizeof(arrz1) / sizeof(arrz1[0]) );
-
-//   // set-up the features
-//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
-//   AbsoluteQuantitationStandards::featureConcentration component_concentration;
-//   Feature component, IS_component;
-//   for (size_t i = 0; i < x1.size(); ++i)
-//   {
-//     component.setMetaValue("native_id","ser-L.ser-L_1.Light");
-//     component.setMetaValue("peak_apex_int",x1[i]);
-//     IS_component.setMetaValue("native_id","IS");
-//     IS_component.setMetaValue("peak_apex_int",y1[i]);
-//     component_concentration.feature = component;
-//     component_concentration.IS_feature = IS_component;
-//     component_concentration.actual_concentration = z1[i];
-//     component_concentration.IS_actual_concentration = 1.0;
-//     component_concentration.dilution_factor = 1.0;
-//     component_concentrations.push_back(component_concentration);
-//   }
-
-//   String feature_name = "peak_apex_int";
-//   Param transformation_model_params;
-//   transformation_model_params.setValue("x_datum_min", -1e12);
-//   transformation_model_params.setValue("x_datum_max", 1e12);
-//   transformation_model_params.setValue("y_datum_min", -1e12);
-//   transformation_model_params.setValue("y_datum_max", 1e12);
-//   // String transformation_model = "TransformationModelLinear";
-//   String transformation_model = "linear";
-
-//   Param param = absquant.fitCalibration(component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params);
-
-//   TEST_REAL_SIMILAR(param.getValue("slope"),0.5);
-//   TEST_REAL_SIMILAR(param.getValue("intercept"),0.0);
-
-//   // TEST 2:
-//   static const double arrx2[] = {0.25,0.5,1,2,3,4,5,6};
-//   std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
-//   static const double arry2[] = {1,1,1,1,1,1,1,1};
-//   std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
-//   static const double arrz2[] = {0.5,1,2,4,6,8,10,12};
-//   std::vector<double> z2 (arrz2, arrz2 + sizeof(arrz2) / sizeof(arrz2[0]) );
-
-//   // set-up the features
-//   component_concentrations.clear();
-//   for (size_t i = 0; i < x2.size(); ++i)
-//   {
-//     component.setMetaValue("native_id","ser-L.ser-L_1.Light");
-//     component.setMetaValue("peak_apex_int",x2[i]);
-//     IS_component.setMetaValue("native_id","IS");
-//     IS_component.setMetaValue("peak_apex_int",y2[i]);
-//     component_concentration.feature = component;
-//     component_concentration.IS_feature = IS_component;
-//     component_concentration.actual_concentration = z2[i];
-//     component_concentration.IS_actual_concentration = 1.0;
-//     component_concentration.dilution_factor = 1.0;
-//     component_concentrations.push_back(component_concentration);
-//   }
-
-//   transformation_model_params.setValue("x_weight", "ln(x)");
-//   transformation_model_params.setValue("y_weight", "ln(y)");
-
-//   param = absquant.fitCalibration(component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params);
-
-//   TEST_REAL_SIMILAR(param.getValue("slope"), 1.0);
-//   TEST_REAL_SIMILAR(param.getValue("intercept"), -0.69314718);
-
-// END_SECTION
-
-// START_SECTION((void optimizeCalibrationCurveIterative(
-//   std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
-//   const String & feature_name,
-//   const String & transformation_model,
-//   const Param & transformation_model_params,
-//   Param & optimized_params)))
-
-//   AbsoluteQuantitation absquant;
-
-//   // TEST 1: ser-L
-//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations = make_serL_standards();
-
-//   // set-up the class parameters
-//   Param absquant_params;
-//   absquant_params.setValue("min_points", 4);
-//   absquant_params.setValue("max_bias", 30.0);
-//   absquant_params.setValue("min_correlation_coefficient", 0.9);
-//   absquant_params.setValue("max_iters", 100);
-//   absquant_params.setValue("outlier_detection_method", "iter_jackknife");
-//   absquant_params.setValue("use_chauvenet", "false");
-//   absquant.setParameters(absquant_params);
-
-//   // set-up the function parameters
-//   const String feature_name = "peak_apex_int";
-//   const String transformation_model = "linear";
-//   Param transformation_model_params;
-//   transformation_model_params.setValue("x_weight", "ln(x)");
-//   transformation_model_params.setValue("y_weight", "ln(y)");
-//   transformation_model_params.setValue("x_datum_min", -1e12);
-//   transformation_model_params.setValue("x_datum_max", 1e12);
-//   transformation_model_params.setValue("y_datum_min", -1e12);
-//   transformation_model_params.setValue("y_datum_max", 1e12);
-//   Param optimized_params;
-
-//   absquant.optimizeCalibrationCurveIterative(
-//     component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params,
-//     optimized_params);
-
-//   TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.04);
-//   TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 40.0);
-//   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.9011392589);
-//   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 1.870185076);
-
-//   // TEST 2: amp
-//   component_concentrations = make_amp_standards();
-
-//   absquant.optimizeCalibrationCurveIterative(
-//     component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params,
-//     optimized_params);
-
-//   TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.02);
-//   TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 8.0);
-//   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.95799683);
-//   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), -1.047543387);
-
-//   // TEST 3: atp
-//   component_concentrations = make_atp_standards();
-
-//   absquant.optimizeCalibrationCurveIterative(
-//     component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params,
-//     optimized_params);
-
-//   TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.02);
-//   TEST_REAL_SIMILAR(component_concentrations[3].actual_concentration, 8.0);
-//   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.623040824);
-//   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 0.36130172586);
-
-// END_SECTION
-
-// START_SECTION((void optimizeCalibrationCurves(AbsoluteQuantitationStandards::components_to_concentrations & components_concentrations)))
-
-//   AbsoluteQuantitation absquant;
-
-//   // set-up the class parameters
-//   Param absquant_params;
-//   absquant_params.setValue("min_points", 4);
-//   absquant_params.setValue("max_bias", 30.0);
-//   absquant_params.setValue("min_correlation_coefficient", 0.9);
-//   absquant_params.setValue("max_iters", 100);
-//   absquant_params.setValue("outlier_detection_method", "iter_jackknife");
-//   absquant_params.setValue("use_chauvenet", "false");
-//   absquant.setParameters(absquant_params);
-
-//   // set up the quantitation method
-//   AbsoluteQuantitationMethod aqm;
-//   String feature_name = "peak_apex_int";
-//   String transformation_model;
-//   Param param;
-//   transformation_model = "linear";
-//   param.setValue("slope",1.0);
-//   param.setValue("intercept",0.0);
-//   param.setValue("x_weight", "ln(x)");
-//   param.setValue("y_weight", "ln(y)");
-//   param.setValue("x_datum_min", -1e12);
-//   param.setValue("x_datum_max", 1e12);
-//   param.setValue("y_datum_min", -1e12);
-//   param.setValue("y_datum_max", 1e12);
-//   aqm.setTransformationModel(transformation_model);
-//   aqm.setTransformationModelParams(param);
-//   // set-up the quant_method map
-//   std::vector<AbsoluteQuantitationMethod> quant_methods;
-//   // component_1
-//   aqm.setComponentName("ser-L.ser-L_1.Light");
-//   aqm.setISName("ser-L.ser-L_1.Heavy");
-//   aqm.setFeatureName(feature_name);
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
-//   // component_2
-//   aqm.setComponentName("amp.amp_1.Light");
-//   aqm.setISName("amp.amp_1.Heavy");
-//   aqm.setFeatureName(feature_name); // test IS outside component_group
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
-//   // component_3
-//   aqm.setComponentName("atp.atp_1.Light");
-//   aqm.setISName("atp.atp_1.Heavy");
-//   aqm.setFeatureName(feature_name);
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
-
-//   absquant.setQuantMethods(quant_methods);
-
-//   // set up the standards
-//   std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_concentrations;
-//   components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
-//   components_concentrations["amp.amp_1.Light"] = make_amp_standards();
-//   components_concentrations["atp.atp_1.Light"] = make_atp_standards();
-
-//   absquant.optimizeCalibrationCurves(components_concentrations);
-//   std::map<String, AbsoluteQuantitationMethod> quant_methods_map = absquant.getQuantMethodsAsMap();
-
-//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.04);
-//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 40.0);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.999320072);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.04);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 11);
-
-//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
-//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
-//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("slope"), 0.95799683);
-//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("intercept"), -1.047543387);
-//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getCorrelationCoefficient(), 0.99916926);
-//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getLLOQ(), 0.02);
-//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getULOQ(), 40.0);
-//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getNPoints(), 11);
-
-//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
-//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
-//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("slope"), 0.623040824);
-//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("intercept"), 0.36130172586);
-//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getCorrelationCoefficient(), 0.998208402);
-//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getLLOQ(), 0.02);
-//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getULOQ(), 40.0);
-//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getNPoints(), 6);
-
-//   components_concentrations.clear();
-//   components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
-//   absquant_params.setValue("min_points", 20); // so that an optimal calibration curve is not found, and the sorting is not saved
-//   absquant.setParameters(absquant_params);
-//   absquant.optimizeCalibrationCurves(components_concentrations);
-//   quant_methods_map = absquant.getQuantMethodsAsMap();
-
-//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.01);
-//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 4.0);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.997143769417099);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.01);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 14);
-// END_SECTION
-
-// START_SECTION(void optimizeSingleCalibrationCurve(
-//   const String& component_name,
-//   std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations
-// ))
-//   // set up the quantitation method
-//   Param param;
-//   param.setValue("slope",1.0);
-//   param.setValue("intercept",0.0);
-//   param.setValue("x_weight", "ln(x)");
-//   param.setValue("y_weight", "ln(y)");
-//   param.setValue("x_datum_min", -1e12);
-//   param.setValue("x_datum_max", 1e12);
-//   param.setValue("y_datum_min", -1e12);
-//   param.setValue("y_datum_max", 1e12);
-//   AbsoluteQuantitationMethod aqm;
-//   aqm.setTransformationModel("linear");
-//   aqm.setTransformationModelParams(param);
-//   // set-up the quant_method map
-//   std::vector<AbsoluteQuantitationMethod> quant_methods;
-//   const String feature_name = "peak_apex_int";
-//   // component_1
-//   aqm.setComponentName("ser-L.ser-L_1.Light");
-//   aqm.setISName("ser-L.ser-L_1.Heavy");
-//   aqm.setFeatureName(feature_name);
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
-//   // component_2
-//   aqm.setComponentName("amp.amp_1.Light");
-//   aqm.setISName("amp.amp_1.Heavy");
-//   aqm.setFeatureName(feature_name); // test IS outside component_group
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
-//   // component_3
-//   aqm.setComponentName("atp.atp_1.Light");
-//   aqm.setISName("atp.atp_1.Heavy");
-//   aqm.setFeatureName(feature_name);
-//   aqm.setConcentrationUnits("uM");
-//   quant_methods.push_back(aqm);
-
-//   AbsoluteQuantitation absquant;
-//   // set-up the class parameters
-//   Param absquant_params;
-//   absquant_params.setValue("min_points", 4);
-//   absquant_params.setValue("max_bias", 30.0);
-//   absquant_params.setValue("min_correlation_coefficient", 0.9);
-//   absquant_params.setValue("max_iters", 100);
-//   absquant_params.setValue("outlier_detection_method", "iter_jackknife");
-//   absquant_params.setValue("use_chauvenet", "false");
-//   absquant.setParameters(absquant_params);
-//   absquant.setQuantMethods(quant_methods);
-
-//   // set up the standards
-//   std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_concentrations;
-//   components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
-//   components_concentrations["amp.amp_1.Light"] = make_amp_standards();
-//   components_concentrations["atp.atp_1.Light"] = make_atp_standards();
-
-//   absquant.optimizeSingleCalibrationCurve("ser-L.ser-L_1.Light", components_concentrations.at("ser-L.ser-L_1.Light"));
-//   absquant.optimizeSingleCalibrationCurve("amp.amp_1.Light", components_concentrations.at("amp.amp_1.Light"));
-//   absquant.optimizeSingleCalibrationCurve("atp.atp_1.Light", components_concentrations.at("atp.atp_1.Light"));
-//   std::map<String, AbsoluteQuantitationMethod> quant_methods_map = absquant.getQuantMethodsAsMap();
-
-//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.04);
-//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 40.0);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
-//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.999320072);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.04);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
-//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 11);
-
-//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
-//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
-//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
-//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
-//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("slope"), 0.95799683);
-//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("intercept"), -1.047543387);
-//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getCorrelationCoefficient(), 0.99916926);
-//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getLLOQ(), 0.02);
-//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getULOQ(), 40.0);
-//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getNPoints(), 11);
-
-//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
-//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
-//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
-//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
-//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("slope"), 0.623040824);
-//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("intercept"), 0.36130172586);
-//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getCorrelationCoefficient(), 0.998208402);
-//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getLLOQ(), 0.02);
-//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getULOQ(), 40.0);
-//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getNPoints(), 6);
-// END_SECTION
-
-// /////////////////////////////
-// /* Protected Members **/
-// /////////////////////////////
-
-// START_SECTION((std::vector<AbsoluteQuantitationStandards::featureConcentration> extractComponents_(
-//       const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
-//       const std::vector<size_t>& component_concentrations_indices)))
-
-//   AbsoluteQuantitation_test absquant;
-//   // make the components_concentrations
-//   static const double arrx1[] = { 1.1, 2.0, 3.3, 3.9, 4.9, 6.2  };
-//   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
-//   static const double arry1[] = { 0.9, 1.9, 3.0, 3.7, 5.2, 6.1  };
-//   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-//   // set-up the features
-//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
-//   AbsoluteQuantitationStandards::featureConcentration component_concentration;
-//   Feature component, IS_component;
-//   for (size_t i = 0; i < x1.size(); ++i)
-//   {
-//     component.setMetaValue("native_id","component" + std::to_string(i));
-//     component.setMetaValue("peak_apex_int",y1[i]);
-//     IS_component.setMetaValue("native_id","IS" + std::to_string(i));
-//     IS_component.setMetaValue("peak_apex_int",1.0);
-//     component_concentration.feature = component;
-//     component_concentration.IS_feature = IS_component;
-//     component_concentration.actual_concentration = x1[i];
-//     component_concentration.IS_actual_concentration = 1.0;
-//     component_concentration.dilution_factor = 1.0;
-//     component_concentrations.push_back(component_concentration);
-//   }
-
-//   // make the indices to extract
-//   static const size_t arrx2[] = { 0, 1, 3  };
-//   std::vector<size_t> component_concentrations_indices(arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
-
-//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations_sub = absquant.extractComponents_(
-//     component_concentrations, component_concentrations_indices);
-
-//   TEST_EQUAL(component_concentrations_sub[0].feature.getMetaValue("native_id"), "component0");
-//   TEST_REAL_SIMILAR(component_concentrations_sub[0].actual_concentration, 1.1);
-
-//   TEST_EQUAL(component_concentrations_sub[1].feature.getMetaValue("native_id"), "component1");
-//   TEST_REAL_SIMILAR(component_concentrations_sub[1].actual_concentration, 2.0);
-
-//   TEST_EQUAL(component_concentrations_sub[2].feature.getMetaValue("native_id"), "component3");
-//   TEST_REAL_SIMILAR(component_concentrations_sub[2].actual_concentration, 3.9);
-
-// END_SECTION
-
-// START_SECTION((int jackknifeOutlierCandidate_(
-//       const std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations,
-//       const String & feature_name,
-//       const String & transformation_model,
-//       const Param & transformation_model_params)))
-
-//   AbsoluteQuantitation_test absquant;
-
-//   static const double arrx1[] = { 1.1, 2.0,3.3,3.9,4.9,6.2  };
-//   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
-//   static const double arry1[] = { 0.9, 1.9,3.0,3.7,5.2,6.1  };
-//   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-//   // set-up the features
-//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
-//   AbsoluteQuantitationStandards::featureConcentration component_concentration;
-//   Feature component, IS_component;
-//   for (size_t i = 0; i < x1.size(); ++i)
-//   {
-//     component.setMetaValue("native_id","component");
-//     component.setMetaValue("peak_apex_int",y1[i]);
-//     IS_component.setMetaValue("native_id","IS");
-//     IS_component.setMetaValue("peak_apex_int",1.0);
-//     component_concentration.feature = component;
-//     component_concentration.IS_feature = IS_component;
-//     component_concentration.actual_concentration = x1[i];
-//     component_concentration.IS_actual_concentration = 1.0;
-//     component_concentration.dilution_factor = 1.0;
-//     component_concentrations.push_back(component_concentration);
-//   }
-
-//   String feature_name = "peak_apex_int";
-
-//   // set-up the model and params
-//   // y = m*x + b
-//   // x = (y - b)/m
-//   Param transformation_model_params;
-//  //   String transformation_model = "TransformationModelLinear";
-//   String transformation_model = "linear";
-
-//   int c1 = absquant.jackknifeOutlierCandidate_(
-//     component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params);
-//   TEST_EQUAL(c1,4);
-
-//   static const double arrx2[] = { 1,2,3,4,5,6  };
-//   std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
-//   static const double arry2[] = { 1,2,3,4,5,6};
-//   std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
-//   component_concentrations.clear();
-//   for (size_t i = 0; i < x2.size(); ++i)
-//   {
-//     component.setMetaValue("native_id","component");
-//     component.setMetaValue("peak_apex_int",y2[i]);
-//     IS_component.setMetaValue("native_id","IS");
-//     IS_component.setMetaValue("peak_apex_int",1.0);
-//     component_concentration.feature = component;
-//     component_concentration.IS_feature = IS_component;
-//     component_concentration.actual_concentration = x2[i];
-//     component_concentration.IS_actual_concentration = 1.0;
-//     component_concentration.dilution_factor = 1.0;
-//     component_concentrations.push_back(component_concentration);
-//   }
-
-//   int c2 = absquant.jackknifeOutlierCandidate_(
-//     component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params);
-//   TEST_EQUAL(c2,0);
-
-// END_SECTION
-
-// START_SECTION((int residualOutlierCandidate_(
-//   const std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations,
-//   const String & feature_name,
-//   const String & transformation_model,
-//   const Param & transformation_model_params)))
-
-//   AbsoluteQuantitation_test absquant;
-
-//   static const double arrx1[] = { 1.1, 2.0,3.3,3.9,4.9,6.2  };
-//   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
-//   static const double arry1[] = { 0.9, 1.9,3.0,3.7,5.2,6.1  };
-//   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-//   // set-up the features
-//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
-//   AbsoluteQuantitationStandards::featureConcentration component_concentration;
-//   Feature component, IS_component;
-//   for (size_t i = 0; i < x1.size(); ++i)
-//   {
-//     component.setMetaValue("native_id","component");
-//     component.setMetaValue("peak_apex_int",y1[i]);
-//     IS_component.setMetaValue("native_id","IS");
-//     IS_component.setMetaValue("peak_apex_int",1.0);
-//     component_concentration.feature = component;
-//     component_concentration.IS_feature = IS_component;
-//     component_concentration.actual_concentration = x1[i];
-//     component_concentration.IS_actual_concentration = 1.0;
-//     component_concentration.dilution_factor = 1.0;
-//     component_concentrations.push_back(component_concentration);
-//   }
-
-//   String feature_name = "peak_apex_int";
-
-//   // set-up the model and params
-//   // y = m*x + b
-//   // x = (y - b)/m
-//   Param transformation_model_params;
-//   // String transformation_model = "TransformationModelLinear";
-//   String transformation_model = "linear";
-
-//   int c1 = absquant.residualOutlierCandidate_(
-//     component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params);
-//   TEST_EQUAL(c1,4);
-
-//   static const double arrx2[] = { 1,2,3,4,5,6  };
-//   std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
-//   static const double arry2[] = { 1,2,3,4,5,6};
-//   std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
-//   component_concentrations.clear();
-//   for (size_t i = 0; i < x2.size(); ++i)
-//   {
-//     component.setMetaValue("native_id","component");
-//     component.setMetaValue("peak_apex_int",y2[i]);
-//     IS_component.setMetaValue("native_id","IS");
-//     IS_component.setMetaValue("peak_apex_int",1.0);
-//     component_concentration.feature = component;
-//     component_concentration.IS_feature = IS_component;
-//     component_concentration.actual_concentration = x2[i];
-//     component_concentration.IS_actual_concentration = 1.0;
-//     component_concentration.dilution_factor = 1.0;
-//     component_concentrations.push_back(component_concentration);
-//   }
-
-//   int c2 = absquant.residualOutlierCandidate_(
-//     component_concentrations,
-//     feature_name,
-//     transformation_model,
-//     transformation_model_params);
-//   TEST_EQUAL(c2,0);
-
-// END_SECTION
+START_SECTION((Param AbsoluteQuantitation::fitCalibration(
+    const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
+    const String & feature_name,
+    const String & transformation_model,
+    const Param & transformation_model_params)))
+
+  AbsoluteQuantitation absquant;
+
+  // TEST 1:
+  static const double arrx1[] = {-1, -2, -3, 1, 2, 3};
+  std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
+  static const double arry1[] = {1, 1, 1, 1, 1, 1};
+  std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
+  static const double arrz1[] = {-2, -4, -6, 2, 4, 6};
+  std::vector<double> z1 (arrz1, arrz1 + sizeof(arrz1) / sizeof(arrz1[0]) );
+
+  // set-up the features
+  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
+  AbsoluteQuantitationStandards::featureConcentration component_concentration;
+  Feature component, IS_component;
+  for (size_t i = 0; i < x1.size(); ++i)
+  {
+    component.setMetaValue("native_id","ser-L.ser-L_1.Light");
+    component.setMetaValue("peak_apex_int",x1[i]);
+    IS_component.setMetaValue("native_id","IS");
+    IS_component.setMetaValue("peak_apex_int",y1[i]);
+    component_concentration.feature = component;
+    component_concentration.IS_feature = IS_component;
+    component_concentration.actual_concentration = z1[i];
+    component_concentration.IS_actual_concentration = 1.0;
+    component_concentration.dilution_factor = 1.0;
+    component_concentrations.push_back(component_concentration);
+  }
+
+  String feature_name = "peak_apex_int";
+  Param transformation_model_params;
+  transformation_model_params.setValue("x_datum_min", -1e12);
+  transformation_model_params.setValue("x_datum_max", 1e12);
+  transformation_model_params.setValue("y_datum_min", -1e12);
+  transformation_model_params.setValue("y_datum_max", 1e12);
+  // String transformation_model = "TransformationModelLinear";
+  String transformation_model = "linear";
+
+  Param param = absquant.fitCalibration(component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params);
+
+  TEST_REAL_SIMILAR(param.getValue("slope"),0.5);
+  TEST_REAL_SIMILAR(param.getValue("intercept"),0.0);
+
+  // TEST 2:
+  static const double arrx2[] = {0.25,0.5,1,2,3,4,5,6};
+  std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
+  static const double arry2[] = {1,1,1,1,1,1,1,1};
+  std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
+  static const double arrz2[] = {0.5,1,2,4,6,8,10,12};
+  std::vector<double> z2 (arrz2, arrz2 + sizeof(arrz2) / sizeof(arrz2[0]) );
+
+  // set-up the features
+  component_concentrations.clear();
+  for (size_t i = 0; i < x2.size(); ++i)
+  {
+    component.setMetaValue("native_id","ser-L.ser-L_1.Light");
+    component.setMetaValue("peak_apex_int",x2[i]);
+    IS_component.setMetaValue("native_id","IS");
+    IS_component.setMetaValue("peak_apex_int",y2[i]);
+    component_concentration.feature = component;
+    component_concentration.IS_feature = IS_component;
+    component_concentration.actual_concentration = z2[i];
+    component_concentration.IS_actual_concentration = 1.0;
+    component_concentration.dilution_factor = 1.0;
+    component_concentrations.push_back(component_concentration);
+  }
+
+  transformation_model_params.setValue("x_weight", "ln(x)");
+  transformation_model_params.setValue("y_weight", "ln(y)");
+
+  param = absquant.fitCalibration(component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params);
+
+  TEST_REAL_SIMILAR(param.getValue("slope"), 1.0);
+  TEST_REAL_SIMILAR(param.getValue("intercept"), -0.69314718);
+
+END_SECTION
+
+START_SECTION((void optimizeCalibrationCurveIterative(
+  std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
+  const String & feature_name,
+  const String & transformation_model,
+  const Param & transformation_model_params,
+  Param & optimized_params)))
+
+  AbsoluteQuantitation absquant;
+
+  // TEST 1: ser-L
+  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations = make_serL_standards();
+
+  // set-up the class parameters
+  Param absquant_params;
+  absquant_params.setValue("min_points", 4);
+  absquant_params.setValue("max_bias", 30.0);
+  absquant_params.setValue("min_correlation_coefficient", 0.9);
+  absquant_params.setValue("max_iters", 100);
+  absquant_params.setValue("outlier_detection_method", "iter_jackknife");
+  absquant_params.setValue("use_chauvenet", "false");
+  absquant.setParameters(absquant_params);
+
+  // set-up the function parameters
+  const String feature_name = "peak_apex_int";
+  const String transformation_model = "linear";
+  Param transformation_model_params;
+  transformation_model_params.setValue("x_weight", "ln(x)");
+  transformation_model_params.setValue("y_weight", "ln(y)");
+  transformation_model_params.setValue("x_datum_min", -1e12);
+  transformation_model_params.setValue("x_datum_max", 1e12);
+  transformation_model_params.setValue("y_datum_min", -1e12);
+  transformation_model_params.setValue("y_datum_max", 1e12);
+  Param optimized_params;
+
+  absquant.optimizeCalibrationCurveIterative(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params,
+    optimized_params);
+
+  TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.04);
+  TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 40.0);
+  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.9011392589);
+  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 1.870185076);
+
+  // TEST 2: amp
+  component_concentrations = make_amp_standards();
+
+  absquant.optimizeCalibrationCurveIterative(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params,
+    optimized_params);
+
+  TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.02);
+  TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 8.0);
+  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.95799683);
+  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), -1.047543387);
+
+  // TEST 3: atp
+  component_concentrations = make_atp_standards();
+
+  absquant.optimizeCalibrationCurveIterative(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params,
+    optimized_params);
+
+  TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.02);
+  TEST_REAL_SIMILAR(component_concentrations[3].actual_concentration, 8.0);
+  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.623040824);
+  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 0.36130172586);
+
+END_SECTION
+
+START_SECTION((void optimizeCalibrationCurves(AbsoluteQuantitationStandards::components_to_concentrations & components_concentrations)))
+
+  AbsoluteQuantitation absquant;
+
+  // set-up the class parameters
+  Param absquant_params;
+  absquant_params.setValue("min_points", 4);
+  absquant_params.setValue("max_bias", 30.0);
+  absquant_params.setValue("min_correlation_coefficient", 0.9);
+  absquant_params.setValue("max_iters", 100);
+  absquant_params.setValue("outlier_detection_method", "iter_jackknife");
+  absquant_params.setValue("use_chauvenet", "false");
+  absquant.setParameters(absquant_params);
+
+  // set up the quantitation method
+  AbsoluteQuantitationMethod aqm;
+  String feature_name = "peak_apex_int";
+  String transformation_model;
+  Param param;
+  transformation_model = "linear";
+  param.setValue("slope",1.0);
+  param.setValue("intercept",0.0);
+  param.setValue("x_weight", "ln(x)");
+  param.setValue("y_weight", "ln(y)");
+  param.setValue("x_datum_min", -1e12);
+  param.setValue("x_datum_max", 1e12);
+  param.setValue("y_datum_min", -1e12);
+  param.setValue("y_datum_max", 1e12);
+  aqm.setTransformationModel(transformation_model);
+  aqm.setTransformationModelParams(param);
+  // set-up the quant_method map
+  std::vector<AbsoluteQuantitationMethod> quant_methods;
+  // component_1
+  aqm.setComponentName("ser-L.ser-L_1.Light");
+  aqm.setISName("ser-L.ser-L_1.Heavy");
+  aqm.setFeatureName(feature_name);
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
+  // component_2
+  aqm.setComponentName("amp.amp_1.Light");
+  aqm.setISName("amp.amp_1.Heavy");
+  aqm.setFeatureName(feature_name); // test IS outside component_group
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
+  // component_3
+  aqm.setComponentName("atp.atp_1.Light");
+  aqm.setISName("atp.atp_1.Heavy");
+  aqm.setFeatureName(feature_name);
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
+
+  absquant.setQuantMethods(quant_methods);
+
+  // set up the standards
+  std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_concentrations;
+  components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
+  components_concentrations["amp.amp_1.Light"] = make_amp_standards();
+  components_concentrations["atp.atp_1.Light"] = make_atp_standards();
+
+  absquant.optimizeCalibrationCurves(components_concentrations);
+  std::map<String, AbsoluteQuantitationMethod> quant_methods_map = absquant.getQuantMethodsAsMap();
+
+  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.04);
+  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 40.0);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.999320072);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.04);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 11);
+
+  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
+  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
+  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("slope"), 0.95799683);
+  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("intercept"), -1.047543387);
+  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getCorrelationCoefficient(), 0.99916926);
+  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getLLOQ(), 0.02);
+  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getULOQ(), 40.0);
+  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getNPoints(), 11);
+
+  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
+  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
+  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("slope"), 0.623040824);
+  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("intercept"), 0.36130172586);
+  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getCorrelationCoefficient(), 0.998208402);
+  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getLLOQ(), 0.02);
+  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getULOQ(), 40.0);
+  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getNPoints(), 6);
+
+  components_concentrations.clear();
+  components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
+  absquant_params.setValue("min_points", 20); // so that an optimal calibration curve is not found, and the sorting is not saved
+  absquant.setParameters(absquant_params);
+  absquant.optimizeCalibrationCurves(components_concentrations);
+  quant_methods_map = absquant.getQuantMethodsAsMap();
+
+  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.01);
+  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 4.0);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.997143769417099);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.01);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 14);
+END_SECTION
+
+START_SECTION(void optimizeSingleCalibrationCurve(
+  const String& component_name,
+  std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations
+))
+  // set up the quantitation method
+  Param param;
+  param.setValue("slope",1.0);
+  param.setValue("intercept",0.0);
+  param.setValue("x_weight", "ln(x)");
+  param.setValue("y_weight", "ln(y)");
+  param.setValue("x_datum_min", -1e12);
+  param.setValue("x_datum_max", 1e12);
+  param.setValue("y_datum_min", -1e12);
+  param.setValue("y_datum_max", 1e12);
+  AbsoluteQuantitationMethod aqm;
+  aqm.setTransformationModel("linear");
+  aqm.setTransformationModelParams(param);
+  // set-up the quant_method map
+  std::vector<AbsoluteQuantitationMethod> quant_methods;
+  const String feature_name = "peak_apex_int";
+  // component_1
+  aqm.setComponentName("ser-L.ser-L_1.Light");
+  aqm.setISName("ser-L.ser-L_1.Heavy");
+  aqm.setFeatureName(feature_name);
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
+  // component_2
+  aqm.setComponentName("amp.amp_1.Light");
+  aqm.setISName("amp.amp_1.Heavy");
+  aqm.setFeatureName(feature_name); // test IS outside component_group
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
+  // component_3
+  aqm.setComponentName("atp.atp_1.Light");
+  aqm.setISName("atp.atp_1.Heavy");
+  aqm.setFeatureName(feature_name);
+  aqm.setConcentrationUnits("uM");
+  quant_methods.push_back(aqm);
+
+  AbsoluteQuantitation absquant;
+  // set-up the class parameters
+  Param absquant_params;
+  absquant_params.setValue("min_points", 4);
+  absquant_params.setValue("max_bias", 30.0);
+  absquant_params.setValue("min_correlation_coefficient", 0.9);
+  absquant_params.setValue("max_iters", 100);
+  absquant_params.setValue("outlier_detection_method", "iter_jackknife");
+  absquant_params.setValue("use_chauvenet", "false");
+  absquant.setParameters(absquant_params);
+  absquant.setQuantMethods(quant_methods);
+
+  // set up the standards
+  std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_concentrations;
+  components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
+  components_concentrations["amp.amp_1.Light"] = make_amp_standards();
+  components_concentrations["atp.atp_1.Light"] = make_atp_standards();
+
+  absquant.optimizeSingleCalibrationCurve("ser-L.ser-L_1.Light", components_concentrations.at("ser-L.ser-L_1.Light"));
+  absquant.optimizeSingleCalibrationCurve("amp.amp_1.Light", components_concentrations.at("amp.amp_1.Light"));
+  absquant.optimizeSingleCalibrationCurve("atp.atp_1.Light", components_concentrations.at("atp.atp_1.Light"));
+  std::map<String, AbsoluteQuantitationMethod> quant_methods_map = absquant.getQuantMethodsAsMap();
+
+  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.04);
+  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 40.0);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
+  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.999320072);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.04);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
+  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 11);
+
+  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
+  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
+  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
+  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
+  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("slope"), 0.95799683);
+  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("intercept"), -1.047543387);
+  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getCorrelationCoefficient(), 0.99916926);
+  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getLLOQ(), 0.02);
+  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getULOQ(), 40.0);
+  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getNPoints(), 11);
+
+  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
+  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
+  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
+  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
+  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("slope"), 0.623040824);
+  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("intercept"), 0.36130172586);
+  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getCorrelationCoefficient(), 0.998208402);
+  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getLLOQ(), 0.02);
+  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getULOQ(), 40.0);
+  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getNPoints(), 6);
+END_SECTION
+
+/////////////////////////////
+/* Protected Members **/
+/////////////////////////////
+
+START_SECTION((std::vector<AbsoluteQuantitationStandards::featureConcentration> extractComponents_(
+      const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
+      const std::vector<size_t>& component_concentrations_indices)))
+
+  AbsoluteQuantitation_test absquant;
+  // make the components_concentrations
+  static const double arrx1[] = { 1.1, 2.0, 3.3, 3.9, 4.9, 6.2  };
+  std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
+  static const double arry1[] = { 0.9, 1.9, 3.0, 3.7, 5.2, 6.1  };
+  std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
+  // set-up the features
+  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
+  AbsoluteQuantitationStandards::featureConcentration component_concentration;
+  Feature component, IS_component;
+  for (size_t i = 0; i < x1.size(); ++i)
+  {
+    component.setMetaValue("native_id","component" + std::to_string(i));
+    component.setMetaValue("peak_apex_int",y1[i]);
+    IS_component.setMetaValue("native_id","IS" + std::to_string(i));
+    IS_component.setMetaValue("peak_apex_int",1.0);
+    component_concentration.feature = component;
+    component_concentration.IS_feature = IS_component;
+    component_concentration.actual_concentration = x1[i];
+    component_concentration.IS_actual_concentration = 1.0;
+    component_concentration.dilution_factor = 1.0;
+    component_concentrations.push_back(component_concentration);
+  }
+
+  // make the indices to extract
+  static const size_t arrx2[] = { 0, 1, 3  };
+  std::vector<size_t> component_concentrations_indices(arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
+
+  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations_sub = absquant.extractComponents_(
+    component_concentrations, component_concentrations_indices);
+
+  TEST_EQUAL(component_concentrations_sub[0].feature.getMetaValue("native_id"), "component0");
+  TEST_REAL_SIMILAR(component_concentrations_sub[0].actual_concentration, 1.1);
+
+  TEST_EQUAL(component_concentrations_sub[1].feature.getMetaValue("native_id"), "component1");
+  TEST_REAL_SIMILAR(component_concentrations_sub[1].actual_concentration, 2.0);
+
+  TEST_EQUAL(component_concentrations_sub[2].feature.getMetaValue("native_id"), "component3");
+  TEST_REAL_SIMILAR(component_concentrations_sub[2].actual_concentration, 3.9);
+
+END_SECTION
+
+START_SECTION((int jackknifeOutlierCandidate_(
+      const std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations,
+      const String & feature_name,
+      const String & transformation_model,
+      const Param & transformation_model_params)))
+
+  AbsoluteQuantitation_test absquant;
+
+  static const double arrx1[] = { 1.1, 2.0,3.3,3.9,4.9,6.2  };
+  std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
+  static const double arry1[] = { 0.9, 1.9,3.0,3.7,5.2,6.1  };
+  std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
+  // set-up the features
+  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
+  AbsoluteQuantitationStandards::featureConcentration component_concentration;
+  Feature component, IS_component;
+  for (size_t i = 0; i < x1.size(); ++i)
+  {
+    component.setMetaValue("native_id","component");
+    component.setMetaValue("peak_apex_int",y1[i]);
+    IS_component.setMetaValue("native_id","IS");
+    IS_component.setMetaValue("peak_apex_int",1.0);
+    component_concentration.feature = component;
+    component_concentration.IS_feature = IS_component;
+    component_concentration.actual_concentration = x1[i];
+    component_concentration.IS_actual_concentration = 1.0;
+    component_concentration.dilution_factor = 1.0;
+    component_concentrations.push_back(component_concentration);
+  }
+
+  String feature_name = "peak_apex_int";
+
+  // set-up the model and params
+  // y = m*x + b
+  // x = (y - b)/m
+  Param transformation_model_params;
+ //   String transformation_model = "TransformationModelLinear";
+  String transformation_model = "linear";
+
+  int c1 = absquant.jackknifeOutlierCandidate_(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params);
+  TEST_EQUAL(c1,4);
+
+  static const double arrx2[] = { 1,2,3,4,5,6  };
+  std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
+  static const double arry2[] = { 1,2,3,4,5,6};
+  std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
+  component_concentrations.clear();
+  for (size_t i = 0; i < x2.size(); ++i)
+  {
+    component.setMetaValue("native_id","component");
+    component.setMetaValue("peak_apex_int",y2[i]);
+    IS_component.setMetaValue("native_id","IS");
+    IS_component.setMetaValue("peak_apex_int",1.0);
+    component_concentration.feature = component;
+    component_concentration.IS_feature = IS_component;
+    component_concentration.actual_concentration = x2[i];
+    component_concentration.IS_actual_concentration = 1.0;
+    component_concentration.dilution_factor = 1.0;
+    component_concentrations.push_back(component_concentration);
+  }
+
+  int c2 = absquant.jackknifeOutlierCandidate_(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params);
+  TEST_EQUAL(c2,0);
+
+END_SECTION
+
+START_SECTION((int residualOutlierCandidate_(
+  const std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations,
+  const String & feature_name,
+  const String & transformation_model,
+  const Param & transformation_model_params)))
+
+  AbsoluteQuantitation_test absquant;
+
+  static const double arrx1[] = { 1.1, 2.0,3.3,3.9,4.9,6.2  };
+  std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
+  static const double arry1[] = { 0.9, 1.9,3.0,3.7,5.2,6.1  };
+  std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
+  // set-up the features
+  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
+  AbsoluteQuantitationStandards::featureConcentration component_concentration;
+  Feature component, IS_component;
+  for (size_t i = 0; i < x1.size(); ++i)
+  {
+    component.setMetaValue("native_id","component");
+    component.setMetaValue("peak_apex_int",y1[i]);
+    IS_component.setMetaValue("native_id","IS");
+    IS_component.setMetaValue("peak_apex_int",1.0);
+    component_concentration.feature = component;
+    component_concentration.IS_feature = IS_component;
+    component_concentration.actual_concentration = x1[i];
+    component_concentration.IS_actual_concentration = 1.0;
+    component_concentration.dilution_factor = 1.0;
+    component_concentrations.push_back(component_concentration);
+  }
+
+  String feature_name = "peak_apex_int";
+
+  // set-up the model and params
+  // y = m*x + b
+  // x = (y - b)/m
+  Param transformation_model_params;
+  // String transformation_model = "TransformationModelLinear";
+  String transformation_model = "linear";
+
+  int c1 = absquant.residualOutlierCandidate_(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params);
+  TEST_EQUAL(c1,4);
+
+  static const double arrx2[] = { 1,2,3,4,5,6  };
+  std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
+  static const double arry2[] = { 1,2,3,4,5,6};
+  std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
+  component_concentrations.clear();
+  for (size_t i = 0; i < x2.size(); ++i)
+  {
+    component.setMetaValue("native_id","component");
+    component.setMetaValue("peak_apex_int",y2[i]);
+    IS_component.setMetaValue("native_id","IS");
+    IS_component.setMetaValue("peak_apex_int",1.0);
+    component_concentration.feature = component;
+    component_concentration.IS_feature = IS_component;
+    component_concentration.actual_concentration = x2[i];
+    component_concentration.IS_actual_concentration = 1.0;
+    component_concentration.dilution_factor = 1.0;
+    component_concentrations.push_back(component_concentration);
+  }
+
+  int c2 = absquant.residualOutlierCandidate_(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    transformation_model_params);
+  TEST_EQUAL(c2,0);
+
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -416,6 +416,7 @@ START_SECTION((void (
   std::vector<double> biases = {0.0};
   double correlation_coefficient = 0.0;
 
+  // will cause an "InvalidRange" exception
   absquant.calculateBiasAndR(
     component_concentrations,
     feature_name,
@@ -424,7 +425,7 @@ START_SECTION((void (
     biases,
     correlation_coefficient);
 
-  TEST_REAL_SIMILAR(biases[0], 0.0);
+  TEST_EQUAL(biases.size(), 0);
   TEST_REAL_SIMILAR(correlation_coefficient, 0.0);
 
   // point #1

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -209,6 +209,9 @@ START_SECTION((double calculateRatio(const Feature & component_1, const Feature 
   double inf = std::numeric_limits<double>::infinity();
   // dummy features
   OpenMS::Feature component_1, component_2;
+
+  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),0.0);
+
   component_1.setMetaValue(feature_name, 5.0);
   component_1.setMetaValue("native_id","component1");
   component_2.setMetaValue(feature_name, 5.0);

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -203,189 +203,189 @@ START_SECTION((~AbsoluteQuantitation()))
   delete ptr;
 END_SECTION
 
-START_SECTION((double calculateRatio(const Feature & component_1, const Feature & component_2, const String feature_name)))
-  AbsoluteQuantitation absquant;
-  String feature_name = "peak_apex_int";
-  double inf = std::numeric_limits<double>::infinity();
-  // dummy features
-  OpenMS::Feature component_1, component_2;
+// START_SECTION((double calculateRatio(const Feature & component_1, const Feature & component_2, const String feature_name)))
+//   AbsoluteQuantitation absquant;
+//   String feature_name = "peak_apex_int";
+//   double inf = std::numeric_limits<double>::infinity();
+//   // dummy features
+//   OpenMS::Feature component_1, component_2;
 
-  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),0.0);
+//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),0.0);
 
-  component_1.setMetaValue(feature_name, 5.0);
-  component_1.setMetaValue("native_id","component1");
-  component_2.setMetaValue(feature_name, 5.0);
-  component_2.setMetaValue("native_id","component2");
-  // tests
-  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),1.0);
-  component_2.setMetaValue(feature_name, 0.0);
-  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),inf);
-  // dummy features
-  OpenMS::Feature component_3, component_4;
-  component_3.setMetaValue("peak_area", 5.0);
-  component_3.setMetaValue("native_id","component3");
-  component_4.setMetaValue("peak_area", 5.0);
-  component_4.setMetaValue("native_id","component4");
-  TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_4,feature_name),5.0);
-  TEST_REAL_SIMILAR(absquant.calculateRatio(component_3,component_4,feature_name),0.0);
-  // feature_name == "intensity"
-  Feature component_5, component_6, component_7;
-  feature_name = "intensity";
-  component_5.setMetaValue("native_id", "component5");
-  component_6.setMetaValue("native_id", "component6");
-  component_5.setIntensity(3.0);
-  component_6.setIntensity(4.0);
-  TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_6, feature_name), 0.75);
-  TEST_REAL_SIMILAR(absquant.calculateRatio(component_6, component_5, feature_name), 1.33333333333333);
-  component_7.setMetaValue("native_id", "component7");
-  TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_7, feature_name), inf);
-END_SECTION
+//   component_1.setMetaValue(feature_name, 5.0);
+//   component_1.setMetaValue("native_id","component1");
+//   component_2.setMetaValue(feature_name, 5.0);
+//   component_2.setMetaValue("native_id","component2");
+//   // tests
+//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),1.0);
+//   component_2.setMetaValue(feature_name, 0.0);
+//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_2,feature_name),inf);
+//   // dummy features
+//   OpenMS::Feature component_3, component_4;
+//   component_3.setMetaValue("peak_area", 5.0);
+//   component_3.setMetaValue("native_id","component3");
+//   component_4.setMetaValue("peak_area", 5.0);
+//   component_4.setMetaValue("native_id","component4");
+//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_1,component_4,feature_name),5.0);
+//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_3,component_4,feature_name),0.0);
+//   // feature_name == "intensity"
+//   Feature component_5, component_6, component_7;
+//   feature_name = "intensity";
+//   component_5.setMetaValue("native_id", "component5");
+//   component_6.setMetaValue("native_id", "component6");
+//   component_5.setIntensity(3.0);
+//   component_6.setIntensity(4.0);
+//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_6, feature_name), 0.75);
+//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_6, component_5, feature_name), 1.33333333333333);
+//   component_7.setMetaValue("native_id", "component7");
+//   TEST_REAL_SIMILAR(absquant.calculateRatio(component_5, component_7, feature_name), inf);
+// END_SECTION
 
-START_SECTION((double calculateBias(const double & actual_concentration, const double & calculated_concentration)))
-  AbsoluteQuantitation absquant;
-  double actual_concentration = 5.0;
-  double calculated_concentration = 5.0;
-  TEST_REAL_SIMILAR(absquant.calculateBias(actual_concentration,calculated_concentration),0.0);
-  calculated_concentration = 4.0;
-  TEST_REAL_SIMILAR(absquant.calculateBias(actual_concentration,calculated_concentration),20.0);
-END_SECTION
+// START_SECTION((double calculateBias(const double & actual_concentration, const double & calculated_concentration)))
+//   AbsoluteQuantitation absquant;
+//   double actual_concentration = 5.0;
+//   double calculated_concentration = 5.0;
+//   TEST_REAL_SIMILAR(absquant.calculateBias(actual_concentration,calculated_concentration),0.0);
+//   calculated_concentration = 4.0;
+//   TEST_REAL_SIMILAR(absquant.calculateBias(actual_concentration,calculated_concentration),20.0);
+// END_SECTION
 
-START_SECTION((double applyCalibration(const Feature & component,
-  const Feature & IS_component,
-  const String & feature_name,
-  const String & transformation_model,
-  const Param & transformation_model_params)))
+// START_SECTION((double applyCalibration(const Feature & component,
+//   const Feature & IS_component,
+//   const String & feature_name,
+//   const String & transformation_model,
+//   const Param & transformation_model_params)))
 
-  AbsoluteQuantitation absquant;
+//   AbsoluteQuantitation absquant;
 
-  // set-up the features
-  Feature component, IS_component;
-  component.setMetaValue("native_id","component");
-  component.setMetaValue("peak_apex_int",2.0);
-  IS_component.setMetaValue("native_id","IS");
-  IS_component.setMetaValue("peak_apex_int",1.0);
-  String feature_name = "peak_apex_int";
+//   // set-up the features
+//   Feature component, IS_component;
+//   component.setMetaValue("native_id","component");
+//   component.setMetaValue("peak_apex_int",2.0);
+//   IS_component.setMetaValue("native_id","IS");
+//   IS_component.setMetaValue("peak_apex_int",1.0);
+//   String feature_name = "peak_apex_int";
 
-  // set-up the model and params
-  // y = m*x + b
-  // x = (y - b)/m
-  String transformation_model;
-  Param param;
-  // transformation_model = "TransformationModelLinear";
-  transformation_model = "linear";
-  param.setValue("slope",2.0);
-  param.setValue("intercept",1.0);
+//   // set-up the model and params
+//   // y = m*x + b
+//   // x = (y - b)/m
+//   String transformation_model;
+//   Param param;
+//   // transformation_model = "TransformationModelLinear";
+//   transformation_model = "linear";
+//   param.setValue("slope",2.0);
+//   param.setValue("intercept",1.0);
 
-  TEST_REAL_SIMILAR(absquant.applyCalibration(component,
-    IS_component,
-    feature_name,
-    transformation_model,
-    param),0.5);
-END_SECTION
+//   TEST_REAL_SIMILAR(absquant.applyCalibration(component,
+//     IS_component,
+//     feature_name,
+//     transformation_model,
+//     param),0.5);
+// END_SECTION
 
-START_SECTION((void quantifyComponents(std::vector<FeatureMap>& unknowns)))
+// START_SECTION((void quantifyComponents(std::vector<FeatureMap>& unknowns)))
 
-  AbsoluteQuantitation absquant;
+//   AbsoluteQuantitation absquant;
 
-  // set-up the unknown FeatureMap
-  FeatureMap unknown_feature_map;
-  // set-up the features and sub-features
-  std::vector<Feature> unknown_feature_subordinates;
-  Feature unknown_feature, component, IS_component;
-  String feature_name = "peak_apex_int";
-  // component 1
-  unknown_feature.setMetaValue("PeptideRef","component_group1");
-  component.setMetaValue("native_id","component1");
-  component.setMetaValue(feature_name,2.0);
-  IS_component.setMetaValue("native_id","IS1");
-  IS_component.setMetaValue(feature_name,2.0);
-  unknown_feature_subordinates.push_back(IS_component);
-  unknown_feature_subordinates.push_back(component);
-  unknown_feature.setSubordinates(unknown_feature_subordinates);
-  unknown_feature_map.push_back(unknown_feature);
-  unknown_feature_subordinates.clear();
-  // component 2
-  unknown_feature.setMetaValue("PeptideRef","component_group2");
-  component.setMetaValue("native_id","component2");
-  component.setMetaValue(feature_name,4.0);
-  IS_component.setMetaValue("native_id","IS2");
-  IS_component.setMetaValue(feature_name,4.0);
-  unknown_feature_subordinates.push_back(IS_component);
-  unknown_feature_subordinates.push_back(component);
-  unknown_feature.setSubordinates(unknown_feature_subordinates);
-  unknown_feature_map.push_back(unknown_feature);
-  unknown_feature_subordinates.clear();
-  // component 3
-  unknown_feature.setMetaValue("PeptideRef","component_group3");
-  component.setMetaValue("native_id","component3");
-  component.setMetaValue(feature_name,6.0);
-  IS_component.setMetaValue("native_id","IS3");
-  IS_component.setMetaValue(feature_name,6.0);
-  unknown_feature_subordinates.push_back(component);  // test order change
-  unknown_feature_subordinates.push_back(IS_component);
-  unknown_feature.setSubordinates(unknown_feature_subordinates);
-  unknown_feature_map.push_back(unknown_feature);
-  unknown_feature_subordinates.clear();
-  // // set-up the unknowns
-  // std::vector<FeatureMap> unknowns;
-  // unknowns.push_back(unknown_feature_map);
+//   // set-up the unknown FeatureMap
+//   FeatureMap unknown_feature_map;
+//   // set-up the features and sub-features
+//   std::vector<Feature> unknown_feature_subordinates;
+//   Feature unknown_feature, component, IS_component;
+//   String feature_name = "peak_apex_int";
+//   // component 1
+//   unknown_feature.setMetaValue("PeptideRef","component_group1");
+//   component.setMetaValue("native_id","component1");
+//   component.setMetaValue(feature_name,2.0);
+//   IS_component.setMetaValue("native_id","IS1");
+//   IS_component.setMetaValue(feature_name,2.0);
+//   unknown_feature_subordinates.push_back(IS_component);
+//   unknown_feature_subordinates.push_back(component);
+//   unknown_feature.setSubordinates(unknown_feature_subordinates);
+//   unknown_feature_map.push_back(unknown_feature);
+//   unknown_feature_subordinates.clear();
+//   // component 2
+//   unknown_feature.setMetaValue("PeptideRef","component_group2");
+//   component.setMetaValue("native_id","component2");
+//   component.setMetaValue(feature_name,4.0);
+//   IS_component.setMetaValue("native_id","IS2");
+//   IS_component.setMetaValue(feature_name,4.0);
+//   unknown_feature_subordinates.push_back(IS_component);
+//   unknown_feature_subordinates.push_back(component);
+//   unknown_feature.setSubordinates(unknown_feature_subordinates);
+//   unknown_feature_map.push_back(unknown_feature);
+//   unknown_feature_subordinates.clear();
+//   // component 3
+//   unknown_feature.setMetaValue("PeptideRef","component_group3");
+//   component.setMetaValue("native_id","component3");
+//   component.setMetaValue(feature_name,6.0);
+//   IS_component.setMetaValue("native_id","IS3");
+//   IS_component.setMetaValue(feature_name,6.0);
+//   unknown_feature_subordinates.push_back(component);  // test order change
+//   unknown_feature_subordinates.push_back(IS_component);
+//   unknown_feature.setSubordinates(unknown_feature_subordinates);
+//   unknown_feature_map.push_back(unknown_feature);
+//   unknown_feature_subordinates.clear();
+//   // // set-up the unknowns
+//   // std::vector<FeatureMap> unknowns;
+//   // unknowns.push_back(unknown_feature_map);
 
-  // set-up the model and params
-  AbsoluteQuantitationMethod aqm;
-  String transformation_model;
-  Param param;
-  // transformation_model = "TransformationModelLinear";
-  transformation_model = "linear";
-  param.setValue("slope",1.0);
-  param.setValue("intercept",0.0);
-  aqm.setTransformationModel(transformation_model);
-  aqm.setTransformationModelParams(param);
-  // set-up the quant_method map
-  std::vector<AbsoluteQuantitationMethod> quant_methods;
-  // component_1
-  aqm.setComponentName("component1");
-  aqm.setISName("IS1");
-  aqm.setFeatureName(feature_name);
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
-  // component_2
-  aqm.setComponentName("component2");
-  aqm.setISName("IS1");
-  aqm.setFeatureName(feature_name); // test IS outside component_group
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
-  // component_3
-  aqm.setComponentName("component3");
-  aqm.setISName("IS3");
-  aqm.setFeatureName(feature_name);
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
+//   // set-up the model and params
+//   AbsoluteQuantitationMethod aqm;
+//   String transformation_model;
+//   Param param;
+//   // transformation_model = "TransformationModelLinear";
+//   transformation_model = "linear";
+//   param.setValue("slope",1.0);
+//   param.setValue("intercept",0.0);
+//   aqm.setTransformationModel(transformation_model);
+//   aqm.setTransformationModelParams(param);
+//   // set-up the quant_method map
+//   std::vector<AbsoluteQuantitationMethod> quant_methods;
+//   // component_1
+//   aqm.setComponentName("component1");
+//   aqm.setISName("IS1");
+//   aqm.setFeatureName(feature_name);
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
+//   // component_2
+//   aqm.setComponentName("component2");
+//   aqm.setISName("IS1");
+//   aqm.setFeatureName(feature_name); // test IS outside component_group
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
+//   // component_3
+//   aqm.setComponentName("component3");
+//   aqm.setISName("IS3");
+//   aqm.setFeatureName(feature_name);
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
 
-  absquant.setQuantMethods(quant_methods);
-  absquant.quantifyComponents(unknown_feature_map);
+//   absquant.setQuantMethods(quant_methods);
+//   absquant.quantifyComponents(unknown_feature_map);
 
-  // DEBUGGING:
-  // for (size_t i = 0; i < unknowns.size(); ++i)
-  // {
-  //   for (size_t j = 0; j < unknowns[i].size(); ++j)
-  //   {
-  //     for (size_t k = 0; k < unknowns[i][j].getSubordinates().size(); ++k)
-  //     {
-  //       std::cout << "component = " << unknowns[i][j].getSubordinates()[k].getMetaValue("native_id") << std::endl;
-  //       std::cout << "calculated_concentration = " << unknowns[i][j].getSubordinates()[k].getMetaValue("calculated_concentration") << std::endl;
-  //     }
-  //   }
-  // }
+//   // DEBUGGING:
+//   // for (size_t i = 0; i < unknowns.size(); ++i)
+//   // {
+//   //   for (size_t j = 0; j < unknowns[i].size(); ++j)
+//   //   {
+//   //     for (size_t k = 0; k < unknowns[i][j].getSubordinates().size(); ++k)
+//   //     {
+//   //       std::cout << "component = " << unknowns[i][j].getSubordinates()[k].getMetaValue("native_id") << std::endl;
+//   //       std::cout << "calculated_concentration = " << unknowns[i][j].getSubordinates()[k].getMetaValue("calculated_concentration") << std::endl;
+//   //     }
+//   //   }
+//   // }
 
-  TEST_EQUAL(unknown_feature_map[0].getSubordinates()[0].getMetaValue("calculated_concentration"),"");
-  TEST_STRING_EQUAL(unknown_feature_map[0].getSubordinates()[0].getMetaValue("concentration_units"),"");
-  TEST_REAL_SIMILAR(unknown_feature_map[0].getSubordinates()[1].getMetaValue("calculated_concentration"),1.0);
-  TEST_STRING_EQUAL(unknown_feature_map[0].getSubordinates()[1].getMetaValue("concentration_units"),"uM");
-  TEST_REAL_SIMILAR(unknown_feature_map[1].getSubordinates()[1].getMetaValue("calculated_concentration"),2.0);
-  TEST_STRING_EQUAL(unknown_feature_map[1].getSubordinates()[1].getMetaValue("concentration_units"),"uM");
-  TEST_REAL_SIMILAR(unknown_feature_map[2].getSubordinates()[0].getMetaValue("calculated_concentration"),1.0);
-  TEST_STRING_EQUAL(unknown_feature_map[2].getSubordinates()[0].getMetaValue("concentration_units"),"uM");
-END_SECTION
+//   TEST_EQUAL(unknown_feature_map[0].getSubordinates()[0].getMetaValue("calculated_concentration"),"");
+//   TEST_STRING_EQUAL(unknown_feature_map[0].getSubordinates()[0].getMetaValue("concentration_units"),"");
+//   TEST_REAL_SIMILAR(unknown_feature_map[0].getSubordinates()[1].getMetaValue("calculated_concentration"),1.0);
+//   TEST_STRING_EQUAL(unknown_feature_map[0].getSubordinates()[1].getMetaValue("concentration_units"),"uM");
+//   TEST_REAL_SIMILAR(unknown_feature_map[1].getSubordinates()[1].getMetaValue("calculated_concentration"),2.0);
+//   TEST_STRING_EQUAL(unknown_feature_map[1].getSubordinates()[1].getMetaValue("concentration_units"),"uM");
+//   TEST_REAL_SIMILAR(unknown_feature_map[2].getSubordinates()[0].getMetaValue("calculated_concentration"),1.0);
+//   TEST_STRING_EQUAL(unknown_feature_map[2].getSubordinates()[0].getMetaValue("concentration_units"),"uM");
+// END_SECTION
 
 START_SECTION((void (
   const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
@@ -475,569 +475,569 @@ START_SECTION((void (
 
 END_SECTION
 
-START_SECTION((Param AbsoluteQuantitation::fitCalibration(
-    const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
-    const String & feature_name,
-    const String & transformation_model,
-    const Param & transformation_model_params)))
-
-  AbsoluteQuantitation absquant;
-
-  // TEST 1:
-  static const double arrx1[] = {-1, -2, -3, 1, 2, 3};
-  std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
-  static const double arry1[] = {1, 1, 1, 1, 1, 1};
-  std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-  static const double arrz1[] = {-2, -4, -6, 2, 4, 6};
-  std::vector<double> z1 (arrz1, arrz1 + sizeof(arrz1) / sizeof(arrz1[0]) );
-
-  // set-up the features
-  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
-  AbsoluteQuantitationStandards::featureConcentration component_concentration;
-  Feature component, IS_component;
-  for (size_t i = 0; i < x1.size(); ++i)
-  {
-    component.setMetaValue("native_id","ser-L.ser-L_1.Light");
-    component.setMetaValue("peak_apex_int",x1[i]);
-    IS_component.setMetaValue("native_id","IS");
-    IS_component.setMetaValue("peak_apex_int",y1[i]);
-    component_concentration.feature = component;
-    component_concentration.IS_feature = IS_component;
-    component_concentration.actual_concentration = z1[i];
-    component_concentration.IS_actual_concentration = 1.0;
-    component_concentration.dilution_factor = 1.0;
-    component_concentrations.push_back(component_concentration);
-  }
-
-  String feature_name = "peak_apex_int";
-  Param transformation_model_params;
-  transformation_model_params.setValue("x_datum_min", -1e12);
-  transformation_model_params.setValue("x_datum_max", 1e12);
-  transformation_model_params.setValue("y_datum_min", -1e12);
-  transformation_model_params.setValue("y_datum_max", 1e12);
-  // String transformation_model = "TransformationModelLinear";
-  String transformation_model = "linear";
-
-  Param param = absquant.fitCalibration(component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params);
-
-  TEST_REAL_SIMILAR(param.getValue("slope"),0.5);
-  TEST_REAL_SIMILAR(param.getValue("intercept"),0.0);
-
-  // TEST 2:
-  static const double arrx2[] = {0.25,0.5,1,2,3,4,5,6};
-  std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
-  static const double arry2[] = {1,1,1,1,1,1,1,1};
-  std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
-  static const double arrz2[] = {0.5,1,2,4,6,8,10,12};
-  std::vector<double> z2 (arrz2, arrz2 + sizeof(arrz2) / sizeof(arrz2[0]) );
-
-  // set-up the features
-  component_concentrations.clear();
-  for (size_t i = 0; i < x2.size(); ++i)
-  {
-    component.setMetaValue("native_id","ser-L.ser-L_1.Light");
-    component.setMetaValue("peak_apex_int",x2[i]);
-    IS_component.setMetaValue("native_id","IS");
-    IS_component.setMetaValue("peak_apex_int",y2[i]);
-    component_concentration.feature = component;
-    component_concentration.IS_feature = IS_component;
-    component_concentration.actual_concentration = z2[i];
-    component_concentration.IS_actual_concentration = 1.0;
-    component_concentration.dilution_factor = 1.0;
-    component_concentrations.push_back(component_concentration);
-  }
-
-  transformation_model_params.setValue("x_weight", "ln(x)");
-  transformation_model_params.setValue("y_weight", "ln(y)");
-
-  param = absquant.fitCalibration(component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params);
-
-  TEST_REAL_SIMILAR(param.getValue("slope"), 1.0);
-  TEST_REAL_SIMILAR(param.getValue("intercept"), -0.69314718);
-
-END_SECTION
-
-START_SECTION((void optimizeCalibrationCurveIterative(
-  std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
-  const String & feature_name,
-  const String & transformation_model,
-  const Param & transformation_model_params,
-  Param & optimized_params)))
-
-  AbsoluteQuantitation absquant;
-
-  // TEST 1: ser-L
-  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations = make_serL_standards();
-
-  // set-up the class parameters
-  Param absquant_params;
-  absquant_params.setValue("min_points", 4);
-  absquant_params.setValue("max_bias", 30.0);
-  absquant_params.setValue("min_correlation_coefficient", 0.9);
-  absquant_params.setValue("max_iters", 100);
-  absquant_params.setValue("outlier_detection_method", "iter_jackknife");
-  absquant_params.setValue("use_chauvenet", "false");
-  absquant.setParameters(absquant_params);
-
-  // set-up the function parameters
-  const String feature_name = "peak_apex_int";
-  const String transformation_model = "linear";
-  Param transformation_model_params;
-  transformation_model_params.setValue("x_weight", "ln(x)");
-  transformation_model_params.setValue("y_weight", "ln(y)");
-  transformation_model_params.setValue("x_datum_min", -1e12);
-  transformation_model_params.setValue("x_datum_max", 1e12);
-  transformation_model_params.setValue("y_datum_min", -1e12);
-  transformation_model_params.setValue("y_datum_max", 1e12);
-  Param optimized_params;
-
-  absquant.optimizeCalibrationCurveIterative(
-    component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params,
-    optimized_params);
-
-  TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.04);
-  TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 40.0);
-  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.9011392589);
-  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 1.870185076);
-
-  // TEST 2: amp
-  component_concentrations = make_amp_standards();
-
-  absquant.optimizeCalibrationCurveIterative(
-    component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params,
-    optimized_params);
-
-  TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.02);
-  TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 8.0);
-  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.95799683);
-  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), -1.047543387);
-
-  // TEST 3: atp
-  component_concentrations = make_atp_standards();
-
-  absquant.optimizeCalibrationCurveIterative(
-    component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params,
-    optimized_params);
-
-  TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.02);
-  TEST_REAL_SIMILAR(component_concentrations[3].actual_concentration, 8.0);
-  TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.623040824);
-  TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 0.36130172586);
-
-END_SECTION
-
-START_SECTION((void optimizeCalibrationCurves(AbsoluteQuantitationStandards::components_to_concentrations & components_concentrations)))
-
-  AbsoluteQuantitation absquant;
-
-  // set-up the class parameters
-  Param absquant_params;
-  absquant_params.setValue("min_points", 4);
-  absquant_params.setValue("max_bias", 30.0);
-  absquant_params.setValue("min_correlation_coefficient", 0.9);
-  absquant_params.setValue("max_iters", 100);
-  absquant_params.setValue("outlier_detection_method", "iter_jackknife");
-  absquant_params.setValue("use_chauvenet", "false");
-  absquant.setParameters(absquant_params);
-
-  // set up the quantitation method
-  AbsoluteQuantitationMethod aqm;
-  String feature_name = "peak_apex_int";
-  String transformation_model;
-  Param param;
-  transformation_model = "linear";
-  param.setValue("slope",1.0);
-  param.setValue("intercept",0.0);
-  param.setValue("x_weight", "ln(x)");
-  param.setValue("y_weight", "ln(y)");
-  param.setValue("x_datum_min", -1e12);
-  param.setValue("x_datum_max", 1e12);
-  param.setValue("y_datum_min", -1e12);
-  param.setValue("y_datum_max", 1e12);
-  aqm.setTransformationModel(transformation_model);
-  aqm.setTransformationModelParams(param);
-  // set-up the quant_method map
-  std::vector<AbsoluteQuantitationMethod> quant_methods;
-  // component_1
-  aqm.setComponentName("ser-L.ser-L_1.Light");
-  aqm.setISName("ser-L.ser-L_1.Heavy");
-  aqm.setFeatureName(feature_name);
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
-  // component_2
-  aqm.setComponentName("amp.amp_1.Light");
-  aqm.setISName("amp.amp_1.Heavy");
-  aqm.setFeatureName(feature_name); // test IS outside component_group
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
-  // component_3
-  aqm.setComponentName("atp.atp_1.Light");
-  aqm.setISName("atp.atp_1.Heavy");
-  aqm.setFeatureName(feature_name);
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
-
-  absquant.setQuantMethods(quant_methods);
-
-  // set up the standards
-  std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_concentrations;
-  components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
-  components_concentrations["amp.amp_1.Light"] = make_amp_standards();
-  components_concentrations["atp.atp_1.Light"] = make_atp_standards();
-
-  absquant.optimizeCalibrationCurves(components_concentrations);
-  std::map<String, AbsoluteQuantitationMethod> quant_methods_map = absquant.getQuantMethodsAsMap();
-
-  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.04);
-  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 40.0);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.999320072);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.04);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 11);
-
-  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
-  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
-  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("slope"), 0.95799683);
-  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("intercept"), -1.047543387);
-  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getCorrelationCoefficient(), 0.99916926);
-  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getLLOQ(), 0.02);
-  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getULOQ(), 40.0);
-  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getNPoints(), 11);
-
-  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
-  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
-  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("slope"), 0.623040824);
-  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("intercept"), 0.36130172586);
-  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getCorrelationCoefficient(), 0.998208402);
-  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getLLOQ(), 0.02);
-  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getULOQ(), 40.0);
-  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getNPoints(), 6);
-
-  components_concentrations.clear();
-  components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
-  absquant_params.setValue("min_points", 20); // so that an optimal calibration curve is not found, and the sorting is not saved
-  absquant.setParameters(absquant_params);
-  absquant.optimizeCalibrationCurves(components_concentrations);
-  quant_methods_map = absquant.getQuantMethodsAsMap();
-
-  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.01);
-  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 4.0);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.997143769417099);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.01);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 14);
-END_SECTION
-
-START_SECTION(void optimizeSingleCalibrationCurve(
-  const String& component_name,
-  std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations
-))
-  // set up the quantitation method
-  Param param;
-  param.setValue("slope",1.0);
-  param.setValue("intercept",0.0);
-  param.setValue("x_weight", "ln(x)");
-  param.setValue("y_weight", "ln(y)");
-  param.setValue("x_datum_min", -1e12);
-  param.setValue("x_datum_max", 1e12);
-  param.setValue("y_datum_min", -1e12);
-  param.setValue("y_datum_max", 1e12);
-  AbsoluteQuantitationMethod aqm;
-  aqm.setTransformationModel("linear");
-  aqm.setTransformationModelParams(param);
-  // set-up the quant_method map
-  std::vector<AbsoluteQuantitationMethod> quant_methods;
-  const String feature_name = "peak_apex_int";
-  // component_1
-  aqm.setComponentName("ser-L.ser-L_1.Light");
-  aqm.setISName("ser-L.ser-L_1.Heavy");
-  aqm.setFeatureName(feature_name);
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
-  // component_2
-  aqm.setComponentName("amp.amp_1.Light");
-  aqm.setISName("amp.amp_1.Heavy");
-  aqm.setFeatureName(feature_name); // test IS outside component_group
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
-  // component_3
-  aqm.setComponentName("atp.atp_1.Light");
-  aqm.setISName("atp.atp_1.Heavy");
-  aqm.setFeatureName(feature_name);
-  aqm.setConcentrationUnits("uM");
-  quant_methods.push_back(aqm);
-
-  AbsoluteQuantitation absquant;
-  // set-up the class parameters
-  Param absquant_params;
-  absquant_params.setValue("min_points", 4);
-  absquant_params.setValue("max_bias", 30.0);
-  absquant_params.setValue("min_correlation_coefficient", 0.9);
-  absquant_params.setValue("max_iters", 100);
-  absquant_params.setValue("outlier_detection_method", "iter_jackknife");
-  absquant_params.setValue("use_chauvenet", "false");
-  absquant.setParameters(absquant_params);
-  absquant.setQuantMethods(quant_methods);
-
-  // set up the standards
-  std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_concentrations;
-  components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
-  components_concentrations["amp.amp_1.Light"] = make_amp_standards();
-  components_concentrations["atp.atp_1.Light"] = make_atp_standards();
-
-  absquant.optimizeSingleCalibrationCurve("ser-L.ser-L_1.Light", components_concentrations.at("ser-L.ser-L_1.Light"));
-  absquant.optimizeSingleCalibrationCurve("amp.amp_1.Light", components_concentrations.at("amp.amp_1.Light"));
-  absquant.optimizeSingleCalibrationCurve("atp.atp_1.Light", components_concentrations.at("atp.atp_1.Light"));
-  std::map<String, AbsoluteQuantitationMethod> quant_methods_map = absquant.getQuantMethodsAsMap();
-
-  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.04);
-  TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 40.0);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
-  TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.999320072);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.04);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
-  TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 11);
-
-  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
-  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
-  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
-  TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
-  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("slope"), 0.95799683);
-  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("intercept"), -1.047543387);
-  TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getCorrelationCoefficient(), 0.99916926);
-  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getLLOQ(), 0.02);
-  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getULOQ(), 40.0);
-  TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getNPoints(), 11);
-
-  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
-  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
-  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
-  TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
-  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("slope"), 0.623040824);
-  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("intercept"), 0.36130172586);
-  TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getCorrelationCoefficient(), 0.998208402);
-  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getLLOQ(), 0.02);
-  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getULOQ(), 40.0);
-  TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getNPoints(), 6);
-END_SECTION
-
-/////////////////////////////
-/* Protected Members **/
-/////////////////////////////
-
-START_SECTION((std::vector<AbsoluteQuantitationStandards::featureConcentration> extractComponents_(
-      const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
-      const std::vector<size_t>& component_concentrations_indices)))
-
-  AbsoluteQuantitation_test absquant;
-  // make the components_concentrations
-  static const double arrx1[] = { 1.1, 2.0, 3.3, 3.9, 4.9, 6.2  };
-  std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
-  static const double arry1[] = { 0.9, 1.9, 3.0, 3.7, 5.2, 6.1  };
-  std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-  // set-up the features
-  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
-  AbsoluteQuantitationStandards::featureConcentration component_concentration;
-  Feature component, IS_component;
-  for (size_t i = 0; i < x1.size(); ++i)
-  {
-    component.setMetaValue("native_id","component" + std::to_string(i));
-    component.setMetaValue("peak_apex_int",y1[i]);
-    IS_component.setMetaValue("native_id","IS" + std::to_string(i));
-    IS_component.setMetaValue("peak_apex_int",1.0);
-    component_concentration.feature = component;
-    component_concentration.IS_feature = IS_component;
-    component_concentration.actual_concentration = x1[i];
-    component_concentration.IS_actual_concentration = 1.0;
-    component_concentration.dilution_factor = 1.0;
-    component_concentrations.push_back(component_concentration);
-  }
-
-  // make the indices to extract
-  static const size_t arrx2[] = { 0, 1, 3  };
-  std::vector<size_t> component_concentrations_indices(arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
-
-  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations_sub = absquant.extractComponents_(
-    component_concentrations, component_concentrations_indices);
-
-  TEST_EQUAL(component_concentrations_sub[0].feature.getMetaValue("native_id"), "component0");
-  TEST_REAL_SIMILAR(component_concentrations_sub[0].actual_concentration, 1.1);
-
-  TEST_EQUAL(component_concentrations_sub[1].feature.getMetaValue("native_id"), "component1");
-  TEST_REAL_SIMILAR(component_concentrations_sub[1].actual_concentration, 2.0);
-
-  TEST_EQUAL(component_concentrations_sub[2].feature.getMetaValue("native_id"), "component3");
-  TEST_REAL_SIMILAR(component_concentrations_sub[2].actual_concentration, 3.9);
-
-END_SECTION
-
-START_SECTION((int jackknifeOutlierCandidate_(
-      const std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations,
-      const String & feature_name,
-      const String & transformation_model,
-      const Param & transformation_model_params)))
-
-  AbsoluteQuantitation_test absquant;
-
-  static const double arrx1[] = { 1.1, 2.0,3.3,3.9,4.9,6.2  };
-  std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
-  static const double arry1[] = { 0.9, 1.9,3.0,3.7,5.2,6.1  };
-  std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-  // set-up the features
-  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
-  AbsoluteQuantitationStandards::featureConcentration component_concentration;
-  Feature component, IS_component;
-  for (size_t i = 0; i < x1.size(); ++i)
-  {
-    component.setMetaValue("native_id","component");
-    component.setMetaValue("peak_apex_int",y1[i]);
-    IS_component.setMetaValue("native_id","IS");
-    IS_component.setMetaValue("peak_apex_int",1.0);
-    component_concentration.feature = component;
-    component_concentration.IS_feature = IS_component;
-    component_concentration.actual_concentration = x1[i];
-    component_concentration.IS_actual_concentration = 1.0;
-    component_concentration.dilution_factor = 1.0;
-    component_concentrations.push_back(component_concentration);
-  }
-
-  String feature_name = "peak_apex_int";
-
-  // set-up the model and params
-  // y = m*x + b
-  // x = (y - b)/m
-  Param transformation_model_params;
- //   String transformation_model = "TransformationModelLinear";
-  String transformation_model = "linear";
-
-  int c1 = absquant.jackknifeOutlierCandidate_(
-    component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params);
-  TEST_EQUAL(c1,4);
-
-  static const double arrx2[] = { 1,2,3,4,5,6  };
-  std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
-  static const double arry2[] = { 1,2,3,4,5,6};
-  std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
-  component_concentrations.clear();
-  for (size_t i = 0; i < x2.size(); ++i)
-  {
-    component.setMetaValue("native_id","component");
-    component.setMetaValue("peak_apex_int",y2[i]);
-    IS_component.setMetaValue("native_id","IS");
-    IS_component.setMetaValue("peak_apex_int",1.0);
-    component_concentration.feature = component;
-    component_concentration.IS_feature = IS_component;
-    component_concentration.actual_concentration = x2[i];
-    component_concentration.IS_actual_concentration = 1.0;
-    component_concentration.dilution_factor = 1.0;
-    component_concentrations.push_back(component_concentration);
-  }
-
-  int c2 = absquant.jackknifeOutlierCandidate_(
-    component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params);
-  TEST_EQUAL(c2,0);
-
-END_SECTION
-
-START_SECTION((int residualOutlierCandidate_(
-  const std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations,
-  const String & feature_name,
-  const String & transformation_model,
-  const Param & transformation_model_params)))
-
-  AbsoluteQuantitation_test absquant;
-
-  static const double arrx1[] = { 1.1, 2.0,3.3,3.9,4.9,6.2  };
-  std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
-  static const double arry1[] = { 0.9, 1.9,3.0,3.7,5.2,6.1  };
-  std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
-  // set-up the features
-  std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
-  AbsoluteQuantitationStandards::featureConcentration component_concentration;
-  Feature component, IS_component;
-  for (size_t i = 0; i < x1.size(); ++i)
-  {
-    component.setMetaValue("native_id","component");
-    component.setMetaValue("peak_apex_int",y1[i]);
-    IS_component.setMetaValue("native_id","IS");
-    IS_component.setMetaValue("peak_apex_int",1.0);
-    component_concentration.feature = component;
-    component_concentration.IS_feature = IS_component;
-    component_concentration.actual_concentration = x1[i];
-    component_concentration.IS_actual_concentration = 1.0;
-    component_concentration.dilution_factor = 1.0;
-    component_concentrations.push_back(component_concentration);
-  }
-
-  String feature_name = "peak_apex_int";
-
-  // set-up the model and params
-  // y = m*x + b
-  // x = (y - b)/m
-  Param transformation_model_params;
-  // String transformation_model = "TransformationModelLinear";
-  String transformation_model = "linear";
-
-  int c1 = absquant.residualOutlierCandidate_(
-    component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params);
-  TEST_EQUAL(c1,4);
-
-  static const double arrx2[] = { 1,2,3,4,5,6  };
-  std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
-  static const double arry2[] = { 1,2,3,4,5,6};
-  std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
-  component_concentrations.clear();
-  for (size_t i = 0; i < x2.size(); ++i)
-  {
-    component.setMetaValue("native_id","component");
-    component.setMetaValue("peak_apex_int",y2[i]);
-    IS_component.setMetaValue("native_id","IS");
-    IS_component.setMetaValue("peak_apex_int",1.0);
-    component_concentration.feature = component;
-    component_concentration.IS_feature = IS_component;
-    component_concentration.actual_concentration = x2[i];
-    component_concentration.IS_actual_concentration = 1.0;
-    component_concentration.dilution_factor = 1.0;
-    component_concentrations.push_back(component_concentration);
-  }
-
-  int c2 = absquant.residualOutlierCandidate_(
-    component_concentrations,
-    feature_name,
-    transformation_model,
-    transformation_model_params);
-  TEST_EQUAL(c2,0);
-
-END_SECTION
+// START_SECTION((Param AbsoluteQuantitation::fitCalibration(
+//     const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
+//     const String & feature_name,
+//     const String & transformation_model,
+//     const Param & transformation_model_params)))
+
+//   AbsoluteQuantitation absquant;
+
+//   // TEST 1:
+//   static const double arrx1[] = {-1, -2, -3, 1, 2, 3};
+//   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
+//   static const double arry1[] = {1, 1, 1, 1, 1, 1};
+//   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
+//   static const double arrz1[] = {-2, -4, -6, 2, 4, 6};
+//   std::vector<double> z1 (arrz1, arrz1 + sizeof(arrz1) / sizeof(arrz1[0]) );
+
+//   // set-up the features
+//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
+//   AbsoluteQuantitationStandards::featureConcentration component_concentration;
+//   Feature component, IS_component;
+//   for (size_t i = 0; i < x1.size(); ++i)
+//   {
+//     component.setMetaValue("native_id","ser-L.ser-L_1.Light");
+//     component.setMetaValue("peak_apex_int",x1[i]);
+//     IS_component.setMetaValue("native_id","IS");
+//     IS_component.setMetaValue("peak_apex_int",y1[i]);
+//     component_concentration.feature = component;
+//     component_concentration.IS_feature = IS_component;
+//     component_concentration.actual_concentration = z1[i];
+//     component_concentration.IS_actual_concentration = 1.0;
+//     component_concentration.dilution_factor = 1.0;
+//     component_concentrations.push_back(component_concentration);
+//   }
+
+//   String feature_name = "peak_apex_int";
+//   Param transformation_model_params;
+//   transformation_model_params.setValue("x_datum_min", -1e12);
+//   transformation_model_params.setValue("x_datum_max", 1e12);
+//   transformation_model_params.setValue("y_datum_min", -1e12);
+//   transformation_model_params.setValue("y_datum_max", 1e12);
+//   // String transformation_model = "TransformationModelLinear";
+//   String transformation_model = "linear";
+
+//   Param param = absquant.fitCalibration(component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params);
+
+//   TEST_REAL_SIMILAR(param.getValue("slope"),0.5);
+//   TEST_REAL_SIMILAR(param.getValue("intercept"),0.0);
+
+//   // TEST 2:
+//   static const double arrx2[] = {0.25,0.5,1,2,3,4,5,6};
+//   std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
+//   static const double arry2[] = {1,1,1,1,1,1,1,1};
+//   std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
+//   static const double arrz2[] = {0.5,1,2,4,6,8,10,12};
+//   std::vector<double> z2 (arrz2, arrz2 + sizeof(arrz2) / sizeof(arrz2[0]) );
+
+//   // set-up the features
+//   component_concentrations.clear();
+//   for (size_t i = 0; i < x2.size(); ++i)
+//   {
+//     component.setMetaValue("native_id","ser-L.ser-L_1.Light");
+//     component.setMetaValue("peak_apex_int",x2[i]);
+//     IS_component.setMetaValue("native_id","IS");
+//     IS_component.setMetaValue("peak_apex_int",y2[i]);
+//     component_concentration.feature = component;
+//     component_concentration.IS_feature = IS_component;
+//     component_concentration.actual_concentration = z2[i];
+//     component_concentration.IS_actual_concentration = 1.0;
+//     component_concentration.dilution_factor = 1.0;
+//     component_concentrations.push_back(component_concentration);
+//   }
+
+//   transformation_model_params.setValue("x_weight", "ln(x)");
+//   transformation_model_params.setValue("y_weight", "ln(y)");
+
+//   param = absquant.fitCalibration(component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params);
+
+//   TEST_REAL_SIMILAR(param.getValue("slope"), 1.0);
+//   TEST_REAL_SIMILAR(param.getValue("intercept"), -0.69314718);
+
+// END_SECTION
+
+// START_SECTION((void optimizeCalibrationCurveIterative(
+//   std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
+//   const String & feature_name,
+//   const String & transformation_model,
+//   const Param & transformation_model_params,
+//   Param & optimized_params)))
+
+//   AbsoluteQuantitation absquant;
+
+//   // TEST 1: ser-L
+//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations = make_serL_standards();
+
+//   // set-up the class parameters
+//   Param absquant_params;
+//   absquant_params.setValue("min_points", 4);
+//   absquant_params.setValue("max_bias", 30.0);
+//   absquant_params.setValue("min_correlation_coefficient", 0.9);
+//   absquant_params.setValue("max_iters", 100);
+//   absquant_params.setValue("outlier_detection_method", "iter_jackknife");
+//   absquant_params.setValue("use_chauvenet", "false");
+//   absquant.setParameters(absquant_params);
+
+//   // set-up the function parameters
+//   const String feature_name = "peak_apex_int";
+//   const String transformation_model = "linear";
+//   Param transformation_model_params;
+//   transformation_model_params.setValue("x_weight", "ln(x)");
+//   transformation_model_params.setValue("y_weight", "ln(y)");
+//   transformation_model_params.setValue("x_datum_min", -1e12);
+//   transformation_model_params.setValue("x_datum_max", 1e12);
+//   transformation_model_params.setValue("y_datum_min", -1e12);
+//   transformation_model_params.setValue("y_datum_max", 1e12);
+//   Param optimized_params;
+
+//   absquant.optimizeCalibrationCurveIterative(
+//     component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params,
+//     optimized_params);
+
+//   TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.04);
+//   TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 40.0);
+//   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.9011392589);
+//   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 1.870185076);
+
+//   // TEST 2: amp
+//   component_concentrations = make_amp_standards();
+
+//   absquant.optimizeCalibrationCurveIterative(
+//     component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params,
+//     optimized_params);
+
+//   TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.02);
+//   TEST_REAL_SIMILAR(component_concentrations[8].actual_concentration, 8.0);
+//   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.95799683);
+//   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), -1.047543387);
+
+//   // TEST 3: atp
+//   component_concentrations = make_atp_standards();
+
+//   absquant.optimizeCalibrationCurveIterative(
+//     component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params,
+//     optimized_params);
+
+//   TEST_REAL_SIMILAR(component_concentrations[0].actual_concentration, 0.02);
+//   TEST_REAL_SIMILAR(component_concentrations[3].actual_concentration, 8.0);
+//   TEST_REAL_SIMILAR(optimized_params.getValue("slope"), 0.623040824);
+//   TEST_REAL_SIMILAR(optimized_params.getValue("intercept"), 0.36130172586);
+
+// END_SECTION
+
+// START_SECTION((void optimizeCalibrationCurves(AbsoluteQuantitationStandards::components_to_concentrations & components_concentrations)))
+
+//   AbsoluteQuantitation absquant;
+
+//   // set-up the class parameters
+//   Param absquant_params;
+//   absquant_params.setValue("min_points", 4);
+//   absquant_params.setValue("max_bias", 30.0);
+//   absquant_params.setValue("min_correlation_coefficient", 0.9);
+//   absquant_params.setValue("max_iters", 100);
+//   absquant_params.setValue("outlier_detection_method", "iter_jackknife");
+//   absquant_params.setValue("use_chauvenet", "false");
+//   absquant.setParameters(absquant_params);
+
+//   // set up the quantitation method
+//   AbsoluteQuantitationMethod aqm;
+//   String feature_name = "peak_apex_int";
+//   String transformation_model;
+//   Param param;
+//   transformation_model = "linear";
+//   param.setValue("slope",1.0);
+//   param.setValue("intercept",0.0);
+//   param.setValue("x_weight", "ln(x)");
+//   param.setValue("y_weight", "ln(y)");
+//   param.setValue("x_datum_min", -1e12);
+//   param.setValue("x_datum_max", 1e12);
+//   param.setValue("y_datum_min", -1e12);
+//   param.setValue("y_datum_max", 1e12);
+//   aqm.setTransformationModel(transformation_model);
+//   aqm.setTransformationModelParams(param);
+//   // set-up the quant_method map
+//   std::vector<AbsoluteQuantitationMethod> quant_methods;
+//   // component_1
+//   aqm.setComponentName("ser-L.ser-L_1.Light");
+//   aqm.setISName("ser-L.ser-L_1.Heavy");
+//   aqm.setFeatureName(feature_name);
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
+//   // component_2
+//   aqm.setComponentName("amp.amp_1.Light");
+//   aqm.setISName("amp.amp_1.Heavy");
+//   aqm.setFeatureName(feature_name); // test IS outside component_group
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
+//   // component_3
+//   aqm.setComponentName("atp.atp_1.Light");
+//   aqm.setISName("atp.atp_1.Heavy");
+//   aqm.setFeatureName(feature_name);
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
+
+//   absquant.setQuantMethods(quant_methods);
+
+//   // set up the standards
+//   std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_concentrations;
+//   components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
+//   components_concentrations["amp.amp_1.Light"] = make_amp_standards();
+//   components_concentrations["atp.atp_1.Light"] = make_atp_standards();
+
+//   absquant.optimizeCalibrationCurves(components_concentrations);
+//   std::map<String, AbsoluteQuantitationMethod> quant_methods_map = absquant.getQuantMethodsAsMap();
+
+//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.04);
+//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 40.0);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.999320072);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.04);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 11);
+
+//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
+//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
+//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("slope"), 0.95799683);
+//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("intercept"), -1.047543387);
+//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getCorrelationCoefficient(), 0.99916926);
+//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getLLOQ(), 0.02);
+//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getULOQ(), 40.0);
+//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getNPoints(), 11);
+
+//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
+//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
+//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("slope"), 0.623040824);
+//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("intercept"), 0.36130172586);
+//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getCorrelationCoefficient(), 0.998208402);
+//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getLLOQ(), 0.02);
+//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getULOQ(), 40.0);
+//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getNPoints(), 6);
+
+//   components_concentrations.clear();
+//   components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
+//   absquant_params.setValue("min_points", 20); // so that an optimal calibration curve is not found, and the sorting is not saved
+//   absquant.setParameters(absquant_params);
+//   absquant.optimizeCalibrationCurves(components_concentrations);
+//   quant_methods_map = absquant.getQuantMethodsAsMap();
+
+//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.01);
+//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 4.0);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.997143769417099);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.01);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 14);
+// END_SECTION
+
+// START_SECTION(void optimizeSingleCalibrationCurve(
+//   const String& component_name,
+//   std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations
+// ))
+//   // set up the quantitation method
+//   Param param;
+//   param.setValue("slope",1.0);
+//   param.setValue("intercept",0.0);
+//   param.setValue("x_weight", "ln(x)");
+//   param.setValue("y_weight", "ln(y)");
+//   param.setValue("x_datum_min", -1e12);
+//   param.setValue("x_datum_max", 1e12);
+//   param.setValue("y_datum_min", -1e12);
+//   param.setValue("y_datum_max", 1e12);
+//   AbsoluteQuantitationMethod aqm;
+//   aqm.setTransformationModel("linear");
+//   aqm.setTransformationModelParams(param);
+//   // set-up the quant_method map
+//   std::vector<AbsoluteQuantitationMethod> quant_methods;
+//   const String feature_name = "peak_apex_int";
+//   // component_1
+//   aqm.setComponentName("ser-L.ser-L_1.Light");
+//   aqm.setISName("ser-L.ser-L_1.Heavy");
+//   aqm.setFeatureName(feature_name);
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
+//   // component_2
+//   aqm.setComponentName("amp.amp_1.Light");
+//   aqm.setISName("amp.amp_1.Heavy");
+//   aqm.setFeatureName(feature_name); // test IS outside component_group
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
+//   // component_3
+//   aqm.setComponentName("atp.atp_1.Light");
+//   aqm.setISName("atp.atp_1.Heavy");
+//   aqm.setFeatureName(feature_name);
+//   aqm.setConcentrationUnits("uM");
+//   quant_methods.push_back(aqm);
+
+//   AbsoluteQuantitation absquant;
+//   // set-up the class parameters
+//   Param absquant_params;
+//   absquant_params.setValue("min_points", 4);
+//   absquant_params.setValue("max_bias", 30.0);
+//   absquant_params.setValue("min_correlation_coefficient", 0.9);
+//   absquant_params.setValue("max_iters", 100);
+//   absquant_params.setValue("outlier_detection_method", "iter_jackknife");
+//   absquant_params.setValue("use_chauvenet", "false");
+//   absquant.setParameters(absquant_params);
+//   absquant.setQuantMethods(quant_methods);
+
+//   // set up the standards
+//   std::map<String, std::vector<AbsoluteQuantitationStandards::featureConcentration>> components_concentrations;
+//   components_concentrations["ser-L.ser-L_1.Light"] = make_serL_standards();
+//   components_concentrations["amp.amp_1.Light"] = make_amp_standards();
+//   components_concentrations["atp.atp_1.Light"] = make_atp_standards();
+
+//   absquant.optimizeSingleCalibrationCurve("ser-L.ser-L_1.Light", components_concentrations.at("ser-L.ser-L_1.Light"));
+//   absquant.optimizeSingleCalibrationCurve("amp.amp_1.Light", components_concentrations.at("amp.amp_1.Light"));
+//   absquant.optimizeSingleCalibrationCurve("atp.atp_1.Light", components_concentrations.at("atp.atp_1.Light"));
+//   std::map<String, AbsoluteQuantitationMethod> quant_methods_map = absquant.getQuantMethodsAsMap();
+
+//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][0].actual_concentration, 0.04);
+//   TEST_REAL_SIMILAR(components_concentrations["ser-L.ser-L_1.Light"][8].actual_concentration, 40.0);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("slope"), 0.9011392589);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getTransformationModelParams().getValue("intercept"), 1.87018507);
+//   TEST_REAL_SIMILAR(quant_methods_map["ser-L.ser-L_1.Light"].getCorrelationCoefficient(), 0.999320072);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getLLOQ(), 0.04);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getULOQ(), 200);
+//   TEST_EQUAL(quant_methods_map["ser-L.ser-L_1.Light"].getNPoints(), 11);
+
+//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
+//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
+//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][0].actual_concentration, 0.02);
+//   TEST_REAL_SIMILAR(components_concentrations["amp.amp_1.Light"][8].actual_concentration, 8.0);
+//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("slope"), 0.95799683);
+//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getTransformationModelParams().getValue("intercept"), -1.047543387);
+//   TEST_REAL_SIMILAR(quant_methods_map["amp.amp_1.Light"].getCorrelationCoefficient(), 0.99916926);
+//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getLLOQ(), 0.02);
+//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getULOQ(), 40.0);
+//   TEST_EQUAL(quant_methods_map["amp.amp_1.Light"].getNPoints(), 11);
+
+//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
+//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
+//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][0].actual_concentration, 0.02);
+//   TEST_REAL_SIMILAR(components_concentrations["atp.atp_1.Light"][3].actual_concentration, 8.0);
+//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("slope"), 0.623040824);
+//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getTransformationModelParams().getValue("intercept"), 0.36130172586);
+//   TEST_REAL_SIMILAR(quant_methods_map["atp.atp_1.Light"].getCorrelationCoefficient(), 0.998208402);
+//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getLLOQ(), 0.02);
+//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getULOQ(), 40.0);
+//   TEST_EQUAL(quant_methods_map["atp.atp_1.Light"].getNPoints(), 6);
+// END_SECTION
+
+// /////////////////////////////
+// /* Protected Members **/
+// /////////////////////////////
+
+// START_SECTION((std::vector<AbsoluteQuantitationStandards::featureConcentration> extractComponents_(
+//       const std::vector<AbsoluteQuantitationStandards::featureConcentration> & component_concentrations,
+//       const std::vector<size_t>& component_concentrations_indices)))
+
+//   AbsoluteQuantitation_test absquant;
+//   // make the components_concentrations
+//   static const double arrx1[] = { 1.1, 2.0, 3.3, 3.9, 4.9, 6.2  };
+//   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
+//   static const double arry1[] = { 0.9, 1.9, 3.0, 3.7, 5.2, 6.1  };
+//   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
+//   // set-up the features
+//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
+//   AbsoluteQuantitationStandards::featureConcentration component_concentration;
+//   Feature component, IS_component;
+//   for (size_t i = 0; i < x1.size(); ++i)
+//   {
+//     component.setMetaValue("native_id","component" + std::to_string(i));
+//     component.setMetaValue("peak_apex_int",y1[i]);
+//     IS_component.setMetaValue("native_id","IS" + std::to_string(i));
+//     IS_component.setMetaValue("peak_apex_int",1.0);
+//     component_concentration.feature = component;
+//     component_concentration.IS_feature = IS_component;
+//     component_concentration.actual_concentration = x1[i];
+//     component_concentration.IS_actual_concentration = 1.0;
+//     component_concentration.dilution_factor = 1.0;
+//     component_concentrations.push_back(component_concentration);
+//   }
+
+//   // make the indices to extract
+//   static const size_t arrx2[] = { 0, 1, 3  };
+//   std::vector<size_t> component_concentrations_indices(arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
+
+//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations_sub = absquant.extractComponents_(
+//     component_concentrations, component_concentrations_indices);
+
+//   TEST_EQUAL(component_concentrations_sub[0].feature.getMetaValue("native_id"), "component0");
+//   TEST_REAL_SIMILAR(component_concentrations_sub[0].actual_concentration, 1.1);
+
+//   TEST_EQUAL(component_concentrations_sub[1].feature.getMetaValue("native_id"), "component1");
+//   TEST_REAL_SIMILAR(component_concentrations_sub[1].actual_concentration, 2.0);
+
+//   TEST_EQUAL(component_concentrations_sub[2].feature.getMetaValue("native_id"), "component3");
+//   TEST_REAL_SIMILAR(component_concentrations_sub[2].actual_concentration, 3.9);
+
+// END_SECTION
+
+// START_SECTION((int jackknifeOutlierCandidate_(
+//       const std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations,
+//       const String & feature_name,
+//       const String & transformation_model,
+//       const Param & transformation_model_params)))
+
+//   AbsoluteQuantitation_test absquant;
+
+//   static const double arrx1[] = { 1.1, 2.0,3.3,3.9,4.9,6.2  };
+//   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
+//   static const double arry1[] = { 0.9, 1.9,3.0,3.7,5.2,6.1  };
+//   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
+//   // set-up the features
+//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
+//   AbsoluteQuantitationStandards::featureConcentration component_concentration;
+//   Feature component, IS_component;
+//   for (size_t i = 0; i < x1.size(); ++i)
+//   {
+//     component.setMetaValue("native_id","component");
+//     component.setMetaValue("peak_apex_int",y1[i]);
+//     IS_component.setMetaValue("native_id","IS");
+//     IS_component.setMetaValue("peak_apex_int",1.0);
+//     component_concentration.feature = component;
+//     component_concentration.IS_feature = IS_component;
+//     component_concentration.actual_concentration = x1[i];
+//     component_concentration.IS_actual_concentration = 1.0;
+//     component_concentration.dilution_factor = 1.0;
+//     component_concentrations.push_back(component_concentration);
+//   }
+
+//   String feature_name = "peak_apex_int";
+
+//   // set-up the model and params
+//   // y = m*x + b
+//   // x = (y - b)/m
+//   Param transformation_model_params;
+//  //   String transformation_model = "TransformationModelLinear";
+//   String transformation_model = "linear";
+
+//   int c1 = absquant.jackknifeOutlierCandidate_(
+//     component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params);
+//   TEST_EQUAL(c1,4);
+
+//   static const double arrx2[] = { 1,2,3,4,5,6  };
+//   std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
+//   static const double arry2[] = { 1,2,3,4,5,6};
+//   std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
+//   component_concentrations.clear();
+//   for (size_t i = 0; i < x2.size(); ++i)
+//   {
+//     component.setMetaValue("native_id","component");
+//     component.setMetaValue("peak_apex_int",y2[i]);
+//     IS_component.setMetaValue("native_id","IS");
+//     IS_component.setMetaValue("peak_apex_int",1.0);
+//     component_concentration.feature = component;
+//     component_concentration.IS_feature = IS_component;
+//     component_concentration.actual_concentration = x2[i];
+//     component_concentration.IS_actual_concentration = 1.0;
+//     component_concentration.dilution_factor = 1.0;
+//     component_concentrations.push_back(component_concentration);
+//   }
+
+//   int c2 = absquant.jackknifeOutlierCandidate_(
+//     component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params);
+//   TEST_EQUAL(c2,0);
+
+// END_SECTION
+
+// START_SECTION((int residualOutlierCandidate_(
+//   const std::vector<AbsoluteQuantitationStandards::featureConcentration>& component_concentrations,
+//   const String & feature_name,
+//   const String & transformation_model,
+//   const Param & transformation_model_params)))
+
+//   AbsoluteQuantitation_test absquant;
+
+//   static const double arrx1[] = { 1.1, 2.0,3.3,3.9,4.9,6.2  };
+//   std::vector<double> x1 (arrx1, arrx1 + sizeof(arrx1) / sizeof(arrx1[0]) );
+//   static const double arry1[] = { 0.9, 1.9,3.0,3.7,5.2,6.1  };
+//   std::vector<double> y1 (arry1, arry1 + sizeof(arry1) / sizeof(arry1[0]) );
+//   // set-up the features
+//   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
+//   AbsoluteQuantitationStandards::featureConcentration component_concentration;
+//   Feature component, IS_component;
+//   for (size_t i = 0; i < x1.size(); ++i)
+//   {
+//     component.setMetaValue("native_id","component");
+//     component.setMetaValue("peak_apex_int",y1[i]);
+//     IS_component.setMetaValue("native_id","IS");
+//     IS_component.setMetaValue("peak_apex_int",1.0);
+//     component_concentration.feature = component;
+//     component_concentration.IS_feature = IS_component;
+//     component_concentration.actual_concentration = x1[i];
+//     component_concentration.IS_actual_concentration = 1.0;
+//     component_concentration.dilution_factor = 1.0;
+//     component_concentrations.push_back(component_concentration);
+//   }
+
+//   String feature_name = "peak_apex_int";
+
+//   // set-up the model and params
+//   // y = m*x + b
+//   // x = (y - b)/m
+//   Param transformation_model_params;
+//   // String transformation_model = "TransformationModelLinear";
+//   String transformation_model = "linear";
+
+//   int c1 = absquant.residualOutlierCandidate_(
+//     component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params);
+//   TEST_EQUAL(c1,4);
+
+//   static const double arrx2[] = { 1,2,3,4,5,6  };
+//   std::vector<double> x2 (arrx2, arrx2 + sizeof(arrx2) / sizeof(arrx2[0]) );
+//   static const double arry2[] = { 1,2,3,4,5,6};
+//   std::vector<double> y2 (arry2, arry2 + sizeof(arry2) / sizeof(arry2[0]) );
+//   component_concentrations.clear();
+//   for (size_t i = 0; i < x2.size(); ++i)
+//   {
+//     component.setMetaValue("native_id","component");
+//     component.setMetaValue("peak_apex_int",y2[i]);
+//     IS_component.setMetaValue("native_id","IS");
+//     IS_component.setMetaValue("peak_apex_int",1.0);
+//     component_concentration.feature = component;
+//     component_concentration.IS_feature = IS_component;
+//     component_concentration.actual_concentration = x2[i];
+//     component_concentration.IS_actual_concentration = 1.0;
+//     component_concentration.dilution_factor = 1.0;
+//     component_concentrations.push_back(component_concentration);
+//   }
+
+//   int c2 = absquant.residualOutlierCandidate_(
+//     component_concentrations,
+//     feature_name,
+//     transformation_model,
+//     transformation_model_params);
+//   TEST_EQUAL(c2,0);
+
+// END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitation_test.cpp
@@ -401,6 +401,32 @@ START_SECTION((void (
   std::vector<AbsoluteQuantitationStandards::featureConcentration> component_concentrations;
   AbsoluteQuantitationStandards::featureConcentration component_concentration;
   Feature component, IS_component;
+
+  String feature_name = "peak_apex_int";
+
+  // set-up the model and params
+  // y = m*x + b
+  // x = (y - b)/m
+  String transformation_model;
+  Param param;
+  // transformation_model = "TransformationModelLinear";
+  transformation_model = "linear";
+  param.setValue("slope",1.0);
+  param.setValue("intercept",0.0);
+  std::vector<double> biases = {0.0};
+  double correlation_coefficient = 0.0;
+
+  absquant.calculateBiasAndR(
+    component_concentrations,
+    feature_name,
+    transformation_model,
+    param,
+    biases,
+    correlation_coefficient);
+
+  TEST_REAL_SIMILAR(biases[0], 0.0);
+  TEST_REAL_SIMILAR(correlation_coefficient, 0.0);
+
   // point #1
   component.setMetaValue("native_id","component");
   component.setMetaValue("peak_apex_int",1.0);
@@ -434,20 +460,6 @@ START_SECTION((void (
   component_concentration.IS_actual_concentration = 1.0;
   component_concentration.dilution_factor = 1.0;
   component_concentrations.push_back(component_concentration);
-
-  String feature_name = "peak_apex_int";
-
-  // set-up the model and params
-  // y = m*x + b
-  // x = (y - b)/m
-  String transformation_model;
-  Param param;
-  // transformation_model = "TransformationModelLinear";
-  transformation_model = "linear";
-  param.setValue("slope",1.0);
-  param.setValue("intercept",0.0);
-  std::vector<double> biases;
-  double correlation_coefficient;
 
   absquant.calculateBiasAndR(
     component_concentrations,


### PR DESCRIPTION
### Description
When the IS for a feature is missing, but expected in the AbsoluteQuantitationMethod, strange behavior most likely resulting from some sort of memory fault occurs.  This strange behavior includes generating all 0s for each feature/IS ratio for seemingly random samples for the same component in what otherwise should be valid ratios.  

### Workaround
Filtering out all components that are missing an IS prior to calling OptimizeCalibrationCurves

### Fix (so as to not have to use the workaround)
- When an IS is expected, but not found during the call to `AbsoluteQuantitationStandards::mapComponentsToConcentrations`, the component is excluded.
- A check before weighting the data and calculating the pearson correlation coefficient is done so as to avoid an "invalidRange" error.