### PR TITLE
[FEATURE] MRMFeatureFilter: Add score to component and component groups

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 
 #ifndef OPENMS_ANALYSIS_OPENSWATH_MRMFEATUREFILTER_H

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
@@ -129,6 +129,25 @@ public:
     double calculateResolution(Feature & component_1, Feature & component_2);
 
     /**
+      @brief Checks if the metaValue is within the user specified range
+
+      @param[in] component component of the numerator
+      @param[in] meta_value_key Name of the metaValue
+      @param[in] meta_value_l Lower bound (inclusive) for the metaValue range
+      @param[in] meta_value_u Upper bound (inclusive) for the metaValue range
+      @param[out] key_exists true if the given key is found, false otherwise
+
+      @return True if the metaValue is within the bounds, and False otherwise.
+    */
+    bool checkMetaValue(
+      const Feature & component,
+      const String & meta_value_key,
+      const double & meta_value_l,
+      const double & meta_value_u,
+      bool & key_exists
+    ) const;
+
+    /**
       @brief Count the number of heavy/light labels and quantifying/detecting/identifying transitions
 
       @param component component_group with subordinates
@@ -151,7 +170,7 @@ public:
 
 private:
     template <typename T>
-    bool checkRange(T const& value, T const& value_l, T const& value_u);
+    bool checkRange(const T& value, const T& value_l, const T& value_u) const;
 
     // Members
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
@@ -127,19 +127,7 @@ public:
       @return The difference.
     */ 
     double calculateResolution(Feature & component_1, Feature & component_2);
