### PR TITLE
Background subtraction

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -118,7 +118,7 @@ public:
     ///@}
 
     /** @name calculatePeakShapeMetrics() output
-     *
+      
         The calculatePeakShapeMetrics() method uses this struct to save its results.
     */
     ///@{
@@ -210,7 +210,7 @@ public:
     ///@}
 
     /** @name Constant expressions for parameters
-     *
+      
         Constants expressions used throughout the code and tests to set
         the integration and baseline types.
     */
@@ -223,7 +223,7 @@ public:
     static constexpr const char* INTEGRATION_TYPE_SIMPSON = "simpson";
     /// Baseline type: base to base
     static constexpr const char* BASELINE_TYPE_BASETOBASE = "base_to_base";
-    /// Baseline type: vertical division (min of end points)
+    /// Baseline type: vertical division (min of end points; only for backwards compatibility)
     static constexpr const char* BASELINE_TYPE_VERTICALDIVISION = "vertical_division";
     /// Baseline type: vertical division (min of end points)
     static constexpr const char* BASELINE_TYPE_VERTICALDIVISION_MIN = "vertical_division_min";

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -45,8 +45,24 @@
 
 namespace OpenMS
 {
+
   /**
     @brief Compute the area, background and shape metrics of a peak.
+
+    The area computation is performed in integratePeak() and it supports
+    integration by simple sum of the intensity, integration by Simpson's rule
+    implementations for an odd number of unequally spaced points or integration
+    by the trapezoid rule.
+
+    The background computation is performed in estimateBackground() and it
+    supports three different approaches to baseline correction, namely
+    computing a rectangular shape under the peak based on the minimum value of
+    the peak borders (vertical_division_min), a rectangular shape based on the
+    maximum value of the beak borders (vertical_division_max) or a trapezoidal
+    shape based on a straight line between the peak borders (base_to_base).
+
+    Peak shape metrics are computed in calculatePeakShapeMetrics() and multiple
+    metrics are supported.
 
     The containers supported by the methods are MSChromatogram and MSSpectrum.
   */
@@ -102,7 +118,8 @@ public:
     ///@}
 
     /** @name calculatePeakShapeMetrics() output
-      The calculatePeakShapeMetrics() method uses this struct to save its results.
+     *
+        The calculatePeakShapeMetrics() method uses this struct to save its results.
     */
     ///@{
     struct PeakShapeMetrics
@@ -193,8 +210,9 @@ public:
     ///@}
 
     /** @name Constant expressions for parameters
-      Constants expressions used throughout the code and tests to set
-      the integration and baseline types.
+     *
+        Constants expressions used throughout the code and tests to set
+        the integration and baseline types.
     */
     ///@{
     /// Integration type: intensity sum
@@ -205,8 +223,12 @@ public:
     static constexpr const char* INTEGRATION_TYPE_SIMPSON = "simpson";
     /// Baseline type: base to base
     static constexpr const char* BASELINE_TYPE_BASETOBASE = "base_to_base";
-    /// Baseline type: vertical division
+    /// Baseline type: vertical division (min of end points)
     static constexpr const char* BASELINE_TYPE_VERTICALDIVISION = "vertical_division";
+    /// Baseline type: vertical division (min of end points)
+    static constexpr const char* BASELINE_TYPE_VERTICALDIVISION_MIN = "vertical_division_min";
+    /// Baseline type: vertical division (max of end points)
+    static constexpr const char* BASELINE_TYPE_VERTICALDIVISION_MAX = "vertical_division_max";
     ///@}
 
     /**
@@ -547,6 +569,7 @@ protected:
     ) const;
 
 private:
+
     /** @name Parameters
       The user is supposed to select a value for these parameters.
       By default, the integration_type_ is "intensity_sum" and the baseline_type_ is "base_to_base".
@@ -559,7 +582,7 @@ private:
     String integration_type_ = INTEGRATION_TYPE_INTENSITYSUM;
     /**
       The baseline type to use in estimateBackground().
-      Possible values are: "vertical_division", "base_to_base".
+      Possible values are: "vertical_division_max", "vertical_division_min", "base_to_base".
     */
     String baseline_type_ = BASELINE_TYPE_BASETOBASE;
     ///@}
@@ -568,6 +591,7 @@ private:
       The Simpson's rule implementations for an odd number of unequally spaced points.
     */
     ///@{
+
     /**
       @brief Simpson's rule algorithm
 
@@ -583,6 +607,7 @@ private:
       @return The computed area
     */
     double simpson(MSChromatogram::ConstIterator it_begin, MSChromatogram::ConstIterator it_end) const;
+
     /**
       @brief Simpson's rule algorithm
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.cpp
@@ -57,7 +57,7 @@ namespace OpenMS
     defaults_.setValue("peak_integration", "original", "Calculate the peak area and height either the smoothed or the raw chromatogram data.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("peak_integration", ListUtils::create<String>("original,smoothed"));
 
-    defaults_.setValue("background_subtraction", "none", "Try to apply a background subtraction to the peak (experimental). The background is estimated as the average noise at the peak boundaries (original) or at the exact left and right peak positions (exact).  The same original or smoothed chromatogram specified by peak_integration will be used for background estimation.", ListUtils::create<String>("advanced"));
+    defaults_.setValue("background_subtraction", "none", "Remove background from peak signal using estimated noise levels. The 'original' method is only provided for historical purposes, please use the 'exact' method and set parameters using the PeakIntegrator: settings. The same original or smoothed chromatogram specified by peak_integration will be used for background estimation.", ListUtils::create<String>("advanced"));
     defaults_.setValidStrings("background_subtraction", ListUtils::create<String>("none,original,exact"));
 
     defaults_.setValue("recalculate_peaks", "false", "Tries to get better peak picking by looking at peak consistency of all picked peaks. Tries to use the consensus (median) peak border if theof variation within the picked peaks is too large.", ListUtils::create<String>("advanced"));

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -291,7 +291,7 @@ namespace OpenMS
       }
       else if (integration_type_ == INTEGRATION_TYPE_INTENSITYSUM)
       {
-        area = std::max(int_r, int_l) * std::distance(p.PosBegin(left), p.PosEnd(right));;
+        area = std::max(int_r, int_l) * std::distance(p.PosBegin(left), p.PosEnd(right));
       }
     }
     else

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -118,10 +118,10 @@ namespace OpenMS
   void PeakIntegrator::getDefaultParameters(Param& params)
   {
     params.clear();
-    params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM, "The integration technique to use in integratePeak() and estimateBackground().");
+    params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM, "The integration technique to use in integratePeak() and estimateBackground() which uses either the summed intensity, integration by Simpson's rule or trapezoidal integration.");
     params.setValidStrings("integration_type", ListUtils::create<String>("intensity_sum,simpson,trapezoid"));
-    params.setValue("baseline_type", BASELINE_TYPE_BASETOBASE, "The baseline type to use in estimateBackground().");
-    params.setValidStrings("baseline_type", ListUtils::create<String>("base_to_base,vertical_division"));
+    params.setValue("baseline_type", BASELINE_TYPE_BASETOBASE, "The baseline type to use in estimateBackground() based on the peak boundaries. A rectangular baseline shape is computed based either on the minimal intensity of the peak boundaries, the maximum intensity or the average intensity (base_to_base).");
+    params.setValidStrings("baseline_type", ListUtils::create<String>("base_to_base,vertical_division,vertical_division_min,vertical_division_max"));
   }
 
   void PeakIntegrator::updateMembers_()
@@ -261,7 +261,7 @@ namespace OpenMS
         area = (area - n_points * p.PosBegin(left)->getPos()) * delta_int / delta_pos + n_points * int_l;
       }
     }
-    else if (baseline_type_ == BASELINE_TYPE_VERTICALDIVISION)
+    else if (baseline_type_ == BASELINE_TYPE_VERTICALDIVISION || baseline_type_ == BASELINE_TYPE_VERTICALDIVISION_MIN)
     {
       height = std::min(int_r, int_l);
       if (integration_type_ == INTEGRATION_TYPE_TRAPEZOID || integration_type_ == INTEGRATION_TYPE_SIMPSON)
@@ -271,6 +271,18 @@ namespace OpenMS
       else if (integration_type_ == INTEGRATION_TYPE_INTENSITYSUM)
       {
         area = std::min(int_r, int_l) * std::distance(p.PosBegin(left), p.PosEnd(right));;
+      }
+    }
+    else if (baseline_type_ == BASELINE_TYPE_VERTICALDIVISION_MAX)
+    {
+      height = std::max(int_r, int_l);
+      if (integration_type_ == INTEGRATION_TYPE_TRAPEZOID || integration_type_ == INTEGRATION_TYPE_SIMPSON)
+      {
+        area = delta_pos * std::max(int_r, int_l);
+      }
+      else if (integration_type_ == INTEGRATION_TYPE_INTENSITYSUM)
+      {
+        area = std::max(int_r, int_l) * std::distance(p.PosBegin(left), p.PosEnd(right));;
       }
     }
     else

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakIntegrator.cpp
@@ -264,9 +264,9 @@ namespace OpenMS
         // We construct the background area as the sum of a rectangular part
         // and a triangle on top. The triangle is constructed as the sum of the
         // line's y value at each sampled point: \sum_{i=0}^{n} (x_i - x_0)  * m
-        double rectangle_area = n_points * int_l;
-        double slope = delta_int / delta_pos;
-        double triangle_area = (pos_sum - n_points * p.PosBegin(left)->getPos()) * slope;
+        const double rectangle_area = n_points * int_l;
+        const double slope = delta_int / delta_pos;
+        const double triangle_area = (pos_sum - n_points * p.PosBegin(left)->getPos()) * slope;
         area = triangle_area + rectangle_area;
       }
     }

--- a/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
@@ -333,6 +333,8 @@ START_SECTION((template <typename SpectrumT, typename TransitionT> MRMFeature cr
     TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 61405.95106);
     TEST_REAL_SIMILAR((double)mrmfeature.getFeature("1").getMetaValue("peak_apex_int"), 30286.9130513267);
 
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity()/mrmfeature.getFeature("1").getIntensity(), 8.72556) // ratio should be stable
+
     // feature dimension
     TEST_EQUAL(mrmfeature.getRT(), 1490.0)
     TEST_REAL_SIMILAR( mrmfeature.getMetaValue("leftWidth"), left_start);
@@ -348,38 +350,15 @@ START_SECTION((template <typename SpectrumT, typename TransitionT> MRMFeature cr
     picker.setParameters(picker_param);
 
     MRMFeature mrmfeature = picker.createMRMFeature(transition_group, picked_chroms, smoothed_chroms, chr_idx, peak_idx);
-    TEST_REAL_SIMILAR(mrmfeature.getRT(), 1490.0)
 
-    // test the number of hull points (should be equal)
-    TEST_EQUAL( mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size(), 12);
-    TEST_EQUAL( mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size(), 12);
-
-    // the intensity of the hull points should not have changed
-    ConvexHull2D::PointArrayType data1_points = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints();
-    double sum = 0.0;
-    for (ConvexHull2D::PointArrayType::iterator it = data1_points.begin(); it != data1_points.end(); it++)
-    {
-      sum += it->getY();
-    }
-    TEST_REAL_SIMILAR(sum, 535801.503);
     TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity(), 514583); // slightly reduced value due to background subtraction
     TEST_REAL_SIMILAR((double)mrmfeature.getFeature("2").getMetaValue("peak_apex_int"), 155925.8085); // slightly reduced value due to background subtraction
-    ConvexHull2D::PointArrayType data2_points = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints();
-    sum = 0.0;
-    for (ConvexHull2D::PointArrayType::iterator it = data2_points.begin(); it != data2_points.end(); it++)
-    {
-      sum += it->getY();
-    }
-    TEST_REAL_SIMILAR(sum, 61405.95106);
     TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 60913.8); // slightly reduced value due to background subtraction
     TEST_REAL_SIMILAR((double)mrmfeature.getFeature("2").getMetaValue("peak_apex_int"), 155925.8085); // slightly reduced value due to background subtraction
-
-    // feature dimension
-    TEST_EQUAL(mrmfeature.getRT(), 1490.0)
-    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("leftWidth"), left_start);
-    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("rightWidth"), right_end);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity()/mrmfeature.getFeature("1").getIntensity(), 8.44773) // ratio should be stable
   }
 
+  // background subtraction with peak integrator
   {
     MRMTransitionGroupPicker picker;
     Param picker_param = picker.getDefaults();
@@ -389,78 +368,31 @@ START_SECTION((template <typename SpectrumT, typename TransitionT> MRMFeature cr
     picker.setParameters(picker_param);
 
     MRMFeature mrmfeature = picker.createMRMFeature(transition_group, picked_chroms, smoothed_chroms, chr_idx, peak_idx);
-    TEST_REAL_SIMILAR(mrmfeature.getRT(), 1490.0)
 
-    // test the number of hull points (should be equal)
-    TEST_EQUAL( mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size(), 12);
-    TEST_EQUAL( mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size(), 12);
-
-    // the intensity of the hull points should not have changed
-    ConvexHull2D::PointArrayType data1_points = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints();
-    double sum = 0.0;
-    for (ConvexHull2D::PointArrayType::iterator it = data1_points.begin(); it != data1_points.end(); it++)
-    {
-      sum += it->getY();
-    }
-    TEST_REAL_SIMILAR(sum, 535801.503);
     TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity(), 514590); // slightly reduced value due to background subtraction
     TEST_REAL_SIMILAR((double)mrmfeature.getFeature("2").getMetaValue("peak_apex_int"), 155331.37806798); // slightly reduced value due to background subtraction
-    ConvexHull2D::PointArrayType data2_points = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints();
-    sum = 0.0;
-    for (ConvexHull2D::PointArrayType::iterator it = data2_points.begin(); it != data2_points.end(); it++)
-    {
-      sum += it->getY();
-    }
-    TEST_REAL_SIMILAR(sum, 61405.95106);
     TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 61009.7); // slightly reduced value due to background subtraction
     TEST_REAL_SIMILAR((double)mrmfeature.getFeature("1").getMetaValue("peak_apex_int"), 30251.2414481247); // slightly reduced value due to background subtraction
-
-    // feature dimension
-    TEST_EQUAL(mrmfeature.getRT(), 1490.0)
-    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("leftWidth"), left_start);
-    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("rightWidth"), right_end);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity()/mrmfeature.getFeature("1").getIntensity(), 8.43456040596823) // ratio should be stable
   }
 
+  // integration with Simpon's rule (with background subtraction)
   {
     MRMTransitionGroupPicker picker;
     Param picker_param = picker.getDefaults();
     picker_param.setValue("PeakPickerMRM::method", "legacy"); // old parameters
     picker_param.setValue("PeakPickerMRM::peak_width", 40.0); // old parameters
     picker_param.setValue("background_subtraction", "exact");
-    picker_param.setValue("PeakIntegrator:integration_type", "trapezoid");
+    picker_param.setValue("PeakIntegrator:integration_type", "simpson");
     picker.setParameters(picker_param);
 
     MRMFeature mrmfeature = picker.createMRMFeature(transition_group, picked_chroms, smoothed_chroms, chr_idx, peak_idx);
-    TEST_REAL_SIMILAR(mrmfeature.getRT(), 1490.0)
 
-    // test the number of hull points (should be equal)
-    TEST_EQUAL( mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size(), 12);
-    TEST_EQUAL( mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size(), 12);
-
-    // the intensity of the hull points should not have changed
-    ConvexHull2D::PointArrayType data1_points = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints();
-    double sum = 0.0;
-    for (ConvexHull2D::PointArrayType::iterator it = data1_points.begin(); it != data1_points.end(); it++)
-    {
-      sum += it->getY();
-    }
-    TEST_REAL_SIMILAR(sum, 535801.503);
-    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity(), 514590); // slightly reduced value due to background subtraction
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity(), 1.42194e+06); // slightly reduced value due to background subtraction
     TEST_REAL_SIMILAR((double)mrmfeature.getFeature("2").getMetaValue("peak_apex_int"), 155331.37806798); // slightly reduced value due to background subtraction
-    ConvexHull2D::PointArrayType data2_points = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints();
-    sum = 0.0;
-    for (ConvexHull2D::PointArrayType::iterator it = data2_points.begin(); it != data2_points.end(); it++)
-    {
-      sum += it->getY();
-    }
-    TEST_REAL_SIMILAR(sum, 61405.95106);
-    TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 61009.7); // slightly reduced value due to background subtraction
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 168685); // slightly reduced value due to background subtraction
     TEST_REAL_SIMILAR((double)mrmfeature.getFeature("1").getMetaValue("peak_apex_int"), 30251.2414481247); // slightly reduced value due to background subtraction
-
-    // feature dimension
-    TEST_EQUAL(mrmfeature.getRT(), 1490.0)
-    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("leftWidth"), left_start);
-    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("rightWidth"), right_end);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity()/mrmfeature.getFeature("1").getIntensity(), 8.42957) // ratio should be stable
   }
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMTransitionGroupPicker_test.cpp
@@ -74,10 +74,10 @@ sum(datapoints[3:10])
 */
 
   static const double rtdata_1[] = {1474.34, 1477.11, 1479.88, 1482.64,
-    1485.41, 1488.19, 1490.95, 1493.72, 1496.48, 1499.25, 1502.03, 1504.8 ,
+    1485.41, 1488.19, 1490.95, 1493.72, 1496.48, 1499.25, 1502.03, 1504.8,
     1507.56, 1510.33, 1513.09, 1515.87, 1518.64, 1521.42};
   static const double rtdata_2[] = {1473.55, 1476.31, 1479.08, 1481.84,
-    1484.61, 1487.39, 1490.15, 1492.92, 1495.69, 1498.45, 1501.23, 1504   ,
+    1484.61, 1487.39, 1490.15, 1492.92, 1495.69, 1498.45, 1501.23, 1504,
     1506.76, 1509.53, 1512.29, 1515.07, 1517.84, 1520.62};
 
   static const double intdata_1[] = {3.26958, 3.74189, 3.31075, 86.1901,
@@ -188,8 +188,8 @@ MRMTransitionGroupPicker* nullPointer = nullptr;
 
 START_SECTION(MRMTransitionGroupPicker())
 {
-	ptr = new MRMTransitionGroupPicker();
-	TEST_NOT_EQUAL(ptr, nullPointer)
+  ptr = new MRMTransitionGroupPicker();
+  TEST_NOT_EQUAL(ptr, nullPointer)
 }
 END_SECTION
 
@@ -298,42 +298,128 @@ START_SECTION((template <typename SpectrumT, typename TransitionT> MRMFeature cr
 
   // create the corresponding first mrm feature
   int chr_idx = 1, peak_idx = 0;
-  MRMTransitionGroupPicker picker;
 
-  Param picker_param = picker.getDefaults();
-  picker_param.setValue("PeakPickerMRM::method", "legacy"); // old parameters
-  picker_param.setValue("PeakPickerMRM::peak_width", 40.0); // old parameters
-  picker.setParameters(picker_param);
-
-  MRMFeature mrmfeature = picker.createMRMFeature(transition_group, picked_chroms, smoothed_chroms, chr_idx, peak_idx);
-  TEST_REAL_SIMILAR(mrmfeature.getRT(), 1490.0)
-
-  // test the number of hull points (should be equal)
-  TEST_EQUAL( mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size(), 12);
-  TEST_EQUAL( mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size(), 12);
-
-  // the intensity of the hull points should not have changed
-  ConvexHull2D::PointArrayType data1_points = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints();
-  double sum = 0.0;
-  for (ConvexHull2D::PointArrayType::iterator it = data1_points.begin(); it != data1_points.end(); it++)
   {
-    sum += it->getY();
-  }
-  TEST_REAL_SIMILAR(sum, 535801.503);
-  TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity(), 535801.503);
-  ConvexHull2D::PointArrayType data2_points = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints();
-  sum = 0.0;
-  for (ConvexHull2D::PointArrayType::iterator it = data2_points.begin(); it != data2_points.end(); it++)
-  {
-    sum += it->getY();
-  }
-  TEST_REAL_SIMILAR(sum, 61405.95106);
-  TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 61405.95106);
+    MRMTransitionGroupPicker picker;
+    Param picker_param = picker.getDefaults();
+    picker_param.setValue("PeakPickerMRM::method", "legacy"); // old parameters
+    picker_param.setValue("PeakPickerMRM::peak_width", 40.0); // old parameters
+    picker.setParameters(picker_param);
 
-  // feature dimension
-  TEST_EQUAL(mrmfeature.getRT(), 1490.0)
-  TEST_REAL_SIMILAR( mrmfeature.getMetaValue("leftWidth"), left_start);
-  TEST_REAL_SIMILAR( mrmfeature.getMetaValue("rightWidth"), right_end);
+    MRMFeature mrmfeature = picker.createMRMFeature(transition_group, picked_chroms, smoothed_chroms, chr_idx, peak_idx);
+    TEST_REAL_SIMILAR(mrmfeature.getRT(), 1490.0)
+
+    // test the number of hull points (should be equal)
+    TEST_EQUAL( mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size(), 12);
+    TEST_EQUAL( mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size(), 12);
+
+    // the intensity of the hull points should not have changed
+    ConvexHull2D::PointArrayType data1_points = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints();
+    double sum = 0.0;
+    for (ConvexHull2D::PointArrayType::iterator it = data1_points.begin(); it != data1_points.end(); it++)
+    {
+      sum += it->getY();
+    }
+    TEST_REAL_SIMILAR(sum, 535801.503);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity(), 535801.503);
+    TEST_REAL_SIMILAR((double)mrmfeature.getFeature("2").getMetaValue("peak_apex_int"), 157694);
+    ConvexHull2D::PointArrayType data2_points = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints();
+    sum = 0.0;
+    for (ConvexHull2D::PointArrayType::iterator it = data2_points.begin(); it != data2_points.end(); it++)
+    {
+      sum += it->getY();
+    }
+    TEST_REAL_SIMILAR(sum, 61405.95106);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 61405.95106);
+    TEST_REAL_SIMILAR((double)mrmfeature.getFeature("1").getMetaValue("peak_apex_int"), 30286.9130513267);
+
+    // feature dimension
+    TEST_EQUAL(mrmfeature.getRT(), 1490.0)
+    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("leftWidth"), left_start);
+    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("rightWidth"), right_end);
+  }
+
+  {
+    MRMTransitionGroupPicker picker;
+    Param picker_param = picker.getDefaults();
+    picker_param.setValue("PeakPickerMRM::method", "legacy"); // old parameters
+    picker_param.setValue("PeakPickerMRM::peak_width", 40.0); // old parameters
+    picker_param.setValue("background_subtraction", "original");
+    picker.setParameters(picker_param);
+
+    MRMFeature mrmfeature = picker.createMRMFeature(transition_group, picked_chroms, smoothed_chroms, chr_idx, peak_idx);
+    TEST_REAL_SIMILAR(mrmfeature.getRT(), 1490.0)
+
+    // test the number of hull points (should be equal)
+    TEST_EQUAL( mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size(), 12);
+    TEST_EQUAL( mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size(), 12);
+
+    // the intensity of the hull points should not have changed
+    ConvexHull2D::PointArrayType data1_points = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints();
+    double sum = 0.0;
+    for (ConvexHull2D::PointArrayType::iterator it = data1_points.begin(); it != data1_points.end(); it++)
+    {
+      sum += it->getY();
+    }
+    TEST_REAL_SIMILAR(sum, 535801.503);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity(), 514583); // slightly reduced value due to background subtraction
+    TEST_REAL_SIMILAR((double)mrmfeature.getFeature("2").getMetaValue("peak_apex_int"), 155925.8085); // slightly reduced value due to background subtraction
+    ConvexHull2D::PointArrayType data2_points = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints();
+    sum = 0.0;
+    for (ConvexHull2D::PointArrayType::iterator it = data2_points.begin(); it != data2_points.end(); it++)
+    {
+      sum += it->getY();
+    }
+    TEST_REAL_SIMILAR(sum, 61405.95106);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 60913.8); // slightly reduced value due to background subtraction
+    TEST_REAL_SIMILAR((double)mrmfeature.getFeature("2").getMetaValue("peak_apex_int"), 155925.8085); // slightly reduced value due to background subtraction
+
+    // feature dimension
+    TEST_EQUAL(mrmfeature.getRT(), 1490.0)
+    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("leftWidth"), left_start);
+    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("rightWidth"), right_end);
+  }
+
+  {
+    MRMTransitionGroupPicker picker;
+    Param picker_param = picker.getDefaults();
+    picker_param.setValue("PeakPickerMRM::method", "legacy"); // old parameters
+    picker_param.setValue("PeakPickerMRM::peak_width", 40.0); // old parameters
+    picker_param.setValue("background_subtraction", "exact");
+    picker.setParameters(picker_param);
+
+    MRMFeature mrmfeature = picker.createMRMFeature(transition_group, picked_chroms, smoothed_chroms, chr_idx, peak_idx);
+    TEST_REAL_SIMILAR(mrmfeature.getRT(), 1490.0)
+
+    // test the number of hull points (should be equal)
+    TEST_EQUAL( mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints().size(), 12);
+    TEST_EQUAL( mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints().size(), 12);
+
+    // the intensity of the hull points should not have changed
+    ConvexHull2D::PointArrayType data1_points = mrmfeature.getFeature("2").getConvexHulls()[0].getHullPoints();
+    double sum = 0.0;
+    for (ConvexHull2D::PointArrayType::iterator it = data1_points.begin(); it != data1_points.end(); it++)
+    {
+      sum += it->getY();
+    }
+    TEST_REAL_SIMILAR(sum, 535801.503);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("2").getIntensity(), 514590); // slightly reduced value due to background subtraction
+    TEST_REAL_SIMILAR((double)mrmfeature.getFeature("2").getMetaValue("peak_apex_int"), 155331.37806798); // slightly reduced value due to background subtraction
+    ConvexHull2D::PointArrayType data2_points = mrmfeature.getFeature("1").getConvexHulls()[0].getHullPoints();
+    sum = 0.0;
+    for (ConvexHull2D::PointArrayType::iterator it = data2_points.begin(); it != data2_points.end(); it++)
+    {
+      sum += it->getY();
+    }
+    TEST_REAL_SIMILAR(sum, 61405.95106);
+    TEST_REAL_SIMILAR(mrmfeature.getFeature("1").getIntensity(), 61009.7); // slightly reduced value due to background subtraction
+    TEST_REAL_SIMILAR((double)mrmfeature.getFeature("1").getMetaValue("peak_apex_int"), 30251.2414481247); // slightly reduced value due to background subtraction
+
+    // feature dimension
+    TEST_EQUAL(mrmfeature.getRT(), 1490.0)
+    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("leftWidth"), left_start);
+    TEST_REAL_SIMILAR( mrmfeature.getMetaValue("rightWidth"), right_end);
+  }
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
+++ b/src/tests/class_tests/openms/source/PeakIntegrator_test.cpp
@@ -132,7 +132,8 @@ constexpr const char* INTEGRATION_TYPE_INTENSITYSUM = "intensity_sum";
 constexpr const char* INTEGRATION_TYPE_TRAPEZOID = "trapezoid";
 constexpr const char* INTEGRATION_TYPE_SIMPSON = "simpson";
 constexpr const char* BASELINE_TYPE_BASETOBASE = "base_to_base";
