### PR TITLE
Fix/small fixes

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -249,49 +249,6 @@ public:
 
     /// Sets the integer meta data arrays
     void setIntegerDataArrays(const IntegerDataArrays& ida);
-
-    /// Returns a mutable reference to the first integer meta data array with the given name
-    inline IntegerDataArray& getIntegerDataArrayByName(String name)
-    {
-      return *std::find_if(integer_data_arrays_.begin(), integer_data_arrays_.end(), 
-        [&name](const IntegerDataArray& da) { return da.getName() == name; } );
-    }
-
-    /// Returns a mutable reference to the first string meta data array with the given name
-    inline StringDataArray& getStringDataArrayByName(String name)
-    {
-      return *std::find_if(string_data_arrays_.begin(), string_data_arrays_.end(), 
-        [&name](const StringDataArray& da) { return da.getName() == name; } );
-    }
-
-    /// Returns a mutable reference to the first float meta data array with the given name
-    inline FloatDataArray& getFloatDataArrayByName(String name)
-    {
-      return *std::find_if(float_data_arrays_.begin(), float_data_arrays_.end(), 
-        [&name](const FloatDataArray& da) { return da.getName() == name; } );
-    }
-
-    /// Returns a const reference to the first integer meta data array with the given name
-    inline const IntegerDataArray& getIntegerDataArrayByName(String name) const
-    {
-      return *std::find_if(integer_data_arrays_.begin(), integer_data_arrays_.end(), 
-        [&name](const IntegerDataArray& da) { return da.getName() == name; } );
-    }
-
-    /// Returns a const reference to the first string meta data array with the given name
-    inline const StringDataArray& getStringDataArrayByName(String name) const
-    {
-      return *std::find_if(string_data_arrays_.begin(), string_data_arrays_.end(), 
-        [&name](const StringDataArray& da) { return da.getName() == name; } );
-    }
-
-    /// Returns a const reference to the first float meta data array with the given name
-    inline const FloatDataArray& getFloatDataArrayByName(String name) const
-    {
-      return *std::find_if(float_data_arrays_.begin(), float_data_arrays_.end(), 
-        [&name](const FloatDataArray& da) { return da.getName() == name; } );
-    }
-
     //@}
 
     ///@name Sorting peaks

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -814,13 +814,9 @@ namespace OpenMS
         if (!swath_present)
         {
           mrmfeature->addScore("main_var_xx_lda_prelim_score", xx_lda_prescore);
-          mrmfeature->addScore("xx_lda_prelim_score", xx_lda_prescore);
-          mrmfeature->setOverallQuality(xx_lda_prescore);
         }
-        else
-        {
-          mrmfeature->addScore("xx_lda_prelim_score", xx_lda_prescore);
-        }
+        mrmfeature->setOverallQuality(xx_lda_prescore);
+        mrmfeature->addScore("xx_lda_prelim_score", xx_lda_prescore);
 
         // Add the DIA / SWATH scores
         if (swath_present && su_.use_dia_scores_)

--- a/src/pyOpenMS/pxds/MSSpectrum.pxd
+++ b/src/pyOpenMS/pxds/MSSpectrum.pxd
@@ -62,10 +62,6 @@ cdef extern from "<OpenMS/KERNEL/MSSpectrum.h>" namespace "OpenMS":
         libcpp_vector[IntegerDataArray] getIntegerDataArrays() nogil except +
         libcpp_vector[StringDataArray] getStringDataArrays() nogil except +
 
-        FloatDataArray getFloatDataArrayByName(String name) nogil except +
-        IntegerDataArray getIntegerDataArrayByName(String name) nogil except +
-        StringDataArray getStringDataArrayByName(String name) nogil except +
-
         void setFloatDataArrays(libcpp_vector[FloatDataArray] fda) nogil except +
         void setIntegerDataArrays(libcpp_vector[IntegerDataArray] ida) nogil except +
         void setStringDataArrays(libcpp_vector[StringDataArray] sda) nogil except +
