### PR TITLE
fix PercolatorAdapter

### DIFF
--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -181,8 +181,9 @@ protected:
     registerIntOption_("matches_per_spec", "<num>", 1, "Number of matches per spectrum to be reported (MS-GF+ parameter '-n')", false);
     setMinInt_("matches_per_spec", 1);
 
-    registerFlag_("add_features", "Output additional features - needed e.g. by Percolator (default: basic scores only; MS-GF+ parameter '-addFeatures')", true);
-
+    registerStringOption_("add_features", "<bool>", "true", "Output additional features - needed e.g. by Percolator (default: basic scores only; MS-GF+ parameter '-addFeatures')");
+    setValidStrings_("add_features", ListUtils::create<String>("true,false"));
+    
     registerIntOption_("max_mods", "<num>", 2, "Maximum number of modifications per peptide. If this value is large, the search may take very long.", false);
     setMinInt_("max_mods", 0);
 
@@ -509,7 +510,7 @@ protected:
                    << "-minCharge" << QString::number(min_precursor_charge)
                    << "-maxCharge" << QString::number(max_precursor_charge)
                    << "-n" << QString::number(getIntOption_("matches_per_spec"))
-                   << "-addFeatures" << QString::number(int(getFlag_("add_features")))
+                   << "-addFeatures" << QString::number(int((getParam_().getValue("add_features") == "true")))
                    << "-thread" << QString::number(getIntOption_("threads"));
 
     if (!mod_file.empty())

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -181,7 +181,7 @@ protected:
     registerIntOption_("matches_per_spec", "<num>", 1, "Number of matches per spectrum to be reported (MS-GF+ parameter '-n')", false);
     setMinInt_("matches_per_spec", 1);
 
-    registerStringOption_("add_features", "<bool>", "true", "Output additional features - needed e.g. by Percolator (default: basic scores only; MS-GF+ parameter '-addFeatures')");
+    registerStringOption_("add_features", "<true/false>", "true", "Output additional features - needed e.g. by Percolator (default: basic scores only; MS-GF+ parameter '-addFeatures')", false, false);
     setValidStrings_("add_features", ListUtils::create<String>("true,false"));
     
     registerIntOption_("max_mods", "<num>", 2, "Maximum number of modifications per peptide. If this value is large, the search may take very long.", false);

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -181,7 +181,7 @@ protected:
     registerIntOption_("matches_per_spec", "<num>", 1, "Number of matches per spectrum to be reported (MS-GF+ parameter '-n')", false);
     setMinInt_("matches_per_spec", 1);
 
-    registerStringOption_("add_features", "<true/false>", "true", "Output additional features - needed e.g. by Percolator (default: basic scores only; MS-GF+ parameter '-addFeatures')", false, false);
+    registerStringOption_("add_features", "<true/false>", "true", "Output additional features (MS-GF+ parameter '-addFeatures'). This is required by Percolator and hence by default enabled.", false, false);
     setValidStrings_("add_features", ListUtils::create<String>("true,false"));
     
     registerIntOption_("max_mods", "<num>", 2, "Maximum number of modifications per peptide. If this value is large, the search may take very long.", false);

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -181,7 +181,7 @@ protected:
     registerIntOption_("matches_per_spec", "<num>", 1, "Number of matches per spectrum to be reported (MS-GF+ parameter '-n')", false);
     setMinInt_("matches_per_spec", 1);
 
-    registerFlag_("add_features", "Output additional features - needed e.g. by Percolator (default: basic scores only; MS-GF+ parameter '-addFeatures')", false);
+    registerFlag_("add_features", "Output additional features - needed e.g. by Percolator (default: basic scores only; MS-GF+ parameter '-addFeatures')", true);
 
     registerIntOption_("max_mods", "<num>", 2, "Maximum number of modifications per peptide. If this value is large, the search may take very long.", false);
     setMinInt_("max_mods", 0);

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -453,6 +453,9 @@ protected:
         aa_before = aa_before=="["?'-':aa_before;
         aa_after = aa_after=="]"?'-':aa_after;
         sequence += aa_before;
+        // In OpenMS sequence nomenclature, dots are set only for modified N/C-term modifications, e.g. .(Dimethyl)VGDMYTSSDIFDSVR
+        // In Percolator sequence nomenclature, dots are always present for all N/C-term modifications, e.g. R.(Dimethyl)VGDMYTSSDIFDSVR.F
+        // Consequently, dots need only be added for unmodified N/C-termini.
         if (hit.getSequence().getNTerminalModificationName().empty())
         {
           sequence += ".";

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -452,9 +452,18 @@ protected:
         String aa_after(hit.getPeptideEvidences().front().getAAAfter());
         aa_before = aa_before=="["?'-':aa_before;
         aa_after = aa_after=="]"?'-':aa_after;
-        sequence += aa_before; 
-        sequence += "." + hit.getSequence().toString() + ".";
+        sequence += aa_before;
+        if (hit.getSequence().getNTerminalModificationName().empty())
+        {
+          sequence += ".";
+        }
+        sequence += hit.getSequence().toString();
+        if (hit.getSequence().getCTerminalModificationName().empty())
+        {
+          sequence += ".";
+        }
         sequence += aa_after;
+        
         hit.setMetaValue("Peptide", sequence);
         
         //proteinId1


### PR DESCRIPTION
Set dots in the AA sequence only, if no N/C terminal mods are present.
Fixes #3188.