-constexpr const char* BASELINE_TYPE_VERTICALDIVISION = "vertical_division";
+constexpr const char* BASELINE_TYPE_VERTICALDIVISION_MIN = "vertical_division_min";
+constexpr const char* BASELINE_TYPE_VERTICALDIVISION_MAX = "vertical_division_max";
 
 START_SECTION(PeakIntegrator())
 {
@@ -174,13 +175,21 @@ START_SECTION(PeakBackground estimateBackground(
   TEST_REAL_SIMILAR(pb.area, 123446.661339019)
   TEST_REAL_SIMILAR(pb.height, 1908.59690598823)
 
-  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION);
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MIN);
   params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM);
   ptr->setParameters(params);
   pa = ptr->integratePeak(chromatogram, left, right);
   pb = ptr->estimateBackground(chromatogram, left, right, pa.apex_pos);
   TEST_REAL_SIMILAR(pb.area, 50217)
   TEST_REAL_SIMILAR(pb.height, 881)
+
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MAX);
+  params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM);
+  ptr->setParameters(params);
+  pa = ptr->integratePeak(chromatogram, left, right);
+  pb = ptr->estimateBackground(chromatogram, left, right, pa.apex_pos);
+  TEST_REAL_SIMILAR(pb.area, 190095)
+  TEST_REAL_SIMILAR(pb.height, 3335)
 
   params.setValue("baseline_type", BASELINE_TYPE_BASETOBASE);
   params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
