### PR TITLE
[BUILD]: Implement CMake flag to build documentation (BUILD_DOCS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option(MT_ENABLE_TBB "Enable Intel TBB support" OFF)
 option(MT_ENABLE_OPENMP "Enable OpenMP support" ON)
 option(BOOST_USE_STATIC "Use Boost static libraries." ON)
 option(HAS_XSERVER "Indicates if an X server is available. If set to Off it will disable certain tests and the doc target." ON)
+option(BUILD_DOCS "Indicates whether documentation should be built." ON)
 option(ENABLE_TUTORIALS "Indicates whether tutorials should be build. Note that this also depends on the availability of (pdf)latex." ON)
 option(WITH_GUI "Build GUI parts of OpenMS (TOPPView&Co). This requires QtGui." ON)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -48,254 +48,208 @@ endmacro()
 if(BUILD_DOCS)
   message(STATUS "Documentation is built (-D BUILD_DOCS=On).")
 
-#------------------------------------------------------------------------------
-# decide which doc target is part of all
-#------------------------------------------------------------------------------
-if (HAS_XSERVER)
-  set(_DOC_ALL "ALL")
-  set(_DOC_MINIMAL_ALL "")
-  set(_DOC_MINIMAL_EXTRA_MESSAGE )
-else ()
-  set(_DOC_ALL "")
-  set(_DOC_MINIMAL_ALL "ALL")
-  set(_DOC_MINIMAL_EXTRA_MESSAGE
-      COMMAND ${CMAKE_COMMAND} -E echo "We build only a minimal doc since OpenMS was configured without HAS_XSERVER=Off."
-      COMMAND ${CMAKE_COMMAND} -E echo "If you want the full doc, either execute cmake --build . --target doc manually"
-      COMMAND ${CMAKE_COMMAND} -E echo "or rerun cmake with -DHAS_XSERVER=On."
-  )
-endif ()
-
-#------------------------------------------------------------------------------
-# doc programs
-#------------------------------------------------------------------------------
-set(OpenMS_doc_executables)
-include(doxygen/parameters/executables.cmake)
-
-set(OPENMS_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "doxygen/parameters")
-
-# check whether OpenMS_GUI is available or not
-set(_doc_progs_include )
-set(_doc_progs_link_libraries )
-if(WITH_GUI)
   #------------------------------------------------------------------------------
-  # QT dependencies
-  find_package(Qt5 COMPONENTS Core Network Svg OpenGL REQUIRED)
-  set(_doc_progs_include ${OpenMS_GUI_INCLUDE_DIRECTORIES})
-  set(_doc_progs_link_libraries ${OpenMS_GUI_LIBRARIES})
-else()
-  find_package(Qt5 COMPONENTS Core Network REQUIRED)
-  set(_doc_progs_include ${OpenMS_INCLUDE_DIRECTORIES})
-  set(_doc_progs_link_libraries ${OpenMS_LIBRARIES})
-endif()
+  # decide which doc target is part of all
+  #------------------------------------------------------------------------------
+  if (HAS_XSERVER)
+    set(_DOC_ALL "ALL")
+    set(_DOC_MINIMAL_ALL "")
+    set(_DOC_MINIMAL_EXTRA_MESSAGE )
+  else ()
+    set(_DOC_ALL "")
+    set(_DOC_MINIMAL_ALL "ALL")
+    set(_DOC_MINIMAL_EXTRA_MESSAGE
+        COMMAND ${CMAKE_COMMAND} -E echo "We build only a minimal doc since OpenMS was configured without HAS_XSERVER=Off."
+        COMMAND ${CMAKE_COMMAND} -E echo "If you want the full doc, either execute cmake --build . --target doc manually"
+        COMMAND ${CMAKE_COMMAND} -E echo "or rerun cmake with -DHAS_XSERVER=On."
+    )
+  endif ()
 
-include_directories(SYSTEM ${_doc_progs_include})
-add_definitions(/DBOOST_ALL_NO_LIB)
+  #------------------------------------------------------------------------------
+  # doc programs
+  #------------------------------------------------------------------------------
+  set(OpenMS_doc_executables)
+  include(doxygen/parameters/executables.cmake)
 
-# build doc executables
-foreach(i ${OpenMS_doc_executables})
-  add_executable(${i} EXCLUDE_FROM_ALL doxygen/parameters/${i}.cpp)
-  target_link_libraries(${i} ${_doc_progs_link_libraries})
+  set(OPENMS_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "doxygen/parameters")
 
-  # let the doc progs decide how to handle a missing OpenMS_GUI library
+  # check whether OpenMS_GUI is available or not
+  set(_doc_progs_include )
+  set(_doc_progs_link_libraries )
   if(WITH_GUI)
-    set_target_properties(${i} PROPERTIES COMPILE_DEFINITIONS "WITH_GUI=1")
-  endif()
-endforeach(i)
-
-# collection target
-add_custom_target(doc_progs)
-add_dependencies(doc_progs ${OpenMS_doc_executables} TOPP UTILS)
-
-if(WITH_GUI)
-  add_dependencies(doc_progs GUI)
-endif()
-
-#------------------------------------------------------------------------------
-# Initialize variables needed for a proper doxygen configuration
-#------------------------------------------------------------------------------
-set(CF_OPENMS_BIN_PATH ${PROJECT_BINARY_DIR})
-set(CF_OPENMS_SRC_PATH ${OPENMS_HOST_DIRECTORY})
-
-# make it a doxygen conform list
-make_doxygen_path(CF_OPENMS_DOCUMENTATION_DIRECTORIES OPENMS_DOCUMENTATION_DIRECTORIES)
-make_doxygen_path(CF_OPENMS_DOCUMENTATION_STRIP_INCLUDES OPENMS_DOCUMENTATION_DIRECTORIES)
-make_doxygen_path(CF_STRIP_PATH OPENMS_DOCUMENTATION_DIRECTORIES)
-
-#------------------------------------------------------------------------------
-# find the necessary packages
-find_package(Doxygen)
-find_package(LATEX)
-# Doxygen with formulas built with LaTeX actually also needs Ghostscript but there is no official find module for it, yet.
-#find_package(Ghostscript)
-
-#------------------------------------------------------------------------------
-# the doc targets
-#------------------------------------------------------------------------------
-# As soon as there is a TeX formula in the html documentation we need LaTeX, dvips and ghostscript.
-# Probably only affects class documentation.
-
-if (DOXYGEN_FOUND)
-  #------------------------------------------------------------------------------
-  # configure doxygen configuration files
-  configure_file(${PROJECT_SOURCE_DIR}/doxygen/Doxyfile.in ${PROJECT_BINARY_DIR}/doxygen/Doxyfile)
-  configure_file(${PROJECT_SOURCE_DIR}/doxygen/Doxyfile_dot.in ${PROJECT_BINARY_DIR}/doxygen/Doxyfile_dot)
-  configure_file(${PROJECT_SOURCE_DIR}/doxygen/Doxyfile_noclass.in ${PROJECT_BINARY_DIR}/doxygen/Doxyfile_noclass)
-  configure_file(${PROJECT_SOURCE_DIR}/doxygen/Doxyfile_xml.in ${PROJECT_BINARY_DIR}/doxygen/Doxyfile_xml)
-
-  #------------------------------------------------------------------------------
-  # create refman files for PDF tutorials
-  configure_file(${PROJECT_SOURCE_DIR}/OpenMS_tutorial/refman_overwrite.tex.in ${PROJECT_BINARY_DIR}/OpenMS_tutorial/refman_overwrite.tex)
-  configure_file(${PROJECT_SOURCE_DIR}/TOPP_tutorial/refman_overwrite.tex.in ${PROJECT_BINARY_DIR}/TOPP_tutorial/refman_overwrite.tex)
-
-  #------------------------------------------------------------------------------
-  # doc paths (bin path, topp documenter, defaultparamhandler documenter)
-  #------------------------------------------------------------------------------
-  # Checks for Multiconfiguration generators like MSVC or XCode
-  if(NOT CMAKE_CONFIGURATION_TYPES)
-    set(_TOPPDOCUMENTER_EXECUTABLE "${PROJECT_BINARY_DIR}/doxygen/parameters/TOPPDocumenter")
-    set(_DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE "${PROJECT_BINARY_DIR}/doxygen/parameters/DefaultParamHandlerDocumenter")
-    set(_BINARY_PATH "${OPENMS_RUNTIME_OUTPUT_DIRECTORY}")
-  else()
-    set(_TOPPDOCUMENTER_EXECUTABLE "${PROJECT_BINARY_DIR}/doxygen/parameters/${CMAKE_CFG_INTDIR}/TOPPDocumenter")
-    set(_DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE "${PROJECT_BINARY_DIR}/doxygen/parameters/${CMAKE_CFG_INTDIR}/DefaultParamHandlerDocumenter")
-    set(_BINARY_PATH "${OPENMS_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
-  endif()
-
-  file(TO_NATIVE_PATH "${_TOPPDOCUMENTER_EXECUTABLE}" TOPPDOCUMENTER_EXECUTABLE)
-  file(TO_NATIVE_PATH "${_DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE}" DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE)
-  file(TO_NATIVE_PATH "${_BINARY_PATH}" BINARY_PATH)
-
-  #------------------------------------------------------------------------------
-  # doc_param_internal targets
-  add_custom_target(doc_param_internal
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E echo "Creating the algorithm parameter and TOPP parameter documentation"
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "Note: A functioning OpenMS/TOPP installation and a running X-server (Unix) is required for this step!"
-                    COMMAND ${CMAKE_COMMAND} -E echo "      Windows only: OpenMS and Open_GUI.dll's need to be accessible by the Documenter executables in"
-                    COMMAND ${CMAKE_COMMAND} -E echo "      doxygen/parameters/. If the automatic CMake post build copy step did not work, try to add them"
-                    COMMAND ${CMAKE_COMMAND} -E echo "      to your Path variable."
-                    COMMAND ${CMAKE_COMMAND} -E echo "      If this step fails, use the target 'doc_minimal'."
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "Building OpenMS parameter docu:"
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E make_directory doxygen/parameters/output/
-                    COMMAND ${CMAKE_COMMAND} -E chdir doxygen/parameters/ ${DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE}
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "Building TOPP/UTILS docu:"
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E chdir doxygen/parameters/ ${TOPPDOCUMENTER_EXECUTABLE} ${BINARY_PATH}
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMENT "Build the parameters documentation"
-                    VERBATIM)
-  add_dependencies(doc_param_internal doc_progs)
-
-  #------------------------------------------------------------------------------
-  # doc(_html) generation code reused in two independent targets
-  set(_DOC_HTML_CODE
-    COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation"
-    COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMAND ${CMAKE_COMMAND} -E remove_directory html
-    COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doxygen/common/style_ini.css html/style_ini.css
-    COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    COMMAND ${CMAKE_COMMAND} -E echo "The documentation has been successfully created."
-    COMMAND ${CMAKE_COMMAND} -E echo "You can now open 'doc/index.html' in a web browser."
-    COMMAND ${CMAKE_COMMAND} -E echo ""
-    COMMENT "Build the doxygen documentation"
-  )
-
-  # regular doc target executed to generate full class and tool documentation (without tutorials)
-  add_custom_target(doc ${_DOC_ALL}
-                    ${_DOC_HTML_CODE}
-                    DEPENDS doc_param_internal
-                    VERBATIM)
-
-  # doc_html_only to generate only the doxygen documentation (e.g., when writing new documentation)
-  add_custom_target(doc_class_only
-                    ${_DOC_HTML_CODE}
-                    COMMAND ${CMAKE_COMMAND} -E echo "NOTE: The algorithm/TOPP parameter documentation was not generated/updated."
-                    COMMAND ${CMAKE_COMMAND} -E echo "      You will only see updates to the class documentation/doxygen files."
-                    COMMAND ${CMAKE_COMMAND} -E echo "      To build the full documentation execute the doc target."
-                    VERBATIM)
-
-  #------------------------------------------------------------------------------
-  # doc_internal target
-  add_custom_target(doc_xml
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E echo "Creating XML documentation"
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E remove_directory xml_output
-                    COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_xml
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E echo "The XML documentation has been successfully created."
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMENT "Build the doxygen documentation"
-                    VERBATIM)
-
-  #------------------------------------------------------------------------------
-  # doc_noclass target
-  add_custom_target(doc_noclass
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation without class documentation"
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E remove_directory html
-                    COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_noclass
-                    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
-                    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doxygen/common/style_ini.css html/style_ini.css
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E echo "The documentation has been successfully created."
-                    COMMAND ${CMAKE_COMMAND} -E echo "You can now open 'doc/index.html' in a web browser."
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMENT "Build the doxygen documentation"
-                    VERBATIM)
-  add_dependencies(doc_noclass doc_param_internal)
-
-  #------------------------------------------------------------------------------
-  # doc_minimal target
-  add_custom_target(doc_minimal ${_DOC_MINIMAL_ALL}
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation without class/TOPP/UTILS documentation"
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E remove_directory html
-                    COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_noclass
-                    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
-                    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doxygen/common/style_ini.css html/style_ini.css
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                    COMMAND ${CMAKE_COMMAND} -E echo "The documentation has been successfully created."
-                    COMMAND ${CMAKE_COMMAND} -E echo "You can now open 'doc/index.html' in a web browser."
-                    ${_DOC_MINIMAL_EXTRA_MESSAGE}
-                    COMMAND ${CMAKE_COMMAND} -E echo ""
-                    COMMENT "Build the doxygen documentation"
-                    VERBATIM)
-  #------------------------------------------------------------------------------
-  # add virtual dependency of doc_minimal on TOPP & UTILS
-  # this is not necessary but defers the generation of doc_minimal to a later
-  # stage to avoid confusion if doc_minimal is build first
-  add_dependencies(doc_minimal TOPP UTILS)
-
-  if (DOXYGEN_DOT_FOUND OR DOXYGEN_DOT_EXECUTABLE)
     #------------------------------------------------------------------------------
-    # doc_dot target
-    add_custom_target(doc_dot
+    # QT dependencies
+    find_package(Qt5 COMPONENTS Core Network Svg OpenGL REQUIRED)
+    set(_doc_progs_include ${OpenMS_GUI_INCLUDE_DIRECTORIES})
+    set(_doc_progs_link_libraries ${OpenMS_GUI_LIBRARIES})
+  else()
+    find_package(Qt5 COMPONENTS Core Network REQUIRED)
+    set(_doc_progs_include ${OpenMS_INCLUDE_DIRECTORIES})
+    set(_doc_progs_link_libraries ${OpenMS_LIBRARIES})
+  endif()
+
+  include_directories(SYSTEM ${_doc_progs_include})
+  add_definitions(/DBOOST_ALL_NO_LIB)
+
+  # build doc executables
+  foreach(i ${OpenMS_doc_executables})
+    add_executable(${i} EXCLUDE_FROM_ALL doxygen/parameters/${i}.cpp)
+    target_link_libraries(${i} ${_doc_progs_link_libraries})
+
+    # let the doc progs decide how to handle a missing OpenMS_GUI library
+    if(WITH_GUI)
+      set_target_properties(${i} PROPERTIES COMPILE_DEFINITIONS "WITH_GUI=1")
+    endif()
+  endforeach(i)
+
+  # collection target
+  add_custom_target(doc_progs)
+  add_dependencies(doc_progs ${OpenMS_doc_executables} TOPP UTILS)
+
+  if(WITH_GUI)
+    add_dependencies(doc_progs GUI)
+  endif()
+
+  #------------------------------------------------------------------------------
+  # Initialize variables needed for a proper doxygen configuration
+  #------------------------------------------------------------------------------
+  set(CF_OPENMS_BIN_PATH ${PROJECT_BINARY_DIR})
+  set(CF_OPENMS_SRC_PATH ${OPENMS_HOST_DIRECTORY})
+
+  # make it a doxygen conform list
+  make_doxygen_path(CF_OPENMS_DOCUMENTATION_DIRECTORIES OPENMS_DOCUMENTATION_DIRECTORIES)
+  make_doxygen_path(CF_OPENMS_DOCUMENTATION_STRIP_INCLUDES OPENMS_DOCUMENTATION_DIRECTORIES)
+  make_doxygen_path(CF_STRIP_PATH OPENMS_DOCUMENTATION_DIRECTORIES)
+
+  #------------------------------------------------------------------------------
+  # find the necessary packages
+  find_package(Doxygen)
+  find_package(LATEX)
+  # Doxygen with formulas built with LaTeX actually also needs Ghostscript but there is no official find module for it, yet.
+  #find_package(Ghostscript)
+
+  #------------------------------------------------------------------------------
+  # the doc targets
+  #------------------------------------------------------------------------------
+  # As soon as there is a TeX formula in the html documentation we need LaTeX, dvips and ghostscript.
+  # Probably only affects class documentation.
+
+  if (DOXYGEN_FOUND)
+    #------------------------------------------------------------------------------
+    # configure doxygen configuration files
+    configure_file(${PROJECT_SOURCE_DIR}/doxygen/Doxyfile.in ${PROJECT_BINARY_DIR}/doxygen/Doxyfile)
+    configure_file(${PROJECT_SOURCE_DIR}/doxygen/Doxyfile_dot.in ${PROJECT_BINARY_DIR}/doxygen/Doxyfile_dot)
+    configure_file(${PROJECT_SOURCE_DIR}/doxygen/Doxyfile_noclass.in ${PROJECT_BINARY_DIR}/doxygen/Doxyfile_noclass)
+    configure_file(${PROJECT_SOURCE_DIR}/doxygen/Doxyfile_xml.in ${PROJECT_BINARY_DIR}/doxygen/Doxyfile_xml)
+
+    #------------------------------------------------------------------------------
+    # create refman files for PDF tutorials
+    configure_file(${PROJECT_SOURCE_DIR}/OpenMS_tutorial/refman_overwrite.tex.in ${PROJECT_BINARY_DIR}/OpenMS_tutorial/refman_overwrite.tex)
+    configure_file(${PROJECT_SOURCE_DIR}/TOPP_tutorial/refman_overwrite.tex.in ${PROJECT_BINARY_DIR}/TOPP_tutorial/refman_overwrite.tex)
+
+    #------------------------------------------------------------------------------
+    # doc paths (bin path, topp documenter, defaultparamhandler documenter)
+    #------------------------------------------------------------------------------
+    # Checks for Multiconfiguration generators like MSVC or XCode
+    if(NOT CMAKE_CONFIGURATION_TYPES)
+      set(_TOPPDOCUMENTER_EXECUTABLE "${PROJECT_BINARY_DIR}/doxygen/parameters/TOPPDocumenter")
+      set(_DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE "${PROJECT_BINARY_DIR}/doxygen/parameters/DefaultParamHandlerDocumenter")
+      set(_BINARY_PATH "${OPENMS_RUNTIME_OUTPUT_DIRECTORY}")
+    else()
+      set(_TOPPDOCUMENTER_EXECUTABLE "${PROJECT_BINARY_DIR}/doxygen/parameters/${CMAKE_CFG_INTDIR}/TOPPDocumenter")
+      set(_DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE "${PROJECT_BINARY_DIR}/doxygen/parameters/${CMAKE_CFG_INTDIR}/DefaultParamHandlerDocumenter")
+      set(_BINARY_PATH "${OPENMS_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
+    endif()
+
+    file(TO_NATIVE_PATH "${_TOPPDOCUMENTER_EXECUTABLE}" TOPPDOCUMENTER_EXECUTABLE)
+    file(TO_NATIVE_PATH "${_DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE}" DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE)
+    file(TO_NATIVE_PATH "${_BINARY_PATH}" BINARY_PATH)
+
+    #------------------------------------------------------------------------------
+    # doc_param_internal targets
+    add_custom_target(doc_param_internal
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                      COMMAND ${CMAKE_COMMAND} -E echo "Creating DOT html documentation"
+                      COMMAND ${CMAKE_COMMAND} -E echo "Creating the algorithm parameter and TOPP parameter documentation"
                       COMMAND ${CMAKE_COMMAND} -E echo ""
-                      COMMAND ${CMAKE_COMMAND} -E remove_directory html-dot
-                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_dot
+                      COMMAND ${CMAKE_COMMAND} -E echo "Note: A functioning OpenMS/TOPP installation and a running X-server (Unix) is required for this step!"
+                      COMMAND ${CMAKE_COMMAND} -E echo "      Windows only: OpenMS and Open_GUI.dll's need to be accessible by the Documenter executables in"
+                      COMMAND ${CMAKE_COMMAND} -E echo "      doxygen/parameters/. If the automatic CMake post build copy step did not work, try to add them"
+                      COMMAND ${CMAKE_COMMAND} -E echo "      to your Path variable."
+                      COMMAND ${CMAKE_COMMAND} -E echo "      If this step fails, use the target 'doc_minimal'."
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E echo "Building OpenMS parameter docu:"
+                      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                      COMMAND ${CMAKE_COMMAND} -E make_directory doxygen/parameters/output/
+                      COMMAND ${CMAKE_COMMAND} -E chdir doxygen/parameters/ ${DEFAULTPARAMHANDLERDOCUMENTER_EXECUTABLE}
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E echo "Building TOPP/UTILS docu:"
+                      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~"
+                      COMMAND ${CMAKE_COMMAND} -E chdir doxygen/parameters/ ${TOPPDOCUMENTER_EXECUTABLE} ${BINARY_PATH}
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMENT "Build the parameters documentation"
+                      VERBATIM)
+    add_dependencies(doc_param_internal doc_progs)
+
+    #------------------------------------------------------------------------------
+    # doc(_html) generation code reused in two independent targets
+    set(_DOC_HTML_CODE
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+      COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation"
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      COMMAND ${CMAKE_COMMAND} -E remove_directory html
+      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile
+      COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
+      COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doxygen/common/style_ini.css html/style_ini.css
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+      COMMAND ${CMAKE_COMMAND} -E echo "The documentation has been successfully created."
+      COMMAND ${CMAKE_COMMAND} -E echo "You can now open 'doc/index.html' in a web browser."
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      COMMENT "Build the doxygen documentation"
+    )
+
+    # regular doc target executed to generate full class and tool documentation (without tutorials)
+    add_custom_target(doc ${_DOC_ALL}
+                      ${_DOC_HTML_CODE}
+                      DEPENDS doc_param_internal
+                      VERBATIM)
+
+    # doc_html_only to generate only the doxygen documentation (e.g., when writing new documentation)
+    add_custom_target(doc_class_only
+                      ${_DOC_HTML_CODE}
+                      COMMAND ${CMAKE_COMMAND} -E echo "NOTE: The algorithm/TOPP parameter documentation was not generated/updated."
+                      COMMAND ${CMAKE_COMMAND} -E echo "      You will only see updates to the class documentation/doxygen files."
+                      COMMAND ${CMAKE_COMMAND} -E echo "      To build the full documentation execute the doc target."
+                      VERBATIM)
+
+    #------------------------------------------------------------------------------
+    # doc_internal target
+    add_custom_target(doc_xml
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                      COMMAND ${CMAKE_COMMAND} -E echo "Creating XML documentation"
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E remove_directory xml_output
+                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_xml
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                      COMMAND ${CMAKE_COMMAND} -E echo "The XML documentation has been successfully created."
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMENT "Build the doxygen documentation"
+                      VERBATIM)
+
+    #------------------------------------------------------------------------------
+    # doc_noclass target
+    add_custom_target(doc_noclass
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                      COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation without class documentation"
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E remove_directory html
+                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_noclass
                       COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
                       COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doxygen/common/style_ini.css html/style_ini.css
                       COMMAND ${CMAKE_COMMAND} -E echo ""
@@ -305,110 +259,156 @@ if (DOXYGEN_FOUND)
                       COMMAND ${CMAKE_COMMAND} -E echo ""
                       COMMENT "Build the doxygen documentation"
                       VERBATIM)
-    add_dependencies(doc_dot doc_param_internal)
-  else()
-    message(STATUS "DOT not found. Disabling target 'doc_dot'!")
-  endif()
+    add_dependencies(doc_noclass doc_param_internal)
 
-  #------------------------------------------------------------------------------
-  # Install documentation
-  install_directory(${PROJECT_BINARY_DIR}/html ${INSTALL_DOC_DIR} doc)
-  install_file(${PROJECT_BINARY_DIR}/index.html ${INSTALL_DOC_DIR} doc)
+    #------------------------------------------------------------------------------
+    # doc_minimal target
+    add_custom_target(doc_minimal ${_DOC_MINIMAL_ALL}
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                      COMMAND ${CMAKE_COMMAND} -E echo "Creating html documentation without class/TOPP/UTILS documentation"
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E remove_directory html
+                      COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_noclass
+                      COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
+                      COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doxygen/common/style_ini.css html/style_ini.css
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                      COMMAND ${CMAKE_COMMAND} -E echo "The documentation has been successfully created."
+                      COMMAND ${CMAKE_COMMAND} -E echo "You can now open 'doc/index.html' in a web browser."
+                      ${_DOC_MINIMAL_EXTRA_MESSAGE}
+                      COMMAND ${CMAKE_COMMAND} -E echo ""
+                      COMMENT "Build the doxygen documentation"
+                      VERBATIM)
+    #------------------------------------------------------------------------------
+    # add virtual dependency of doc_minimal on TOPP & UTILS
+    # this is not necessary but defers the generation of doc_minimal to a later
+    # stage to avoid confusion if doc_minimal is build first
+    add_dependencies(doc_minimal TOPP UTILS)
 
-  #------------------------------------------------------------------------------
-  # PDF Tutorials
-  #------------------------------------------------------------------------------
-  # DOXYGEN_FOUND is true. Otherwise we would not list any doc targets at all.
-  if (PDFLATEX_COMPILER)
-
-    if (ENABLE_TUTORIALS)
-      set(DOC_TUTORIALS_ACTIVE TRUE)
-
-      # configure doxyfiles for tutorials
-      configure_file(${PROJECT_SOURCE_DIR}/OpenMS_tutorial/Doxyfile.in ${PROJECT_BINARY_DIR}/OpenMS_tutorial/Doxyfile)
-      configure_file(${PROJECT_SOURCE_DIR}/TOPP_tutorial/Doxyfile.in ${PROJECT_BINARY_DIR}/TOPP_tutorial/Doxyfile)
-
-      # check doxygen for bug with generated latex files
-      set(DOXYGEN_START_BUGGY "1.6.3")
-      set(DOXYGEN_END_BUGGY "1.7.2")
-      exec_program(${DOXYGEN_EXECUTABLE}
-        ARGS "--version"
-        OUTPUT_VARIABLE DOXYGEN_VERSION)
-
-      if (DOXYGEN_VERSION STRGREATER DOXYGEN_START_BUGGY AND DOXYGEN_VERSION STRLESS DOXYGEN_END_BUGGY )
-        message(ERROR "Warning, DoxygenBug ( 1.6.? < vers. installed < 1.7.3 ) disguises generated tex inputfiles and files will not be recognized")
-      endif()
-
+    if (DOXYGEN_DOT_FOUND OR DOXYGEN_DOT_EXECUTABLE)
       #------------------------------------------------------------------------------
-      # doc_tutorials target
-      add_custom_target(doc_tutorials ALL
+      # doc_dot target
+      add_custom_target(doc_dot
                         COMMAND ${CMAKE_COMMAND} -E echo ""
                         COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                        COMMAND ${CMAKE_COMMAND} -E echo "Creating OpenMS pdf tutorial"
+                        COMMAND ${CMAKE_COMMAND} -E echo "Creating DOT html documentation"
                         COMMAND ${CMAKE_COMMAND} -E echo ""
-                        COMMAND ${CMAKE_COMMAND} -E remove_directory OpenMS_tutorial/latex_output
-                        COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/ "${DOXYGEN_EXECUTABLE}" Doxyfile
-                        COMMAND ${CMAKE_COMMAND} -E copy OpenMS_tutorial/refman_overwrite.tex OpenMS_tutorial/latex_output/refman.tex
-                        COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
-                        COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/latex_output/  "${MAKEINDEX_COMPILER}" refman.idx
-                        COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
-                        COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
-                        COMMAND ${CMAKE_COMMAND} -E copy OpenMS_tutorial/latex_output/refman.pdf OpenMS_tutorial.pdf
-                        COMMAND ${CMAKE_COMMAND} -E echo ""
-                        COMMAND ${CMAKE_COMMAND} -E echo "The OpenMS tutorial in PDF format has been successfully created:"
-                        COMMAND ${CMAKE_COMMAND} -E echo "doc/OpenMS_tutorial.pdf"
+                        COMMAND ${CMAKE_COMMAND} -E remove_directory html-dot
+                        COMMAND ${CMAKE_COMMAND} -E chdir ${PROJECT_BINARY_DIR} "${DOXYGEN_EXECUTABLE}" doxygen/Doxyfile_dot
+                        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/index.html index.html
+                        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/doxygen/common/style_ini.css html/style_ini.css
                         COMMAND ${CMAKE_COMMAND} -E echo ""
                         COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-                        COMMAND ${CMAKE_COMMAND} -E echo "Creating TOPP/TOPPView pdf tutorial"
+                        COMMAND ${CMAKE_COMMAND} -E echo "The documentation has been successfully created."
+                        COMMAND ${CMAKE_COMMAND} -E echo "You can now open 'doc/index.html' in a web browser."
                         COMMAND ${CMAKE_COMMAND} -E echo ""
-                        COMMAND ${CMAKE_COMMAND} -E remove_directory TOPP_tutorial/latex_output
-                        COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/ "${DOXYGEN_EXECUTABLE}" Doxyfile
-                        COMMAND ${CMAKE_COMMAND} -E copy TOPP_tutorial/refman_overwrite.tex TOPP_tutorial/latex_output/refman.tex
-                        COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
-                        COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/latex_output/  "${MAKEINDEX_COMPILER}" refman.idx
-                        COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
-                        COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
-                        COMMAND ${CMAKE_COMMAND} -E copy TOPP_tutorial/latex_output/refman.pdf TOPP_tutorial.pdf
-                        COMMAND ${CMAKE_COMMAND} -E echo ""
-                        COMMAND ${CMAKE_COMMAND} -E echo "The OpenMS tutorial in PDF format has been successfully created:"
-                        COMMAND ${CMAKE_COMMAND} -E echo "doc/TOPP_tutorial.pdf"
-                        COMMAND ${CMAKE_COMMAND} -E echo ""
-                        COMMENT "Build the OpenMS/TOPP pdf tutorial"
+                        COMMENT "Build the doxygen documentation"
                         VERBATIM)
-
-      #------------------------------------------------------------------------------
-      # add virtual dependency of tutorials on TOPP & UTILS
-      # this is not necessary but defers the generation of the tutorials to a later
-      # stage to avoid confusion if tutorials are build first
-      add_dependencies(doc_tutorials TOPP UTILS)
-
-      #------------------------------------------------------------------------------
-      # install also the tutorial pdfs
-      install_file(${PROJECT_BINARY_DIR}/TOPP_tutorial.pdf ${INSTALL_DOC_DIR} doc)
-      install_file(${PROJECT_BINARY_DIR}/OpenMS_tutorial.pdf ${INSTALL_DOC_DIR} doc)
-
-      #------------------------------------------------------------------------------
-      # inform the user
-      message(STATUS "Enabled tutorials (-D ENABLE_TUTORIALS=On).")
+      add_dependencies(doc_dot doc_param_internal)
     else()
-      message(STATUS "Disabled tutorials (-D ENABLE_TUTORIALS=Off).")
+      message(STATUS "DOT not found. Disabling target 'doc_dot'!")
+    endif()
+
+    #------------------------------------------------------------------------------
+    # Install documentation
+    install_directory(${PROJECT_BINARY_DIR}/html ${INSTALL_DOC_DIR} doc)
+    install_file(${PROJECT_BINARY_DIR}/index.html ${INSTALL_DOC_DIR} doc)
+
+    #------------------------------------------------------------------------------
+    # PDF Tutorials
+    #------------------------------------------------------------------------------
+    # DOXYGEN_FOUND is true. Otherwise we would not list any doc targets at all.
+    if (PDFLATEX_COMPILER)
+
+      if (ENABLE_TUTORIALS)
+        set(DOC_TUTORIALS_ACTIVE TRUE)
+
+        # configure doxyfiles for tutorials
+        configure_file(${PROJECT_SOURCE_DIR}/OpenMS_tutorial/Doxyfile.in ${PROJECT_BINARY_DIR}/OpenMS_tutorial/Doxyfile)
+        configure_file(${PROJECT_SOURCE_DIR}/TOPP_tutorial/Doxyfile.in ${PROJECT_BINARY_DIR}/TOPP_tutorial/Doxyfile)
+
+        # check doxygen for bug with generated latex files
+        set(DOXYGEN_START_BUGGY "1.6.3")
+        set(DOXYGEN_END_BUGGY "1.7.2")
+        exec_program(${DOXYGEN_EXECUTABLE}
+          ARGS "--version"
+          OUTPUT_VARIABLE DOXYGEN_VERSION)
+
+        if (DOXYGEN_VERSION STRGREATER DOXYGEN_START_BUGGY AND DOXYGEN_VERSION STRLESS DOXYGEN_END_BUGGY )
+          message(ERROR "Warning, DoxygenBug ( 1.6.? < vers. installed < 1.7.3 ) disguises generated tex inputfiles and files will not be recognized")
+        endif()
+
+        #------------------------------------------------------------------------------
+        # doc_tutorials target
+        add_custom_target(doc_tutorials ALL
+                          COMMAND ${CMAKE_COMMAND} -E echo ""
+                          COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                          COMMAND ${CMAKE_COMMAND} -E echo "Creating OpenMS pdf tutorial"
+                          COMMAND ${CMAKE_COMMAND} -E echo ""
+                          COMMAND ${CMAKE_COMMAND} -E remove_directory OpenMS_tutorial/latex_output
+                          COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/ "${DOXYGEN_EXECUTABLE}" Doxyfile
+                          COMMAND ${CMAKE_COMMAND} -E copy OpenMS_tutorial/refman_overwrite.tex OpenMS_tutorial/latex_output/refman.tex
+                          COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
+                          COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/latex_output/  "${MAKEINDEX_COMPILER}" refman.idx
+                          COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
+                          COMMAND ${CMAKE_COMMAND} -E chdir OpenMS_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
+                          COMMAND ${CMAKE_COMMAND} -E copy OpenMS_tutorial/latex_output/refman.pdf OpenMS_tutorial.pdf
+                          COMMAND ${CMAKE_COMMAND} -E echo ""
+                          COMMAND ${CMAKE_COMMAND} -E echo "The OpenMS tutorial in PDF format has been successfully created:"
+                          COMMAND ${CMAKE_COMMAND} -E echo "doc/OpenMS_tutorial.pdf"
+                          COMMAND ${CMAKE_COMMAND} -E echo ""
+                          COMMAND ${CMAKE_COMMAND} -E echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+                          COMMAND ${CMAKE_COMMAND} -E echo "Creating TOPP/TOPPView pdf tutorial"
+                          COMMAND ${CMAKE_COMMAND} -E echo ""
+                          COMMAND ${CMAKE_COMMAND} -E remove_directory TOPP_tutorial/latex_output
+                          COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/ "${DOXYGEN_EXECUTABLE}" Doxyfile
+                          COMMAND ${CMAKE_COMMAND} -E copy TOPP_tutorial/refman_overwrite.tex TOPP_tutorial/latex_output/refman.tex
+                          COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
+                          COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/latex_output/  "${MAKEINDEX_COMPILER}" refman.idx
+                          COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
+                          COMMAND ${CMAKE_COMMAND} -E chdir TOPP_tutorial/latex_output/  "${PDFLATEX_COMPILER}" refman.tex
+                          COMMAND ${CMAKE_COMMAND} -E copy TOPP_tutorial/latex_output/refman.pdf TOPP_tutorial.pdf
+                          COMMAND ${CMAKE_COMMAND} -E echo ""
+                          COMMAND ${CMAKE_COMMAND} -E echo "The OpenMS tutorial in PDF format has been successfully created:"
+                          COMMAND ${CMAKE_COMMAND} -E echo "doc/TOPP_tutorial.pdf"
+                          COMMAND ${CMAKE_COMMAND} -E echo ""
+                          COMMENT "Build the OpenMS/TOPP pdf tutorial"
+                          VERBATIM)
+
+        #------------------------------------------------------------------------------
+        # add virtual dependency of tutorials on TOPP & UTILS
+        # this is not necessary but defers the generation of the tutorials to a later
+        # stage to avoid confusion if tutorials are build first
+        add_dependencies(doc_tutorials TOPP UTILS)
+
+        #------------------------------------------------------------------------------
+        # install also the tutorial pdfs
+        install_file(${PROJECT_BINARY_DIR}/TOPP_tutorial.pdf ${INSTALL_DOC_DIR} doc)
+        install_file(${PROJECT_BINARY_DIR}/OpenMS_tutorial.pdf ${INSTALL_DOC_DIR} doc)
+
+        #------------------------------------------------------------------------------
+        # inform the user
+        message(STATUS "Enabled tutorials (-D ENABLE_TUTORIALS=On).")
+      else()
+        message(STATUS "Disabled tutorials (-D ENABLE_TUTORIALS=Off).")
+      endif()
+    else()
+      set(DOC_TUTORIALS_ACTIVE FALSE)
+      message(STATUS "PDFLaTeX missing. Disabling 'doc_tutorials' target!")
     endif()
   else()
-    set(DOC_TUTORIALS_ACTIVE FALSE)
-    message(STATUS "PDFLaTeX missing. Disabling 'doc_tutorials' target!")
+    message(STATUS "Doxygen not found. Disabling all documentation targets!")
+    message(STATUS "Note that no documentation will be installed alongside OpenMS.")
   endif()
-else()
-  message(STATUS "Doxygen not found. Disabling all documentation targets!")
-  message(STATUS "Note that no documentation will be installed alongside OpenMS.")
-endif()
 
-#------------------------------------------------------------------------------
-# Examples / Tutorials
-#------------------------------------------------------------------------------
-option(BUILD_EXAMPLES "Compile OpenMS code examples" ON)
-if(BUILD_EXAMPLES AND "${PACKAGE_TYPE}" STREQUAL "none")
-  add_subdirectory(code_examples)
-endif(BUILD_EXAMPLES AND "${PACKAGE_TYPE}" STREQUAL "none")
+  #------------------------------------------------------------------------------
+  # Examples / Tutorials
+  #------------------------------------------------------------------------------
+  option(BUILD_EXAMPLES "Compile OpenMS code examples" ON)
+  if(BUILD_EXAMPLES AND "${PACKAGE_TYPE}" STREQUAL "none")
+    add_subdirectory(code_examples)
+  endif(BUILD_EXAMPLES AND "${PACKAGE_TYPE}" STREQUAL "none")
 
 else()
   message(STATUS "Documentation is not built (-D BUILD_DOCS=Off).")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -45,6 +45,9 @@ macro(make_doxygen_path doxygen_style_list_var doc_path_list_var)
   endforeach()
 endmacro()
 
+if(BUILD_DOCS)
+  message(STATUS "Documentation is built (-D BUILD_DOCS=On).")
+
 #------------------------------------------------------------------------------
 # decide which doc target is part of all
 #------------------------------------------------------------------------------
@@ -406,3 +409,7 @@ option(BUILD_EXAMPLES "Compile OpenMS code examples" ON)
 if(BUILD_EXAMPLES AND "${PACKAGE_TYPE}" STREQUAL "none")
   add_subdirectory(code_examples)
 endif(BUILD_EXAMPLES AND "${PACKAGE_TYPE}" STREQUAL "none")
+
+else()
+  message(STATUS "Documentation is not built (-D BUILD_DOCS=Off).")
+endif()

--- a/doc/doxygen/install/install-linux.doxygen
+++ b/doc/doxygen/install/install-linux.doxygen
@@ -366,6 +366,11 @@
       %OpenMS without a GUI, set this flag to "Off" (Default: On)</td>
     </tr>
     <tr>
+      <td valign="top">\c BUILD_DOCS</td>
+      <td>Defines if %OpenMS should build the documentation.
+      (Default: On)</td>
+    </tr>
+    <tr>
       <td valign="top">\c ENABLE_TUTORIALS</td>
       <td>Defines if %OpenMS should build and install the pdf tutorials.
       (Default: On)</td>

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -177,14 +177,6 @@ if (CMAKE_COMPILER_IS_INTELCXX OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_
   set(${CMAKE_CXX_FLAGS_RELEASE} ${_TMP_CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
-if(BUILD_DOCS)
-#------------------------------------------------------------------------------
-# all target that we require to show up in the targets list
-# and in the nightly build log (to test if they can be build properly)
-add_custom_target(extra_targets ALL)
-add_dependencies(extra_targets Tutorials_build)
-endif()
-
 #------------------------------------------------------------------------------
 # add filenames to Visual Studio solution tree
 set(sources_VS)

--- a/src/tests/class_tests/openms/CMakeLists.txt
+++ b/src/tests/class_tests/openms/CMakeLists.txt
@@ -177,11 +177,13 @@ if (CMAKE_COMPILER_IS_INTELCXX OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_
   set(${CMAKE_CXX_FLAGS_RELEASE} ${_TMP_CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
+if(BUILD_DOCS)
 #------------------------------------------------------------------------------
 # all target that we require to show up in the targets list
 # and in the nightly build log (to test if they can be build properly)
 add_custom_target(extra_targets ALL)
 add_dependencies(extra_targets Tutorials_build)
+endif()
 
 #------------------------------------------------------------------------------
 # add filenames to Visual Studio solution tree


### PR DESCRIPTION
Solution proposal for https://github.com/OpenMS/OpenMS/issues/3290

I don't have experience with CMake so there is a high chance the solution is very hacky / not elegant. :smile: 

I avoided adding indentation where necessary, to make the diffs easier to read. If the solution is ok, I'd take care of fixing the indentation (or do you have a better idea? It'd be many lines getting more indentation)

EDIT:
So users can now add `-DBUILD_DOCS=Off` to their `cmake` command in order to not build documentation.