### PR TITLE
[FIX] Missing win boost macro

### DIFF
--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -187,7 +187,8 @@ for module in mnames:
         libraries=libraries,
         include_dirs=include_dirs + autowrap_include_dirs,
         extra_compile_args=extra_compile_args,
-        extra_link_args=extra_link_args
+        extra_link_args=extra_link_args,
+		define_macros=[('BOOST_ALL_NO_LIB', None)]
     ))
 
 share_data = []

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -188,7 +188,9 @@ for module in mnames:
         include_dirs=include_dirs + autowrap_include_dirs,
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
-		define_macros=[('BOOST_ALL_NO_LIB', None)]
+		define_macros=[('BOOST_ALL_NO_LIB', None)] ## Deactivates boost autolink (esp. on win).
+		## Alternative is to specify the boost naming scheme (--layout param; easy if built from contrib)
+		## TODO just take over compile definitions from OpenMS (CMake)
     ))
 
 share_data = []


### PR DESCRIPTION
Would be cool if we just would take over the OpenMS compile/macro definitions. This solves that for now without renaming the libs.