@@ -190,13 +199,21 @@ START_SECTION(PeakBackground estimateBackground(
   TEST_REAL_SIMILAR(pb.area, 1140.392865964)
   TEST_REAL_SIMILAR(pb.height, 1908.59690598823)
 
-  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION);
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MIN);
   params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
   ptr->setParameters(params);
   pa = ptr->integratePeak(chromatogram, left, right);
   pb = ptr->estimateBackground(chromatogram, left, right, pa.apex_pos);
   TEST_REAL_SIMILAR(pb.area, 476.606316373)
   TEST_REAL_SIMILAR(pb.height, 881)
+
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MAX);
+  params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
+  ptr->setParameters(params);
+  pa = ptr->integratePeak(chromatogram, left, right);
+  pb = ptr->estimateBackground(chromatogram, left, right, pa.apex_pos);
+  TEST_REAL_SIMILAR(pb.area, 1804.179415555)
+  TEST_REAL_SIMILAR(pb.height, 3335)
 }
 END_SECTION
 
@@ -217,13 +234,21 @@ START_SECTION(PeakBackground estimateBackground(
   TEST_REAL_SIMILAR(pb.area, 123446.661339019)
   TEST_REAL_SIMILAR(pb.height, 1908.59690598823)
 
-  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION);
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MIN);
   params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM);
   ptr->setParameters(params);
   pa = ptr->integratePeak(chromatogram, chrom_left_it, chrom_right_it);
   pb = ptr->estimateBackground(chromatogram, chrom_left_it, chrom_right_it, pa.apex_pos);
   TEST_REAL_SIMILAR(pb.area, 50217)
   TEST_REAL_SIMILAR(pb.height, 881)
