### PR TITLE
FileInfo and Comet optimizations

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -70,8 +70,11 @@ public:
     /**
        @brief Rename a file
        
-       If the target already exists, this function will fail unless @p overwrite_existing is true.
-
+       If @p from and @p to point to the same file (symlinks are resolved),
+       no action will be taken and true is returned.
+       If the target already exists (and is not identical to the source),
+       this function will fail unless @p overwrite_existing is true.
+       
        @param from Source filename
        @param to Target filename
        @param overwrite_existing Delete already existing target, before renaming

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -36,13 +36,12 @@
 #define OPENMS_SYSTEM_FILE_H
 
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
-#include <OpenMS/DATASTRUCTURES/Param.h>
 #include <OpenMS/config.h>
 
 
 namespace OpenMS
 {
-
+  class Param;
   class TOPPBase;
 
   /**
@@ -68,8 +67,18 @@ public:
     /// Return true if the file does not exist or the file is empty
     static bool empty(const String& file);
 
-    /// Rename file; return true on success
-    static bool rename(const String& from, const String& to);
+    /**
+       @brief Rename a file
+       
+       If the target already exists, this function will fail unless @p overwrite_existing is true.
+
+       @param from Source filename
+       @param to Target filename
+       @param overwrite_existing Delete already existing target, before renaming
+       @param verbose Print message to LOG_ERROR if something goes wrong.
+       @return True on success
+    */
+    static bool rename(const String& from, const String& to, bool overwrite_existing = true, bool verbose = true);
 
     /**
       @brief Removes a file (if it exists).
@@ -221,7 +230,7 @@ private:
 
 
     /**
-      @brief Internal helper class, which holds temporary filenames and deletes these file at program exit
+      @brief Internal helper class, which holds temporary filenames and deletes these files at program exit
     */
     class TemporaryFiles_
     {
@@ -232,7 +241,8 @@ private:
 
         ~TemporaryFiles_();
       private:
-        TemporaryFiles_(const TemporaryFiles_&); // copy is forbidden
+        TemporaryFiles_(const TemporaryFiles_&) = delete; // copy is forbidden
+        TemporaryFiles_& operator=(const TemporaryFiles_&) = delete;
         StringList filenames_;
     };
 

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -68,6 +68,9 @@ public:
     /// Return true if the file does not exist or the file is empty
     static bool empty(const String& file);
 
