### PR TITLE
[FIX] make Debugging:irt_mzml parameter functional

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathWorkflow.h
@@ -119,6 +119,8 @@ namespace OpenMS
      * @param irt_detection_param Parameter set for the detection of the iRTs (outlier detection, peptides per bin etc)
      * @param mz_correction_function If correction in m/z is desired, which function should be used
      * @param debug_level Debug level (writes out the RT normalization chromatograms if larger than 1)
+     * @param irt_mzml_out Output Chromatogram mzML containing the iRT peptides (if not empty,
+     *        iRT chromatograms will be stored in this file)
      *
     */
     TransformationDescription performRTNormalization(const OpenMS::TargetedExperiment & irt_transitions,
@@ -129,6 +131,7 @@ namespace OpenMS
       const ChromExtractParams & cp_irt,
       const Param & irt_detection_param,
       const String & mz_correction_function,
+      const String& irt_mzml_out,
       Size debug_level,
       bool sonar = false,
       bool load_into_memory = false);

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -47,6 +47,7 @@ namespace OpenMS
     const ChromExtractParams & cp_irt,
     const Param & irt_detection_param,
     const String & mz_correction_function,
+    const String& irt_mzml_out,
     Size debug_level,
     bool sonar,
     bool load_into_memory)
@@ -56,21 +57,25 @@ namespace OpenMS
     simpleExtractChromatograms(swath_maps, irt_transitions, irt_chromatograms, cp_irt, sonar, load_into_memory);
 
     // debug output of the iRT chromatograms
-    if (debug_level > 1)
+    if (irt_mzml_out.empty() and debug_level > 1)
+      {
+        String irt_mzml_out = "debug_irts.mzML";
+      }
+    if (!irt_mzml_out.empty())
     {
       try
       {
         PeakMap exp;
         exp.setChromatograms(irt_chromatograms);
-        MzMLFile().store("debug_irts.mzML", exp);
+        MzMLFile().store(irt_mzml_out, exp);
       }
       catch (OpenMS::Exception::UnableToCreateFile& /*e*/)
       {
-        LOG_DEBUG << "Error creating file 'debug_irts.mzML', not writing out iRT chromatogram file"  << std::endl;
+        LOG_DEBUG << "Error creating file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << std::endl;
       }
       catch (OpenMS::Exception::BaseException& /*e*/)
       {
-        LOG_DEBUG << "Error writing to file 'debug_irts.mzML', not writing out iRT chromatogram file"  << std::endl;
+        LOG_DEBUG << "Error writing to file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << std::endl;
       }
     }
     LOG_DEBUG << "Extracted number of chromatograms from iRT files: " << irt_chromatograms.size() <<  std::endl;

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -626,6 +626,10 @@ protected:
    * @param irt_detection_param Parameter set for the detection of the iRTs (outlier detection, peptides per bin etc)
    * @param mz_correction_function If correction in m/z is desired, which function should be used
    * @param debug_level Debug level (writes out the RT normalization chromatograms if larger than 1)
+   * @param irt_trafo_out Output trafoXML file (if not empty and no input trafoXML file is given,
+   *        the transformation parameters will be stored in this file)
+   * @param irt_mzml_out Output Chromatogram mzML containing the iRT peptides (if not empty,
+   *        iRT chromatograms will be stored in this file)
    *
    *
    */
@@ -633,7 +637,8 @@ protected:
     std::vector< OpenSwath::SwathMap > & swath_maps, double min_rsq, double min_coverage,
     const Param& feature_finder_param, const ChromExtractParams& cp_irt,
     const Param& irt_detection_param, const String & mz_correction_function,
-    Size debug_level, bool sonar, bool load_into_memory, const String& irt_trafo_out)
+    Size debug_level, bool sonar, bool load_into_memory, const String& irt_trafo_out,
+    const String& irt_mzml_out)
   {
     TransformationDescription trafo_rtnorm;
     
@@ -661,7 +666,8 @@ protected:
       OpenSwathRetentionTimeNormalization wf;
       wf.setLogType(log_type_);
       trafo_rtnorm = wf.performRTNormalization(irt_transitions, swath_maps, min_rsq, min_coverage,
-          feature_finder_param, cp_irt, irt_detection_param, mz_correction_function, debug_level, sonar, load_into_memory);
+      feature_finder_param, cp_irt, irt_detection_param, mz_correction_function, irt_mzml_out,
+      debug_level, sonar, load_into_memory);
 
       if (!irt_trafo_out.empty())
       {
@@ -935,10 +941,11 @@ protected:
     // Get the transformation information (using iRT peptides)
     ///////////////////////////////////
     String irt_trafo_out = debug_params.getValue("irt_trafo");
+    String irt_mzml_out = debug_params.getValue("irt_mzml");
     TransformationDescription trafo_rtnorm = loadTrafoFile(trafo_in,
         irt_tr_file, swath_maps, min_rsq, min_coverage, feature_finder_param,
         cp_irt, irt_detection_param, mz_correction_function, debug_level,
-        sonar, load_into_memory, irt_trafo_out);
+        sonar, load_into_memory, irt_trafo_out, irt_mzml_out);
 
     ///////////////////////////////////
     // Set up chromatogram output


### PR DESCRIPTION
Until now OpenSwathWorkflow wrote the debugging output file containing iRT peptides in the current working directory with the fixed filename:  "debug_irts.mzML". The filename can now be set with the parameter -Debugging:irt_mzml