### PR TITLE
[FEATURE] move IDConflict resolver to algorithm, keep conflicting (make unmapped)

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
@@ -89,7 +89,6 @@ protected:
     for (PeptideIdentification & p : map.getUnassignedPeptideIdentifications())
     {
       p.setMetaValue("feature_id", "not mapped"); // not mapped to a feature
-      p.setMetaValue("feature_leader", false); // and, thus, no id leader of a feature
     }
 
     for (auto & c : map)
@@ -153,7 +152,6 @@ protected:
     // copy conflicting ones left to best one
     for (auto it = peptides.begin(); it != pos; ++it)
     {
-      it->setMetaValue("feature_leader", false);
       removed.push_back(*it);
     }
      
@@ -161,13 +159,11 @@ protected:
     vector<PeptideIdentification>::iterator pos1p = pos + 1;
     for (auto it = pos1p; it != peptides.end(); ++it)
     {
-      it->setMetaValue("feature_leader", false);
       removed.push_back(*it);
     }
 
     // set best one to first position and shrink vector
     peptides[0] = *pos;
-    peptides[0].setMetaValue("feature_leader", true);
     peptides.resize(1);
   }
 };

--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
@@ -1,0 +1,178 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2017.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hendrik Weisser $
+// $Authors: Hendrik Weisser, Lucia Espona $
+// --------------------------------------------------------------------------
+
+#ifndef OPENMS_ANALYSIS_ID_IDCONFLICTRESOLVERALGORITHM
+#define OPENMS_ANALYSIS_ID_IDCONFLICTRESOLVERALGORITHM
+
+#include <OpenMS/APPLICATIONS/TOPPBase.h>
+
+#include <OpenMS/FORMAT/ConsensusXMLFile.h>
+#include <OpenMS/FORMAT/FeatureXMLFile.h>
+#include <OpenMS/FORMAT/FileHandler.h>
+#include <OpenMS/METADATA/PeptideIdentification.h>
+
+#include <algorithm>
+
+using namespace OpenMS;
+using namespace std;
+
+//-------------------------------------------------------------
+// Doxygen docu
+//-------------------------------------------------------------
+
+/**
+    @page TOPP_IDConflictResolver IDConflictResolver
+
+    @brief Resolves ambiguous annotations of features with peptide identifications.
+
+    The peptide identifications are filtered so that only one identification
+    with a single hit (with the best score) is associated to each feature. (If
+    two IDs have the same best score, either one of them may be selected.)
+
+    The the filtered identifications are added to the vector of unassigned peptides
+    and also reduced to a single best hit.
+
+*/
+
+namespace OpenMS
+{
+
+class OPENMS_DLLAPI IDConflictResolverAlgorithm
+{
+public:
+  static void resolve(FeatureMap & features)
+  {
+    resolveConflict_(features);
+  }
+
+  static void resolve(ConsensusMap & features)
+  {
+    resolveConflict_(features);
+  }
+
+protected:
+  template<class T>
+  static void resolveConflict_(T & map)
+  {
+    // annotate as not part of the resolution
+    for (PeptideIdentification & p : map.getUnassignedPeptideIdentifications())
+    {
+      p.setMetaValue("feature_id", "not mapped"); // not mapped to a feature
+      p.setMetaValue("feature_leader", false); // and, thus, no id leader of a feature
+    }
+
+    for (auto & c : map)
+    {
+      c.setMetaValue("feature_id", String(c.getUniqueId()));
+      resolveConflict_(c.getPeptideIdentifications(), 
+        map.getUnassignedPeptideIdentifications(),
+        c.getUniqueId());
+    }
+  }
+
+  // compare peptide IDs by score of best hit (hits must be sorted first!)
+  // (note to self: the "static" is necessary to avoid cryptic "no matching
+  // function" errors from gcc when the comparator is used below)
+  static bool compareIDsSmallerScores_(const PeptideIdentification & left,
+                          const PeptideIdentification & right)
+  {
+    // if any of them is empty, the other is considered "greater"
+    // independent of the score in the first hit
+    if (left.getHits().empty()) return true;
+    if (right.getHits().empty()) return false;
+    if (left.getHits()[0].getScore() < right.getHits()[0].getScore())
+    {
+      return true;
+    }
+    return false;
+  }
+
+  static void resolveConflict_(
+    vector<PeptideIdentification> & peptides, 
+    vector<PeptideIdentification> & removed,
+    UInt64 uid)
+  {
+    if (peptides.empty()) { return; }
+
+    for (PeptideIdentification & pep : peptides)
+    {
+      // sort hits
+      pep.sort();
+
+      // remove all but the best hit
+      if (!pep.getHits().empty())
+      {
+        vector<PeptideHit> best_hit(1, pep.getHits()[0]);
+        pep.setHits(best_hit);
+      }
+      // annotate feature id
+      pep.setMetaValue("feature_id", String(uid));
+    }
+
+    vector<PeptideIdentification>::iterator pos;
+    if (peptides[0].isHigherScoreBetter())     // find highest-scoring ID
+    {
+      pos = max_element(peptides.begin(), peptides.end(), compareIDsSmallerScores_);
+    }
+    else  // find lowest-scoring ID
+    {
+      pos = min_element(peptides.begin(), peptides.end(), compareIDsSmallerScores_);
+    }
+
+    // copy conflicting ones left to best one
+    for (auto it = peptides.begin(); it != pos; ++it)
+    {
+      it->setMetaValue("feature_leader", false);
+      removed.push_back(*it);
+    }
+     
+    // copy conflicting ones right of best one
+    vector<PeptideIdentification>::iterator pos1p = pos + 1;
+    for (auto it = pos1p; it != peptides.end(); ++it)
+    {
+      it->setMetaValue("feature_leader", false);
+      removed.push_back(*it);
+    }
+
+    // set best one to first position and shrink vector
+    peptides[0] = *pos;
+    peptides[0].setMetaValue("feature_leader", true);
+    peptides.resize(1);
+  }
+};
+
+}
+
+#endif
+