+
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MAX);
+  params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM);
+  ptr->setParameters(params);
+  pa = ptr->integratePeak(chromatogram, chrom_left_it, chrom_right_it);
+  pb = ptr->estimateBackground(chromatogram, chrom_left_it, chrom_right_it, pa.apex_pos);
+  TEST_REAL_SIMILAR(pb.area, 190095)
+  TEST_REAL_SIMILAR(pb.height, 3335)
 
   params.setValue("baseline_type", BASELINE_TYPE_BASETOBASE);
   params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
@@ -233,13 +258,21 @@ START_SECTION(PeakBackground estimateBackground(
   TEST_REAL_SIMILAR(pb.area, 1140.392865964)
   TEST_REAL_SIMILAR(pb.height, 1908.59690598823)
 
-  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION);
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MIN);
   params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
   ptr->setParameters(params);
   pa = ptr->integratePeak(chromatogram, chrom_left_it, chrom_right_it);
   pb = ptr->estimateBackground(chromatogram, chrom_left_it, chrom_right_it, pa.apex_pos);
   TEST_REAL_SIMILAR(pb.area, 476.606316373)
   TEST_REAL_SIMILAR(pb.height, 881)
+
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MAX);
+  params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
+  ptr->setParameters(params);
+  pa = ptr->integratePeak(chromatogram, chrom_left_it, chrom_right_it);
+  pb = ptr->estimateBackground(chromatogram, chrom_left_it, chrom_right_it, pa.apex_pos);
+  TEST_REAL_SIMILAR(pb.area, 1804.179415555)
+  TEST_REAL_SIMILAR(pb.height, 3335)
 }
 END_SECTION
 
