### PR TITLE
Feature/version info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,8 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Windows")
 #------------------------------------------------------------------------------
 
 set(OPENMS_PACKAGE_VERSION_MAJOR "2")
-set(OPENMS_PACKAGE_VERSION_MINOR "3")
-set(OPENMS_PACKAGE_VERSION_PATCH "0")
+set(OPENMS_PACKAGE_VERSION_MINOR "4")
+set(OPENMS_PACKAGE_VERSION_PATCH "alpha")
 
 #------------------------------------------------------------------------------
 # retrieve detailed informations on the working copy (git)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Windows")
 
 set(OPENMS_PACKAGE_VERSION_MAJOR "2")
 set(OPENMS_PACKAGE_VERSION_MINOR "4")
-set(OPENMS_PACKAGE_VERSION_PATCH "alpha")
+set(OPENMS_PACKAGE_VERSION_PATCH "0-alpha")
 
 #------------------------------------------------------------------------------
 # retrieve detailed informations on the working copy (git)

--- a/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
+++ b/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include <OpenMS/CONCEPT/Types.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
 
 namespace OpenMS
 {
@@ -63,10 +64,10 @@ public:
     {
       Int version_major;
       Int version_minor;
-      Int version_patch;
+      String version_patch;
 
       VersionDetails() :
-        version_major(0), version_minor(0), version_patch(0)
+        version_major(0), version_minor(0), version_patch("")
       {
       }
 

--- a/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
+++ b/src/openms/include/OpenMS/CONCEPT/VersionInfo.h
@@ -47,8 +47,11 @@ namespace OpenMS
       The OpenMS release version and revision data can be retrieved as a string
       or as integers.
 
-      Note that the term <i>"version"</i> refers to releases (such as 1.0, 1.1, 1.1.1,
-      1.2, ...),  whereas the term <i>"revision"</i> refers to a revision control system
+      Note that the term <i>"version"</i> refers to releases (such as 1.0,
+      1.1.1-alpha, 1.2, ...), which follows the https://semver.org/ definition
+      of version numbers using major, minor, patch and pre-release identifiers
+      (separated by a dash).
+      The term <i>"revision"</i> refers to a revision control system
       such as git and is mainly of interest for developers. The term <i>"branch"</i>
       refers to the git branch that this build of OpenMS is based on.
 
@@ -64,10 +67,11 @@ public:
     {
       Int version_major;
       Int version_minor;
-      String version_patch;
+      Int version_patch;
+      String pre_release_identifier;
 
       VersionDetails() :
-        version_major(0), version_minor(0), version_patch("")
+        version_major(0), version_minor(0), version_patch(0), pre_release_identifier("")
       {
       }
 
@@ -75,7 +79,8 @@ public:
       VersionDetails(const VersionDetails & other):
         version_major(other.version_major),
         version_minor(other.version_minor),
-        version_patch(other.version_patch)
+        version_patch(other.version_patch),
+        pre_release_identifier(other.pre_release_identifier)
       {
       }
 

--- a/src/openms/source/CONCEPT/VersionInfo.cpp
+++ b/src/openms/source/CONCEPT/VersionInfo.cpp
@@ -31,7 +31,9 @@
 // $Maintainer: Chris Bielow $
 // $Authors: Clemens Groepl, Chris Bielow $
 // --------------------------------------------------------------------------
+
 #include <OpenMS/CONCEPT/VersionInfo.h>
+
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/CONCEPT/Exception.h>
 
@@ -49,6 +51,13 @@ namespace OpenMS
 
   bool VersionInfo::VersionDetails::operator<(const VersionInfo::VersionDetails & rhs) const
   {
+    // first try to compare with integer patch numbers
+    try {
+      return (this->version_major  < rhs.version_major)
+             || (this->version_major == rhs.version_major && this->version_minor  < rhs.version_minor)
+             || (this->version_major == rhs.version_major && this->version_minor == rhs.version_minor && this->version_patch.toInt() < rhs.version_patch.toInt());
+    } catch (Exception::ConversionError) {}
+
     return (this->version_major  < rhs.version_major)
            || (this->version_major == rhs.version_major && this->version_minor  < rhs.version_minor)
            || (this->version_major == rhs.version_major && this->version_minor == rhs.version_minor && this->version_patch < rhs.version_patch);

--- a/src/openms/source/CONCEPT/VersionInfo.cpp
+++ b/src/openms/source/CONCEPT/VersionInfo.cpp
@@ -78,7 +78,9 @@ namespace OpenMS
     size_t first_dot = version.find('.');
     // we demand at least one "."
     if (first_dot == string::npos)
+    {
       return VersionInfo::VersionDetails::EMPTY;
+    }
 
     try
     {
@@ -108,7 +110,7 @@ namespace OpenMS
     size_t third_dot = version.find('.', second_dot + 1);
     try
     {
-      result.version_patch = String(version.substr(second_dot + 1, third_dot - (second_dot + 1))).toInt();
+      result.version_patch = String(version.substr(second_dot + 1, third_dot - (second_dot + 1)));
     }
     catch (Exception::ConversionError & /*e*/)
     {

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -2477,10 +2477,10 @@ namespace OpenMS
 
     tab_bar_->addTab(caption.toQString(), sw->getWindowId());
 
-    //connect slots and sigals for removing the widget from the bar, when it is closed
+    //connect slots and signals for removing the widget from the bar, when it is closed
     //- through the menu entry
     //- through the tab bar
-    //- thourgh the MDI close button
+    //- through the MDI close button
     connect(sw, SIGNAL(aboutToBeDestroyed(int)), tab_bar_, SLOT(removeId(int)));
 
     tab_bar_->setCurrentId(sw->getWindowId());
@@ -2702,7 +2702,6 @@ namespace OpenMS
       addDataFile(filename, true, true);
     }
   }
-
 
   void TOPPViewBase::rerunTOPPTool()
   {
@@ -3413,19 +3412,21 @@ namespace OpenMS
 
   void TOPPViewBase::showAboutDialog()
   {
-    //dialog and grid layout
+    // dialog and grid layout
     QDialog* dlg = new QDialog(this);
     QGridLayout* grid = new QGridLayout(dlg);
     dlg->setWindowTitle("About TOPPView");
 
-    //image
+    // image
     QLabel* label = new QLabel(dlg);
     label->setPixmap(QPixmap(":/TOPP_about.png"));
     grid->addWidget(label, 0, 0);
 
-    //text
+    // text
     QString text = QString("<BR>"
                            "<FONT size=+3>TOPPView</font><BR>"
+                           "<BR>"
+                           "Version %1 %2"
                            "<BR>"
                            "OpenMS and TOPP is free software available under the<BR>"
                            "BSD 3-Clause License (BSD-new)<BR>"
@@ -3439,16 +3440,18 @@ namespace OpenMS
                            "Kohlbacher et al., Bioinformatics (2007), 23:e191-e197<BR>"
                            ).arg(VersionInfo::getVersion().toQString()
                            ).arg( // if we have a revision, embed it also into the shown version number
-                             VersionInfo::getRevision() != "" ? QString(" (") + VersionInfo::getRevision().toQString() + ")" : "");    label = new QLabel(text, dlg);
+                             VersionInfo::getRevision() != "" ? QString(" (") + VersionInfo::getRevision().toQString() + ")" : "");
+
+    label = new QLabel(text, dlg);
 
     grid->addWidget(label, 0, 1, Qt::AlignTop | Qt::AlignLeft);
 
-    //close button
+    // close button
     QPushButton* button = new QPushButton("Close", dlg);
     grid->addWidget(button, 1, 1, Qt::AlignBottom | Qt::AlignRight);
     connect(button, SIGNAL(clicked()), dlg, SLOT(close()));
 
-    //execute
+    // execute
     dlg->exec();
   }
 

--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -463,10 +463,17 @@ endif()
 message(STATUS "Py extra args ${PY_EXTRA_ARGS}")
 
 
-add_custom_target(pyopenms_build
-          COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext ${PY_EXTRA_ARGS}
-          DEPENDS pyopenms_create_cpp
-          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND PY_NO_OUTPUT)
+  add_custom_target(pyopenms_build
+            COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext ${PY_EXTRA_ARGS} 2> /dev/null
+            DEPENDS pyopenms_create_cpp
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+ELSE()
+  add_custom_target(pyopenms_build
+            COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext ${PY_EXTRA_ARGS}
+            DEPENDS pyopenms_create_cpp
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+ENDIF()
 
 add_dependencies(pyopenms_build OpenMS)
 

--- a/src/pyOpenMS/CMakeLists.txt
+++ b/src/pyOpenMS/CMakeLists.txt
@@ -484,13 +484,23 @@ add_custom_command(
   )
 endif()
 
-add_custom_target(pyopenms
-          COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_egg
-          COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel
-          COMMAND ${PYTHON_EXECUTABLE} setup.py bdist --format=zip
-          COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext --inplace
-          DEPENDS pyopenms_build
-          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND PY_NO_OUTPUT)
+  add_custom_target(pyopenms
+            COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_egg 2> /dev/null
+            COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel 2> /dev/null
+            COMMAND ${PYTHON_EXECUTABLE} setup.py bdist --format=zip 2> /dev/null
+            COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext --inplace 2> /dev/null
+            DEPENDS pyopenms_build
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+ELSE()
+  add_custom_target(pyopenms
+            COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_egg
+            COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel
+            COMMAND ${PYTHON_EXECUTABLE} setup.py bdist --format=zip
+            COMMAND ${PYTHON_EXECUTABLE} setup.py build_ext --inplace
+            DEPENDS pyopenms_build
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/pyOpenMS )
+ENDIF()
 
 
 ###########################################################################

--- a/src/pyOpenMS/pxds/VersionInfo.pxd
+++ b/src/pyOpenMS/pxds/VersionInfo.pxd
@@ -12,7 +12,8 @@ cdef extern from "<OpenMS/CONCEPT/VersionInfo.h>" namespace "OpenMS::VersionInfo
     cdef cppclass VersionDetails:
         Int version_major
         Int version_minor
-        String version_patch
+        Int version_patch
+        String pre_release_identifier
 
         VersionDetails() nogil except +
         VersionDetails(VersionDetails) nogil except +   #wrap-ignore

--- a/src/pyOpenMS/pxds/VersionInfo.pxd
+++ b/src/pyOpenMS/pxds/VersionInfo.pxd
@@ -12,8 +12,7 @@ cdef extern from "<OpenMS/CONCEPT/VersionInfo.h>" namespace "OpenMS::VersionInfo
     cdef cppclass VersionDetails:
         Int version_major
         Int version_minor
-        Int version_patch
-        # VersionDetails EMPTY
+        String version_patch
 
         VersionDetails() nogil except +
         VersionDetails(VersionDetails) nogil except +   #wrap-ignore
@@ -30,5 +29,4 @@ cdef extern from "<OpenMS/CONCEPT/VersionInfo.h>" namespace "OpenMS::VersionInfo
 cdef extern from "<OpenMS/CONCEPT/VersionInfo.h>" namespace "OpenMS::VersionInfo::VersionDetails":
 
     VersionDetails create(String) #wrap-attach:VersionDetails
-
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -4195,13 +4195,19 @@ def testVersion():
     vd = pyopenms.VersionDetails.create(b"19.2.1")
     assert vd.version_major == 19
     assert vd.version_minor == 2
-    assert vd.version_patch == b"1"
+    assert vd.version_patch == 1
+
+    vd = pyopenms.VersionDetails.create(b"19.2.1-alpha")
+    assert vd.version_major == 19
+    assert vd.version_minor == 2
+    assert vd.version_patch == 1
+    assert vd.pre_release_identifier == b"alpha"
 
     assert vd == vd
     assert not vd < vd
     assert not vd > vd
 
-    assert  isinstance(pyopenms.version.version, str)
+    assert isinstance(pyopenms.version.version, str)
 
 @report
 def testInspectInfile():

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -4195,7 +4195,7 @@ def testVersion():
     vd = pyopenms.VersionDetails.create(b"19.2.1")
     assert vd.version_major == 19
     assert vd.version_minor == 2
-    assert vd.version_patch == 1
+    assert vd.version_patch == b"1"
 
     assert vd == vd
     assert not vd < vd

--- a/src/tests/class_tests/openms/source/VersionInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/VersionInfo_test.cpp
@@ -60,7 +60,7 @@ END_SECTION
 
 START_SECTION(static String getVersion() )
 {
-  TEST_STRING_EQUAL(VersionInfo::getVersion(),String(OPENMS_PACKAGE_VERSION).trim());
+  TEST_STRING_EQUAL(VersionInfo::getVersion(), String(OPENMS_PACKAGE_VERSION).trim());
 }
 END_SECTION
 
@@ -68,8 +68,8 @@ START_SECTION((static VersionDetails getVersionStruct()))
 {
   VersionInfo::VersionDetails detail;
   detail.version_major = 2;
-  detail.version_minor = 3;
-  detail.version_patch = 0;
+  detail.version_minor = 4;
+  detail.version_patch = "alpha";
   TEST_EQUAL(VersionInfo::getVersionStruct() == detail, true);
 }
 END_SECTION
@@ -97,11 +97,11 @@ START_SECTION(([VersionInfo::VersionDetails] bool operator<(const VersionDetails
   VersionInfo::VersionDetails c;
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = 2;
+  c.version_patch = "2";
   TEST_EQUAL(detail < c, false)
-  c.version_patch = 3;
+  c.version_patch = "3";
   TEST_EQUAL(detail < c, true)
-  c.version_patch = 1;
+  c.version_patch = "1";
   TEST_EQUAL(detail < c, false)
   c.version_major = 2;
   TEST_EQUAL(detail < c, true)
@@ -114,11 +114,11 @@ START_SECTION(([VersionInfo::VersionDetails] bool operator==(const VersionDetail
   VersionInfo::VersionDetails c;
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = 2;
+  c.version_patch = "2";
   TEST_EQUAL(detail == c, true)
-  c.version_patch = 3;
+  c.version_patch = "3";
   TEST_EQUAL(detail == c, false)
-  c.version_patch = 1;
+  c.version_patch = "1";
   TEST_EQUAL(detail == c, false)
   c.version_major = 2;
   TEST_EQUAL(detail == c, false)
@@ -131,11 +131,11 @@ START_SECTION(([VersionInfo::VersionDetails] bool operator>(const VersionDetails
   VersionInfo::VersionDetails c;
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = 2;
+  c.version_patch = "2";
   TEST_EQUAL(detail > c, false)
-  c.version_patch = 3;
+  c.version_patch = "3";
   TEST_EQUAL(detail > c, false)
-  c.version_patch = 1;
+  c.version_patch = "1";
   TEST_EQUAL(detail > c, true)
   c.version_major = 2;
   TEST_EQUAL(detail > c, false)
@@ -148,31 +148,40 @@ START_SECTION(([VersionInfo::VersionDetails] static VersionDetails create(const 
   VersionInfo::VersionDetails c;
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = 2;
+  c.version_patch = "2";
   TEST_EQUAL(detail == c, true)
 
   detail = VersionInfo::VersionDetails::create("1.9");
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = 0;
+  c.version_patch = "";
   TEST_EQUAL(detail == c, true)
 
   detail = VersionInfo::VersionDetails::create("1.0");
   c.version_major = 1;
   c.version_minor = 0;
-  c.version_patch = 0;
+  c.version_patch = "";
   TEST_EQUAL(detail == c, true)
 
   detail = VersionInfo::VersionDetails::create("somestring");
   c.version_major = 0;
   c.version_minor = 0;
-  c.version_patch = 0;
+  c.version_patch = "";
   TEST_EQUAL(detail == c, true)
 
   detail = VersionInfo::VersionDetails::create("1.2a.bla");
   c.version_major = 0;
   c.version_minor = 0;
-  c.version_patch = 0;
+  c.version_patch = "";
+  TEST_EQUAL(detail == c, true)
+
+  detail = VersionInfo::VersionDetails::create("1.2.bla");
+  c.version_major = 1;
+  c.version_minor = 2;
+  c.version_patch = "bla";
+  TEST_EQUAL(detail.version_major, c.version_major)
+  TEST_EQUAL(detail.version_minor, c.version_minor)
+  TEST_EQUAL(detail.version_patch, c.version_patch)
   TEST_EQUAL(detail == c, true)
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/VersionInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/VersionInfo_test.cpp
@@ -69,7 +69,12 @@ START_SECTION((static VersionDetails getVersionStruct()))
   VersionInfo::VersionDetails detail;
   detail.version_major = 2;
   detail.version_minor = 4;
-  detail.version_patch = "alpha";
+  detail.version_patch = 0;
+  detail.pre_release_identifier = "alpha";
+  TEST_EQUAL(VersionInfo::getVersionStruct().version_major, detail.version_major);
+  TEST_EQUAL(VersionInfo::getVersionStruct().version_minor, detail.version_minor);
+  TEST_EQUAL(VersionInfo::getVersionStruct().version_patch, detail.version_patch);
+  TEST_EQUAL(VersionInfo::getVersionStruct().pre_release_identifier, detail.pre_release_identifier);
   TEST_EQUAL(VersionInfo::getVersionStruct() == detail, true);
 }
 END_SECTION
@@ -97,11 +102,11 @@ START_SECTION(([VersionInfo::VersionDetails] bool operator<(const VersionDetails
   VersionInfo::VersionDetails c;
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = "2";
+  c.version_patch = 2;
   TEST_EQUAL(detail < c, false)
-  c.version_patch = "3";
+  c.version_patch = 3;
   TEST_EQUAL(detail < c, true)
-  c.version_patch = "1";
+  c.version_patch = 1;
   TEST_EQUAL(detail < c, false)
   c.version_major = 2;
   TEST_EQUAL(detail < c, true)
@@ -114,11 +119,11 @@ START_SECTION(([VersionInfo::VersionDetails] bool operator==(const VersionDetail
   VersionInfo::VersionDetails c;
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = "2";
+  c.version_patch = 2;
   TEST_EQUAL(detail == c, true)
-  c.version_patch = "3";
+  c.version_patch = 3;
   TEST_EQUAL(detail == c, false)
-  c.version_patch = "1";
+  c.version_patch = 1;
   TEST_EQUAL(detail == c, false)
   c.version_major = 2;
   TEST_EQUAL(detail == c, false)
@@ -131,16 +136,18 @@ START_SECTION(([VersionInfo::VersionDetails] bool operator>(const VersionDetails
   VersionInfo::VersionDetails c;
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = "2";
+  c.version_patch = 2;
   TEST_EQUAL(detail > c, false)
-  c.version_patch = "3";
+  c.version_patch = 3;
   TEST_EQUAL(detail > c, false)
-  c.version_patch = "1";
+  c.version_patch = 1;
   TEST_EQUAL(detail > c, true)
-  c.version_patch = "11";
+  c.version_patch = 11;
   TEST_EQUAL(detail < c, true)
-  c.version_major = 2;
+  c.version_patch = 2;
   TEST_EQUAL(detail > c, false)
+  c.pre_release_identifier = "alpha";
+  TEST_EQUAL(detail > c, true)
 }
 END_SECTION
 
@@ -150,40 +157,42 @@ START_SECTION(([VersionInfo::VersionDetails] static VersionDetails create(const 
   VersionInfo::VersionDetails c;
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = "2";
+  c.version_patch = 2;
   TEST_EQUAL(detail == c, true)
 
   detail = VersionInfo::VersionDetails::create("1.9");
   c.version_major = 1;
   c.version_minor = 9;
-  c.version_patch = "";
+  c.version_patch = 0;
   TEST_EQUAL(detail == c, true)
 
   detail = VersionInfo::VersionDetails::create("1.0");
   c.version_major = 1;
   c.version_minor = 0;
-  c.version_patch = "";
+  c.version_patch = 0;
   TEST_EQUAL(detail == c, true)
 
   detail = VersionInfo::VersionDetails::create("somestring");
   c.version_major = 0;
   c.version_minor = 0;
-  c.version_patch = "";
+  c.version_patch = 0;
   TEST_EQUAL(detail == c, true)
 
   detail = VersionInfo::VersionDetails::create("1.2a.bla");
   c.version_major = 0;
   c.version_minor = 0;
-  c.version_patch = "";
+  c.version_patch = 0;
   TEST_EQUAL(detail == c, true)
 
-  detail = VersionInfo::VersionDetails::create("1.2.bla");
+  detail = VersionInfo::VersionDetails::create("1.2.1-bla");
   c.version_major = 1;
   c.version_minor = 2;
-  c.version_patch = "bla";
+  c.version_patch = 1;
+  c.pre_release_identifier = "bla";
   TEST_EQUAL(detail.version_major, c.version_major)
   TEST_EQUAL(detail.version_minor, c.version_minor)
   TEST_EQUAL(detail.version_patch, c.version_patch)
+  TEST_EQUAL(detail.pre_release_identifier, c.pre_release_identifier)
   TEST_EQUAL(detail == c, true)
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/VersionInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/VersionInfo_test.cpp
@@ -146,6 +146,8 @@ START_SECTION(([VersionInfo::VersionDetails] bool operator>(const VersionDetails
   TEST_EQUAL(detail < c, true)
   c.version_patch = 2;
   TEST_EQUAL(detail > c, false)
+  
+  // note that any version with a pre-release identifier should be "less than" the release version
   c.pre_release_identifier = "alpha";
   TEST_EQUAL(detail > c, true)
 }

--- a/src/tests/class_tests/openms/source/VersionInfo_test.cpp
+++ b/src/tests/class_tests/openms/source/VersionInfo_test.cpp
@@ -137,6 +137,8 @@ START_SECTION(([VersionInfo::VersionDetails] bool operator>(const VersionDetails
   TEST_EQUAL(detail > c, false)
   c.version_patch = "1";
   TEST_EQUAL(detail > c, true)
+  c.version_patch = "11";
+  TEST_EQUAL(detail < c, true)
   c.version_major = 2;
   TEST_EQUAL(detail > c, false)
 }

--- a/src/tests/topp/INIUpdater_1_noupdate.toppas
+++ b/src/tests/topp/INIUpdater_1_noupdate.toppas
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NODE name="info" description="">
-    <ITEM name="version" value="2.4.alpha" type="string" description="" required="false" advanced="false" />
+    <ITEM name="version" value="2.4.0-alpha" type="string" description="" required="false" advanced="false" />
     <ITEM name="num_vertices" value="7" type="int" description="" required="false" advanced="false" />
     <ITEM name="num_edges" value="6" type="int" description="" required="false" advanced="false" />
     <ITEM name="description" value="&lt;![CDATA[&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt; &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt; p, li { white-space: pre-wrap; } &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt; &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;]]&gt;" type="string" description="" required="false" advanced="false" />

--- a/src/tests/topp/INIUpdater_1_noupdate.toppas
+++ b/src/tests/topp/INIUpdater_1_noupdate.toppas
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NODE name="info" description="">
-    <ITEM name="version" value="2.3.0" type="string" description="" required="false" advanced="false" />
+    <ITEM name="version" value="2.4.alpha" type="string" description="" required="false" advanced="false" />
     <ITEM name="num_vertices" value="7" type="int" description="" required="false" advanced="false" />
     <ITEM name="num_edges" value="6" type="int" description="" required="false" advanced="false" />
     <ITEM name="description" value="&lt;![CDATA[&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt; &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt; p, li { white-space: pre-wrap; } &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt; &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;]]&gt;" type="string" description="" required="false" advanced="false" />

--- a/src/tests/topp/WRITE_INI_OUT.ini
+++ b/src/tests/topp/WRITE_INI_OUT.ini
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NODE name="PeakPickerWavelet" description="Finds mass spectrometric peaks in profile mass spectra.">
-    <ITEM name="version" value="2.4.alpha" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
+    <ITEM name="version" value="2.4.0-alpha" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;PeakPickerWavelet&apos;">
       <ITEM name="in" value="" type="input-file" description="input profile data file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="out" value="" type="output-file" description="output peak file " required="true" advanced="false" supported_formats="*.mzML" />

--- a/src/tests/topp/WRITE_INI_OUT.ini
+++ b/src/tests/topp/WRITE_INI_OUT.ini
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <PARAMETERS version="1.6.2" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/Param_1_6_2.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NODE name="PeakPickerWavelet" description="Finds mass spectrometric peaks in profile mass spectra.">
-    <ITEM name="version" value="2.3.0" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
+    <ITEM name="version" value="2.4.alpha" type="string" description="Version of the tool that generated this parameters file." required="false" advanced="true" />
     <NODE name="1" description="Instance &apos;1&apos; section for &apos;PeakPickerWavelet&apos;">
       <ITEM name="in" value="" type="input-file" description="input profile data file " required="true" advanced="false" supported_formats="*.mzML" />
       <ITEM name="out" value="" type="output-file" description="output peak file " required="true" advanced="false" supported_formats="*.mzML" />
@@ -51,8 +51,8 @@
           <ITEM name="scaling" value="0.12" type="double" description="Initial scaling of the cwt used in the separation of heavily overlapping peaks. The initial value is used for charge 1, for higher charges it is adapted to scaling/charge." required="false" advanced="true" restrictions="0:" />
           <NODE name="fitting" description="">
             <ITEM name="fwhm_threshold" value="0.7" type="double" description="If the FWHM of a peak is higher than &apos;fwhm_thresholds&apos; it is assumed that it consists of more than one peak and the deconvolution procedure is started." required="false" advanced="true" restrictions="0:" />
-            <ITEM name="eps_abs" value="9.99999974737875e-006" type="double" description="if the absolute error gets smaller than this value the fitting is stopped." required="false" advanced="true" restrictions="0:" />
-            <ITEM name="eps_rel" value="9.99999974737875e-006" type="double" description="if the relative error gets smaller than this value the fitting is stopped." required="false" advanced="true" restrictions="0:" />
+            <ITEM name="eps_abs" value="9.99999974737875e-06" type="double" description="if the absolute error gets smaller than this value the fitting is stopped." required="false" advanced="true" restrictions="0:" />
+            <ITEM name="eps_rel" value="9.99999974737875e-06" type="double" description="if the relative error gets smaller than this value the fitting is stopped." required="false" advanced="true" restrictions="0:" />
             <ITEM name="max_iteration" value="10" type="int" description="maximal number of iterations for the fitting step" required="false" advanced="true" restrictions="1:" />
             <NODE name="penalties" description="">
               <ITEM name="position" value="0" type="double" description="penalty term for the fitting of the peak position:If the position changes more than 0.5Da during the fitting it can be penalized as well as discrepancies of the peptide mass rule." required="false" advanced="true" restrictions="0:" />
@@ -71,7 +71,7 @@
           <ITEM name="bin_count" value="30" type="int" description="number of bins for intensity values" required="false" advanced="true" restrictions="3:" />
           <ITEM name="stdev_mp" value="3" type="double" description="multiplier for stdev" required="false" advanced="true" restrictions="0.01:999" />
           <ITEM name="min_required_elements" value="10" type="int" description="minimum number of elements required in a window (otherwise it is considered sparse)" required="false" advanced="true" restrictions="1:" />
-          <ITEM name="noise_for_empty_window" value="1e+020" type="double" description="noise value used for sparse windows" required="false" advanced="true" />
+          <ITEM name="noise_for_empty_window" value="1e+20" type="double" description="noise value used for sparse windows" required="false" advanced="true" />
         </NODE>
       </NODE>
     </NODE>


### PR DESCRIPTION
somehow the version is not displayed any more in TOPPView -> re-add this feature (this is useful when talking to collaborators about which versions they are working with).

Also, I feel that we should switch the naming convention right after a freeze to "x.y.alpha" for the new release where y = prev_release + 1. According to this we are now at `2.4.alpha` - I would also accept `pre-alpha`