--- a/src/openms/include/OpenMS/ANALYSIS/ID/sources.cmake
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/sources.cmake
@@ -18,6 +18,7 @@ ConsensusIDAlgorithmWorst.h
 FalseDiscoveryRate.h
 HiddenMarkovModel.h
 IDDecoyProbability.h
+IDConflictResolverAlgorithm.h
 IDMapper.h
 IDRipper.h
 MetaboliteSpectralMatching.h

--- a/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
@@ -1,0 +1,40 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2017.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hendrik Weisser $
+// $Authors: Hendrik Weisser, Lucia Espona $
+// --------------------------------------------------------------------------
+
+#include <OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h>
+
+using namespace OpenMS;
+using namespace std;
+
+/// @endcond

--- a/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
@@ -34,7 +34,85 @@
 
 #include <OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h>
 
-using namespace OpenMS;
 using namespace std;
+
+
+namespace OpenMS
+{
+  void IDConflictResolverAlgorithm::resolve(FeatureMap & features)
+  {
+    resolveConflict_(features);
+  }
+
+  void IDConflictResolverAlgorithm::resolve(ConsensusMap & features)
+  {
+    resolveConflict_(features);
+  }
+
+  // static
+  void IDConflictResolverAlgorithm::resolveConflict_(
+    vector<PeptideIdentification> & peptides, 
+    vector<PeptideIdentification> & removed,
+    UInt64 uid)
+  {
+    if (peptides.empty()) { return; }
+
+    for (PeptideIdentification & pep : peptides)
+    {
+      // sort hits
+      pep.sort();
+
+      // remove all but the best hit
+      if (!pep.getHits().empty())
+      {
+        vector<PeptideHit> best_hit(1, pep.getHits()[0]);
+        pep.setHits(best_hit);
+      }
+      // annotate feature id
+      pep.setMetaValue("feature_id", String(uid));
+    }
+
+    vector<PeptideIdentification>::iterator pos;
+    if (peptides[0].isHigherScoreBetter())     // find highest-scoring ID
+    {
+      pos = max_element(peptides.begin(), peptides.end(), compareIDsSmallerScores_);
+    }
+    else  // find lowest-scoring ID
+    {
+      pos = min_element(peptides.begin(), peptides.end(), compareIDsSmallerScores_);
+    }
+
+    // copy conflicting ones left to best one
+    for (auto it = peptides.begin(); it != pos; ++it)
+    {
+      removed.push_back(*it);
+    }
+     
+    // copy conflicting ones right of best one
+    vector<PeptideIdentification>::iterator pos1p = pos + 1;
+    for (auto it = pos1p; it != peptides.end(); ++it)
+    {
+      removed.push_back(*it);
+    }
+
+    // set best one to first position and shrink vector
+    peptides[0] = *pos;
+    peptides.resize(1);
+  }
+
+  // static
+  bool IDConflictResolverAlgorithm::compareIDsSmallerScores_(const PeptideIdentification & left, const PeptideIdentification & right)
+  {
+    // if any of them is empty, the other is considered "greater"
+    // independent of the score in the first hit
+    if (left.getHits().empty()) return true;
+    if (right.getHits().empty()) return false;
+    if (left.getHits()[0].getScore() < right.getHits()[0].getScore())
+    {
+      return true;
+    }
+    return false;
+  }
+}
 
 /// @endcond

--- a/src/openms/source/ANALYSIS/ID/sources.cmake
+++ b/src/openms/source/ANALYSIS/ID/sources.cmake
@@ -17,6 +17,7 @@ ConsensusIDAlgorithmSimilarity.cpp
 ConsensusIDAlgorithmWorst.cpp
 FalseDiscoveryRate.cpp
 HiddenMarkovModel.cpp
+IDConflictResolverAlgorithm.cpp
 IDMapper.cpp
 IDRipper.cpp
 IDDecoyProbability.cpp

--- a/src/tests/topp/IDConflictResolver_1_output.featureXML
+++ b/src/tests/topp/IDConflictResolver_1_output.featureXML
@@ -36,6 +36,84 @@
 			</ProteinHit>
 		</ProteinIdentification>
 	</IdentificationRun>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="545.274231" RT="1264.31" >
+		<PeptideHit score="0.998128" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="1373363315366016197"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="545.2715454" RT="1286.21" >
+		<PeptideHit score="0.999999" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="1373363315366016197"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="545.2719116" RT="1297.85" >
+		<PeptideHit score="0.999999" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="1373363315366016197"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="545.2719116" RT="1297.85" >
+		<PeptideHit score="0.999999" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="1373363315366016197"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2857056" RT="2663.79" >
+		<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2883301" RT="2674.49" >
+		<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.284668" RT="2685.11" >
+		<PeptideHit score="0.938827" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2865601" RT="2695.58" >
+		<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2855225" RT="2708.57" >
+		<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="508.2750854" RT="531.874" >
+		<PeptideHit score="0.999999" sequence="LAQGDVVEGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="12405256131250299722"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="483.2566223" RT="799.228" >
+		<PeptideHit score="0.999999" sequence="AKFDDLTR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_3">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="8424675462742455963"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="483.2566223" RT="799.228" >
+		<PeptideHit score="0.999999" sequence="AKFDDLTR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_3">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="8424675462742455963"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="483.2565613" RT="810.464" >
+		<PeptideHit score="0.999999" sequence="AKFDDLTR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_3">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="8424675462742455963"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
 	<featureList count="4">
 		<feature id="f_1373363315366016197">
 			<position dim="0">1277.99789929456</position>
