### PR TITLE
[FIX] enable scrolling again while preventing bug

### DIFF
--- a/src/openms_gui/source/VISUAL/Spectrum3DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum3DCanvas.cpp
@@ -199,7 +199,7 @@ namespace OpenMS
       {
         openglwidget()->updateIntensityScale();
       }
-      // openglwidget()->initializeGL();
+      openglwidget()->initializeGL();
     }
     openglwidget()->resizeGL(width(), height());
     // openglwidget()->paintGL();

--- a/src/openms_gui/source/VISUAL/Spectrum3DOpenGLCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum3DOpenGLCanvas.cpp
@@ -180,8 +180,11 @@ namespace OpenMS
 
   void Spectrum3DOpenGLCanvas::initializeGL()
   {
-    makeCurrent();
-    glEnable(GL_DEPTH_TEST);
+    // The following line triggered a bug where the whole screen would turn
+    // black during scrolling (specifically it seems that multiple calls to
+    // this function causes the issue):
+    // glEnable(GL_DEPTH_TEST);
+
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     QColor color(canvas_3d_.param_.getValue("background_color").toQString());


### PR DESCRIPTION
- re-enables scrolling in 3D view using the OpenGL Canvas
- works around a bug that caused black / black windows during scrolling
  or when opening multiple 3D windows