@@ -260,13 +293,21 @@ START_SECTION(PeakBackground estimateBackground(
   TEST_REAL_SIMILAR(pb.area, 123446.661339019)
   TEST_REAL_SIMILAR(pb.height, 1908.59690598823)
 
-  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION);
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MIN);
   params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM);
   ptr->setParameters(params);
   pa = ptr->integratePeak(spectrum, left, right);
   pb = ptr->estimateBackground(spectrum, left, right, pa.apex_pos);
   TEST_REAL_SIMILAR(pb.area, 50217)
   TEST_REAL_SIMILAR(pb.height, 881)
+
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MAX);
+  params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM);
+  ptr->setParameters(params);
+  pa = ptr->integratePeak(spectrum, left, right);
+  pb = ptr->estimateBackground(spectrum, left, right, pa.apex_pos);
+  TEST_REAL_SIMILAR(pb.area, 190095)
+  TEST_REAL_SIMILAR(pb.height, 3335)
 
   params.setValue("baseline_type", BASELINE_TYPE_BASETOBASE);
   params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
@@ -276,13 +317,21 @@ START_SECTION(PeakBackground estimateBackground(
   TEST_REAL_SIMILAR(pb.area, 1140.392865964)
   TEST_REAL_SIMILAR(pb.height, 1908.59690598823)
 
-  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION);
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MIN);
   params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
   ptr->setParameters(params);
   pa = ptr->integratePeak(spectrum, left, right);
   pb = ptr->estimateBackground(spectrum, left, right, pa.apex_pos);
   TEST_REAL_SIMILAR(pb.area, 476.606316373)
   TEST_REAL_SIMILAR(pb.height, 881)
