### PR TITLE
Feature/cached ms2 spectra

### DIFF
--- a/doc/code_examples/Tutorial_GUI_Spectrum1D.cpp
+++ b/doc/code_examples/Tutorial_GUI_Spectrum1D.cpp
@@ -32,6 +32,7 @@
 #include <OpenMS/VISUAL/Spectrum1DWidget.h>
 #include <OpenMS/FORMAT/DTAFile.h>
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/KERNEL/OnDiscMSExperiment.h>
 #include <OpenMS/VISUAL/LayerData.h>
 
 using namespace OpenMS;
@@ -49,8 +50,9 @@ Int main(int argc, const char ** argv)
   exp.resize(1);
   DTAFile().load(tutorial_data_path + "/data/Tutorial_Spectrum1D.dta", exp[0]);
   LayerData::ExperimentSharedPtrType exp_sptr(new PeakMap(exp));
+  LayerData::ODExperimentSharedPtrType on_disc_exp_sptr(new OnDiscMSExperiment());
   Spectrum1DWidget * widget = new Spectrum1DWidget(Param(), nullptr);
-  widget->canvas()->addLayer(exp_sptr);
+  widget->canvas()->addLayer(exp_sptr, on_disc_exp_sptr);
   widget->show();
 
   return app.exec();

--- a/share/OpenMS/examples/CHROMATOGRAMS/Spyogenes.chrom.mzML
+++ b/share/OpenMS/examples/CHROMATOGRAMS/Spyogenes.chrom.mzML
@@ -1,0 +1,3645 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<indexedmzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0_idx.xsd">
+<mzML xmlns="http://psi.hupo.org/ms/mzml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psi.hupo.org/ms/mzml http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd" accession="" version="1.1.0">
+	<cvList count="5">
+		<cv id="MS" fullName="Proteomics Standards Initiative Mass Spectrometry Ontology" URI="http://psidev.cvs.sourceforge.net/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo"/>
+		<cv id="UO" fullName="Unit Ontology" URI="http://obo.cvs.sourceforge.net/obo/obo/ontology/phenotype/unit.obo"/>
+		<cv id="BTO" fullName="BrendaTissue545" version="unknown" URI="http://www.brenda-enzymes.info/ontology/tissue/tree/update/update_files/BrendaTissueOBO"/>
+		<cv id="GO" fullName="Gene Ontology - Slim Versions" version="unknown" URI="http://www.geneontology.org/GO_slims/goslim_goa.obo"/>
+		<cv id="PATO" fullName="Quality ontology" version="unknown" URI="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/quality.obo"/>
+	</cvList>
+	<fileDescription>
+		<fileContent>
+			<cvParam cvRef="MS" accession="MS:1000294" name="mass spectrum" />
+		</fileContent>
+		<sourceFileList count="1">
+			<sourceFile id="sf_ru_0" name="hroest_K120808_Strep0%PlasmaBiolRepl1_R01_SW.wiff" location="file://C:\Users\Hannes\Documents\strep\new">
+				<cvParam cvRef="MS" accession="MS:1000569" name="SHA-1" value="8d39a6183065b92a5c8969a2ba3c606c47416aec" />
+				<cvParam cvRef="MS" accession="MS:1000562" name="ABI WIFF format" />
+				<cvParam cvRef="MS" accession="MS:1000770" name="WIFF nativeID format" />
+			</sourceFile>
+		</sourceFileList>
+	</fileDescription>
+	<sampleList count="1">
+		<sample id="sa_0" name="">
+			<cvParam cvRef="MS" accession="MS:1000004" name="sample mass" value="0" unitAccession="UO:0000021" unitName="gram" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000005" name="sample volume" value="0" unitAccession="UO:0000098" unitName="milliliter" unitCvRef="UO" />
+			<cvParam cvRef="MS" accession="MS:1000006" name="sample concentration" value="0" unitAccession="UO:0000175" unitName="gram per liter" unitCvRef="UO" />
+		</sample>
+	</sampleList>
+	<softwareList count="4">
+		<software id="so_in_0" version="unknown" >
+			<cvParam cvRef="MS" accession="MS:1000551" name="Analyst" />
+		</software>
+		<software id="so_default" version="" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="" />
+		</software>
+		<software id="so_dp_sp_0_pm_0" version="2.3.0" >
+			<cvParam cvRef="MS" accession="MS:1000799" name="custom unreleased software tool" value="OpenSwathWorkflow" />
+		</software>
+		<software id="so_dp_sp_0_pm_1" version="2.3.0" >
+			<cvParam cvRef="MS" accession="MS:1000757" name="FileFilter" />
+		</software>
+	</softwareList>
+	<instrumentConfigurationList count="1">
+		<instrumentConfiguration id="ic_0">
+			<cvParam cvRef="MS" accession="MS:1000495" name="Applied Biosystems instrument model" />
+			<softwareRef ref="so_in_0" />
+		</instrumentConfiguration>
+	</instrumentConfigurationList>
+	<dataProcessingList count="1">
+		<dataProcessing id="dp_sp_0">
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_0">
+				<cvParam cvRef="MS" accession="MS:1000592" name="smoothing" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="2018-04-21+14:38" />
+				<userParam name="parameter: in" type="xsd:string" value="[../data/strep/raw/hroest_K120808_Strep0PlasmaBiolRepl1_R01_SW.mzML.gz]"/>
+				<userParam name="parameter: tr" type="xsd:string" value="../data/strep/lib/strep_iRT_small.TraML"/>
+				<userParam name="parameter: tr_type" type="xsd:string" value=""/>
+				<userParam name="parameter: tr_irt" type="xsd:string" value="../data/strep/lib/strep_iRT_small.TraML"/>
+				<userParam name="parameter: rt_norm" type="xsd:string" value=""/>
+				<userParam name="parameter: swath_windows_file" type="xsd:string" value="strep_win.txt"/>
+				<userParam name="parameter: sort_swath_maps" type="xsd:string" value="true"/>
+				<userParam name="parameter: use_ms1_traces" type="xsd:string" value="true"/>
+				<userParam name="parameter: enable_uis_scoring" type="xsd:string" value="false"/>
+				<userParam name="parameter: out_features" type="xsd:string" value=""/>
+				<userParam name="parameter: out_tsv" type="xsd:string" value="/localscratch/hroest.4041515.0/output.tsv"/>
+				<userParam name="parameter: out_osw" type="xsd:string" value=""/>
+				<userParam name="parameter: out_chrom" type="xsd:string" value="/localscratch/hroest.4041515.0/output.chrom.mzML"/>
+				<userParam name="parameter: min_upper_edge_dist" type="xsd:double" value="0"/>
+				<userParam name="parameter: rt_extraction_window" type="xsd:double" value="450"/>
+				<userParam name="parameter: extra_rt_extraction_window" type="xsd:double" value="100"/>
+				<userParam name="parameter: mz_extraction_window" type="xsd:double" value="50"/>
+				<userParam name="parameter: ppm" type="xsd:string" value="true"/>
+				<userParam name="parameter: sonar" type="xsd:string" value="false"/>
+				<userParam name="parameter: min_rsq" type="xsd:double" value="0.95"/>
+				<userParam name="parameter: min_coverage" type="xsd:double" value="0.6"/>
+				<userParam name="parameter: split_file_input" type="xsd:string" value="false"/>
+				<userParam name="parameter: use_elution_model_score" type="xsd:string" value="false"/>
+				<userParam name="parameter: readOptions" type="xsd:string" value="cacheWorkingInMemory"/>
+				<userParam name="parameter: mz_correction_function" type="xsd:string" value="quadratic_regression_delta_ppm"/>
+				<userParam name="parameter: irt_mz_extraction_window" type="xsd:double" value="0.05"/>
+				<userParam name="parameter: ppm_irtwindow" type="xsd:string" value="false"/>
+				<userParam name="parameter: tempDirectory" type="xsd:string" value="/localscratch/hroest.4041515.0/"/>
+				<userParam name="parameter: extraction_function" type="xsd:string" value="tophat"/>
+				<userParam name="parameter: batchSize" type="xsd:integer" value="1000"/>
+				<userParam name="parameter: log" type="xsd:string" value=""/>
+				<userParam name="parameter: debug" type="xsd:integer" value="0"/>
+				<userParam name="parameter: threads" type="xsd:integer" value="4"/>
+				<userParam name="parameter: no_progress" type="xsd:string" value="false"/>
+				<userParam name="parameter: force" type="xsd:string" value="false"/>
+				<userParam name="parameter: test" type="xsd:string" value="false"/>
+				<userParam name="parameter: Debugging:irt_mzml" type="xsd:string" value=""/>
+				<userParam name="parameter: Debugging:irt_trafo" type="xsd:string" value=""/>
+				<userParam name="parameter: Library:retentionTimeInterpretation" type="xsd:string" value="iRT"/>
+				<userParam name="parameter: Library:override_group_label_check" type="xsd:string" value="false"/>
+				<userParam name="parameter: Library:force_invalid_mods" type="xsd:string" value="false"/>
+				<userParam name="parameter: RTNormalization:alignmentMethod" type="xsd:string" value="linear"/>
+				<userParam name="parameter: RTNormalization:outlierMethod" type="xsd:string" value="iter_residual"/>
+				<userParam name="parameter: RTNormalization:useIterativeChauvenet" type="xsd:string" value="false"/>
+				<userParam name="parameter: RTNormalization:RANSACMaxIterations" type="xsd:integer" value="1000"/>
+				<userParam name="parameter: RTNormalization:RANSACMaxPercentRTThreshold" type="xsd:integer" value="3"/>
+				<userParam name="parameter: RTNormalization:RANSACSamplingSize" type="xsd:integer" value="10"/>
+				<userParam name="parameter: RTNormalization:estimateBestPeptides" type="xsd:string" value="false"/>
+				<userParam name="parameter: RTNormalization:InitialQualityCutoff" type="xsd:double" value="0.5"/>
+				<userParam name="parameter: RTNormalization:OverallQualityCutoff" type="xsd:double" value="5.5"/>
+				<userParam name="parameter: RTNormalization:NrRTBins" type="xsd:integer" value="10"/>
+				<userParam name="parameter: RTNormalization:MinPeptidesPerBin" type="xsd:integer" value="1"/>
+				<userParam name="parameter: RTNormalization:MinBinsFilled" type="xsd:integer" value="8"/>
+				<userParam name="parameter: RTNormalization:lowess:span" type="xsd:double" value="0.666666666666667"/>
+				<userParam name="parameter: RTNormalization:b_spline:num_nodes" type="xsd:integer" value="5"/>
+				<userParam name="parameter: Scoring:stop_report_after_feature" type="xsd:integer" value="5"/>
+				<userParam name="parameter: Scoring:rt_normalization_factor" type="xsd:double" value="100"/>
+				<userParam name="parameter: Scoring:quantification_cutoff" type="xsd:double" value="0"/>
+				<userParam name="parameter: Scoring:write_convex_hull" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:uis_threshold_sn" type="xsd:integer" value="0"/>
+				<userParam name="parameter: Scoring:uis_threshold_peak_area" type="xsd:integer" value="0"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:stop_after_feature" type="xsd:integer" value="-1"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:min_peak_width" type="xsd:double" value="7"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:peak_integration" type="xsd:string" value="original"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:background_subtraction" type="xsd:string" value="none"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:recalculate_peaks" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:use_precursors" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:recalculate_peaks_max_z" type="xsd:double" value="0.75"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:minimal_quality" type="xsd:double" value="-1.5"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:resample_boundary" type="xsd:double" value="15"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:compute_peak_quality" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:compute_peak_shape_metrics" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:boundary_selection_method" type="xsd:string" value="largest"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:sgolay_frame_length" type="xsd:integer" value="11"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:sgolay_polynomial_order" type="xsd:integer" value="3"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:gauss_width" type="xsd:double" value="30"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:use_gauss" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:peak_width" type="xsd:double" value="-1"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:signal_to_noise" type="xsd:double" value="0.1"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:write_sn_log_messages" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:remove_overlapping_peaks" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakPickerMRM:method" type="xsd:string" value="corrected"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakIntegrator:integration_type" type="xsd:string" value="intensity_sum"/>
+				<userParam name="parameter: Scoring:TransitionGroupPicker:PeakIntegrator:baseline_type" type="xsd:string" value="base_to_base"/>
+				<userParam name="parameter: Scoring:DIAScoring:dia_extraction_window" type="xsd:double" value="0.05"/>
+				<userParam name="parameter: Scoring:DIAScoring:dia_extraction_unit" type="xsd:string" value="Th"/>
+				<userParam name="parameter: Scoring:DIAScoring:dia_centroided" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:DIAScoring:dia_byseries_intensity_min" type="xsd:double" value="300"/>
+				<userParam name="parameter: Scoring:DIAScoring:dia_byseries_ppm_diff" type="xsd:double" value="10"/>
+				<userParam name="parameter: Scoring:DIAScoring:dia_nr_isotopes" type="xsd:integer" value="4"/>
+				<userParam name="parameter: Scoring:DIAScoring:dia_nr_charges" type="xsd:integer" value="4"/>
+				<userParam name="parameter: Scoring:DIAScoring:peak_before_mono_max_ppm_diff" type="xsd:double" value="20"/>
+				<userParam name="parameter: Scoring:EMGScoring:max_iteration" type="xsd:integer" value="10"/>
+				<userParam name="parameter: Scoring:Scores:use_shape_score" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_coelution_score" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_rt_score" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_library_score" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_intensity_score" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_nr_peaks_score" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_total_xic_score" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_sn_score" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_dia_scores" type="xsd:string" value="true"/>
+				<userParam name="parameter: Scoring:Scores:use_ms1_correlation" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:Scores:use_sonar_scores" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:Scores:use_ms1_fullscan" type="xsd:string" value="false"/>
+				<userParam name="parameter: Scoring:Scores:use_uis_scores" type="xsd:string" value="false"/>
+			</processingMethod>
+			<processingMethod order="0" softwareRef="so_dp_sp_0_pm_1">
+				<cvParam cvRef="MS" accession="MS:1001486" name="data filtering" />
+				<cvParam cvRef="MS" accession="MS:1000747" name="completion time" value="2018-04-21+16:44" />
+				<userParam name="parameter: in" type="xsd:string" value="/tmp/strep_irt.chrom.mzML"/>
+				<userParam name="parameter: log" type="xsd:string" value=""/>
+				<userParam name="parameter: debug" type="xsd:integer" value="0"/>
+				<userParam name="parameter: threads" type="xsd:integer" value="1"/>
+				<userParam name="parameter: no_progress" type="xsd:string" value="false"/>
+				<userParam name="parameter: force" type="xsd:string" value="false"/>
+				<userParam name="parameter: test" type="xsd:string" value="false"/>
+				<userParam name="parameter: in_type" type="xsd:string" value=""/>
+				<userParam name="parameter: out" type="xsd:string" value="/tmp/Spyogenes.chrom.mzML"/>
+				<userParam name="parameter: out_type" type="xsd:string" value=""/>
+				<userParam name="parameter: rt" type="xsd:string" value=":"/>
+				<userParam name="parameter: mz" type="xsd:string" value=":"/>
+				<userParam name="parameter: int" type="xsd:string" value=":"/>
+				<userParam name="parameter: sort" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:sn" type="xsd:double" value="0"/>
+				<userParam name="parameter: peak_options:rm_pc_charge" type="xsd:string" value="[]"/>
+				<userParam name="parameter: peak_options:pc_mz_range" type="xsd:string" value=":"/>
+				<userParam name="parameter: peak_options:pc_mz_list" type="xsd:string" value="[]"/>
+				<userParam name="parameter: peak_options:level" type="xsd:string" value="[1, 2, 3]"/>
+				<userParam name="parameter: peak_options:sort_peaks" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:no_chromatograms" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:remove_chromatograms" type="xsd:string" value="false"/>
+				<userParam name="parameter: peak_options:mz_precision" type="xsd:string" value="64"/>
+				<userParam name="parameter: peak_options:int_precision" type="xsd:string" value="32"/>
+				<userParam name="parameter: peak_options:indexed_file" type="xsd:string" value="true"/>
+				<userParam name="parameter: peak_options:zlib_compression" type="xsd:string" value="true"/>
+				<userParam name="parameter: peak_options:numpress:masstime" type="xsd:string" value="none"/>
+				<userParam name="parameter: peak_options:numpress:masstime_error" type="xsd:double" value="0.0001"/>
+				<userParam name="parameter: peak_options:numpress:intensity" type="xsd:string" value="none"/>
+				<userParam name="parameter: peak_options:numpress:intensity_error" type="xsd:double" value="0.0001"/>
+				<userParam name="parameter: spectra:remove_zoom" type="xsd:string" value="false"/>
+				<userParam name="parameter: spectra:remove_mode" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:remove_activation" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:remove_collision_energy" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:remove_isolation_window_width" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_zoom" type="xsd:string" value="false"/>
+				<userParam name="parameter: spectra:select_mode" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:select_activation" type="xsd:string" value=""/>
+				<userParam name="parameter: spectra:select_collision_energy" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_isolation_window_width" type="xsd:string" value=":"/>
+				<userParam name="parameter: spectra:select_polarity" type="xsd:string" value=""/>
+				<userParam name="parameter: feature:q" type="xsd:string" value=":"/>
+				<userParam name="parameter: consensus:map" type="xsd:string" value="[]"/>
+				<userParam name="parameter: consensus:map_and" type="xsd:string" value="false"/>
+				<userParam name="parameter: consensus:blackorwhitelist:blacklist" type="xsd:string" value="true"/>
+				<userParam name="parameter: consensus:blackorwhitelist:file" type="xsd:string" value=""/>
+				<userParam name="parameter: consensus:blackorwhitelist:maps" type="xsd:string" value="[]"/>
+				<userParam name="parameter: consensus:blackorwhitelist:rt" type="xsd:double" value="60"/>
+				<userParam name="parameter: consensus:blackorwhitelist:mz" type="xsd:double" value="0.01"/>
+				<userParam name="parameter: consensus:blackorwhitelist:use_ppm_tolerance" type="xsd:string" value="false"/>
+				<userParam name="parameter: f_and_c:charge" type="xsd:string" value=":"/>
+				<userParam name="parameter: f_and_c:size" type="xsd:string" value=":"/>
+				<userParam name="parameter: f_and_c:remove_meta" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:remove_clashes" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:keep_best_score_id" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:sequences_whitelist" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:accessions_whitelist" type="xsd:string" value="[]"/>
+				<userParam name="parameter: id:remove_annotated_features" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:remove_unannotated_features" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:remove_unassigned_ids" type="xsd:string" value="false"/>
+				<userParam name="parameter: id:blacklist" type="xsd:string" value=""/>
+				<userParam name="parameter: id:rt" type="xsd:double" value="0.1"/>
+				<userParam name="parameter: id:mz" type="xsd:double" value="0.001"/>
+				<userParam name="parameter: id:blacklist_imperfect" type="xsd:string" value="false"/>
+				<userParam name="parameter: algorithm:SignalToNoise:max_intensity" type="xsd:integer" value="-1"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_max_stdev_factor" type="xsd:double" value="3"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_max_percentile" type="xsd:integer" value="95"/>
+				<userParam name="parameter: algorithm:SignalToNoise:auto_mode" type="xsd:integer" value="0"/>
+				<userParam name="parameter: algorithm:SignalToNoise:win_len" type="xsd:double" value="200"/>
+				<userParam name="parameter: algorithm:SignalToNoise:bin_count" type="xsd:integer" value="30"/>
+				<userParam name="parameter: algorithm:SignalToNoise:min_required_elements" type="xsd:integer" value="10"/>
+				<userParam name="parameter: algorithm:SignalToNoise:noise_for_empty_window" type="xsd:double" value="1e+20"/>
+				<userParam name="parameter: algorithm:SignalToNoise:write_log_messages" type="xsd:string" value="true"/>
+			</processingMethod>
+		</dataProcessing>
+	</dataProcessingList>
+	<run id="ru_0" defaultInstrumentConfigurationRef="ic_0" sampleRef="sa_0" startTimeStamp="2012-08-08T11:18:49" defaultSourceFileRef="sf_ru_0">
+		<userParam name="mzml_id" type="xsd:string" value="hroest_K120808_Strep0%PlasmaBiolRepl1_R01_SW-Strep 0% Plasma Biol Repl1"/>
+		<chromatogramList count="106" defaultDataProcessingRef="dp_sp_0">
+			<chromatogram id="4197_AAGGISSLEDAK/2_Precursor_i0" index="0" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="559.788" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGGISSLEDAK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="540">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAx+GW6BCxy9Jh2cOydIjYiF3ydogOER2iQ0RMdIgookPMIYYOQ4exQ+v98zvEsMvQYegwREt2DhEb0SGiJTpEh4id8Xu+l8/lOX5Lpe7KadJLqZImX3qrpklfb7U06fzp7jBN6t+7C1yDa2qLb/NnfIe/5K65W+5eH/ln/pXvz6IfzKJ7m0U3rB+z6D9n0Y/y4/xXboqb0Tl+gV/iV/g1boPb1l1+j9/nD/g6l3FH3E895k/4U/6cv+D+cjd6xz/wT/wL35dHN5BHN6Tv8+g/5NF/yqMf4ce4CW5Sp/lZfp5f5Je5VW6d29QdvsxX+Cpf4w65oA2+ybf4Nn/GdbhLveZv+X/8I//MvXL9RexgEf27Ivrhwq8Kv+JGuXH9xk/xM/wcv8AtcSvcmm7w2/wuv8fvcwdcXTP+iP/FH/Mn3Cl3rhf8FX/D3/EP3BP3om9C9AMh+qHgV8Gvgl9xI9yYTvCT/DQ/y89zi9yyrvLr/Ba/w5e5ClfVGv+DD3yDb3Itrq2/Q/Ifklocqw==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="748">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxVUX9Ik1EU3dcqCpvKijAEmRFEiTmyQBZz5jvvfaEUIVgkWUZkEmxFJoP9cm6tiGGJEtVqzkFYBILSHwa5XywobBVFFAUrMYYRutRBTtq35ffBhC5c7uW+yznnnrc5PoDqSAGdz1bTOrzFguouOC5JpjM1uJjVkyqLQAyqIMQqWwmN8zJ6ZZcg9jrbBPG5rNjd7UXGPIdx6344uWa4w62InxVwODiNoP8xNmljiHonkZIVQNxPOybJOcsJjHBnJJzlWjM0dRSndE/gyfbB330eQlEtvVfspgfHfXRNcoQ2tyiZ0hqhu5SN9Hb9Aj705NBf+hVqoZC+ChglHFGjy5yQNP+yHcet0HVpno+4aZao6q2SBvGm8pyWiv2ovImq5ppon2UJYiq1R2lXbpDucBjw6fUhKlSkaMfJCRr+M8wiwmfW8eU0X2gY5o1qF59+6Wedijf0jnwRDvtNqMLbJM4uJ8FexyKhYYKPVzOkMdtAyrmHZMgbkvjzfuZ152c1wjJxlz39731V/4qnYrX7ruFCbg/eH0it/kNxeAY3LDHpLnEvZv2B0WwA7rXtePS3Vdrbrg2gcmcpO9bynL0zDbIKYxGr9IzSpaRS8uHKVAxbhh6gPTcvcW/M6DCVfUGeffNAH+JgCJQgrNGjzdKAhH0rTFoFrYqmaOf9IyzaY2fysRmm/17Gl6RnmXpsPf/bvI43KDbwP/c5WcLWS0XM/rYBSZ/IJ6bHJeAf94wGRw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3414_VATTQGIQSTR/2_Precursor_i0" index="1" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="581.315" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VATTQGIQSTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EgwEcxvFihxEdIoooYocYURSRV4wOI4ooxg7TKMYOo8MYO4xRvP/ftx3GWIxi7DBGh7HDmDZihxjFKEaHGB3GaK/f97l8L5/j032d7VRVrrxFVWXOW4KmVaXwMFteVXa8OarS9XwZX8M1cV06wI/wf3ifJn5JE7euiQvSA038sSb+HB/DJ3EZ3B0t4Cv4Or6Ff8N94H5wE+rXxS/r4jd18du6+ENdXBh3QeP4FD6LV/FF3BOuQdv4Pn6I/8VPcQuGuBVDXIDuGuKPDPEnhvgI/hp3i8tRE1/CV/Ev+A7uHfdFx/h5U/yiKX7NFL9litszxYXoGT6KT+DT+DzOwZVxNdrE9/AD/Aj/h/NZ/IpuWOKDFr+y+JXFr3AxXJJm8Pf4Ar6Cr+NauDf6if/BT/B+m1/Z/MrmVza/omFb/CU+jk/hszgVV6TP+Aa+je/jh7hf3JQuOOJXHfEBh185/MrhV7gIvcHf4nN4E1/CVXEvuA59x3/jx/h5l1+5/MrlV3TfFR9y+RU+ik/g0rg8dfCP+Bq+ie/hBq7yD+xTD2w=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="636">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJzb8dfYyZmBwekmS4KTAcsFRwYg6Psf72j/T92JAQl0/3/v+IXlldPMv61g8cLf/s4tzA7Olkxn4OrE/1mD2Rl/+eFiq/8qo5gDAjf+LnQ697/fEVms/J+3006GCKfH//c7gtxx5Y89WB7E1mY+gWLGOgYeJwbGaU7eTBOdt+9xdjGW7Xbp/i/k0ve/1xlZncBfZicQ3gH0I0j91v/LndhYMsBY6I85ipkg98D8dq5hovP5vbouKX/FXDazXHFe84fH+QDjLCcQ3slsAHbjfyYN5+D/rM4r/m12Yvw731GMucHx7z8156fNC13EmL+4Ln+k5R5d+sr9zoJoj89n4z0unuPymLPd1v3anm7XKAYR5+lVL5zN9ra6FDedcmmvmesiuOe0y6XfOS4bD8m5FPxZ4nybocPJk2UP2D3L//c7nf+z02nev7lOsox3wP5Adrsyo4STCZMS2O9l/9Y6mTKmOPH8m+70l0nCWY6xwWkn4xOwepCZMD0gORB/3l93Z5D5v//NB8tFMITCwzD+vwmY/an6MJh+wMDinMTogxLGlf/0wXzbf51OP377gtn39ku6vGMKcwa5Zd5/BbDY0b/aTsLMc5xd/2x3LmGKdgaF3zqmQrAcACcByR0=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="2448_AMVTEYGMSEK/2_Precursor_i0" index="2" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="623.278" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AMVTEYGMSEK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EiGqLh4aHhoSGi4Yg74on8bogb4mg4Go7oUdwQx/MQDdEQ0RAN6ejh94+IHqIhGiKeyHNDxBPREA0RDdEQ0Z3v67O8l9f4KRY7K8RRT3elOGr/6+x7HLX2OivH0WJ3Fa3GUZcXa3ydX+AbXJNb0TV+g9/id/gWF3MH3JGe8Gf8BX/FX3P/uXt95J/5V/6d70mC60+CG9SvSfDfkuBHkuDH+HFugpvSaX6Gn+Xn+HluiVvmfuoqv85v8tv8LrfPZXrIH/On/Dn/l2tzN3rHP/BP/Av/xn1wfWnoQBr8lzT4oTT44TT4Ua7AlXSSL/MVvsrXuDq3wDW0ya/wa/wGv8XtcC2N+QP+D3/Cn3EX3JVe87f8Pf/IP3Ov3Lv2ZsH3Z8EPZn6V+VXmV9wYN64T/BQ/zc/ws9wcN69L/DL/i1/l17lNblt3+d98xh/yx9wpd66XfJu/4e/4B+6Je+He9IPvy/0q96vcr3K/yv1KC3yJn+TLfIWrcjWt8z/4Bt/Mo0+vyhpz</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="712">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUW1IU2EUvvdutSChkhb7EZEXpSDQSKKgKdve570jl/SBUIMcLovlSIqgHzG23SYMItS2EH+EI6VYn1STIAS3Gy4YDARF3D/rFtIHEeaval7X3jf2xwOH93DOec57zvP4HFuQyPYiIG2F7DOQHuiAULWRXA+soTB+q/sw5KA48GkQV03NOBMO4F7MIFafirN5P+Q9KRyVZzCp6TgvFjFraKSgVnBOm0KpfBLWnlk+j1kstEwYNhQpkT7pMOKChf/BaonIDx4zZz3MWX7YmOPvA+ERVLEJ39RR8kFY4LlEw3N8j7owF7XDIrRgvzpBchP3cVyqhyzFid90DKw3ZV6txhfJEXMnaZAek1NOgkDFia9RLzJrdhQqHXzedDTHX7bDnfAQvbzYqbwZjyk7V94rdWnBPey1uQ+V/yiDm7LK69FLCqu3eFN087UwzdS308zeLIqRViRdA7Cu7qC6FqfzzQVqufKLni4tUjaXcbxW5+bxytIyXLKLdlcc8KC3uqsNTaZ+pGM6UVO30e+6iY9SnnOREh+S4kyQc3XQsCG/niNMl93rr0jw1gsiGx7CsMmlONflevkvYbclzTdIoxHkd00K4+iSNPSJHuj6NF4Ku/DEGCHb/WOYH1NxwtmNGu+1e2qabNTm7jaJPlPf4Yt2AV1tU3BX2tBu/68lw9U0r/VvxH8O/SRvRR+eio3kH5h6+a0=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="643_VPIVLDIFAER/2_Precursor_i0" index="3" defaultArrayLength="162">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="636.371" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VPIVLDIFAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="588">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEtHEcwPFniHeIhpeXIhoi3iHiIoo8DdFwREM0RMRFQzRENJSGOG44bjgdvRw3HDccvZ7nEQ0RDemGiCIaoohoiIaILv/Pb/ktXx+/4VcodKeYxJ2r7pSSOPcz5SSuHXanEvZANYmj7uzVkvgnfz4Kfb4e+v8NXVPXCjtqh75wzE/4J/xT3ZnunH/Bv+R3+Nf8G92t7l73wH/kP/Ff+K/ueNO96z74n/wvfpQGvycN/q80dL1p6PrCjn6nwf8T+qv+0OcGQ384pBvWjYT9/Jc/yh/jj/MndJO6af4Mf5Y/x8/z53ULukXdEn+Zv8Jf5a+5Y123odvkb/G3+Tv8Xf6+7kBX5Jf4ZX6FX+XXdEe6uq7Bb/Jb/Db/2B2J7kR3yj/jn/Mv+Jf8ju5ad8O/49/zH/iP/Cfdi+6V/8Z/53/wP/lfuijzV5m/CjvXmwW/L/NXmb/K/JVuUDcU9sBw6PdGMn/FH+WP6cZ1E/wp/jR/hj/Ln9PldfP8Bf4if4m/zF/RrerW+Ov8Df4mf4u/rdvR7er2+Qf8Ir/EL7ujoqvqavx//Dq/wW/yW7p2Fn8Dt/UycQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="620">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYGBgYP1d4izBIOYcyGjsDOQybGS2cN77byeYDQLeDF3O9UwtzleYM5ym/TnsBBKLaep0LmR+6mzTeBCurotZASx38M92JwYcYNk/PxT1xs2TwfwqJg3nPEYbsL7/jCpOIv/dnUWZXODmuPwpBrM3M64Cq2dlroHLmf7jcZZkeeKUxFztzMscBDe/6t9puJrg2rlwcetGU5et/1mcbzE4Op/4q+j8q+6G85o/9s6bmE3AatgYEp1balY7azMxOKf98XZmqg1xmavQ6/K2banrj9m2bp+0r7qlh3m5+9Q3upetdHY/32/mfjuG0X3uv1C3mWt2u+6sD3EF6Xl4SN7l135Jl2V72V0KD7K4xLPcgbsBBNya3ztr/s0Hi1kybwO7FWTnvT/yzrtrvzvX1u50XtYg4VK8n9ElmyHGuY35n9OEpvnOhf+bwWp/MDY4L2Dqcb7z2995yv/7TuoMe8Di4gyhKPbAwJdf2WDxs0z5cPmcpgasar2Y9ZwfM/1yAvn/7J9gZ6P6RrC6CoYDTrJ/2YBuPO7csFfBBSR2s4HDZdn//c4PGAydQXIv/s1zlv9rgWLuwT9fwW5z+e/qfOgvwk6QnnOMfM4AGwCrSQ==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="2228_AVYLKPEDPFTWASGIK/3_Precursor_i0" index="4" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="641.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVYLKPEDPFTWASGIK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="588">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEpAEUwPE5LHuI6LDsELFLdIiYiA6ZDhFFdIhoiSg6RHSIDiV2iQ7RITt0iA4RHb7v6xAdIuYwmsMwzGGYwzBpiQ4Ru8Q23u9d3uXv5x1eoVAopOWkWOhOJSmWfn9MNSnmulNLiqvdqSfF6sPHNHRNXUvXjr3Xif7xKfrZ5+jTl+jzr7o33V/+Oz+Xhv8pDf9zGn5PGl1vGl1f7Nkv0adfo8/3R783EP3jN92gbog/zB/hj/LH+OO6Cd0kf4o/zZ/hz/HndQu6Rd0Sf5m/wl/jr7tjQ7ep2+Jv83f4u/x9/k/dge6Qf8Q/5p/wS/xT3ZnunH/Bv+Rf8RP+te5Gd8u/49/zy/wKv6qr6eq6Br/Jb/Hb/I47nnTPuhf+K/+N/4//zs9l/irzV7HzPVn4vVn4fZm/yvyVrl83EDv3PfrVwegfhvjD/BHdqG6MP86f4E/yp/jTuhndnG6ev8Bf5P/gL7tjRbemW+dv8Df5W/xt/o5uV7fP/8U/4B/yj/jHuhNdiX/KP+Of8y/4l7orXcK/5t/wb/l3/HtdWVfRVfk1fp3f4Dfd0dK1dR3+n6z4H2IiMaA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="756">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxtUF9IFHEQ3t9uJWFdPqgchXEhakXmQyd5qB3sN7tSRP9QKNCkQgwJwogsytvbW8SzB4MeynzILLXMPwdxFoLpdVBBoFaWCKZI95ApYZov3d3e1m7UUx8M38wwfDPztecuSeMF7dJZW6qUwm5QuZ5Pb4QITqpBhAwNYc8BKglX0Xx8D8X407Q45KZ0JYl2GW5EYj/wjcuh3kQ38XKftEbslx6uy5J3NmXIYnWO3Ftrl5OzA9J3T61UGf5KBUVT1OXJon5vG4r4cZzXVzHiKaUj6hbq1j4ipnxGwJgR81g1bqrT2C28gjNkJ58wgVl2DVe5e3CwDyj2RXGCHxPvKxGYd53TFsD9Ro3+GgFWiB4unVQxjS6HD5HZHzDWE3Q7bWprpGRtGD9HONo/nE2TaitWlRVEE3sxXf8ISbwNtcY7dOqtqGZO9PleYIBLRbn6CYeNHhxT3+M2uyhuFb5Y+14Kf/aaiLT5Ka9+gQ7OPKXZ5XxpyvFASskV5CubbXKplGqF/VSJtNLslJbujtHk86O0wl2Hlii0NIJCGTL4W1ZeZbj+6ZpoNhqt+ky8Av7EM3GtuoxRt5vKuO00yDaSq7KBPKwOXq+D/uqxzC4aVcj635wdRI3lgfnLDqGQMpUQTL8KRjaQS+FpMXaJWoaK6QmnUofHRg3sMbZpOi54/RZz/8F4fN7q39GPWzyo11k8oc/CmQgioudYdZR50cF3Ik3Yh4qEKjaxOdH0V9TeYo5rwS/gAu//</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="170_AAGASAQVLGQEGK/2_Precursor_i0" index="5" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="643.839" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGASAQVLGQEGK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="572">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9Eg3Ecx/FGFKOIInaIKEaHtENEHiOKDjF2GLHDrIgOY+wwohhF7DCe/8+zxdhhjA4jGjvEmBpRjGLsMMYOsRQdps33/b28D7/X7/aJx8eXUZWpyeVUxdDHV1CVrclVVOXleXyPqjJh8SZt43v4Id6jiZ/TxPk0cX66rYnf08SH8FH8OS6Nu6Yqvoi/x9fxLdwHro/7odO6+AVd/IoufkMXv6OL28eFaQyfwF/gb/EGroSr0if8K76DH+D/cLOGuEW6aojfNMTvGuIPDfER3AkuibukWbyDL+Mf8A3cG65Lv/AjvNcUv2yKXzPFBUxxQXpkij/Gn+FT+AwuhyvQCr6Gb+Lb+B5uiPNY0nlLvM8S77fYlcWucCFclJ7j0/gbvIov4u5xdVyLfuL7+F/8tM2ubHZlsyu6Y4s/sMWH8TF8AneBu6UmvoSv4p/wr7gObkD/8LOO+CWHXTnsymFXDrvCRegpPom/wmfxDq6Me6AN/Du+i//Cj3Bel13RdVd8wBUfdNmVy65wZ7gUzeBz+Dt8BV/DNXFt2sN/8z6Vl38zeeUfBQYfPA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="668">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYGBgaGF64sSABSz+7Y4ins7YhVVdHuMNp4rf/x1d/mqjyH/+fx/Mz2cwcvb4d9zZqmGb8xPmSWD26//bnLOq1zlXMTY5Xf9t7oysDyQHoqN//nZOZfRy9vi7GUUeBCb/jXSeVbfDRbOt1qXmf6ELNnfBQEXjQudjzfOccxmFXE4wLXOeXeOJov5JY7PzKmttsNh1Rz4wzcXU7hzFGgK3d8rfOWD2Zeb5ziBs2GTvWj1/gpvVlmPu1mXvPSapxnkeEXDzdHkj4JkrNN3jtAmvx+sr6e5CVaLuhxYzuj/Sknd/Hsntnr33j9u6/9vdHrWGuHmmKLiVWMi7zTv53XVapapbkaWm29f8areDmyPcAif4urH4q7m9CeBz45v81rX1Ob/bSg92t3PJG1xleDTdlt+57dqS9dn1Hdc+V+VoObelRipuRvM53CZoL3NV3nYMKDbPNbiuz3WR2jrXjZtjXZNSa11PRP8Fh1fXX1vX14J2YHEZGTvX9j97XUBqv7f2gfkgtSC8IF4OrAekbsr+WFfP6g8uZqqtrrGLTVzDmV1cPzW9crHdX+RaEpzjKmWj5PojJcX10gYZ142XhV2VF8xzOfmOxxUUZjObxVz76oxcFwoouV74d99log6D6y+7FS4ia4RdmWpWugAAt/7MnA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="4864_DGGVEIATTNVSK/2_Precursor_i0" index="6" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="645.83" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGGVEIATTNVSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFk1nEcx/HnMDo8RDEWI4rSYYweRvH4L8ZoLDuMxcMYLcWIxdghFmN0eCimsf/z/P//HWIpRoeHYsRieg6xFKPDQyliUXaIpT2+r+/lffi9frdP+/3xVdPkVvfG0qTUvZt6O03Wnh7f/TS53L2HadLu+jqfcs+5lr7jP/Id/hf/jys3wp3Ri43wlUb4a43wNxrha9xdbkGX+Sd8zr/k33C73Gf9xv/xXmrGvxPNeD/ZjP+9zXD9zXDn9BI/yA/xVX6Eu85N6BQ/zc/yc/w8t8gt6Qpf51f5dX6D2+S2tMVv8zt8m9/j9rkO910P+EP+iO/JwpezcKeycH16Ngt/IQs/wFf4K9wwN6rj/CRf42f4O9w9bkEf8Mv8I/4xv8Zl3DPuhb7iX/Nv+V3+A/eJ+6Jf+Z/8b/4vX8rtKrcr7c3D9+fhz+d2xQ9yQ1xVR/gxfoKf4qe5WW6Om9dFfolf4ev8KrfObegmv8W3+G1+h2tze7rPd/gf/AF/yB1xPUW0XIQ/XYTvK+yqsCtugKvoVX6YH+XH+Umuxs0UyX+0jiOQ</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="772">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw1kl1Ik2EUx9990EUXIyHSZJqUSPSxlaEX2tT2/M/7LkgJGwjmEkcykBRbSU6dbmtBn2SuuihUArUPG4K1CiWRrSCElPIiUtTIJFPKEryZe2c9L+2BP4dzeDj8/vyPyyOzj6dluP7VLp8bN3QF1CaMKLW93E13+2do0JauzBZL0kn4/242nUGkchxH4kF21b/EHOYX+GHW0IHsndQh9MHq7CNVqFh0XdBIk8JxqbGmU5poaJd82ZclTwVJiwvL4qkyh/gh1UnWDC3V+d5hSO1BUP2AlYR3IDs2zGpUvWwtlorq2Gc2PqpHxdsWbJYDLOTtYOfadOiJOpkj3saW4h50yb/Zlw0rs6qIqbVPUVwVgD4soDzahEC8Fq82ZrCvcBDcB+fXZI6A+01pXWW8T2KHlfkjexjftaXIi63gtuBUdtYXZiHZlIIFrx15uXM027kgvozdl/qbNZZv89ssweHXUv6x85LGOSuWBm2iaShZDBx9T/nbn1BjKEITmd1UklFAa5Ue+jU3TFdyaqk5jVFLWhLdisjYZf6D3ou55JkbwjO1Htz37vVV3Ml3Y4u3WmG+5P7EjLPPMdA6pnBz8Qx4bgkvPK+lNzbKO3RQfLh/k+ha/UrXuu/RlNlEOapuGPx1yr4ivxk+/zLsghFZBh3V640UNU/j5LSFJqv2UmB0ElvXz+KnPI+QthiPe9ZR1hJhJ/TjcGsMKCIHpmJjbI/cAJ13BYmb4AycOXFLXNdVUbYYr0PixrgSf7k4+1+W7g3v</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="1789_TIAMESTDGLTR/2_Precursor_i0" index="7" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="647.819" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIAMESTDGLTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EnjoaHhoeH4qEhoogoGiK/hmiIKKIh4slFQzRENERDxPMQDemG6PfvoiGiIRqiIdIN0RBHw9FwRA9xQxzPne/rs7yX1/gpFlurxtFIe7U4+tZePY4qj619xFHpuLVGHLVZsckVktDvSfA/kuC7k+B7k+D7uSFuVMf5SX6an+UXuCXuN7emG/wWv8Pv8X+4Q66kp/wZf8Ff8TfcHfegT/wL/8q/8e/cJ/elHWnwnWnwXWnwP9Pgf6XB9XED3LCO8RP8FD/Dz3GL3LKu8uv8Jr/N73L73IEe8Sd8yp/zl9w1d6v3fIV/5qt8jatzH1xDm3wh86vMrzK/yvwq8ysd4kf5cX6Sn+ZmuQVd4lf4NX6D3+J2uD39yx/yJf6UP+MuuCvuRu/4B/6Jf+FfuTfuXT/5L74j96vcr3K/yv1K+/LgB/lhfoyf4Ka4GZ3nF/llfpVf5za5bW5X9/kD/og/4VPunLvUa/6Wv+cr/DNX5Wpa5//xDb7JF8p+VfYr7SkH31uO/gMVfhMO</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="676">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYGBgSPx70RlIMWT9Xez8rXG/s3LVX+ebDbUuMBokB2Ifca11Efn707mMJR8shiwOY8PED/zXA4uVH2hzsYvtdVlaM8v5d9Ni58pkOVeQuo4Fq8DmczOmudxkuOdc/NcBrD78v5ezvv0UMHtnw3bnf4zL4GZGMqq4LGiY42zLXAgWW/nb3tmM4ajzZQZDMD/gkLfL9H85cPUNf6uctQ9Wu8gf3O7i+WCSi7rTNJe0v39cNP/2u5x9fMrlItM+Z6e/CS48/0Rd8tZVu56oa3Bxa57sjOwPZDYoLK4n1romfz3qZhk9z129Rthjbe1b968M+92DM+Tc385jcjsb/ddlkdw+sN/siuRcQXyRjbGuO5ntXKfw2IH5IHFeln0uRvc2uZQzibj4/lnsciKO03Uz4wnn6MfvXDYxcLnU/T0MDoODddwu/o03XfgPt7u0Hs4Eizn8qXPZ9ajdJe5vnEtZvbJL+uPtLgWNXWB3g7BY7Svn/Ux7nNkZGF2sDNRdFYsfuMoHzXcVSdrlcvqvGjzurPfbuIDcAXKvexK7a/I9Ftdnf3xcTrC8Avs5mbHRGWR3ab6Qa/gaX9eHr0Ph/gD5ATltIIdR9a93YL7m317nbqbJLif+zQWnmQ91d1wWNYq6Ohx66jJpjr7rnrwG1x11010A0WjokQ==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="4703_LVLTSDDILDLR/2_Precursor_i0" index="8" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="686.888" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="LVLTSDDILDLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="588">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEpAEUwPE5LHuI6LDsELFLdIjYiA6ZDhFFdIjYJWKiQwxzGOYwGVqGOQzDrh06RIeIDt/3dYjYJTqkDhEdokOUDtEhYpfYGe/3Lu/y9/MOr1jsTikpXJx3p5wUvvSmkhQ6v7pTTQq53tRib9aTQi9/2Ip+vhF92ow+39K1dT9iFzv8bf4Of5e/p9vXHfAT/iH/iH/M/6070Z3yz/gX/Ev+Ff9ad6O71d3x7/mP/Cf+sztedK+6v/w3fi4N/10a/vs0/L40uv40uoHY8x+iTz9Gnx+MfnMo+odPumHdCH+UP8Yf50/wJ3VTumn+DH+WP8df4C/qlnTLuq/8Ff4qf42/7o4NXUlX5lf4VX6NX+dv6Rq6Jr/Fb/N/8jv8bd2Obpe/x9/nH/AT/qHuSHfM/8M/4Z/yz/gXukvdle6af8O/5d/x793xqHvSPfNf+K/8f/w3fi7zV5m/ip3vy8Lvz8IfyPxV5q90g7qh2LnP0ReHoz8f4Y/yx3Tjugn+JH+KP82f4c/q5nQLukX+En+Z/42/4o5V3Zpunb/BL/HL/Aq/qqvp6vzv/Aa/yW/x21nhPzwTMT0=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="812">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw1kG1Ik2EUhp9nm0ZNpRRE2Ew3f4TIpFJLc5Y+5zzuR4FE+KckS6yhYUUQBblNN/vwA7NZtrIynZqkJlZYll8ZfYA/lKQscBrVhArKPjSzve+be6n7z30OHM59c4VVG/hCSTh37Anmr/eu4B9HI/hcRhQfizPzEGcL14w383U7z/DyhTo+mVjId5SkcFeZFyvyXDhojMF8oQs6fM2g9e2C+wOh2EmusV9kJYz92Q5Ia0GrjIc+yQYbpEggS9qvXAsVlMIsPQYOxQjoLElYCYcwyFOLTtU8NvXF8vmzYXxrjZbbR4O4eboHLwmtWC6ehgnxNvjdIByQM9ZYusBIVagrHYKHlkicsbnhJYmGUF+O7HohizVSZN3SM0b+qY5GsJvkPEsmanijmGThqqdMr+hjLseA3PeRpQFQHGf+3z2+u7BY3ARp0gQEZuhQIe0Dt6TGz5areCQ3ITPkHTGt/pJrOh6vNXm+OzOnvRszb7BV/EHULVw/RPDxlEv2C5TBh/5oNFtfwHJixt1iArwfNuG21EKs3ZKBi2+bsNF9Dzu0bThAT2EvHMWK9E78lF6AzmENptinwSi2Axc0MJVzBQdzf2OiVI9PmBt/CHEYI2Rje38AXqav2OzmJJwtrYQ6wYDVpS5ooVky94Oqw3BOfxIDSTj69+eKTagTBuE/lwZhGVBSBb0+DysgyZCWpsFUYYTVkzZQS9chX3LLDP0Z3Ypg/Co4oEbZCnckO/yk+qU5h/n7ecU5+a7MWiXzLZJMMEOMYLPaIUC8yIpt3+AE9UKUvQi9vljMK7bgXx6fBP0=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="5410_AVDNVNNIIAEAIIGYDVR/3_Precursor_i0" index="9" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="687.032" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVDNVNNIIAEAIIGYDVR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="588">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEpGEYwPEvlj0se4jYYdlDxC4RG3MYxjeHYQ7DMIdhDhGbjQ7RIaJDo0NEh+iQnUNEh+gQJd/30iFilzSH6BDRIYqIDtEhYhvv77k8l7+f5/AkSZJ0ilma9KeUpb/7U87S3vn7VLL0Z3+qWdr98z41XV3XiPu+Gft6K/aH7dgXJmLfmdT90k3zZ/iz/Dn+PH9Bt6hb0i3zV/ir/DX+ujs2dJu6Ln+Lv83f4e/y93T7ugP+ET/wj/kn/FPdX90Zv8e/4F/yr/jXuhvdre6O/8B/5D/xn93xonvVvfEH8uh/yKP/MY/+pzz6n/PYDeqG4r7/Evv619gffot9YTj2nRHdd90of4w/zi/yS/yyrqKr8mv8Or/Bb/JburZuQjfJn+JP82f4s+6Y083rFviL/CX+Mn+Fv6pb063zN/ib/C5/i7+t29Ht8vf4+/wD/hE/6I51J7pT/j/+Gb/Hv3DHpe5Kd82/4d/y7/gP/Efdk+6Z/8J/5b/xB4K/Cv4q+Kvgr+IuDIboDwV/FfxV8Fe6Yd1I3MkP/ih/jD/OL+pKujK/wq/ya/w6v6Fr6lr8dkj/AyklMl0=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="844">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw1jX8s1HEcxu/rd3+ElK3MqnOqq+R3m07hvp/P+/P9dlTLOjfcJNUxZBMhYnR29OPo1hq186PDFhol1JVotnAxa3SbU3LNH21ZJaQNd1d3y/PP89rzvPd+ePIAzPmn9JJSZPUZOzEaMjcjleU3beSM0fOUP+qmCmw8ZapHeywcnGrfinooBxxFe+BMhxGa818RJZWokIpCI/ZBmLV3Rh6OZ2w/0fo+NGaqsfHeshUUJzei6NIhVGtqp2Etw5aHcp4iKz+ws6De1Z801wEhv9c+OCySwu39IXhBqMbelg5c0JeBvc0GNFDij1uK29HGtvW2Yb2ItnYbWZZZgLzM7ihJLsQu72PANHmXzC4YGPGVKjZdpGbF+SpWcqqcFemlrFtHCNu7amKCKqcZRf8z5t2WCqZpQsakHEpmHNWhzHC8I7OWtokpU4yRtqRlcmTJSBJkr4i8VkukOY9Ig66OLJ/sI8xhNZmc1ZDFnUrya/tlQrncICr1daIcjiWVNTFk2DeNxPZi8rXFnSz/kRLXjxIi5AUSCetJTgjciM4wB91F3yHl4RyEfTCC/vg30OyegsDY/eSAxY/kXLUj4roV0PoOwUTzS5jmdcH6Yji8oVqBf6cW8j2fQJ6SC9lnG2HbYCZoB5Jhxv08SPyrIdEiAr1GATcjXmB+hwEEXeXwQ/oZxu/pQKGrg0TeZpiOagLNUj0Exykh3iiDW7oKMETLQD+aDp3Ot6GnrRCCv4iAP+gFB68JYT48FbSJU3irOQI6G0Ng9NMOyC3mQu4lLgRk+cD9c6fh7VEnyNt1ATrHI+G5awo4mbOhejIB1o5VwWPBRfgLcvMIsQ==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="6948_SYVTEEELAAER/2_Precursor_i0" index="10" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="698.833" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SYVTEEELAAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="524">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9ExHEAxuHiaIiGiCIaoiEiOhqO/Iq4IRoiGqIhFw3REFFEQzRENKQbIvr90xBRREM0RLohGiKKaIiGiIaI7nyfd/ksz/hWKvUV4miosdY4amqsPY5q9/V1xlH1oL6eOGqwSp8O8EW+xI/yZW6Sm9ZZfp5f5Jf5VW6D29Idfo+v8kd8xp1y59yV3vB3/AP/xL9w79ynfvO/fHMSfEsSfFsSXEcSXLf2JsH384P8MD/CjXMTOsXP8HP8Ar/ErXBr3KZu87v8Pn/IH3Mn3Jle8tf8LV/jH7ln7k0/+C/+h//jC6lfpX6lXWnwPWnwfalf8UWuxI1yZZ3kp/lZfp5f5Ja5Vd3gt/gdfo+vckdcpqf8BX/F3/B33AP3pK/8O//Jf/O/XHPmV9qWBd+RBd+d+VXmV9wgN8yN6Dg/wU/xM/wct8At6Qq/zm/y2/wut88dasyf8Gf8JX/N3XI1feSf+Tf+g//ifrg/rpCHtubBt+d+lftV7lfcAFfUEj/Gl/PoH7ueFDg=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="664">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJyz/SvmwgAExf/3OjNAQX/dX2dkDBNjQALbq9+B+aF/lcF05v+pLpn1HC6ajFwusX/VwWamNXK7hDVHusD0fPzX73zvt7eLB2OHc6wTRM3Ev4HO9+u4wOxP9bVg2pF5D9jMCX/jnN/8P+js3ajmwssY6tzx556zyb9PYLm/v387azrWws3+/ucKWHwxUxbcnaH/BMDysn9vobgdZg86gPnRkHEVXL2vApfro6e8bplt3W429/jdNWaLuXfXXHCbY2LlZiTo7Kr9f5Uz15/DzlpNm8B6Uv9Ju6xmdHDhZ3R2+fjf0eV5vRHYrsgFa11gZsf+ZQaz9zJud45jPOyc8ifPGcTmYTQDm2H/Z7uzGdNyZ1CcgPztx+DkXPTXyKUp9raLNFMFWM31+kZnr5qHzrIHrFzimxY7b4mf6RL3v8HZ5Z20q0CTl4tsvJrrEn0F10fMJ5yb/7uB9WxyqnaJSdzmct8wy1WD8YdLcuJfF0uufa5JTPtcXQQZ3TYxH3P5wjDZ5ePdpy4af3tcnugruT7a9dMlSemDS+KB3y7xC865ZDBnuLzc3+iiyzDRea49v8t1hwiX2Q3qLqA4BMWb+j8J59ONV5wP2XO6vD7g7RJVnepyqDbZ5drvKOcqW2mX/P8MYL97NDXB4xIAYBLMfQ==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="4469_DGPVILTSQGEER/2_Precursor_i0" index="11" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="700.854" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGPVILTSQGEER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/En4hniGR4eGqIhHoqIi4bIryEaIopoiHgeHQ1HPBE3xA1xFEfDeY4n+v0TN0Q0REPEE+mGaIhoiIaIhmiI6M739Vney2v8FArtFePoS2elOGpdtfdHy3HU+NteJY5WOqvGUYcXanyd+8el2uSP+BP+jP/PtbgbveMf+Cf+hX/jPrjuJLQnCf57EnxvEnx/EvxPbpgb1XF+kp/mZ/kFbon7xa3qGr/Bb/Jb/Da3yzV0nz/gD/lj/pQ75y71mr/l7/lH/pl75d61Kw3+axr8tzT4H2nwfWlwA9wgN6Jj/AQ/xc/wc9wit6xFvsSv82W+wlW5mtb5PT7lm/wRd8Kd6QXf4m/4O/6Be+JeuDf94Lszv8r8KvOrzK8yv9JhfpQf5yf5aW6WW9Al/je/yq/xG9wmt6U7/C7f4Pf5A+6QO+ZO9Zy/5K/5W/6ee+Se9ZV/57tyv8r9Kver3K90IA9+iB/hx/gJboqb0Xl+kV/mi3yJW+fKXEWrfI2v83t8yjXz6BOwyxnA</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="644">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxTrH7n/FNxjQtb/SFnBiAQcdJ3uduwyFnXIdPF499E59T/rWDxb3+DwTQIhDH4gtk8/xudc5kOOYHYLb8vOms4zHABsX/NvO76bw6b2w6Dda6y8bWuP5ntXCP/7HW5LrMPLG/2r9Llz/93ziA+c+1fsFkwORAfJubPtN5Zp8bJ5VDNZudlDTYumnWznLPt+l1d2/tcFzmouc3PlXFLWXHX9f2DVNfdTPdcQhgPOvPUT3fe8tsL7tYnddudM/+puqz4fxhs7uN/i112Ncm4wOSjmQpc9P5Odjlwd5aLxF8dl8OMPs7Xnaa4fH3I5so3P9HVPPG3a0jCdLcrbAbuDR9t3eVWB7vXSke7l37ndK/RCnTbb6LgVnfrumvL/mJXtQ02rp9rtV2m1wm7zK2udYH5BYSx8UF+nil3weUM02xn/kNJYDdtc1zmgqwGFibIbGQxRWD8gdy/r3mHy6XYTpf5jCect8xd5XJkzxqXSQorXHYkHnLxa+J28WUQBOtn/ysN9/srBh8XXoZ4Z6FaZZf/jbIurHVdKHEBAnbNjnC2x79YZ5O/V5xBeiz/fgKr3X+gGiwPil/txlku0+rkXaYxLnGWqNN3MXSwcZnzvwGs7m3jJDCd9m8v3P0wcwELRt+0</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="6778_SVYPESISSSNSR/2_Precursor_i0" index="12" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="706.836" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SVYPESISSSNSR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="556">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9Ew3EYx/EdohjRYSlGFKVDLIvoML9iRKPsEIsYUSkiFmOHWIxRjGJafn/XYSzFKEYRZTHtEKWIYpQiFmWHsbR53p/L+/B9fW+P293Yjqo04z5QldJtYxlVWWzuTFVszV2rSmq/sTvcK+6L1vBtmvhOTXyfJn5YE+fRxPlwc3QZv4HfwifwGu4Il6c3+Ad8Gf+N/8PZdXHddEAXP6KLn9DFz+ji53GruDCN4ffwFv4Ef4Er4p7oO/6Xd5sh/1oNeW835L/DEOc0xPXSQbwLP4r34L24KZyfBvBB/BJ+DR/CRXBRGscn8Em8ij/EZXE5msdf4gv4Ev4e94wr4z5oBV/F1/Etpni7Ka7DFNdFe0zx/ab4IfwIfgw3jpuk0/hZ/Dx+Ab+CW8eF6SY+ht/G7+JTOBOXwR3TU/w5/gpfxN/hHnEv9A3/hf/B1/A2i7uyuCvqsMQ7LfF9FneFd+FGcR7qxfvwfnwAH8Qt4dZwIRrBR/FxfAKfxKm4Q5rF5/B5/CW+gCvh7ukzvoz/xFfwVVwd15KW2tPKP0qIKZ0=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="488">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYECAooa9zgxYQFftX2dsbHR+k+I+F2z6fZprXeY0fXA+3fgGrNaOeR1We5DBo+aHzuh2oYOy+h3OzgwHwGrq/4SA6a0MS8H0KcYovHrr/jU4l/wucH76P8Sl75+LcwyjjnPsPyawHj2GCOf/v946rfk/GasZh5s/Oe9iUnA5b7/Hxen5ZVfrCDn32hZRDwMVTQ95SVYP21/l7v2f8twuv0t2bfm7xVngPxs4XOKYvZz3HeRyAfnra5OXy71/E5yFmMXAcjK1y53vNDK7vGFOdp75K90ZFm4gegfjHpfn/2vA7K/1jmDan8HRpah5G0p432T8DHfvqr97XaqbrjuD7Gf+14Y1ztBpM0dJF1D4pTCrugQ0i7v8/38ZLN7Y8NT5QM0hsF0/nPXB9OGFs13S15m5Hrsr5fbSQMCtV3OGq3GguKvsv1UuLnINLs37ql1CGCDhua/xJtx+FYYlzgWN++H2gjAADW+bhg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="1579_VAALELEGDDATGR/2_Precursor_i0" index="13" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="708.852" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VAALELEGDDATGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/GL4xmi4SGeiIZoeHiIoiHya4iGaIhoOBryREM0RDwP0RANEQ3phojfvzRE9BANR8OR54a4IY4ejoYjnogb4ujO9/VZ3str/BQK3VXiqJdCNY5qf7urxVH5tLt6HP3srRFHE701uRb3n2trhy8mwfcnwX9Ngv+WBDeSBDemP/hJfpqf5ee5RW5ZS/wav8Fv8TvcLrevh/wxX+bP+Zy74m64O73nH/hH/ol/5l64V33nP/i+NPgvafADaXCDaXDDOpoG/50f56f4GW6OW9AlfoVf5df5TW6b+8Xt6QF/xJ/wZ3zMXXLXestX+Cpf4+tcg2tqi3/j23yHL2Z+lfmVDmXBj2TBj2V+xU9y09wsN6+L/DJf4tf4DW6L29Fdfp8/5I/5MnfO5XrF/+Hv+Hv+gXvknvQf/8K/8u/8B9eX+5UO5MEP5sEP536V+xU3zk1xMzrHL/BL/Aq/yq1zm7rN/+b3+AP+iDvhzjThL/lr/pavcFWupnW+wTf5Fv/GtbkOV7yIPgFpnh0V</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="752">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUW1IU2EUvrtzIRXZ6IPAWTTKLQg0zSDclus9Z96CmtBwYim2ZfRB/Wj/ltfblsh1W2ulM3SWReqPJVFCJiu2/ck+CBKJMCzCX1HgH0sctXc3742JB16ew3POczjneWNeHh5JZkx6KWGWQ8bYMifneSzP9pMz6jtKPR9y32rNaszH+I6kog/kuskRdhdJSTqY0vf+n53tIrbsN/KpXQWb/UHymNECL+2HnyodHM85QSh4T6KsSFoOB6HkkKhoFvnAyvzmqxcULi0xYDQZoNKnhWHapNTjrAFsag+pYC+SKXXbym5lmnNQNzAIM40TqLUM2eiHS7Uj0wyHnz1cHwa56oYq7nnB0VpdA28TOzbYerxhRPd2rHfdw1YXxeKnX1H2ynKKx1lXJxrZOJRmP4KJ6YbmyD6MuqNQqF8Ee3kL+l0iTj7gsGtMj+t/qTBpZnBP0SYsFcbg5qgDizV1cMs0A/NteuAsjeCsCUEPEyei/zu5nDsGccEBd6WzMJp0QpCOkxcMITpTJZTQA2R+QIS9aSOcZAMw6P1DlnJmspU6FD/6rGvgWcoDbrqk3N0h+EjoZQgyNENetz9UuHBiDoTYAiSEg8g+uYaJtefRXlGG9eYtiv+TOQ6G5wrxbcSKp2k/8ukm5d32hdFIr2Dk7yvs1fzAIqYTZ79YMcNshImaalh3PQFvdt6HIf9ukP9zIddK3pmrYJpaQO75zRuUHU+wJrCntkFKukHke/4BAEbtbQ==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="2883_GNVVEIEEDASTR/2_Precursor_i0" index="14" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="709.841" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="GNVVEIEEDASTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EinuHhGeLhiYeGiCciiobIryEa4ngejoYjnlzcEDfE0XA0HPFE3JDnhsjvXzRENERDNES6IRoiGqIhooiGiO58X5/lvbzGT7ncWSGOxrsrxlFPd6U4al929jeOWv87q2g1jrq8XOPrfIP/xzW5lu7ye/wBf8SfcGfchV7xN/wd/8A/ca/cu/YmwX9Jgv+WBP89Cf5nEtwQ94sb00l+mp/l5/nf3AK3qMv8Cr/Kr/Hr3Aa3pdv8Dp/w+/whd8yd6jnf5q/5W/6ee+SeuTf94PvS4L+mwfenwf9IgxtMgxvWUX6Cn+Jn+DmuwBW1xC/xFb7K17g619BNvsm3+F1+jzvgjrgTPeMv+Cv+hr/jHrgnfeXf+d7MrzK/yvwq8ysdyoIf4cf4SX6am+Xm9Q+/wC/yy/wKt8qtceu6wW/x2/wOn3D73KEe86f8Od/mr7lb7l4f+Rf+jf/g+3K/yv1KB/LgB/Pgh3O/4ie4KW6Gm9MCX+RL/BJf4apcTet8g9/km3n0CSEVFlM=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="708">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx1UF1IU2EYPjtHiFC8MKgYLYq6CCskKRJsonuf70xnYZg3YQnlCoJiaUHgXHaWk5TaxbJBotAv0Y8Wrh8oFTdHeBN2E2PQVptEIP2Adnf+6jsxWBd98PC+7/c+z/s97ycIgrDNq4P8Ov1JhS4lRjulKviUhFX3XJyi9qAdPC9w/nfu2Zr/6R8z7lNDnFCoewKj9Ejoooz5l6dJzIpx4wm9i6/HvPaNorkB3BjLYVL0U6up0vDcXks/KMzTa7EGb231lmZWm6ZFIWqB8/idXblOxT75XsV1sf+8cBAvzRE6pEfpmTlMF6Q64v0CVm+dga9jI+NR6/vOVq4OyWtufZHTS243R4uxJFd4XXJZWYrFPt1mHm8ja3tfy1acCxg3S1nTkQTyW34h0ZtGqyuPw8IoQoaKNrMZHmMV9kgPEDTTcE44mP/4EPg73Ff74lN82DAFZggoSXagurcbGTFLjs0hLCSyeKMtU1U2Ar7zRF/A0kAZoY9GP6515hC2RdiZmzvk2nUv5N3n97tbJjvdsdllOVXukZ3qNEv262gwnezzQJglL4XZuboATksz4LNOzB1lccmHtWIlSsUwdUtJ+mqM0U/1B226+xgV9TH4pZOoEZpIVw7AnlXQKG7Hcz2CULAamvmQ+J5XXGcRNhXLu7fEtP7ccWccuzoGcXlfJcoNCRk1Radsr0g1EvQbmXjv9w==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="4772_FTQAGSEVSALLGR/2_Precursor_i0" index="15" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="718.381" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="FTQAGSEVSALLGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="604">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0l9EnXEYwPFzEWMjirEYTReHLg5xRhR5m42mOHRxiEY0J5oumi4OXZyJRjSijM7sImJjvH+WjbHZRewixcbYGItYNmIjlkasc36f5+bx8nm/fhdPff18DuKo0phfcVRszJ84yjXmJI72ds/nzG5JonrDX0qCb0+C70iCv5YEl+cK3HW7n7/B3+ZLfJm7w9217/H3+Spf4x9yj7g1+wm/wT/nE/41947btnf4T/xXfp8/5I64Y/tfcFu5tPnd0ZI2/YMLabNzeDFt/jfSmgbXFnbxcvDrV4LPXQ2+0hn8bheX57q5gn6PflG/V7/POwa4Qe6m/pD+sH5Jf1S/zI1x4/oT+pP6U/rT+jPcLDfHVfXn9Wv6C/qL3rHELXMr+qv6j/Xr+k/1N7hN7pn+C/1Y/6X+K/033Fvuvf62/gf9Hf09/Y/cZ+6L/jf97/oH+j/0f3JH3G/uWP+v/qn+mX4uc1eZu8rcVdiV1iz02zJ3lbmrzF1xnVxX2CP54Le69Qv6PfpFrpfr0x/QH9S/pT+kP8yVuFGurD+mP64/oT/pHVPcNDejP6s/p1/Vn9evcQvcov6S/rL+iv5qFv0HPf0n1Q==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="836">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwdkV1IU2EAhnfOYUyZxRhIaXOtUUZGppHIbD9t3/ttEEpokGjqchpKhiVWNnRz08o/xJGKipmNgWE/FkVFG+omRF21sqKZsWaQF8MbA4NwO8t67567h+ctm7yB84I1ssIo8XZzlUSYrySNZ0Ha4kTP2YmZe0O8rIuIzW745gfgEzQSwdbmAy3w+k4gNHsGA4lGwhAp/PxJcpQVkUDCRT4JConNnoQPsddEy9ViVHMBQb9si+U4zOuQK2wl4506cIkSpB1PwcvZDqw7hJBwGqQYZIjHPSTKFUDirMR3Qx3iC6nYcB6DhRfjITuNkG4fpMJm+GK5GJxTQET2Yqo9HUqewRh/juQzGqIizfAIsrFuGcMO9hAp5w8gK7KKtUdiWt+hp9Kwmv6s0tDyQD61RO7/9yriclDIW2FlukhP+y9Sp76KK44qRLRWvLB0w1s9jAbnBJGu9GGPs5+WNfUav23bbqp36U1l/SWm/RvUdNM9Z/zTGKN3/SoadXgR7KjAtbbH+F3xHIs1r8BmK6kiowe1rTXochigZaLE2Z4MWSANCoMaYV035MpOTGaM4mCYoyOTSXT4h4Tm6VnqHpBR96k8WhpU0Ouej3AJShFaceNI4ixETZdpSzFjLFiaMGYuiE3e3C/G9dFOY3L9TmPhXA/N67ThksGG0xNODMXWyL9vwvNyLOum0Pc0ndaRZ1t93mOxWkUv3sqnuwd30Qw2h767PYNpphcNagtENj95EstCdDYTS+Ze3Iu4oGorgvDOA4zEZxDcBA1bPbQlPkTH2yqpnQshVdCNaq0Z0xqKYt4OCTOG1Jgey44ufGbl+AuOoAiz</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="632_AISEGMEVYGINR/2_Precursor_i0" index="16" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="719.853" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AISEGMEVYGINR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/GiIeIZoiEeGqIhGlI0RH7iaDgajughbsjdEEfD0XBEETdE9JDnhmiI3z+iIeJ5iIZIRTREQ0RDNEQ8EdGd7+uzvJfX+KlU2ivE0URnxTjq6qwUR9dX7S3GUetPe+U46rBKlatpnW/wG3yT3+H2uH095DP+mD/lz7gL7lrv+Af+iX/h37j/3BfXk4T2JcH3J8EPJsEPJcGPcGPcpE7zs/wcP88vcEvcsq7wq/wav85vcdvcrrb4Az7mj/gT7i93rpf8LX/PP/LP3Cv3zn1qdxp8bxr8jzT4gTT4n2lww9yojvNT/Axf4ItciVvUMl/la3ydb3AbXFN3+D1+nz/kM+6YO+XO9IK/4e/4B/6Je+He9IP/4nsyv8r8KvOrzK90JAt+jJ/kp/lZbo6b1wV+iV/mV/hVbo1b57Z0m//Nt/gDPuaOuBP9x5/zl/wtf889cs/6yr/zn3x37le5X+V+lfuVDufBj/Lj/BQ/wxW4opb4X3yZr/I1rs41dJNv5tE3bI0dHA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="736">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx1UV1IU2EYPu4sIUtQvLCirEgrLzKY0o+1GHue7QirFSYkhEqrpJt+DALLLfW4IkzJ/jRvwiz6ITES0ovZ3FSCyGI3FqswoouwDEs0Ks/OF+dQQhc98PG88D3v+7w8b50lBukPHvZ7aHBbbQLGM+pqfQrOhItRfQjHxCIuSTTBI5dyj3YSU1rJXK+BV4mDmF8Tx3d5ADmWFkz67yCzoXFO81oaRY/ei5DUjeEGG89LKr5p6UgTXmy0lv8zyynicCbFsTrq4PFt2eZegyJmaq3qDyBylrVbyjge2UfpP9glV3OsYTNtsoK9gVZE/Z2mR1jPNdkrLcVH/SqeIp/V/WtZE3yLE9jAYss4Hqi/kGpJRonlmqk9cGYCX+t78DefwtpVpu8Fey/f7M5w37iep9i6YspUIqNovLxPOTXmUL5sF+7TfU3uxWXZbiU14YqdS3FPFoy6muWIy1fZ4Zp5YXcJ+xMWD4c5GK7kp85GeiJFHPlwm1mPLzNL7eCjSDPvLbvFUXGR8ffP6L0ZpeK4wuVhG/OH1rHAf5T1SUf4El1s9dWzJTiLqtkZzFsR5OHADj5P+ol2tc3cO1MPIKSPQNekucyyxSG0qWt4Sag08q3wl9L4TxYTKBTTkKyfUaFVsUh4+M6SbvL9UMhkR9jHqkCyOWuhPOE0vFdGUpgTzaVsz6Pm30/r1k2crvNyvWjGArkdO7UxGLd163eR5u9CUB/AbxwC9A0=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="2939_VDLVDDEELLELVEMEIR/3_Precursor_i0" index="17" defaultArrayLength="162">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="720.364" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VDLVDDEELLELVEMEIR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jGEQgEYwPEi7ogbjoaIG+KGI+JFQ+TdEQ2PhoiGaEjREDdEQ3QaouGIhvMajrgjGqKIvPc4GiKvIRqOGyIujoaIhjiu8/2/5Vv+fr7hUxRFGYUNtaPrujdiqI7zPEUNNX+e7b2hLmzb1mKy7bihKv+jSa8npHckpc+n6NJ0GdmjLH4Ov4BfxC/RPdKV8Sv4Vfwafh2/Qdeke6Zr4bfxX/A7+K/c0aV7o+vh9/EH+EP8Mf6EzqT7wJ/iz/Dn+Av8Jd2K7hP/C3+Nv8H/xv+h29Ht6Q74R/wT/i++05Q7XKZ0F6Z0btn2lSn+tSm+R3qHV/q8j+6Gzi97dCu99w4/gB/ED9GF6SL4UfwH/Bh+HF+jS9Al6VL4afwMfhY/xx0FuiJdCf8Rv4xfwa/i1+jqdA38Jv4zfgu/jf9C16F7xe/iv+P38Pv4A7oh3Rh/gm/if+BP8Wd0c7oF3RJ/hf+J/4W/5o4N3TfdD/4Of49/wD/in+h+6ZyW+C5L/EtLfLfFX1n8FZ2Hziv7ySf99kZ6zW/xVxZ/RRegC9KF8MP4Efwo/gN3xOjidBp+Aj+Jn8JP42cs9Q9sJj5M</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="732">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw9UW1IU2EUvu+2SggzJIqoyUj7YeQicRGUhO9z7vxTFihELYoVFP7o61/K3Ha1mimUfZDTNEVsSMiixkKQ7AMK+xEkfWBBBlbioJQFiaP73rfupduBA+c95zzP+/CcGbkWO0UCKSWfMtEfmIooVOzYQ72al86x4N+eQNo9Rkce1dDJpjgySgtc56dxQxjwjvlI+RetTEV7ZAjjxnMsl7tQzpJ8pdKNeHMaIjSHt1ofbusvoD1hNKnvx0c9BRtbGYnhmejABv0YSo0UD7hCqHDUYUC7jFC4iAIsijVSQ4ytwqQoh5C3eMDRgDnRy018RnFhWsThUw4jbtyHye8xTmNBOMmtLCNTa83jQsr9zmHGqMdx6aavsgUTIoS0sdX62+TukuuQ5xy39Js8PifHiCy1dJoaVosyS98Jlo86thtBOYpc+Bf40U4qyJaole8n1MZaqfbc2exv/7nFX1y4wr/3+7x6N/dUbR26rj5IVqgXs+tV5U2JevbzN8qGB2k2GKNtfV10KnqJyrQ2UptribQLtFiUsLxdInaQk+dRwui3fCxl73C1aRj1+geYPl1hGTRrPVjKpnBAacU14yayjkG0yXswMQ/DHViQr3GoqR/7olk0Sge91LotfzcpBSDmwaJe/f8WdvTpX3iD8YpvZwPc65rlG5UR/kl2Vh2UGp83qnmOneFJ1l9l7nqZp8qs7bR7Ztp89tvetWfDst264R83SgEd</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="1321_VFHEVLSMDDAAEAISSK/2_Precursor_i0" index="18" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="974.97" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VFHEVLSMDDAAEAISSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="600">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0n9k1HEcx/H7Y4xiLKIRy/449scxLsZivkux7BjFKMUo31GKUoxiKYtRjKVsKUYpyvfHphhlYxSzpSjFKEZTjGKUYnR3n8fnn5fjcU/fP95xXH2VJCrX3pEkKtTesSRaWa6+wSSamqy+oSSqsficvcRf4a/zY/w4d5d7YB/xz/gZfo5f4N5wb+1HfpVf43/wv7g/3JZtSIPfnga/Iw2+JQ1+TxpckStxe+0+fj9/iO/nB7gT3Cl7hr/AD/Mj/A3uFnfb3uOn+Sd8yr/gXnGLdol/z3/mv/Lr3Aa3af8FN1vI6r9bGrK6v9qY1Tvr27L6/ypNWXDNYcs7g5/cFXxhd/Bxa/DLbVyRa+dK+h36Zf1O/S7f0c31cAf0e/X79Pv1D+sPcEe54/qD+if1h/RP65/lznMXuWH9y/oj+tf0R33HGHeTG9ef0L+jP6V/X3+ae8g91n+qn+jP6D/Xn+NecvP6i/qv9Zf0V/TfcR+4T/qr+l/01/S/6X/nNrif3Kb+b/2/+lv6hdxd5e4qd1dh46Y89Jtzd5W7q9xdca1cW9hKMfjZdv2Sfod+mevkuvS79Xv0D+r35tF/Hr0lOA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="620">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUU1IVFEUvvcNDAy5aRNYqzAkMkaFDIRZxP3uKyLECMNyIERFJKNc5cZ5z5mUCqTkMWgu1JCSYMafICoS05lNY0TQJgrJCUpamCuDIN69N+bUvH7O5vv4zjnfOZzzzV3AKK+CcK6jlh3GSZYX7HfoxBpG2AEsqluIsPso6zF3m3iTThJeyVXKVR4m7lg9eGxA/ELokmjX+4kXuUe+bwYVjmoVeJ3SDI1qk3LNejbQ/47P/DSWdRhZtjvID7AhVPOuP/XWNGLGYMX8IC2jzhDW8nnCdGiAZmT4PcKojou07herqlV0+92o5z4yylDugXUH40ZQX73fhhH+OrjJ/7GT47LMN/zvVOfyGPU+0h6uOgV0DFbKZzoka8wLDCcOyr7Lu2z3+VP76yY7PrF33l5Yu21HOqP22b4qe8902O7Ix+WM0ytHj0Xlu4RPXgW9BTjvkXM+YZ/qx8NrRRT0ujhhjVF+LtSCGXMDKT+Ot6qBtHF+Ea8SN4MbRdT5f25yKJmm+i+Tnpy12uSSygW1dda5gHtuFhX5I7Ih5WE5OYYNfZdun2YfRbNZ/zXfvCRsZVMo/aa0T6f6IIq+HfiU/pfiWVHaq6y1qyfiJ4vmvBc=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3358_TIEQAHALDATLEELGLR/2_Precursor_i0" index="19" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1000628" name="basepeak chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="990.523" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIEQAHALDATLEELGLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="0" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="580">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFErWEYwPFviDtc4l6iuDQcouFw6HA4w/Gd4RBFNERDRNxoiGiIhq6GiIZoSIeGaIi4Ud/7EQ0RDekMEQ3REEVEQzREdI739yzP8vfzDE+StKeQpX87M5Clrev2DGbpUGeKWdrcaU8pSztZUtZV4n6uxn60FvuTeuz7GrH/N6wb0Y3pxvkT/En+FH/aHTO6Wd0cf56/wF/kL/GXdSu6Vf4af52/wd/kb+m2dU3+Ln+Pv88/4B/q/uuO+YF/yj/jn/MvdJe6K12Lf8O/5d/x793xoHvUPfFf+K/8N/47/0P3qfviJyH6XSH6P0L0f4bod4fY/dL16HrjHvoT+53+2CeF4K+Cv9IVdSV+mV/hV/k1fl3X0A3zR/lj/HH+BH9SN6Wb5s/wZ/lz/Hn+gm5Rt6Rb5q/wV/lr/HV3bOg2dVv8bX6Tv8vf4+/rDnSH/CP+MT/wT/lnunPdBf+Sf8Vv8W/4t7o73b3ugf/If+K/8F/d8aZ7133wP/lf/CT3V7m/yv1V7q/iTn7n0e+J/XVv7q9yf6Ur6Abifh7kF/klfplf0VV1NX6d38jTb4ElKQE=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="792">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw9UF1Ik2EYfbfPLB2UP6EuQwhCu8i0pExyc9tzvmnkz8IsnNmFQfaHYhf9qd83pxgZiKkh0k0lWFJJWGTm3OamNxkkdCOLNEwvMgQ1zIjvJ/dddG7OeR7Oczg8w3oLsU2MqgasSSdwRblH37lz5BDbSGIl1MwVUqVUr3muSusa2+QysnK5WFY5MrJ+bReGQQlRpPKQ6nRFdFwO0oKYgdr6GzigPqB80148NifhmtxjG1Pu0obcTgu2VAjyABlFmaoatyHMlSxEfXILLamDWu548xmEeYZzanOyUkvX2R9Nn2RzFMMdpkj16f8Oq/4ohHMvCE0Usu5DpjRJbiVNy7yjXtJ8c2yNEoQRTZOLh8HSDWl2Hh2xsXyBYwuf82g3/84zjeWzXzAslqAp+B4DFfOI2hPF73A9gZGbQfvLLD6h4y1/sGiD/zFitmd5TtlrLb32+CNx9rq2n/yK5xk/ugJ+McXIm3xjqLHO46vfhT5fEwotDOXMAv2sF4LagM++rVj0ZkMfiMdHVxGq/En4ZT6KXlcduvWdxAQDAj5Cl3oLurEhZDMHVlk0Dik5tC47ES0P0W/PfkzqIuBRqlE+cXHzl2moESYobXw7pvJOI1FMR78uGaJUgQ6dhzKkRRqMEKmNC9IrVkDj6jfqdC9TovyJvK4XVKZW2+LEnShV9PgreGk6rxhv2C7c5kYpfH+/MQYZymsyic/RJZch05+PlkAPnHoTnO4pSo+oRnZuA+JTehESLuOYcBNLtlK0ypn4YD6PVrUYUw2pGFYU+gepIwEa</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="24328_AAGGISSLEDAK/2_b4" index="20" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="559.788" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGGISSLEDAK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="257.125" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E5nEAx/FHNBwNETfEDRE3REOnIaIf0RDREA0RRachGiIaouEhiniGeLo7nt8/Dw0PD88QzxAPHQ/dieiIhmiIaIiGiLt7Ht/XZ3kvr/FTKHRWjKPfvzo7iKNvJ52V4uhrd+U4+tJdJY66rFDVGt/gm3yLb3NX3I3e8Q/8E//Cv3F/ud4ktC8JfiAJfjAJfigJ/jM3yo3rJD/Nz/Lz/CK3zK1xG7rF7/B7/D5/xB1z3zXlT/k6f8afcxfcpV7zt/w9/8g/c6/cu/akwX9Ig+9Pg/+YBv8pDW6YG+HGdIKf4mf4OX6BW+JWdJ3f5Lf5Xb7IHXAlLfMVvsrX+AbX5Fra5q/4P/wd/8A9cS/6xv/jezO/yvwq86vMrzK/0lF+nJ/kp/lZbp5b1GV+jd/gt/gdbo/b1yP+mP/Bp/wpV+fO9Jz/yV/y1/wtd889cs/6yr/zPblf5X6V+1XuVzqcBz/Cj/ET/BQ3w83pAr/Er/Lr/Ca3ze1qkT/kS3yZr3BVrsY1tMm3+HYe/Qc35SqO</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="456">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkTFLA0EQhfewsYgSQcRObLWxtZHczoEYbSy0EWyC2mnhD8iZoBgQwV7U+wNW2thoJ6QWKxU0BrSRgI3N7bnf4kgOljez++bNzZtpMynt6Mp283vbdTt2NhqTEPuzYi7ispuwNXduz8yRJQb1faSIpBz17Ev0ZBeiUojDu9cBqQvaPq8O9GJyYvgg/P7e6MMjr7v5kCuqJoiO9kNLefq/cPpzNDnK49347y2/DrhpfuLnIrNr+aI9yF/tjDkOuk03JePpvqwXc1JzJRkuOoHP91nECbjqtpLLymCy27iTVqMjy8WJtPKqUM9s9OOoF9zrHTEzBT/8zHCW0lPZTtvSbHzIY2Uo+bodTQ7djXDe6w+yYTL53suEPf376OdCW3cVZvR6eKQIV/n0VB/wiDj4/ucbMRw00dO9gfSgRnPlUUcf9ZndqN/aizfdifal9hc6wyU4</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="24327_AAGGISSLEDAK/2_a5" index="21" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="559.788" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGGISSLEDAK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="342.214" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E5nEAx/FHNBwNETfEDRE3REOnIaIf0RDREA0RRachGiIaouEhiniGeLo7nt8/Dw0PD88QzxAPHQ/dieiIhmiIaIiGiLt7Ht/XZ3kvr/FTKHRWjKPfvzo7iKNvJ52V4uhrd+U4+tJdJY66rFDVGt/gm3yLb3NX3I3e8Q/8E//Cv3F/ud4ktC8JfiAJfjAJfigJ/jM3yo3rJD/Nz/Lz/CK3zK1xG7rF7/B7/D5/xB1z3zXlT/k6f8afcxfcpV7zt/w9/8g/c6/cu/akwX9Ig+9Pg/+YBv8pDW6YG+HGdIKf4mf4OX6BW+JWdJ3f5Lf5Xb7IHXAlLfMVvsrX+AbX5Fra5q/4P/wd/8A9cS/6xv/jezO/yvwq86vMrzK/0lF+nJ/kp/lZbp5b1GV+jd/gt/gdbo/b1yP+mP/Bp/wpV+fO9Jz/yV/y1/wtd889cs/6yr/zPblf5X6V+1XuVzqcBz/Cj/ET/BQ3w83pAr/Er/Lr/Ca3ze1qkT/kS3yZr3BVrsY1tMm3+HYe/Qc35SqO</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="484">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkjFIA0EQRe9yihYRBbETjCgpBCuJBFHD3WxIIyhJoU1sLUMKK8HkCgsxFnZ2CoKtCFYR0UaUWNoIAVvLaKMIXk7fwkiKz8zNzvz/53YHnENZyQ2Zp9qLbEc7ctEdk2Z0EJSdpEwlroJFJyUb0ZJUEzm5dItyHRflrNaQce89SMcVoW/Ozdjvh+6ERTaqBF/uqc3hW3M2LWc1attaGBX+cfzT8QHnlfjE13lqSffR8mikzgy+tHfSTfnqlzN60aFGn/IBcng1Z1Zz+Jgn9urBy87r3X7TuCmZ1OuHmY4T+WFnN78/0pd/W141R/UjYUa9AXL1rvrowf/peIIPfJKjkXW2bOyEzb/7KJjZbmhKtxnzfbdgWn7WIqqlzV590LTDc3l2EjLqtawWu8JP1P0AWnigh3vgjtQfvXoXvRFPzMCvNXJm9Yyd5uMZCb2yfRd4v4+q9r3Qi5ZCZ+Ahotv7T8AvWaYZmw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="24325_AAGGISSLEDAK/2_y7" index="22" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="559.788" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGGISSLEDAK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="749.367" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E5nEAx/FHNBwNETfEDRE3REOnIaIf0RDREA0RRachGiIaouEhiniGeLo7nt8/Dw0PD88QzxAPHQ/dieiIhmiIaIiGiLt7Ht/XZ3kvr/FTKHRWjKPfvzo7iKNvJ52V4uhrd+U4+tJdJY66rFDVGt/gm3yLb3NX3I3e8Q/8E//Cv3F/ud4ktC8JfiAJfjAJfigJ/jM3yo3rJD/Nz/Lz/CK3zK1xG7rF7/B7/D5/xB1z3zXlT/k6f8afcxfcpV7zt/w9/8g/c6/cu/akwX9Ig+9Pg/+YBv8pDW6YG+HGdIKf4mf4OX6BW+JWdJ3f5Lf5Xb7IHXAlLfMVvsrX+AbX5Fra5q/4P/wd/8A9cS/6xv/jezO/yvwq86vMrzK/0lF+nJ/kp/lZbp5b1GV+jd/gt/gdbo/b1yP+mP/Bp/wpV+fO9Jz/yV/y1/wtd889cs/6yr/zPblf5X6V+1XuVzqcBz/Cj/ET/BQ3w83pAr/Er/Lr/Ca3ze1qkT/kS3yZr3BVrsY1tMm3+HYe/Qc35SqO</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="520">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxz/Xfcqf7ffMcFfzY7LWD84MgABMV/u8FiINzMoODUx+jh1MHyAYwlmO44gdTm/p8PpkFqYXyQOp9/+WBzwDRQ/P8/RmdXoB0gvYJMPM4gdUH/jcFiILk9zB5g7MMY5GzIcMQ54p+Li3STgQvLISOXE3aaLhaN55xN/4s6g8wCuxNoNsR8ebjbQHwQDZIH2QsSB9kDY4MwWB/UnTC3w8wC+RnmZpC5ILPAfgG6SZvlsfPfBZ0uO/pEXVMudrjO6H/tqp7k76Yp0ebGM13NbU1BvutGxx6XX/82O5v/13T2+d8IpnOY7ZxhYQOiQX6AuR/iTnlH9DAGqQOJw9y5mFHRef6/2c5L9sq5lD3qcVHv43SNEYhxjVqQ5prmG+f6b6G8a0zsBxfJ2BkuH/7Gupzfy+9S9XeV87y6HnB4WrGkOx/4OwHOB4U/KKxBbgOFP8Q+RBiB+DB3gORB6kF+AcU5CMP0gNiwcALRMH+CxGHxAVIL0weLC1icw8yEpQcAkXIW9Q==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="24326_AAGGISSLEDAK/2_y10" index="23" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="559.788" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGGISSLEDAK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="976.486" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E5nEAx/FHNBwNETfEDRE3REOnIaIf0RDREA0RRachGiIaouEhiniGeLo7nt8/Dw0PD88QzxAPHQ/dieiIhmiIaIiGiLt7Ht/XZ3kvr/FTKHRWjKPfvzo7iKNvJ52V4uhrd+U4+tJdJY66rFDVGt/gm3yLb3NX3I3e8Q/8E//Cv3F/ud4ktC8JfiAJfjAJfigJ/jM3yo3rJD/Nz/Lz/CK3zK1xG7rF7/B7/D5/xB1z3zXlT/k6f8afcxfcpV7zt/w9/8g/c6/cu/akwX9Ig+9Pg/+YBv8pDW6YG+HGdIKf4mf4OX6BW+JWdJ3f5Lf5Xb7IHXAlLfMVvsrX+AbX5Fra5q/4P/wd/8A9cS/6xv/jezO/yvwq86vMrzK/0lF+nJ/kp/lZbp5b1GV+jd/gt/gdbo/b1yP+mP/Bp/wpV+fO9Jz/yV/y1/wtd889cs/6yr/zPblf5X6V+1XuVzqcBz/Cj/ET/BQ3w83pAr/Er/Lr/Ca3ze1qkT/kS3yZr3BVrsY1tMm3+HYe/Qc35SqO</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="364">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxtkTFLA0EQhd3r4n8QFkljbWNjcbNZks7OSrCzsbDQPpUgqI2k1USxsPdH+A9srKKlYHrJ3eoneTAcHjxmbmbe7JuZGKLlMq13qpHdtieGjb8xgE8OrK2+4XJRn7WX9r1c2H3ZTmCz3fqz8EuINYBDraxiAP+hPNtpebFJGabP6iDtVzMDvebNqPccz0WD/LjSjlW9NEpHF+JKm+f7HDH03IWjNA8faXp4PXjd3cjv4zpfzSf54rHJX+dP+Xivn2/G6wP2IQ578LNLD3lymol/zfOfzu586sdduAG92BdvNk1I+AL7BdTpluqLVkAdN4DLv5+ferRpp/4WPta9lZ+N3prB6yeGLsA7P7HgFRw=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19793_VATTQGIQSTR/2_y4" index="24" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="581.315" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VATTQGIQSTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="491.254" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EgwEcxvFiFNFhRIcoYoeIaHSIvCI6RBSjiB1mY4exFDuMscMYi/f/+/Yexthh7DB2GLHDGMXUGB1GFKOIHcbYIUab3/e5fC+f4xONzhZSlYX5IqriPc6WVJX9+TKq8vY6W0FV5izq4Sq0gW/je/hP/BD3h1vSpGua+G1N/J4m/kgTf4a7wsVwdzSLV/FFfBX/hHvGvdMBfoSf4ld08eu6uIAuLkiPdfHnuvgbfByfwuVwBi3ha/gmvoPv475xY9yCIV01xG8Y4ncM8QeG+BPcBS5ME/g0Po938GVcHdeiXfwH/hc/wftMcX5T3CbdNcUfmuJPTfEhfASXxGVwBerhK/gGvo3v4T5xQ/qHX7b4lcWvLH5l8SuLX9FrfAx/j8/iVVwRV6VP+Bf8O36AH+GmuBWbX9GALT5o8yubX9n8ChfHpWgOb+JL+Bq+ievg+vQHP8YvOvzK4VcOv3L4lcOv6CU+jE/g0/g8zsGVaR3fwnfxH/hf3ATnc6V+V/yWy69cfuXyK1wIF6G3+Az+Ae/hK7gGro3r0S9X+QemyxWF</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="296">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJzLYljgyAAEJ//JO4IwAxaALAdjZwH1wdjo+mD8LKjZ6OLo5iHT2OzEJo9NHNleZLfB+MhuwmUvSB6E6/68B+sB0cjmgdTA5ND9D1Lny3DCyfCAqcuxhTGueX5CbhML4908bH3d1Ne+cjXTF3e9zrDFCWZHwX93p4b/3U5T/uQ7weyCmQ1TA1MHEwPJI7sBOayQ1YDMBdkFwk/+MTofZ1JwBtnTw3wHbFbBP3kUO2F+hIUPtnACYZhbQTTIDDAGug9mBkwfiA8S//Q3yHnCXx6w/chhi6wOAFKo4QQ=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19789_VATTQGIQSTR/2_y6" index="25" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="581.315" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VATTQGIQSTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="661.364" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EgwEcxvFiFNFhRIcoYoeIaHSIvCI6RBSjiB1mY4exFDuMscMYi/f/+/Yexthh7DB2GLHDGMXUGB1GFKOIHcbYIUab3/e5fC+f4xONzhZSlYX5IqriPc6WVJX9+TKq8vY6W0FV5izq4Sq0gW/je/hP/BD3h1vSpGua+G1N/J4m/kgTf4a7wsVwdzSLV/FFfBX/hHvGvdMBfoSf4ld08eu6uIAuLkiPdfHnuvgbfByfwuVwBi3ha/gmvoPv475xY9yCIV01xG8Y4ncM8QeG+BPcBS5ME/g0Po938GVcHdeiXfwH/hc/wftMcX5T3CbdNcUfmuJPTfEhfASXxGVwBerhK/gGvo3v4T5xQ/qHX7b4lcWvLH5l8SuLX9FrfAx/j8/iVVwRV6VP+Bf8O36AH+GmuBWbX9GALT5o8yubX9n8ChfHpWgOb+JL+Bq+ievg+vQHP8YvOvzK4VcOv3L4lcOv6CU+jE/g0/g8zsGVaR3fwnfxH/hf3ATnc6V+V/yWy69cfuXyK1wIF6G3+Az+Ae/hK7gGro3r0S9X+QemyxWF</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="228">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYCAOlDMqOBIjRglANg/EhmFq2oFuHz6Mz23Y5MIYC5zkmrY6f73H4WrqLOyWJHnC7ZK4nHv3Akn3Etvlbq8YV7ja1t1wfvp/vuN6pg9gjOwOkDgIo7sBJIbLbmQ5mF4YG4a/Mng4NTH1OHGwfHDSZd7iBOLD7AaxzzEqOMHMBonDzMBmF8w+EA3yL0i/G/MCMI2uBgRAZoPMAcnD/AgTh4UDAIyJb/c=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19790_VATTQGIQSTR/2_y7" index="26" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="581.315" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VATTQGIQSTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="789.426" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EgwEcxvFiFNFhRIcoYoeIaHSIvCI6RBSjiB1mY4exFDuMscMYi/f/+/Yexthh7DB2GLHDGMXUGB1GFKOIHcbYIUab3/e5fC+f4xONzhZSlYX5IqriPc6WVJX9+TKq8vY6W0FV5izq4Sq0gW/je/hP/BD3h1vSpGua+G1N/J4m/kgTf4a7wsVwdzSLV/FFfBX/hHvGvdMBfoSf4ld08eu6uIAuLkiPdfHnuvgbfByfwuVwBi3ha/gmvoPv475xY9yCIV01xG8Y4ncM8QeG+BPcBS5ME/g0Po938GVcHdeiXfwH/hc/wftMcX5T3CbdNcUfmuJPTfEhfASXxGVwBerhK/gGvo3v4T5xQ/qHX7b4lcWvLH5l8SuLX9FrfAx/j8/iVVwRV6VP+Bf8O36AH+GmuBWbX9GALT5o8yubX9n8ChfHpWgOb+JL+Bq+ievg+vQHP8YvOvzK4VcOv3L4lcOv6CU+jE/g0/g8zsGVaR3fwnfxH/hf3ATnc6V+V/yWy69cfuXyK1wIF6G3+Az+Ae/hK7gGro3r0S9X+QemyxWF</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="220">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYGBg+MWg4MiAROMDAkwL4GqQ1ROjF5s6EB+GiVGPy250M7DZQ8idyH5D1gcSB+FHDB5OIDyRQcEJJo5sL4jW/M/o/FJ+oos55ypXSbsYt+yMTW6b/q12m2xg6PbR18o1jznGGV0fNvvR5a+zfHAE2QuiQRhZDbo+mHtBfJhbkd2IKw6Qwwc9LNDlYfbA3AXzE3oYI7sZxEZWC8IgPgCEgGrV</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19792_VATTQGIQSTR/2_y8" index="27" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="581.315" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VATTQGIQSTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="890.468" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EgwEcxvFiFNFhRIcoYoeIaHSIvCI6RBSjiB1mY4exFDuMscMYi/f/+/Yexthh7DB2GLHDGMXUGB1GFKOIHcbYIUab3/e5fC+f4xONzhZSlYX5IqriPc6WVJX9+TKq8vY6W0FV5izq4Sq0gW/je/hP/BD3h1vSpGua+G1N/J4m/kgTf4a7wsVwdzSLV/FFfBX/hHvGvdMBfoSf4ld08eu6uIAuLkiPdfHnuvgbfByfwuVwBi3ha/gmvoPv475xY9yCIV01xG8Y4ncM8QeG+BPcBS5ME/g0Po938GVcHdeiXfwH/hc/wftMcX5T3CbdNcUfmuJPTfEhfASXxGVwBerhK/gGvo3v4T5xQ/qHX7b4lcWvLH5l8SuLX9FrfAx/j8/iVVwRV6VP+Bf8O36AH+GmuBWbX9GALT5o8yubX9n8ChfHpWgOb+JL+Bq+ievg+vQHP8YvOvzK4VcOv3L4lcOv6CU+jE/g0/g8zsGVaR3fwnfxH/hf3ATnc6V+V/yWy69cfuXyK1wIF6G3+Az+Ae/hK7gGro3r0S9X+QemyxWF</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="172">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYMAO6v/Od8QhRVWwlknBEYSJUUepXZ//vcdrF6nugLFhNCjM3Bi1nE3qAl0WfGtyleyTcSsWb3QL31nu1nqTyW1KgYJrHJOYM0gdSA/IPchsZDdiM5sY9yKLwczG5S9kO0AY3Q5sfoWZCWML/ZV3gonhcyOyHLp7AB27Uiw=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19791_VATTQGIQSTR/2_y9" index="28" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="581.315" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VATTQGIQSTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="991.52" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EgwEcxvFiFNFhRIcoYoeIaHSIvCI6RBSjiB1mY4exFDuMscMYi/f/+/Yexthh7DB2GLHDGMXUGB1GFKOIHcbYIUab3/e5fC+f4xONzhZSlYX5IqriPc6WVJX9+TKq8vY6W0FV5izq4Sq0gW/je/hP/BD3h1vSpGua+G1N/J4m/kgTf4a7wsVwdzSLV/FFfBX/hHvGvdMBfoSf4ld08eu6uIAuLkiPdfHnuvgbfByfwuVwBi3ha/gmvoPv475xY9yCIV01xG8Y4ncM8QeG+BPcBS5ME/g0Po938GVcHdeiXfwH/hc/wftMcX5T3CbdNcUfmuJPTfEhfASXxGVwBerhK/gGvo3v4T5xQ/qHX7b4lcWvLH5l8SuLX9FrfAx/j8/iVVwRV6VP+Bf8O36AH+GmuBWbX9GALT5o8yubX9n8ChfHpWgOb+JL+Bq+ievg+vQHP8YvOvzK4VcOv3L4lcOv6CU+jE/g0/g8zsGVaR3fwnfxH/hf3ATnc6V+V/yWy69cfuXyK1wIF6G3+Az+Ae/hK7gGro3r0S9X+QemyxWF</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="144">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYBg4cP6/vCMyTS6oZFxAkX5SzAK5deX/9zjVCDEucBL/5+eSKlDuevevnNvWw81ua2YVuS2ayeLm9J/DlY35hBM2M0D2gsSxhQW2cCI1zNDV4wt7ZHfgYoPcCwsrdLMImYmuBgCeh084</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="14154_AMVTEYGMSEK/2_y5" index="29" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="623.278" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AMVTEYGMSEK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="551.255" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/HTEA0RDQ8ND/FENESPJ+KGHzfE0XA0HFHERdwQR0M0RDREQzTcI/L71xDREA0RPUTDpSGiIRoieoiGiKLufF+f5b28xk+h0N5oHF212vujxTj622yvFEcLnZXj6HdnlTjq8EKVm+VqWucb/Aq/xm9wW9wOt6spf8Af8Sf8GXfBtfSGv+Mf+Cf+hXvjPrQrCb4nCb4vCf5HEvzPJLhf3IiO8RN8xE/yU9w0N6Pz/CK/xC/zq9w6t8lta5Pf4/f5Q/6YO+XO9ZK/5m/5e/6Re+Ze9Z3/4rvT4HvT4PvT4AbS4AZ1OA1+lB/ni3yJK3MVrqpzfI2v8w1+hVvjNnSL3+F3+ZQ/4I64Ez3jL/gWf8PfcQ/ck77wb/wn35X5VeZXmV9lfqVDWfAj/Bg/wUfcJDel0/wMP88v8kvcMreq6/wmv803+T1unzvkjvWU/8df8tf8LXfPPep//pV/57/47tyvcr/SgTz4wdyvcr/ix7kiV9IyX+Gr/Bxf4+pcI4++Aay/JZs=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="540">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUT1IQlEYvbeCwAxCyqFFp6Aag5awl+/7IveGcBBqqKGWjGjU96whihoKijYNbAkqcIqChECLwCBoCBEMjYgW0yEofK/Ogxs9uLz7/Zzzne/chhgkafloxB6isBigO7uoI85Zktakm+ZlSMcd9admXl9pXdSRc9mb+rv069siGcS90Mw4MfDI5WUtGGlJ6l5RczCIgUcd/aghj7+6Y46qoReY/9zI7dpupwc8CocYc9Q89EOjmocYO13GUmSLKKk8sDiIgcO+BTFHJStA3bFT6hKfdPJ8yDeJCjdGLW6Pt40/+G7Z0M75dXqdX2QHH5jH9GVFHd+gH3yKKye8VBUpysgjSmc7eUGOcX+sjyevZ3kmMMEkh3kp6+G64eJHu+TMVnqxr9IGH7CP8lT8frijB0fV8AcGHMofaIAucIILb4we4PyW33nXDbFDU+YelcUqXQjN0aH0AwPvkEMvxxNkGhXC3mEjTR6xT0WxRWXjjJbNK6rG6/RmfhC8gX+a1sP3wV5m+9vxISJDf9xqxx+vDBQQ</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="14153_AMVTEYGMSEK/2_y6" index="30" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="623.278" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AMVTEYGMSEK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="714.313" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/HTEA0RDQ8ND/FENESPJ+KGHzfE0XA0HFHERdwQR0M0RDREQzTcI/L71xDREA0RPUTDpSGiIRoieoiGiKLufF+f5b28xk+h0N5oHF212vujxTj622yvFEcLnZXj6HdnlTjq8EKVm+VqWucb/Aq/xm9wW9wOt6spf8Af8Sf8GXfBtfSGv+Mf+Cf+hXvjPrQrCb4nCb4vCf5HEvzPJLhf3IiO8RN8xE/yU9w0N6Pz/CK/xC/zq9w6t8lta5Pf4/f5Q/6YO+XO9ZK/5m/5e/6Re+Ze9Z3/4rvT4HvT4PvT4AbS4AZ1OA1+lB/ni3yJK3MVrqpzfI2v8w1+hVvjNnSL3+F3+ZQ/4I64Ez3jL/gWf8PfcQ/ck77wb/wn35X5VeZXmV9lfqVDWfAj/Bg/wUfcJDel0/wMP88v8kvcMreq6/wmv803+T1unzvkjvWU/8df8tf8LXfPPep//pV/57/47tyvcr/SgTz4wdyvcr/ix7kiV9IyX+Gr/Bxf4+pcI4++Aay/JZs=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="456">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUc8rRFEUfu+tlCQbO7HRMKWUjYUa7517E0mxUpoFMrMwhZWNkUFRbGRHmmZhQzayVEOjJGVWNvwBlmNj593Ld+t7vVun75zv/LznzHn7Uot7I+//DQd9Yfa3lQhsSMlMRIgBQuBDPLiirTod3K15TmKW7ZHzrcZrLhd+6KgHzAV3zs8aQPCnti6H4aBaemyozb0VdZ0bVfmwTS3YA7m3J/LqB3KzcyzoNW5aiVS8rKDmvK263kTEbZlPZ6MHEQIec9FG/zPTLlf+pGS2X6RcnlI/tYZa7xnS580x/fZd0KWoqL8WB3TXw7vqz2k1YztV099wc/HvmCf9L/KojXku/F2ZrlzKh9ctT2YkyUsLcjkbdP6Nt+DO4WM8d0ueyP2n41CLHPbEuwJ5G+iIS9u8K4Q+5IFHb+wUt+gICpKJZ6Xu5x1iJ/g7cjgj5/sDbq0yTw==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="14149_AMVTEYGMSEK/2_y8" index="31" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="623.278" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AMVTEYGMSEK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="944.427" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/HTEA0RDQ8ND/FENESPJ+KGHzfE0XA0HFHERdwQR0M0RDREQzTcI/L71xDREA0RPUTDpSGiIRoieoiGiKLufF+f5b28xk+h0N5oHF212vujxTj622yvFEcLnZXj6HdnlTjq8EKVm+VqWucb/Aq/xm9wW9wOt6spf8Af8Sf8GXfBtfSGv+Mf+Cf+hXvjPrQrCb4nCb4vCf5HEvzPJLhf3IiO8RN8xE/yU9w0N6Pz/CK/xC/zq9w6t8lta5Pf4/f5Q/6YO+XO9ZK/5m/5e/6Re+Ze9Z3/4rvT4HvT4PvT4AbS4AZ1OA1+lB/ni3yJK3MVrqpzfI2v8w1+hVvjNnSL3+F3+ZQ/4I64Ez3jL/gWf8PfcQ/ck77wb/wn35X5VeZXmV9lfqVDWfAj/Bg/wUfcJDel0/wMP88v8kvcMreq6/wmv803+T1unzvkjvWU/8df8tf8LXfPPep//pV/57/47tyvcr/SgTz4wdyvcr/ix7kiV9IyX+Gr/Bxf4+pcI4++Aay/JZs=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="432">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdkb1LA0EQxe92RQlaKCIWAU0EC1s/KrHIzi5EsBBSiY2NhTYpLSKIh6WFWFgk6MFVqUQhf4SlYHGFjZV1WsG71Xf4YHFhmJ3Zmbe/2e35tLWi2+ZOj1u93330t6aiRhUj3y+WTRizhj3sRx17Qx0Ya7GnHjw192Ildb0lF9/vZj4aG56FPaylkQn1535azvSLuSxSk/uuCRnJhTxYqUsdnMPm9Ki6e1jsyH35JuvNB6tfl1ya37jFp2d3dZA7v//oJpuJq2Ubbjf7sNvJkf0sZ+yq2pRTvyDQAAvuOVHXlSZ1YbOqLRPJQA79SPqqIciBGeyYHT2I4cEEPs5Ebmhjdvrwj+DRCyMD58Y+K7oChq+4I/VyIDq+lY4/FluuVexgAn/Yh/txhhwYwz9CDWL+L2K+K5kZ/393cv8AzoX4AA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="14151_AMVTEYGMSEK/2_y9" index="32" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="623.278" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AMVTEYGMSEK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1043.47" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/HTEA0RDQ8ND/FENESPJ+KGHzfE0XA0HFHERdwQR0M0RDREQzTcI/L71xDREA0RPUTDpSGiIRoieoiGiKLufF+f5b28xk+h0N5oHF212vujxTj622yvFEcLnZXj6HdnlTjq8EKVm+VqWucb/Aq/xm9wW9wOt6spf8Af8Sf8GXfBtfSGv+Mf+Cf+hXvjPrQrCb4nCb4vCf5HEvzPJLhf3IiO8RN8xE/yU9w0N6Pz/CK/xC/zq9w6t8lta5Pf4/f5Q/6YO+XO9ZK/5m/5e/6Re+Ze9Z3/4rvT4HvT4PvT4AbS4AZ1OA1+lB/ni3yJK3MVrqpzfI2v8w1+hVvjNnSL3+F3+ZQ/4I64Ez3jL/gWf8PfcQ/ck77wb/wn35X5VeZXmV9lfqVDWfAj/Bg/wUfcJDel0/wMP88v8kvcMreq6/wmv803+T1unzvkjvWU/8df8tf8LXfPPep//pV/57/47tyvcr/SgTz4wdyvcr/ix7kiV9IyX+Gr/Bxf4+pcI4++Aay/JZs=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="372">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJyTYVJwfvpP3on3X7cTiP7H5OEkxbjAEcRewqQApr/8fe/IgAOA1IJokFpsfBgbhpH5MDayHhAG2QfCMHeA2Oh6kc2H2QtzM7pZMDZIDbrd6GpB/r/8V9Q5jPmuM/++yS5uGwRcdzcnu7bd6HGVKJzuKhs2wbVdttg1LkjLVaNhoUuLrbbLpL93nY8wVzmDwhCEl/zLB4cjP8MdMBvkLpg/QGaD1PL/m+Bs9/+9kzPDCafgv6nO/xhyndUbDjhnM2g5hzMsAIuD1IPYIL0gd4L4YD8CzQT5BYRh4YTsfpidIBrmbxCGuQ/kBpgbkc2AsUFysDiHiYPEYHyYPuQ0A2KDaJh+cJhC9YD8gBxHyHaCaAACCuSC</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="987_AAGASAQVLGQEGK/2_b3" index="33" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="643.839" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGASAQVLGQEGK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="200.105" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="568">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9Ew3EYx/GMKKKIDjE6RIeIyugQ/RRRRIcYO0Sp2WGMHcYooogdIuL3/f1PNMYOYxSjGDuM1WIUY4cYO4xRjEakzfN+Lm8er+MnHO5fSteGBqd0zTT6d0/zurY8uKKuvb70r6prAx5u4Nu4H9ywkk4q8TNK/IISv6rEb+GCuCMax5/hr/AWPoN7wJVoDf+J7+B/8SOGuClD3KwhbpGuGeJ3DPEhfASfwJ3jrqmHz+IL+DL+HdfEfdE//JgpftoUP2eKD5ji1k1xu3QfH8Un8Zf4G9wdLod7ohV8Hd/Cd/E+S9y4Jc5P5y3xK5b4TUv8Hv4AF8Od0BRe4dP4PL6Iq+IatI3v4YdtdmWzK5td2eyKbtvig/hjfBx/hrvCWTSDf8SX8DX8J66D+8WNONIpR/ysI37JYVcOu8KFcBGawF/gr/EePosr4Mr0A9/Ef+P/8GMuu3LZFQ244jdc8bsuu8JHcUncJe6G3uFz+Gd8BV/HtXBd6vPET3ji/R678tiVx65we/QQH8Of4lN4hUvj8rSIf8M38G18j7/vVvzorfYPFg4k1Q==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYGBgsGJe4HiAUcERyGQA0TA2A5ocujy6WmSArgedja4PXRxEO/xzd6r6L++kzfgBbA+I5mHa4lT7r9r5eSOzy2kncZf1/wucz7N8cOL+c9sJpB6kBsQHuRuGQWIwc0D6QRimFuY/GIapA7kBxIbJw8y48Y/JueOvqPP5WhkXqzwG173njdzMuEXcd5iZuv80V3B3qn/o5n8izW3++v2u3vOMXMM+8boWL/ruMl+I0/WTI4urdvRrl99M811YnPVcRBnlXVIP8brk7jVwueFg7OLEVOBy8EGXywe7cpcPNk4uYo2KYD/q/2V3ef77nHNx4z1nJnspl1jGA84/G74739vL5ZLP8sfZjuWm89a/E51X/C1y/tW41bmOqdf51t8aZ1lmbWf/2g6I3P8Nztv+rnKuZTrlvLpxoTPn/3Zn+b/cznMZ14DV/m6a46zAUO2czNTsrF3X5LyaYSFYbsn/ac69/+46x//Z6vzxnwdYDch8FcYMcDiA7ACFtwOTuHP9/24nEHs2Y7Cz7z8FZ1A88dVPArthN+MCJ5DZIDGtxrfOzftFXAKY/zqD/AIA8wTYqQ==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3707_VPIVLDIFAER/2_b3" index="34" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="636.371" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VPIVLDIFAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="310.214" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEtHEcwPF6iYaXd3iJG+IdXl4aIomG6NEQUURDNES8nWiIhoiGoyGOG44b7t7jjeOG44Y4z/MQDRENPTVEQ0RDPENEQzRE3nv9P7/lt3x9/IZfsdifchz9X3kljq6zLFusxtFkf3q1OPrTaDQK9Tga6E+pqfura4WdtUM/2Ql9oxv6gZPQF3u6RHfKP+Of8y/4l/wr3Y3uln/Hv+c/8B/5T7pc98x/4b/y3/jv/A/dp24wCd1Q2NlwEvyvSfC/JcH/noQ7RnQF3WjYvR+hL/wMfelX6PMx/rhuQjfFn+bP8Gf5c/x53YJuSbfMX+Gv8tf46+7Y0P3WbfG3+Tv8Xf4ef193oCvxD/lH/DK/wq/qaro6v8k/5rf4bX5H19Wd6Hr8hH/KP+Ofu+NCd6m74t/wb/l3/Hv+g+5R98TP+c/8F/4r/033rvvgf/K/pMEfSv1V6q9Sf5X6K91I2Hkh9Iujqb9K/VXqr3RjunH+BH+KP82f4c/q5nTz/AX+En+Zv8Jf1a3p1vkb/E3+Fn+bv6Pb1e3x9/kH/BL/kH+kK+squiq/xq/zm/xjd7R0bV2H302jf1RJPGg=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="384">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJyT+N/t5PBP3tGMcYEjiAbhDgYFJwYgmPPfHSy3ivGDI0wNjA1SA1MPEwfRMHOQ1YLYILMYoADZLhAbJAZTi6weZgYMg9TB5JHlYPyc/5udtJkLnEBuA9EgMZhf0N0N4oPYyHZJAMMCxAZhmDkgvPXPcacbDNXOhcx/nTUcdrlUfTR1PXxssqt/ZotrxaMS1zs9fq76tiddrJgLXLL/3HV++lfeWZBpgRPnf2NnbiYmMFuf+QPYHGQ7YG5ADmMQBqkHYZgaEBumD6YH5m9YeIDEYO4GiSHHHUgvTD9IHuZfZDYMw/wMC0OYu0BuQA4jmB2wMATJw+IW5jZkcw7913T2+Bvt7Fu7y7llH6vL1PqFzuF/Lzv//hfrDACCJ+o7</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="985_AAGASAQVLGQEGK/2_y5" index="35" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="643.839" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGASAQVLGQEGK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="518.258" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="568">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9Ew3EYx/GMKKKIDjE6RIeIyugQ/RRRRIcYO0Sp2WGMHcYooogdIuL3/f1PNMYOYxSjGDuM1WIUY4cYO4xRjEakzfN+Lm8er+MnHO5fSteGBqd0zTT6d0/zurY8uKKuvb70r6prAx5u4Nu4H9ywkk4q8TNK/IISv6rEb+GCuCMax5/hr/AWPoN7wJVoDf+J7+B/8SOGuClD3KwhbpGuGeJ3DPEhfASfwJ3jrqmHz+IL+DL+HdfEfdE//JgpftoUP2eKD5ji1k1xu3QfH8Un8Zf4G9wdLod7ohV8Hd/Cd/E+S9y4Jc5P5y3xK5b4TUv8Hv4AF8Od0BRe4dP4PL6Iq+IatI3v4YdtdmWzK5td2eyKbtvig/hjfBx/hrvCWTSDf8SX8DX8J66D+8WNONIpR/ysI37JYVcOu8KFcBGawF/gr/EePosr4Mr0A9/Ef+P/8GMuu3LZFQ244jdc8bsuu8JHcUncJe6G3uFz+Gd8BV/HtXBd6vPET3ji/R678tiVx65we/QQH8Of4lN4hUvj8rSIf8M38G18j7/vVvzorfYPFg4k1Q==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="596">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxj+yfvyAbEi5kWwGkGJAASg9EwjCyOrhakH2YWut7Nf92dQPT+v/JOyGpBfBCG6QOxc/7mOzEzLHAC6RFg+gB3F4wNEgepg8kjux3ZfJA5ysyFzpqMvc4vGk46X6jf4Hz3f43zmvoe58Z/ms7KDEzO+/9tdoKZB7Njwv9uuHtgdoDkJ/x67wTSE1iv7bIqN9E1e+5GN5ujO9010j67f761331faYv74Tff3OIzfd22W29xvb2w2jVmZZMrb3iPq7JfrevmpzWu1X9UXXnmHXIJmtfpwndwucsplisuk+4ccvFIvu7ycYOCq9Hh5y6Hal67+C3YCZb3dIhzUWSOc1E5VOlSYufvknHQ1EWPJcQldXeYy7OWaJfgfVYuBfuUXUztOVx+MYi6GLLcdS5ruOF87/9O57kM550XO8q4BDnKgzGvrThYzbVf35w3M51yfs1409mz9rlzUdNS568NC5xBYXX03xuwnMG/9WD9jP+2OPv9P+LM/ve587XGac7sjGlgsVlM98DhCBJzYZ4DZoP0H/kX6NzKUuB8rK7JueJ/OjicQWKzGKudfZu3Omv++w3WG/dnKVg9AFct/yI=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="12884_AVYLKPEDPFTWASGIK/3_y6" index="36" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="641.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVYLKPEDPFTWASGIK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="661.373" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFE7AEcwPEaoiEeb4gbouHxaIgkoqG/hoge0RANEUk0RDREw9EQ0RAN9aIhGiLec/+/hmiIuOGuG47jhuOG4yiiIRoi3fl9fstv+fr4Db+ncmeKhWS8O6VC8vesM5VC0tOdaiFZ704tdrteSJ46+Xwj+rQZfa4Vfb6te9a96t747/wP/if/K/pybxpdXxpdf+zcQBr+jzT8n2n4g9GnOd2Qbjh2z6/o139HXx7hj/LHdBO6Sf4Uf5o/w5/lz+nmdQu6Rf4Sf5m/wl91x5puQ7fJ3+Jv83f4u/w9XV63zz/gH/KP+Mf8E92p7px/wb/kX/Gv+Te6f7qUf8u/49/zH/iPuqKuxK/wq/wav85v6Jq6lq7Nf+G/8t/47+740H3qvvi9Wfh9Wfj9mb/K/FXmr3SDscu56MeHoj8bzvxV5q90I7pR/hh/gj/Jn+JP62Z0s/w5/h/+An+Rv6Rb1q3oVvlr/A3+Jn/LHdu6Hd0uf4+f5+/zD/iHuiPdMf+Ef8o/51/wL3VXumv+Df8/P+Xf8u9097oH3SO/yC/xK/yqO2q6uq7Bb/Jb/Db/JUu+AWgaNkM=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="340">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUSEOwkAQbMHwADxFYCDBYDBAetekHs0LMIQPUDweJFAcmgRFAg7DDxD8oAbbK52j02x6yWZv73ZnZndj01K9LPE7ZqGOaajg4/wNhpiGeJztfd7tv+v5eIMxf2c2yskP/uBtTX6HgYcYxFm6B8tPT1zyVf/iQi85EPNODsTEKTFzPuChP+mZX9Up9ZOj7FPkSGN/39TTn/VZX+/DIHrMg8ZEBa9VP+hGW910pnrmPP9zLWpkP3Kmco6SH8Y9KeeigHkzoU6ygQZuO2vpuklsDrjkTk/G1aPa29ZhV3bvhQ7OWe6ZeqiRR+qS+mQ+8InHGcrdMP4Bl5v7dg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="28178_DGGVEIATTNVSK/2_y7" index="37" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="645.83" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGGVEIATTNVSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="720.394" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9E33Ecx/FpRIfRYURs7DDid4h+ZB3iy49Fhyx+h4jFjyKi2CEbv8OIzWKHbOw38/3L7xCxWewQUcSm5neI2Cx2yMZixMbvMNrv5/N4X558PD63V7ncuUocfT7q3L04Wuje/Ti60r2lOHrd6NzDOOqy8hPuheb8W36XP+S/cD+4P9qTBN+fBH8jCb6UBH8nCe4uV9Uav8zX+Wf8K67Jvdc9vsV/43/xbe89afB92p8GN5CG/zfT4G+nwZe4EW6Mi3SCn+Kr/Cxf4xa5FV3l6/wav85vcA0u0Sa/xW/zO/w+95Fr6Ql/yp/x5/wF1+Yuud4s9FoW/PUs+MEs+FtZ8EPcMDeq43yFn+Sn+RlujpvXJf4B/4h/zD/lnnMvuTda8Jv8O/4Dv8sdcEd6zH/lv/M/+d/cX+6fXs2D78vtKrer3K5yu+JKOsKP8RE/wU9xVW5Wa/wiv8Kv8nVujVvnNrTBp3yT3+K3uR1uXz/xLf6EP+XPuHPuQtv8Jd9b2FVhV4VdFXalQ0Xww/woP85XuElumpvROX6hiP4DEsEbMA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUT1IglEUfT4riAbFJNpUooaKpoYQTP3u9dO5oR8saKopyqGGhtRoDEKCfoiwqamfwRCCoKBAInBwk6DBISiiH2grP+u8fCA9uJz7zj33nfvey397wvnfEPXlqGXDWeE1gA/2BYV+6y2sa4hGLaJfxIyYXDfQBy36gOBxttZBA17v83Xv/L8ZsPRe69CnOWC5VjDggxw+2lfrwTXmepbG2YHoO5TDdFTNqfmfhZdKqSPKVKPcJdxM6WcalyO0ZM3Ty8oNBV89kfdbr/noPjZz5Q/zbq9oJoZWzUST06wENiLXB57I2PAp79TSvBaa4MnkHJdkhHvEALcEfBy/8PPZpY8d0skVkVHntstl+rQF6dw+Q51ySvk9iUEas9oIs2GPWndqi6KyT3HQIYcGWpeVJnhcZTe5GCxwc+iEt70Z3g+7OGn9+bzYetU9gaM1G7XaOxS3a8UpIGbp6yum6gi8L94GqN8GiD9ELMoD9aao6wCHP0B9unpvwONCvBuYEb3IweNc1HAH+P4AsaH8tg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="988_AAGASAQVLGQEGK/2_y7" index="38" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="643.839" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGASAQVLGQEGK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="730.41" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="568">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9Ew3EYx/GMKKKIDjE6RIeIyugQ/RRRRIcYO0Sp2WGMHcYooogdIuL3/f1PNMYOYxSjGDuM1WIUY4cYO4xRjEakzfN+Lm8er+MnHO5fSteGBqd0zTT6d0/zurY8uKKuvb70r6prAx5u4Nu4H9ywkk4q8TNK/IISv6rEb+GCuCMax5/hr/AWPoN7wJVoDf+J7+B/8SOGuClD3KwhbpGuGeJ3DPEhfASfwJ3jrqmHz+IL+DL+HdfEfdE//JgpftoUP2eKD5ji1k1xu3QfH8Un8Zf4G9wdLod7ohV8Hd/Cd/E+S9y4Jc5P5y3xK5b4TUv8Hv4AF8Od0BRe4dP4PL6Iq+IatI3v4YdtdmWzK5td2eyKbtvig/hjfBx/hrvCWTSDf8SX8DX8J66D+8WNONIpR/ysI37JYVcOu8KFcBGawF/gr/EePosr4Mr0A9/Ef+P/8GMuu3LZFQ244jdc8bsuu8JHcUncJe6G3uFz+Gd8BV/HtXBd6vPET3ji/R678tiVx65we/QQH8Of4lN4hUvj8rSIf8M38G18j7/vVvzorfYPFg4k1Q==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="492">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYGBgCGdUcGRAAoT4uAAudcjibf/nO8LEkNmEzITRID0wfYTUTmX2cAKxYXZZs34As2/8lXeKYylwAvFBGJ/dIHmYOTC15xm2OCUz2zk/2SDuWpvr4ma1Vd+d9WGie52elfuDZczuSXX1bqxpL1yf8Nm5TnTkcJW4K+gqelfCdcNFIddda8VcuxOnu2yqNXZpP8AFxqcbFV3WHlJzYWGucjE/FOGS4Fzl4tfo5SLLrO4i/ZfdRbyey6XvkIzLgbrfzqv2ibso/OUHsmc76//d6cxfc9K5p36985r6/c47Wt46s/6Jdp5d2+T8mFHc+TzjJGdpxjSwmCZjj/O7xgXOsY37nLtqljqD3H+8vsd5DVOQs+u/BWB1ILF9f+Sd5RkLnf3/GTsnMTU5uzHyON/6V+m8ldHeOY4hGCwHEgOpA4l7/RN1/v+P0VmQWcv5AbMHWBxkDkgMFE4gcZAakPgG5g9OIP0w9TAaANxcpLg=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="10362_TIAMESTDGLTR/2_y7" index="39" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="647.819" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIAMESTDGLTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="749.385" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="540">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E5nEAx/GIh4ZoiLgjGuKGODqiIX40REM0RDREw49oiIaIjmiIhoiGJw35/SUaIi4eGqIhntMQDfFwx0PDQ1zEM8Rzz+P7+izv5TV+4ri7RhL96K2ZRH29tZLod727f9pOotNqd50k6vG4kgY/mAY/nAb3JQ1uTL+lwX/np/gZfpab5xa5ZV3lY36D3+J3uD3uQI/4E/6MT/kL7or7pbf8PV/nn/gX7g/3qm/8B//J92fBD2TBDWXBjWTBjep4FvwEP8lP8xE3xy3oEr/Cr/Hr/Ca3ze3qPn/IH/NV/pwruEvuWmv8Hf/AP/LPXINraot/59t8h6/kfpX7lX7Ngx/L/Sr3K36Km+FmdZ5f5Jf5VT7mNrgt3eH3+AP+iD/hzrhUL/gr/oa/5e+5OvfEvehf/pV/4z/4T66/8CsdKoIfKYIfLfyq8CtukpvWiJ/jF/glfoVb49Z1k9/mf/L7/CF3zFX1nC/5S/6ar3F33AP3qM98g2/yLf6da3MdrZTBD5bBD5d+VfpVGf0H+9QmTg==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="420">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkTtLA1EQhe+Odrbar4KCD1Kl0SKwd7K74B+wSS1opVjYia/OQjutJLUighb5ATZ2phFS+AOsJI2NxES/hQNbDPM8Z86d6yHNFpLXOLI0LoVuvJlcRP+vkX/aMHv/LePu9F4V46lvhG5GTsysTD0MHFxPUx8V/mw85+QY8c/oOWLMihcMWtBBDSw1euTMsgcO1bUDzMt4xnthGDFyZqRf+HoNLBrIma+/S7t0F2bQ/XBy3u43bvP+bF58HVwV35s7xb4lRedtMb9szbfLo4Gv273fTUpnvhnSKkbTsnX8MaxUOe9cC03fTlYdL+3oodcwc90OndTw6IFXt8LA0YMbrt7xqW/ZtR9ay6VdWDiJdS/dmL26B3xg4YOLHD3slVZ6zNT/Vf+o/+GWuis5vv7PmvsDkuUHPA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3706_VPIVLDIFAER/2_y6" index="40" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="636.371" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VPIVLDIFAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="750.383" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEtHEcwPF6iYaXd3iJG+IdXl4aIomG6NEQUURDNES8nWiIhoiGoyGOG44b7t7jjeOG44Y4z/MQDRENPTVEQ0RDPENEQzRE3nv9P7/lt3x9/IZfsdifchz9X3kljq6zLFusxtFkf3q1OPrTaDQK9Tga6E+pqfura4WdtUM/2Ql9oxv6gZPQF3u6RHfKP+Of8y/4l/wr3Y3uln/Hv+c/8B/5T7pc98x/4b/y3/jv/A/dp24wCd1Q2NlwEvyvSfC/JcH/noQ7RnQF3WjYvR+hL/wMfelX6PMx/rhuQjfFn+bP8Gf5c/x53YJuSbfMX+Gv8tf46+7Y0P3WbfG3+Tv8Xf4ef193oCvxD/lH/DK/wq/qaro6v8k/5rf4bX5H19Wd6Hr8hH/KP+Ofu+NCd6m74t/wb/l3/Hv+g+5R98TP+c/8F/4r/033rvvgf/K/pMEfSv1V6q9Sf5X6K91I2Hkh9Iujqb9K/VXqr3RjunH+BH+KP82f4c/q5nTz/AX+En+Zv8Jf1a3p1vkb/E3+Fn+bv6Pb1e3x9/kH/BL/kH+kK+squiq/xq/zm/xjd7R0bV2H302jf1RJPGg=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="412">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkr8rRWEYx897JmW6Bot0zYzuRlfnfc4bw/0LSEoZLEymU1ey3josBik3ZTMom1JMumYppaRMFjJRnON+5Ktz6un59X2+z4/35GU9eXbdZCR+S/K+LT3jOv4mnvMf8YP//J61+XLQ3otJaxSHv3EETM2NeWoQeBQbLc+8sMqTg1uiXuCR/G+WqP9R1/xa9/jqIR9befVVXn0VVy22esKPDQ4NF3bmFu0lymylvfe/KzNfFtc+29q1qYuJ9OjqNt1utcLS+Wk4qfXC6t1B6E2vhafNodBY7qav7XuD5zEeN2bhbuJnPvpJax5wYJiVfpLhqGn0loCp3k37IboFdeInzq7gqndTrWrko4WvvqneusovTtXqPZTX3bUTOx6XO8a/NOA6tlEuGP5+UbcfS8769Q==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="12883_AVYLKPEDPFTWASGIK/3_y7" index="41" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="641.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVYLKPEDPFTWASGIK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="762.414" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFE7AEcwPEaoiEeb4gbouHxaIgkoqG/hoge0RANEUk0RDREw9EQ0RAN9aIhGiLec/+/hmiIuOGuG47jhuOG4yiiIRoi3fl9fstv+fr4Db+ncmeKhWS8O6VC8vesM5VC0tOdaiFZ704tdrteSJ46+Xwj+rQZfa4Vfb6te9a96t747/wP/if/K/pybxpdXxpdf+zcQBr+jzT8n2n4g9GnOd2Qbjh2z6/o139HXx7hj/LHdBO6Sf4Uf5o/w5/lz+nmdQu6Rf4Sf5m/wl91x5puQ7fJ3+Jv83f4u/w9XV63zz/gH/KP+Mf8E92p7px/wb/kX/Gv+Te6f7qUf8u/49/zH/iPuqKuxK/wq/wav85v6Jq6lq7Nf+G/8t/47+740H3qvvi9Wfh9Wfj9mb/K/FXmr3SDscu56MeHoj8bzvxV5q90I7pR/hh/gj/Jn+JP62Z0s/w5/h/+An+Rv6Rb1q3oVvlr/A3+Jn/LHdu6Hd0uf4+f5+/zD/iHuiPdMf+Ef8o/51/wL3VXumv+Df8/P+Xf8u9097oH3SO/yC/xK/yqO2q6uq7Bb/Jb/Db/JUu+AWgaNkM=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="384">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdkrFKA0EQhnfPyqeI6cQ8QhC8ncX0dkKwTC1iKYRLEYRYaJUm4Fn4AIIWYpsiYGEnFhbiCyiCXXIJ3+EfFg+GndmZf2b+f29z6W3iLsKHL8PcbYVR1Vn7z9V1jp3Pv3LuX/19nb+tGvmlPw4y7qgBQ0wenE6MGk5maQ6YFKc7cJjmklet+/vw6UeOGJ8e7Y3vsO3f1zO0I5zOsll9woM9uFffdCY5sNon3U28pE+aF26y6NhVOIxH5TiOP6exKG/i6d5JHLofa/Uf7dftGHuKl3SSRsTiiZ/OVg1c4Lmbda3Xf7On4sHovz8orbksaiP/kh0YNXeLRh0zV33wpb80RRu9mfhJ93Q37S6sOGhP/VN6QzQS5r+uK/TVLf8=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="28180_DGGVEIATTNVSK/2_y8" index="42" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="645.83" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGGVEIATTNVSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="833.475" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9E33Ecx/FpRIfRYURs7DDid4h+ZB3iy49Fhyx+h4jFjyKi2CEbv8OIzWKHbOw38/3L7xCxWewQUcSm5neI2Cx2yMZixMbvMNrv5/N4X558PD63V7ncuUocfT7q3L04Wuje/Ti60r2lOHrd6NzDOOqy8hPuheb8W36XP+S/cD+4P9qTBN+fBH8jCb6UBH8nCe4uV9Uav8zX+Wf8K67Jvdc9vsV/43/xbe89afB92p8GN5CG/zfT4G+nwZe4EW6Mi3SCn+Kr/Cxf4xa5FV3l6/wav85vcA0u0Sa/xW/zO/w+95Fr6Ql/yp/x5/wF1+Yuud4s9FoW/PUs+MEs+FtZ8EPcMDeq43yFn+Sn+RlujpvXJf4B/4h/zD/lnnMvuTda8Jv8O/4Dv8sdcEd6zH/lv/M/+d/cX+6fXs2D78vtKrer3K5yu+JKOsKP8RE/wU9xVW5Wa/wiv8Kv8nVujVvnNrTBp3yT3+K3uR1uXz/xLf6EP+XPuHPuQtv8Jd9b2FVhV4VdFXalQ0Xww/woP85XuElumpvROX6hiP4DEsEbMA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="436">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJzz+ivvyAAEXkAaGTNAQeS/+XA2sjoGNABSh6z/NOMHR3T9MDUwc7Dpg/HRxZHNhcmD9CPb8+mvvJMXmn9A4shmwfQh+wGfHmR7bBhNnTsdZrtoBa10PZ5k79a7rNHtt02qW5WXmBvPrBmu6f4Krj/uL3J512jqcsNRCEh/cp6/j8vl1B5jl9cMn5ytDoq4fPn923l34x3nO/U7nfOa2p3t/0U7f2BKc+76q+kc/Y/ReTfjBycQTv1/28ntj7sziP7zb75TBVOBU9y/zWA2iFb5exwsBvIzH4OCM0hsJmO7M5ODuMstu3IXz3+mLoebnFxqGJ87J/5vdF71l9t5FZOY8wKmHrB+kD6QPSAzQGaC7IaZDZIDsUF+NvnnDqZBfJBekBzMXhAGmQlyCyz8QepB8qCwA/FB4iD9IAxTgx4fAJhLBcY=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="990_AAGASAQVLGQEGK/2_y8" index="43" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="643.839" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGASAQVLGQEGK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="858.47" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="568">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9Ew3EYx/GMKKKIDjE6RIeIyugQ/RRRRIcYO0Sp2WGMHcYooogdIuL3/f1PNMYOYxSjGDuM1WIUY4cYO4xRjEakzfN+Lm8er+MnHO5fSteGBqd0zTT6d0/zurY8uKKuvb70r6prAx5u4Nu4H9ywkk4q8TNK/IISv6rEb+GCuCMax5/hr/AWPoN7wJVoDf+J7+B/8SOGuClD3KwhbpGuGeJ3DPEhfASfwJ3jrqmHz+IL+DL+HdfEfdE//JgpftoUP2eKD5ji1k1xu3QfH8Un8Zf4G9wdLod7ohV8Hd/Cd/E+S9y4Jc5P5y3xK5b4TUv8Hv4AF8Od0BRe4dP4PL6Iq+IatI3v4YdtdmWzK5td2eyKbtvig/hjfBx/hrvCWTSDf8SX8DX8J66D+8WNONIpR/ysI37JYVcOu8KFcBGawF/gr/EePosr4Mr0A9/Ef+P/8GMuu3LZFQ244jdc8bsuu8JHcUncJe6G3uFz+Gd8BV/HtXBd6vPET3ji/R678tiVx65we/QQH8Of4lN4hUvj8rSIf8M38G18j7/vVvzorfYPFg4k1Q==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="600">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYIAADyYFRwYsbELA+/98R+P/7/HqhYmB1IIwsWZjcxcIg8zAJo6uHmbf8v/yTp+YtjidY+RxTvwb6Pzn31Lnz4w9zl//RDvv+3fcKepft1PNX0ZnkBqQWhC/h9EDjHX+vHc6+FceLCfEWu3c86/A+d/DVpd7+oyuhXP9XY+eU3KbvIzbnb1cy90il8t9M8tFN9lVfm5iTkddT1xQd53/+5+L+CVG1z8MPK4sfx+5fLRb5/L+boMLlx2zy2bmy87fG+86+zDsct7FyOzSWifp0mvv7nJ6f5gL339Jl9hDXC5mtRwuW5tOOtfXP3f+9XeLc1zDWefgun3OO5tmO+vZcrkU119y1vi72XnlvyXOk5vXO4Pc+I5R23k7w2zn942rnBfVsroo1N9xzq2/DNZz6G+bM8g/IKzNbAKmj9Y1gdWD1HI1lLok2y91aXi4weWGwmuX8Dm7Xfb687qWTJR33T/ZxXV14lTXFS4bXMUWnnHV1H7lGq//3vVX+2lXg5Y9rodYF7gunLLO1Wt/i+t5+zZXc49211b5bNfJmy1dOxj/uDTOvu9y+PENF3vZ6S6K+7Rd+BvanUHhDgA1GtDc</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3704_VPIVLDIFAER/2_y7" index="44" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="636.371" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VPIVLDIFAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="863.463" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEtHEcwPF6iYaXd3iJG+IdXl4aIomG6NEQUURDNES8nWiIhoiGoyGOG44b7t7jjeOG44Y4z/MQDRENPTVEQ0RDPENEQzRE3nv9P7/lt3x9/IZfsdifchz9X3kljq6zLFusxtFkf3q1OPrTaDQK9Tga6E+pqfura4WdtUM/2Ql9oxv6gZPQF3u6RHfKP+Of8y/4l/wr3Y3uln/Hv+c/8B/5T7pc98x/4b/y3/jv/A/dp24wCd1Q2NlwEvyvSfC/JcH/noQ7RnQF3WjYvR+hL/wMfelX6PMx/rhuQjfFn+bP8Gf5c/x53YJuSbfMX+Gv8tf46+7Y0P3WbfG3+Tv8Xf4ef193oCvxD/lH/DK/wq/qaro6v8k/5rf4bX5H19Wd6Hr8hH/KP+Ofu+NCd6m74t/wb/l3/Hv+g+5R98TP+c/8F/4r/033rvvgf/K/pMEfSv1V6q9Sf5X6K91I2Hkh9Iujqb9K/VXqr3RjunH+BH+KP82f4c/q5nTz/AX+En+Zv8Jf1a3p1vkb/E3+Fn+bv6Pb1e3x9/kH/BL/kH+kK+squiq/xq/zm/xjd7R0bV2H302jf1RJPGg=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="404">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwTYlZwZAACISj98t98RxAGsQ/8fe8IwiA5+X/uTiAMUyuEpA+GQWqjmBScrP93O8kzLnD6z3TH6dz/92AaxN/+dzMYg8wB0SB7XBgLnJDtAdEg/SBxEB/mHmR7QHYg2w/i6/11d77WONHZ2YHZJfEfu8vU+mXOixhjnUH2gsyCmQfTAzMX5BaQ+0D6C/YxuJgcYHXprVMEY+//Z53/Nu10vsiU7vz7zzPnEttIF/dHsq6Crza73l4k4Ga9WtDt3fxfrouv7XH9NifWVd7+tMudJiuXQ38uO4P8DQ8LaNiBxGB2guRAbkIOA5AYiI9MwzBMHlkdLL5g/oIBmB6Yvejhh6wPZg4IgNQiq0GOe5i5MPeCwhXkN5g9yOEJY6P7B6QP5m9YuID4AH2F7H8=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="10361_TIAMESTDGLTR/2_y8" index="45" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="647.819" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIAMESTDGLTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="878.42" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="540">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E5nEAx/GIh4ZoiLgjGuKGODqiIX40REM0RDREw49oiIaIjmiIhoiGJw35/SUaIi4eGqIhntMQDfFwx0PDQ1zEM8Rzz+P7+izv5TV+4ri7RhL96K2ZRH29tZLod727f9pOotNqd50k6vG4kgY/mAY/nAb3JQ1uTL+lwX/np/gZfpab5xa5ZV3lY36D3+J3uD3uQI/4E/6MT/kL7or7pbf8PV/nn/gX7g/3qm/8B//J92fBD2TBDWXBjWTBjep4FvwEP8lP8xE3xy3oEr/Cr/Hr/Ca3ze3qPn/IH/NV/pwruEvuWmv8Hf/AP/LPXINraot/59t8h6/kfpX7lX7Ngx/L/Sr3K36Km+FmdZ5f5Jf5VT7mNrgt3eH3+AP+iD/hzrhUL/gr/oa/5e+5OvfEvehf/pV/4z/4T66/8CsdKoIfKYIfLfyq8CtukpvWiJ/jF/glfoVb49Z1k9/mf/L7/CF3zFX1nC/5S/6ar3F33AP3qM98g2/yLf6da3MdrZTBD5bBD5d+VfpVGf0H+9QmTg==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="408">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxtkr1LA0EQxXf3YpfOWj2EIKhNsEljkd3kDDYWglXAxt6kFRQNhFgIQrBV0wj21vZindLGv8A02p2Y38ILW3gwzPeb2TdXdy7clS9+w+b+0ubNE9uJGjHz77P8ao7cJPrY1KU+mphy9K/aSRRwZ+ZjYZO7tZsBnWJhUzc0b/7HVgM12OS7WS/2YYNDfc3ceM3EF8Z/e1JLjF5wiGk+7xO+5lFPTpLOZK/x+qj1vnvfvn7eKxq1cXF8NCym/aVi5WG5vX++1dqunIVv1wl5ZeZfs254dL3Qzw4DduPqKZxeDGKM94JX/V1bSH1+C3aYmkF8PxgH5U4Qn3BDH1yyNzZavCO6pXghT0wcgEsdcfWmd0jviE2NOGMf/Sdg6QYpv8ImLl/3IwaPKTbyB4063kY=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="989_AAGASAQVLGQEGK/2_y9" index="46" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="643.839" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AAGASAQVLGQEGK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="929.512" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="568">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9Ew3EYx/GMKKKIDjE6RIeIyugQ/RRRRIcYO0Sp2WGMHcYooogdIuL3/f1PNMYOYxSjGDuM1WIUY4cYO4xRjEakzfN+Lm8er+MnHO5fSteGBqd0zTT6d0/zurY8uKKuvb70r6prAx5u4Nu4H9ywkk4q8TNK/IISv6rEb+GCuCMax5/hr/AWPoN7wJVoDf+J7+B/8SOGuClD3KwhbpGuGeJ3DPEhfASfwJ3jrqmHz+IL+DL+HdfEfdE//JgpftoUP2eKD5ji1k1xu3QfH8Un8Zf4G9wdLod7ohV8Hd/Cd/E+S9y4Jc5P5y3xK5b4TUv8Hv4AF8Od0BRe4dP4PL6Iq+IatI3v4YdtdmWzK5td2eyKbtvig/hjfBx/hrvCWTSDf8SX8DX8J66D+8WNONIpR/ysI37JYVcOu8KFcBGawF/gr/EePosr4Mr0A9/Ef+P/8GMuu3LZFQ244jdc8bsuu8JHcUncJe6G3uFz+Gd8BV/HtXBd6vPET3ji/R678tiVx65we/QQH8Of4lN4hUvj8rSIf8M38G18j7/vVvzorfYPFg4k1Q==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="484">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYEAAW0YFRxBG5jMQAFP+zsepBqafGHNw6QWZf+q/vNNOpgVON//ddkK2j5DdIAzSC6JBakEYxF7y9z1Wf8L0wPTVMWg5ZzB/cAJhh78xzpaM2525HatccmVXuaxJfOAy54CLa/NlaTfja5zuwh5K7s1zud0V47a5nTzi6Vb3dImrj52iq8wiRteI+z9cKhQvuLTIPHQJcjjk0tPU4TLNVsiFnfGG85sDrC5Pme863/7P7+Ld5OUi0ujusm2PqcuTg8ouR5g+Ob+t/+i88u8W54O1R5z7mWaDsUHTNOfQuqXOuY0LwHIrGPc7O9ctcwa58cn/Cc6uDe3Os39HO09lUgDj7D9Vzt4MHs489ROdQX5awVgF9tczZjswX4WRFywPCl+QOEjs6z9jsF6QGAjD2Pf/HHcyYGByBtEgtVpMPU41/7idGf6KOoNokDgIg9SC1MH0g+Q2/AsE2wuKS5gaEA0AYDDGHA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="28177_DGGVEIATTNVSK/2_y9" index="47" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="645.83" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGGVEIATTNVSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="962.514" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="560">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9E33Ecx/FpRIfRYURs7DDid4h+ZB3iy49Fhyx+h4jFjyKi2CEbv8OIzWKHbOw38/3L7xCxWewQUcSm5neI2Cx2yMZixMbvMNrv5/N4X558PD63V7ncuUocfT7q3L04Wuje/Ti60r2lOHrd6NzDOOqy8hPuheb8W36XP+S/cD+4P9qTBN+fBH8jCb6UBH8nCe4uV9Uav8zX+Wf8K67Jvdc9vsV/43/xbe89afB92p8GN5CG/zfT4G+nwZe4EW6Mi3SCn+Kr/Cxf4xa5FV3l6/wav85vcA0u0Sa/xW/zO/w+95Fr6Ql/yp/x5/wF1+Yuud4s9FoW/PUs+MEs+FtZ8EPcMDeq43yFn+Sn+RlujpvXJf4B/4h/zD/lnnMvuTda8Jv8O/4Dv8sdcEd6zH/lv/M/+d/cX+6fXs2D78vtKrer3K5yu+JKOsKP8RE/wU9xVW5Wa/wiv8Kv8nVujVvnNrTBp3yT3+K3uR1uXz/xLf6EP+XPuHPuQtv8Jd9b2FVhV4VdFXalQ0Xww/woP85XuElumpvROX6hiP4DEsEbMA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="496">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx1kb9LQlEUx98PkaytKPpBYQRCrgVtivfc96S1LWhpqwZ1E2wQxcGoRYggl6zFaLAhAwV7hkFUhDU0JDX0BwS6l7f4PrryiLrw5fy453w491y36g316YWQ+8fmRTuk/HNwD4saaEaEWVE5Zm9qjcEHQ0oyIWfvbx44sOjvaF4m2TIv+53WyXbWQWDIGjmr5HtcsR4f/l9zOueCDx7iMa3ARLJKi5e6YZ11jSdfzjxab5pstWie38VNV8tjTtQzxkZzxHjxHvA9a4s/BJd55KKf7wfD/KTh47HALPc3pvhQ2qJI5p1ORYrK+hKNizxlRZTmVI1iX2Gqqn5qfyToXgvYubSq23UyHnW9MsTXYsCOS8oNe9Zy9Jka5EWK82j9kEcmKzyrJfhucJqPqJbNXNPnqaav2PVgPGodhjzeCNaCtmP/Iyz2I3WrlHuqiGF7jpaaoFLyija724Q8WNgReuXOIPmn4EIyBy5i7PgbxFvHsA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3703_VPIVLDIFAER/2_y8" index="48" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="636.371" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VPIVLDIFAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="962.539" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEtHEcwPF6iYaXd3iJG+IdXl4aIomG6NEQUURDNES8nWiIhoiGoyGOG44b7t7jjeOG44Y4z/MQDRENPTVEQ0RDPENEQzRE3nv9P7/lt3x9/IZfsdifchz9X3kljq6zLFusxtFkf3q1OPrTaDQK9Tga6E+pqfura4WdtUM/2Ql9oxv6gZPQF3u6RHfKP+Of8y/4l/wr3Y3uln/Hv+c/8B/5T7pc98x/4b/y3/jv/A/dp24wCd1Q2NlwEvyvSfC/JcH/noQ7RnQF3WjYvR+hL/wMfelX6PMx/rhuQjfFn+bP8Gf5c/x53YJuSbfMX+Gv8tf46+7Y0P3WbfG3+Tv8Xf4ef193oCvxD/lH/DK/wq/qaro6v8k/5rf4bX5H19Wd6Hr8hH/KP+Ofu+NCd6m74t/wb/l3/Hv+g+5R98TP+c/8F/4r/033rvvgf/K/pMEfSv1V6q9Sf5X6K91I2Hkh9Iujqb9K/VXqr3RjunH+BH+KP82f4c/q5nTz/AX+En+Zv8Jf1a3p1vkb/E3+Fn+bv6Pb1e3x9/kH/BL/kH+kK+squiq/xq/zm/xjd7R0bV2H302jf1RJPGg=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="300">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx7+U/e8SUQMwDBSzT2D6YFKOIwMWR1yGrc/7/HKYfLXBhdx6jghCwGs4cBDYDUIduF7B6QGIgPUoNsBzazsPkHpB+kF0bD2Kb/GJ37Gm84d95f7qLVE+LqKnXSlXGHgtutvY5uJh2Sbu5T7ro+iC5zFXAwcrVi8HeZ3zDN+ReDlnMwg4nzuj+bndQYeZyvMxaA3TTnv7sTCMPsg7kZ2Q3I4QDzM0wNslpkf8FoWLgg+xOZjStckeMQpAYWjiA+yO0wDFIDcj+yOuT0AXMDehzA7AbpBdHIaQUAAEz4TQ==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="12888_AVYLKPEDPFTWASGIK/3_y9" index="49" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="641.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVYLKPEDPFTWASGIK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1006.55" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFE7AEcwPEaoiEeb4gbouHxaIgkoqG/hoge0RANEUk0RDREw9EQ0RAN9aIhGiLec/+/hmiIuOGuG47jhuOG4yiiIRoi3fl9fstv+fr4Db+ncmeKhWS8O6VC8vesM5VC0tOdaiFZ704tdrteSJ46+Xwj+rQZfa4Vfb6te9a96t747/wP/if/K/pybxpdXxpdf+zcQBr+jzT8n2n4g9GnOd2Qbjh2z6/o139HXx7hj/LHdBO6Sf4Uf5o/w5/lz+nmdQu6Rf4Sf5m/wl91x5puQ7fJ3+Jv83f4u/w9XV63zz/gH/KP+Mf8E92p7px/wb/kX/Gv+Te6f7qUf8u/49/zH/iPuqKuxK/wq/wav85v6Jq6lq7Nf+G/8t/47+740H3qvvi9Wfh9Wfj9mb/K/FXmr3SDscu56MeHoj8bzvxV5q90I7pR/hh/gj/Jn+JP62Z0s/w5/h/+An+Rv6Rb1q3oVvlr/A3+Jn/LHdu6Hd0uf4+f5+/zD/iHuiPdMf+Ef8o/51/wL3VXumv+Df8/P+Xf8u9097oH3SO/yC/xK/yqO2q6uq7Bb/Jb/Db/JUu+AWgaNkM=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="312">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUa0OwmAM/DaBx2BB4hA8wb4KsAgc74BF8TO9YJHgZ3kBAjwBCWoKgyEBHoCNHXDksiVN26/XXntL3SM6BC2flt79vmfR/MdZsImYI6YtXN8Ti5g47cXM9Defb+TiGzwMfToDGOWj6X5VPu7ImdhrkY8/fuISz5mowSOv8gKrWqgGyq/7saaze/PY9u5ktfBijVlmvfhm12lit9felkFi7Xxg9aJrOzeyo2vYubj7Trj15FC9mVNzra3ytYcNw+x7a2mfuMRSB9UDWO6oGqjuvI159Z/xXu1VTak5uFRj7q0e9Tf1ueey</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="10360_TIAMESTDGLTR/2_y9" index="50" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="647.819" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIAMESTDGLTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1009.47" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="540">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E5nEAx/GIh4ZoiLgjGuKGODqiIX40REM0RDREw49oiIaIjmiIhoiGJw35/SUaIi4eGqIhntMQDfFwx0PDQ1zEM8Rzz+P7+izv5TV+4ri7RhL96K2ZRH29tZLod727f9pOotNqd50k6vG4kgY/mAY/nAb3JQ1uTL+lwX/np/gZfpab5xa5ZV3lY36D3+J3uD3uQI/4E/6MT/kL7or7pbf8PV/nn/gX7g/3qm/8B//J92fBD2TBDWXBjWTBjep4FvwEP8lP8xE3xy3oEr/Cr/Hr/Ca3ze3qPn/IH/NV/pwruEvuWmv8Hf/AP/LPXINraot/59t8h6/kfpX7lX7Ngx/L/Sr3K36Km+FmdZ5f5Jf5VT7mNrgt3eH3+AP+iD/hzrhUL/gr/oa/5e+5OvfEvehf/pV/4z/4T66/8CsdKoIfKYIfLfyq8CtukpvWiJ/jF/glfoVb49Z1k9/mf/L7/CF3zFX1nC/5S/6ar3F33AP3qM98g2/yLf6da3MdrZTBD5bBD5d+VfpVGf0H+9QmTg==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="396">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxtkjFLA0EQhfc2CIKgjdgE4RTSWIpgGbKbHKljZ6tgFVJaKQp2VuYPmCZgbxU7sQkprdNJwC5w2N7F+5Y82cKDYWb2zc6bN7e5TVum+jaKZWtcDtypHYWcL68wzjnDH5iuwxKbOrDYqMGI6UNdv3x0u6ulIx+bUfCc0etl9Rpq8jU/d8nFo15waT68ajQTPZ/N3NXtnp8X1oMHvrUW6dGMugtOb+XEyqU71k9fZt50zfbhx0Xncns/S8/Os7JxnD3MPjtv5rs9vJ145sB2ake+m1z5hj3x7OC93ArxorgP2I9JQ53mZz83yfRvZ3CSMxO8wjHwr1rPX989eTy9wf/TE2uINSuW1260f92R9vBfKw71E669xjzxe4gxDH16C2Dkv7H94+w=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3705_VPIVLDIFAER/2_y9" index="51" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="636.371" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VPIVLDIFAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1075.62" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEtHEcwPF6iYaXd3iJG+IdXl4aIomG6NEQUURDNES8nWiIhoiGoyGOG44b7t7jjeOG44Y4z/MQDRENPTVEQ0RDPENEQzRE3nv9P7/lt3x9/IZfsdifchz9X3kljq6zLFusxtFkf3q1OPrTaDQK9Tga6E+pqfura4WdtUM/2Ql9oxv6gZPQF3u6RHfKP+Of8y/4l/wr3Y3uln/Hv+c/8B/5T7pc98x/4b/y3/jv/A/dp24wCd1Q2NlwEvyvSfC/JcH/noQ7RnQF3WjYvR+hL/wMfelX6PMx/rhuQjfFn+bP8Gf5c/x53YJuSbfMX+Gv8tf46+7Y0P3WbfG3+Tv8Xf4ef193oCvxD/lH/DK/wq/qaro6v8k/5rf4bX5H19Wd6Hr8hH/KP+Ofu+NCd6m74t/wb/l3/Hv+g+5R98TP+c/8F/4r/033rvvgf/K/pMEfSv1V6q9Sf5X6K91I2Hkh9Iujqb9K/VXqr3RjunH+BH+KP82f4c/q5nTz/AX+En+Zv8Jf1a3p1vkb/E3+Fn+bv6Pb1e3x9/kH/BL/kH+kK+squiq/xq/zm/xjd7R0bV2H302jf1RJPGg=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="252">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJzb+Oe9o+q/+Y4MQPCQScERhEHsjVBxmBgIw/jIamF6keVgAGQGTA4Zo6uDAWQzYebCxJFpdLfiMgNZDYwNcxOyemz+RLavgUnB6fEfd+fjex1dKpSfuKj7+ri2r5juWsO31PXo9gmuYvsDXQ/W3XRZvaDP5Rtjj7PsP2NnkBkgfR/+b3a6xeDhBLIXxMdmH7ofYf6HuRWXu7DJoctj4yPrw6cW5k4YjRx2yGxkNcjuQFeL7kcYHwBpzqnW</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="10357_TIAMESTDGLTR/2_y10" index="52" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="647.819" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIAMESTDGLTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1080.51" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="540">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E5nEAx/GIh4ZoiLgjGuKGODqiIX40REM0RDREw49oiIaIjmiIhoiGJw35/SUaIi4eGqIhntMQDfFwx0PDQ1zEM8Rzz+P7+izv5TV+4ri7RhL96K2ZRH29tZLod727f9pOotNqd50k6vG4kgY/mAY/nAb3JQ1uTL+lwX/np/gZfpab5xa5ZV3lY36D3+J3uD3uQI/4E/6MT/kL7or7pbf8PV/nn/gX7g/3qm/8B//J92fBD2TBDWXBjWTBjep4FvwEP8lP8xE3xy3oEr/Cr/Hr/Ca3ze3qPn/IH/NV/pwruEvuWmv8Hf/AP/LPXINraot/59t8h6/kfpX7lX7Ngx/L/Sr3K36Km+FmdZ5f5Jf5VT7mNrgt3eH3+AP+iD/hzrhUL/gr/oa/5e+5OvfEvehf/pV/4z/4T66/8CsdKoIfKYIfLfyq8CtukpvWiJ/jF/glfoVb49Z1k9/mf/L7/CF3zFX1nC/5S/6ar3F33AP3qM98g2/yLf6da3MdrZTBD5bBD5d+VfpVGf0H+9QmTg==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="508">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUj1IQlEYfe/mZkOC1RLpUlAOBREIieX73tNchbZoaBCioLYoLNQhiqSWcgq0QGgRB4MokIIgcXMIGiIih9rCFofU9/Jc+CS6cDjf/f7v4VbVlHaizGsfoh54aLs0v8gGlM7BHSxUt/SDGZzDzHmoga/a6VlTBKVsiwReVsfp0Sxrh80X6X+27MR56A3wTOyCGM8B2M/5sIG/O/E+bLOfdwJzz7/M+Rz/3wvzLm0bchbeUY30GYNbnqD94jM4fD4a+rp2hrzWaTAfzhmrpWP9IF6jvJWhM5GjJ1uDtuNX9LabpZ97RffufFM6diNjaz13VDALNJZI0Ui8QfvWukTG7Jd6udUIVcwpyXutEA1YUannUtslNWUtAdQAQ8kkve7maFOkabrVJF/iSK+YPiPsmDGKJcVQ27M6tGfNPSKrofek8NOKLdqdCZ3Loi7j0Bk2NGDdGezjfrgDqHOaxe6f4ln4A3hbLXZLC613mjAd+ly7V/8FSnreVg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="12887_AVYLKPEDPFTWASGIK/3_y12" index="53" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="641.34" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVYLKPEDPFTWASGIK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1347.68" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFE7AEcwPEaoiEeb4gbouHxaIgkoqG/hoge0RANEUk0RDREw9EQ0RAN9aIhGiLec/+/hmiIuOGuG47jhuOG4yiiIRoi3fl9fstv+fr4Db+ncmeKhWS8O6VC8vesM5VC0tOdaiFZ704tdrteSJ46+Xwj+rQZfa4Vfb6te9a96t747/wP/if/K/pybxpdXxpdf+zcQBr+jzT8n2n4g9GnOd2Qbjh2z6/o139HXx7hj/LHdBO6Sf4Uf5o/w5/lz+nmdQu6Rf4Sf5m/wl91x5puQ7fJ3+Jv83f4u/w9XV63zz/gH/KP+Mf8E92p7px/wb/kX/Gv+Te6f7qUf8u/49/zH/iPuqKuxK/wq/wav85v6Jq6lq7Nf+G/8t/47+740H3qvvi9Wfh9Wfj9mb/K/FXmr3SDscu56MeHoj8bzvxV5q90I7pR/hh/gj/Jn+JP62Z0s/w5/h/+An+Rv6Rb1q3oVvlr/A3+Jn/LHdu6Hd0uf4+f5+/zD/iHuiPdMf+Ef8o/51/wL3VXumv+Df8/P+Xf8u9097oH3SO/yC/xK/yqO2q6uq7Bb/Jb/Db/JUu+AWgaNkM=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="176">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw7xLjAseLve0cGILBlUADTID6IjcxHloexkdUgA1ziyGag0/gAur2E7MIlRsgefPbjcwMyOAQMz0mMW5xu/q903sX0xpnTQcVF0oHBpe7fSueV/wOdVzB8cLrNwOQMUodsFrbwwBW2+NxJrBpk9x7CkgYImUOM/bjSC3p4AgCPSDpt</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="7627_VFHEVLSMDDAAEAISSK/2_b4" index="54" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="974.97" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VFHEVLSMDDAAEAISSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="513.249" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFEnWEYwPEsxkZ0MY4joouIRRRxLuK9iEMmYiO6iNghNiI2YrPoImIjujiJjdiIvu97FRvRRcTGmY2IjdjIuojYiC6ineP9PTePc87v/L0XT63WnLEstFZtIgtDrZnMQltrprPwtdGcx1lYrzfnCTfPLXCL9jL/ml/jN/hNbosr7I/8Pn/IN/gj7gf3yz7jL/hL/pq/lSd3J0+u0y7lyXfnyffmyd/nB7kKF+wqP84/5Kf4GW6Wm+Oe2S/4JX6FX+Xr3Fvuvb3N7/J7/AH/mfvGHdsn/Cl/zv/lr7ib9LncXqTvbxfJ3y3S7x1F+l9nkXr3uBLXlfar7uT/9CT/oDf5nb7ky/3cADfIDetX9Ef0g/6od1S5MW5cf0L/kf6k/pT+NDfD1fRn9Z/qz+nP6z/nFriX3KL+kv6y/or+G+9Y5da4uv6G/jv9Tf0P+lvcNhf1d/U/6e/p7+sfcIfcF/2G/nf9I/1j/Z/cCfebO9U/0z/Xv9D/5x2X3BV3rX+j3x7dVXRX0V1FdxXdVdo7peTLXdFdRXcV3RXXx/XrD+gP6Q/rV/RHuMCN6ldj+A9l8i1d</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="300">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwT/Tff8QmjgqMokOZl/gBnw3AQg4ITSBxEw/jIakGYAQkgi8HYIAxSD9KHrhZmD0geWQyZDbNz0l93pxf/851AcjA1okjuB/FBakF8EA3DMLfC7J35f7MTTB/ITFGmBU7I/oG5FTk8cPkJ2W6QWTB/gNwJcwvMj2A20K6+xvXObftEXI7N63MJd8h1EapPdZE+yOUi1bTA+eQ/RmeFf7edev69B7sL5mdks8BuRoobEBukBkaD5GF+h6lD5sPkQXqxmQVThy6OnE6Q4wc9fcDUI8ctjEbHIPUAdxvWWg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="7631_VFHEVLSMDDAAEAISSK/2_b5" index="55" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="974.97" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VFHEVLSMDDAAEAISSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="612.32" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFEnWEYwPEsxkZ0MY4joouIRRRxLuK9iEMmYiO6iNghNiI2YrPoImIjujiJjdiIvu97FRvRRcTGmY2IjdjIuojYiC6ineP9PTePc87v/L0XT63WnLEstFZtIgtDrZnMQltrprPwtdGcx1lYrzfnCTfPLXCL9jL/ml/jN/hNbosr7I/8Pn/IN/gj7gf3yz7jL/hL/pq/lSd3J0+u0y7lyXfnyffmyd/nB7kKF+wqP84/5Kf4GW6Wm+Oe2S/4JX6FX+Xr3Fvuvb3N7/J7/AH/mfvGHdsn/Cl/zv/lr7ib9LncXqTvbxfJ3y3S7x1F+l9nkXr3uBLXlfar7uT/9CT/oDf5nb7ky/3cADfIDetX9Ef0g/6od1S5MW5cf0L/kf6k/pT+NDfD1fRn9Z/qz+nP6z/nFriX3KL+kv6y/or+G+9Y5da4uv6G/jv9Tf0P+lvcNhf1d/U/6e/p7+sfcIfcF/2G/nf9I/1j/Z/cCfebO9U/0z/Xv9D/5x2X3BV3rX+j3x7dVXRX0V1FdxXdVdo7peTLXdFdRXcV3RXXx/XrD+gP6Q/rV/RHuMCN6ldj+A9l8i1d</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="292">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxtkrENwjAQRc8FBQUF1EhG7EERJxIrMAYTgESdHWAIKBEtFQUDUNFQ0dAmoBfx0cki0tf57p//fdsxM7u3sajDrrDvRw4s4w7NswD9NiZqQH1+rej1pKF9aFBHT3uVqx+I91pay4960NSMa1gmct8jbbhFqH84NvOk+ZqtmPvLz+o5799reb/MetmknJ561WMVq+F6VA02t3L/nnWAG4dz5/3SbtO/c0gXTveELtAseadHGqrla/Ty95Bf/w7y4f8RZlIXR86d4p19RDjq3hM5kfwD92sRsg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19473_TIEQAHALDATLEELGLR/2_y9" index="56" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="990.523" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIEQAHALDATLEELGLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1001.57" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEbQEYwPGIhnjD45FEQ0RD3OFw6XE5w+UOJRqiIaLh0hDxHtGQGiIaoiHO0xAN0RDpnCMaIhriPiLeIxoiiWiIhoi6+X7f8i1/P9/wNZvtGczTv632DMUeG87TpD3HlTz9k2VZb5KnHe1ZqebpV/4woqvpUl09dtaIvmM0+uY4fyL6ZFI3pZvmz/Bn+U3+HH9et6D7xV/kL/GX+av8Nd26boO/yd/ib/Mz/o5uV7fH3+cf8A/5R/xcd6I71Z3xz/kX/Et+yx1XumvdP/4N/5Z/x7/nP+qedM/8F/4r/43/zv/QdRbRdRXRdcfOvhXhfy/C/1GE3xN90qfr1w3EXhmM/mGo8Ff8Cj/RVXUj/Bo/5df5Df6oblw3wZ/kT/Gn+TP8WV1TN6eb5y/wf/MX+UvuWNat6tb46/wN/iZ/i7+ty3Q7/F3+Hn+ff8A/1B3pcv4J/5R/xj/nX+gudS3+Ff+a/59/w7/V3enudY/8J/4z/4X/6o433bvug99Zht9Vht9d+qvSX5X+StcTe6wv+uP+6HsHSn9V+ivdsK7CT/hV/k9+jZ/q6rpGmX4C6nc2BA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="404">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUb9LQlEUvueZW7PQkq+hqS0cw3rnXGixRRtdc0iC/oEsGgrCpUlo0BadmqTZcBD3Bqf+hAeFjZHPPvGDSxcO59c93znnO6nESfonTfec1KOvpOPaui2Xehe9KmL0kYPAbvwe64vESpt51ACLccSIDXHrBztd98UfYDEe5oABISb+4T9ixaynnAd9oTFrPRODPpUPHWZT7bpN23A1e5CSwT+IDu1q8alvsrOKQSOPupnk7Fz2DDWWFe1bCjZvte3H3Rp6DFzVMF/synYyyvv98Zm/v1b/dNT3nfjRV24u/CRq+m4573db77aVa6zq0I/8cd9wH3IPP+SA/IU8khvwxVrsyzuF9wjvCs2+9JkHFupCjP83Iu+8PWdlHwj3oaYwTyzW0V4CTz/Wmg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19475_TIEQAHALDATLEELGLR/2_y10" index="57" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="990.523" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIEQAHALDATLEELGLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1116.61" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEbQEYwPGIhnjD45FEQ0RD3OFw6XE5w+UOJRqiIaLh0hDxHtGQGiIaoiHO0xAN0RDpnCMaIhriPiLeIxoiiWiIhoi6+X7f8i1/P9/wNZvtGczTv632DMUeG87TpD3HlTz9k2VZb5KnHe1ZqebpV/4woqvpUl09dtaIvmM0+uY4fyL6ZFI3pZvmz/Bn+U3+HH9et6D7xV/kL/GX+av8Nd26boO/yd/ib/Mz/o5uV7fH3+cf8A/5R/xcd6I71Z3xz/kX/Et+yx1XumvdP/4N/5Z/x7/nP+qedM/8F/4r/43/zv/QdRbRdRXRdcfOvhXhfy/C/1GE3xN90qfr1w3EXhmM/mGo8Ff8Cj/RVXUj/Bo/5df5Df6oblw3wZ/kT/Gn+TP8WV1TN6eb5y/wf/MX+UvuWNat6tb46/wN/iZ/i7+ty3Q7/F3+Hn+ff8A/1B3pcv4J/5R/xj/nX+gudS3+Ff+a/59/w7/V3enudY/8J/4z/4X/6o433bvug99Zht9Vht9d+qvSX5X+StcTe6wv+uP+6HsHSn9V+ivdsK7CT/hV/k9+jZ/q6rpGmX4C6nc2BA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="328">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUTsKwkAQncQr2CdgJX6wtFLcXQiWYukhvIGFnWBvaew8gK2KraWFlSlyANEDSFZf8MGQhWVmZ9+8eTMjInItotGt2JY38omBRSz7zM3ev8r4DybwReF1HuPMa0tsYBkDBm8jh5JTx4GV/+EffHLzrevBh1bgYcFBLurBwRuXfcCnRvZLvcdgbdg/NQHLXNiepGYjDxP61OanhusMWm51TlzXz9yzGLvdpe+Gy9xmi9TefdNOJbScG3lZh7qqNXSf+nIfen6ITYK4rIN69drbaBw5uQs9K82jsZwBNVMP8XqenAlyuI9qrt4pMNwz/79XuTqC</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="7629_VFHEVLSMDDAAEAISSK/2_y12" index="58" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="974.97" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VFHEVLSMDDAAEAISSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1224.55" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFEnWEYwPEsxkZ0MY4joouIRRRxLuK9iEMmYiO6iNghNiI2YrPoImIjujiJjdiIvu97FRvRRcTGmY2IjdjIuojYiC6ineP9PTePc87v/L0XT63WnLEstFZtIgtDrZnMQltrprPwtdGcx1lYrzfnCTfPLXCL9jL/ml/jN/hNbosr7I/8Pn/IN/gj7gf3yz7jL/hL/pq/lSd3J0+u0y7lyXfnyffmyd/nB7kKF+wqP84/5Kf4GW6Wm+Oe2S/4JX6FX+Xr3Fvuvb3N7/J7/AH/mfvGHdsn/Cl/zv/lr7ib9LncXqTvbxfJ3y3S7x1F+l9nkXr3uBLXlfar7uT/9CT/oDf5nb7ky/3cADfIDetX9Ef0g/6od1S5MW5cf0L/kf6k/pT+NDfD1fRn9Z/qz+nP6z/nFriX3KL+kv6y/or+G+9Y5da4uv6G/jv9Tf0P+lvcNhf1d/U/6e/p7+sfcIfcF/2G/nf9I/1j/Z/cCfebO9U/0z/Xv9D/5x2X3BV3rX+j3x7dVXRX0V1FdxXdVdo7peTLXdFdRXcV3RXXx/XrD+gP6Q/rV/RHuMCN6ldj+A9l8i1d</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="272">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx7yKDg+BCKGfAAZHkYeyvDArhebGagiyGrB7FBYhv+vkcxC0R/+t/tBKLnMnk4ZTF9cPrHsMBJl/GEU8o/eTgGyYNomF58bofZA1OHbDfMTmS3YTMT3Z/YwgtdDzIfpufr33yn3L/Rzrcb1jubHLJ1Yf4v5iLG+M1Z75+78x4GHmeQP0H+h4UByI8gPSA2zA+gcAGxYRhkLrJfQHqQwxnmDhgfFubY4gVmBzIN0wsTwxUOyGEHcjPIDxyMW5yQ4xamBpkGAOXUuLU=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19472_TIEQAHALDATLEELGLR/2_y11" index="59" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="990.523" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIEQAHALDATLEELGLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1229.7" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEbQEYwPGIhnjD45FEQ0RD3OFw6XE5w+UOJRqiIaLh0hDxHtGQGiIaoiHO0xAN0RDpnCMaIhriPiLeIxoiiWiIhoi6+X7f8i1/P9/wNZvtGczTv632DMUeG87TpD3HlTz9k2VZb5KnHe1ZqebpV/4woqvpUl09dtaIvmM0+uY4fyL6ZFI3pZvmz/Bn+U3+HH9et6D7xV/kL/GX+av8Nd26boO/yd/ib/Mz/o5uV7fH3+cf8A/5R/xcd6I71Z3xz/kX/Et+yx1XumvdP/4N/5Z/x7/nP+qedM/8F/4r/43/zv/QdRbRdRXRdcfOvhXhfy/C/1GE3xN90qfr1w3EXhmM/mGo8Ff8Cj/RVXUj/Bo/5df5Df6oblw3wZ/kT/Gn+TP8WV1TN6eb5y/wf/MX+UvuWNat6tb46/wN/iZ/i7+ty3Q7/F3+Hn+ff8A/1B3pcv4J/5R/xj/nX+gudS3+Ff+a/59/w7/V3enudY/8J/4z/4X/6o433bvug99Zht9Vht9d+qvSX5X+StcTe6wv+uP+6HsHSn9V+ivdsK7CT/hV/k9+jZ/q6rpGmX4C6nc2BA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="444">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkrtKxFAQhienEUEbCwtRXDsRUom9ORMvhZWdWPgKAcXCIrsbxMILdopWa7GNnZBGwcZGLOK+gIqF1voCJu4XmGUDw/xzOf8/c04KaURn0omKvp+unv2y5J64+/cTteTUX5ZrPgwaehRM6nu5qHHw5qlhW+XsANOHl/5nMTxmxZCO9RCDh+voL7lfj1YvzXRXFnSnnWtWXde237yoc9iVOO26dQ1donfuQMfLbe017/VFMg3lVZPqROfLvI6ps8OjbA52oZ/d2Hs1GFN0icHw0su+39LxlkNzVB70SwodSTfim4/jeKV1GLc/z2s/9bQXi5uImXkmva05OIMmHHj0yM25xHPHGNzk0SMPxrhHcty1vQ8Yg486eWaExzipg+2dOEcPxhnDcBuHzWJcdo462P4HOE3TdIyXO7S5DTOn7YTHTJd3/wc/3/ge</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19471_TIEQAHALDATLEELGLR/2_y12" index="60" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="990.523" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIEQAHALDATLEELGLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1300.72" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEbQEYwPGIhnjD45FEQ0RD3OFw6XE5w+UOJRqiIaLh0hDxHtGQGiIaoiHO0xAN0RDpnCMaIhriPiLeIxoiiWiIhoi6+X7f8i1/P9/wNZvtGczTv632DMUeG87TpD3HlTz9k2VZb5KnHe1ZqebpV/4woqvpUl09dtaIvmM0+uY4fyL6ZFI3pZvmz/Bn+U3+HH9et6D7xV/kL/GX+av8Nd26boO/yd/ib/Mz/o5uV7fH3+cf8A/5R/xcd6I71Z3xz/kX/Et+yx1XumvdP/4N/5Z/x7/nP+qedM/8F/4r/43/zv/QdRbRdRXRdcfOvhXhfy/C/1GE3xN90qfr1w3EXhmM/mGo8Ff8Cj/RVXUj/Bo/5df5Df6oblw3wZ/kT/Gn+TP8WV1TN6eb5y/wf/MX+UvuWNat6tb46/wN/iZ/i7+ty3Q7/F3+Hn+ff8A/1B3pcv4J/5R/xj/nX+gudS3+Ff+a/59/w7/V3enudY/8J/4z/4X/6o433bvug99Zht9Vht9d+qvSX5X+StcTe6wv+uP+6HsHSn9V+ivdsK7CT/hV/k9+jZ/q6rpGmX4C6nc2BA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="312">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYPzgyIAE9jIoQPhQcRB/5r/5jksYCpyW/ZN3mveP0ZmT6YMT639N5wv/5MH4CyOPsx5zgbMlgwmYBsmB1IH08P7rdgKZBTIDZBbMPLD5UHEGLADmDpg8jI9sBogGuQnGRlaLrB5ZDF0/Mo3OVvzn7gTCyOIg+yb/m+VcaS/jwmaX62Ka2OEyR+6KS7rCQZfr/1tdHjq0u+Q0+LicrF/qzMXQBA4bWNiB/AujYWYihwNGGMHcD40LFD1IfHQMC0PksEUOT+Qwg5mHHjcwcfRwQrYD2Y0o8YjkH/S4QY8TEA0AHnTQyQ==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="7632_VFHEVLSMDDAAEAISSK/2_y13" index="61" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="974.97" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VFHEVLSMDDAAEAISSK"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1337.64" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFEnWEYwPEsxkZ0MY4joouIRRRxLuK9iEMmYiO6iNghNiI2YrPoImIjujiJjdiIvu97FRvRRcTGmY2IjdjIuojYiC6ineP9PTePc87v/L0XT63WnLEstFZtIgtDrZnMQltrprPwtdGcx1lYrzfnCTfPLXCL9jL/ml/jN/hNbosr7I/8Pn/IN/gj7gf3yz7jL/hL/pq/lSd3J0+u0y7lyXfnyffmyd/nB7kKF+wqP84/5Kf4GW6Wm+Oe2S/4JX6FX+Xr3Fvuvb3N7/J7/AH/mfvGHdsn/Cl/zv/lr7ib9LncXqTvbxfJ3y3S7x1F+l9nkXr3uBLXlfar7uT/9CT/oDf5nb7ky/3cADfIDetX9Ef0g/6od1S5MW5cf0L/kf6k/pT+NDfD1fRn9Z/qz+nP6z/nFriX3KL+kv6y/or+G+9Y5da4uv6G/jv9Tf0P+lvcNhf1d/U/6e/p7+sfcIfcF/2G/nf9I/1j/Z/cCfebO9U/0z/Xv9D/5x2X3BV3rX+j3x7dVXRX0V1FdxXdVdo7peTLXdFdRXcV3RXXx/XrD+gP6Q/rV/RHuMCN6ldj+A9l8i1d</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="280">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx1UTsKAkEMnSnF0gNos9cQnLHwNArbWWkjWIhn2BOIhTewcI8g2K/T6QXWuG/gQQxr4JFJJp/3SPKTWepQuCp7wnV2llf2MOZoqO/7Qx59QFKzda/eAf+UceA+xpzR+EVAXLsqYA7Aertb62COMzUHy11z6dNpZ9oa8KFuvoGdP2Qd8NQFPXt5hNGmjidp4loG87S9xrefxmN7y1rvn2FEHcA+cuBN4DU31lktOtZ5csFOoPSXDHBdtqufe1Ab3//28mb8tz32PrzlF53hxwE=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="19476_TIEQAHALDATLEELGLR/2_y13" index="62" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="990.523" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="TIEQAHALDATLEELGLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1437.79" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFEbQEYwPGIhnjD45FEQ0RD3OFw6XE5w+UOJRqiIaLh0hDxHtGQGiIaoiHO0xAN0RDpnCMaIhriPiLeIxoiiWiIhoi6+X7f8i1/P9/wNZvtGczTv632DMUeG87TpD3HlTz9k2VZb5KnHe1ZqebpV/4woqvpUl09dtaIvmM0+uY4fyL6ZFI3pZvmz/Bn+U3+HH9et6D7xV/kL/GX+av8Nd26boO/yd/ib/Mz/o5uV7fH3+cf8A/5R/xcd6I71Z3xz/kX/Et+yx1XumvdP/4N/5Z/x7/nP+qedM/8F/4r/43/zv/QdRbRdRXRdcfOvhXhfy/C/1GE3xN90qfr1w3EXhmM/mGo8Ff8Cj/RVXUj/Bo/5df5Df6oblw3wZ/kT/Gn+TP8WV1TN6eb5y/wf/MX+UvuWNat6tb46/wN/iZ/i7+ty3Q7/F3+Hn+ff8A/1B3pcv4J/5R/xj/nX+gudS3+Ff+a/59/w7/V3enudY/8J/4z/4X/6o433bvug99Zht9Vht9d+qvSX5X+StcTe6wv+uP+6HsHSn9V+ivdsK7CT/hV/k9+jZ/q6rpGmX4C6nc2BA==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="280">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJyTY1jg6Meo4CgHpEGYAQiQaZAcjG33390JxobJvf3zHoVGxzCzQACkBkQjy8HMRxaHiaHTIP0wd8DsQ5aHqUE2B6YH2R/IZiH7E0aD8LV/8mA7HP7lO4HYIBqmR4RpgdMWhgXOyxxFXB7W+rhcr01wabONc2mtM3URZ5RxKag/7HyjocdZ/98EZ5AeEAa5GWQGzO0ws2Bs5DDAFhbobkSmGZAAup+QwwbdDmx8WJghuwHkf+Q4g4UNjI3sRmzugsWJL0MPOAxg6mBmAADdOKjm</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="40272_SYVTEEELAAER/2_y4" index="63" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="698.833" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SYVTEEELAAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="446.237" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="520">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9ExHEAxuEjimiIhoiGaDiiOG6I4xdHw9EQ0RA3xFFEQzRENERDRBEXEfX71xANEQ3RENERDdEQ0RANEQ3RUOf7vMtneca3df+/zjg6aP6vJ44a7fXpQByV2huKo0J7xThqtf0oX+YqXFVr/DQ/y9f5BrfEregav8Fv8Tv8PnfIHespf85f8tf8LXfPPeoz/8q/85/8N/fLdSTBdWtvEnx/EvxgEvxwEvwIV+LGdYKf5Kf4GX6Om+cWdJlf5df5TX6b2+WaesSn/Bl/wV9xN9wd96BP/Av/xn/wX9wPV0hDu9Lge9Lg+1K/Sv2KK3KjWuYrfJWv8dPcLFfXBr/Er/Br/Aa3xe3oPn/In/Cn/Dl3yV1zt9riH/ln/pV/5z65b/3lO7LguzO/yvwq86vMr3SEL/Hj/AQ/yU1xM9yczvOL/DK/yq9zm9y27vFN/ohP+TPugrvSG/6Of+Cf+BfujfvQL/6HL+R+lftV7le5X+lQHnyRH+PLfIWrcrU8+gNk6iDC</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="420">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNka1LBFEUxd8bi8IaNohtXaNG0Sgy7+6CGDe5wWwSzcIqBpPBjyy6SQy2tYkYLYLR4AdrM8n4B8yM+3tyZAYu9+Ode+49d+q+mb4UR2HCrYZuMQiNciasjWWp/G1xmdZHGOyz3I41N/rwepfBA4Ze+OiBE3srHwMY6mCIwWHK4SOmj1gc4hevYuZNun64yufs3nXsO8lijVkYsWrih0+8ynmXHmlnD7iH+31LHmZb17271nCr1r5YbrQXikErcR9245fsyyf27Gv27pvRjv200cd83RMu7V2ds5m//t9TdwNDX/VWeHBoYQZ6d92KnRycW1bu2Lo7i/4w37CnfCruoVvq34pDtwH3U8zH/ZlHPp4s/vXmHevtnUZd7AgHXrrgIaaPOvuAJQeLoQUMOrSH4uqd8b9xKRxy</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="31344_AVDNVNNIIAEAIIGYDVR/3_y4" index="64" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="687.032" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVDNVNNIIAEAIIGYDVR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="552.278" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFE7AEcwPFEQzze8Igi3iPe8GgoccNxx3Ec77jhOIpo6DRENERDHA3REA1RryEaIhrihv/94z2iIbpENERDxA3REA0ReXd+n9/yW74+fsPvut2dTJKf7E02yf/Z604uyff1ppDk670pxu6Ukvx1N/9djr5ZiX64Gn2jppvWzcZuz/Hn+Qv8Rf6Sblm3wl/lr/Eb/HX+hm5Tt8Xf5u/wd/n7/APdoe5Id8w/4Z/ym/zEHWe6v7pz/gX/kn/Fv+Hf6u509/wH/iP/id/hP+tedK/8N/47/4P/ye9vRTfQim4wduNLK/yvrfC/tcIfin54RDeq+64bi93+Gf3kL/44fyL6+pQuo8vyc/wCv8gv8cu6iq7Kr/Fn+LP8Of68bkG3yF/iL/NX+Kv8NV1Dt67b4G/yt/jb/B137Or2dQf8Q/4R/5h/wj/VNXUJ/4z/j3/Ov+Bf6q50N/xb/h3/nv/Af9Q96Tq6Z/4L/5X/xn93x4fuU9efhj+Qhj+Y+qvUX6X+SjekG4m9Nxp934/o62Opv0r9lW5cN8Gf4mf4WX6OX9AVdSVdmV/hV/k1/kya/w8OsDal</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="720">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw1Tl1IFFEUnpndJcWQiMUg0CSWflxll8Swh91wzrkjEmRKmKEiPWQ9CIpEZjgyO1tUSKUSQVo5EMtSikUFgpKyrUThRojQS/bjFinCpgZNDzozdS748HHOPd/P/cqsT3KXYMinhLfyU3uV73eEQmgRJKD51amEBaEIAlYD6E4N1Ns5MCrlQdl/37hVCuSRxJfcT56HTi+fxJNu1qmUaSdedrfz/IRQyLHFUcZPyaggDd0og3jS0pt8lLnphGFVquJ9SEsgLWmoA+mI28okEEedB511qHZOsxZ/s9LXGlfMY3HFd+OeEszqVXbMnFHcGVQum17l7vdfrPTIGza2OMj87wfYF/Uiq207zuaagHWtBVir6mPJ/J0sfSiP/WhcwsnhdcyZ+oPN+T6WHRBYeGw7q2lM4WYyhVXRSZz7puHedASDYj/GX2m4pt7EEv0WPt9ow2KrAesT5/g+GjmLGd2H+7AONVc1zgqHMZwIYnk0iCesAuyc2oX3K/bgSduLByIuXA4dxAJxN17Qp6FJy8A2OwaXxA/wwprn+7w4AqmNNISkCciVzkNMN8Blz4Db9QyK7CF4ZPVDbvQJrOifwdRjHHQn72P1Hdd22h5c0EK4/+h1rB2+giWvr+K43MERMgYwajzA34u38aNUjtccP+9WHPFgn20C9cqoE/w/o8eL2d1/Ictagm63BclpD9b1DIGpjfCe/wATrRpt</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="31339_AVDNVNNIIAEAIIGYDVR/3_y5" index="65" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="687.032" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVDNVNNIIAEAIIGYDVR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="609.3" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFE7AEcwPFEQzze8Igi3iPe8GgoccNxx3Ec77jhOIpo6DRENERDHA3REA1RryEaIhrihv/94z2iIbpENERDxA3REA0ReXd+n9/yW74+fsPvut2dTJKf7E02yf/Z604uyff1ppDk670pxu6Ukvx1N/9djr5ZiX64Gn2jppvWzcZuz/Hn+Qv8Rf6Sblm3wl/lr/Eb/HX+hm5Tt8Xf5u/wd/n7/APdoe5Id8w/4Z/ym/zEHWe6v7pz/gX/kn/Fv+Hf6u509/wH/iP/id/hP+tedK/8N/47/4P/ye9vRTfQim4wduNLK/yvrfC/tcIfin54RDeq+64bi93+Gf3kL/44fyL6+pQuo8vyc/wCv8gv8cu6iq7Kr/Fn+LP8Of68bkG3yF/iL/NX+Kv8NV1Dt67b4G/yt/jb/B137Or2dQf8Q/4R/5h/wj/VNXUJ/4z/j3/Ov+Bf6q50N/xb/h3/nv/Af9Q96Tq6Z/4L/5X/xn93x4fuU9efhj+Qhj+Y+qvUX6X+SjekG4m9Nxp934/o62Opv0r9lW5cN8Gf4mf4WX6OX9AVdSVdmV/hV/k1/kya/w8OsDal</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="840">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwdjmtI02EYxXcLpkMlS/tQsmYiLW9lgYWkyPM+75+iD14wqGmFWChIrQtGbXNuCOEFU8luKOpkLI1IzUtG22ptpnjZcjQtUpSyZqShEma7/GP7cDhfzvmdw636BU2aUdDw56FIuw6R7Bicz+CQhz4WzirXYNkzC4aqFfArfgQzi/5tJEEbSvZXWWGnwAxW5Sz84XYEO/G8O7Dlz4A0721wCuRBxQtK4CanAHi+NniuvA/uyn5gvZPwzcghD9RjcNLvDDJyVa8gV6uFACPgy345hGm7gbD64E7gQ7EvjaRWhBH9vxVY5bvhiboFSn3dQNXtwd+B/LGKAahR2GGdaw8yo3k98LJyFxk6dRAV965SR3YDc2PQxsjMNkaXZ2X03C7G8LuGmb6uYQ5bTjDNc0lMistLa2/NUdWmja6WNFOxu4E2bSjo5+JSOmjJoeXVMrqvldCNzBQaLouivToBtY9E0cSsGOr+LqT9op8oLuTSD76vmHFpCesKZvBQyzhq9Sb89G4Ua5qH0SDtRHG+DiuvPcLCzVaMMzaiKqsOTQsazJKdRh7Jx2qzAnNfZKPhQhJOXT6DH/fIcWkasPP1Oey9koClzxLRwQvBI5ki1BTMEK9pikyotsiS2kYWOW5SXhiL9X4+Wr64yQE5H3dbJ0mf2kLeSoxkjR0hTR4XiegYIHZjD3Gx48ShcpGJNzuwrPUvOb7XTYryktHpuYhxonocWR3Hx0ozpr6/i0eX23F43oEiqROLo4cwsrEW1xZyUNInRY8vHbtSRbgRKcSnkxEYJQ7DsnAJWtokyOq2ozA8BkXaWPSbhBiaHILpFpb8B8y7KB4=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="40270_SYVTEEELAAER/2_y7" index="66" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="698.833" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SYVTEEELAAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="817.403" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="520">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9ExHEAxuEjimiIhoiGaDiiOG6I4xdHw9EQ0RA3xFFEQzRENERDRBEXEfX71xANEQ3RENERDdEQ0RANEQ3RUOf7vMtneca3df+/zjg6aP6vJ44a7fXpQByV2huKo0J7xThqtf0oX+YqXFVr/DQ/y9f5BrfEregav8Fv8Tv8PnfIHespf85f8tf8LXfPPeoz/8q/85/8N/fLdSTBdWtvEnx/EvxgEvxwEvwIV+LGdYKf5Kf4GX6Om+cWdJlf5df5TX6b2+WaesSn/Bl/wV9xN9wd96BP/Av/xn/wX9wPV0hDu9Lge9Lg+1K/Sv2KK3KjWuYrfJWv8dPcLFfXBr/Er/Br/Aa3xe3oPn/In/Cn/Dl3yV1zt9riH/ln/pV/5z65b/3lO7LguzO/yvwq86vMr3SEL/Hj/AQ/yU1xM9yczvOL/DK/yq9zm9y27vFN/ohP+TPugrvSG/6Of+Cf+BfujfvQL/6HL+R+lftV7le5X+lQHnyRH+PLfIWrcrU8+gNk6iDC</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="400">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxVkT9LA0EQxe8S0qVOFYiQyi6CnUmxfw60SGGrNuIHsLKJGCSNoJ0fwAS0sUghSWtALGz8BhaCjaVWNnFvze/gwbnwmNmdNzNvZzqhZXaq23Yrndif8Ga7ScM1K2uWN5N8W/ndODadFRfI5534a/gytd/jf77u4/yqeMMH5HEHxKgBxNMbFqBLdY5iw12GuVsO9/38cdf3F31/cPbuztNNp57kUoc8bC+8WMWkGXDnH3CwyeooFx/7mc/sran5u3jj76cb2fPsNDu5uM72Ru3sIT30lbjunmLL5Um9sMzuIx8UFqBBKM9HM9U86A+kC77mpBhgBqqjGuVZik8ucbjoYo/ShGa4xFVXfO2Z/uXa5f1Jt/ppP+Spp2avPepv+r/6KO8Pjw4D7A==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="31342_AVDNVNNIIAEAIIGYDVR/3_y7" index="67" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="687.032" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVDNVNNIIAEAIIGYDVR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="835.47" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFE7AEcwPFEQzze8Igi3iPe8GgoccNxx3Ec77jhOIpo6DRENERDHA3REA1RryEaIhrihv/94z2iIbpENERDxA3REA0ReXd+n9/yW74+fsPvut2dTJKf7E02yf/Z604uyff1ppDk670pxu6Ukvx1N/9djr5ZiX64Gn2jppvWzcZuz/Hn+Qv8Rf6Sblm3wl/lr/Eb/HX+hm5Tt8Xf5u/wd/n7/APdoe5Id8w/4Z/ym/zEHWe6v7pz/gX/kn/Fv+Hf6u509/wH/iP/id/hP+tedK/8N/47/4P/ye9vRTfQim4wduNLK/yvrfC/tcIfin54RDeq+64bi93+Gf3kL/44fyL6+pQuo8vyc/wCv8gv8cu6iq7Kr/Fn+LP8Of68bkG3yF/iL/NX+Kv8NV1Dt67b4G/yt/jb/B137Or2dQf8Q/4R/5h/wj/VNXUJ/4z/j3/Ov+Bf6q50N/xb/h3/nv/Af9Q96Tq6Z/4L/5X/xn93x4fuU9efhj+Qhj+Y+qvUX6X+SjekG4m9Nxp934/o62Opv0r9lW5cN8Gf4mf4WX6OX9AVdSVdmV/hV/k1/kya/w8OsDal</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="728">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw1Tl1oUnEUv1cfysQ9xDaMNH0IYfRFrmgR5ub5/e8K+qBRRMFMjFLpa0VRbOl1EkRlq4fmGo6WBnswCLYcfbfaCkaxBctYUEEbwQwWFAwJ1Hvrf8GHwzm/c34fJ60YKa/76vGX+z1TYlarKv24h++8ut8en3pNu+WUGuJ4pyoS5zSpNk3HcUJppv3iBg2n//vxXYXP9fvKddqtWz3lqWgqmHtXOs/lfO5fyTWWbZqGF8/hHO7LZ945l/N4rl1s1bIrP50UThPPrhfj1PXcDZMuxCyPr0oL09+kwYlZyWzNSedKWWmFeEMaYeelvoAkPdpVJf29uMDq3GMs7n3COm52sROrL7B6vY99cm5mxuMtbFN1gHUMuZh1nZ0V2mqZ7rvIMk4zM/hr2JuWWnbUm8d46xe0uydxIJ3BGfso7nkeYKjxIWK+AVA4hdDMLQz3DUCydmO93IMxWwIFJQBqDMIh7oVT14C5sAvXm5qxUnFiq7oRh5VVMEYcSHcGYVG344i6CMnRauwJm3AsvBjuzl90Vp6ghJChn6U/NCw8pbboJN2W52hKnqe16jSlivNkjoxQvtRPa+QkPZMFRMNxKoTv0jYhRrlYRtvx+vBCQMjVoP0WLPfira8Hy+5cQvpQEu/Kg/jof4nlkSsQt7Rjh7gbhtcO3JeXwF8sUErU433xs5Z3UDChV52hy1ELfshZzf9VbCkM8izpBCP+ARzhGNk=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="31343_AVDNVNNIIAEAIIGYDVR/3_b8" index="68" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="687.032" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AVDNVNNIIAEAIIGYDVR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="840.42" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="584">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0jFE7AEcwPFEQzze8Igi3iPe8GgoccNxx3Ec77jhOIpo6DRENERDHA3REA1RryEaIhrihv/94z2iIbpENERDxA3REA0ReXd+n9/yW74+fsPvut2dTJKf7E02yf/Z604uyff1ppDk670pxu6Ukvx1N/9djr5ZiX64Gn2jppvWzcZuz/Hn+Qv8Rf6Sblm3wl/lr/Eb/HX+hm5Tt8Xf5u/wd/n7/APdoe5Id8w/4Z/ym/zEHWe6v7pz/gX/kn/Fv+Hf6u509/wH/iP/id/hP+tedK/8N/47/4P/ye9vRTfQim4wduNLK/yvrfC/tcIfin54RDeq+64bi93+Gf3kL/44fyL6+pQuo8vyc/wCv8gv8cu6iq7Kr/Fn+LP8Of68bkG3yF/iL/NX+Kv8NV1Dt67b4G/yt/jb/B137Or2dQf8Q/4R/5h/wj/VNXUJ/4z/j3/Ov+Bf6q50N/xb/h3/nv/Af9Q96Tq6Z/4L/5X/xn93x4fuU9efhj+Qhj+Y+qvUX6X+SjekG4m9Nxp934/o62Opv0r9lW5cN8Gf4mf4WX6OX9AVdSVdmV/hV/k1/kya/w8OsDal</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="684">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw1UU1IFGEY3plFKlT69QfcTOginso9uLKlzrzvNyWFZddk3SAj2GL1EObBWdswIS1ci41YcoPazIg6VGQErhbiBrEHgygKKwkMItouHmpnpp6P5vDyft/z+w0TstJ6qdqrR7379T6lTg/9u69YCn2zHunN3hY6oBb0NeUIFR0/VamVtNtTRuChPWmnNZzheWqN6tBigLk6bHjRAe6tp06DHn04w+f2ozP0/z3AXQ7YHk9O+rExwNyBD7qI/VNz34U7cOQiZ0c8Q1q+SdwZ7zJuHH5iTP+eMj6VTxrK0nUjpXYYl2vajZqxWmPrzlUx35UX287OiMfNIyITHhSHEhHxsaxe3L3P4lS6QVS1BcWuznLxvm2TuDpZIUqPVYrz0XUiUqgWax0+0bj8nHP6C772+RbHtye4PTQhpzd8ibtfDvDS3EU+bffwl+BRfjDYyVMt/fx6PsAfYns54fHzldkS7rZa+cxQgJu09bxZq+Bgq48XrRKpSWbr+XjRoWFHZcP7g3znVgjft8F8RtXmTdLjY5SyRumdk6Yh5Q19jf2ig8UozTjTNGxOUNhM0oKSoqw1Lvf32EMKxFP06s8A+c0sNdgZ6ndyUodMcPAjExg6oAXeaM/KnGX7gsT7rBOSw3/fYu+j2tg9WrV7KG+OSD+6oC04t2XWRjVJfwEYIBg+</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="40271_SYVTEEELAAER/2_y8" index="69" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="698.833" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SYVTEEELAAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="946.442" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="520">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9ExHEAxuEjimiIhoiGaDiiOG6I4xdHw9EQ0RA3xFFEQzRENERDRBEXEfX71xANEQ3RENERDdEQ0RANEQ3RUOf7vMtneca3df+/zjg6aP6vJ44a7fXpQByV2huKo0J7xThqtf0oX+YqXFVr/DQ/y9f5BrfEregav8Fv8Tv8PnfIHespf85f8tf8LXfPPeoz/8q/85/8N/fLdSTBdWtvEnx/EvxgEvxwEvwIV+LGdYKf5Kf4GX6Om+cWdJlf5df5TX6b2+WaesSn/Bl/wV9xN9wd96BP/Av/xn/wX9wPV0hDu9Lge9Lg+1K/Sv2KK3KjWuYrfJWv8dPcLFfXBr/Er/Br/Aa3xe3oPn/In/Cn/Dl3yV1zt9riH/ln/pV/5z65b/3lO7LguzO/yvwq86vMr3SEL/Hj/AQ/yU1xM9yczvOL/DK/yq9zm9y27vFN/ohP+TPugrvSG/6Of+Cf+BfujfvQL/6HL+R+lftV7le5X+lQHnyRH+PLfIWrcrU8+gNk6iDC</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="448">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUj1LA0EQ3Y0IFlqJhRZeIGhvY6dHdu7ghFj4A1KqkEaxFI4TLSwSBBEsEiFnyhTaqI2ipa32ViKIiGhjIXh7+hYfHB4MM/vm472dvc73e7XzZ9e5Z+Bn7ZpRv19Xlasw4ns6MqwlfqLPDPAF9WAm8jH5inelsfMsn74KVgbepL41GNypSxnNWzKn553Vs2VZVZFMJalU9LG8xKfyatsyrbflwA5LTfXMUz4imA2ucds0M7mWo+RQHu2mRKV91w/OtvXkXH+4POo3SqnDqMvLbp3HfeKsW4VBO2PeBRzFPHmbSUv6V41gKJ0M+/5iWKush737cnhx4wdBtuQ0oA688NwfMXBDK2LgmM89wmOHwBFDM3cNQw81ooZnzMb5/1vwDVEDXfCYybshxz2ghzOKnNCBHD3nUQdreGYvd8p/hnxFrFhXnPsD2CMnMA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="27233_LVLTSDDILDLR/2_y8" index="70" defaultArrayLength="162">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="686.888" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="LVLTSDDILDLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="946.487" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEpAEUwPERsYdlD0u0RIdlDxEZ0SH6dIjY6BDRITo0osPQYRhahjkMw8Ywh9oOER2iQ+b77BIdokP0bYfoENEh5hAdIjpEdtb7vcu7/P28wysWe1PuJL92erMRe7DSSQq9qVU7Sak33c1O8jfP8++1TvI/T+u6hq6p+xm71Io+b0df3ObvRl/Y0+3rDviH/CP+MT/l/9ad6E75Z/xz/gX/kn+lu9bd8G/5d/x7/gO/q3vUPfGf+S/8V/4b/13Xl0bXH7v7IQ3/Yxr+pzT8z2n4A7pB3ZBuOHbxa/Q736IvjPBHo8/HdOO6Cf4kf4o/zZ/hz+rmdPP8Bf4if4m/zF/RrerW+Ov8Mn+DX+FXdZu6mq7Ob/Cb/C1+yx1t3bZul7/H3+cf8A/5R7pjXcr/wz/hn/LP+Oe6C90l/4p/zb/h3/LvdPe6B36X/8h/4j/zX3SvujfdO78vC78/81eZv8r8VeavdAOxC1+iLw1Fnw9n/irzV7oR3Sh/jD/On+BP8qd007oZ/ix/jj/PX+Av6pZ0y/wV/ip/jb/OL+s2dBVdlf+DX+PX+Q13NHVbuha/nSX/AAeWMOk=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="424">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkr1KA1EQhfdesYnEzlJMKRGsRCGF4p2sCjaLhU20FFsRbFVErPIGImrjCwhWFqIWlvb+gA8gphR1s+a7cJZdGOb3zpw5s5nvhmwgeXEenL9YxL7zjbCXf0UbjY9kldrVYjl8JjvxDTl8bHLEiWGjL/Prsg+a/H0xYbv5mFEz57wh2MTf/Ix9FyO23n8JaHxyr74XiC25DWslK9b1mzbtmzY8NG/kft1T7E8tM8GEJIOPmTXXiBjwhUu4eWtuzZp+oZxX7YGwO7OQo8MPmz2bSn/eb9Pt8cf0efQ4zR967c5+rX11cGo3/ZMSE7uBE38yqccZxNmfWWjt3frbijn2FN/g0A3EL4Jd5YV31It/tHbAVo5aYnCle8CNemt3eNHdsHVvaeEUP7wT/9U69RHX4GCe/h3u8Q9pzBBo</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="40268_SYVTEEELAAER/2_y9" index="71" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="698.833" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SYVTEEELAAER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1047.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="520">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9ExHEAxuEjimiIhoiGaDiiOG6I4xdHw9EQ0RA3xFFEQzRENERDRBEXEfX71xANEQ3RENERDdEQ0RANEQ3RUOf7vMtneca3df+/zjg6aP6vJ44a7fXpQByV2huKo0J7xThqtf0oX+YqXFVr/DQ/y9f5BrfEregav8Fv8Tv8PnfIHespf85f8tf8LXfPPeoz/8q/85/8N/fLdSTBdWtvEnx/EvxgEvxwEvwIV+LGdYKf5Kf4GX6Om+cWdJlf5df5TX6b2+WaesSn/Bl/wV9xN9wd96BP/Av/xn/wX9wPV0hDu9Lge9Lg+1K/Sv2KK3KjWuYrfJWv8dPcLFfXBr/Er/Br/Aa3xe3oPn/In/Cn/Dl3yV1zt9riH/ln/pV/5z65b/3lO7LguzO/yvwq86vMr3SEL/Hj/AQ/yU1xM9yczvOL/DK/yq9zm9y27vFN/ohP+TPugrvSG/6Of+Cf+BfujfvQL/6HL+R+lftV7le5X+lQHnyRH+PLfIWrcrU8+gNk6iDC</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="444">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdkDFIw1AQhvNSUVBcRJwE7eBicZAKQgehOVPq2LFjFxGh0NlBoavO2kkLFRxVtNDJxUFcBAehqKs4KUXn5JnvmRNp4Lg/9+7+/79rRXNFL/mO/XaxleJXMx+Aye4/M/jD+k+/9oK1xpxmxfSMmsYvZ9o3rKeawxrK838WDN9q/BJ8xxX5sDey0ezKUXQlY3ttOTNrUjA5aXibDk/asvTsfpA1ZeeDTMBXsyeuBtYet28Sn9aIvd1ez9cKYb3yGK68jZfqvVxp+espNFMj4XPzXN5tXjpmRma9a+eHGWLLTsiSPwioE/SgRaYPzX505zK6vKGtmTq78ub8JfdRLubgdl7TuylWDoJe5t19030IPKtv7qNZ76b+0YEHDmpwkztmUaregVzuPshh5l6m41OJ/AvHueDvJG9Z0buyg94UrLdWv9R+AA/w9JI=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="27229_LVLTSDDILDLR/2_y9" index="72" defaultArrayLength="162">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="686.888" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="LVLTSDDILDLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1047.54" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEpAEUwPERsYdlD0u0RIdlDxEZ0SH6dIjY6BDRITo0osPQYRhahjkMw8Ywh9oOER2iQ+b77BIdokP0bYfoENEh5hAdIjpEdtb7vcu7/P28wysWe1PuJL92erMRe7DSSQq9qVU7Sak33c1O8jfP8++1TvI/T+u6hq6p+xm71Io+b0df3ObvRl/Y0+3rDviH/CP+MT/l/9ad6E75Z/xz/gX/kn+lu9bd8G/5d/x7/gO/q3vUPfGf+S/8V/4b/13Xl0bXH7v7IQ3/Yxr+pzT8z2n4A7pB3ZBuOHbxa/Q736IvjPBHo8/HdOO6Cf4kf4o/zZ/hz+rmdPP8Bf4if4m/zF/RrerW+Ov8Mn+DX+FXdZu6mq7Ob/Cb/C1+yx1t3bZul7/H3+cf8A/5R7pjXcr/wz/hn/LP+Oe6C90l/4p/zb/h3/LvdPe6B36X/8h/4j/zX3SvujfdO78vC78/81eZv8r8VeavdAOxC1+iLw1Fnw9n/irzV7oR3Sh/jD/On+BP8qd007oZ/ix/jj/PX+Av6pZ0y/wV/ip/jb/OL+s2dBVdlf+DX+PX+Q13NHVbuha/nSX/AAeWMOk=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="412">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUr9LQlEYvdeGFgUnx1DaBBdpaol3v/sKGiREp8YgXEJoEYeCHCJwyNFFEv8Bl0YpwkGnlP6EltokCIfwvZfnwoF74XC+n+e+735PNqsgp/JGtqy2p6GHQS+VD8iIA/CZZy0Oe9+jE0MbYC9j7CMjT0CH9WD0QI93+vV+LfUY9/2HqOn6qeHXwIY+gLqyLsp10pOz6EO+jjK2snNqW/rCfsb3dn9ybjsvJatvXyUbd+Utmrva5ObQFp6uwsX4J/y93D02d4NwUS6G9aBm/1RHoDlNtPQ3MwOMVE4edVrAiBOjpCrfqupy4HXqwDF69tSzaccr17/UQwd8P+L4dmjBzsRdg9k4D3ww3hHzc1bqII8c34l5gLvk+1OHQJ4xMHfMHtr+v8CdU593cyfw/wH1xfsN</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="27234_LVLTSDDILDLR/2_y10" index="73" defaultArrayLength="162">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="686.888" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="LVLTSDDILDLR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1160.62" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="592">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEpAEUwPERsYdlD0u0RIdlDxEZ0SH6dIjY6BDRITo0osPQYRhahjkMw8Ywh9oOER2iQ+b77BIdokP0bYfoENEh5hAdIjpEdtb7vcu7/P28wysWe1PuJL92erMRe7DSSQq9qVU7Sak33c1O8jfP8++1TvI/T+u6hq6p+xm71Io+b0df3ObvRl/Y0+3rDviH/CP+MT/l/9ad6E75Z/xz/gX/kn+lu9bd8G/5d/x7/gO/q3vUPfGf+S/8V/4b/13Xl0bXH7v7IQ3/Yxr+pzT8z2n4A7pB3ZBuOHbxa/Q736IvjPBHo8/HdOO6Cf4kf4o/zZ/hz+rmdPP8Bf4if4m/zF/RrerW+Ov8Mn+DX+FXdZu6mq7Ob/Cb/C1+yx1t3bZul7/H3+cf8A/5R7pjXcr/wz/hn/LP+Oe6C90l/4p/zb/h3/LvdPe6B36X/8h/4j/zX3SvujfdO78vC78/81eZv8r8VeavdAOxC1+iLw1Fnw9n/irzV7oR3Sh/jD/On+BP8qd007oZ/ix/jj/PX+Av6pZ0y/wV/ip/jb/OL+s2dBVdlf+DX+PX+Q13NHVbuha/nSX/AAeWMOk=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="372">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJz7zqDguIRRwek7kJ7HtAADg8RhmAEIQGIgGqQHpm8y0wc4hukDsUFyX/65OyHrh6mB2ccABcj2MyABmDkgGqYOhpHNgtkFwiB3IZuJrgfGRrYL5maQXhC7+V+3U8XffCcQfeLfZqflf1Kdt9dfcjZqsnK5/e+6S6S+qKv1wT5XETtGt1+iPG6/yne5HteVcH21V9lFiqnJWfNvoPNnhhNOS/9zg2mQOfV/bZ1B5rAy3wGzQWqWM31wOvZXFCwOwsoMWmCxc//nO4H0gfwDC1uQ22D+A5kHomFuRBYH6QWJw+II5B+QGIgNokEYpB45vL9D0wHIHpAcyM/I9oHMQ9aHLAejYXaB+Mhxhc0eZDmQnQAGsff7</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="27629_FTQAGSEVSALLGR/2_y7_2" index="74" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="718.381" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="FTQAGSEVSALLGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="359.171" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="604">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFklWEYwPFjzHaRupjGkTGJJKY5pl1M+0zGrDEV0y6mXWyNyZiMaRdHu5h2MY3JVhKpi5TzfW8jiiSSaOsidZEiSZOUpJTMpnPO+3tuHj6/7++9eAqF8nwuJbnKfLN/lZL1tfL8KyVXVsqTS5PRytSlSYUXdqbR7U6j22PvTaM/wB/iD/NHuKNcr32cP8Wf5s/wZ7lz3Hn7An+Rv8Rf5q9xN7k79j3+Af+Yf8avc6+5d9xH+wv/g//Db/E1Wfxem0VfH/exHVnVre7Kqv/nG7KqLzZGv5HnmrjmuAv7ol/ZH33uoH6LfivXxrXrd+h36nfpd+v3cH1cP3dCf0B/UH9If9g7Rrgxblx/Qn9Sf0p/Wn+GK3Kz+nP68/oL+ov6S9wyd1X/uv4N/Vv6t/Xvchm3yt3Xf6j/SP+J/lPveM694F7qv9J/o/9W/73+B+4Tt6H/Vf+7/k/93/p/uU1uW78mxH5tiP364K6Cuwruimvk8nGPNkW/1hzcVXBXwV1xLVyrfpt+u36Hfqd+F9fN9ej36ffrn9Qf0B/khrhh/RH9Mf1x/Qn9SW6Km+Zm9Iv6s/pz+vPescAtcksh+Q/c4i/g</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="456">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkq9LBFEQx9/uXVE8TBYR9jSJiEHOdq7cm33of2DSoBwGETEJ4o9ksnv1hEMQBC+cyWIwaDtQ0KAiiMF0QYNld/WzMLJhmN/f+c68F6Y9O+P/yGN1Nfq8GHNzd4eub6Xh2ufLrtsO3UYQuIel16h83R+JubXfca/2kQRWhVgpOcp0K9m0I35Z7uMhGTTPdtE0Mwn/ZryYTib4YNCTx8JO/IWslhxYCHF6wCRHjPphr/mPQR+CT4468t3Ey3rgxmw4IdTgo/Hz3L7iihRNQcBTXjpPbTiQbx08SdGeRftTnrsaHXCNk3E3+f4W7YRBRI7Z62ZCFJuevG755Zpy1ln4zNL5micGju6JJqb3V1xq4Kd7EsPWOsWkPn9nxUPDA7vqVWTPlIQ3RerertQLW5nNbqfprLDfTXws4q/JdDov3Fz/gv6L7eTSEtf/kOeI/gVdORzt</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="25889_DGPVILTSQGEER/2_b4" index="75" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="700.854" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGPVILTSQGEER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="369.178" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGhwxJ7iA7RYYk9LB3ipUPEG7FLdIgOER2GOQxRxBxi2GXoMHQYYpYY779hl+gQUUSHiIboEB0iWqJDdIjosDN+n+fyvXyOTxT1V07i0mDVJO5d9beRxL/b/dWSuDJYPYkHLGpwTW3xbb7Dd/kD7og70XP+kr/mb/l77pF75l71nS+lwX9Kg/+cBj+aBjeeBjeh3/gpfpqf5ee5BW5JV/g1vsKv81vcNvdTd/hdfo/f5zPuD3fIHesZf8H3+Bv+jnvgnvSFf+M/+KEs+OEsuJEsuDH9kgX/NQt+ko/4GW6O+66L/DK/ypf5KrfB1bi6Nvgm3+LbfIfrcgd6xJ/y5/wlf83dcvf6j3/mX/l3vpT7Ve5XOpoHP54HP5H7FT/FTXOz3Lwu8Ev8Cr/GV7h1bku3+V/8Dr/L73H7XKZ/+UP+mD/jL7ged6N3/AP/xL/wb9wHN1SEDhfBjxTBjxV+VfgVN8lF3IzO8T/4RX6ZX+XKXFU3+Rpf5xt8k2txbe3w3SL+D6BYHCI=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="516">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw1kj1IA0EUhPdOsNJYBRGVxNJWYiUEcu8OEStttRPRIpEUxkYTDCkUDFpoowj+FRYiCKJgCiGdsVBQAkKQFDYWggFTSXKn38IWw7ud93Z2dvbS7UjixTp2zlTUSapGYspOOyD9zwN4FYzrHngLjhKs2TPXWpCSFZV9vyLn6lNaqtP11ZjbV1ZuLH+v+Zw9LT/BsHyphlPww9JvdcliYOsKx1lo8U1FG8DvtmrOoF3U3/j4sB4czj9oX2sODbMHnnl45gCalt0ruY5ZoRe244IHKmv6eOMMgBba8FRmMutFeRracE9DA97I4ZrXrKe86u2WN7G04y2nIt52fc8Nl0fdUK4kq9lHyagTSeaVO1l4ld/clb7nvB/XOXEuayp4DtKav7RiYrzjoxZYAuitWN3S41f0fYxPssArWiYf+uTA/dDCP0DDZM0M+6gmX3j6ZMSZ9Hmz7/aNnjW5UO/8d+3N6BstsjfZAfN+cPipqk2ZyV5IU03of4EZ/iUz9wcwiwnC</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="27630_FTQAGSEVSALLGR/2_b3" index="76" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="718.381" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="FTQAGSEVSALLGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="377.18" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="604">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFklWEYwPFjzHaRupjGkTGJJKY5pl1M+0zGrDEV0y6mXWyNyZiMaRdHu5h2MY3JVhKpi5TzfW8jiiSSaOsidZEiSZOUpJTMpnPO+3tuHj6/7++9eAqF8nwuJbnKfLN/lZL1tfL8KyVXVsqTS5PRytSlSYUXdqbR7U6j22PvTaM/wB/iD/NHuKNcr32cP8Wf5s/wZ7lz3Hn7An+Rv8Rf5q9xN7k79j3+Af+Yf8avc6+5d9xH+wv/g//Db/E1Wfxem0VfH/exHVnVre7Kqv/nG7KqLzZGv5HnmrjmuAv7ol/ZH33uoH6LfivXxrXrd+h36nfpd+v3cH1cP3dCf0B/UH9If9g7Rrgxblx/Qn9Sf0p/Wn+GK3Kz+nP68/oL+ov6S9wyd1X/uv4N/Vv6t/Xvchm3yt3Xf6j/SP+J/lPveM694F7qv9J/o/9W/73+B+4Tt6H/Vf+7/k/93/p/uU1uW78mxH5tiP364K6Cuwruimvk8nGPNkW/1hzcVXBXwV1xLVyrfpt+u36Hfqd+F9fN9ej36ffrn9Qf0B/khrhh/RH9Mf1x/Qn9SW6Km+Zm9Iv6s/pz+vPescAtcksh+Q/c4i/g</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="380">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkj1qAlEUhWemMWj2oCnSpMoGLN5PQCGVRcAiSNyA2KZKl8IFKBZJGmsbISGNjSAWriB1alfw5un34MAbuNzfd++5584itO0qzux3OJlRtbGN2HL42Lbe23U4JU3so/60i0s9uWGcJCHHG+rei45Dnqs7RwybeHH59FazjmXHvFZf5rfoJV8xfOUUkzCPHtSQF040OWYg5IlJ6w1YkH4sHbhjuHa7+GcR7UMd9fShd46bmYj63VZTN9g++qfxxv+Yq4f/8ui77YN/qe+9eZu7ZpgkLtDMYx9h1yzpnAPZymMzExvM8LosbxK3wkiNbqSdtYd6ikPlscWzZuQ48MV9fqucD8V0O/m6lXCJV/4LMMGL7nMGioo1FA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3641_AISEGMEVYGINR/2_y4" index="77" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="719.853" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AISEGMEVYGINR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="459.265" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGXDkuHiI2lw7KHZekQc4iINzoMsRFziDnEMIehwxAtMYeYQwwdInaIDtH7T+wSHaJDRDR0iGiJDhEb0SE6RDN+n+fyvXyOTxT1V07i3mV/P5O4+7u/ilaTuD5YLYlLgzWSeMCjJr/Gtbg219Ftvsvv8Qf8IXfEnegZf8Ff8Tf8HffA/dcX/o2P0uA/pcGPpMF9ToMb129p8D/4SX6Kn+HmuHld5Jf4Zb7Or3Cr3Dq3oZv8Fr/D7/L7XM790WP+lD/ne/w1d8vd6yP/zL/y7/xQFtxwFtyofsmC/5oF/z0LfoIvcdPcLFfWBb7CV/ka3+Ca3Jq2+Dbf4bf5LrfHHeghf8Sf8Gf8BXfF3egd/8A/8S/8GxflfqUjefBjefDjuV/lfsVNclPcjM7x8/wiv8Qvc3VuRVf5dX6D3+S3uB1uV/f5nP/LH/On3DnX4671H3/PP/LP/Cv3zg0VocNF8KOFXxV+VfgVN8GVdJqf5cv8Al/hqlxNG3yT/8W3+DbXKeIPWjopxQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="452">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdkr1LA0EQxe/Oyg/Uxk5I0D4KQctEd+diI1goFmpAbG1MKVgYtLPTf+A6xVIURRKthGBpJ8EINpZR4ZqYy5nfwYRgYHgz89687M5eI56wF+0b23LGpVYW2bFGpvMZmXJebaPLHcQpM+cEBhzzgkWNHzedoNP9aa0aevX2kslGzZ5O+fnOSaKBV9xwr81Cx7UzUWBB6ntvz2y2m4kGH3T6X/joPL4EHH0C/f+zkStq3h86q/549J+fnDntgdtOzTy5JfschHK69uW/l1YLYWW5cD766b997PsPKyP+UfFOXqrHMniYkbPcpLQqeck9zspldUh+o7KNorrBh73cuunk/tRg6BUTnqCuDmzZ9U7WXsXDdtfLWfZDDqfBm/V7ske9HzsD6RHcBw19kHdm98zjrX0QDzj9FvQt4VRHsBe80abi756eeTxVp+eA/wMlewZO</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="39279_SVYPESISSSNSR/2_y10_2" index="78" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="706.836" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SVYPESISSSNSR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="532.255" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="556">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFkm3Ecx+GQwyg9lB1G2WGMjbJD6CGMt5QcRg8l7FB6CGWl5DDKRtih9BBGR8l437x5U8IOoayMHEoOJTSEHUIPYeRQchhhI+ywxv/5XT5e7/PyHr7D24c7i6OD5aVxlFteN46+Nh6uF0eF5Q10HEfDpZ/ycz6XBL+aBLeeBPdCN5Pgt5Pgd/l9/oj7wJ3qOX/BX/LX/C13x93rXz7fDH6tGfzTZvAbzeCKzeBKXFkrfJWv8XW+wXW479rnR/yEn/EL7/NpeF7RtTT4J6n/TMN3z1P/yxW4om7xJX6HL/N7XIV7x1X1mK/xJ3ydP+MaXKodvstf8T2+zw24kY75CT/lZ/ycW3C5VuijVvCrreAft4JfbwX/jHvJveI29TW/zb/hd/m33D53oEf8e/4j/4k/5T5z5xrzF/w3/pL/wV1zNzrkf/J3/C/+nvvN/eH+aT4LfiWzq8yuMrvK7Irb0AJf5Lf4Er/Dlbk9rfCHfJU/5mvcCVfXL3yDT/kO3+WuuJ72+QE/4sf8hJtyM26uCz7Xtqu2XbWj/0QcFeA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="456">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdkT0sQ1EUx29fJQZsDAZRHQwddZFopL33vmcykIi1g8WCUUITFRsDI4uOEovhzaQkIkRiYnjCIJFYfG6Svqu/Fyd5DCfn63/+50sppW7cYCUt6jdWcPt/hHjee6+Mtib0gHev0cSbblETz2dySQybenzBp23wj25Tiy085KvZUD/FU2altWPGXNG81LfMlVcw0i/p0xbq/EwjEYnDAa6349P0j+/Zo+jZzkcftnR8YHebt3budMQOrfXYmmuYYZUzda/bhOpCV1t9hr4llzHMBTc82Gh46YGP4FN3uPplFq7L/t1sMXjtvAyi8DzomtwIps8ivxx/25n1k6QPM8JJD3rCiV6Ol5Ida+5Nwwc3GLlLctf23WT3NGY7+6DlrvCzv8wHPn0b8NjMTR5buOTu8h98+T0xfs4c6T9LTjjlJ9TJP8n/5wfP3gg2ezPbD3E/DJo=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="17031_VDLVDDEELLELVEMEIR/3_y4" index="79" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="720.364" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VDLVDDEELLELVEMEIR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="548.286" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="596">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEZHEcwPERe1j2sMSujT0sHSI6NDoMwzyGOYwdNoY5DB2i0SE6RHSIOUSHiA7RWxEdokNEEb33okNEb0WHiA4RGx0iOkSHdtb/87v8Ll8fv8OvUOhNKYn+r245iTq9+VtJoj95nv+sJlGxNwe1JPodx/G3uq6h+xV2pxn6vBX6Yjv08UToC5O6Kd20boY/y5/jz/MX3LGo6+qW+Mv8Ff4qf42/rtvQbfK3+Nv8Hf4uf0+3rzvQHfGP+Sf8U/6ZO851F7pL/hX/mn/Dv+Xf6e51D/xH/hP/mf/Cf9W96d75fWnwP6TB/5gG/1Ma/M9p6Pp1X3QDYeffQ1/8Efp4MPSFodB3hnUjulH+GL/EL/Mr/KqupqvzG/xxfpPf4rd1E7pJ/hR/mj/Dn+XP6eZ1C/xFfpe/xF/mr+hWdWu6df4Gf5O/xd92x45uV7fH3+cf8o/4x/wT3anujH/Ov+Bf8q/417ob3S3/jn/Pf+A/8p90z7oX3Sv/jf/O78v8VeavMn+V+auw4/4s+F9D3xnI/FXmr3SDuqGwu8P8Ef4of4xf0pV1FX6VX+PX+Q3+uK6pa/HbWfQP7TYx1g==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="364">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYGBg8Pgv7zSTUcERhK/9e+8ozrAAjEHiMD4DFID4IHUgNkwdiA+jQXpgbAao2S8ZC5xgapYxeTiBxGF8ZDtANEgeZi5MHpkGqTnP2OMEwof/bnZCdjvMXpg/kM0DqT3wfz5YH8xOEBskD3IfzA3o9iP7FRYGyH4GmbufYY6zDuNb55CH/S779t51sVP453L20WMX//9bXVLlmlwu/LUC42pHURfWuufOyoyFzg8YtzoHN/Y4WzClOcszTXfeyOjpLMak5Wzw971T2r/jYL/B/Adyn9M/RrAakBhIDcztMD+C/AbzFwjD/AQLN5B6kLkw9TD9sDBF9hdID3r8IocrAx4ACy9iACwtAABD4NYE</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="39281_SVYPESISSSNSR/2_y11_2" index="80" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="706.836" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SVYPESISSSNSR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="613.783" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="556">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFkm3Ecx+GQwyg9lB1G2WGMjbJD6CGMt5QcRg8l7FB6CGWl5DDKRtih9BBGR8l437x5U8IOoayMHEoOJTSEHUIPYeRQchhhI+ywxv/5XT5e7/PyHr7D24c7i6OD5aVxlFteN46+Nh6uF0eF5Q10HEfDpZ/ycz6XBL+aBLeeBPdCN5Pgt5Pgd/l9/oj7wJ3qOX/BX/LX/C13x93rXz7fDH6tGfzTZvAbzeCKzeBKXFkrfJWv8XW+wXW479rnR/yEn/EL7/NpeF7RtTT4J6n/TMN3z1P/yxW4om7xJX6HL/N7XIV7x1X1mK/xJ3ydP+MaXKodvstf8T2+zw24kY75CT/lZ/ycW3C5VuijVvCrreAft4JfbwX/jHvJveI29TW/zb/hd/m33D53oEf8e/4j/4k/5T5z5xrzF/w3/pL/wV1zNzrkf/J3/C/+nvvN/eH+aT4LfiWzq8yuMrvK7Irb0AJf5Lf4Er/Dlbk9rfCHfJU/5mvcCVfXL3yDT/kO3+WuuJ72+QE/4sf8hJtyM26uCz7Xtqu2XbWj/0QcFeA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="252">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJw78Ufe8QQQM0ABjI0shgsgq3nNuMBxBvMHFL0wGiSObt4JqL3YMLI8up7jf+WdQHbB5JDZ6GqR5ZDdADMb2b0gtchyMD66W2F8kN4LjLudV1h/c3Ez+OUakFbo1pbS4aaRr+o2S67F1Smh12U3S40zzA7Xf91OMH0/mTyc4hkLnI7/nQ8XQ3cbCIPUpTOIOf/5e9sJpB/ER/Y3tvCEycEwvrjDFr641OFSix7vyOGI7BZsboDFJQC7eLj4</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="27627_FTQAGSEVSALLGR/2_y6" index="81" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="718.381" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="FTQAGSEVSALLGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="616.376" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="604">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFklWEYwPFjzHaRupjGkTGJJKY5pl1M+0zGrDEV0y6mXWyNyZiMaRdHu5h2MY3JVhKpi5TzfW8jiiSSaOsidZEiSZOUpJTMpnPO+3tuHj6/7++9eAqF8nwuJbnKfLN/lZL1tfL8KyVXVsqTS5PRytSlSYUXdqbR7U6j22PvTaM/wB/iD/NHuKNcr32cP8Wf5s/wZ7lz3Hn7An+Rv8Rf5q9xN7k79j3+Af+Yf8avc6+5d9xH+wv/g//Db/E1Wfxem0VfH/exHVnVre7Kqv/nG7KqLzZGv5HnmrjmuAv7ol/ZH33uoH6LfivXxrXrd+h36nfpd+v3cH1cP3dCf0B/UH9If9g7Rrgxblx/Qn9Sf0p/Wn+GK3Kz+nP68/oL+ov6S9wyd1X/uv4N/Vv6t/Xvchm3yt3Xf6j/SP+J/lPveM694F7qv9J/o/9W/73+B+4Tt6H/Vf+7/k/93/p/uU1uW78mxH5tiP364K6Cuwruimvk8nGPNkW/1hzcVXBXwV1xLVyrfpt+u36Hfqd+F9fN9ej36ffrn9Qf0B/khrhh/RH9Mf1x/Qn9SW6Km+Zm9Iv6s/pz+vPescAtcksh+Q/c4i/g</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="348">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkrFKxEAQhnePK4WDE66UtFYWFgeCRTZZ8BnS+gJia+4JbK63SLjqEOwsbZSAL2AlNjbaSV5Ac/mX+2QWfjKzMzv/PzOp3FX4cY/hzWeh9W1+5vtcXzeeb5clW5CtWOMvQj3pE4I/KDaTj3A/vAby3P5g85baAlxwCLzDVvxhuP3PE6+ATy3qWy7u8QG81dizfNWnptVOvtVuc3SXZvB8Wl7PjuL0chWP102cL+/i4clN7D635UvdFU9/58WXX6QZSZN46UOQHvhlk2N70xcNysVnF+giZuesWu+/TWBe2pOgvsUHP3fsxtaHA73MjxiztzOzexH0f9m+6IG3OxTN0O0=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3638_AISEGMEVYGINR/2_y5" index="82" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="719.853" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AISEGMEVYGINR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="622.332" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGXDkuHiI2lw7KHZekQc4iINzoMsRFziDnEMIehwxAtMYeYQwwdInaIDtH7T+wSHaJDRDR0iGiJDhEb0SE6RDN+n+fyvXyOTxT1V07i3mV/P5O4+7u/ilaTuD5YLYlLgzWSeMCjJr/Gtbg219Ftvsvv8Qf8IXfEnegZf8Ff8Tf8HffA/dcX/o2P0uA/pcGPpMF9ToMb129p8D/4SX6Kn+HmuHld5Jf4Zb7Or3Cr3Dq3oZv8Fr/D7/L7XM790WP+lD/ne/w1d8vd6yP/zL/y7/xQFtxwFtyofsmC/5oF/z0LfoIvcdPcLFfWBb7CV/ka3+Ca3Jq2+Dbf4bf5LrfHHeghf8Sf8Gf8BXfF3egd/8A/8S/8GxflfqUjefBjefDjuV/lfsVNclPcjM7x8/wiv8Qvc3VuRVf5dX6D3+S3uB1uV/f5nP/LH/On3DnX4671H3/PP/LP/Cv3zg0VocNF8KOFXxV+VfgVN8GVdJqf5cv8Al/hqlxNG3yT/8W3+DbXKeIPWjopxQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="500">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUTtIA0EQzW4rJI3B0kgaUbCJhY1KdvbutBDBQhBMkSKK2NiIYGWwsJBYaBs1pNBCbAyICtoIIqjR3vhJmjRCNJWSuz3zDkY8GGb2zbyZNzcRsaQmTZT2/A6adVMUFjKwvO8oYCeijwZMgR6yOfrIbtC4v6ma/r7aNSV1ESokQ+2PPTiIn023gl3KWBC/eo0k1wDDG4aY+XiD/2niql++q2N3kJ5aL+rcu1ORtkbux7XwwHkmDDG0Q3NedtGYWKVvEaMbWVGnoRGCbugHD/pRDwx9gaEva4dB23+trJcx9FhcL9NjsdfStYRdTR3Z1YVDu/4zZNfTJWtmwrFq6bD1Vmlqvbait+Sc7hzd1gfXGW1dxfWwLAdaoRHzofFeTFHOSxD2h/5p1yHcBzV8G7yjpqHOxPwfH7faaWWCPPblXbAfemNv3hkx+IhRw7eEB84c5HrkbdCLPTjwy+YryGMucpgJHuf5HvwvkcdceJ7B+V/aTSYK</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="39280_SVYPESISSSNSR/2_y6" index="83" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="706.836" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SVYPESISSSNSR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="637.29" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="556">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFkm3Ecx+GQwyg9lB1G2WGMjbJD6CGMt5QcRg8l7FB6CGWl5DDKRtih9BBGR8l437x5U8IOoayMHEoOJTSEHUIPYeRQchhhI+ywxv/5XT5e7/PyHr7D24c7i6OD5aVxlFteN46+Nh6uF0eF5Q10HEfDpZ/ycz6XBL+aBLeeBPdCN5Pgt5Pgd/l9/oj7wJ3qOX/BX/LX/C13x93rXz7fDH6tGfzTZvAbzeCKzeBKXFkrfJWv8XW+wXW479rnR/yEn/EL7/NpeF7RtTT4J6n/TMN3z1P/yxW4om7xJX6HL/N7XIV7x1X1mK/xJ3ydP+MaXKodvstf8T2+zw24kY75CT/lZ/ycW3C5VuijVvCrreAft4JfbwX/jHvJveI29TW/zb/hd/m33D53oEf8e/4j/4k/5T5z5xrzF/w3/pL/wV1zNzrkf/J3/C/+nvvN/eH+aT4LfiWzq8yuMrvK7Irb0AJf5Lf4Er/Dlbk9rfCHfJU/5mvcCVfXL3yDT/kO3+WuuJ72+QE/4sf8hJtyM26uCz7Xtqu2XbWj/0QcFeA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="364">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdkbFqAkEQhi8RhIM0NrbR9D6Et3oWPoCFWFoH7CysJJUvIFxhYRuiIBELWyHmFSK26S4PILvqt/iHxYWf2Zn595/Zmdg+149uVo+vNroe7gf7531B8fjGBcTgnR8rCX7fTRL8nW0lQHFBmvK5w4lu516f3Id79RrowSFPHbB1s/86aAPicMgVo6pZuq7Z2J75HGVmaFvmcPrxb9CFq3/gh70D6at3eKqlGk8P1tTmL81xXk4HpWU6zfdp/ttJ22/vzXUla7Td0MDjHZa31BLQX5xXPi9NzQMffjgv/VfQDMN9hDtUv1i9DXU1R6z+Sj/qk7vyWAGd78KXz4f7DnesHsOY5qwd6n4BwVNLag==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="17029_VDLVDDEELLELVEMEIR/3_y5" index="84" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="720.364" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VDLVDDEELLELVEMEIR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="677.327" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="596">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEZHEcwPERe1j2sMSujT0sHSI6NDoMwzyGOYwdNoY5DB2i0SE6RHSIOUSHiA7RWxEdokNEEb33okNEb0WHiA4RGx0iOkSHdtb/87v8Ll8fv8OvUOhNKYn+r245iTq9+VtJoj95nv+sJlGxNwe1JPodx/G3uq6h+xV2pxn6vBX6Yjv08UToC5O6Kd20boY/y5/jz/MX3LGo6+qW+Mv8Ff4qf42/rtvQbfK3+Nv8Hf4uf0+3rzvQHfGP+Sf8U/6ZO851F7pL/hX/mn/Dv+Xf6e51D/xH/hP/mf/Cf9W96d75fWnwP6TB/5gG/1Ma/M9p6Pp1X3QDYeffQ1/8Efp4MPSFodB3hnUjulH+GL/EL/Mr/KqupqvzG/xxfpPf4rd1E7pJ/hR/mj/Dn+XP6eZ1C/xFfpe/xF/mr+hWdWu6df4Gf5O/xd92x45uV7fH3+cf8o/4x/wT3anujH/Ov+Bf8q/417ob3S3/jn/Pf+A/8p90z7oX3Sv/jf/O78v8VeavMn+V+auw4/4s+F9D3xnI/FXmr3SDuqGwu8P8Ef4of4xf0pV1FX6VX+PX+Q3+uK6pa/HbWfQP7TYx1g==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="436">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxtUTtIQ0EQ3EfARmwtRDCFIqltAhIxt3eSQixstUhqkRfEUk2ijUKqCKI2PgvBJgTRRtKIjalSpQwpBQsJloK5M3OwcIgHy+xn5t7Ou5jSaoY6KnHDPOKECj7/oES1qa+A66PYo3Disabg5vKXUeJr5MtUVwjoMReOBGbSR4AneiBq8KSWb6EXzoDYBxzcE+6EnvSFL54Q0GEPeJmwQ1/33KNH8Y0cEWrDPUNv/p7UCteOpnQzOde7xUXzXto034f75rW1ZGZVzrwcD3Sm2NXPNw29d3um27Wcfouyeu3gi+dtn6+rXX6odnhj9MRld8cLlTrvpMq8arf4p3LBpzTte3gL5J9um68ozfdukvFuCPTFV8NmuGkjhi94hA4eMAcXfflv8CB+MBePND5AmaNGTsGR96c/J+RJ/p8WKHf/Ajnh88M=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="9121_VAALELEGDDATGR/2_y7" index="85" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="708.852" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VAALELEGDDATGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="691.303" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EfDfHQQzQ8PMNDPEM0xPE8RPyiIaIhGiJuiBuiIaIhGiIaoiGiiIbfv0Q0RMMRRRwdRw9Hw9FwxA1xQxzPw3Pn+/os7+U1fqKov2oS15/7e0jis9P+aklcGayRxKXBmkk8YFFL23yH7/I9PkqDG06DG9GxNPjvafDjafAT/BT3i5vh5nSBX+JX+DJf4Ta4Ld3h9/gD/og/4c65RK/4G/6Ov+efuDr3oq/8G//Of/Cf3F9uKAv9kgU/mgX/LQv+Rxb8T26SK3HTOsvP84v8Mr/KrXHruslv87v8Pn/IHXOnesHn/DV/y1e5B67GNbTJt/g23+G7XI+L8tDhPPivuV/lfpX7FTfBTelvfoaf4xf4JW6FK2uF3+C3+B1+jzvgjvSEP+cT/oq/4e64e+5J6/wf/pV/49+5D+5T//FDhV8VflX4VeFXhV/pJF/ip/lZfp5b5JZ1lV/j1/lNfpvb5fa5Qz3mz/gLPuevuVuuqo98jW/wTb7FtbmOdvkeH13G/wHueCN1</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="496">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkc8rw3EYx/f9bjdnTKEVKf4DpdY+z+e7aTtNkZOL4uKwu7Rf0vKjKAdFceBAEuViDspl/8BuK5cJaSEXyr4br9VTPvXu+f1+Ps/zlN1IbLl9GAv8vfXQR8wGIwbZ20wY1ddCGVP+y0NXGxT8DUMegIMY8qVdM+JXzIE/Ko+BRak5RwakAq4A6rC1XvvCST29+A8c+JHfgetODfmfrS5J+u9mzomI9oKXOD2JkY8fTnR4RpweeXAXZCzfEH+l20u/nnpb2el4PRhK7IbHE5dv0UT9+CT+Vb3wqoMh736gaPcm5m3Y8eyPP2SX3KSdafXZp1zQnhXLUnHuxLgZKbWnOrzn/rZc+DdSyo3Y2Wi/Law+SyN7Izut004M3Lr7MpzflJQzKVfNtPBf/gXQmQFddwWw8TM3swD8ajMbe0FHMjNxtfWWejO40NkP+wPsDElMb0w9+eTRSznVpzfUOynX/1tpDrXaU+9JT2K/C8URkg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="25886_DGPVILTSQGEER/2_y7" index="86" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="700.854" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGPVILTSQGEER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="806.363" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGhwxJ7iA7RYYk9LB3ipUPEG7FLdIgOER2GOQxRxBxi2GXoMHQYYpYY779hl+gQUUSHiIboEB0iWqJDdIjosDN+n+fyvXyOTxT1V07i0mDVJO5d9beRxL/b/dWSuDJYPYkHLGpwTW3xbb7Dd/kD7og70XP+kr/mb/l77pF75l71nS+lwX9Kg/+cBj+aBjeeBjeh3/gpfpqf5ee5BW5JV/g1vsKv81vcNvdTd/hdfo/f5zPuD3fIHesZf8H3+Bv+jnvgnvSFf+M/+KEs+OEsuJEsuDH9kgX/NQt+ko/4GW6O+66L/DK/ypf5KrfB1bi6Nvgm3+LbfIfrcgd6xJ/y5/wlf83dcvf6j3/mX/l3vpT7Ve5XOpoHP54HP5H7FT/FTXOz3Lwu8Ev8Cr/GV7h1bku3+V/8Dr/L73H7XKZ/+UP+mD/jL7ged6N3/AP/xL/wb9wHN1SEDhfBjxTBjxV+VfgVN8lF3IzO8T/4RX6ZX+XKXFU3+Rpf5xt8k2txbe3w3SL+D6BYHCI=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="436">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxtka9LBFEQx3dXFgwWOfCCwRPTGgyeWbj3dlfLBav9mmARxHAYFCwGBYNFtBiMJ+diUUQEk2IQDKIG/wB/FIPe0/ssfI8NPvjy5s18Z74z80K/Yi6CSu3GP6h53cPNG5tbGPPfezaxsJsHFz/3fxA/LGjAL9bCJv7trs3rz4o9n+6Ph1dH4+r6l50LNuy8P2SJHQazud6dt2ngX7k3g13ta/di0pAmfnLh1d2+KblFM9F5zP3YmR9YYgAePvJ4bwVTttVp2OxyKX56KSene8fJ8sNn0qhH6dnHeLqwXUp3WkfJ4G2U3D/vxjPNcpw1T+zIWttOegM5qI+u+kSbN37NhSb9qC/NV9yV9kUcUEM52NSh/q+Lcj3AftCgnv6IfyNPe9Ks8OlX8wP9MT79p/oQR7sDxb4UJxcoLo606Z/7DzrM5tU=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="16710_GNVVEIEEDASTR/2_y7" index="87" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="709.841" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="GNVVEIEEDASTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="807.347" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EfDRHPQzTEMzzEM0RDHD1E/CJ6iIaj4Ygb4oY4iqPhiCfihrghjnuI+P3jeYiGaIhoiOiIhmiIhoiGaIhoeO58X5/lvbzGTxT1V07iQaJKEveu+6sm8Z9uf7Ukrg1WT+LSYA2uyf3WFt/mO/wBn3J/uWPuVM/5S77H3/L33CP3rK/8O//JD6XBj6TBjabBjev3NPgfafBTfImf5ea5RV3mV/hVfo1f5za4LW5bd/k9fp/v8odcwR3pCX/GX/BX/A13xz3oE//Cv/EffJQFN5wF90XHsuC/ZcFPZMFP8tPcDDfHLegSX+YrfJWvcXWuoU1+h2/xbb7DHXCp/uOP+VP+nL/ketyt3vOP/DP/yr9zn9xQHjqSBz+aBz+e+1XuV9wUV+JmdZ7/xS/zK/wqt8at6ya/xW/zu/wet8919ZAv+CP+hD/jLrgr7kbv+Af+iX/h37gPLipCh4vgvxZ+VfhV4VfcJDetP/k5foFf4stchatqja/zDb7J73Atrq2dIv4Pn+8eAQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="488">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUjFLw1AQTjIWq8Gh6FCqBQU7CR2lSHLvUQcHxR9QEJwLgqgFoV1qChlEHJXi4qIgIgpCiYtDcBJBQbBLFgcHCw4ueYl+Dw86fNy7733fvbtLvLjq3pq+xmF67T7HdTeTFNwLVXAQZdrVHO56SddpmwMHuffng4YB/7AHyFoDDebgAXDOGaGuBw9H6Pj+KsiIjWJffNpZOXH6JjbXp+TRybR8WtgWdrMs7NSneaNEtpUjvM09oRYADjn6ReTayHkOjjwD63gP6L1ozInxyp2Iol3ZCUMZz3zJs+UX+Z2vya3eq+i3jsXl/aJQwZjoND9oJQmo1tonX5VpSVWona7Szd45PagDipIGjRoNelRVzU+mddpRBT0D9LPWiD7nrXe9H7yPXWAWnBGR/5gWoceStab98AHgcAcdavAOeB5ooEfO7/C38v7/A2iQswcc7w4c+gI/DOwRGuxyWIsz/PxNAK7Juwd+Af/EKIY=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="9123_VAALELEGDDATGR/2_y8" index="88" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="708.852" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VAALELEGDDATGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="820.348" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EfDfHQQzQ8PMNDPEM0xPE8RPyiIaIhGiJuiBuiIaIhGiIaoiGiiIbfv0Q0RMMRRRwdRw9Hw9FwxA1xQxzPw3Pn+/os7+U1fqKov2oS15/7e0jis9P+aklcGayRxKXBmkk8YFFL23yH7/I9PkqDG06DG9GxNPjvafDjafAT/BT3i5vh5nSBX+JX+DJf4Ta4Ld3h9/gD/og/4c65RK/4G/6Ov+efuDr3oq/8G//Of/Cf3F9uKAv9kgU/mgX/LQv+Rxb8T26SK3HTOsvP84v8Mr/KrXHruslv87v8Pn/IHXOnesHn/DV/y1e5B67GNbTJt/g23+G7XI+L8tDhPPivuV/lfpX7FTfBTelvfoaf4xf4JW6FK2uF3+C3+B1+jzvgjvSEP+cT/oq/4e64e+5J6/wf/pV/49+5D+5T//FDhV8VflX4VeFXhV/pJF/ip/lZfp5b5JZ1lV/j1/lNfpvb5fa5Qz3mz/gLPuevuVuuqo98jW/wTb7FtbmOdvkeH13G/wHueCN1</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="496">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUj1LA0EQvYuNkkqN2CRETCUWYlIrurPJ6R+wULzKoIJEC0GbRcTCRsHEr/IqsbDVJpAEKwUhRUyhKIitTUiRIHp76lsc8eAxO/Pezu6821rgTdZ+MBHEDazfj3MAPGqIbx+NPx3vQ+0uiAtgPXAE6ojImftfR5zVT2JED1DbuhSjnw2jLVm3YiO0Z/ZsattwK6E1U4MG+bQOU1I1qaiictCfNxBWTHYFBwQOGuhxL/TEPvTgOdA75a9S3S3J8EshXd4fz8y81zOPuYQzdxZzrnqOMout83R3tiU95UpVGZY71wm5sBWXzXJU5lWVbmyfOv0xwpnLeoiS2yeUVnnqDU3RYccDVVWb3EpEFkW/vLcv6FQfG/7Z2jUazBbxs7SkUyYihx8AeNwZM7x+eYJ95FkwHwCvwGMmzAcdeHiQ032mHzSs53/BWvjBPXA+Inicy74jhxZrBnhE6NETOe6ANddYy35z5HeANed4R9+xHzQP</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="39278_SVYPESISSSNSR/2_y8" index="89" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="706.836" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SVYPESISSSNSR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="837.411" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="556">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFkm3Ecx+GQwyg9lB1G2WGMjbJD6CGMt5QcRg8l7FB6CGWl5DDKRtih9BBGR8l437x5U8IOoayMHEoOJTSEHUIPYeRQchhhI+ywxv/5XT5e7/PyHr7D24c7i6OD5aVxlFteN46+Nh6uF0eF5Q10HEfDpZ/ycz6XBL+aBLeeBPdCN5Pgt5Pgd/l9/oj7wJ3qOX/BX/LX/C13x93rXz7fDH6tGfzTZvAbzeCKzeBKXFkrfJWv8XW+wXW479rnR/yEn/EL7/NpeF7RtTT4J6n/TMN3z1P/yxW4om7xJX6HL/N7XIV7x1X1mK/xJ3ydP+MaXKodvstf8T2+zw24kY75CT/lZ/ycW3C5VuijVvCrreAft4JfbwX/jHvJveI29TW/zb/hd/m33D53oEf8e/4j/4k/5T5z5xrzF/w3/pL/wV1zNzrkf/J3/C/+nvvN/eH+aT4LfiWzq8yuMrvK7Irb0AJf5Lf4Er/Dlbk9rfCHfJU/5mvcCVfXL3yDT/kO3+WuuJ72+QE/4sf8hJtyM26uCz7Xtqu2XbWj/0QcFeA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="380">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdkjFLA0EQhTeeYCMhjY1EtLCxkmCXRm7HO1MKadIIVlcF8gf8B4KlbQR7LSV2gmCh1hZiYaGFTXrJ3ep3+GC5g2F2Zt68mXmcc85tJJcp9vd0J8lWirn/vGLsvZyncV05YeP+63LTU5MXjlo8T5zxLNX4PsLE41+rM68+3rdLgzoPv2rNmaMwrWt4eOCmDyx18YGP71Lc3EmeXnieTu+svbuS7W138sngKu/ezPKqX+QXy9/Z+f44O+o+HKwvXiy4oX0tDu2nevTP5ZphvdaqjcJbfYfmsWOsMbOUi/VVLA2IhSN3H+a+qHasSI5Nt5OXV5+0ECcxerEPxn6fZctmLjHpGusEnpvEjUl7MMzWHfF/0PwXfgE1UfMS</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3642_AISEGMEVYGINR/2_y7" index="90" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="719.853" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AISEGMEVYGINR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="850.436" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGXDkuHiI2lw7KHZekQc4iINzoMsRFziDnEMIehwxAtMYeYQwwdInaIDtH7T+wSHaJDRDR0iGiJDhEb0SE6RDN+n+fyvXyOTxT1V07i3mV/P5O4+7u/ilaTuD5YLYlLgzWSeMCjJr/Gtbg219Ftvsvv8Qf8IXfEnegZf8Ff8Tf8HffA/dcX/o2P0uA/pcGPpMF9ToMb129p8D/4SX6Kn+HmuHld5Jf4Zb7Or3Cr3Dq3oZv8Fr/D7/L7XM790WP+lD/ne/w1d8vd6yP/zL/y7/xQFtxwFtyofsmC/5oF/z0LfoIvcdPcLFfWBb7CV/ka3+Ca3Jq2+Dbf4bf5LrfHHeghf8Sf8Gf8BXfF3egd/8A/8S/8GxflfqUjefBjefDjuV/lfsVNclPcjM7x8/wiv8Qvc3VuRVf5dX6D3+S3uB1uV/f5nP/LH/On3DnX4671H3/PP/LP/Cv3zg0VocNF8KOFXxV+VfgVN8GVdJqf5cv8Al/hqlxNG3yT/8W3+DbXKeIPWjopxQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="416">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkc0rBVEYxmfOWEi2rCzmLm8kOzs1c87cruxMUWIr2bjJxoLtLWwsbFH+AQtRFnQVWbKc/BFkcxXTuL/Jo3Pq9H497/N+FUGcNsuz9Nh00tPwKN2J2mkx8DXMeYKOH5sYUj7i1+V7jUFi3wRxEgweUnFsxcESEw6/dOX7NcWNpD46/uKvZz8Pn7Bf4UeNf6maFl02WPWlTx75yhUPePoQRnifA/xttWtd49MNb39n9/2tVr680joYKbOpu262tjeRLVy8ug1z4i6rebdezbh+b9KNV7l7SgL3sN+1vXDUPv681T3G0XM9M7NtmlWLPAwWa8xSOWZN2LZDxlhw01HH5sFcbc+GV/8z0jM2nEjtkBn9mZgB2/9g9akhLurCzx7w6xbi9ncHr3878WinuqV/518O4vPN</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="17032_VDLVDDEELLELVEMEIR/3_y7" index="91" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="720.364" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VDLVDDEELLELVEMEIR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="889.485" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="596">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEZHEcwPERe1j2sMSujT0sHSI6NDoMwzyGOYwdNoY5DB2i0SE6RHSIOUSHiA7RWxEdokNEEb33okNEb0WHiA4RGx0iOkSHdtb/87v8Ll8fv8OvUOhNKYn+r245iTq9+VtJoj95nv+sJlGxNwe1JPodx/G3uq6h+xV2pxn6vBX6Yjv08UToC5O6Kd20boY/y5/jz/MX3LGo6+qW+Mv8Ff4qf42/rtvQbfK3+Nv8Hf4uf0+3rzvQHfGP+Sf8U/6ZO851F7pL/hX/mn/Dv+Xf6e51D/xH/hP/mf/Cf9W96d75fWnwP6TB/5gG/1Ma/M9p6Pp1X3QDYeffQ1/8Efp4MPSFodB3hnUjulH+GL/EL/Mr/KqupqvzG/xxfpPf4rd1E7pJ/hR/mj/Dn+XP6eZ1C/xFfpe/xF/mr+hWdWu6df4Gf5O/xd92x45uV7fH3+cf8o/4x/wT3anujH/Ov+Bf8q/417ob3S3/jn/Pf+A/8p90z7oX3Sv/jf/O78v8VeavMn+V+auw4/4s+F9D3xnI/FXmr3SDuqGwu8P8Ef4of4xf0pV1FX6VX+PX+Q3+uK6pa/HbWfQP7TYx1g==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="336">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJyTYFRwZACCGuYPjgv/zneUAPJBbBgfRIPEQGwQBqnN+SfvBKJh6kF8mHoYRtaDLA8zH90eCag7kGmYGphdMLNA/GAmDyd082DuQzYPpB4mh6wG2X0wu2DiyHYiq4XZA8MgNxgx3HHS/ZfqbFV319lHocNl093LLsfu33fROLTVZfH+VheT2jiXZfsMXNz/n3UOrTvnXM1U5bzyf6Dz1H9azrr/o53d/os6a/9zdwaZA6In/D/uxMiwxQlEb2ZcADY/kKEHzO5iKACzQX4C8WHhB3IHSA6Ekdmw8AKZBVIHiweYGpA4TB1yOCKHF3LYkAKI0QMLXwDtf8QW</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="25885_DGPVILTSQGEER/2_y8" index="92" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="700.854" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGPVILTSQGEER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="919.446" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGhwxJ7iA7RYYk9LB3ipUPEG7FLdIgOER2GOQxRxBxi2GXoMHQYYpYY779hl+gQUUSHiIboEB0iWqJDdIjosDN+n+fyvXyOTxT1V07i0mDVJO5d9beRxL/b/dWSuDJYPYkHLGpwTW3xbb7Dd/kD7og70XP+kr/mb/l77pF75l71nS+lwX9Kg/+cBj+aBjeeBjeh3/gpfpqf5ee5BW5JV/g1vsKv81vcNvdTd/hdfo/f5zPuD3fIHesZf8H3+Bv+jnvgnvSFf+M/+KEs+OEsuJEsuDH9kgX/NQt+ko/4GW6O+66L/DK/ypf5KrfB1bi6Nvgm3+LbfIfrcgd6xJ/y5/wlf83dcvf6j3/mX/l3vpT7Ve5XOpoHP54HP5H7FT/FTXOz3Lwu8Ev8Cr/GV7h1bku3+V/8Dr/L73H7XKZ/+UP+mD/jL7ged6N3/AP/xL/wb9wHN1SEDhfBjxTBjxV+VfgVN8lF3IzO8T/4RX6ZX+XKXFU3+Rpf5xt8k2txbe3w3SL+D6BYHCI=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="408">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx9kT9LA0EQxffORhHSpbA6G4t8AiuF271bBW3VQrCyFExhKeZPEVAEBUG0ChZ+AUkliK0fIRCLNKksFEnp3ZrfkgmLhQePmZ2Z9+YxNy6T9Nht6APXTZfiZQ3Gk5qafETe9MglSg3Mqy9fe1WXWjgy9zcPdf+DeEE75Ms79CTzQE2/0JtE8Qn3Pn6fYV319FOZGCI9IrOjomaui55pPDSz/sthflRVtv24axtpxw6fr+wgbdpoq8xvVjr5WaWWX7TPs+9oLzs57ZtB69bsq02PpPjUq2XV3LlFQ+QN2CP7uT/3m3NdH3fiN++FXP6H9HjTR0t08Q/wvOCi2U60RWs7qns+9yBnJ5ofP2veJ3w41JmnF96YukSARuiXXDzLLZkB5HC4q+zGIxzwC9YQC9s=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="16709_GNVVEIEEDASTR/2_y8" index="93" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="709.841" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="GNVVEIEEDASTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="920.434" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EfDRHPQzTEMzzEM0RDHD1E/CJ6iIaj4Ygb4oY4iqPhiCfihrghjnuI+P3jeYiGaIhoiOiIhmiIhoiGaIhoeO58X5/lvbzGTxT1V07iQaJKEveu+6sm8Z9uf7Ukrg1WT+LSYA2uyf3WFt/mO/wBn3J/uWPuVM/5S77H3/L33CP3rK/8O//JD6XBj6TBjabBjev3NPgfafBTfImf5ea5RV3mV/hVfo1f5za4LW5bd/k9fp/v8odcwR3pCX/GX/BX/A13xz3oE//Cv/EffJQFN5wF90XHsuC/ZcFPZMFP8tPcDDfHLegSX+YrfJWvcXWuoU1+h2/xbb7DHXCp/uOP+VP+nL/ketyt3vOP/DP/yr9zn9xQHjqSBz+aBz+e+1XuV9wUV+JmdZ7/xS/zK/wqt8at6ya/xW/zu/wet8919ZAv+CP+hD/jLrgr7kbv+Af+iX/h37gPLipCh4vgvxZ+VfhV4VfcJDetP/k5foFf4stchatqja/zDb7J73Atrq2dIv4Pn+8eAQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="512">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUjtIA0EQvT0VRFLEImAhxFgERFFQwSqY7OxiGkFBbCwCWggifjotNJwSksPKUk5QJCISbDRY2Bi7FBZ2IhoLyyBoF0HvTl/ISA6G+b+Zt3O2F04U3VX5ZH4mIJa3JwfcCQkNf0cUZUGUZdUNy0HjOMFi//UZja/ZZhy7gQss+Ohv1ohDGIt7vr4/5HapTYmeMxUYmdJ+Nqft2Ike7r3UmYijnYeofo7cq+WtblWybunCT1JIjNKVL4hnhcSLxN7MBTOxC+I8hznCZq68G3bIm/304/fRmBFWKeNOLcl5Hdt41cGDmp6ZfNTBhRW9O9SiA5Wq6ho/V7W0ra79d3qLt6usu0lrZoGq1j5VrFOa9sqUN7L1XaFz3hy1ph06NG8oJRzqNNcpLpI064f+xTQCBA4Z/6gu2B8aHMC1ww8TYtBRc5GwM/K4FfLwwQtY6EEd58GLsVGDesTBnefhLdjGG8FHD+7Ft+P/hu/IOb4n6hmTc+hhASZiv9vAIik=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="27628_FTQAGSEVSALLGR/2_y9" index="94" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="718.381" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="FTQAGSEVSALLGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="931.517" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="604">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFklWEYwPFjzHaRupjGkTGJJKY5pl1M+0zGrDEV0y6mXWyNyZiMaRdHu5h2MY3JVhKpi5TzfW8jiiSSaOsidZEiSZOUpJTMpnPO+3tuHj6/7++9eAqF8nwuJbnKfLN/lZL1tfL8KyVXVsqTS5PRytSlSYUXdqbR7U6j22PvTaM/wB/iD/NHuKNcr32cP8Wf5s/wZ7lz3Hn7An+Rv8Rf5q9xN7k79j3+Af+Yf8avc6+5d9xH+wv/g//Db/E1Wfxem0VfH/exHVnVre7Kqv/nG7KqLzZGv5HnmrjmuAv7ol/ZH33uoH6LfivXxrXrd+h36nfpd+v3cH1cP3dCf0B/UH9If9g7Rrgxblx/Qn9Sf0p/Wn+GK3Kz+nP68/oL+ov6S9wyd1X/uv4N/Vv6t/Xvchm3yt3Xf6j/SP+J/lPveM694F7qv9J/o/9W/73+B+4Tt6H/Vf+7/k/93/p/uU1uW78mxH5tiP364K6Cuwruimvk8nGPNkW/1hzcVXBXwV1xLVyrfpt+u36Hfqd+F9fN9ej36ffrn9Qf0B/khrhh/RH9Mf1x/Qn9SW6Km+Zm9Iv6s/pz+vPescAtcksh+Q/c4i/g</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="388">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNkr1Lw1AUxV/SRcFBEMHJ2q12FtHNvJuHo6BbaUE7uNa/oKsOLg4BQcEKLu4uzg5ODoKL4Oiuu02qv9AjL3A59+Pcj/NI4b6zw+omG6VrNYb0xH9Odn3xl8cHixkH3HZjfzlt+n764IfVsu258zqmJlQ/MXPxQTf7yIPaSawe3YIPh7zqIAYHU11c7eQmceL7yaOJ29FBL9Ytn+sZqjNDCBcTFx8eeJA18n7rPm+Pl8LR/mo4vWiHzZ1WuM228rukZ4uNj38++0Byg+lXjZqDzz7djX52gbFeYtX0bjHGbx6/m3SJo3nSqLrmx/ukW7doh3L0abb8p6ppr8mZdcpHe5u82Jx7t5/Rlc0nx7ZSDu063bB1t2D6134BoxcAHA==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="9122_VAALELEGDDATGR/2_y9" index="95" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="708.852" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VAALELEGDDATGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="933.432" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EfDfHQQzQ8PMNDPEM0xPE8RPyiIaIhGiJuiBuiIaIhGiIaoiGiiIbfv0Q0RMMRRRwdRw9Hw9FwxA1xQxzPw3Pn+/os7+U1fqKov2oS15/7e0jis9P+aklcGayRxKXBmkk8YFFL23yH7/I9PkqDG06DG9GxNPjvafDjafAT/BT3i5vh5nSBX+JX+DJf4Ta4Ld3h9/gD/og/4c65RK/4G/6Ov+efuDr3oq/8G//Of/Cf3F9uKAv9kgU/mgX/LQv+Rxb8T26SK3HTOsvP84v8Mr/KrXHruslv87v8Pn/IHXOnesHn/DV/y1e5B67GNbTJt/g23+G7XI+L8tDhPPivuV/lfpX7FTfBTelvfoaf4xf4JW6FK2uF3+C3+B1+jzvgjvSEP+cT/oq/4e64e+5J6/wf/pV/49+5D+5T//FDhV8VflX4VeFXhV/pJF/ip/lZfp5b5JZ1lV/j1/lNfpvb5fa5Qz3mz/gLPuevuVuuqo98jW/wTb7FtbmOdvkeH13G/wHueCN1</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="540">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxNUU0ohFEUffNjw1ip2cnvggYLTPJTzHffm7FgYa+YjWzEehjxTVEokWxQiI2SJEvJxoyNJFFmsqHYCOWnzHzzmfNya16d3n3n3Xvuue8lxWYg+Y9mZ3ngS7xrMCdyC3s+x9hyjxmoOcyUGfm5DK7J10XMd/fOTWM3GzIOnCkjbMc1cIYea2JnjnWQN2EPUb9jnM4zo9QjPAQtzgfgjWvYGzjktTmWaO80IV8SG2rttjc44nsIxu6qQ6lXX+hkZjnojm6rn453ORkYlr/OsKw1m+TxWafsiwpZ7CqTqxPPuvdz1KTWqVkaEN05Dyb5rXl9Xrc8MpJO0Y3bou/MteaBOduh/V5ZM/pcMr1Epa5mqsvWEt5g0T4yMAvP4xcLGuBRi3cAj/nB4Q4c5vpMv+kYHLQQo4bfAXWIo6KcVoRX920viFDQ3CWvSFBDbI9GxSv5qEJaVous6dqRj4NF6sk0lPfCVPurs+qjKqwuOzpVoV2p4qcvsjFbLz3Cp3WgB0+HDhfBC/fjnf+WveX/+x/xZhDV</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="39282_SVYPESISSSNSR/2_y9" index="96" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="706.836" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SVYPESISSSNSR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="966.451" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="556">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFkm3Ecx+GQwyg9lB1G2WGMjbJD6CGMt5QcRg8l7FB6CGWl5DDKRtih9BBGR8l437x5U8IOoayMHEoOJTSEHUIPYeRQchhhI+ywxv/5XT5e7/PyHr7D24c7i6OD5aVxlFteN46+Nh6uF0eF5Q10HEfDpZ/ycz6XBL+aBLeeBPdCN5Pgt5Pgd/l9/oj7wJ3qOX/BX/LX/C13x93rXz7fDH6tGfzTZvAbzeCKzeBKXFkrfJWv8XW+wXW479rnR/yEn/EL7/NpeF7RtTT4J6n/TMN3z1P/yxW4om7xJX6HL/N7XIV7x1X1mK/xJ3ydP+MaXKodvstf8T2+zw24kY75CT/lZ/ycW3C5VuijVvCrreAft4JfbwX/jHvJveI29TW/zb/hd/m33D53oEf8e/4j/4k/5T5z5xrzF/w3/pL/wV1zNzrkf/J3/C/+nvvN/eH+aT4LfiWzq8yuMrvK7Irb0AJf5Lf4Er/Dlbk9rfCHfJU/5mvcCVfXL3yDT/kO3+WuuJ72+QE/4sf8hJtyM26uCz7Xtqu2XbWj/0QcFeA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="312">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx1UbEKwjAUTAuubu5dHPoRDk3aIji5q7uDkNHN4iYqiKOLbi5u/oSTqwjFzbkfIFa9wsEj1MCRl3vvXS4vVgWRclav3Ef2x9uaHHnmGKNHnmX97VVUkHVY4Fxd6UHm6nbplTE1yeN8VoEGeJY6vId9mTrocRmah2/1VXX1v3ch98nmphit4+Z9mUx3YToYdtLFNk+em3YymTXivp9r3od67NClT8QAvNEv6gBwnr/S9IHYnR39E+ghTy28BzxiaFGHc6n7a8TI0Rs0+IcSnCf9cM7043o8vlsGOHmXShs7ZvQFuXPKKg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="17033_VDLVDDEELLELVEMEIR/3_y8" index="97" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="720.364" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VDLVDDEELLELVEMEIR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1018.53" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="596">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFEZHEcwPERe1j2sMSujT0sHSI6NDoMwzyGOYwdNoY5DB2i0SE6RHSIOUSHiA7RWxEdokNEEb33okNEb0WHiA4RGx0iOkSHdtb/87v8Ll8fv8OvUOhNKYn+r245iTq9+VtJoj95nv+sJlGxNwe1JPodx/G3uq6h+xV2pxn6vBX6Yjv08UToC5O6Kd20boY/y5/jz/MX3LGo6+qW+Mv8Ff4qf42/rtvQbfK3+Nv8Hf4uf0+3rzvQHfGP+Sf8U/6ZO851F7pL/hX/mn/Dv+Xf6e51D/xH/hP/mf/Cf9W96d75fWnwP6TB/5gG/1Ma/M9p6Pp1X3QDYeffQ1/8Efp4MPSFodB3hnUjulH+GL/EL/Mr/KqupqvzG/xxfpPf4rd1E7pJ/hR/mj/Dn+XP6eZ1C/xFfpe/xF/mr+hWdWu6df4Gf5O/xd92x45uV7fH3+cf8o/4x/wT3anujH/Ov+Bf8q/417ob3S3/jn/Pf+A/8p90z7oX3Sv/jf/O78v8VeavMn+V+auw4/4s+F9D3xnI/FXmr3SDuqGwu8P8Ef4of4xf0pV1FX6VX+PX+Q3+uK6pa/HbWfQP7TYx1g==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="368">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJy7xbjA8dH/92B8C8je+E8ezgZhBiCAyfsyKjiB5EEYJA5TCxK/BTUHxK5iKnCCicHMhNEgcRAG6YeZDzMPpr+ZyQOsBsSH2QfjgzCyPMweZHfB9IHUgeRAaqoZtzhdYzgBdxtIDiQGoq/+mw93P8wMmPuWMPY4wcTQ1cDMffQ/0Hn5/+fORk7uLv9qp7u07dvqwrBokcvHhk6XJ3+SXLIPari8ZfjtHNb0yDn2/2ZnkHqlhiZnfwZ75zd/RZ0vM6SB6Rf/GZ09mD84geyE0SD3gtggt4PsamHUcoaJw8IA5C4QH8SG0TD/g/iw8AL5E8SGhQty+ML8A4szkB0wNswOWFwhhxEyGxsgJA8CAKfS7ic=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="25887_DGPVILTSQGEER/2_y9" index="98" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="700.854" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="DGPVILTSQGEER"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1032.54" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGhwxJ7iA7RYYk9LB3ipUPEG7FLdIgOER2GOQxRxBxi2GXoMHQYYpYY779hl+gQUUSHiIboEB0iWqJDdIjosDN+n+fyvXyOTxT1V07i0mDVJO5d9beRxL/b/dWSuDJYPYkHLGpwTW3xbb7Dd/kD7og70XP+kr/mb/l77pF75l71nS+lwX9Kg/+cBj+aBjeeBjeh3/gpfpqf5ee5BW5JV/g1vsKv81vcNvdTd/hdfo/f5zPuD3fIHesZf8H3+Bv+jnvgnvSFf+M/+KEs+OEsuJEsuDH9kgX/NQt+ko/4GW6O+66L/DK/ypf5KrfB1bi6Nvgm3+LbfIfrcgd6xJ/y5/wlf83dcvf6j3/mX/l3vpT7Ve5XOpoHP54HP5H7FT/FTXOz3Lwu8Ev8Cr/GV7h1bku3+V/8Dr/L73H7XKZ/+UP+mD/jL7ged6N3/AP/xL/wb9wHN1SEDhfBjxTBjxV+VfgVN8lF3IzO8T/4RX6ZX+XKXFU3+Rpf5xt8k2txbe3w3SL+D6BYHCI=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="424">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUjFIA0EQ/MurjZ2xsfK7hzSCtRhy+39BBAsrwS6k18ImIElIkyKxSCFaiNqLXVotJEGsUkkgpLC28A2Wkr9kHgaeP1h29253Z3Y4326XJuoxMX8ZO8vDHDHuaLh7+Y9KNeVp2Kvq6x33XDOf2bJG3VPcSd5Qizt4GOdkc/QSi9jEx0EtY/L0M7yJzT569qZxsnPhUc89UHs4f9CfqifdZjHoV/6CraNO+GbG4UlrzfyM8iZfyJm9g1a4e7Ya6sZd4DobweRyJr/1nlyrnECDCzVNdMAsGHLgDOy7xju0g6eu1AYcyI37UTPMu7VlMXFNqvV24q/Uvqy4x/IVrwt6v60nQ+UJap/nkUaMmq5zI5uND7m3p4IZ5AYe8JgPPsSnLrQ0b+TkD4z0jtgfM/DOffgP0vtQ8wXNLwld</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3639_AISEGMEVYGINR/2_y9" index="99" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="719.853" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AISEGMEVYGINR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1038.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGXDkuHiI2lw7KHZekQc4iINzoMsRFziDnEMIehwxAtMYeYQwwdInaIDtH7T+wSHaJDRDR0iGiJDhEb0SE6RDN+n+fyvXyOTxT1V07i3mV/P5O4+7u/ilaTuD5YLYlLgzWSeMCjJr/Gtbg219Ftvsvv8Qf8IXfEnegZf8Ff8Tf8HffA/dcX/o2P0uA/pcGPpMF9ToMb129p8D/4SX6Kn+HmuHld5Jf4Zb7Or3Cr3Dq3oZv8Fr/D7/L7XM790WP+lD/ne/w1d8vd6yP/zL/y7/xQFtxwFtyofsmC/5oF/z0LfoIvcdPcLFfWBb7CV/ka3+Ca3Jq2+Dbf4bf5LrfHHeghf8Sf8Gf8BXfF3egd/8A/8S/8GxflfqUjefBjefDjuV/lfsVNclPcjM7x8/wiv8Qvc3VuRVf5dX6D3+S3uB1uV/f5nP/LH/On3DnX4671H3/PP/LP/Cv3zg0VocNF8KOFXxV+VfgVN8GVdJqf5cv8Al/hqlxNG3yT/8W3+DbXKeIPWjopxQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="420">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdkj1Lw1AYhfPh2OKki0OcCoKbg1sl9yZBHaRQCDh0da1F8Ac4uCgqOAgurZuTCDo2ox8/QnFyD7iINI19AkeCgZfz5p7zft7bcfOwOe0brDPz7TQwubMcBu4oPPM3DcgZ5sw+NPBg3XSGXr7ygMSSo64F5VMLflwOzaA4qfq59PLqH554aeDIW4/jrN4jvHr/X0/zKAf1MGopDh/N0Hk0H5M1S340qgdWvv9uDy7m46V2K3n9uk4+D0+T45/VZOvuNk4babxbNOPn3lU0GqfR/bQbnWc70WLWjQZZK/qe9O2Tt2e3/ba9KYMKqbfhebZXrljmf3AblQ8HojsqFv44tOtzbwbbL16M7lK9YtpTfV/aB3NyRl3NzL/i2QU+PPnRgHoruivtU/utvyfFk48+tX/dzS+wifbH</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="16705_GNVVEIEEDASTR/2_y9" index="100" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="709.841" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="GNVVEIEEDASTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1049.48" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EfDRHPQzTEMzzEM0RDHD1E/CJ6iIaj4Ygb4oY4iqPhiCfihrghjnuI+P3jeYiGaIhoiOiIhmiIhoiGaIhoeO58X5/lvbzGTxT1V07iQaJKEveu+6sm8Z9uf7Ukrg1WT+LSYA2uyf3WFt/mO/wBn3J/uWPuVM/5S77H3/L33CP3rK/8O//JD6XBj6TBjabBjev3NPgfafBTfImf5ea5RV3mV/hVfo1f5za4LW5bd/k9fp/v8odcwR3pCX/GX/BX/A13xz3oE//Cv/EffJQFN5wF90XHsuC/ZcFPZMFP8tPcDDfHLegSX+YrfJWvcXWuoU1+h2/xbb7DHXCp/uOP+VP+nL/ketyt3vOP/DP/yr9zn9xQHjqSBz+aBz+e+1XuV9wUV+JmdZ7/xS/zK/wqt8at6ya/xW/zu/wet8919ZAv+CP+hD/jLrgr7kbv+Af+iX/h37gPLipCh4vgvxZ+VfhV4VfcJDetP/k5foFf4stchatqja/zDb7J73Atrq2dIv4Pn+8eAQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="492">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUbFKA0EQ3bsrtZSIIl6KFJLGwsbGhOzsxdQ2KmkCQkoJNoKYBINgc2IKJYhI0tgEkRSBVIIIImIjUbCQCAqKCIF8QO5O3+LA4cJjdmbfe7PMJIN6KvkH8XsQ2+ZAg+tPQzu16tmS73hDDOfM/TIKEtzD4a3GiOnqaFoZCR5yvEOHfqiHeyCyN3IAOkTw4c859w3/DRz+E+tR+88Je7IH9837L3JFxKkTdOnD31Dm+rTT/+w4meZEutWaT+8W4+lyv+qUX+POvneucvaeql1uqoiYVA/Fd+oZJ/S449JBpUHjRo9mrTu6Kj0TPKfMAp36DfoWLi2WzujNv6BsMEfSylPTWKIFY4tyRoTuRYKuRVvPbVmM6juAWcbEQPZElDCLI2HqN/wZETnPHj7Qgofe0MAPXNyrXl37YyeshTfq0KKOfGa7S2siprrBsbpJ1FS0klRjXlbrAd43+Lx/AH3YG0AN/eAJHu/+B+RfCNI=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="27626_FTQAGSEVSALLGR/2_y11" index="101" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="718.381" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="FTQAGSEVSALLGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1059.58" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="604">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0lFklWEYwPFjzHaRupjGkTGJJKY5pl1M+0zGrDEV0y6mXWyNyZiMaRdHu5h2MY3JVhKpi5TzfW8jiiSSaOsidZEiSZOUpJTMpnPO+3tuHj6/7++9eAqF8nwuJbnKfLN/lZL1tfL8KyVXVsqTS5PRytSlSYUXdqbR7U6j22PvTaM/wB/iD/NHuKNcr32cP8Wf5s/wZ7lz3Hn7An+Rv8Rf5q9xN7k79j3+Af+Yf8avc6+5d9xH+wv/g//Db/E1Wfxem0VfH/exHVnVre7Kqv/nG7KqLzZGv5HnmrjmuAv7ol/ZH33uoH6LfivXxrXrd+h36nfpd+v3cH1cP3dCf0B/UH9If9g7Rrgxblx/Qn9Sf0p/Wn+GK3Kz+nP68/oL+ov6S9wyd1X/uv4N/Vv6t/Xvchm3yt3Xf6j/SP+J/lPveM694F7qv9J/o/9W/73+B+4Tt6H/Vf+7/k/93/p/uU1uW78mxH5tiP364K6Cuwruimvk8nGPNkW/1hzcVXBXwV1xLVyrfpt+u36Hfqd+F9fN9ej36ffrn9Qf0B/khrhh/RH9Mf1x/Qn9SW6Km+Zm9Iv6s/pz+vPescAtcksh+Q/c4i/g</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="356">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxdUbsKwkAQzFnY2vgBEf8iRSC5O7USxHRWdhaKlW2IFjYKdnZCPsLSXv9BEDuxkNhZ+IiZ4MiRg2Ufdzs7O+emiWdlp/tu+ldh+4gvIvZgbnaHOuKTsPM4sLb+Ih37E1GSa7HMe1BHzF5494fLnAc4jHmHGuv0nAn8Ih/MN/NyKc5zvDVxcA8jjrkjZ+Ce+NyV/JGz3+QKjHvakUk4Urekr9uDo/6oh94FVmPlnPWwZuv9M1S9qaNaYV1VoljG0UxuXknOHVoVPebAkwO1hWE/vGMOHvDkzn9BT1XYEvHcOvyxqQ31oTbUg1qbntqY/2NqYf4ja8Si7pwJLjDw4n58h94vqvPrJg==</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="9124_VAALELEGDDATGR/2_y10" index="102" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="708.852" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="VAALELEGDDATGR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1062.47" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="532">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EfDfHQQzQ8PMNDPEM0xPE8RPyiIaIhGiJuiBuiIaIhGiIaoiGiiIbfv0Q0RMMRRRwdRw9Hw9FwxA1xQxzPw3Pn+/os7+U1fqKov2oS15/7e0jis9P+aklcGayRxKXBmkk8YFFL23yH7/I9PkqDG06DG9GxNPjvafDjafAT/BT3i5vh5nSBX+JX+DJf4Ta4Ld3h9/gD/og/4c65RK/4G/6Ov+efuDr3oq/8G//Of/Cf3F9uKAv9kgU/mgX/LQv+Rxb8T26SK3HTOsvP84v8Mr/KrXHruslv87v8Pn/IHXOnesHn/DV/y1e5B67GNbTJt/g23+G7XI+L8tDhPPivuV/lfpX7FTfBTelvfoaf4xf4JW6FK2uF3+C3+B1+jzvgjvSEP+cT/oq/4e64e+5J6/wf/pV/49+5D+5T//FDhV8VflX4VeFXhV/pJF/ip/lZfp5b5JZ1lV/j1/lNfpvb5fa5Qz3mz/gLPuevuVuuqo98jW/wTb7FtbmOdvkeH13G/wHueCN1</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="428">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYGBg+PJnviMDErj1Rx7OB8mB+CAMYmf/e++ILA7iw+Rh+pD1I5upxqTgBNOPbCayfmQMkgPpQeZ/+Z3vxM7s4bSQYYvTlP+iziD6MMMCsBhIHsQH6QGpg7kNxIfZbc/4wWn9/83OlfYrXY48bXNlsJJ2Yz2+yW3NDS73o4kc7pGJLW5WHxtddR5tdAloiXb5Zcvv0uTE6/KF8ZHzssbZztvrLzu/+r/P+RRDgbMIo4ezCZOdM8gdQf/lnRX+VYLx27r1zrn/mFyM9zO4vGdsd476N9V5IRMPWI0jgxaYBvEz/jLCxbQYe5xAGOROkH9A7oT5ASaO7IfIP7fB6pDjAxQGID4Mw/TAwhHGRpYH2QGiQXph4YzsFpB6kD0wt8DiABbOIDkYGywPlIPphfFh9oPYIPNBdiG7BQBApwnf</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="39277_SVYPESISSSNSR/2_y10" index="103" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="706.836" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="SVYPESISSSNSR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1063.5" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="556">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0kFkm3Ecx+GQwyg9lB1G2WGMjbJD6CGMt5QcRg8l7FB6CGWl5DDKRtih9BBGR8l437x5U8IOoayMHEoOJTSEHUIPYeRQchhhI+ywxv/5XT5e7/PyHr7D24c7i6OD5aVxlFteN46+Nh6uF0eF5Q10HEfDpZ/ycz6XBL+aBLeeBPdCN5Pgt5Pgd/l9/oj7wJ3qOX/BX/LX/C13x93rXz7fDH6tGfzTZvAbzeCKzeBKXFkrfJWv8XW+wXW479rnR/yEn/EL7/NpeF7RtTT4J6n/TMN3z1P/yxW4om7xJX6HL/N7XIV7x1X1mK/xJ3ydP+MaXKodvstf8T2+zw24kY75CT/lZ/ycW3C5VuijVvCrreAft4JfbwX/jHvJveI29TW/zb/hd/m33D53oEf8e/4j/4k/5T5z5xrzF/w3/pL/wV1zNzrkf/J3/C/+nvvN/eH+aT4LfiWzq8yuMrvK7Irb0AJf5Lf4Er/Dlbk9rfCHfJU/5mvcCVfXL3yDT/kO3+WuuJ72+QE/4sf8hJtyM26uCz7Xtqu2XbWj/0QcFeA=</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="308">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxjYEAFJ/7IOy3+I+/Ix7zAESYG4oMwiA0Sh/FhamHqQfQ1pg9gNowPY4MwSD2IBqkByZn8yXeCsWH6QGrQ3YILw9wGokH6YTTMPra/7k4weXS3I7sJ5g5kt8LMw+YWkNyGP7edNvwPc7E5tsx15YQ1bqIOwe5mdWnu0jms7rucnNw+XvZzrXEUdQGZDdJ7lGGB02aGHieQvqB/x51a/4s6g+RAbFgYwOyG2QfCMHeBaJg6ZD8hhxfMj8jmoasHsUHugInB9COrQQbIaQE57EF2wOITPe6xpQOQX7GZBWIDANkf2ts=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="16707_GNVVEIEEDASTR/2_y10" index="104" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="709.841" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="GNVVEIEEDASTR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1148.55" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0j9E9HEAx/EfDRHPQzTEMzzEM0RDHD1E/CJ6iIaj4Ygb4oY4iqPhiCfihrghjnuI+P3jeYiGaIhoiOiIhmiIhoiGaIhoeO58X5/lvbzGTxT1V07iQaJKEveu+6sm8Z9uf7Ukrg1WT+LSYA2uyf3WFt/mO/wBn3J/uWPuVM/5S77H3/L33CP3rK/8O//JD6XBj6TBjabBjev3NPgfafBTfImf5ea5RV3mV/hVfo1f5za4LW5bd/k9fp/v8odcwR3pCX/GX/BX/A13xz3oE//Cv/EffJQFN5wF90XHsuC/ZcFPZMFP8tPcDDfHLegSX+YrfJWvcXWuoU1+h2/xbb7DHXCp/uOP+VP+nL/ketyt3vOP/DP/yr9zn9xQHjqSBz+aBz+e+1XuV9wUV+JmdZ7/xS/zK/wqt8at6ya/xW/zu/wet8919ZAv+CP+hD/jLrgr7kbv+Af+iX/h37gPLipCh4vgvxZ+VfhV4VfcJDetP/k5foFf4stchatqja/zDb7J73Atrq2dIv4Pn+8eAQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="404">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJx1kL1KQ0EQhWcvaJPCSlARI8TGdIpNGiE7uxBsgq0PoGhjwMpCJLdRMLaxjChaW6RQ8Ae7gK9gJ9gqaCPqXjkLRxbBhYHZb2bnnB0RkbGiXP8bZ/IaI823soatyLS+mwUN0rJgh6FXl38O6mmOXjLOBaMme5mzxndpX+o11SSjL3hOPaYzmaecf8X/akVJ27t9Hb49cYvNml+qnvqN4ys/NHLtZ1qz/vLu3JXCvJu6n3Bz4UZXsq5O5h19C0aPTFVXi1Hd/lqO+xpIQ3fybuSoP4Wezb9ffvc5Lh0LTbB104/5pwwsOBjegeMtGGq4k6EfHMG9QgP8OZQtcs7DHYEa9oPgv8mpj/n7sqYf2UWMg1Bxm+296PnBPFr65j5Tb/REPejwjpz6Pxev7MY=</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+			<chromatogram id="3637_AISEGMEVYGINR/2_y11" index="105" defaultArrayLength="161">
+				<cvParam cvRef="MS" accession="MS:1001473" name="selected reaction monitoring chromatogram" />
+					<precursor>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="719.853" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+						<activation>
+							<cvParam cvRef="MS" accession="MS:1000044" name="dissociation method" />
+							<userParam name="peptide_sequence" type="xsd:string" value="AISEGMEVYGINR"/>
+						</activation>
+					</precursor>
+					<product>
+						<isolationWindow>
+							<cvParam cvRef="MS" accession="MS:1000827" name="isolation window target m/z" value="1254.59" unitAccession="MS:1000040" unitName="m/z" unitCvRef="MS" />
+						</isolationWindow>
+					</product>
+				<binaryDataArrayList count="2">
+					<binaryDataArray encodedLength="536">
+						<cvParam cvRef="MS" accession="MS:1000595" name="time array" unitAccession="UO:0000010" unitName="second" unitCvRef="MS" />
+						<cvParam cvRef="MS" accession="MS:1000523" name="64-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJwt0k9EpHEAxvGXDkuHiI2lw7KHZekQc4iINzoMsRFziDnEMIehwxAtMYeYQwwdInaIDtH7T+wSHaJDRDR0iGiJDhEb0SE6RDN+n+fyvXyOTxT1V07i3mV/P5O4+7u/ilaTuD5YLYlLgzWSeMCjJr/Gtbg219Ftvsvv8Qf8IXfEnegZf8Ff8Tf8HffA/dcX/o2P0uA/pcGPpMF9ToMb129p8D/4SX6Kn+HmuHld5Jf4Zb7Or3Cr3Dq3oZv8Fr/D7/L7XM790WP+lD/ne/w1d8vd6yP/zL/y7/xQFtxwFtyofsmC/5oF/z0LfoIvcdPcLFfWBb7CV/ka3+Ca3Jq2+Dbf4bf5LrfHHeghf8Sf8Gf8BXfF3egd/8A/8S/8GxflfqUjefBjefDjuV/lfsVNclPcjM7x8/wiv8Qvc3VuRVf5dX6D3+S3uB1uV/f5nP/LH/On3DnX4671H3/PP/LP/Cv3zg0VocNF8KOFXxV+VfgVN8GVdJqf5cv8Al/hqlxNG3yT/8W3+DbXKeIPWjopxQ==</binary>
+					</binaryDataArray>
+					<binaryDataArray encodedLength="384">
+						<cvParam cvRef="MS" accession="MS:1000515" name="intensity array" unitAccession="MS:1000131" unitName="number of detector counts" unitCvRef="MS"/>
+						<cvParam cvRef="MS" accession="MS:1000521" name="32-bit float" />
+						<cvParam cvRef="MS" accession="MS:1000574" name="zlib compression" />
+						<binary>eJxrYf7gyAAE3//JO4IwjA2i3RkWOLYA5UF8/n/yTjA1IHFkPcj6kPkgdbjkkAE2M2B2I7sHRMPcg+5WZPtg+rGpwWYXTC+6O9H1oZsBcotP/SPncuufLh+my7v56i11+3p2ktukTVJuPyKXuO747OWq9IHX9dCDmS5Ce/Jdzvw3d7llo+byzS7BhYNRz8WRcZqzA5OC87E/m53Y/2s6P2TgcQbRoLA+yCjmrPIv0LmF6Y6Twp/jTox/5zu5sRQ4wfggNlgfI5MzSG7XH3cwBslr/n3vBDIDJgby2+y/3WAxkBxILwiD5EDiIP0gc0DyIDNBZoDEQHw/BjuwO2B2gMRgcQPiw8wBiYPYMDkQH0SD+CAM4sP0wtTA5AEg2fRh</binary>
+					</binaryDataArray>
+				</binaryDataArrayList>
+			</chromatogram>
+		</chromatogramList>
+	</run>
+</mzML>
+<indexList count="1">
+	<index name="chromatogram">
+		<offset idRef="4197_AAGGISSLEDAK/2_Precursor_i0">21273</offset>
+		<offset idRef="3414_VATTQGIQSTR/2_Precursor_i0">24256</offset>
+		<offset idRef="2448_AMVTEYGMSEK/2_Precursor_i0">27145</offset>
+		<offset idRef="643_VPIVLDIFAER/2_Precursor_i0">30082</offset>
+		<offset idRef="2228_AVYLKPEDPFTWASGIK/3_Precursor_i0">32982</offset>
+		<offset idRef="170_AAGASAQVLGQEGK/2_Precursor_i0">36030</offset>
+		<offset idRef="4864_DGGVEIATTNVSK/2_Precursor_i0">38968</offset>
+		<offset idRef="1789_TIAMESTDGLTR/2_Precursor_i0">41996</offset>
+		<offset idRef="4703_LVLTSDDILDLR/2_Precursor_i0">44903</offset>
+		<offset idRef="5410_AVDNVNNIIAEAIIGYDVR/3_Precursor_i0">47998</offset>
+		<offset idRef="6948_SYVTEEELAAER/2_Precursor_i0">51139</offset>
+		<offset idRef="4469_DGPVILTSQGEER/2_Precursor_i0">54023</offset>
+		<offset idRef="6778_SVYPESISSSNSR/2_Precursor_i0">56897</offset>
+		<offset idRef="1579_VAALELEGDDATGR/2_Precursor_i0">59639</offset>
+		<offset idRef="2883_GNVVEIEEDASTR/2_Precursor_i0">62627</offset>
+		<offset idRef="4772_FTQAGSEVSALLGR/2_Precursor_i0">65569</offset>
+		<offset idRef="632_AISEGMEVYGINR/2_Precursor_i0">68709</offset>
+		<offset idRef="2939_VDLVDDEELLELVEMEIR/3_Precursor_i0">71674</offset>
+		<offset idRef="1321_VFHEVLSMDDAAEAISSK/2_Precursor_i0">74706</offset>
+		<offset idRef="3358_TIEQAHALDATLEELGLR/2_Precursor_i0">77633</offset>
+		<offset idRef="24328_AAGGISSLEDAK/2_b4">80713</offset>
+		<offset idRef="24327_AAGGISSLEDAK/2_a5">83418</offset>
+		<offset idRef="24325_AAGGISSLEDAK/2_y7">86151</offset>
+		<offset idRef="24326_AAGGISSLEDAK/2_y10">88920</offset>
+		<offset idRef="19793_VATTQGIQSTR/2_y4">91534</offset>
+		<offset idRef="19789_VATTQGIQSTR/2_y6">94101</offset>
+		<offset idRef="19790_VATTQGIQSTR/2_y7">96600</offset>
+		<offset idRef="19792_VATTQGIQSTR/2_y8">99091</offset>
+		<offset idRef="19791_VATTQGIQSTR/2_y9">101534</offset>
+		<offset idRef="14154_AMVTEYGMSEK/2_y5">103948</offset>
+		<offset idRef="14153_AMVTEYGMSEK/2_y6">106731</offset>
+		<offset idRef="14149_AMVTEYGMSEK/2_y8">109430</offset>
+		<offset idRef="14151_AMVTEYGMSEK/2_y9">112105</offset>
+		<offset idRef="987_AAGASAQVLGQEGK/2_b3">114720</offset>
+		<offset idRef="3707_VPIVLDIFAER/2_b3">117587</offset>
+		<offset idRef="985_AAGASAQVLGQEGK/2_y5">120273</offset>
+		<offset idRef="12884_AVYLKPEDPFTWASGIK/3_y6">123152</offset>
+		<offset idRef="28178_DGGVEIATTNVSK/2_y7">125798</offset>
+		<offset idRef="988_AAGASAQVLGQEGK/2_y7">128608</offset>
+		<offset idRef="10362_TIAMESTDGLTR/2_y7">131382</offset>
+		<offset idRef="3706_VPIVLDIFAER/2_y6">134055</offset>
+		<offset idRef="12883_AVYLKPEDPFTWASGIK/3_y7">136769</offset>
+		<offset idRef="28180_DGGVEIATTNVSK/2_y8">139459</offset>
+		<offset idRef="990_AAGASAQVLGQEGK/2_y8">142169</offset>
+		<offset idRef="3704_VPIVLDIFAER/2_y7">145051</offset>
+		<offset idRef="10361_TIAMESTDGLTR/2_y8">147757</offset>
+		<offset idRef="989_AAGASAQVLGQEGK/2_y9">150417</offset>
+		<offset idRef="28177_DGGVEIATTNVSK/2_y9">153184</offset>
+		<offset idRef="3703_VPIVLDIFAER/2_y8">155954</offset>
+		<offset idRef="12888_AVYLKPEDPFTWASGIK/3_y9">158556</offset>
+		<offset idRef="10360_TIAMESTDGLTR/2_y9">161174</offset>
+		<offset idRef="3705_VPIVLDIFAER/2_y9">163823</offset>
+		<offset idRef="10357_TIAMESTDGLTR/2_y10">166377</offset>
+		<offset idRef="12887_AVYLKPEDPFTWASGIK/3_y12">169139</offset>
+		<offset idRef="7627_VFHEVLSMDDAAEAISSK/2_b4">171622</offset>
+		<offset idRef="7631_VFHEVLSMDDAAEAISSK/2_b5">174229</offset>
+		<offset idRef="19473_TIEQAHALDATLEELGLR/2_y9">176827</offset>
+		<offset idRef="19475_TIEQAHALDATLEELGLR/2_y10">179540</offset>
+		<offset idRef="7629_VFHEVLSMDDAAEAISSK/2_y12">182178</offset>
+		<offset idRef="19472_TIEQAHALDATLEELGLR/2_y11">184758</offset>
+		<offset idRef="19471_TIEQAHALDATLEELGLR/2_y12">187511</offset>
+		<offset idRef="7632_VFHEVLSMDDAAEAISSK/2_y13">190133</offset>
+		<offset idRef="19476_TIEQAHALDATLEELGLR/2_y13">192721</offset>
+		<offset idRef="40272_SYVTEEELAAER/2_y4">195311</offset>
+		<offset idRef="31344_AVDNVNNIIAEAIIGYDVR/3_y4">197964</offset>
+		<offset idRef="31339_AVDNVNNIIAEAIIGYDVR/3_y5">200995</offset>
+		<offset idRef="40270_SYVTEEELAAER/2_y7">204144</offset>
+		<offset idRef="31342_AVDNVNNIIAEAIIGYDVR/3_y7">206777</offset>
+		<offset idRef="31343_AVDNVNNIIAEAIIGYDVR/3_b8">209815</offset>
+		<offset idRef="40271_SYVTEEELAAER/2_y8">212809</offset>
+		<offset idRef="27233_LVLTSDDILDLR/2_y8">215490</offset>
+		<offset idRef="40268_SYVTEEELAAER/2_y9">218219</offset>
+		<offset idRef="27229_LVLTSDDILDLR/2_y9">220895</offset>
+		<offset idRef="27234_LVLTSDDILDLR/2_y10">223612</offset>
+		<offset idRef="27629_FTQAGSEVSALLGR/2_y7_2">226290</offset>
+		<offset idRef="25889_DGPVILTSQGEER/2_b4">229069</offset>
+		<offset idRef="27630_FTQAGSEVSALLGR/2_b3">231836</offset>
+		<offset idRef="3641_AISEGMEVYGINR/2_y4">234536</offset>
+		<offset idRef="39279_SVYPESISSSNSR/2_y10_2">237238</offset>
+		<offset idRef="17031_VDLVDDEELLELVEMEIR/3_y4">239968</offset>
+		<offset idRef="39281_SVYPESISSSNSR/2_y11_2">242653</offset>
+		<offset idRef="27627_FTQAGSEVSALLGR/2_y6">245179</offset>
+		<offset idRef="3638_AISEGMEVYGINR/2_y5">247848</offset>
+		<offset idRef="39280_SVYPESISSSNSR/2_y6">250598</offset>
+		<offset idRef="17029_VDLVDDEELLELVEMEIR/3_y5">253232</offset>
+		<offset idRef="9121_VAALELEGDDATGR/2_y7">255989</offset>
+		<offset idRef="25886_DGPVILTSQGEER/2_y7">258733</offset>
+		<offset idRef="16710_GNVVEIEEDASTR/2_y7">261420</offset>
+		<offset idRef="9123_VAALELEGDDATGR/2_y8">264159</offset>
+		<offset idRef="39278_SVYPESISSSNSR/2_y8">266903</offset>
+		<offset idRef="3642_AISEGMEVYGINR/2_y7">269554</offset>
+		<offset idRef="17032_VDLVDDEELLELVEMEIR/3_y7">272220</offset>
+		<offset idRef="25885_DGPVILTSQGEER/2_y8">274877</offset>
+		<offset idRef="16709_GNVVEIEEDASTR/2_y8">277536</offset>
+		<offset idRef="27628_FTQAGSEVSALLGR/2_y9">280299</offset>
+		<offset idRef="9122_VAALELEGDDATGR/2_y9">283008</offset>
+		<offset idRef="39282_SVYPESISSSNSR/2_y9">285796</offset>
+		<offset idRef="17033_VDLVDDEELLELVEMEIR/3_y8">288379</offset>
+		<offset idRef="25887_DGPVILTSQGEER/2_y9">291068</offset>
+		<offset idRef="3639_AISEGMEVYGINR/2_y9">293743</offset>
+		<offset idRef="16705_GNVVEIEEDASTR/2_y9">296412</offset>
+		<offset idRef="27626_FTQAGSEVSALLGR/2_y11">299156</offset>
+		<offset idRef="9124_VAALELEGDDATGR/2_y10">301835</offset>
+		<offset idRef="39277_SVYPESISSSNSR/2_y10">304513</offset>
+		<offset idRef="16707_GNVVEIEEDASTR/2_y10">307093</offset>
+		<offset idRef="3637_AISEGMEVYGINR/2_y11">309750</offset>
+	</index>
+</indexList>
+<indexListOffset>312420</indexListOffset>
+<fileChecksum>0</fileChecksum>
+</indexedmzML>

--- a/src/openms/include/OpenMS/KERNEL/OnDiscMSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/OnDiscMSExperiment.h
@@ -170,6 +170,11 @@ public:
       return boost::static_pointer_cast<const ExperimentalSettings>(meta_ms_experiment_);
     }
 
+    boost::shared_ptr<PeakMap> getMetaData() const
+    {
+      return meta_ms_experiment_;
+    }
+
     /// alias for getSpectrum
     inline MSSpectrum operator[](Size n)
     {
@@ -237,7 +242,6 @@ private:
       f.setOptions(options);
       f.load(filename, *meta_ms_experiment_.get());
     }
-
 
 protected:
 

--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
@@ -124,6 +124,8 @@ public:
     typedef LayerData::ExperimentType ExperimentType;
     //Main managed data type (experiment)
     typedef LayerData::ExperimentSharedPtrType ExperimentSharedPtrType;
+    //Main on-disc managed data type (experiment)
+    typedef LayerData::ODExperimentSharedPtrType ODExperimentSharedPtrType;
     ///Peak spectrum type
     typedef ExperimentType::SpectrumType SpectrumType;
     //@}
@@ -154,6 +156,7 @@ public:
       @param consensus_map The consensus feature data (empty if not consensus feature data)
       @param peptides The peptide identifications (empty if not ID data)
       @param peak_map The peak data (empty if not peak data)
+      @param on_disc_peak_map The peak data managed on disc (empty if not peak data)
       @param data_type Type of the data
       @param show_as_1d Force dataset to be opened in 1D mode (even if it contains several spectra)
       @param show_options If the options dialog should be shown (otherwise the defaults are used)
@@ -162,7 +165,19 @@ public:
       @param window_id in which window the file is opened if opened as a new layer (0 or default equals current
       @param spectrum_id determines the spectrum to show in 1D view.
     */
-    void addData(FeatureMapSharedPtrType feature_map, ConsensusMapSharedPtrType consensus_map, std::vector<PeptideIdentification>& peptides, ExperimentSharedPtrType peak_map, LayerData::DataType data_type, bool show_as_1d, bool show_options, bool as_new_window = true, const String& filename = "", const String& caption = "", UInt window_id = 0, Size spectrum_id = 0);
+    void addData(FeatureMapSharedPtrType feature_map,
+                 ConsensusMapSharedPtrType consensus_map,
+                 std::vector<PeptideIdentification>& peptides,
+                 ExperimentSharedPtrType peak_map,
+                 ODExperimentSharedPtrType on_disc_peak_map,
+                 LayerData::DataType data_type,
+                 bool show_as_1d,
+                 bool show_options,
+                 bool as_new_window = true,
+                 const String& filename = "",
+                 const String& caption = "",
+                 UInt window_id = 0,
+                 Size spectrum_id = 0);
 
     /// Opens all the files in the string list
     void loadFiles(const StringList& list, QSplashScreen* splash_screen);

--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
@@ -90,6 +90,28 @@ namespace OpenMS
   /**
     @brief Main window of TOPPView tool
 
+    Uses the default QMainWindow layout (see Qt documentation) with a central
+    widget in the middle (consistent of a EnhancedTabBar and an
+    EnhancedWorkspace) and multiple docked widgets around it (to the right and
+    below) and multiple tool bars. On top and bottom are a menu bar and a
+    status bar.
+
+    The main layout is using 
+    - Central Widget: 
+      - EnhancedTabBar: tab_bar_
+      - EnhancedWorkspace: ws_
+    - Docked to the right:
+      - layer_dock_widget_
+      - views_dockwidget_
+      - filter_dock_widget_
+    - Docked to the bottom:
+      - log_bar (only connected through slots)
+
+    The views_dockwidget_ internally holds a tab widget views_tabwidget_ which
+    holds the two different views on the data (spectra and identification view)
+    which are implemented using identificationview_behavior_ and
+    spectraview_behavior_.
+
     @improvement Use DataRepository singleton to share data between TOPPView and the canvas classes (Hiwi)
 
     @improvement For painting single mass traces with no width we currently paint each line twice (once going down, and then coming back up).
@@ -438,15 +460,15 @@ protected:
     */
     //@{
     QToolBar* tool_bar_;
-    //common intensity modes
 
+    // common intensity modes
     QButtonGroup* intensity_button_group_;
-    //1D specific stuff
 
+    // 1D specific stuff
     QToolBar* tool_bar_1d_;
     QButtonGroup* draw_group_1d_;
 
-    //2D specific stuff
+    // 2D specific stuff
     QToolBar* tool_bar_2d_peak_;
     QToolBar* tool_bar_2d_feat_;
     QToolBar* tool_bar_2d_cons_;

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -299,6 +299,8 @@ public:
       }
     }
 
+    void updateRanges();
+
     /// updates the PeakAnnotations in the current PeptideHit with manually changed annotations
     /// if no PeptideIdentification or PeptideHit for the spectrum exist, it is generated
     void synchronizePeakAnnotations();

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -182,9 +182,6 @@ public:
       annotations_1d.resize(1);
     }
 
-    /// Returns a const reference to the current spectrum (1d view)
-    const ExperimentType::SpectrumType & getCurrentSpectrum() const;
-
     /// Returns a const reference to the current feature data
     const FeatureMapSharedPtrType & getFeatureMap() const
     {
@@ -209,29 +206,46 @@ public:
       return consensus;
     }
 
-    /// Returns a const reference to the current peak data
+    /**
+    @brief Returns a const reference to the current in-memory peak data
+
+    @note Do *not* use this function to access the current spectrum for the 1D view
+    @note Be careful when using this function as the actual peak data 
+    may not be loaded completely in memory, in which case the spectra will be empty.
+    */
     const ConstExperimentSharedPtrType getPeakData() const;
 
+    /**
+    @brief Returns a mutable reference to the current in-memory peak data
+
+    @note Do *not* use this function to access the current spectrum for the 1D view
+    @note Be careful when using this function as the actual peak data 
+    may not be loaded completely in memory, in which case the spectra will be empty.
+    */
     const ExperimentSharedPtrType & getPeakDataMuteable() {return peaks;}
 
-    /// Returns a mutable reference to the current peak data
+    /**
+    @brief Set the current in-memory peak data
+    */
     void setPeakData(ExperimentSharedPtrType p)
     {
       peaks = p;
       updateCache_();
     }
 
+    /// Set the current on-disc data
     void setOnDiscPeakData(ODExperimentSharedPtrType p)
     {
       on_disc_peaks = p;
     }
 
+    /// Returns a mutable reference to the on-disc data
     const ODExperimentSharedPtrType & getOnDiscPeakData() const
     {
       return on_disc_peaks;
     }
 
-    /// Returns a const reference to the current chromatogram data
+    /// Returns a mutable reference to the current chromatogram data
     const ExperimentSharedPtrType & getChromatogramData() const
     {
       return chromatograms;
@@ -243,32 +257,43 @@ public:
       return chromatograms;
     }
 
-    /// Returns a const reference to the annotations of the current spectrum (1d view)
+    /// Returns a const reference to the annotations of the current spectrum (1D view)
     const Annotations1DContainer & getCurrentAnnotations() const
     {
       return annotations_1d[current_spectrum_];
     }
 
-    /// Returns a mutable reference to the annotations of the current spectrum (1d view)
+    /// Returns a mutable reference to the annotations of the current spectrum (1D view)
     Annotations1DContainer & getCurrentAnnotations()
     {
       return annotations_1d[current_spectrum_];
     }
 
-    /// Returns a const reference to the annotations of the current spectrum (1d view)
+    /// Returns a const reference to the annotations of the current spectrum (1D view)
     const Annotations1DContainer & getAnnotations(Size spectrum_index) const
     {
       return annotations_1d[spectrum_index];
     }
 
-    /// Returns a mutable reference to the annotations of the current spectrum (1d view)
+    /// Returns a mutable reference to the annotations of the current spectrum (1D view)
     Annotations1DContainer & getAnnotations(Size spectrum_index)
     {
       return annotations_1d[spectrum_index];
     }
 
-    /// Returns a mutable reference to the current spectrum (1d view)
+    /**
+    @brief Returns a mutable reference to the current spectrum (1D view)
+
+    @note Only use this function to access the current spectrum for the 1D view
+    */
     ExperimentType::SpectrumType & getCurrentSpectrum();
+
+    /**
+    @brief Returns a const reference to the current spectrum (1D view)
+
+    @note Only use this function to access the current spectrum for the 1D view
+    */
+    const ExperimentType::SpectrumType & getCurrentSpectrum() const;
 
     /// Returns a copy of the required spectrum
     ExperimentType::SpectrumType getSpectrum(Size spectrum_idx) const
@@ -286,23 +311,27 @@ public:
       return (*peaks)[spectrum_idx];
     }
       
-    /// Get the index of the current spectrum
+    /// Get the index of the current spectrum (1D view)
     Size getCurrentSpectrumIndex() const
     {
       return current_spectrum_;
     }
 
-    /// Set the index of the current spectrum
+    /// Set the index of the current spectrum (1D view)
     void setCurrentSpectrumIndex(Size index)
     {
       current_spectrum_ = index;
       updateCache_();
     }
-
-    /// Check whether the current layer is a chromatogram
-    // we need this specifically because this->type will *not* distinguish
-    // chromatogram and spectra data since we need to store chromatograms for
-    // the 1D case in a layer that looks like PEAK data to all tools.
+    
+    /**
+    @brief Check whether the current layer is a chromatogram
+     
+    This is needed because type will *not* distinguish properly between
+    chromatogram and spectra data. This is due to the fact that we store 
+    chromatograms for display in 1D in a data layer using MSSpectrum and 
+    so the layer looks like PEAK data to tools. 
+    */
     bool chromatogram_flag_set() const
     {
       return this->getPeakData()->size() > 0 &&
@@ -310,13 +339,13 @@ public:
              this->getPeakData()->getMetaValue("is_chromatogram").toBool();
     }
 
-    // set the chromatogram flag
+    /// set the chromatogram flag
     void set_chromatogram_flag()
     {
       peaks->setMetaValue("is_chromatogram", "true");
     }
 
-    // remove the chromatogram flag
+    /// remove the chromatogram flag
     void remove_chromatogram_flag()
     {
       if (this->chromatogram_flag_set())
@@ -324,7 +353,13 @@ public:
         peaks->removeMetaValue("is_chromatogram");
       }
     }
+    
+    /**
+    @brief Update ranges of all data structures
 
+    Updates ranges of all tracked data structures 
+    (spectra, chromatograms, features etc).
+    */
     void updateRanges();
 
     /// updates the PeakAnnotations in the current PeptideHit with manually changed annotations

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -57,6 +57,27 @@ namespace OpenMS
   /**
   @brief Class that stores the data for one layer
 
+  The data for a layer can be peak data, feature data (feature, consensus),
+  chromatogram or peptide identification data. 
+
+  For 2D and 3D data, the data is generally accessible through getPeakData()
+  while features are accessible through getFeatureMap() and getConsensusMap().
+  For 1D data, the current spectrum must be accessed through
+  getCurrentSpectrum().
+
+  Peak data is stored using a shared pointer to an MSExperiment data structure
+  as well as a shared pointer to a OnDiscMSExperiment data structure. Note that
+  the actual data may not be in memory as this is not efficient for large files
+  and therefore may have to be retrieved from disk on-demand. 
+
+  @note The spectrum for 1D viewing retrieved through getCurrentSpectrum() may
+  be different than the one retrieved through getPeakData()[index] due to the
+  getCurrentSpectrum() being loaded from disk on-demoand and the calling code
+  cannot assume that they are the same.
+
+  @note Layer is mainly used as a member variable of SpectrumCanvas which holds
+  a vector of LayerData objects.
+
   @ingroup SpectrumWidgets
   */
   class LayerData
@@ -67,12 +88,12 @@ public:
     /// Dataset types
     enum DataType
     {
-      DT_PEAK,                ///< Spectrum profile or centroided data
+      DT_PEAK,            ///< Spectrum profile or centroided data
       DT_FEATURE,         ///< Feature data
       DT_CONSENSUS,       ///< Consensus feature data
       DT_CHROMATOGRAM,    ///< Chromatogram data
       DT_IDENT,           ///< Peptide identification data
-      DT_UNKNOWN              ///< Undefined data type indicating an error
+      DT_UNKNOWN          ///< Undefined data type indicating an error
     };
 
     /// Flags that determine which information is shown.
@@ -94,11 +115,11 @@ public:
     /// Label used in visualization
     enum LabelType
     {
-      L_NONE,                           ///< No label is displayed
-      L_INDEX,                          ///< The element number is used
-      L_META_LABEL,                 ///< The 'label' meta information is used
-      L_ID,                                 ///< The best peptide hit of the first identification run is used
-      L_ID_ALL,                         ///< All peptide hits of the first identification run are used
+      L_NONE,             ///< No label is displayed
+      L_INDEX,            ///< The element number is used
+      L_META_LABEL,       ///< The 'label' meta information is used
+      L_ID,               ///< The best peptide hit of the first identification run is used
+      L_ID_ALL,           ///< All peptide hits of the first identification run are used
       SIZE_OF_LABEL_TYPE
     };
 

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -123,6 +123,8 @@ public:
     /// SharedPtr on MSExperiment
     typedef boost::shared_ptr<ExperimentType> ExperimentSharedPtrType;
 
+    typedef boost::shared_ptr<const ExperimentType> ConstExperimentSharedPtrType;
+
     /// SharedPtr on On-Disc MSExperiment
     typedef boost::shared_ptr<OnDiscMSExperiment> ODExperimentSharedPtrType;
 
@@ -186,7 +188,9 @@ public:
     }
 
     /// Returns a const reference to the current peak data
-    const ExperimentSharedPtrType & getPeakData() const;
+    const ConstExperimentSharedPtrType getPeakData() const;
+
+    const ExperimentSharedPtrType & getPeakDataMuteable() {return peaks;}
 
     /// Returns a mutable reference to the current peak data
     void setPeakData(ExperimentSharedPtrType p)
@@ -287,7 +291,7 @@ public:
     // set the chromatogram flag
     void set_chromatogram_flag()
     {
-      this->getPeakData()->setMetaValue("is_chromatogram", "true");
+      peaks->setMetaValue("is_chromatogram", "true");
     }
 
     // remove the chromatogram flag
@@ -295,7 +299,7 @@ public:
     {
       if (this->chromatogram_flag_set())
       {
-        this->getPeakData()->removeMetaValue("is_chromatogram");
+        peaks->removeMetaValue("is_chromatogram");
       }
     }
 

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -252,6 +252,22 @@ public:
       return cached_spectrum_;
     }
 
+    /// Returns a copy of the required spectrum
+    ExperimentType::SpectrumType getSpectrum(Size spectrum_idx) const
+    {
+      if (spectrum_idx == current_spectrum_) return cached_spectrum_;
+
+      if ((*peaks)[spectrum_idx].size() > 0)
+      {
+        return (*peaks)[spectrum_idx];
+      }
+      else if (!on_disc_peaks->empty())
+      {
+        return on_disc_peaks->getSpectrum(spectrum_idx);
+      }
+      return (*peaks)[spectrum_idx];
+    }
+      
     /// Get the index of the current spectrum
     Size getCurrentSpectrumIndex() const
     {

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -57,7 +57,7 @@ namespace OpenMS
   /**
   @brief Class that stores the data for one layer
 
-      @ingroup SpectrumWidgets
+  @ingroup SpectrumWidgets
   */
   class LayerData
   {
@@ -152,16 +152,14 @@ public:
       peaks(new ExperimentType()),
       on_disc_peaks(new OnDiscMSExperiment()),
       chromatograms(new ExperimentType()),
-      current_spectrum_(0)
+      current_spectrum_(0),
+      cached_spectrum_()
     {
       annotations_1d.resize(1);
     }
 
     /// Returns a const reference to the current spectrum (1d view)
-    const ExperimentType::SpectrumType & getCurrentSpectrum() const
-    {
-      return cached_spectrum_;
-    }
+    const ExperimentType::SpectrumType & getCurrentSpectrum() const;
 
     /// Returns a const reference to the current feature data
     const FeatureMapSharedPtrType & getFeatureMap() const
@@ -188,10 +186,7 @@ public:
     }
 
     /// Returns a const reference to the current peak data
-    const ExperimentSharedPtrType & getPeakData() const
-    {
-      return peaks;
-    }
+    const ExperimentSharedPtrType & getPeakData() const;
 
     /// Returns a mutable reference to the current peak data
     void setPeakData(ExperimentSharedPtrType p)
@@ -247,10 +242,7 @@ public:
     }
 
     /// Returns a mutable reference to the current spectrum (1d view)
-    ExperimentType::SpectrumType & getCurrentSpectrum()
-    {
-      return cached_spectrum_;
-    }
+    ExperimentType::SpectrumType & getCurrentSpectrum();
 
     /// Returns a copy of the required spectrum
     ExperimentType::SpectrumType getSpectrum(Size spectrum_idx) const
@@ -363,17 +355,7 @@ public:
 private:
 
     /// Update current cached spectrum for easy retrieval
-    void updateCache_()
-    {
-      if ((*peaks)[current_spectrum_].size() > 0)
-      {
-        cached_spectrum_ = (*peaks)[current_spectrum_];
-      }
-      else if (!on_disc_peaks->empty())
-      {
-        cached_spectrum_ = on_disc_peaks->getSpectrum(current_spectrum_);
-      }
-    }
+    void updateCache_();
 
     /// updates the PeakAnnotations in the current PeptideHit with manually changed annotations
     void updatePeptideHitAnnotations_(PeptideHit& hit);

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -194,14 +194,15 @@ public:
     }
 
     /// Returns a mutable reference to the current peak data
-    ExperimentSharedPtrType & getPeakData()
+    void setPeakData(ExperimentSharedPtrType p)
     {
-      return peaks;
+      peaks = p;
+      updateCache_();
     }
 
-    ODExperimentSharedPtrType & getOnDiscPeakData()
+    void setOnDiscPeakData(ODExperimentSharedPtrType p)
     {
-      return on_disc_peaks;
+      on_disc_peaks = p;
     }
 
     const ODExperimentSharedPtrType & getOnDiscPeakData() const

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -73,7 +73,8 @@ namespace OpenMS
   @note The spectrum for 1D viewing retrieved through getCurrentSpectrum() may
   be different than the one retrieved through getPeakData()[index] due to the
   getCurrentSpectrum() being loaded from disk on-demoand and the calling code
-  cannot assume that they are the same.
+  cannot assume that they are the same. Therefore all calls in Spectrum1DCanvas
+  should only go through getCurrentSpectrum() and never through getPeakData().
 
   @note Layer is mainly used as a member variable of SpectrumCanvas which holds
   a vector of LayerData objects.

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
@@ -180,7 +180,7 @@ public slots:
     void activateLayer(Size layer_index) override;
     // Docu in base class
     void removeLayer(Size layer_index) override;
-    //docu in base class
+    // Docu in base class
     void updateLayer(Size i) override;
 
     /**

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
@@ -341,17 +341,20 @@ public:
     virtual void activateLayer(Size layer_index) = 0;
     ///removes the layer with index @p layer_index
     virtual void removeLayer(Size layer_index) = 0;
+
     /**
         @brief Add a peak data layer
 
-        If chromatograms are present, a chromatogram layer is shown. Otherwise a peak layer is shown. Make sure to remove chromatograms from peak data and vice versa.
+        If chromatograms are present, a chromatogram layer is shown. Otherwise
+        a peak layer is shown. Make sure to remove chromatograms from peak data
+        and vice versa.
 
-  @param map Shared Pointer to input map. It can be performed in constant time and does not double the required memory.
+        @param map Shared pointer to input map. It can be performed in constant time and does not double the required memory.
+        @param od_map Shared pointer to on disk data which potentially caches some data to save memory (the map can be empty, but do not pass nullptr).
         @param filename This @em absolute filename is used to monitor changes in the file and reload the data
 
         @return If a new layer was created
     */
-    bool addLayer(ExperimentSharedPtrType map, const String & filename = "");
     bool addLayer(ExperimentSharedPtrType map, ODExperimentSharedPtrType od_map, const String & filename = "");
 
     /**

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
@@ -82,12 +82,12 @@ namespace OpenMS
         - Activated using the CTRL key
         - Zoom stack traversal with CTRL+/CTRL- or mouses wheel
         - Pressing the @em Backspace key resets the zoom (and stack)
-  - Measure mode
-    - Activated using the SHIFT key
+      - Measure mode
+        - Activated using the SHIFT key
 
-  @improvement Add log mode (Hiwi)
+      @improvement Add log mode (Hiwi)
 
-  @todo Allow reordering the layer list by drag-and-drop (Hiwi, Johannes)
+      @todo Allow reordering the layer list by drag-and-drop (Hiwi, Johannes)
 
       @htmlinclude OpenMS_SpectrumCanvas.parameters
 
@@ -662,17 +662,17 @@ protected:
     double getIdentificationMZ_(const Size layer_index,
                                     const PeptideIdentification & peptide) const;
 
-    ///Method that is called when a new layer has been added
+    /// Method that is called when a new layer has been added
     virtual bool finishAdding_() = 0;
 
-    ///Returns the layer with index @p index
+    /// Returns the layer with index @p index
     inline LayerData & getLayer_(Size index)
     {
       OPENMS_PRECONDITION(index < layers_.size(), "SpectrumCanvas::getLayer_(index) index overflow");
       return layers_[index];
     }
 
-    ///Returns the currently active layer
+    /// Returns the currently active layer
     inline LayerData & getCurrentLayer_()
     {
       return getLayer_(current_layer_);

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
@@ -107,6 +107,7 @@ public:
     typedef LayerData::ExperimentType ExperimentType;
     /// Main managed data type (experiment)
     typedef LayerData::ExperimentSharedPtrType ExperimentSharedPtrType;
+    typedef LayerData::ODExperimentSharedPtrType ODExperimentSharedPtrType;
     /// Main data type (features)
     typedef LayerData::FeatureMapType FeatureMapType;
     /// Main managed data type (features)
@@ -351,6 +352,7 @@ public:
         @return If a new layer was created
     */
     bool addLayer(ExperimentSharedPtrType map, const String & filename = "");
+    bool addLayer(ExperimentSharedPtrType map, ODExperimentSharedPtrType od_map, const String & filename = "");
 
     /**
         @brief Add a feature data layer

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
@@ -678,12 +678,6 @@ protected:
       return getLayer_(current_layer_);
     }
 
-    /// Returns the currently active layer (mutable)
-    inline ExperimentSharedPtrType currentPeakData_()
-    {
-      return getCurrentLayer_().getPeakData();
-    }
-
     ///@name reimplemented QT events
     //@{
     void resizeEvent(QResizeEvent * e) override;

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
@@ -65,14 +65,18 @@ namespace OpenMS
   /**
       @brief Base class for visualization canvas classes
 
-      This class is the base class for the spectrum data views.
+      This class is the base class for the spectrum data views which are used
+      for 1D, 2D and 3D visualization of data. In TOPPView, each SpectrumCanvas
+      is paired with an enclosing SpectrumWidget (see also the
+      getSpectrumWidget() function that provides a back-reference).  To provide
+      additional spectrum views, you can derive from this class and you should
+      also create a subclass from SpectrumWidget which encloses your class
+      derived from SpectrumCanvas. A spectrum canvas can display multiple data
+      layers at the same time (see layers_ member variable).
 
-      It also provides commonly used constants such as ActionModes or IntensityModes.
-
-      To provide additional spectrum views, you can derive from this class.
-      You should also create a subclass from SpectrumWidget which encloses
-      your class derived from SpectrumCanvas. To integrate your class into
-      TOPPView, you also need to derive a class from SpectrumWidget.
+      The actual data to be displayed is stored as a vector of LayerData
+      objects which hold the actual data.  It also stores information about the
+      commonly used constants such as ActionModes or IntensityModes.
 
       All derived classes should follow these interface conventions:
       - Translate mode
@@ -133,19 +137,19 @@ public:
     typedef DRange<2> AreaType;
 
 
-    ///Mouse action modes
+    /// Mouse action modes
     enum ActionModes
     {
-      AM_TRANSLATE,       ///< translate
-      AM_ZOOM,                  ///< zoom
-      AM_MEASURE          ///< measure
+      AM_TRANSLATE,   ///< translate
+      AM_ZOOM,        ///< zoom
+      AM_MEASURE      ///< measure
     };
 
-    ///Display modes of intensity
+    /// Display modes of intensity
     enum IntensityModes
     {
-      IM_NONE,                  ///< Normal mode: f(x)=x
-      IM_PERCENTAGE,        ///< Shows intensities normalized by layer maximum: f(x)=x/max(x)*100
+      IM_NONE,        ///< Normal mode: f(x)=x
+      IM_PERCENTAGE,  ///< Shows intensities normalized by layer maximum: f(x)=x/max(x)*100
       IM_SNAP,        ///< Shows the maximum displayed intensity as if it was the overall maximum intensity
       IM_LOG          ///< Logarithmic mode
     };
@@ -745,11 +749,11 @@ protected:
     */
     virtual void updateScrollbars_();
 
-
     /**
         @brief Convert widget to chart coordinates
 
         Translates widget coordinates to chart coordinates.
+
         @param x the widget coordinate x
         @param y the widget coordinate y
         @return chart coordinates
@@ -822,7 +826,7 @@ protected:
       }
     }
 
-    ///Helper function to paint grid lines
+    /// Helper function to paint grid lines
     virtual void paintGridLines_(QPainter & painter);
 
     /// Buffer that stores the actual peak information

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumCanvas.h
@@ -107,6 +107,7 @@ public:
     typedef LayerData::ExperimentType ExperimentType;
     /// Main managed data type (experiment)
     typedef LayerData::ExperimentSharedPtrType ExperimentSharedPtrType;
+    typedef LayerData::ConstExperimentSharedPtrType ConstExperimentSharedPtrType;
     typedef LayerData::ODExperimentSharedPtrType ODExperimentSharedPtrType;
     /// Main data type (features)
     typedef LayerData::FeatureMapType FeatureMapType;

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectrumWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectrumWidget.h
@@ -56,17 +56,24 @@ namespace OpenMS
   /**
       @brief Base class for spectrum widgets
 
-      This class is the base class for the different MDI window
-      types in the TOPPView application. For each type of spectrum
-      view (such as 1D view, 2D view etc.), there must exist a
-      corresponding class derived from this class.
+      This class is the base class for the different MDI window types in the
+      TOPPView application. For each type of spectrum view (such as 1D view, 2D
+      view, 3D view etc.), there must exist a corresponding class derived from
+      this class.
+
+      In TOPPView, each SpectrumWidget holds an enclosed SpectrumCanvas with
+      which it is paired (e.g. a Spectrum1DWidget holds a Spectrum1DCanvas)
+      which can retrieved with the canvas() function. While the SpectrumCanvas
+      does the actual drawing, the SpectrumWidget holds information about the
+      axes (axis widgets), scrolling (scrollbars) etc. The SpectrumWidget uses
+      a grid layout (QGridLayout) with a default 3x3 grid where the upper right
+      corner of the grid is the canvas and the spaces left and below the canvas
+      are for the axes widget and scrollbars.
 
       To integrate a new spectrum view (i.e. classes derived from
       SpectrumWidget and SpectrumCanvas) into the TOPPView application,
       a class must be derived from this class which holds an
       instance of the SpectrumCanvas class as a child widget.
-
-      This Widget also provides axis widgets and scrollbars.
 
       @todo Add support to store the displayed data as SVG image (HiWi)
   */
@@ -109,19 +116,19 @@ public:
       return canvas_;
     }
 
-    ///Returns a pointer to the x-axis axis widget.
+    /// Returns a pointer to the x-axis axis widget.
     virtual inline AxisWidget * xAxis()
     {
       return x_axis_;
     }
 
-    ///Returns a pointer to the y-axis axis widget.
+    /// Returns a pointer to the y-axis axis widget.
     virtual inline AxisWidget * yAxis()
     {
       return y_axis_;
     }
 
-    ///Get the mouse action mode
+    /// Get the mouse action mode
     Int getActionMode() const;
 
     /// Returns if the axis labels are shown
@@ -144,6 +151,7 @@ public:
 
     /// setter for the EnhancedTabBar window id as defined in the interface
     void setWindowId(Int window_id) override;
+
 signals:
     /// Emits a status message that should be displayed for @p time ms. If @p time is 0 the message should be displayed until the next message is emitted.
     void sendStatusMessage(std::string, OpenMS::UInt);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPView.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPView.cpp
@@ -165,7 +165,7 @@ int main(int argc, const char** argv)
     }
 
     // We are about to show the application.
-    // Proper time to  remove the splashscreen, if at least 1.5 seconds have passed...
+    // Proper time to remove the splashscreen, if at least 1.5 seconds have passed...
     while (stop_watch.getClockTime() < 1.5) /*wait*/
     {
     }

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/IDEvaluationBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/IDEvaluationBase.cpp
@@ -385,7 +385,7 @@ namespace OpenMS
 
     PeakMap* exp = new PeakMap();
     exp->addSpectrum(points);
-    spec_1d_->canvas()->addLayer(SpectrumCanvas::ExperimentSharedPtrType(exp));
+    spec_1d_->canvas()->addLayer(SpectrumCanvas::ExperimentSharedPtrType(exp), SpectrumCanvas::ODExperimentSharedPtrType(new OnDiscMSExperiment()));
     spec_1d_->canvas()->setLayerName(spec_1d_->canvas()->getLayerCount() - 1, points.getMetaValue("search_engine"));
     // set intensity mode (after spectrum has been added!)
     setIntensityMode((int) SpectrumCanvas::IM_SNAP);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -611,6 +611,8 @@ namespace OpenMS
     defaults_.setValidStrings("preferences:topp_cleanup", ListUtils::create<String>("true,false"));
     defaults_.setValue("preferences:use_cached_ms2", "false", "If possible, only load MS1 spectra into memory and keep MS2 spectra on disk (using indexed mzML).");
     defaults_.setValidStrings("preferences:use_cached_ms2", ListUtils::create<String>("true,false"));
+    defaults_.setValue("preferences:use_cached_ms1", "false", "If possible, do not load MS1 spectra into memory spectra into memory and keep MS2 spectra on disk (using indexed mzML).");
+    defaults_.setValidStrings("preferences:use_cached_ms1", ListUtils::create<String>("true,false"));
     // 1d view
     Spectrum1DCanvas* def1 = new Spectrum1DCanvas(Param(), nullptr);
     defaults_.insert("preferences:1d:", def1->getDefaults());
@@ -1091,7 +1093,7 @@ namespace OpenMS
     ODExperimentSharedPtrType on_disc_peaks(new OnDiscMSExperiment);
 
     bool cache_ms2_on_disc = ((String)param_.getValue("preferences:use_cached_ms2") == "true");
-    bool cache_ms1_on_disc = false;
+    bool cache_ms1_on_disc = ((String)param_.getValue("preferences:use_cached_ms1") == "true");
 
     try
     {
@@ -1185,12 +1187,17 @@ namespace OpenMS
           indexed_mzml_file_.openFile(filename);
           if ( indexed_mzml_file_.getParsingSuccess() && cache_ms2_on_disc)
           {
-            std::cout << "INFO: will use cached MS2 spectra" << std::endl;
+            LOG_INFO << "INFO: will use cached MS2 spectra" << std::endl;
+            if (cache_ms1_on_disc)
+            {
+              LOG_INFO << "log INFO: will use cached MS1 spectra" << std::endl;
+            }
             parsing_success = true;
             MzMLFile f;
             PeakFileOptions options = f.getOptions();
             options.setFillData(false);
             f.setOptions(options);
+            f.setLogType(ProgressLogger::GUI);
             f.load(filename, *peak_map_sptr);
 
             // Load all MS1 data into memory

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -756,6 +756,8 @@ namespace OpenMS
     // default tab
     QLineEdit* default_path = dlg.findChild<QLineEdit*>("default_path");
     QCheckBox* default_path_current = dlg.findChild<QCheckBox*>("default_path_current");
+    QCheckBox* use_cached_ms1 = dlg.findChild<QCheckBox*>("use_cached_ms1");
+    QCheckBox* use_cached_ms2 = dlg.findChild<QCheckBox*>("use_cached_ms2");
     QLineEdit* temp_path = dlg.findChild<QLineEdit*>("temp_path");
     QSpinBox* recent_files = dlg.findChild<QSpinBox*>("recent_files");
     QComboBox* map_default = dlg.findChild<QComboBox*>("map_default");
@@ -815,6 +817,23 @@ namespace OpenMS
     {
       default_path_current->setChecked(false);
     }
+    if ((String)param_.getValue("preferences:use_cached_ms1") == "true")
+    {
+      use_cached_ms1->setChecked(true);
+    }
+    else
+    {
+      use_cached_ms1->setChecked(false);
+    }
+    if ((String)param_.getValue("preferences:use_cached_ms2") == "true")
+    {
+      use_cached_ms2->setChecked(true);
+    }
+    else
+    {
+      use_cached_ms2->setChecked(false);
+    }
+
     temp_path->setText(param_.getValue("preferences:tmp_file_path").toQString());
     recent_files->setValue((Int)param_.getValue("preferences:number_of_recent_files"));
     map_default->setCurrentIndex(map_default->findText(param_.getValue("preferences:default_map_view").toQString()));
@@ -960,6 +979,22 @@ namespace OpenMS
       else
       {
         param_.setValue("preferences:default_path_current", "false");
+      }
+      if (use_cached_ms1->isChecked())
+      {
+        param_.setValue("preferences:use_cached_ms1", "true");
+      }
+      else
+      {
+        param_.setValue("preferences:use_cached_ms1", "false");
+      }
+      if (use_cached_ms2->isChecked())
+      {
+        param_.setValue("preferences:use_cached_ms2", "true");
+      }
+      else
+      {
+        param_.setValue("preferences:use_cached_ms2", "false");
       }
       param_.setValue("preferences:tmp_file_path", temp_path->text());
       param_.setValue("preferences:number_of_recent_files", recent_files->value());
@@ -3894,7 +3929,9 @@ namespace OpenMS
   {
     //do not update if the user disabled this feature.
     if (param_.getValue("preferences:default_path_current") != "true")
+    {
       return;
+    }
 
     //reset
     current_path_ = param_.getValue("preferences:default_path");

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1196,7 +1196,7 @@ namespace OpenMS
             // Load all MS1 data into memory
             for (Size k = 0; k < indexed_mzml_file_.getNrSpectra() && !cache_ms1_on_disc; k++)
             {
-              if ( peak_map_sptr->getSpectrum(k).getMSLevel() == 1) 
+              if ( peak_map_sptr->getSpectrum(k).getMSLevel() == 1)
               {
                 peak_map_sptr->getSpectrum(k) = on_disc_peaks->getSpectrum(k);
               }
@@ -3257,7 +3257,7 @@ namespace OpenMS
       ExperimentSharedPtrType new_exp_sptr(new PeakMap(new_exp));
       FeatureMapSharedPtrType f_dummy(new FeatureMapType());
       ConsensusMapSharedPtrType c_dummy(new ConsensusMapType());
-      ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment()); // TODO 
+      ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
       vector<PeptideIdentification> p_dummy;
       addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerData::DT_CHROMATOGRAM, false, true, true, "", seq_string + QString(" (theoretical)"));
 
@@ -3427,7 +3427,7 @@ namespace OpenMS
 
       ExperimentSharedPtrType exp_sptr = layer.getPeakData();
 
-      if (!w->canvas()->addLayer(exp_sptr, layer.filename))
+      if (!w->canvas()->addLayer(exp_sptr, SpectrumCanvas::ODExperimentSharedPtrType(new OnDiscMSExperiment()), layer.filename))
       {
         return;
       }
@@ -3820,10 +3820,10 @@ namespace OpenMS
         ExperimentSharedPtrType peaks = layer.getPeakData();
         ConsensusMapSharedPtrType consensus = layer.getConsensusMap();
         vector<PeptideIdentification> peptides = layer.peptides;
-        ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment()); // TODO 
+        ODExperimentSharedPtrType on_disc_peaks = layer.getOnDiscPeakData();
 
         //add the data
-        addData(features, consensus, peptides, peaks, od_dummy, layer.type, false, false, true, layer.filename, layer.name, new_id);
+        addData(features, consensus, peptides, peaks, on_disc_peaks, layer.type, false, false, true, layer.filename, layer.name, new_id);
       }
       else if (source == spectra_view_treewidget)
       {
@@ -4009,7 +4009,7 @@ namespace OpenMS
           }
           layer.getConsensusMap()->updateRanges();
         }
-        else if (layer.type == LayerData::DT_CHROMATOGRAM) //chromatgram
+        else if (layer.type == LayerData::DT_CHROMATOGRAM) //chromatogram
         {
           //TODO CHROM
           try

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -609,6 +609,8 @@ namespace OpenMS
     defaults_.setValidStrings("preferences:on_file_change", ListUtils::create<String>("none,ask,update automatically"));
     defaults_.setValue("preferences:topp_cleanup", "true", "If the temporary files for calling of TOPP tools should be removed after the call.");
     defaults_.setValidStrings("preferences:topp_cleanup", ListUtils::create<String>("true,false"));
+    defaults_.setValue("preferences:use_cached_ms2", "false", "If possible, only load MS1 spectra into memory and keep MS2 spectra on disk (using indexed mzML).");
+    defaults_.setValidStrings("preferences:use_cached_ms2", ListUtils::create<String>("true,false"));
     // 1d view
     Spectrum1DCanvas* def1 = new Spectrum1DCanvas(Param(), nullptr);
     defaults_.insert("preferences:1d:", def1->getDefaults());
@@ -1088,7 +1090,7 @@ namespace OpenMS
 
     ODExperimentSharedPtrType on_disc_peaks(new OnDiscMSExperiment);
 
-    bool cache_ms2_on_disc = true;
+    bool cache_ms2_on_disc = ((String)param_.getValue("preferences:use_cached_ms2") == "true");
     bool cache_ms1_on_disc = false;
 
     try
@@ -1183,6 +1185,8 @@ namespace OpenMS
           indexed_mzml_file_.openFile(filename);
           if ( indexed_mzml_file_.getParsingSuccess() && cache_ms2_on_disc)
           {
+            std::cout << "INFO: will use cached MS2 spectra" << std::endl;
+            parsing_success = true;
             MzMLFile f;
             PeakFileOptions options = f.getOptions();
             options.setFillData(false);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1200,6 +1200,8 @@ namespace OpenMS
             f.setLogType(ProgressLogger::GUI);
             f.load(filename, *peak_map_sptr);
 
+            // Load at least one spectrum into memory (TOPPView assumes that at least one spectrum is in memory)
+            if (cache_ms1_on_disc) peak_map_sptr->getSpectrum(0) = on_disc_peaks->getSpectrum(0);
             // Load all MS1 data into memory
             for (Size k = 0; k < indexed_mzml_file_.getNrSpectra() && !cache_ms1_on_disc; k++)
             {

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1213,6 +1213,10 @@ namespace OpenMS
                 peak_map_sptr->getSpectrum(k) = on_disc_peaks->getSpectrum(k);
               }
             }
+            for (Size k = 0; k < indexed_mzml_file_.getNrChromatograms(); k++)
+            {
+              peak_map_sptr->getChromatogram(k) = on_disc_peaks->getChromatogram(k);
+            }
 
             // Load at least one spectrum into memory (TOPPView assumes that at least one spectrum is in memory)
             if (cache_ms1_on_disc) peak_map_sptr->getSpectrum(0) = on_disc_peaks->getSpectrum(0);

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -159,13 +159,16 @@ namespace OpenMS
       (int)(0.8 * screen_geometry.height())
       );
 
-    // create dummy widget (to be able to have a layout), Tab bar and workspace
-    QWidget* dummy = new QWidget(this);
-    setCentralWidget(dummy);
-    QVBoxLayout* box_layout = new QVBoxLayout(dummy);
+    //################## Main Window #################
+    // Create main workspace using a QVBoxLayout ordering the items vertically
+    // (the tab bar and the main workspace). Uses a dummy central widget (to be able to
+    // have a layout), then adds vertically the tab bar and workspace.
+    QWidget* dummy_cw = new QWidget(this);
+    setCentralWidget(dummy_cw);
+    QVBoxLayout* box_layout = new QVBoxLayout(dummy_cw);
 
     // create empty tab bar and workspace which will hold the main visualization widgets (e.g. spectrawidgets...)
-    tab_bar_ = new EnhancedTabBar(dummy);
+    tab_bar_ = new EnhancedTabBar(dummy_cw);
     tab_bar_->setWhatsThis("Tab bar<BR><BR>Close tabs through the context menu or by double-clicking them.<BR>The tab bar accepts drag-and-drop from the layer bar.");
     tab_bar_->addTab("dummy", 4710);
     tab_bar_->setMinimumSize(tab_bar_->sizeHint());
@@ -179,7 +182,7 @@ namespace OpenMS
     connect(tab_bar_, SIGNAL(dropOnTab(const QMimeData*, QWidget*, int)), this, SLOT(copyLayer(const QMimeData*, QWidget*, int)));
     box_layout->addWidget(tab_bar_);
 
-    ws_ = new EnhancedWorkspace(dummy);
+    ws_ = new EnhancedWorkspace(dummy_cw);
     connect(ws_, SIGNAL(subWindowActivated(QMdiSubWindow*)), this, SLOT(updateToolBar()));
     connect(ws_, SIGNAL(subWindowActivated(QMdiSubWindow*)), this, SLOT(updateTabBar(QMdiSubWindow*)));
     connect(ws_, SIGNAL(subWindowActivated(QMdiSubWindow*)), this, SLOT(updateLayerBar()));
@@ -200,11 +203,11 @@ namespace OpenMS
     file->addAction("&Close", this, SLOT(closeFile()), Qt::CTRL + Qt::Key_W);
     file->addSeparator();
 
-    //Meta data
+    // Meta data
     file->addAction("&Show meta data (file)", this, SLOT(metadataFileDialog()));
     file->addSeparator();
 
-    //Recent files
+    // Recent files
     QMenu* recent_menu = new QMenu("&Recent files", this);
     recent_actions_.resize(20);
     for (Size i = 0; i < 20; ++i)
@@ -218,7 +221,7 @@ namespace OpenMS
     file->addAction("&Preferences", this, SLOT(preferencesDialog()));
     file->addAction("&Quit", qApp, SLOT(quit()));
 
-    //Tools menu
+    // Tools menu
     QMenu* tools = new QMenu("&Tools", this);
     menuBar()->addMenu(tools);
     tools->addAction("&Select data range", this, SLOT(showGoToDialog()), Qt::CTRL + Qt::Key_G);
@@ -234,7 +237,7 @@ namespace OpenMS
     tools->addAction("Align spectra", this, SLOT(showSpectrumAlignmentDialog()));
     tools->addAction("Generate theoretical spectrum", this, SLOT(showSpectrumGenerationDialog()));
 
-    //Layer menu
+    // Layer menu
     QMenu* layer = new QMenu("&Layer", this);
     menuBar()->addMenu(layer);
     layer->addAction("Save all data", this, SLOT(saveLayerAll()), Qt::CTRL + Qt::Key_S);
@@ -245,7 +248,7 @@ namespace OpenMS
     layer->addSeparator();
     layer->addAction("Preferences", this, SLOT(showPreferences()));
 
-    //Windows menu
+    // Windows menu
     QMenu* windows = new QMenu("&Windows", this);
     menuBar()->addMenu(windows);
     windows->addAction("&Cascade", this->ws_, SLOT(cascadeSubWindows()));
@@ -255,7 +258,7 @@ namespace OpenMS
     linkZoom_action_ = windows->addAction("Link &Zoom", this, SLOT(linkZoom()));
     windows->addSeparator();
 
-    //Help menu
+    // Help menu
     QMenu* help = new QMenu("&Help", this);
     menuBar()->addMenu(help);
     help->addAction(QWhatsThis::createAction(help));
@@ -268,7 +271,8 @@ namespace OpenMS
     help->addSeparator();
     help->addAction("&About", this, SLOT(showAboutDialog()));
 
-    //create status bar
+    //################## STATUS #################
+    // create status bar
     message_label_ = new QLabel(statusBar());
     statusBar()->addWidget(message_label_, 1);
 
@@ -472,6 +476,9 @@ namespace OpenMS
     connect(dm_ident_2d_, SIGNAL(toggled(bool)), this, SLOT(changeLayerFlag(bool)));
 
     //################## Dock widgets #################
+    // This creates the three default dock widgets on the right (Layers, Views,
+    // Filters) and the Log dock widget on the bottom (by default hidden).
+
     // layer dock widget
     layer_dock_widget_ = new QDockWidget("Layers", this);
     layer_dock_widget_->setObjectName("layer_dock_widget");
@@ -500,7 +507,7 @@ namespace OpenMS
     spectraview_behavior_ = new TOPPViewSpectraViewBehavior(this);
     identificationview_behavior_ = new TOPPViewIdentificationViewBehavior(this);
 
-      // Hook-up controller and views for spectra inspection
+    // Hook-up controller and views for spectra inspection
     spectra_view_widget_ = new SpectraViewWidget();
     connect(spectra_view_widget_, SIGNAL(showSpectrumMetaData(int)), this, SLOT(showSpectrumMetaData(int)));
     connect(spectra_view_widget_, SIGNAL(showSpectrumAs1D(int)), this, SLOT(showSpectrumAs1D(int)));
@@ -551,7 +558,7 @@ namespace OpenMS
 
     windows->addAction(filter_dock_widget_->toggleViewAction());
 
-    //log window
+    // log window
     QDockWidget* log_bar = new QDockWidget("Log", this);
     log_bar->setObjectName("log_bar");
     addDockWidget(Qt::BottomDockWidgetArea, log_bar);
@@ -646,13 +653,11 @@ namespace OpenMS
     event->accept();
   }
 
-
   void TOPPViewBase::showURL()
   {
     QString target = qobject_cast<QAction*>(sender())->data().toString();
     GUIHelpers::openURL(target);
   }
-
 
   // static
   bool TOPPViewBase::containsMS1Scans(const ExperimentType& exp)

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.cpp
@@ -78,4 +78,4 @@ namespace OpenMS
     }
 
   }   //namespace Internal
-} //namspace OpenMS
+} //namespace OpenMS

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.ui
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewPrefDialog.ui
@@ -27,7 +27,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab">
       <attribute name="title">
@@ -47,23 +47,6 @@ p, li { white-space: pre-wrap; }
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QLineEdit" name="default_path">
-         <property name="minimumSize">
-          <size>
-           <width>240</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <widget class="QPushButton" name="browse_default">
-         <property name="text">
-          <string>Browse</string>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="2">
         <widget class="QCheckBox" name="default_path_current">
          <property name="toolTip">
@@ -74,42 +57,6 @@ p, li { white-space: pre-wrap; }
          </property>
          <property name="text">
           <string>use current path</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The path where temporary files are stored, e.g. for the execution of the TOPP tools.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Temporary file path:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QLineEdit" name="temp_path"/>
-       </item>
-       <item row="2" column="3">
-        <widget class="QPushButton" name="browse_temp">
-         <property name="text">
-          <string>Browse</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Number of recent files that are shown in the file menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Number of recent files:</string>
          </property>
         </widget>
        </item>
@@ -126,26 +73,6 @@ p, li { white-space: pre-wrap; }
          </property>
          <property name="maximum">
           <number>20</number>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="4">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_8">
-         <property name="text">
-          <string>Default map view:</string>
          </property>
         </widget>
        </item>
@@ -169,18 +96,18 @@ p, li { white-space: pre-wrap; }
          </item>
         </widget>
        </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_9">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Using this option, the noise level is estimated and a data filter is added in order to speed up the painting. The filter can be removed in the data filter toolbox.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <item row="3" column="4">
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
-         <property name="text">
-          <string>Low intensity cutoff:</string>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
          </property>
-        </widget>
+        </spacer>
        </item>
        <item row="5" column="2">
         <widget class="QComboBox" name="map_cutoff">
@@ -194,6 +121,49 @@ p, li { white-space: pre-wrap; }
            <string>off</string>
           </property>
          </item>
+        </widget>
+       </item>
+       <item row="7" column="2">
+        <widget class="QCheckBox" name="use_cached_ms1">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this for very large files. Prevents TOPPView from loading MS1 data into memory (note that MS1 map will not display properly).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Cache MS1 spectra to disk</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QPushButton" name="browse_temp">
+         <property name="text">
+          <string>Browse</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Using this option, the noise level is estimated and a data filter is added in order to speed up the painting. The filter can be removed in the data filter toolbox.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Low intensity cutoff:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The path where temporary files are stored, e.g. for the execution of the TOPP tools.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Temporary file path:</string>
+         </property>
         </widget>
        </item>
        <item row="6" column="0" colspan="2">
@@ -228,7 +198,30 @@ p, li { white-space: pre-wrap; }
          </item>
         </widget>
        </item>
-       <item row="7" column="1" colspan="2">
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Default map view:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Number of recent files that are shown in the file menu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Number of recent files:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QLineEdit" name="temp_path"/>
+       </item>
+       <item row="9" column="1" colspan="2">
         <spacer>
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -240,6 +233,40 @@ p, li { white-space: pre-wrap; }
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLineEdit" name="default_path">
+         <property name="minimumSize">
+          <size>
+           <width>240</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QPushButton" name="browse_default">
+         <property name="text">
+          <string>Browse</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="2">
+        <widget class="QCheckBox" name="use_cached_ms2">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this for large files. Prevents TOPPView from loading MS2 data into memory (usually without side effects).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Cache MS2 spectra to disk</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Caching Strategy</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/VISUAL/LayerData.h>
+
 #include <OpenMS/VISUAL/ANNOTATION/Annotation1DPeakItem.h>
 
 using namespace std;
@@ -40,11 +41,6 @@ using namespace std;
 namespace OpenMS
 {
   const std::string LayerData::NamesOfLabelType[] = {"None", "Index", "Label meta data", "Peptide identification", "All peptide identifications"};
-
-  const LayerData::ExperimentType::SpectrumType & LayerData::getCurrentSpectrum() const
-  {
-    return (*peaks)[current_spectrum_];
-  }
 
   std::ostream & operator<<(std::ostream & os, const LayerData & rhs)
   {

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -57,6 +57,16 @@ namespace OpenMS
     return peaks;
   }
 
+  void LayerData::updateRanges()
+  {
+    peaks->updateRanges();
+    features->updateRanges();
+    consensus->updateRanges();
+    // on_disc_peaks->updateRanges(); // note: this is not going to work since its on disk! We currently don't have a good way to access these ranges
+    chromatograms->updateRanges();
+    cached_spectrum_.updateRanges();
+  }
+
   void LayerData::updateCache_()
   {
     if ((*peaks)[current_spectrum_].size() > 0)

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -91,12 +91,10 @@ namespace OpenMS
 
   void LayerData::synchronizePeakAnnotations()
   {
-    int spectrum_index = getCurrentSpectrumIndex();
-
     // Return if no valid peak layer attached
     if (getPeakData()->size() == 0 || type != LayerData::DT_PEAK) { return; }
 
-    MSSpectrum & spectrum = (*getPeakDataMuteable())[spectrum_index];
+    MSSpectrum & spectrum = getCurrentSpectrum();
     int ms_level = spectrum.getMSLevel();
 
     if (ms_level == 2)
@@ -215,15 +213,13 @@ namespace OpenMS
 
   void LayerData::removePeakAnnotationsFromPeptideHit(const std::vector<Annotation1DItem*>& selected_annotations)
   {
-    int spectrum_index = getCurrentSpectrumIndex();
-
     // Return if no valid peak layer attached
     if (getPeakData()->size() == 0 || type != LayerData::DT_PEAK) { return; }
 
     // no ID selected
     if (peptide_id_index == -1 || peptide_hit_index == -1) { return; }
 
-    MSSpectrum & spectrum = (*getPeakDataMuteable())[spectrum_index];
+    MSSpectrum & spectrum = getCurrentSpectrum();
     int ms_level = spectrum.getMSLevel();
 
     // wrong MS level
@@ -270,4 +266,5 @@ namespace OpenMS
     }
     if (annotations_changed) { hit.setPeakAnnotations(fas); }
   }
+
 } //Namespace

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -52,9 +52,9 @@ namespace OpenMS
     return os;
   }
 
-  const LayerData::ExperimentSharedPtrType & LayerData::getPeakData() const
+  const LayerData::ConstExperimentSharedPtrType LayerData::getPeakData() const
   {
-    return peaks;
+    return boost::static_pointer_cast<const ExperimentType>(peaks);
   }
 
   void LayerData::updateRanges()
@@ -96,7 +96,7 @@ namespace OpenMS
     // Return if no valid peak layer attached
     if (getPeakData()->size() == 0 || type != LayerData::DT_PEAK) { return; }
 
-    MSSpectrum & spectrum = (*getPeakData())[spectrum_index];
+    MSSpectrum & spectrum = (*getPeakDataMuteable())[spectrum_index];
     int ms_level = spectrum.getMSLevel();
 
     if (ms_level == 2)
@@ -131,7 +131,7 @@ namespace OpenMS
         // copy user annotations to fragment annotation vector
         Annotations1DContainer & las = getAnnotations(current_spectrum_);
 
-        // no annoations so we don't need to synchronize
+        // no annotations so we don't need to synchronize
         bool has_peak_annotation(false);
         for (auto& a : las)
         {
@@ -145,7 +145,7 @@ namespace OpenMS
         pep_id.setIdentifier("Unknown");
 
         // create a dummy ProteinIdentification for all ID-less PeakAnnotations
-        vector<ProteinIdentification>& prot_ids = getPeakData()->getProteinIdentifications();
+        vector<ProteinIdentification>& prot_ids = getPeakDataMuteable()->getProteinIdentifications();
         if (prot_ids.back().getIdentifier() != String("Unknown"))
         {
           ProteinIdentification prot_id;
@@ -223,13 +223,13 @@ namespace OpenMS
     // no ID selected
     if (peptide_id_index == -1 || peptide_hit_index == -1) { return; }
 
-    MSSpectrum & spectrum = (*getPeakData())[spectrum_index];
+    MSSpectrum & spectrum = (*getPeakDataMuteable())[spectrum_index];
     int ms_level = spectrum.getMSLevel();
 
     // wrong MS level
     if (ms_level < 2) { return; }
 
-    // extract Peptideidentification and PeptideHit if possible.
+    // extract PeptideIdentification and PeptideHit if possible.
     // that this function returns prematurely is unlikely,
     // since we are deleting existing annotations,
     // that have to be somewhere, but better make sure

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -52,6 +52,33 @@ namespace OpenMS
     return os;
   }
 
+  const LayerData::ExperimentSharedPtrType & LayerData::getPeakData() const
+  {
+    return peaks;
+  }
+
+  void LayerData::updateCache_()
+  {
+    if ((*peaks)[current_spectrum_].size() > 0)
+    {
+      cached_spectrum_ = (*peaks)[current_spectrum_];
+    }
+    else if (!on_disc_peaks->empty())
+    {
+      cached_spectrum_ = on_disc_peaks->getSpectrum(current_spectrum_);
+    }
+  }
+
+  LayerData::ExperimentType::SpectrumType & LayerData::getCurrentSpectrum()
+  {
+    return cached_spectrum_;
+  }
+
+  const LayerData::ExperimentType::SpectrumType & LayerData::getCurrentSpectrum() const
+  {
+    return cached_spectrum_;
+  }
+
   void LayerData::synchronizePeakAnnotations()
   {
     int spectrum_index = getCurrentSpectrumIndex();

--- a/src/openms_gui/source/VISUAL/LayerData.cpp
+++ b/src/openms_gui/source/VISUAL/LayerData.cpp
@@ -69,11 +69,11 @@ namespace OpenMS
 
   void LayerData::updateCache_()
   {
-    if ((*peaks)[current_spectrum_].size() > 0)
+    if (peaks->getNrSpectra() > current_spectrum_ && (*peaks)[current_spectrum_].size() > 0)
     {
       cached_spectrum_ = (*peaks)[current_spectrum_];
     }
-    else if (!on_disc_peaks->empty())
+    else if (on_disc_peaks->getNrSpectra() > current_spectrum_)
     {
       cached_spectrum_ = on_disc_peaks->getSpectrum(current_spectrum_);
     }

--- a/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
@@ -967,7 +967,7 @@ namespace OpenMS
       hits[num_ph].setMetaValue("selected", sel);
     }
     pep_id[num_id].setHits(hits);
-    (*layer_->getPeakData())[spectrum_index].setPeptideIdentifications(pep_id);
+    (*layer_->getPeakDataMuteable())[spectrum_index].setPeptideIdentifications(pep_id);
 
   }
 

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -579,7 +579,7 @@ namespace OpenMS
       spectra_combo_box_->addItems(qsl);
       spectra_combo_box_->setCurrentIndex(curr);
 
-      LayerData::ExperimentSharedPtrType exp;
+      LayerData::ConstExperimentSharedPtrType exp;
       exp = cl.getPeakData();
 
       if (cl.chromatogram_flag_set())

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1045,7 +1045,9 @@ namespace OpenMS
     {
       layers_.resize(getLayerCount() - 1);
       if (current_layer_ != 0)
+      {
         current_layer_ = current_layer_ - 1;
+      }
       QMessageBox::critical(this, "Error", "Cannot add a dataset that contains no survey scans. Aborting!");
       return false;
     }

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1041,8 +1041,8 @@ namespace OpenMS
     current_layer_ = getLayerCount() - 1;
     currentPeakData_()->updateRanges();
 
-    // Abort if no data points are contained
-    if (getCurrentLayer().getPeakData()->size() == 0 || getCurrentLayer().getPeakData()->getSize() == 0)
+    // Abort if no data points are contained (note that all data could be on disk)
+    if (getCurrentLayer().getPeakData()->size() == 0)
     {
       layers_.resize(getLayerCount() - 1);
       if (current_layer_ != 0)

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1599,6 +1599,7 @@ namespace OpenMS
       }
       else
       {
+        // TODO: this will not work if the data is cached on disk
         FileHandler().storeExperiment(file_name, *layer.getPeakData(), ProgressLogger::GUI);
       }
     }

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1095,7 +1095,7 @@ namespace OpenMS
     // sort spectra in ascending order of position (ensure that we sort all spectra as well as the currently 
     for (Size i = 0; i < getCurrentLayer_().getPeakData()->size(); ++i)
     {
-      (*getCurrentLayer_().getPeakData())[i].sortByPosition();
+      (*getCurrentLayer_().getPeakDataMuteable())[i].sortByPosition();
     }
     getCurrentLayer_().getCurrentSpectrum().sortByPosition();
 

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -296,7 +296,7 @@ namespace OpenMS
           if (selected_peak_.isValid())
           {
             measurement_start_ = selected_peak_;
-            const ExperimentType::PeakType & peak = measurement_start_.getPeak((*getCurrentLayer().getPeakData()));
+            const ExperimentType::PeakType & peak = getCurrentLayer().getCurrentSpectrum()[measurement_start_.peak];
             if (intensity_mode_ == IM_PERCENTAGE)
             {
               updatePercentageFactor_(current_layer_);
@@ -318,7 +318,7 @@ namespace OpenMS
           if (selected_peak_.isValid())
           {
             measurement_start_ = selected_peak_;
-            const ExperimentType::PeakType & peak = measurement_start_.getPeak((*getCurrentLayer().getPeakData()));
+            const ExperimentType::PeakType & peak = getCurrentLayer().getCurrentSpectrum()[measurement_start_.peak];
             updatePercentageFactor_(current_layer_);
             dataToWidget(peak, measurement_start_point_, getCurrentLayer().flipped);
             measurement_start_point_.setX(last_mouse_pos_.x());
@@ -427,7 +427,7 @@ namespace OpenMS
     if (selected_peak_.isValid())
     {
       String status;
-      const ExperimentType::SpectrumType & s = selected_peak_.getSpectrum(*getCurrentLayer().getPeakData());
+      const ExperimentType::SpectrumType & s = getCurrentLayer().getCurrentSpectrum();
       for (Size m = 0; m < s.getFloatDataArrays().size(); ++m)
       {
         if (selected_peak_.peak < s.getFloatDataArrays()[m].size())
@@ -480,8 +480,8 @@ namespace OpenMS
         }
         if (measurement_start_.isValid() && selected_peak_.peak != measurement_start_.peak)
         {
-          const ExperimentType::PeakType & peak_1 = measurement_start_.getPeak(*getCurrentLayer().getPeakData());
-          const ExperimentType::PeakType & peak_2 = selected_peak_.getPeak(*getCurrentLayer().getPeakData());
+          const ExperimentType::PeakType & peak_1 = getCurrentLayer().getCurrentSpectrum()[measurement_start_.peak];
+          const ExperimentType::PeakType & peak_2 = getCurrentLayer().getCurrentSpectrum()[selected_peak_.peak];
           updatePercentageFactor_(current_layer_);
           PointType p = widgetToData(measurement_start_point_, true);
           bool peak_1_less = peak_1.getMZ() < peak_2.getMZ();
@@ -913,7 +913,8 @@ namespace OpenMS
     if (peak.isValid())
     {
       QPoint begin;
-      const ExperimentType::PeakType & sel = peak.getPeak(*getLayer_(layer_index).getPeakData());
+
+      const ExperimentType::PeakType & sel = getLayer_(layer_index).getCurrentSpectrum()[peak.peak];
 
       painter.setPen(QPen(QColor(param_.getValue("highlighted_peak_color").toQString()), 2));
 
@@ -1141,8 +1142,8 @@ namespace OpenMS
       QMessageBox::critical(this, "Error", "This widget supports peak data only. Aborting!");
       return;
     }
-    mz = peak.getPeak(*getCurrentLayer().getPeakData()).getMZ();
-    it = peak.getPeak(*getCurrentLayer().getPeakData()).getIntensity();
+    mz = getCurrentLayer().getCurrentSpectrum()[peak.peak].getMZ();
+    it = getCurrentLayer().getCurrentSpectrum()[peak.peak].getIntensity();
 
     //draw text
     QStringList lines;
@@ -1182,18 +1183,16 @@ namespace OpenMS
 
     if (end.isValid())
     {
-      mz = end.getPeak(*getCurrentLayer().getPeakData()).getMZ() - start.getPeak(*getCurrentLayer().getPeakData()).getMZ();
-      //rt = end.getSpectrum(*getCurrentLayer().getPeakData()).getRT() - start.getSpectrum(*getCurrentLayer().getPeakData()).getRT();
-      it = end.getPeak(*getCurrentLayer().getPeakData()).getIntensity() / start.getPeak(*getCurrentLayer().getPeakData()).getIntensity();
+      mz = getCurrentLayer().getCurrentSpectrum()[end.peak].getMZ() - getCurrentLayer().getCurrentSpectrum()[start.peak].getMZ();
+      it = getCurrentLayer().getCurrentSpectrum()[end.peak].getIntensity() - getCurrentLayer().getCurrentSpectrum()[start.peak].getIntensity();
     }
     else
     {
       PointType point = widgetToData_(last_mouse_pos_);
-      mz = point[0] - start.getPeak(*getCurrentLayer().getPeakData()).getMZ();
-      //rt = point[1] - start.getSpectrum(*getCurrentLayer().getPeakData()).getRT();
+      mz = point[0] - getCurrentLayer().getCurrentSpectrum()[start.peak].getMZ();
       it = std::numeric_limits<double>::quiet_NaN();
     }
-    ppm = (mz / start.getPeak(*getCurrentLayer().getPeakData()).getMZ()) * 1e6;
+    ppm = (mz / getCurrentLayer().getCurrentSpectrum()[start.peak].getMZ()) * 1e6;
 
     //draw text
     QStringList lines;
@@ -1480,7 +1479,7 @@ namespace OpenMS
         }
         else if (result->text() == "Add peak annotation mz")
         {
-          QString label = String::number(near_peak.getPeak(*getCurrentLayer().getPeakData()).getMZ(), 4).toQString();
+          QString label = String::number(getCurrentLayer().getCurrentSpectrum()[near_peak.peak].getMZ(), 4).toQString();
           addPeakAnnotation(near_peak, label, getCurrentLayer_().param.getValue("peak_color").toQString());
         }
         else if (result->text() == "Reset alignment")
@@ -1538,7 +1537,7 @@ namespace OpenMS
 
   Annotation1DItem * Spectrum1DCanvas::addPeakAnnotation(const PeakIndex& peak_index, const QString& text, const QColor& color)
   {
-    PeakType peak = peak_index.getPeak(*getCurrentLayer().getPeakData());
+    PeakType peak = getCurrentLayer().getCurrentSpectrum()[peak_index.peak];
     PointType position(peak.getMZ(), peak.getIntensity());
     Annotation1DItem * item = new Annotation1DPeakItem(position, text, color);
     item->setSelected(false);

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1092,7 +1092,7 @@ namespace OpenMS
       break;
     }
 
-    // sort spectra in ascending order of position
+    // sort spectra in ascending order of position (ensure that we sort all spectra as well as the currently 
     for (Size i = 0; i < getCurrentLayer_().getPeakData()->size(); ++i)
     {
       (*getCurrentLayer_().getPeakData())[i].sortByPosition();
@@ -2000,6 +2000,10 @@ namespace OpenMS
 
   void Spectrum1DCanvas::activateSpectrum(Size index, bool repaint)
   {
+    // Note: even though the current spectrum may be on disk, there will still
+    // be an in-memory representation in the peak data structure. Using
+    // setCurrentSpectrumIndex will select the appropriate spectrum and load it
+    // into memory.
     if (index < getCurrentLayer_().getPeakData()->size())
     {
       getCurrentLayer_().setCurrentSpectrumIndex(index);

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1039,10 +1039,10 @@ namespace OpenMS
     }
 
     current_layer_ = getLayerCount() - 1;
-    currentPeakData_()->updateRanges();
+    getCurrentLayer_().updateRanges();
 
     // Abort if no data points are contained (note that all data could be on disk)
-    if (getCurrentLayer().getPeakData()->size() == 0)
+    if (getCurrentLayer().getCurrentSpectrum().size() == 0)
     {
       layers_.resize(getLayerCount() - 1);
       if (current_layer_ != 0)
@@ -1093,12 +1093,13 @@ namespace OpenMS
     }
 
     // sort spectra in ascending order of position
-    for (Size i = 0; i < currentPeakData_()->size(); ++i)
+    for (Size i = 0; i < getCurrentLayer_().getPeakData()->size(); ++i)
     {
       (*getCurrentLayer_().getPeakData())[i].sortByPosition();
     }
+    getCurrentLayer_().getCurrentSpectrum().sortByPosition();
 
-    getCurrentLayer_().annotations_1d.resize(currentPeakData_()->size());
+    getCurrentLayer_().annotations_1d.resize(getCurrentLayer_().getPeakData()->size());
 
     // update nearest peak
     selected_peak_.clear();
@@ -1999,7 +2000,7 @@ namespace OpenMS
 
   void Spectrum1DCanvas::activateSpectrum(Size index, bool repaint)
   {
-    if (index < currentPeakData_()->size())
+    if (index < getCurrentLayer_().getPeakData()->size())
     {
       getCurrentLayer_().setCurrentSpectrumIndex(index);
       recalculateSnapFactor_();

--- a/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
@@ -1230,8 +1230,8 @@ namespace OpenMS
     if (layers_.back().type == LayerData::DT_PEAK)   //peak data
     {
       update_buffer_ = true;
-      //Abort if no data points are contained
-      if ((currentPeakData_()->size() == 0 || currentPeakData_()->getSize() == 0) && currentPeakData_()->getDataRange().isEmpty())
+      // Abort if no data points are contained (note that all data could be on disk)
+      if (currentPeakData_()->size() == 0)
       {
         layers_.resize(getLayerCount() - 1);
         if (current_layer_ != 0)

--- a/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
@@ -147,7 +147,7 @@ namespace OpenMS
     else if (getCurrentLayer().type == LayerData::DT_CHROMATOGRAM)
     {
       const LayerData & layer = getCurrentLayer();
-      const ExperimentSharedPtrType exp = layer.getPeakData();
+      const ConstExperimentSharedPtrType exp = layer.getPeakData();
 
       // create iterator on chromatogram spectrum passed by PeakIndex
       vector<MSChromatogram >::const_iterator chrom_it = exp->getChromatograms().begin();
@@ -166,7 +166,7 @@ namespace OpenMS
     if (getCurrentLayer().type == LayerData::DT_CHROMATOGRAM) // highlight: chromatogram
     {
       const LayerData & layer = getCurrentLayer();
-      const ExperimentSharedPtrType exp = layer.getPeakData();
+      const ConstExperimentSharedPtrType exp = layer.getPeakData();
 
       vector<MSChromatogram >::const_iterator iter = exp->getChromatograms().begin();
       iter += peak.spectrum;
@@ -1227,7 +1227,7 @@ namespace OpenMS
 
     current_layer_ = getLayerCount() - 1;
 
-    if (layers_.back().type == LayerData::DT_PEAK)   //peak data
+    if (layers_.back().type == LayerData::DT_PEAK)   // peak data
     {
       update_buffer_ = true;
       // Abort if no data points are contained (note that all data could be on disk)
@@ -1246,7 +1246,7 @@ namespace OpenMS
         setLayerFlag(LayerData::P_PRECURSORS, true); // show precursors if no MS1 data is contained
       }
     }
-    else if (layers_.back().type == LayerData::DT_FEATURE)  //feature data
+    else if (layers_.back().type == LayerData::DT_FEATURE)  // feature data
     {
       getCurrentLayer_().getFeatureMap()->updateRanges();
       setLayerFlag(LayerData::F_HULL, true);
@@ -1263,7 +1263,7 @@ namespace OpenMS
         return false;
       }
     }
-    else if (layers_.back().type == LayerData::DT_CONSENSUS)  //consensus feature data
+    else if (layers_.back().type == LayerData::DT_CONSENSUS)  // consensus feature data
     {
       getCurrentLayer_().getConsensusMap()->updateRanges();
 
@@ -1277,12 +1277,10 @@ namespace OpenMS
         return false;
       }
     }
-    else if (layers_.back().type == LayerData::DT_CHROMATOGRAM)  //chromatogram data
+    else if (layers_.back().type == LayerData::DT_CHROMATOGRAM)  // chromatogram data
     {
-
-      //TODO CHROM
-      getCurrentLayer_().getPeakData()->sortChromatograms(true);
-      getCurrentLayer_().getPeakData()->updateRanges(1);
+      getCurrentLayer_().getPeakDataMuteable()->sortChromatograms(true);
+      getCurrentLayer_().getPeakDataMuteable()->updateRanges(1);
 
       update_buffer_ = true;
 

--- a/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
@@ -1231,7 +1231,7 @@ namespace OpenMS
     {
       update_buffer_ = true;
       // Abort if no data points are contained (note that all data could be on disk)
-      if (currentPeakData_()->size() == 0)
+      if (getCurrentLayer_().getPeakData()->size() == 0)
       {
         layers_.resize(getLayerCount() - 1);
         if (current_layer_ != 0)
@@ -1241,7 +1241,7 @@ namespace OpenMS
         QMessageBox::critical(this, "Error", "Cannot add a dataset that contains no survey scans. Aborting!");
         return false;
       }
-      if ((currentPeakData_()->getSize() == 0) && (!currentPeakData_()->getDataRange().isEmpty()))
+      if ((getCurrentLayer_().getPeakData()->getSize() == 0) && (!getCurrentLayer_().getPeakData()->getDataRange().isEmpty()))
       {
         setLayerFlag(LayerData::P_PRECURSORS, true); // show precursors if no MS1 data is contained
       }
@@ -1281,13 +1281,13 @@ namespace OpenMS
     {
 
       //TODO CHROM
-      currentPeakData_()->sortChromatograms(true);
-      currentPeakData_()->updateRanges(1);
+      getCurrentLayer_().getPeakData()->sortChromatograms(true);
+      getCurrentLayer_().getPeakData()->updateRanges(1);
 
       update_buffer_ = true;
 
       // abort if no data points are contained
-      if (currentPeakData_()->getChromatograms().empty())
+      if (getCurrentLayer_().getPeakData()->getChromatograms().empty())
       {
         layers_.resize(getLayerCount() - 1);
         if (current_layer_ != 0)

--- a/src/openms_gui/source/VISUAL/Spectrum2DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DWidget.cpp
@@ -68,17 +68,18 @@ namespace OpenMS
     grid_->setRowStretch(1, 3);
 
     SpectrumCanvas::ExperimentSharedPtrType shr_ptr = SpectrumCanvas::ExperimentSharedPtrType(new SpectrumCanvas::ExperimentType());
+    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
     MSSpectrum dummy_spec;
     dummy_spec.push_back(Peak1D());
     shr_ptr->addSpectrum(dummy_spec);
 
     projection_vert_ = new  Spectrum1DWidget(Param(), this);
     projection_vert_->hide();
-    projection_vert_->canvas()->addLayer(shr_ptr);
+    projection_vert_->canvas()->addLayer(shr_ptr, od_dummy);
     grid_->addWidget(projection_vert_, 1, 3, 2, 1);
 
     projection_horz_ = new Spectrum1DWidget(Param(), this);
-    projection_horz_->canvas()->addLayer(shr_ptr);
+    projection_horz_->canvas()->addLayer(shr_ptr, od_dummy);
     projection_horz_->hide();
     grid_->addWidget(projection_horz_, 0, 1, 1, 2);
 
@@ -350,6 +351,7 @@ namespace OpenMS
 
   void Spectrum2DWidget::horizontalProjection(ExperimentSharedPtrType exp)
   {
+    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
     projection_horz_->canvas()->mzToXAxis(true); // determines the orientation of the data
     projection_horz_->canvas()->setSwappedAxis(canvas()->isMzToXAxis());
     projection_horz_->showLegend(false);
@@ -357,7 +359,7 @@ namespace OpenMS
     Spectrum1DCanvas::DrawModes mode = projection_horz_->canvas()->getDrawMode();
     Spectrum1DCanvas::IntensityModes intensity = projection_horz_->canvas()->getIntensityMode();
     projection_horz_->canvas()->removeLayer(0);
-    projection_horz_->canvas()->addLayer(exp);
+    projection_horz_->canvas()->addLayer(exp, od_dummy);
     projection_horz_->canvas()->setDrawMode(mode);
     projection_horz_->canvas()->setIntensityMode(intensity);
     grid_->setColumnStretch(3, 2);
@@ -367,13 +369,14 @@ namespace OpenMS
 
   void Spectrum2DWidget::verticalProjection(ExperimentSharedPtrType exp)
   {
+    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
     projection_vert_->canvas()->mzToXAxis(false); // determines the orientation of the data
     projection_vert_->canvas()->setSwappedAxis(canvas()->isMzToXAxis());
     projection_vert_->showLegend(false);
     Spectrum1DCanvas::DrawModes mode = projection_vert_->canvas()->getDrawMode();
     Spectrum1DCanvas::IntensityModes intensity = projection_vert_->canvas()->getIntensityMode();
     projection_vert_->canvas()->removeLayer(0);
-    projection_vert_->canvas()->addLayer(exp);
+    projection_vert_->canvas()->addLayer(exp, od_dummy);
     projection_vert_->canvas()->setDrawMode(mode);
     projection_vert_->canvas()->setIntensityMode(intensity);
     grid_->setRowStretch(0, 2);

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -389,12 +389,13 @@ namespace OpenMS
     return current_layer_;
   }
 
-  bool SpectrumCanvas::addLayer(ExperimentSharedPtrType map, const String & filename)
+  bool SpectrumCanvas::addLayer(ExperimentSharedPtrType map, ODExperimentSharedPtrType od_map, const String & filename)
   {
     layers_.resize(layers_.size() + 1);
     layers_.back().param = param_;
     layers_.back().filename = filename;
     layers_.back().getPeakData() = map;
+    layers_.back().getOnDiscPeakData() = od_map;
 
     if (layers_.back().getPeakData()->getChromatograms().size() != 0 
         && layers_.back().getPeakData()->size() != 0)
@@ -413,6 +414,12 @@ namespace OpenMS
       layers_.back().type = LayerData::DT_PEAK;
     }
     return finishAdding_();
+  }
+
+  bool SpectrumCanvas::addLayer(ExperimentSharedPtrType map, const String & filename)
+  {
+    ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
+    return addLayer(map, od_dummy, filename);
   }
 
   bool SpectrumCanvas::addLayer(FeatureMapSharedPtrType map, const String & filename)

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -416,12 +416,6 @@ namespace OpenMS
     return finishAdding_();
   }
 
-  bool SpectrumCanvas::addLayer(ExperimentSharedPtrType map, const String & filename)
-  {
-    ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
-    return addLayer(map, od_dummy, filename);
-  }
-
   bool SpectrumCanvas::addLayer(FeatureMapSharedPtrType map, const String & filename)
   {
     layers_.resize(layers_.size() + 1);

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -713,44 +713,51 @@ namespace OpenMS
     {
       const AreaType & area = getVisibleArea();
       const ExperimentType & peaks = *layer.getPeakData();
-      //copy experimental settings
+      // copy experimental settings
       map.ExperimentalSettings::operator=(peaks);
-      //reserve space for the correct number of spectra in RT range
+      // get begin / end of the range
+      ExperimentType::ConstIterator peak_start = layer.getPeakData()->begin();
       ExperimentType::ConstIterator begin = layer.getPeakData()->RTBegin(area.minPosition()[1]);
       ExperimentType::ConstIterator end = layer.getPeakData()->RTEnd(area.maxPosition()[1]);
+      Size begin_idx = std::distance(peak_start, begin);
+      Size end_idx = std::distance(peak_start, end);
 
-      //Exception for Spectrum1DCanvas, here we copy the currently visualized spectrum
+      // Exception for Spectrum1DCanvas, here we copy the currently visualized spectrum
       bool is_1d = (getName() == "Spectrum1DCanvas");
       if (is_1d)
       {
-        begin = layer.getPeakData()->begin() + layer.getCurrentSpectrumIndex();
-        end = begin + 1;
+        begin_idx = layer.getCurrentSpectrumIndex();
+        end_idx = begin_idx + 1;
       }
 
+      // reserve space for the correct number of spectra in RT range
       map.reserve(end - begin);
-      //copy spectra
-      for (ExperimentType::ConstIterator it = begin; it != end; ++it)
+      // copy spectra
+      for (Size it_idx = begin_idx; it_idx < end_idx; ++it_idx)
       {
         SpectrumType spectrum;
-        //copy spectrum meta information
-        spectrum.SpectrumSettings::operator=(* it);
-        spectrum.setRT(it->getRT());
-        spectrum.setMSLevel(it->getMSLevel());
-        spectrum.setPrecursors(it->getPrecursors());
-        //copy peak information
-        if (!is_1d && it->getMSLevel() > 1 && !it->getPrecursors().empty())       //MS^n (n>1) spectra are copied if their precursor is in the m/z range
+        SpectrumType spectrum_ref = layer.getSpectrum(it_idx);
+        // copy spectrum meta information
+        spectrum.SpectrumSettings::operator=(spectrum_ref);
+        spectrum.setRT(spectrum_ref.getRT());
+        spectrum.setMSLevel(spectrum_ref.getMSLevel());
+        spectrum.setPrecursors(spectrum_ref.getPrecursors());
+        // copy peak information
+        if (!is_1d && spectrum_ref.getMSLevel() > 1 && !spectrum_ref.getPrecursors().empty())
         {
-          if (it->getPrecursors()[0].getMZ() >= area.minPosition()[0] && it->getPrecursors()[0].getMZ() <= area.maxPosition()[0])
+          //MS^n (n>1) spectra are copied if their precursor is in the m/z range
+          if (spectrum_ref.getPrecursors()[0].getMZ() >= area.minPosition()[0] && spectrum_ref.getPrecursors()[0].getMZ() <= area.maxPosition()[0])
           {
-            spectrum.insert(spectrum.begin(), it->begin(), it->end());
+            spectrum.insert(spectrum.begin(), spectrum_ref.begin(), spectrum_ref.end());
             map.addSpectrum(spectrum);
           }
         }
-        else         // MS1(0) spectra are cropped to the m/z range
+        else
         {
-          for (SpectrumType::ConstIterator it2 = it->MZBegin(area.minPosition()[0]); it2 != it->MZEnd(area.maxPosition()[0]); ++it2)
+          // MS1 spectra are cropped to the m/z range
+          for (SpectrumType::ConstIterator it2 = spectrum_ref.MZBegin(area.minPosition()[0]); it2 != spectrum_ref.MZEnd(area.maxPosition()[0]); ++it2)
           {
-            if (layer.filters.passes(*it, it2 - it->begin()))
+            if (layer.filters.passes(spectrum_ref, it2 - spectrum_ref.begin()))
             {
               spectrum.push_back(*it2);
             }
@@ -867,7 +874,7 @@ namespace OpenMS
       if (layer.type == LayerData::DT_PEAK)
       {
         dlg.add(*layer.getPeakData());
-        //Exception for Spectrum1DCanvas, here we add the meta data of the one spectrum
+        // Exception for Spectrum1DCanvas, here we add the meta data of the one spectrum
         if (getName() == "Spectrum1DCanvas")
         {
           dlg.add((*layer.getPeakData())[layer.getCurrentSpectrumIndex()]);

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -873,11 +873,11 @@ namespace OpenMS
     {
       if (layer.type == LayerData::DT_PEAK)
       {
-        dlg.add(*layer.getPeakData());
+        dlg.add(*layer.getPeakDataMuteable());
         // Exception for Spectrum1DCanvas, here we add the meta data of the one spectrum
         if (getName() == "Spectrum1DCanvas")
         {
-          dlg.add((*layer.getPeakData())[layer.getCurrentSpectrumIndex()]);
+          dlg.add((*layer.getPeakDataMuteable())[layer.getCurrentSpectrumIndex()]);
         }
       }
       else if (layer.type == LayerData::DT_FEATURE)
@@ -901,7 +901,7 @@ namespace OpenMS
     {
       if (layer.type == LayerData::DT_PEAK)
       {
-        dlg.add((*layer.getPeakData())[index]);
+        dlg.add((*layer.getPeakDataMuteable())[index]);
       }
       else if (layer.type == LayerData::DT_FEATURE)
       {

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -394,8 +394,8 @@ namespace OpenMS
     layers_.resize(layers_.size() + 1);
     layers_.back().param = param_;
     layers_.back().filename = filename;
-    layers_.back().getPeakData() = map;
-    layers_.back().getOnDiscPeakData() = od_map;
+    layers_.back().setPeakData(map);
+    layers_.back().setOnDiscPeakData(od_map);
 
     if (layers_.back().getPeakData()->getChromatograms().size() != 0 
         && layers_.back().getPeakData()->size() != 0)

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -69,8 +69,8 @@ namespace OpenMS
   void TOPPViewIdentificationViewBehavior::showSpectrumAs1D(int spectrum_index, int peptide_id_index, int peptide_hit_index)
   {
     // basic behavior 1
-    const LayerData& layer = tv_->getActiveCanvas()->getCurrentLayer();
-    ExperimentSharedPtrType exp_sptr = layer.getPeakData();
+    LayerData & layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());
+    ExperimentSharedPtrType exp_sptr = layer.getPeakDataMuteable();
     LayerData::ODExperimentSharedPtrType od_exp_sptr = layer.getOnDiscPeakData();
 
     if (layer.type == LayerData::DT_PEAK)
@@ -809,7 +809,7 @@ namespace OpenMS
     // Return if no valid peak layer attached
     if (current_layer.getPeakData()->size() == 0 || current_layer.type != LayerData::DT_PEAK) { return; }
 
-    MSSpectrum& spectrum = (*current_layer.getPeakData())[spectrum_index];
+    MSSpectrum& spectrum = (*current_layer.getPeakDataMuteable())[spectrum_index];
     int ms_level = spectrum.getMSLevel();
 
     if (ms_level == 2)

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -71,13 +71,14 @@ namespace OpenMS
     // basic behavior 1
     const LayerData& layer = tv_->getActiveCanvas()->getCurrentLayer();
     ExperimentSharedPtrType exp_sptr = layer.getPeakData();
+    LayerData::ODExperimentSharedPtrType od_exp_sptr = layer.getOnDiscPeakData();
 
     if (layer.type == LayerData::DT_PEAK)
     {
       // open new 1D widget with the current default parameters
       Spectrum1DWidget* w = new Spectrum1DWidget(tv_->getSpectrumParameters(1), (QWidget*)tv_->getWorkspace());
       // add data
-      if (!w->canvas()->addLayer(exp_sptr, layer.filename) || (Size)spectrum_index >= w->canvas()->getCurrentLayer().getPeakData()->size())
+      if (!w->canvas()->addLayer(exp_sptr, od_exp_sptr, layer.filename) || (Size)spectrum_index >= w->canvas()->getCurrentLayer().getPeakData()->size())
       {
         return;
       }
@@ -144,7 +145,6 @@ namespace OpenMS
     }
     // else if (layer.type == LayerData::DT_CHROMATOGRAM)
   }
-
 
   void TOPPViewIdentificationViewBehavior::addPeakAnnotations_(const std::vector<PeptideIdentification>& ph)
   {
@@ -671,13 +671,13 @@ namespace OpenMS
     ExperimentSharedPtrType new_exp_sptr(new PeakMap(new_exp));
     FeatureMapSharedPtrType f_dummy(new FeatureMapType());
     ConsensusMapSharedPtrType c_dummy(new ConsensusMapType());
+    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
     vector<PeptideIdentification> p_dummy;
 
     // Block update events for identification widget
     tv_->getSpectraIdentificationViewWidget()->ignore_update = true;
 
     String layer_caption = aa_sequence.toString().toQString() + QString(" (identification view)");
-    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment()); // TODO 
     tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerData::DT_CHROMATOGRAM, false, false, false, "", layer_caption.toQString());
 
     // get layer index of new layer
@@ -907,6 +907,7 @@ namespace OpenMS
 
     PeakMap new_exp;
     new_exp.addSpectrum(ann_spectrum);
+    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
     ExperimentSharedPtrType new_exp_sptr(new PeakMap(new_exp));
     FeatureMapSharedPtrType f_dummy(new FeatureMapType());
     ConsensusMapSharedPtrType c_dummy(new ConsensusMapType());
@@ -916,7 +917,6 @@ namespace OpenMS
     tv_->getSpectraIdentificationViewWidget()->ignore_update = true;
 
     String layer_caption = seq + " (identification view)";
-    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment()); // TODO 
     tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerData::DT_PEAK, true, false, false, "", layer_caption);
 
     // get layer index of new layer

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -677,7 +677,8 @@ namespace OpenMS
     tv_->getSpectraIdentificationViewWidget()->ignore_update = true;
 
     String layer_caption = aa_sequence.toString().toQString() + QString(" (identification view)");
-    tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, LayerData::DT_CHROMATOGRAM, false, false, false, "", layer_caption.toQString());
+    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment()); // TODO 
+    tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerData::DT_CHROMATOGRAM, false, false, false, "", layer_caption.toQString());
 
     // get layer index of new layer
     Size theoretical_spectrum_layer_index = tv_->getActive1DWidget()->canvas()->activeLayerIndex();
@@ -915,7 +916,8 @@ namespace OpenMS
     tv_->getSpectraIdentificationViewWidget()->ignore_update = true;
 
     String layer_caption = seq + " (identification view)";
-    tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, LayerData::DT_PEAK, true, false, false, "", layer_caption);
+    LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment()); // TODO 
+    tv_->addData(f_dummy, c_dummy, p_dummy, new_exp_sptr, od_dummy, LayerData::DT_PEAK, true, false, false, "", layer_caption);
 
     // get layer index of new layer
     Size theoretical_spectrum_layer_index = tv_->getActive1DWidget()->canvas()->activeLayerIndex();

--- a/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
@@ -58,6 +58,7 @@ namespace OpenMS
     // basic behavior 1
     const LayerData & layer = tv_->getActiveCanvas()->getCurrentLayer();
     ExperimentSharedPtrType exp_sptr = layer.getPeakData();
+    LayerData::ODExperimentSharedPtrType od_exp_sptr = layer.getOnDiscPeakData();
 
     // open new 1D widget
     Spectrum1DWidget * w = new Spectrum1DWidget(tv_->getSpectrumParameters(1), (QWidget *)tv_->getWorkspace());
@@ -96,7 +97,7 @@ namespace OpenMS
       caption = layer.name;
 
       //add data
-      if (!w->canvas()->addLayer(exp_sptr, layer.filename) || (Size)index >= w->canvas()->getCurrentLayer().getPeakData()->size())
+      if (!w->canvas()->addLayer(exp_sptr, od_exp_sptr, layer.filename) || (Size)index >= w->canvas()->getCurrentLayer().getPeakData()->size())
       {
         return;
       }
@@ -113,7 +114,7 @@ namespace OpenMS
       UInt ms_level = w->canvas()->getCurrentLayer().getCurrentSpectrum().getMSLevel();
       if (ms_level == 1)
       {
-        // set visible aree to visible area in 2D view
+        // set visible area to visible area in 2D view
         w->canvas()->setVisibleArea(tv_->getActiveCanvas()->getVisibleArea());
       }
     }

--- a/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
@@ -85,7 +85,8 @@ namespace OpenMS
 
       caption = layer.name + "[" + index + "]";
       //add chromatogram data as peak spectrum
-      if (!w->canvas()->addLayer(chrom_exp_sptr, layer.filename))
+      LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
+      if (!w->canvas()->addLayer(chrom_exp_sptr, od_dummy, layer.filename))
       {
         return;
       }
@@ -188,7 +189,8 @@ namespace OpenMS
         caption = caption + " [" + indices[index] + "];";
         chromatogram_caption = layer.name + "[" + indices[index] + "]";
         //add chromatogram data as peak spectrum
-        if (!w->canvas()->addLayer(chrom_exp_sptr, layer.filename))
+        LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
+        if (!w->canvas()->addLayer(chrom_exp_sptr, od_dummy, layer.filename))
         {
           return;
         }
@@ -277,7 +279,8 @@ namespace OpenMS
       chrom_exp_sptr->addSpectrum(spectrum);
       caption = lname + "[" + index + "]";
       //add chromatogram data as peak spectrum
-      if (!widget_1d->canvas()->addLayer(chrom_exp_sptr, fname))
+      LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
+      if (!widget_1d->canvas()->addLayer(chrom_exp_sptr, od_dummy, fname))
       {
         return;
       }
@@ -355,7 +358,8 @@ namespace OpenMS
           caption = String(current_chrom.getPrecursor().getMetaValue("peptide_sequence")) + "[" + indices[index] + "]";
         }
         //add chromatogram data as peak spectrum
-        if (!widget_1d->canvas()->addLayer(chrom_exp_sptr, fname))
+        LayerData::ODExperimentSharedPtrType od_dummy(new OnDiscMSExperiment());
+        if (!widget_1d->canvas()->addLayer(chrom_exp_sptr, od_dummy, fname))
         {
           return;
         }

--- a/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
@@ -97,7 +97,7 @@ namespace OpenMS
     {
       caption = layer.name;
 
-      //add data
+      // add data
       if (!w->canvas()->addLayer(exp_sptr, od_exp_sptr, layer.filename) || (Size)index >= w->canvas()->getCurrentLayer().getPeakData()->size())
       {
         return;

--- a/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
@@ -174,7 +174,6 @@ namespace OpenMS
       SpectrumType spectrum;
       if (layer.type == LayerData::DT_CHROMATOGRAM)
       {
-
         const MSChromatogram & current_chrom = exp_sptr->getChromatograms()[indices[index]];
         for (Size i = 0; i != current_chrom.size(); ++i)
         {

--- a/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
@@ -56,8 +56,8 @@ namespace OpenMS
   void TOPPViewSpectraViewBehavior::showSpectrumAs1D(int index)
   {
     // basic behavior 1
-    const LayerData & layer = tv_->getActiveCanvas()->getCurrentLayer();
-    ExperimentSharedPtrType exp_sptr = layer.getPeakData();
+    LayerData & layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());
+    ExperimentSharedPtrType exp_sptr = layer.getPeakDataMuteable();
     LayerData::ODExperimentSharedPtrType od_exp_sptr = layer.getOnDiscPeakData();
 
     // open new 1D widget
@@ -152,8 +152,8 @@ namespace OpenMS
 
     // show multiple spectra together is only used for chromatograms directly
     // where multiple (SRM) traces are shown together
-    const LayerData & layer = tv_->getActiveCanvas()->getCurrentLayer();
-    ExperimentSharedPtrType exp_sptr = layer.getPeakData();
+    LayerData & layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());
+    ExperimentSharedPtrType exp_sptr = layer.getPeakDataMuteable();
 
     // string for naming the different chromatogram layers with their index
     String chromatogram_caption;
@@ -234,7 +234,7 @@ namespace OpenMS
     if (widget_1d->canvas()->getLayerCount() == 0) return;
 
     widget_1d->canvas()->activateSpectrum(index);
-    const LayerData & layer = tv_->getActiveCanvas()->getCurrentLayer();
+    LayerData & layer = const_cast<LayerData&>(tv_->getActiveCanvas()->getCurrentLayer());
 
     // If we have a chromatogram, we cannot just simply activate this spectrum.
     // we have to do much more work, e.g. creating a new experiment with the
@@ -291,9 +291,9 @@ namespace OpenMS
       widget_1d->canvas()->getCurrentLayer().filename = fname;
       widget_1d->canvas()->getCurrentLayer().getChromatogramData() = exp_sptr; // save the original chromatogram data so that we can access it later
       //this is a hack to store that we have chromatogram data, that we selected multiple ones and which one we selected
-      widget_1d->canvas()->getCurrentLayer().getPeakData()->setMetaValue("is_chromatogram", "true");
-      widget_1d->canvas()->getCurrentLayer().getPeakData()->setMetaValue("multiple_select", "false");
-      widget_1d->canvas()->getCurrentLayer().getPeakData()->setMetaValue("selected_chromatogram", index);
+      widget_1d->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("is_chromatogram", "true");
+      widget_1d->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("multiple_select", "false");
+      widget_1d->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("selected_chromatogram", index);
 
       tv_->updateLayerBar();
       tv_->updateViewBar();
@@ -372,9 +372,9 @@ namespace OpenMS
         widget_1d->canvas()->getCurrentLayer().filename = fname;
         widget_1d->canvas()->getCurrentLayer().getChromatogramData() = exp_sptr; // save the original chromatogram data so that we can access it later
         //this is a hack to store that we have chromatogram data, that we selected multiple ones and which one we selected
-        widget_1d->canvas()->getCurrentLayer().getPeakData()->setMetaValue("is_chromatogram", "true");
-        widget_1d->canvas()->getCurrentLayer().getPeakData()->setMetaValue("multiple_select", "true");
-        widget_1d->canvas()->getCurrentLayer().getPeakData()->setMetaValue("selected_chromatogram", indices[index]);
+        widget_1d->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("is_chromatogram", "true");
+        widget_1d->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("multiple_select", "true");
+        widget_1d->canvas()->getCurrentLayer().getPeakDataMuteable()->setMetaValue("selected_chromatogram", indices[index]);
       }
 
       tv_->updateLayerBar();


### PR DESCRIPTION
Load MS2 spectra on demand for viewing in TOPPView. This works because most MS2 spectral viewing is spectra-by-spectra and there is no need to have all spectra in memory at once.

This saves substantial amount of memory, depending on the data file. The new behavior is off by default but can be turned on through `.TOPPView.ini`. For some files this makes a huge difference, for a sample test file that I generated there is a 10x difference in memory consumption (note that I am loading the same file):

![screenshot from 2018-04-20 00-17-33](https://user-images.githubusercontent.com/464014/39030566-c76bf884-4430-11e8-9208-535da73a4227.png)

The impact for regular users is minimal as this will have no effect unless turned on - but it could help in many cases where loading all data would be too memory-intensive. This is for example true for SWATH-MS data.

I have tested this on a HDD and an SSD drive with MS2 spectra that have 5000 peaks, there is no noticeable lag when opening a specific MS2 spectrum. Basically this is almost as fast as in memory for my test case. 