@@ -112,6 +190,8 @@
 			<PeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="545.2717285" RT="1275.01" >
 				<PeptideHit score="0.999999" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="1373363315366016197"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="170"/>
 			<UserParam type="float" name="score_fit" value="0.582182578033577"/>
@@ -119,6 +199,7 @@
 			<UserParam type="float" name="FWHM" value="19.4875831604004"/>
 			<UserParam type="int" name="spectrum_index" value="1018"/>
 			<UserParam type="string" name="spectrum_native_id" value="scan=1805"/>
+			<UserParam type="string" name="feature_id" value="1373363315366016197"/>
 		</feature>
 		<feature id="f_10678641590729762751">
 			<position dim="0">2692.51931402675</position>
@@ -167,6 +248,8 @@
 			<PeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2877808" RT="2653.28" >
 				<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="10678641590729762751"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="23570"/>
 			<UserParam type="float" name="score_fit" value="0.592367816263975"/>
@@ -174,6 +257,7 @@
 			<UserParam type="float" name="FWHM" value="34.0471076965332"/>
 			<UserParam type="int" name="spectrum_index" value="2288"/>
 			<UserParam type="string" name="spectrum_native_id" value="scan=4010"/>
+			<UserParam type="string" name="feature_id" value="10678641590729762751"/>
 		</feature>
 		<feature id="f_12405256131250299722">
 			<position dim="0">529.286707890525</position>
@@ -206,6 +290,8 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="508.2728271" RT="520.801" >
 				<PeptideHit score="0.999999" sequence="LAQGDVVEGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="12405256131250299722"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="1195"/>
 			<UserParam type="float" name="score_fit" value="0.682223066553369"/>
@@ -213,6 +299,7 @@
 			<UserParam type="float" name="FWHM" value="5.8864631652832"/>
 			<UserParam type="int" name="spectrum_index" value="377"/>
 			<UserParam type="string" name="spectrum_native_id" value="scan=513"/>
+			<UserParam type="string" name="feature_id" value="12405256131250299722"/>
 		</feature>
 		<feature id="f_8424675462742455963">
 			<position dim="0">804.723909144231</position>
@@ -281,6 +368,8 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="483.2566528" RT="787.983" >
 				<PeptideHit score="0.999999" sequence="AKFDDLTR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_3">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="8424675462742455963"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="2801"/>
 			<UserParam type="float" name="score_fit" value="0.682499081560347"/>
@@ -288,6 +377,7 @@
 			<UserParam type="float" name="FWHM" value="15.4546928405762"/>
 			<UserParam type="int" name="spectrum_index" value="610"/>
 			<UserParam type="string" name="spectrum_native_id" value="scan=1005"/>
+			<UserParam type="string" name="feature_id" value="8424675462742455963"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/topp/IDConflictResolver_1_output.featureXML
+++ b/src/tests/topp/IDConflictResolver_1_output.featureXML
@@ -40,79 +40,66 @@
 		<PeptideHit score="0.998128" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="1373363315366016197"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="545.2715454" RT="1286.21" >
 		<PeptideHit score="0.999999" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="1373363315366016197"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="545.2719116" RT="1297.85" >
 		<PeptideHit score="0.999999" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="1373363315366016197"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="545.2719116" RT="1297.85" >
 		<PeptideHit score="0.999999" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="1373363315366016197"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2857056" RT="2663.79" >
 		<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2883301" RT="2674.49" >
 		<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.284668" RT="2685.11" >
 		<PeptideHit score="0.938827" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2865601" RT="2695.58" >
 		<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_0" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="519.2855225" RT="2708.57" >
 		<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="10678641590729762751"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="508.2750854" RT="531.874" >
 		<PeptideHit score="0.999999" sequence="LAQGDVVEGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="12405256131250299722"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="483.2566223" RT="799.228" >
 		<PeptideHit score="0.999999" sequence="AKFDDLTR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_3">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="8424675462742455963"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="483.2566223" RT="799.228" >
 		<PeptideHit score="0.999999" sequence="AKFDDLTR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_3">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="8424675462742455963"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="InterProphet probability" higher_score_better="true" significance_threshold="0" MZ="483.2565613" RT="810.464" >
 		<PeptideHit score="0.999999" sequence="AKFDDLTR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_3">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="8424675462742455963"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<featureList count="4">
 		<feature id="f_1373363315366016197">
@@ -191,7 +178,6 @@
 				<PeptideHit score="0.999999" sequence="LENAMEVAGR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_0">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="1373363315366016197"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="170"/>
 			<UserParam type="float" name="score_fit" value="0.582182578033577"/>
@@ -249,7 +235,6 @@
 				<PeptideHit score="0.999991" sequence="SIITDVYAR" charge="2" aa_before="M" aa_after="E" protein_refs="PH_1">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="10678641590729762751"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="23570"/>
 			<UserParam type="float" name="score_fit" value="0.592367816263975"/>
@@ -291,7 +276,6 @@
 				<PeptideHit score="0.999999" sequence="LAQGDVVEGK" charge="2" aa_before="K" aa_after="V" protein_refs="PH_2">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="12405256131250299722"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="1195"/>
 			<UserParam type="float" name="score_fit" value="0.682223066553369"/>
@@ -369,7 +353,6 @@
 				<PeptideHit score="0.999999" sequence="AKFDDLTR" charge="2" aa_before="R" aa_after="D" protein_refs="PH_3">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="8424675462742455963"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="2801"/>
 			<UserParam type="float" name="score_fit" value="0.682499081560347"/>

--- a/src/tests/topp/IDConflictResolver_2_output.consensusXML
+++ b/src/tests/topp/IDConflictResolver_2_output.consensusXML
@@ -58,6 +58,120 @@
 			</ProteinHit>
 		</ProteinIdentification>
 	</IdentificationRun>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.8854250319" RT="-305731.648356442" >
