### PR TITLE
Fix/mrm

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.h
@@ -121,34 +121,9 @@ protected:
 
         @exception Exception::UnableToFit is thrown if fitting cannot be performed
     */
-    void optimize_(Eigen::VectorXd& x_init, GenericFunctor& functor)
-    {
-      //TODO: this function is copy&paste from TraceFitter.h. Make a generic wrapper for
-      //LM optimization
-      int data_count = functor.values();
-      int num_params = functor.inputs();
+    void optimize_(Eigen::VectorXd& x_init, GenericFunctor& functor);
 
-      // LM always expects N>=p, cause Jacobian be rectangular M x N with M>=N
-      if (data_count < num_params) throw Exception::UnableToFit(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "UnableToFit-FinalSet", "Skipping feature, we always expects N>=p");
-
-      Eigen::LevenbergMarquardt<GenericFunctor> lmSolver (functor);
-      lmSolver.parameters.maxfev = max_iteration_;
-      Eigen::LevenbergMarquardtSpace::Status status = lmSolver.minimize(x_init);
-
-      //the states are poorly documented. after checking the source, we believe that
-      //all states except NotStarted, Running and ImproperInputParameters are good
-      //termination states.
-      if (status <= Eigen::LevenbergMarquardtSpace::ImproperInputParameters)
-      {
-          throw Exception::UnableToFit(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "UnableToFit-FinalSet", "Could not fit the gaussian to the data: Error " + String(status));
-      }
-    }
-
-    void updateMembers_() override
-    {
-      Fitter1D::updateMembers_();
-      max_iteration_ = this->param_.getValue("max_iteration");
-    }
+    void updateMembers_() override;
 
   };
 }

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -200,6 +200,10 @@ namespace OpenMS
     if (pep.hasRetentionTime())
     {
       p.rt = pep.getRetentionTime();
+      if (pep.getRetentionTimeUnit() == TargetedExperimentHelper::RetentionTime::RTUnit::MINUTE)
+      {
+        p.rt = 60 * pep.getRetentionTime();
+      }
     }
     p.setDriftTime(pep.getDriftTime());
 
@@ -267,6 +271,10 @@ namespace OpenMS
     if (compound.hasRetentionTime())
     {
       comp.rt = compound.getRetentionTime();
+      if (compound.getRetentionTimeUnit() == TargetedExperimentHelper::RetentionTime::RTUnit::MINUTE)
+      {
+        comp.rt = 60 * compound.getRetentionTime();
+      }
     }
     comp.setDriftTime(compound.getDriftTime());
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/EmgFitter1D.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/EmgFitter1D.cpp
@@ -95,7 +95,7 @@ namespace OpenMS
       // f'(h)
       derivative_height = w / s * sqrt_2pi * exp1 / exp2;
 
-      // f'(h)
+      // f'(w)
       derivative_width = h / s * sqrt_2pi * exp1 / exp2 + (h * w * w) / (s * s * s) * sqrt_2pi * exp1 / exp2 + (emg_const * h * w) / s * sqrt_2pi * exp1 * (-(t - z) / (w * w) - 1 / s) * exp3 / ((exp2 * exp2) * sqrt_2);
 
       // f'(s)
@@ -227,7 +227,9 @@ namespace OpenMS
 
     QualityType correlation = Math::pearsonCorrelationCoefficient(real_data.begin(), real_data.end(), model_data.begin(), model_data.end());
     if (boost::math::isnan(correlation))
+    {
       correlation = -1.0;
+    }
 
     return correlation;
   }
@@ -249,6 +251,8 @@ namespace OpenMS
         median = i;
     }
 
+    double max_peak_width = fabs(set[set.size() - 1].getPos() - set[median].getPos()); // cannot be wider than this
+
     // calculate the height of the peak
     height_ = set[median].getIntensity();
 
@@ -265,7 +269,7 @@ namespace OpenMS
     if (boost::math::isinf(symmetry_) || boost::math::isnan(symmetry_))
     {
       symmetric_ = true;
-      symmetry_ = 10;
+      symmetry_ = 10.0;
     }
 
     // optimize the symmetry
@@ -273,7 +277,12 @@ namespace OpenMS
     // For s~5 the parameter can be approximated by the Levenberg-Marquardt algorithms.
     // (the other parameters are much greater than one)
     if (symmetry_ < 1)
+    {
       symmetry_ += 5;
+    }
+
+    // Need to ensure that we do not go beyond the maximal width of the peak
+    symmetry_ = std::min(symmetry_, max_peak_width);
 
     // calculate the width of the peak
     // rt-values with intensity zero are not allowed for calculation of the width

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.cpp
@@ -35,5 +35,34 @@
 namespace OpenMS
 {
 
+    void LevMarqFitter1D::optimize_(Eigen::VectorXd& x_init, GenericFunctor& functor)
+    {
+      //TODO: this function is copy&paste from TraceFitter.h. Make a generic wrapper for
+      //LM optimization
+      int data_count = functor.values();
+      int num_params = functor.inputs();
+
+      // LM always expects N>=p, cause Jacobian be rectangular M x N with M>=N
+      if (data_count < num_params) throw Exception::UnableToFit(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "UnableToFit-FinalSet", "Skipping feature, we always expects N>=p");
+
+      Eigen::LevenbergMarquardt<GenericFunctor> lmSolver (functor);
+      lmSolver.parameters.maxfev = max_iteration_;
+      Eigen::LevenbergMarquardtSpace::Status status = lmSolver.minimize(x_init);
+
+      //the states are poorly documented. after checking the source, we believe that
+      //all states except NotStarted, Running and ImproperInputParameters are good
+      //termination states.
+      if (status <= Eigen::LevenbergMarquardtSpace::ImproperInputParameters)
+      {
+          throw Exception::UnableToFit(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "UnableToFit-FinalSet", "Could not fit the gaussian to the data: Error " + String(status));
+      }
+    }
+
+    void LevMarqFitter1D::updateMembers_()
+    {
+      Fitter1D::updateMembers_();
+      max_iteration_ = this->param_.getValue("max_iteration");
+    }
+
 
 } // namespace OpenMS

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.cpp
@@ -32,6 +32,7 @@
 // $Authors: $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/LevMarqFitter1D.h>
 namespace OpenMS
 {
 


### PR DESCRIPTION
multiple fixes for MRM / OpenSWATH code

- correctly use minutes when data interpretation is in minutes
- EMG fitting was using wrong initial parameters that were wider than the peak
- code move