-    
-    /**
-      @brief Checks if the metaValue is within the user specified range
 
-      @param component component of the numerator
-      @param meta_value_key Name of the metaValue
-      @param meta_value_l Lower bound (inclusive) for the metaValue range
-      @param meta_value_u Upper bound (inclusive) for the metaValue range
-
-      @return True if the metaValue is within the bounds, and False otherwise.
-    */ 
-    bool checkMetaValue(const Feature & component, const String & meta_value_key, const double & meta_value_l, const double & meta_value_u);
-    
     /**
       @brief Count the number of heavy/light labels and quantifying/detecting/identifying transitions
 

--- a/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
@@ -134,6 +134,38 @@ START_SECTION(double calculateIonRatio(const Feature & component_1, const Featur
 }
 END_SECTION
 
+START_SECTION(bool checkMetaValue(
+  const Feature & component,
+  const String & meta_value_key,
+  const double & meta_value_l,
+  const double & meta_value_u,
+  bool & key_exists
+) const)
+{
+  MRMFeatureFilter mrmff;
+  bool metavalue_exists;
+
+  //make test feature
+  String feature_name = "peak_apex_int";
+  OpenMS::Feature component_1;
+  component_1.setMetaValue(feature_name, 5.0);
+  component_1.setMetaValue("native_id","component1");
+
+  // test parameters
+  double meta_value_l(4.0), meta_value_u(6.0);
+  TEST_EQUAL(mrmff.checkMetaValue(component_1, feature_name, meta_value_l, meta_value_u, metavalue_exists), true); // pass case
+  TEST_EQUAL(metavalue_exists, true);
+  component_1.setMetaValue(feature_name, 6.0);
+  TEST_EQUAL(mrmff.checkMetaValue(component_1, feature_name, meta_value_l, meta_value_u,metavalue_exists), true); // edge pass case
+  TEST_EQUAL(metavalue_exists, true);
+  component_1.setMetaValue(feature_name, 3.0);
+  TEST_EQUAL(mrmff.checkMetaValue(component_1, feature_name, meta_value_l, meta_value_u, metavalue_exists), false); // fail case
+  TEST_EQUAL(metavalue_exists, true);
+  TEST_EQUAL(mrmff.checkMetaValue(component_1, "peak_area", meta_value_l, meta_value_u, metavalue_exists), true); // not found case
+  TEST_EQUAL(metavalue_exists, false);
+}
+END_SECTION
+
 START_SECTION((std::map<String,int> countLabelsAndTransitionTypes(const Feature & component_group, const TargetedExperiment & transitions)))
 {
   MRMFeatureFilter mrmff;

--- a/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
@@ -28,8 +28,8 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // 
 // --------------------------------------------------------------------------
-// $Maintainer: Douglas McCloskey $
-// $Authors: Douglas McCloskey $
+// $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
+// $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
 // --------------------------------------------------------------------------
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>
@@ -451,6 +451,13 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[1].getMetaValue("QC_transition_group_message"), "n_light;n_transitions");
   TEST_EQUAL(components[1].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[1].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 0.75);
+  TEST_REAL_SIMILAR(components[1].getMetaValue("QC_transition_group_score"), 0.666666666666667);
+  TEST_REAL_SIMILAR(components[1].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[1].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   
   //test filter mode
   params.setValue("flag_or_filter", "filter");
@@ -594,6 +601,10 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), true);
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
   
   // RT
@@ -671,6 +682,10 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "intensity");
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 0.75);
   components.clear();
   
   // OverallQuality
@@ -709,6 +724,10 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "overall_quality");
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 0.75);
   components.clear();
   
   // MetaValue
@@ -747,6 +766,10 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "metaValue[peak_apex_int]");
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 0.75);
   components.clear();
   
   // n_heavy
@@ -782,6 +805,10 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), true);
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 0.842105263157895);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
   
   // n_light
@@ -820,6 +847,10 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), true);
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 0.842105263157895);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
   
   // n_transitions
@@ -849,6 +880,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_transitions");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 0.833333333333333);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
   
   // ion_ratio_pair
@@ -887,6 +921,10 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), true);
+  TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 0.947368421052632);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
+  TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
 
 }

--- a/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
@@ -134,28 +134,6 @@ START_SECTION(double calculateIonRatio(const Feature & component_1, const Featur
 }
 END_SECTION
 
-START_SECTION(bool checkMetaValue(const Feature & component, const String & meta_value_key, const double & meta_value_l, const double & meta_value_u))
-{
-  MRMFeatureFilter mrmff;
-
-  //make test feature
-  String feature_name = "peak_apex_int";
-  OpenMS::Feature component_1;
-  component_1.setMetaValue(feature_name, 5.0);
-  component_1.setMetaValue("native_id","component1");
-
-  // test parameters
-  double meta_value_l(4.0), meta_value_u(6.0);
-  TEST_EQUAL(mrmff.checkMetaValue(component_1, feature_name, meta_value_l, meta_value_u), true); // pass case
-  component_1.setMetaValue(feature_name, 6.0);
-  TEST_EQUAL(mrmff.checkMetaValue(component_1, feature_name, meta_value_l, meta_value_u), true); // edge pass case
-  component_1.setMetaValue(feature_name, 3.0);
-  TEST_EQUAL(mrmff.checkMetaValue(component_1, feature_name, meta_value_l, meta_value_u), false); // fail case
-  TEST_EQUAL(mrmff.checkMetaValue(component_1, "peak_area", meta_value_l, meta_value_u), true);  // not found case
-
-}
-END_SECTION
-
 START_SECTION((std::map<String,int> countLabelsAndTransitionTypes(const Feature & component_group, const TargetedExperiment & transitions)))
 {
   MRMFeatureFilter mrmff;
@@ -569,6 +547,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cqcs.overall_quality_l = 100;
   cqcs.overall_quality_u = 500;
   cqcs.meta_value_qc["peak_apex_int"] = lbub;
+  cqcs.meta_value_qc["peak_area"] = lbub;
   // transition 2
   cqcs.component_name = "component1.1.Light";   
   cqcs.retention_time_l = 2.0;


### PR DESCRIPTION
Metavalues `"QC_transition_score"` and `"QC_transition_group_score"` are added to features and sub-features.

The score is simply:
_(number of QC tests passing) / (number of QC tests)_

A small change was applied to `checkMetaValue()`, which now also informs the caller whether the metavalue actually exists (necessary for counting the number of tests involved).