### PR TITLE
[FIX] fix Cython

### DIFF
--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -431,10 +431,18 @@ configure_file(${_env_py_in} ${_env_py} @ONLY)
 #------------------------------------------------------------------------------
 # create targets in makefile
 
-add_custom_target(pyopenms_create_cpp
-	COMMAND ${PYTHON_EXECUTABLE} create_cpp_extension.py
-	DEPENDS OpenMS SuperHirn
-	WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  add_custom_target(pyopenms_create_cpp
+    COMMAND ${PYTHON_EXECUTABLE} create_cpp_extension.py 2> /dev/null
+    DEPENDS OpenMS SuperHirn
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+ELSE()
+  add_custom_target(pyopenms_create_cpp
+    COMMAND ${PYTHON_EXECUTABLE} create_cpp_extension.py
+    DEPENDS OpenMS SuperHirn
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+ENDIF()
+
 
 set(PY_EXTRA_ARGS "")
 if(PY_SINGLE_THREADED)

--- a/tools/travis/lnx-cibuild.before.sh
+++ b/tools/travis/lnx-cibuild.before.sh
@@ -33,7 +33,7 @@ if [ "${PYOPENMS}" = "ON" ]; then
   pip install -U nose
   pip install -U numpy
   pip install -U wheel
-  pip install -U Cython==0.27
+  pip install -U Cython==0.26
   pip install -U autowrap==0.14
 fi
 

--- a/tools/travis/lnx-cibuild.before.sh
+++ b/tools/travis/lnx-cibuild.before.sh
@@ -33,7 +33,7 @@ if [ "${PYOPENMS}" = "ON" ]; then
   pip install -U nose
   pip install -U numpy
   pip install -U wheel
-  pip install -U Cython==0.26
+  pip install -U Cython
   pip install -U autowrap==0.14
 fi
 

--- a/tools/travis/lnx-cibuild.before.sh
+++ b/tools/travis/lnx-cibuild.before.sh
@@ -33,7 +33,7 @@ if [ "${PYOPENMS}" = "ON" ]; then
   pip install -U nose
   pip install -U numpy
   pip install -U wheel
-  pip install -U Cython
+  pip install -U Cython==0.27
   pip install -U autowrap==0.14
 fi
 


### PR DESCRIPTION
seems like Cython 0.28 creates trouble:

the error logs are full of warnings instead of errors:

```
warning: /.../OpenMS/src/pyOpenMS/pxds/ControlledVocabulary.pxd:80:8: 'NONE' redeclared
```

this is potentially because the warnings are reported to stderr instead of stdout ?