+
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MAX);
+  params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
+  ptr->setParameters(params);
+  pa = ptr->integratePeak(spectrum, left, right);
+  pb = ptr->estimateBackground(spectrum, left, right, pa.apex_pos);
+  TEST_REAL_SIMILAR(pb.area, 1804.179415555)
+  TEST_REAL_SIMILAR(pb.height, 3335)
 }
 END_SECTION
 
@@ -303,13 +352,21 @@ START_SECTION(PeakBackground estimateBackground(
   TEST_REAL_SIMILAR(pb.area, 123446.661339019)
   TEST_REAL_SIMILAR(pb.height, 1908.59690598823)
 
-  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION);
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MIN);
   params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM);
   ptr->setParameters(params);
   pa = ptr->integratePeak(spectrum, spec_left_it, spec_right_it);
   pb = ptr->estimateBackground(spectrum, spec_left_it, spec_right_it, pa.apex_pos);
   TEST_REAL_SIMILAR(pb.area, 50217)
   TEST_REAL_SIMILAR(pb.height, 881)
+
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MAX);
+  params.setValue("integration_type", INTEGRATION_TYPE_INTENSITYSUM);
+  ptr->setParameters(params);
+  pa = ptr->integratePeak(spectrum, spec_left_it, spec_right_it);
+  pb = ptr->estimateBackground(spectrum, spec_left_it, spec_right_it, pa.apex_pos);
+  TEST_REAL_SIMILAR(pb.area, 190095)
+  TEST_REAL_SIMILAR(pb.height, 3335)
 
   params.setValue("baseline_type", BASELINE_TYPE_BASETOBASE);
   params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