+		<PeptideHit score="0.4998" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="2304645711897739226"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.5592250319" RT="-312534.565253865" >
+		<PeptideHit score="0.472" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="2304645711897739226"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.7590250318" RT="-308362.144488949" >
+		<PeptideHit score="0.6882" sequence="NNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="2304645711897739226"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.559158365233" RT="10608.7161749256" >
+		<PeptideHit score="0.5512" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_1">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="10686632238500456877"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.887358365233" RT="10326.5758406826" >
+		<PeptideHit score="0.7523" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_1">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="10686632238500456877"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.887691698567" RT="1170.81289773758" >
+		<PeptideHit score="0.1029" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17432675259469427420"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.887291698567" RT="1183.79546105445" >
+		<PeptideHit score="0.2659" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17432675259469427420"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.8861250319" RT="1152.49356828614" >
+		<PeptideHit score="0.8305" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17432675259469427420"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.559991698567" RT="1121.2987082864" >
+		<PeptideHit score="0.4343" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17432675259469427420"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="454.2384750319" RT="1122.64435371534" >
+		<PeptideHit score="0.8605" sequence="VKQPQADNNNKPFSAR" charge="4" aa_before="K" aa_after="Y" protein_refs="PH_4">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="15316846026783260277"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="712.3170750319" RT="1125" >
+		<PeptideHit score="0.9969" sequence="DNSTADELTTNDK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_5">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="16582703386749133430"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.33557129" RT="2085.81807683832" >
+		<PeptideHit score="0.9981" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3353250319" RT="2021.13480437308" >
+		<PeptideHit score="0.9925" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3353250319" RT="2073.99987642346" >
+		<PeptideHit score="0.9997" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3353250319" RT="2042.69591601378" >
+		<PeptideHit score="0.9996" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3349750319" RT="2116.80655673794" >
+		<PeptideHit score="0.9994" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="717.8194750319" RT="3127.31741068029" >
+		<PeptideHit score="0.9885" sequence="NNTGDANTEEAAAR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_7">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17838151373913571383"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="717.3177250319" RT="664.512361213386" >
+		<PeptideHit score="0.9993" sequence="NNTGDANTEEAAAR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_7">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17838151373913571383"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="717.8178750319" RT="4775.57502901974" >
+		<PeptideHit score="0.8399" sequence="NNTGDANTEEAAAR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_7">
+		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="17838151373913571383"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
 	<mapList count="6">
 		<map id="0" name="test1.realligned.annotated.featureXML" unique_id="16747478305373140212" label="" size="6006">
 		</map>
@@ -81,10 +195,13 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.5590250319" RT="-308362.144488943" >
 				<PeptideHit score="0.9882" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="2304645711897739226"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="18529"/>
 			<UserParam type="int" name="spectrum_index" value="672"/>
 			<UserParam type="string" name="spectrum_native_id" value="scan=798"/>
+			<UserParam type="string" name="feature_id" value="2304645711897739226"/>
 		</consensusElement>
 		<consensusElement id="e_10686632238500456877" quality="0" charge="3">
 			<centroid rt="10571.311395646" mz="417.558952983394" it="6.03816e+06"/>
@@ -94,10 +211,13 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.885391698567" RT="10507.1584078859" >
 				<PeptideHit score="0.8852" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_1">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="10686632238500456877"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="28606"/>
 			<UserParam type="int" name="spectrum_index" value="693"/>
 			<UserParam type="string" name="spectrum_native_id" value="scan=1354"/>
+			<UserParam type="string" name="feature_id" value="10686632238500456877"/>
 		</consensusElement>
 		<consensusElement id="e_17432675259469427420" quality="0.801117" charge="3">
 			<centroid rt="1131.97571942222" mz="417.559141106364" it="5.00001e+06"/>
@@ -109,7 +229,10 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.559391698567" RT="1120.97881038114" >
 				<PeptideHit score="0.9359" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="17432675259469427420"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
+			<UserParam type="string" name="feature_id" value="17432675259469427420"/>
 		</consensusElement>
 		<consensusElement id="e_5215610682377798744" quality="0.599796" charge="3">
 			<centroid rt="1258.37950256756" mz="417.887293849783" it="283081"/>
@@ -120,7 +243,10 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="418.2132250319" RT="1261.47520235853" >
 				<PeptideHit score="0.0975" sequence="DNIIFGSPFNK" charge="3" aa_before="R" aa_after="E" protein_refs="PH_3">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="5215610682377798744"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
+			<UserParam type="string" name="feature_id" value="5215610682377798744"/>
 		</consensusElement>
 		<consensusElement id="e_15316846026783260277" quality="0.852141" charge="4">
 			<centroid rt="1139.10145731572" mz="454.239277781987" it="729120"/>
@@ -132,7 +258,10 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="454.2397750319" RT="1144.50945823654" >
 				<PeptideHit score="0.9457" sequence="VKQPQADNNNKPFSAR" charge="4" aa_before="K" aa_after="Y" protein_refs="PH_4">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="15316846026783260277"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
+			<UserParam type="string" name="feature_id" value="15316846026783260277"/>
 		</consensusElement>
 		<consensusElement id="e_16582703386749133430" quality="0.395181" charge="2">
 			<centroid rt="1135.6351127543" mz="712.316032389249" it="1.67935e+06"/>
@@ -144,7 +273,10 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="712.3141250319" RT="1122.33206665644" >
 				<PeptideHit score="0.9992" sequence="DNSTADELTTNDK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_5">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="16582703386749133430"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
+			<UserParam type="string" name="feature_id" value="16582703386749133430"/>
 		</consensusElement>
 		<consensusElement id="e_17853144546567179050" quality="0.603354" charge="2">
 			<centroid rt="2072.8140610824" mz="716.33482326288" it="8.96256e+07"/>