@@ -80,3 +76,4 @@ cdef extern from "<OpenMS/KERNEL/MSSpectrum.h>" namespace "OpenMS":
         bool metaValueExists(unsigned int) nogil except +
         void removeMetaValue(String) nogil except +
         void removeMetaValue(unsigned int) nogil except +
+

--- a/src/tests/class_tests/openms/source/DIAHelper_test.cpp
+++ b/src/tests/class_tests/openms/source/DIAHelper_test.cpp
@@ -35,20 +35,20 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/DIAHelper.h>
 
 #ifdef USE_BOOST_UNIT_TEST
+
+// include boost unit test framework
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE MyTest
-
 #include <boost/test/unit_test.hpp>
-
-// make work with OpenMS
-#define START_TEST(val)
-#define END_TEST
-#define END_SECTION
-
+// macros for boost
 #define EPS_05 boost::test_tools::fraction_tolerance(1.e-5)
 #define TEST_REAL_SIMILAR(val1, val2) \
-  BOOST_CHECK ( boost::test_tools::check_is_close(val1, val2, boost::test_tools::fraction_tolerance(1.e-5) ));
-#include <iomanip>
+  BOOST_CHECK ( boost::test_tools::check_is_close(val1, val2, EPS_05 ));
+#define TEST_EQUAL(val1, val2) BOOST_CHECK_EQUAL(val1, val2);
+#define END_SECTION
+#define START_TEST(var1, var2)
+#define END_TEST
+
 #else
 #include <OpenMS/CONCEPT/ClassTest.h>
 #include <OpenMS/test_config.h>

--- a/src/tests/class_tests/openms/source/DefaultParamHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/DefaultParamHandler_test.cpp
@@ -54,7 +54,7 @@ class TestHandler
 {
   public:
   	
-		TestHandler(const String& name)
+		explicit TestHandler(const String& name)
 			: DefaultParamHandler(name)
 		{
 			defaults_.setValue("int",0,"intdesc");

--- a/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
+++ b/src/tests/class_tests/openms/source/MSSpectrum_test.cpp
@@ -1272,14 +1272,16 @@ START_SECTION(inline IntegerDataArray& getIntegerDataArrayByName(String name))
 
   ds.sortByPosition();
 
-  TEST_STRING_EQUAL(ds.getFloatDataArrayByName("f1").getName(),"f1")
-  TEST_STRING_EQUAL(ds.getFloatDataArrayByName("f2").getName(),"f2")
-  TEST_STRING_EQUAL(ds.getFloatDataArrayByName("f3").getName(),"f3")
+  // TEST_STRING_EQUAL(ds.getFloatDataArrayByName("f1").getName(),"f1")
+  // TEST_STRING_EQUAL(ds.getFloatDataArrayByName("f2").getName(),"f2")
+  // TEST_STRING_EQUAL(ds.getFloatDataArrayByName("f3").getName(),"f3")
 
-  TEST_STRING_EQUAL(ds.getStringDataArrayByName("s1").getName(),"s1")
-  TEST_STRING_EQUAL(ds.getStringDataArrayByName("s2").getName(),"s2")
+  // TEST_STRING_EQUAL(ds.getStringDataArrayByName("s1").getName(),"s1")
+  // TEST_STRING_EQUAL(ds.getStringDataArrayByName("s2").getName(),"s2")
+  // TEST_EQUAL(ds.getStringDataArrayByName("dummy") == ds.getStringDataArrays().end(), true)
+  // TEST_EQUAL(ds.getStringDataArrayByName("dummy"), ds.getStringDataArrays().end())
 
-  TEST_STRING_EQUAL(ds.getIntegerDataArrayByName("i1").getName(),"i1")
+  // TEST_STRING_EQUAL(ds.getIntegerDataArrayByName("i1").getName(),"i1")
 }
 END_SECTION
 


### PR DESCRIPTION
a series of small fixes that fixes some code and removes the problematic extra array access functions that can cause a segfault (introduced here #2855). We should better use the  https://github.com/OpenMS/OpenMS/blob/develop/src/openms/include/OpenMS/KERNEL/SpectrumHelper.h which returns an iterator and can be checked for `end()`