@@ -319,13 +376,21 @@ START_SECTION(PeakBackground estimateBackground(
   TEST_REAL_SIMILAR(pb.area, 1140.392865964)
   TEST_REAL_SIMILAR(pb.height, 1908.59690598823)
 
-  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION);
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MIN);
   params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
   ptr->setParameters(params);
   pa = ptr->integratePeak(spectrum, spec_left_it, spec_right_it);
   pb = ptr->estimateBackground(spectrum, spec_left_it, spec_right_it, pa.apex_pos);
   TEST_REAL_SIMILAR(pb.area, 476.606316373)
   TEST_REAL_SIMILAR(pb.height, 881)
+
+  params.setValue("baseline_type", BASELINE_TYPE_VERTICALDIVISION_MAX);
+  params.setValue("integration_type", INTEGRATION_TYPE_TRAPEZOID);
+  ptr->setParameters(params);
+  pa = ptr->integratePeak(spectrum, spec_left_it, spec_right_it);
+  pb = ptr->estimateBackground(spectrum, spec_left_it, spec_right_it, pa.apex_pos);
+  TEST_REAL_SIMILAR(pb.area, 1804.179415555)
+  TEST_REAL_SIMILAR(pb.height, 3335)
 }
 END_SECTION
 


### PR DESCRIPTION
Added a further method for background subtraction, based on what Skyline and EncyclopeDIA is apparently doing. See for example: https://www.biorxiv.org/content/early/2018/03/07/277822

```
We calculate trapezoidal
peak areas across Savitsky-Golay smoothed chromatograms. Analogous to Skyline,
peak intensities are background subtracted by removing a peak area rectangle with a
height equal to the largest intensity of either of the boundary edges. If the area of the
rectangle is larger than the area of the peak the intensity is set to zero.
```

@dmccloskey @pasqoo I would also like to change "vertical division" to "rectangular" as that is what we are really doing, a rectangular background subtraction. Any thoughts on this?