@@ -155,7 +287,10 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3350250319" RT="2046.55080652427" >
 				<PeptideHit score="0.9998" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="17853144546567179050"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
+			<UserParam type="string" name="feature_id" value="17853144546567179050"/>
 		</consensusElement>
 		<consensusElement id="e_17838151373913571383" quality="0" charge="2">
 			<centroid rt="1927.35294139832" mz="717.318597821726" it="9.67633e+06"/>
@@ -165,10 +300,13 @@
 			<PeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="717.3178250319" RT="-1682.22304667374" >
 				<PeptideHit score="0.9996" sequence="NNTGDANTEEAAAR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_7">
 				</PeptideHit>
+				<UserParam type="string" name="feature_id" value="17838151373913571383"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="18104"/>
 			<UserParam type="int" name="spectrum_index" value="352"/>
 			<UserParam type="string" name="spectrum_native_id" value="scan=612"/>
+			<UserParam type="string" name="feature_id" value="17838151373913571383"/>
 		</consensusElement>
 	</consensusElementList>
 </consensusXML>

--- a/src/tests/topp/IDConflictResolver_2_output.consensusXML
+++ b/src/tests/topp/IDConflictResolver_2_output.consensusXML
@@ -62,115 +62,96 @@
 		<PeptideHit score="0.4998" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="2304645711897739226"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.5592250319" RT="-312534.565253865" >
 		<PeptideHit score="0.472" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="2304645711897739226"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.7590250318" RT="-308362.144488949" >
 		<PeptideHit score="0.6882" sequence="NNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="2304645711897739226"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.559158365233" RT="10608.7161749256" >
 		<PeptideHit score="0.5512" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_1">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="10686632238500456877"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.887358365233" RT="10326.5758406826" >
 		<PeptideHit score="0.7523" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_1">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="10686632238500456877"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.887691698567" RT="1170.81289773758" >
 		<PeptideHit score="0.1029" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17432675259469427420"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.887291698567" RT="1183.79546105445" >
 		<PeptideHit score="0.2659" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17432675259469427420"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.8861250319" RT="1152.49356828614" >
 		<PeptideHit score="0.8305" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17432675259469427420"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="417.559991698567" RT="1121.2987082864" >
 		<PeptideHit score="0.4343" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17432675259469427420"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="454.2384750319" RT="1122.64435371534" >
 		<PeptideHit score="0.8605" sequence="VKQPQADNNNKPFSAR" charge="4" aa_before="K" aa_after="Y" protein_refs="PH_4">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="15316846026783260277"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="712.3170750319" RT="1125" >
 		<PeptideHit score="0.9969" sequence="DNSTADELTTNDK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_5">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="16582703386749133430"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.33557129" RT="2085.81807683832" >
 		<PeptideHit score="0.9981" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3353250319" RT="2021.13480437308" >
 		<PeptideHit score="0.9925" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3353250319" RT="2073.99987642346" >
 		<PeptideHit score="0.9997" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3353250319" RT="2042.69591601378" >
 		<PeptideHit score="0.9996" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="716.3349750319" RT="2116.80655673794" >
 		<PeptideHit score="0.9994" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17853144546567179050"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="717.8194750319" RT="3127.31741068029" >
 		<PeptideHit score="0.9885" sequence="NNTGDANTEEAAAR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_7">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17838151373913571383"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="717.3177250319" RT="664.512361213386" >
 		<PeptideHit score="0.9993" sequence="NNTGDANTEEAAAR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_7">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17838151373913571383"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_1" score_type="PeptideProphet probability" higher_score_better="true" significance_threshold="0" MZ="717.8178750319" RT="4775.57502901974" >
 		<PeptideHit score="0.8399" sequence="NNTGDANTEEAAAR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_7">
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="17838151373913571383"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="6">
 		<map id="0" name="test1.realligned.annotated.featureXML" unique_id="16747478305373140212" label="" size="6006">
@@ -196,7 +177,6 @@
 				<PeptideHit score="0.9882" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_0">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="2304645711897739226"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="18529"/>
 			<UserParam type="int" name="spectrum_index" value="672"/>
@@ -212,7 +192,6 @@
 				<PeptideHit score="0.8852" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_1">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="10686632238500456877"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="28606"/>
 			<UserParam type="int" name="spectrum_index" value="693"/>
@@ -230,7 +209,6 @@
 				<PeptideHit score="0.9359" sequence="LNNNGIHINNK" charge="3" aa_before="R" aa_after="V" protein_refs="PH_2">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="17432675259469427420"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="17432675259469427420"/>
 		</consensusElement>
@@ -244,7 +222,6 @@
 				<PeptideHit score="0.0975" sequence="DNIIFGSPFNK" charge="3" aa_before="R" aa_after="E" protein_refs="PH_3">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="5215610682377798744"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="5215610682377798744"/>
 		</consensusElement>
@@ -259,7 +236,6 @@
 				<PeptideHit score="0.9457" sequence="VKQPQADNNNKPFSAR" charge="4" aa_before="K" aa_after="Y" protein_refs="PH_4">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="15316846026783260277"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="15316846026783260277"/>
 		</consensusElement>
@@ -274,7 +250,6 @@
 				<PeptideHit score="0.9992" sequence="DNSTADELTTNDK" charge="2" aa_before="K" aa_after="A" protein_refs="PH_5">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="16582703386749133430"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="16582703386749133430"/>
 		</consensusElement>
@@ -288,7 +263,6 @@
 				<PeptideHit score="0.9998" sequence="DGDEIIIDADNNK" charge="2" aa_before="R" aa_after="I" protein_refs="PH_6">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="17853144546567179050"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="17853144546567179050"/>
 		</consensusElement>