+    /// Rename file; return true on success
+    static bool rename(const String& from, const String& to);
+
     /**
       @brief Removes a file (if it exists).
 

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -116,6 +116,11 @@ namespace OpenMS
     return !fi.exists() || fi.size() == 0;
   }
 
+  bool File::rename(const String& from, const String& to)
+  {
+    return QFile::rename(from.toQString(), to.toQString());
+  }
+
   bool File::remove(const String& file)
   {
     if (!exists(file))

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -39,6 +39,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 
 #include <OpenMS/DATASTRUCTURES/DateTime.h>
+#include <OpenMS/DATASTRUCTURES/Param.h>
 
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 
@@ -116,9 +117,21 @@ namespace OpenMS
     return !fi.exists() || fi.size() == 0;
   }
 
-  bool File::rename(const String& from, const String& to)
+  bool File::rename(const String& from, const String& to, bool overwrite_existing, bool verbose)
   {
-    return QFile::rename(from.toQString(), to.toQString());
+    // existing file? Qt won't overwrite, so try to remove it:
+    if (exists(to) && !remove(to))
+    {
+      LOG_ERROR << "Error: Could not overwrite existing file '" << to << "'\n";
+      return false;
+    }
+    // move the file to the actual destination:
+    if (!QFile::rename(from.toQString(), to.toQString()))
+    {
+      LOG_ERROR << "Error: Could not move '" << from << "' to '" << to << "'\n";
+      return false;
+    }
+    return true;
   }
 
   bool File::remove(const String& file)

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -119,6 +119,12 @@ namespace OpenMS
 
   bool File::rename(const String& from, const String& to, bool overwrite_existing, bool verbose)
   {
+    // check for equality
+    if (QFileInfo(from.c_str()).canonicalFilePath() == QFileInfo(to.c_str()).canonicalFilePath())
+    { // same file; no need to to anything
+      return true;
+    }
+
     // existing file? Qt won't overwrite, so try to remove it:
     if (overwrite_existing && exists(to) && !remove(to))
     {

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -120,15 +120,15 @@ namespace OpenMS
   bool File::rename(const String& from, const String& to, bool overwrite_existing, bool verbose)
   {
     // existing file? Qt won't overwrite, so try to remove it:
-    if (exists(to) && !remove(to))
+    if (overwrite_existing && exists(to) && !remove(to))
     {
-      LOG_ERROR << "Error: Could not overwrite existing file '" << to << "'\n";
+      if (verbose) LOG_ERROR << "Error: Could not overwrite existing file '" << to << "'\n";
       return false;
     }
     // move the file to the actual destination:
     if (!QFile::rename(from.toQString(), to.toQString()))
     {
-      LOG_ERROR << "Error: Could not move '" << from << "' to '" << to << "'\n";
+      if (verbose) LOG_ERROR << "Error: Could not move '" << from << "' to '" << to << "'\n";
       return false;
     }
     return true;

--- a/src/tests/topp/FileInfo_17_output.txt
+++ b/src/tests/topp/FileInfo_17_output.txt
@@ -3,12 +3,14 @@
 
 File name: fasta-example.fa
 File type: fasta
-Number of sequences: 11
+Warning: Duplicate header, #7, ID: crab_chick = #2, ID: crab_chick
+Warning: Duplicate header, #10, ID: crab_squac = #9, ID: crab_squac
+Warning: Duplicate sequence, #10, ID: crab_squac = #9, ID: crab_squac
 
-Warning: Duplicate header, Number: 7, ID: crab_chick is same as Number: 2, ID: crab_chick
-Warning: Duplicate header, Number: 10, ID: crab_squac is same as Number: 9, ID: crab_squac
-Warning: Duplicate sequence, Number: 10, ID: crab_squac is same as Number: 9, ID: crab_squac
-Total amino acids: 1933
+Number of sequences   : 11
+# duplicated headers  : 2 (18.1%)
+# duplicated sequences: 1 (9%)
+Total amino acids     : 1933
 
 Amino acid counts: 
 *	2
@@ -33,5 +35,8 @@ T	82
 V	114
 W	24
 Y	21
+Ambiguous amino acids (B/Z/X)  : 0 (0%)
+                      (B/Z/X/I): 115 (5.94%)
+
 
 

--- a/src/tests/topp/FileInfo_17_output.txt
+++ b/src/tests/topp/FileInfo_17_output.txt
@@ -5,7 +5,7 @@ File name: fasta-example.fa
 File type: fasta
 Warning: Duplicate header, #7, ID: crab_chick = #2, ID: crab_chick
 Warning: Duplicate header, #10, ID: crab_squac = #9, ID: crab_squac
-Warning: Duplicate sequence, #10, ID: crab_squac = #9, ID: crab_squac
+Warning: Duplicate sequence, #10, ID: crab_squac == #9, ID: crab_squac
 
 Number of sequences   : 11
 # duplicated headers  : 2 (18.1%)

--- a/src/tests/topp/FileInfo_17_output.txt
+++ b/src/tests/topp/FileInfo_17_output.txt
@@ -9,7 +9,7 @@ Warning: Duplicate sequence, #10, ID: crab_squac == #9, ID: crab_squac
 
 Number of sequences   : 11
 # duplicated headers  : 2 (18.1%)
-# duplicated sequences: 1 (9%)
+# duplicated sequences: 1 (9%) [by exact string matching]
 Total amino acids     : 1933
 
 Amino acid counts: 

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -32,26 +32,19 @@
 // $Authors: Leon Bichmann, Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/APPLICATIONS/TOPPBase.h>
+
 #include <OpenMS/FORMAT/MzMLFile.h>
-#include <OpenMS/FORMAT/MzDataFile.h>
 #include <OpenMS/FORMAT/PepXMLFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
+#include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/CHEMISTRY/ResidueDB.h>
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
-#include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/FORMAT/FileHandler.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
-#include <OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>
-#include <OpenMS/CHEMISTRY/ProteaseDB.h>
 
-#include <QtCore/QFile>
 #include <QtCore/QProcess>
-#include <QDir>
-#include <QDebug>
-#include <iostream>
+
 #include <fstream>
 
 using namespace OpenMS;
@@ -523,24 +516,19 @@ protected:
     //-------------------------------------------------------------
     // parsing parameters
     //-------------------------------------------------------------
+    
+    // do this early, to see if comet is installed
+    String comet_executable = getStringOption_("comet_executable");
+    String tmp_param = File::getTemporaryFile();
+    int status = QProcess::execute(comet_executable.toQString(), QStringList() << "-p" << tmp_param.c_str()); // does automatic escaping etc...
+    if (status != 0)
+    {
+      writeLog_("Comet problem. Aborting! Calling command was: '" + comet_executable + " -p \"" + tmp_param + "\"'.\nDoes the Comet executable exist?");
+      return EXTERNAL_PROGRAM_ERROR;
+    }
 
     String inputfile_name = getStringOption_("in");
-    writeDebug_(String("Input file: ") + inputfile_name, 1);
-    if (inputfile_name.empty())
-    {
-      writeLog_("No input file specified. Aborting!");
-      printUsage_();
-      return ILLEGAL_PARAMETERS;
-    }
-
     String out = getStringOption_("out");
-    writeDebug_(String("Output file___real one: ") + out, 1);
-    if (out.empty())
-    {
-      writeLog_("No output file specified. Aborting!");
-      printUsage_();
-      return ILLEGAL_PARAMETERS;
-    }
 
 
     //-------------------------------------------------------------
@@ -564,11 +552,8 @@ protected:
     }
 
     //tmp_dir
-    //const String tmp_dir = QDir::toNativeSeparators((File::getTempDirectory() + "/").toQString());
     const String tmp_dir = makeTempDirectory_(); //OpenMS::File::getTempDirectory() + "/";
     writeDebug_("Creating temporary directory '" + tmp_dir + "'", 1);
-    //QDir d;
-    //d.mkpath(tmp_dir.toQString());
     String tmp_pepxml = tmp_dir + "result.pep.xml";
     String tmp_pin = tmp_dir + "result.pin";
     String default_params = getStringOption_("default_params_file");
@@ -589,7 +574,7 @@ protected:
 
     PeakMap exp;
     MzMLFile mzml_file;
-    mzml_file.getOptions().addMSLevel(2); // only load msLevel 2 //TO DO: setMSLevels or clearMSLevels
+    mzml_file.getOptions().setMSLevels({2}); // only load msLevel 2 
     mzml_file.setLogType(log_type_);
     mzml_file.load(inputfile_name, exp);
 
@@ -616,13 +601,11 @@ protected:
     String paramN = "-N" + File::removeExtension(File::removeExtension(tmp_pepxml));
     QStringList process_params;
     process_params << paramP.toQString() << paramN.toQString() << inputfile_name.toQString();
-    qDebug() << process_params;
 
-    String comet_executable = getStringOption_("comet_executable");
-    int status = QProcess::execute(comet_executable.toQString(),process_params); // does automatic escaping etc...
+    status = QProcess::execute(comet_executable.toQString(), process_params); // does automatic escaping etc...
     if (status != 0)
     {
-      writeLog_("Comet problem. Aborting! Calling command was: '" + comet_executable + " \"" + inputfile_name + "\"'.\nDoes the Comet executable exist?");
+      writeLog_("Comet problem. Aborting! Calling command was: '" + comet_executable + " \"" + inputfile_name + "\"'.\n");
       return EXTERNAL_PROGRAM_ERROR;
     }
 
@@ -649,13 +632,13 @@ protected:
     if (!pin_out.empty())
     {
       // existing file? Qt won't overwrite, so try to remove it:
-      if (QFile::exists(pin_out.toQString()) && !QFile::remove(pin_out.toQString()))
+      if (File::exists(pin_out) && !File::remove(pin_out))
       {
         writeLog_("Fatal error: Could not overwrite existing file '" + pin_out + "'");
         return CANNOT_WRITE_OUTPUT_FILE;
       }
       // move the temporary file to the actual destination:
-      if (!QFile::rename(tmp_pin.toQString(), pin_out.toQString()))
+      if (!File::rename(tmp_pin, pin_out))
       {
         writeLog_("Fatal error: Could not move temporary mzid file to '" + pin_out + "'");
         return CANNOT_WRITE_OUTPUT_FILE;

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -630,17 +630,9 @@ protected:
 
     String pin_out = getStringOption_("pin_out");
     if (!pin_out.empty())
-    {
-      // existing file? Qt won't overwrite, so try to remove it:
-      if (File::exists(pin_out) && !File::remove(pin_out))
-      {
-        writeLog_("Fatal error: Could not overwrite existing file '" + pin_out + "'");
-        return CANNOT_WRITE_OUTPUT_FILE;
-      }
-      // move the temporary file to the actual destination:
+    { // move the temporary file to the actual destination:
       if (!File::rename(tmp_pin, pin_out))
       {
-        writeLog_("Fatal error: Could not move temporary mzid file to '" + pin_out + "'");
         return CANNOT_WRITE_OUTPUT_FILE;
       }
     }

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -462,7 +462,7 @@ protected:
       os << "\n";
       os << "Number of sequences   : " << entries.size() << "\n";
       os << "# duplicated headers  : " << dup_header << " (" << (entries.empty() ? 0 : (dup_header * 1000 / entries.size()) / 10.0) << "%)\n";
-      os << "# duplicated sequences: " << dup_seq << " (" << (entries.empty() ? 0 : (dup_seq * 1000 / entries.size()) / 10.0) << "%)\n";
+      os << "# duplicated sequences: " << dup_seq << " (" << (entries.empty() ? 0 : (dup_seq * 1000 / entries.size()) / 10.0) << "%) [by exact string matching]\n";
       os << "Total amino acids     : " << number_of_aacids << "\n\n";
       os << "Amino acid counts: \n";
 

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -443,7 +443,7 @@ protected:
             vector<ptrdiff_t>::const_iterator iter = find_if(it_id->second.begin(), it_id->second.end(), [&loopiter, &entries](const ptrdiff_t& idx) { return entries[idx].sequenceMatches(*loopiter); });
             if (iter != it_id->second.end())
             {
-              os << "Warning: Duplicate sequence, #" << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " = #" << *iter << ", ID: " << entries[*iter].identifier << "\n";
+              os << "Warning: Duplicate sequence, #" << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " == #" << *iter << ", ID: " << entries[*iter].identifier << "\n";
               ++dup_seq;
             }
 

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -60,6 +60,8 @@
 
 #include <QtCore/QString>
 
+#include <unordered_map>
+
 using namespace OpenMS;
 using namespace std;
 
@@ -398,46 +400,80 @@ protected:
       vector<FASTAFile::FASTAEntry> entries;
       FASTAFile file;
 
-      map<char, int> aacids;
+      Map<char, int> aacids; // required for default construction of non-existing keys
       size_t number_of_aacids = 0;
 
       SysInfo::MemUsage mu;
-      //loading input
+      // loading input
       file.load(in, entries);
       std::cout << "\n\n" << mu.delta("loading FASTA") << std::endl;
 
-      os << "Number of sequences: " << entries.size() << "\n"
-         << "\n";
+      int dup_header(0);
+      int dup_seq(0);
 
+      typedef std::unordered_map<size_t, vector<ptrdiff_t> > SHashmap;
+      SHashmap m_headers;
+      SHashmap m_seqs;
+      
+      std::hash<string> s_hash;
       for (auto loopiter = entries.begin(); loopiter != entries.end(); ++loopiter)
       {
-        auto iter = find_if(entries.begin(), loopiter, [&loopiter](const FASTAFile::FASTAEntry& entry) { return entry.headerMatches(*loopiter); });
-        if (iter != loopiter)
         {
-          os << "Warning: Duplicate header, Number: " << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " is same as Number: " << std::distance(entries.begin(), iter) << ", ID: " << iter->identifier << "\n";
+          size_t id_hash = s_hash(loopiter->identifier);
+          auto it_id = m_headers.find(id_hash);
+          if (it_id != m_headers.end())
+          { // hash matches ... test the real indices to make sure
+            vector<ptrdiff_t>::const_iterator iter = find_if(it_id->second.begin(), it_id->second.end(), [&loopiter, &entries](const ptrdiff_t& idx) { return entries[idx].headerMatches(*loopiter); });
+            if (iter != it_id->second.end())
+            {
+              os << "Warning: Duplicate header, #" << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " = #" << *iter << ", ID: " << entries[*iter].identifier << "\n";
+              ++dup_header;
+            }
+
+          }
+          // add our own hash
+          m_headers[id_hash] = { std::distance(entries.begin(), loopiter) };
         }
 
-        iter = find_if(entries.begin(), loopiter, [&loopiter](const FASTAFile::FASTAEntry& entry) { return entry.sequenceMatches(*loopiter); });
-        if (iter != loopiter && iter != entries.end())
         {
-          os << "Warning: Duplicate sequence, Number: " << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " is same as Number: " << std::distance(entries.begin(), iter) << ", ID: " << iter->identifier << "\n";
-        }
+          size_t id_seq = s_hash(loopiter->sequence);
+          auto it_id = m_seqs.find(id_seq);
+          if (it_id != m_seqs.end())
+          { // hash matches ... test the real indices to make sure
+            vector<ptrdiff_t>::const_iterator iter = find_if(it_id->second.begin(), it_id->second.end(), [&loopiter, &entries](const ptrdiff_t& idx) { return entries[idx].sequenceMatches(*loopiter); });
+            if (iter != it_id->second.end())
+            {
+              os << "Warning: Duplicate sequence, #" << std::distance(entries.begin(), loopiter) << ", ID: " << loopiter->identifier << " = #" << *iter << ", ID: " << entries[*iter].identifier << "\n";
+              ++dup_seq;
+            }
 
-        for (Size i = 0; i < loopiter->sequence.size(); i++)
+          }
+          // add our own hash
+          m_seqs[id_seq] = { std::distance(entries.begin(), loopiter) };
+        }
+        
+        for (char a : loopiter->sequence)
         {
-          ++aacids[loopiter->sequence[i]];
+          ++aacids[a];
         }
         number_of_aacids += loopiter->sequence.size();
       }
 
-      os << "Total amino acids: " << number_of_aacids << "\n\n";
-      os << "Amino acid counts: "
-         << "\n";
+      os << "\n";
+      os << "Number of sequences   : " << entries.size() << "\n";
+      os << "# duplicated headers  : " << dup_header << " (" << (entries.empty() ? 0 : (dup_header * 1000 / entries.size()) / 10.0) << "%)\n";
+      os << "# duplicated sequences: " << dup_seq << " (" << (entries.empty() ? 0 : (dup_seq * 1000 / entries.size()) / 10.0) << "%)\n";
+      os << "Total amino acids     : " << number_of_aacids << "\n\n";
+      os << "Amino acid counts: \n";
 
       for (auto it = aacids.begin(); it != aacids.end(); ++it)
       {
         os << it->first << '\t' << it->second << "\n";
       }
+      size_t amb = aacids['B'] + aacids['Z'] + aacids['X'] + aacids['b'] + aacids['z'] + aacids['x'];
+      size_t amb_I = amb + aacids['I'] + aacids['i'];
+      os << "Ambiguous amino acids (B/Z/X)  : " << amb   << " (" << (amb > 0 ? (amb * 10000 / number_of_aacids / 100.0) : 0) << "%)\n";
+      os << "                      (B/Z/X/I): " << amb_I << " (" << (amb_I > 0 ? (amb_I * 10000 / number_of_aacids / 100.0) : 0) << "%)\n\n";
     }
 
     else if (in_type == FileTypes::FEATUREXML) //features

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -33,25 +33,20 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
-#include <OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>
+
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/FORMAT/CsvFile.h>
 #include <OpenMS/FORMAT/IdXMLFile.h>
-#include <OpenMS/FORMAT/IdXMLFile.h>
-#include <OpenMS/FORMAT/MascotXMLFile.h>
-#include <OpenMS/FORMAT/MzDataFile.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/FORMAT/MzIdentMLFile.h>
-#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/METADATA/ProteinIdentification.h>
+#include <OpenMS/METADATA/SpectrumMetaDataLookup.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/SYSTEM/JavaInfo.h>
 
-#include <QtCore/QFile>
 #include <QtCore/QProcess>
-#include <QDir>
 
 #include <algorithm>
 #include <fstream>
@@ -745,17 +740,9 @@ protected:
     //-------------------------------------------------------------
 
     if (!mzid_out.empty())
-    {
-      // existing file? Qt won't overwrite, so try to remove it:
-      if (QFile::exists(mzid_out.toQString()) && !QFile::remove(mzid_out.toQString()))
+    { // move the temporary file to the actual destination:
+      if (!File::rename(mzid_temp, mzid_out))
       {
-        writeLog_("Fatal error: Could not overwrite existing file '" + mzid_out + "'");
-        return CANNOT_WRITE_OUTPUT_FILE;
-      }
-      // move the temporary file to the actual destination:
-      if (!QFile::rename(mzid_temp.toQString(), mzid_out.toQString()))
-      {
-        writeLog_("Fatal error: Could not move temporary mzid file to '" + mzid_out + "'");
         return CANNOT_WRITE_OUTPUT_FILE;
       }
     }

--- a/src/topp/MascotAdapterOnline.cpp
+++ b/src/topp/MascotAdapterOnline.cpp
@@ -45,7 +45,6 @@
 
 #include <sstream>
 
-#include <QtCore/QDir>
 #include <QtCore/QFile>
 #include <QtCore/QCoreApplication>
 #include <QtCore/QTimer>

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>
+
 #include <OpenMS/CHEMISTRY/ProteaseDB.h>
 #include <OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
@@ -46,9 +47,7 @@
 #include <OpenMS/METADATA/SpectrumLookup.h>
 #include <OpenMS/SYSTEM/File.h>
 
-#include <QtCore/QFile>
 #include <QtCore/QProcess>
-#include <QDir>
 
 #include <fstream>
 
@@ -364,22 +363,13 @@ protected:
     //-------------------------------------------------------------
 
     if (!xml_out.empty())
-    {
-      // existing file? Qt won't overwrite, so try to remove it:
-      if (QFile::exists(xml_out.toQString()) &&
-          !QFile::remove(xml_out.toQString()))
+    { // move the temporary file to the actual destination:
+      if (!File::rename(tandem_output_filename, xml_out))
       {
-        writeLog_("Fatal error: Could not overwrite existing file '" + xml_out + "'");
-        return CANNOT_WRITE_OUTPUT_FILE;
-      }
-      // move the temporary file to the actual destination:
-      if (!QFile::rename(tandem_output_filename.toQString(), xml_out.toQString()))
-      {
-        writeLog_("Fatal error: Could not move temporary X! Tandem XML file to '" + xml_out + "'");
         return CANNOT_WRITE_OUTPUT_FILE;
       }
     }
-
+    
     if (!out.empty())
     {
       // handle the search parameters


### PR DESCRIPTION
[FIX] FileInfo's FASTA summary uses hashes to detect duplicates (old: quadratic runtime; new linear at the cost of 10% more memory; reporting of duplicate and AAA stats)

[FIX] minor changes to CometAdapter: remove excess includes; check for comet.exe before expensive mzML loading;

[FEATURE] add support for file rename in File.cpp (avoids inclusion of QDir in tools)