### PR TITLE
[FIX] pyOpenMS fix for macOS

### DIFF
--- a/cmake/MacOSX/fix_dependencies.rb
+++ b/cmake/MacOSX/fix_dependencies.rb
@@ -352,7 +352,7 @@ for content in Dir.entries($lib_dir)
   if fixable(content, $lib_dir)
     if isFramework(content)
 #      handleFramework($lib_dir + content, $lib_dir)
-    else
+    elsif (content.end_with?(".dylib") or content.end_with?(".so"))
       handleDyLib($lib_dir + content, $lib_dir)
     end
   else


### PR DESCRIPTION
pyOpenMS currently doesn't build on my macOS system. Specifically, ``fix_dependencies.rb`` tries to patch ``__init__.py`` using ``handleDyLib()``. This fix ensures that only ``dylib`` or ``so`` files are being patched.