@@ -301,7 +275,6 @@
 				<PeptideHit score="0.9996" sequence="NNTGDANTEEAAAR" charge="2" aa_before="K" aa_after="S" protein_refs="PH_7">
 				</PeptideHit>
 				<UserParam type="string" name="feature_id" value="17838151373913571383"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="int" name="label" value="18104"/>
 			<UserParam type="int" name="spectrum_index" value="352"/>

--- a/src/tests/topp/IDConflictResolver_3_output.consensusXML
+++ b/src/tests/topp/IDConflictResolver_3_output.consensusXML
@@ -401,6 +401,112 @@
 			<UserParam type="int" name="y_ions" value="10"/>
 			<UserParam type="string" name="protein_references" value="unique"/>
 		</PeptideHit>
+		<UserParam type="string" name="feature_id" value="not mapped"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75" RT="1586.72680664062" spectrum_reference="spectrum=2385" >
+		<UserParam type="int" name="spectrum_index" value="599"/>
+		<UserParam type="int" name="map_index" value="4"/>
+		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75048828125" RT="1525.90893554688" spectrum_reference="spectrum=2321" >
+		<UserParam type="int" name="spectrum_index" value="540"/>
+		<UserParam type="int" name="map_index" value="2"/>
+		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75048828125" RT="1525.90893554688" spectrum_reference="spectrum=2321" >
+		<UserParam type="int" name="spectrum_index" value="540"/>
+		<UserParam type="int" name="map_index" value="3"/>
+		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.749572753906" RT="1571.3095703125" spectrum_reference="spectrum=2463" >
+		<UserParam type="int" name="spectrum_index" value="585"/>
+		<UserParam type="int" name="map_index" value="1"/>
+		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75" RT="1586.72680664062" spectrum_reference="spectrum=2385" >
+		<UserParam type="int" name="spectrum_index" value="599"/>
+		<UserParam type="int" name="map_index" value="5"/>
+		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="531.220703125" RT="2365.1015625" spectrum_reference="spectrum=3126" >
+		<UserParam type="int" name="spectrum_index" value="1340"/>
+		<UserParam type="int" name="map_index" value="4"/>
+		<UserParam type="string" name="feature_id" value="13678817347185682579"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="531.220703125" RT="2365.1015625" spectrum_reference="spectrum=3126" >
+		<UserParam type="int" name="spectrum_index" value="1340"/>
+		<UserParam type="int" name="map_index" value="5"/>
+		<UserParam type="string" name="feature_id" value="13678817347185682579"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="531.220825195312" RT="2379.37158203125" spectrum_reference="spectrum=3343" >
+		<UserParam type="int" name="spectrum_index" value="1562"/>
+		<UserParam type="int" name="map_index" value="2"/>
+		<UserParam type="string" name="feature_id" value="13678817347185682579"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.205688476562" RT="1985.32336425781" spectrum_reference="spectrum=2901" >
+		<PeptideHit score="0.132857142857143" sequence="AESGALSTGEAIGTGMSILVMVVQSWEDESRR" charge="4" aa_before="R" aa_after="L" start="1359" end="1390" protein_refs="PH_0">
+			<UserParam type="string" name="target_decoy" value="target"/>
+			<UserParam type="float" name="XTandem_score" value="36.2"/>
+			<UserParam type="float" name="nextscore" value="33.2"/>
+			<UserParam type="float" name="delta" value="2.016"/>
+			<UserParam type="float" name="mass" value="3366.63"/>
+			<UserParam type="float" name="E-Value" value="2.8e-06"/>
+			<UserParam type="float" name="hyperscore" value="36.2"/>
+			<UserParam type="float" name="b_score" value="7.4"/>
+			<UserParam type="int" name="b_ions" value="9"/>
+			<UserParam type="float" name="y_score" value="7.7"/>
+			<UserParam type="int" name="y_ions" value="10"/>
+			<UserParam type="string" name="protein_references" value="unique"/>
+		</PeptideHit>
+		<UserParam type="int" name="spectrum_index" value="1023"/>
+		<UserParam type="int" name="map_index" value="0"/>
+		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.206665039062" RT="2017.35913085938" spectrum_reference="spectrum=2953" >
+		<UserParam type="int" name="spectrum_index" value="1075"/>
+		<UserParam type="int" name="map_index" value="0"/>
+		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.205932617188" RT="1932.23840332031" spectrum_reference="spectrum=2680" >
+		<UserParam type="int" name="spectrum_index" value="894"/>
+		<UserParam type="int" name="map_index" value="5"/>
+		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.20751953125" RT="1919.53979492188" spectrum_reference="spectrum=2753" >
+		<UserParam type="int" name="spectrum_index" value="972"/>
+		<UserParam type="int" name="map_index" value="2"/>
+		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.20751953125" RT="1919.53979492188" spectrum_reference="spectrum=2753" >
+		<UserParam type="int" name="spectrum_index" value="972"/>
+		<UserParam type="int" name="map_index" value="3"/>
+		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.205688476562" RT="1985.32336425781" spectrum_reference="spectrum=2901" >
+		<UserParam type="int" name="spectrum_index" value="1023"/>
+		<UserParam type="int" name="map_index" value="1"/>
+		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.206665039062" RT="2017.35913085938" spectrum_reference="spectrum=2953" >
+		<UserParam type="int" name="spectrum_index" value="1075"/>
+		<UserParam type="int" name="map_index" value="1"/>
+		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
+		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="6">
 		<map id="0" name="BSA1.featureXML" unique_id="2091680114383440625" label="" size="749">
@@ -427,6 +533,7 @@
 				<element map="4" id="8706416277738488178" rt="2315.04428672715" mz="696.265865935515" it="730870" charge="1"/>
 				<element map="5" id="4155744174359052958" rt="2315.04428672715" mz="696.265865935515" it="730870" charge="1"/>
 			</groupedElementList>
