### PR TITLE
[FIX] Mapping MRM data and display peptide/transition names properly

### DIFF
--- a/src/openms/source/ANALYSIS/TARGETED/MRMMapping.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/MRMMapping.cpp
@@ -115,12 +115,17 @@ namespace OpenMS
           MSChromatogram c = chromatogram_map.getChromatograms()[i];
           Precursor precursor = c.getPrecursor();
           String pepref = targeted_exp.getTransitions()[j].getPeptideRef();
+          precursor.setMetaValue("peptide_sequence", pepref);
+          precursor.setMetaValue("description", targeted_exp.getTransitions()[j].getNativeID());
           for (Size pep_idx = 0; pep_idx < targeted_exp.getPeptides().size(); pep_idx++)
           {
             const OpenMS::TargetedExperiment::Peptide * pep = &targeted_exp.getPeptides()[pep_idx];
             if (pep->id == pepref)
             {
-              precursor.setMetaValue("peptide_sequence", pep->sequence);
+              if (!pep->sequence.empty())
+              {
+                precursor.setMetaValue("peptide_sequence", pep->sequence);
+              }
               break;
             }
           }

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -633,13 +633,13 @@ namespace OpenMS
           QString mz_string = QString::number(mit->first.getMZ());
           QString charge = QString::number(mit->first.getCharge());
           QString description = "";
-          if (mit->first.metaValueExists("peptide_sequence"))
-          {
-            description = String(mit->first.getMetaValue("peptide_sequence")).toQString();
-          }
           if (mit->first.metaValueExists("description"))
           {
             description = String(mit->first.getMetaValue("description")).toQString();
+          }
+          if (mit->first.metaValueExists("peptide_sequence"))
+          {
+            description = String(mit->first.getMetaValue("peptide_sequence")).toQString();
           }
 
           // Show all: iterate over all chromatograms corresponding to the current precursor and add action containing all chromatograms

--- a/src/tests/topp/MRMMapping_output.chrom.mzML
+++ b/src/tests/topp/MRMMapping_output.chrom.mzML
@@ -88,6 +88,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y5.1.light"/>
 						</activation>
 					</precursor>
 					<product>
@@ -119,6 +120,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y6.1.light"/>
 						</activation>
 					</precursor>
 					<product>
@@ -150,6 +152,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y7.1.light"/>
 						</activation>
 					</precursor>
 					<product>
@@ -181,6 +184,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y5.1.heavy"/>
 						</activation>
 					</precursor>
 					<product>
@@ -212,6 +216,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y6.1.heavy"/>
 						</activation>
 					</precursor>
 					<product>
@@ -243,6 +248,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y7.1.heavy"/>
 						</activation>
 					</precursor>
 					<product>
@@ -271,13 +277,13 @@
 <indexList count="1">
 	<index name="chromatogram">
 		<offset idRef="B2MG.VNHVTLSQPK.3.y5.1.light">5241</offset>
-		<offset idRef="B2MG.VNHVTLSQPK.3.y6.1.light">8249</offset>
-		<offset idRef="B2MG.VNHVTLSQPK.3.y7.1.light">10857</offset>
-		<offset idRef="B2MG.VNHVTLSQPK.3.y5.1.heavy">12840</offset>
-		<offset idRef="B2MG.VNHVTLSQPK.3.y6.1.heavy">16342</offset>
-		<offset idRef="B2MG.VNHVTLSQPK.3.y7.1.heavy">19110</offset>
+		<offset idRef="B2MG.VNHVTLSQPK.3.y6.1.light">8343</offset>
+		<offset idRef="B2MG.VNHVTLSQPK.3.y7.1.light">11045</offset>
+		<offset idRef="B2MG.VNHVTLSQPK.3.y5.1.heavy">13122</offset>
+		<offset idRef="B2MG.VNHVTLSQPK.3.y6.1.heavy">16718</offset>
+		<offset idRef="B2MG.VNHVTLSQPK.3.y7.1.heavy">19580</offset>
 	</index>
 </indexList>
-<indexListOffset>21127</indexListOffset>
+<indexListOffset>21691</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>

--- a/src/tests/topp/MRMMapping_output_2.chrom.mzML
+++ b/src/tests/topp/MRMMapping_output_2.chrom.mzML
@@ -88,6 +88,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y5.1.heavy"/>
 						</activation>
 					</precursor>
 					<product>
@@ -119,6 +120,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y6.1.heavy"/>
 						</activation>
 					</precursor>
 					<product>
@@ -150,6 +152,7 @@
 						<activation>
 							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
 							<userParam name="peptide_sequence" type="xsd:string" value="VNHVTLSQPK"/>
+							<userParam name="description" type="xsd:string" value="B2MG.VNHVTLSQPK.3.y7.1.heavy"/>
 						</activation>
 					</precursor>
 					<product>
@@ -178,10 +181,10 @@
 <indexList count="1">
 	<index name="chromatogram">
 		<offset idRef="B2MG.VNHVTLSQPK.3.y5.1.heavy">5241</offset>
-		<offset idRef="B2MG.VNHVTLSQPK.3.y6.1.heavy">8743</offset>
-		<offset idRef="B2MG.VNHVTLSQPK.3.y7.1.heavy">11511</offset>
+		<offset idRef="B2MG.VNHVTLSQPK.3.y6.1.heavy">8837</offset>
+		<offset idRef="B2MG.VNHVTLSQPK.3.y7.1.heavy">11699</offset>
 	</index>
 </indexList>
-<indexListOffset>13528</indexListOffset>
+<indexListOffset>13810</indexListOffset>
 <fileChecksum>0</fileChecksum>
 </indexedmzML>


### PR DESCRIPTION
Make sure that if transition group-level data is available that it will
be used to analyze the whole transition group (peptide precursor).