+			<UserParam type="string" name="feature_id" value="12173381914808106004"/>
 		</consensusElement>
 		<consensusElement id="e_17962861576887891871" quality="0.880406" charge="2">
 			<centroid rt="1571.27967669544" mz="763.749456309823" it="518860"/>
@@ -441,7 +548,10 @@
 			<PeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.749572753906" RT="1571.3095703125" spectrum_reference="spectrum=2463" >
 				<UserParam type="int" name="spectrum_index" value="585"/>
 				<UserParam type="int" name="map_index" value="0"/>
+				<UserParam type="string" name="feature_id" value="17962861576887891871"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
+			<UserParam type="string" name="feature_id" value="17962861576887891871"/>
 		</consensusElement>
 		<consensusElement id="e_13678817347185682579" quality="0.854528" charge="2">
 			<centroid rt="2397.48754239827" mz="531.221420810368" it="85397.1"/>
@@ -470,7 +580,10 @@
 				</PeptideHit>
 				<UserParam type="int" name="spectrum_index" value="1562"/>
 				<UserParam type="int" name="map_index" value="3"/>
+				<UserParam type="string" name="feature_id" value="13678817347185682579"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
+			<UserParam type="string" name="feature_id" value="13678817347185682579"/>
 		</consensusElement>
 		<consensusElement id="e_60107607427378258" quality="0.933285" charge="1">
 			<centroid rt="1623.98255993453" mz="371.315684578303" it="8.14429e+06"/>
@@ -482,6 +595,7 @@
 				<element map="4" id="1451417439224502937" rt="1645.0859325398" mz="371.315661191974" it="7.80614e+06" charge="1"/>
 				<element map="5" id="12347967316465216374" rt="1645.0859325398" mz="371.315661191974" it="7.80614e+06" charge="1"/>
 			</groupedElementList>
+			<UserParam type="string" name="feature_id" value="60107607427378258"/>
 		</consensusElement>
 		<consensusElement id="e_7556036852336985019" quality="0.860746" charge="2">
 			<centroid rt="1952.89643190768" mz="573.206594089431" it="4.49051e+06"/>
@@ -510,7 +624,10 @@
 				</PeptideHit>
 				<UserParam type="int" name="spectrum_index" value="894"/>
 				<UserParam type="int" name="map_index" value="4"/>
+				<UserParam type="string" name="feature_id" value="7556036852336985019"/>
+				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
+			<UserParam type="string" name="feature_id" value="7556036852336985019"/>
 		</consensusElement>
 	</consensusElementList>
 </consensusXML>

--- a/src/tests/topp/IDConflictResolver_3_output.consensusXML
+++ b/src/tests/topp/IDConflictResolver_3_output.consensusXML
@@ -402,55 +402,46 @@
 			<UserParam type="string" name="protein_references" value="unique"/>
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75" RT="1586.72680664062" spectrum_reference="spectrum=2385" >
 		<UserParam type="int" name="spectrum_index" value="599"/>
 		<UserParam type="int" name="map_index" value="4"/>
 		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75048828125" RT="1525.90893554688" spectrum_reference="spectrum=2321" >
 		<UserParam type="int" name="spectrum_index" value="540"/>
 		<UserParam type="int" name="map_index" value="2"/>
 		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75048828125" RT="1525.90893554688" spectrum_reference="spectrum=2321" >
 		<UserParam type="int" name="spectrum_index" value="540"/>
 		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.749572753906" RT="1571.3095703125" spectrum_reference="spectrum=2463" >
 		<UserParam type="int" name="spectrum_index" value="585"/>
 		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75" RT="1586.72680664062" spectrum_reference="spectrum=2385" >
 		<UserParam type="int" name="spectrum_index" value="599"/>
 		<UserParam type="int" name="map_index" value="5"/>
 		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="531.220703125" RT="2365.1015625" spectrum_reference="spectrum=3126" >
 		<UserParam type="int" name="spectrum_index" value="1340"/>
 		<UserParam type="int" name="map_index" value="4"/>
 		<UserParam type="string" name="feature_id" value="13678817347185682579"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="531.220703125" RT="2365.1015625" spectrum_reference="spectrum=3126" >
 		<UserParam type="int" name="spectrum_index" value="1340"/>
 		<UserParam type="int" name="map_index" value="5"/>
 		<UserParam type="string" name="feature_id" value="13678817347185682579"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="531.220825195312" RT="2379.37158203125" spectrum_reference="spectrum=3343" >
 		<UserParam type="int" name="spectrum_index" value="1562"/>
 		<UserParam type="int" name="map_index" value="2"/>
 		<UserParam type="string" name="feature_id" value="13678817347185682579"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.205688476562" RT="1985.32336425781" spectrum_reference="spectrum=2901" >
 		<PeptideHit score="0.132857142857143" sequence="AESGALSTGEAIGTGMSILVMVVQSWEDESRR" charge="4" aa_before="R" aa_after="L" start="1359" end="1390" protein_refs="PH_0">
@@ -470,43 +461,36 @@
 		<UserParam type="int" name="spectrum_index" value="1023"/>
 		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.206665039062" RT="2017.35913085938" spectrum_reference="spectrum=2953" >
 		<UserParam type="int" name="spectrum_index" value="1075"/>
 		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.205932617188" RT="1932.23840332031" spectrum_reference="spectrum=2680" >
 		<UserParam type="int" name="spectrum_index" value="894"/>
 		<UserParam type="int" name="map_index" value="5"/>
 		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.20751953125" RT="1919.53979492188" spectrum_reference="spectrum=2753" >
 		<UserParam type="int" name="spectrum_index" value="972"/>
 		<UserParam type="int" name="map_index" value="2"/>
 		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.20751953125" RT="1919.53979492188" spectrum_reference="spectrum=2753" >
 		<UserParam type="int" name="spectrum_index" value="972"/>
 		<UserParam type="int" name="map_index" value="3"/>
 		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.205688476562" RT="1985.32336425781" spectrum_reference="spectrum=2901" >
 		<UserParam type="int" name="spectrum_index" value="1023"/>
 		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="573.206665039062" RT="2017.35913085938" spectrum_reference="spectrum=2953" >
 		<UserParam type="int" name="spectrum_index" value="1075"/>
 		<UserParam type="int" name="map_index" value="1"/>
 		<UserParam type="string" name="feature_id" value="7556036852336985019"/>
-		<UserParam type="int" name="feature_leader" value="0"/>
 	</UnassignedPeptideIdentification>
 	<mapList count="6">
 		<map id="0" name="BSA1.featureXML" unique_id="2091680114383440625" label="" size="749">
@@ -549,7 +533,6 @@
 				<UserParam type="int" name="spectrum_index" value="585"/>
 				<UserParam type="int" name="map_index" value="0"/>
 				<UserParam type="string" name="feature_id" value="17962861576887891871"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="17962861576887891871"/>
 		</consensusElement>
@@ -581,7 +564,6 @@
 				<UserParam type="int" name="spectrum_index" value="1562"/>
 				<UserParam type="int" name="map_index" value="3"/>
 				<UserParam type="string" name="feature_id" value="13678817347185682579"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="13678817347185682579"/>
 		</consensusElement>
@@ -625,7 +607,6 @@
 				<UserParam type="int" name="spectrum_index" value="894"/>
 				<UserParam type="int" name="map_index" value="4"/>
 				<UserParam type="string" name="feature_id" value="7556036852336985019"/>
-				<UserParam type="int" name="feature_leader" value="1"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="7556036852336985019"/>
 		</consensusElement>

--- a/src/topp/IDConflictResolver.cpp
+++ b/src/topp/IDConflictResolver.cpp
@@ -38,6 +38,7 @@
 #include <OpenMS/FORMAT/FeatureXMLFile.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 #include <OpenMS/METADATA/PeptideIdentification.h>
+#include <OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h>
 
 #include <algorithm>
 
@@ -75,6 +76,9 @@ using namespace std;
     with a single hit (with the best score) is associated to each feature. (If
     two IDs have the same best score, either one of them may be selected.)
 
+    The the filtered identifications are added to the vector of unassigned peptides
+    and also reduced to a single best hit.
+
     This step may be useful before applying @ref TOPP_ProteinQuantifier
     "ProteinQuantifier", because features with ambiguous annotation are not
     considered for the quantification.
@@ -98,54 +102,6 @@ public:
   {
   }
 
-protected:
-
-  // compare peptide IDs by score of best hit (hits must be sorted first!)
-  // (note to self: the "static" is necessary to avoid cryptic "no matching
-  // function" errors from gcc when the comparator is used below)
-  static bool compareIDsSmallerScores_(const PeptideIdentification & left,
-                          const PeptideIdentification & right)
-  {
-    // if any of them is empty, the other is considered "greater"
-    // independent of the score in the first hit
-    if (left.getHits().empty()) return true;
-    if (right.getHits().empty()) return false;
-    if (left.getHits()[0].getScore() < right.getHits()[0].getScore())
-    {
-      return true;
-    }
-    return false;
-  }
-
-  void resolveConflict_(vector<PeptideIdentification> & peptides)
-  {
-    if (peptides.empty()) return;
-
-    for (vector<PeptideIdentification>::iterator pep_id = peptides.begin();
-         pep_id != peptides.end(); ++pep_id)
-    {
-      pep_id->sort();
-    }
-    vector<PeptideIdentification>::iterator pos;
-    if (peptides[0].isHigherScoreBetter())     // find highest-scoring ID
-    {
-      pos = max_element(peptides.begin(), peptides.end(), compareIDsSmallerScores_);
-    }
-    else  // find lowest-scoring ID
-    {
-      pos = min_element(peptides.begin(), peptides.end(), compareIDsSmallerScores_);
-    }
-    peptides[0] = *pos;
-    peptides.resize(1);
-
-    if (!peptides[0].getHits().empty())
-    {
-      // remove all but the best hit:
-      vector<PeptideHit> best_hit(1, peptides[0].getHits()[0]);
-      peptides[0].setHits(best_hit);
-    }
-  }
-
   void registerOptionsAndFlags_() override
   {
     registerInputFile_("in", "<file>", "", "Input file (data annotated with identifications)");
@@ -162,24 +118,16 @@ protected:
     {
       FeatureMap features;
       FeatureXMLFile().load(in, features);
-      for (FeatureMap::Iterator feat_it = features.begin();
-           feat_it != features.end(); ++feat_it)
-      {
-        resolveConflict_(feat_it->getPeptideIdentifications());
-      }
+      IDConflictResolverAlgorithm::resolve(features);
       addDataProcessing_(features,
                          getProcessingInfo_(DataProcessing::FILTERING));
       FeatureXMLFile().store(out, features);
     }
-    else     // consensusXML
+    else // consensusXML
     {
       ConsensusMap consensus;
       ConsensusXMLFile().load(in, consensus);
-      for (ConsensusMap::Iterator cons_it = consensus.begin();
-           cons_it != consensus.end(); ++cons_it)
-      {
-        resolveConflict_(cons_it->getPeptideIdentifications());
-      }
+      IDConflictResolverAlgorithm::resolve(consensus);
       addDataProcessing_(consensus,
                          getProcessingInfo_(DataProcessing::FILTERING));
       ConsensusXMLFile().store(out, consensus);


### PR DESCRIPTION
Aim of this PR:
- move tool code to algorithm
- keep conflicting IDs but move all but the best to "unmapped" 
- annotate feature identifier as meta value ("feature_id"="17962861576887891871")