### PR TITLE
Feature/openms concurrency

### DIFF
--- a/cmake/multithreading.cmake
+++ b/cmake/multithreading.cmake
@@ -51,7 +51,7 @@ endif()
 
 if (TBB_FOUND)
   INCLUDE_DIRECTORIES(${TBB_INCLUDE_DIRS})
-  add_compile_options(/DOPENMS_HAS_TBB)
+  add_compile_options(-DOPENMS_HAS_TBB)
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/openms/cmake_findExternalLibs.cmake
+++ b/src/openms/cmake_findExternalLibs.cmake
@@ -57,7 +57,7 @@ find_package(XercesC REQUIRED)
 
 #------------------------------------------------------------------------------
 # BOOST
-find_boost(iostreams date_time math_c99 regex)
+find_boost(iostreams date_time math_c99 regex system thread)
 
 if(Boost_FOUND)
   message(STATUS "Found Boost version ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}" )

--- a/src/openms/cmake_findExternalLibs.cmake
+++ b/src/openms/cmake_findExternalLibs.cmake
@@ -57,7 +57,7 @@ find_package(XercesC REQUIRED)
 
 #------------------------------------------------------------------------------
 # BOOST
-find_boost(iostreams date_time math_c99 regex system thread)
+find_boost(iostreams date_time math_c99 regex thread)
 
 if(Boost_FOUND)
   message(STATUS "Found Boost version ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}" )

--- a/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeRNA.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeRNA.h
@@ -47,6 +47,8 @@ namespace OpenMS
   class OPENMS_DLLAPI DigestionEnzymeRNA: public DigestionEnzyme
   {
   public:
+    using DigestionEnzyme::DigestionEnzyme;
+
     /// sets the 3' gain (as a nucleotide modification code)
     void setThreePrimeGain(const String& value);
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -74,15 +74,7 @@ public:
     */
     //@{
     /// returns a pointer to the singleton instance of the element db
-    inline static const ElementDB * getInstance()
-    {
-      static ElementDB * db_ = nullptr;
-      if (db_ == nullptr)
-      {
-        db_ = new ElementDB;
-      }
-      return db_;
-    }
+    static const ElementDB * getInstance();
 
     /// returns a hashmap that contains names mapped to pointers to the elements
     const Map<String, const Element *> & getNames() const;

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -134,6 +134,15 @@ public:
     void addModification(ResidueModification * new_mod);
 
     /**
+       @brief Add a new modification to ModificationsDB.
+
+       Threadsafe alternative to addModification, will not throw if a
+       modification already exists but guarantees that getModification() will
+       be successful using the same fullID.
+    */
+    void ensureModificationIsAdded(ResidueModification * new_mod);
+
+    /**
        @brief Returns the index of the modification in the mods_ vector; a unique name must be given
 
        @throw Exception::ElementNotFound if not exactly one matching modification was found
@@ -244,5 +253,8 @@ private:
     /// Adds modifications from a given file in Unimod XML format
     void readFromUnimodXMLFile(const String& filename);
     
+    /// Adds modifications
+    void addModification_(ResidueModification * new_mod);
+
   };
 }

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
@@ -64,6 +64,9 @@ public:
     /** @name Typedefs
     */
     //@{
+
+    typedef std::set<Residue*> ResidueSetT;
+    typedef std::set<const Residue*> ResidueConstSetT;
     typedef std::set<Residue*>::iterator ResidueIterator;
     typedef std::set<const Residue*>::const_iterator ResidueConstIterator;
     //@}
@@ -135,10 +138,10 @@ public:
 
        @throw Exception::ElementNotFound if the specified residue set is not defined
     */
-    const std::set<const Residue*> getResidues(const String& residue_set = "All") const;
+    const ResidueConstSetT getResidues(const String& residue_set = "All") const;
 
     /// returns all residue sets that are registered which this instance
-    const std::set<String>& getResidueSets() const;
+    const std::set<std::string>& getResidueSets() const;
 
     /// sets the residues from given file
     void setResidues(const String& filename);
@@ -226,6 +229,6 @@ protected:
 
     Map<String, std::set<const Residue*> > residues_by_set_;
 
-    std::set<String> residue_sets_;
+    std::set<std::string> residue_sets_;
   };
 }

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
@@ -64,17 +64,10 @@ public:
     /** @name Typedefs
     */
     //@{
-#if OPENMS_HAS_TBB
-    typedef tbb::concurrent_unordered_set<Residue*> ResidueSetT;
-    typedef tbb::concurrent_unordered_set<const Residue*> ResidueConstSetT;
-    typedef tbb::concurrent_unordered_set<Residue*>::iterator ResidueIterator;
-    typedef tbb::concurrent_unordered_set<const Residue*>::const_iterator ResidueConstIterator;
-#else
-    typedef std::set<Residue*> ResidueSetT;
+    typedef std::set<std::string> ResidueSetT;
     typedef std::set<const Residue*> ResidueConstSetT;
     typedef std::set<Residue*>::iterator ResidueIterator;
     typedef std::set<const Residue*>::const_iterator ResidueConstIterator;
-#endif
 
     //@}
 
@@ -140,7 +133,7 @@ public:
     const ResidueConstSetT getResidues(const String& residue_set = "All") const;
 
     /// returns all residue sets that are registered which this instance
-    const std::set<std::string>& getResidueSets() const;
+    const ResidueSetT& getResidueSets() const;
 
     /// sets the residues from given file
     void setResidues(const String& filename);

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
@@ -64,23 +64,22 @@ public:
     /** @name Typedefs
     */
     //@{
-
+#if OPENMS_HAS_TBB
+    typedef tbb::concurrent_unordered_set<Residue*> ResidueSetT;
+    typedef tbb::concurrent_unordered_set<const Residue*> ResidueConstSetT;
+    typedef tbb::concurrent_unordered_set<Residue*>::iterator ResidueIterator;
+    typedef tbb::concurrent_unordered_set<const Residue*>::const_iterator ResidueConstIterator;
+#else
     typedef std::set<Residue*> ResidueSetT;
     typedef std::set<const Residue*> ResidueConstSetT;
     typedef std::set<Residue*>::iterator ResidueIterator;
     typedef std::set<const Residue*>::const_iterator ResidueConstIterator;
+#endif
+
     //@}
 
     /// this member function serves as a replacement of the constructor
-    inline static ResidueDB* getInstance()
-    {
-      static ResidueDB* db_ = nullptr;
-      if (db_ == nullptr)
-      {
-        db_ = new ResidueDB;
-      }
-      return db_;
-    }
+    static ResidueDB* getInstance();
 
     /** @name Constructors and Destructors
     */

--- a/src/openms/include/OpenMS/CONCEPT/Factory.h
+++ b/src/openms/include/OpenMS/CONCEPT/Factory.h
@@ -58,7 +58,6 @@ namespace OpenMS
 
     @ingroup Concept
   */
-  STATIC_LOCK(mutex_factory) 
   template <typename FactoryProduct>
   class Factory :
     public FactoryBase
@@ -120,7 +119,10 @@ public:
     static FactoryProduct * create(const String & name)
     {
       // unique lock (make sure we only create one instance)
-      //  -> this is the safer place to put the lock (not in instance_())
+      //  -> Since we may call Factory<FactoryProduct>::create for another
+      //     FactoryProduct during initialization, we have to implement locking
+      //     per template class specialization.
+      STATIC_LOCK(mutex_factory)
       OPENMS_UNIQUELOCK(mutex_factory, lock)
 
       MapIterator it = instance_()->inventory_.find(name);

--- a/src/openms/include/OpenMS/CONCEPT/FactoryBase.h
+++ b/src/openms/include/OpenMS/CONCEPT/FactoryBase.h
@@ -41,9 +41,9 @@ namespace OpenMS
   /**
     @brief Base class for Factory<T>
 
-        Just be able to use dynamic_cast on a pointer
+    Just be able to use dynamic_cast on a pointer
 
-        @ingroup Concept
+    @ingroup Concept
     */
   class OPENMS_DLLAPI FactoryBase
   {

--- a/src/openms/include/OpenMS/CONCEPT/MultiThreading.h
+++ b/src/openms/include/OpenMS/CONCEPT/MultiThreading.h
@@ -47,7 +47,7 @@
 
     @code
 
-    STATIC_LOCK(SomeSingleton_mutex) 
+    STATIC_LOCK(SomeSingleton_mutex)
     class SomeSingleton
     {
       int readData()
@@ -80,6 +80,12 @@
     @note The scope of the lock is controlled by RAII, therefore the lock is
     released as soon as it is out of scope.
 
+    @note The actual implementation will only provide shared locks if compiled
+    with boost thread library, these can be replaced with STL mutexes or OpenMP
+    critical sections which only a allow a single thread per block but are much
+    more efficient in locking and have less overhead per acquired lock (see
+    parameters below).
+
     The current implementation uses boost, this can be replaced with C++17
     mutexes at some point.
 
@@ -91,7 +97,6 @@
 
 #ifdef _OPENMP
 #define OPENMS_MULTITHREADING_ON
-#include <boost/thread.hpp>
 #include <mutex>
 #include <omp.h>
 #endif
@@ -101,8 +106,8 @@
 ///   replace all mutexes with OpenMP critical sections:
 // #define USE_OPENMP_CRITICAL
 
-/// Parameter: std::mutex vs boost::shared_mutex 
-///   use std::mutex instead of boostd::shared_mutex (which allows more fine grained locking) 
+/// Parameter: std::mutex vs boost::shared_mutex
+///   use std::mutex instead of boostd::shared_mutex (which allows more fine grained locking)
 ///   note: if USE_OPENMP_CRITICAL is defined, neither will be selected
 // #define USE_STD_MUTEX
 
@@ -127,6 +132,8 @@
   std::lock_guard<std::mutex> lockname(name);
 
 #else // USE_STD_MUTEX
+
+#include <boost/thread.hpp>
 
 /**
     @brief Initialize a lock (static).
@@ -161,7 +168,7 @@
 
 #else // USE_OPENMP_CRITICAL
 
-#define STATIC_LOCK(name) 
+#define STATIC_LOCK(name)
 
 #define OPENMS_UNIQUELOCK(name, lockname) \
   OPENMS_THREAD_CRITICAL(name)
@@ -187,15 +194,15 @@
 
 // NOP for a single threaded environment
 
-#define STATIC_LOCK(name) 
+#define STATIC_LOCK(name)
 
-#define OPENMS_UNIQUELOCK(name) 
+#define OPENMS_UNIQUELOCK(name, lockname)
 
-#define OPENMS_UPGRADEABLE_UNIQUELOCK(name, lockname) 
+#define OPENMS_UPGRADEABLE_UNIQUELOCK(name, lockname)
 
-#define OPENMS_UPGRADE_UNIQUELOCK(name, lockname) 
+#define OPENMS_UPGRADE_UNIQUELOCK(name, lockname)
 
-#define OPENMS_NONUNIQUELOCK(name) 
+#define OPENMS_NONUNIQUELOCK(name, lockname)
 
 #define OPENMS_THREAD_CRITICAL(name)
 

--- a/src/openms/include/OpenMS/CONCEPT/MultiThreading.h
+++ b/src/openms/include/OpenMS/CONCEPT/MultiThreading.h
@@ -1,0 +1,143 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2017.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Hannes Roest $
+// $Authors: Hannes Roest $
+// --------------------------------------------------------------------------
+
+#pragma once
+
+#include <OpenMS/config.h>
+
+/**
+    @defgroup Multithreading Multithreading macros
+
+    @brief Macros used for locking in multithreading environment
+
+    These provide a simple interface to acquire locks of different kinds.
+    Specifically of interest are read-write locks which allow multiple readers
+    but only one writer. A sample implementation will look like this:
+
+
+    @code
+
+    STATIC_LOCK(SomeSingleton_mutex) 
+    class SomeSingleton
+    {
+      int readData()
+      {
+        OPENMS_NONUNIQUELOCK(SomeSingleton_mutex, lock)
+        // do some work that only reads data
+      }
+      int writeData()
+      {
+        OPENMS_UNIQUELOCK(SomeSingleton_mutex, lock)
+        // do some work that requires unique access
+      }
+      int writeDataConditional()
+      {
+        OPENMS_UPGRADEABLE_UNIQUELOCK(SomeSingleton_mutex, lock)
+        // do some work that only reads data
+        OPENMS_UPGRADE_UNIQUELOCK(lock, uniqueLock)
+        // do some work that requires unique access
+      }
+    }
+    @endcode
+
+    This will allow multiple threads to read simultaneously while only a single
+    thread can write at one time. More importantly, while a single thread is
+    writing, all other threads are blocked from reading (and the writing thread
+    has to wait for all readers to finish before it can start writing). The
+    example above thus implements the "single writer - multiple reader"
+    paradigm for a singleton resource.
+
+    @note The scope of the lock is controlled by RAII, therefore the lock is
+    released as soon as it is out of scope.
+
+    The current implementation uses boost, this can be replaced with C++17
+    mutexes at some point.
+
+    @ingroup Concept
+
+    @{
+*/
+
+
+#ifdef _OPENMP
+#define OPENMS_MULTITHREADING_ON
+#include <boost/thread.hpp>
+#endif
+
+
+#ifdef OPENMS_MULTITHREADING_ON
+
+/**
+    @brief Initialize a lock (static).
+*/
+#define STATIC_LOCK(name) \
+  static boost::shared_mutex name;
+
+/**
+    @brief Acquire a unique lock.
+*/
+#define OPENMS_UNIQUELOCK(name, lockname) \
+    boost::unique_lock<boost::shared_mutex> lockname{name};
+
+/**
+    @brief Acquire a shared lock that can be upgraded to a unique lock.
+*/
+#define OPENMS_UPGRADEABLE_UNIQUELOCK(name, lockname) \
+    boost::upgrade_lock<boost::shared_mutex> lockname{name};
+
+/**
+    @brief Upgrade a shared lock to a unique lock.
+*/
+#define OPENMS_UPGRADE_UNIQUELOCK(name, lockname) \
+    boost::upgrade_to_unique_lock<boost::shared_mutex> lockname(name);
+
+/**
+    @brief Acquire a shared lock.
+*/
+#define OPENMS_NONUNIQUELOCK(name, lockname) \
+    boost::shared_lock<boost::shared_mutex> lockname{name};
+
+#else
+
+// NOP for a single threaded environment
+#define STATIC_LOCK(name) 
+#define OPENMS_UNIQUELOCK(name) 
+#define OPENMS_UPGRADEABLE_UNIQUELOCK(name, lockname) 
+#define OPENMS_UPGRADE_UNIQUELOCK(name, lockname) 
+#define OPENMS_NONUNIQUELOCK(name) 
+
+#endif
+
+/** @} */ // end of Multithreading
+

--- a/src/openms/include/OpenMS/CONCEPT/MultiThreading.h
+++ b/src/openms/include/OpenMS/CONCEPT/MultiThreading.h
@@ -128,14 +128,26 @@
 #define OPENMS_NONUNIQUELOCK(name, lockname) \
     boost::shared_lock<boost::shared_mutex> lockname{name};
 
+#define STRINGIFY(a) #a
+
+#define OPENMS_THREAD_CRITICAL(name) \
+  _Pragma( STRINGIFY( omp critical (name) ) )
+
 #else
 
 // NOP for a single threaded environment
+
 #define STATIC_LOCK(name) 
+
 #define OPENMS_UNIQUELOCK(name) 
+
 #define OPENMS_UPGRADEABLE_UNIQUELOCK(name, lockname) 
+
 #define OPENMS_UPGRADE_UNIQUELOCK(name, lockname) 
+
 #define OPENMS_NONUNIQUELOCK(name) 
+
+#define OPENMS_THREAD_CRITICAL(name)
 
 #endif
 

--- a/src/openms/include/OpenMS/CONCEPT/sources.cmake
+++ b/src/openms/include/OpenMS/CONCEPT/sources.cmake
@@ -14,6 +14,7 @@ Helpers.h
 LogConfigHandler.h
 LogStream.h
 Macros.h
+MultiThreading.h
 PrecisionWrapper.h
 ProgressLogger.h
 SingletonRegistry.h

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Map.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Map.h
@@ -96,6 +96,7 @@ public:
     using Base::find;
     using Base::empty;
     using Base::count;
+    using Base::at;
 
     using typename Base::iterator;
     using typename Base::const_iterator;

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/ProductModel.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/ProductModel.h
@@ -51,8 +51,8 @@ namespace OpenMS
 
       @htmlinclude OpenMS_ProductModel.parameters
 
-  @todo This class provides new member functions, which makes
-  Factory<BaseModel<2> >::create("ProductModel2D") pretty much useless!  (Clemens)
+      @todo This class provides new member functions, which makes
+      Factory<BaseModel<2> >::create("ProductModel2D") pretty much useless!  (Clemens)
 
       @ingroup FeatureFinder
   */

--- a/src/openms/source/ANALYSIS/DENOVO/CompNovoIdentificationBase.cpp
+++ b/src/openms/source/ANALYSIS/DENOVO/CompNovoIdentificationBase.cpp
@@ -638,8 +638,8 @@ for (set<Size>::const_iterator it = used_pos.begin(); it != used_pos.end(); ++it
     // init residue mass table
     String residue_set(param_.getValue("residue_set"));
 
-    set<const Residue *> residues = ResidueDB::getInstance()->getResidues(residue_set);
-    for (set<const Residue *>::const_iterator it = residues.begin(); it != residues.end(); ++it)
+    auto residues = ResidueDB::getInstance()->getResidues(residue_set);
+    for (auto it = residues.begin(); it != residues.end(); ++it)
     {
       aa_to_weight_[(*it)->getOneLetterCode()[0]] = (*it)->getMonoWeight(Residue::Internal);
     }

--- a/src/openms/source/ANALYSIS/ID/HiddenMarkovModel.cpp
+++ b/src/openms/source/ANALYSIS/ID/HiddenMarkovModel.cpp
@@ -869,8 +869,8 @@ namespace OpenMS
 #endif
 
 
-    set<const Residue *> residues(ResidueDB::getInstance()->getResidues("Natural20"));
-    for (StringList::const_iterator it = var_modifications_.begin(); it != var_modifications_.end(); ++it)
+    auto residues(ResidueDB::getInstance()->getResidues("Natural20"));
+    for (auto it = var_modifications_.begin(); it != var_modifications_.end(); ++it)
     {
       residues.insert(ResidueDB::getInstance()->getModifiedResidue(*it));
     }
@@ -882,10 +882,10 @@ namespace OpenMS
     for (StringList::const_iterator pathway_it = pathways.begin(); pathway_it != pathways.end(); ++pathway_it)
     {
       String pathway = *pathway_it;
-      for (set<const Residue *>::const_iterator it = residues.begin(); it != residues.end(); ++it)
+      for (auto it = residues.begin(); it != residues.end(); ++it)
       {
         s2 = name_to_state_[pathway];
-        for (set<const Residue *>::const_iterator jt = residues.begin(); jt != residues.end(); ++jt)
+        for (auto jt = residues.begin(); jt != residues.end(); ++jt)
         {
           AASequence first_aa, second_aa;
           first_aa += *it;
@@ -900,7 +900,7 @@ namespace OpenMS
             Size count(0);
             double sum(0);
             // "rows" of the amino acid matrix
-            for (set<const Residue *>::const_iterator kt = residues.begin(); kt != residues.end(); ++kt)
+            for (auto kt = residues.begin(); kt != residues.end(); ++kt)
             {
               AASequence third_aa;
               third_aa += *kt;
@@ -912,7 +912,7 @@ namespace OpenMS
               }
             }
             // "columns" of the amino acid matrix
-            for (set<const Residue *>::const_iterator kt = residues.begin(); kt != residues.end(); ++kt)
+            for (auto kt = residues.begin(); kt != residues.end(); ++kt)
             {
               AASequence third_aa;
               third_aa += *kt;
@@ -954,7 +954,7 @@ namespace OpenMS
     {
       String sc_res = *it;
 
-      for (set<const Residue *>::const_iterator jt = residues.begin(); jt != residues.end(); ++jt)
+      for (auto jt = residues.begin(); jt != residues.end(); ++jt)
       {
         AASequence second_aa;
         second_aa += *jt;
@@ -965,7 +965,7 @@ namespace OpenMS
         {
           Size count(0);
           double sum(0);
-          for (set<const Residue *>::const_iterator kt = residues.begin(); kt != residues.end(); ++kt)
+          for (auto kt = residues.begin(); kt != residues.end(); ++kt)
           {
             AASequence third_aa;
             third_aa += *kt;
@@ -994,7 +994,7 @@ namespace OpenMS
     {
       String pathway = *pathway_it;
       s2 = name_to_state_[pathway];
-      for (set<const Residue *>::const_iterator it = residues.begin(); it != residues.end(); ++it)
+      for (auto it = residues.begin(); it != residues.end(); ++it)
       {
         AASequence first_aa;
         first_aa += *it;
@@ -1003,7 +1003,7 @@ namespace OpenMS
         {
           Size count(0);
           double sum(0);
-          for (set<const Residue *>::const_iterator jt = residues.begin(); jt != residues.end(); ++jt)
+          for (auto jt = residues.begin(); jt != residues.end(); ++jt)
           {
             AASequence second_aa;
             second_aa += *jt;

--- a/src/openms/source/CHEMISTRY/CrossLinksDB.cpp
+++ b/src/openms/source/CHEMISTRY/CrossLinksDB.cpp
@@ -54,7 +54,7 @@ namespace OpenMS
   CrossLinksDB::~CrossLinksDB()
   {
     modification_names_.clear();
-    for (vector<ResidueModification*>::iterator it = mods_.begin(); it != mods_.end(); ++it)
+    for (auto it = mods_.begin(); it != mods_.end(); ++it)
     {
       delete *it;
     }
@@ -320,8 +320,8 @@ namespace OpenMS
       if (it->second.getUniModRecordId() > 0)
       {
         //cerr << "Found UniMod PSI-MOD mapping: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
-        set<const ResidueModification*> mods = modification_names_[it->second.getUniModAccession()];
-        for (set<const ResidueModification*>::const_iterator mit = mods.begin(); mit != mods.end(); ++mit)
+        auto mods = modification_names_[String(it->second.getUniModAccession())];
+        for (auto mit = mods.begin(); mit != mods.end(); ++mit)
         {
           //cerr << "Adding PSIMOD accession: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
           modification_names_[it->second.getPSIMODAccession()].insert(*mit);
@@ -349,7 +349,7 @@ namespace OpenMS
           synonyms.insert(mods_.back()->getFullId());
 
           // now check each of the names and link it to the residue modification
-          for (set<String>::const_iterator nit = synonyms.begin(); nit != synonyms.end(); ++nit)
+          for (auto nit = synonyms.begin(); nit != synonyms.end(); ++nit)
           {
             modification_names_[*nit].insert(mods_.back());
           }
@@ -362,7 +362,7 @@ namespace OpenMS
   {
     modifications.clear();
 
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin(); it != mods_.end(); ++it)
+    for (auto it = mods_.begin(); it != mods_.end(); ++it)
     {
       if ((*it)->getPSIMODAccession() != "")
       {

--- a/src/openms/source/CHEMISTRY/DigestionEnzymeDB.cpp
+++ b/src/openms/source/CHEMISTRY/DigestionEnzymeDB.cpp
@@ -28,7 +28,7 @@
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // --------------------------------------------------------------------------
-// $Maintainer: Xiao Liang  $
+// $Maintainer: Xiao Liang $
 // $Authors: Xiao Liang, Chris Bielow $
 // --------------------------------------------------------------------------
 //

--- a/src/openms/source/CHEMISTRY/MASSDECOMPOSITION/MassDecompositionAlgorithm.cpp
+++ b/src/openms/source/CHEMISTRY/MASSDECOMPOSITION/MassDecompositionAlgorithm.cpp
@@ -58,9 +58,9 @@ namespace OpenMS
     defaults_.setValue("variable_modifications", ListUtils::create<String>(""), "variable modifications, specified using UniMod (www.unimod.org) terms, e.g. 'Carbamidomethyl (C)' or 'Oxidation (M)'");
     defaults_.setValidStrings("variable_modifications", all_mods);
     defaults_.setValue("residue_set", "Natural19WithoutI", "The predefined amino acid set that should be used, see doc of ResidueDB for possible residue sets", ListUtils::create<String>("advanced"));
-    set<String> residue_sets = ResidueDB::getInstance()->getResidueSets();
+    auto residue_sets = ResidueDB::getInstance()->getResidueSets();
     vector<String> valid_strings;
-    for (set<String>::const_iterator it = residue_sets.begin(); it != residue_sets.end(); ++it)
+    for (auto it = residue_sets.begin(); it != residue_sets.end(); ++it)
     {
       valid_strings.push_back(*it);
     }
@@ -103,9 +103,9 @@ namespace OpenMS
 
     Map<char, double> aa_to_weight;
 
-    set<const Residue *> residues = ResidueDB::getInstance()->getResidues((String)param_.getValue("residue_set"));
+    auto residues = ResidueDB::getInstance()->getResidues((String)param_.getValue("residue_set"));
 
-    for (set<const Residue *>::const_iterator it = residues.begin(); it != residues.end(); ++it)
+    for (auto it = residues.begin(); it != residues.end(); ++it)
     {
       aa_to_weight[(*it)->getOneLetterCode()[0]] = (*it)->getMonoWeight(Residue::Internal);
     }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -75,7 +75,7 @@ namespace OpenMS
 
   bool ModificationsDB::isInstantiated()
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
     return is_instantiated_;
   }
 
@@ -90,13 +90,13 @@ namespace OpenMS
 
   Size ModificationsDB::getNumberOfModifications() const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
     return mods_.size();
   }
 
   const ResidueModification& ModificationsDB::getModification(Size index) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
 
     if (index >= mods_.size())
     {
@@ -108,7 +108,7 @@ namespace OpenMS
 
   void ModificationsDB::searchModifications(set<const ResidueModification*>& mods, const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
 
     mods.clear();
 
@@ -133,7 +133,7 @@ namespace OpenMS
 
   const ResidueModification& ModificationsDB::getModification(const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
 
     set<const ResidueModification*> mods;
     // if residue is specified, try residue-specific search first to avoid
@@ -169,7 +169,7 @@ namespace OpenMS
 
   bool ModificationsDB::has(String modification) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
     OPENMS_PRECONDITION( modification_names_.find(modification) == modification_names_.end() || (int)findModificationIndex(modification) >= 0,
         "The modification being present implies that it can be found."); // NOTE: some very smart compilers may remove this statement ...
     return modification_names_.find(modification) != modification_names_.end();
@@ -177,7 +177,7 @@ namespace OpenMS
 
   Size ModificationsDB::findModificationIndex(const String & mod_name) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
 
     if (modification_names_.find(mod_name) == modification_names_.end())
     {
@@ -206,7 +206,7 @@ namespace OpenMS
 
   void ModificationsDB::searchModificationsByDiffMonoMass(vector<String>& mods, double mass, double max_error, const String& residue, ResidueModification::TermSpecificity term_spec)
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
 
     mods.clear();
     for (auto it = mods_.begin(); it != mods_.end(); ++it)
@@ -225,7 +225,7 @@ namespace OpenMS
   const ResidueModification* ModificationsDB::getBestModificationByMonoMass(double mass, double max_error, const String& residue,
                                                                             ResidueModification::TermSpecificity term_spec)
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
 
     double min_error = max_error;
     const ResidueModification* mod = nullptr;
@@ -264,7 +264,7 @@ namespace OpenMS
 
   const ResidueModification* ModificationsDB::getBestModificationByDiffMonoMass(double mass, double max_error, const String& residue, ResidueModification::TermSpecificity term_spec)
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
 
     double min_error = max_error;
     const ResidueModification* mod = nullptr;
@@ -288,7 +288,7 @@ namespace OpenMS
 
   void ModificationsDB::readFromUnimodXMLFile(const String& filename)
   {
-    OPENMS_UNIQUELOCK(mutex, lock)
+    OPENMS_UNIQUELOCK(mutex_mdb, lock)
 
     vector<ResidueModification*> new_mods;
     UnimodXMLFile().load(filename, new_mods);
@@ -313,7 +313,7 @@ namespace OpenMS
   void ModificationsDB::addModification(ResidueModification* new_mod)
   {
     // get upgradeable access (prevent deadlock with has() call)
-    OPENMS_UPGRADEABLE_UNIQUELOCK(mutex, lock) 
+    OPENMS_UPGRADEABLE_UNIQUELOCK(mutex_mdb, lock) 
 
     if (has(new_mod->getFullId()))
     {
@@ -334,7 +334,7 @@ namespace OpenMS
 
   void ModificationsDB::readFromOBOFile(const String& filename)
   {
-    OPENMS_UNIQUELOCK(mutex, lock)
+    OPENMS_UNIQUELOCK(mutex_mdb, lock)
     
     ResidueModification mod;
     // add multiple mods for multiple specificities
@@ -636,7 +636,7 @@ namespace OpenMS
 
   void ModificationsDB::getAllSearchModifications(vector<String>& modifications) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_mdb, lock)
 
     modifications.clear();
 

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -86,7 +86,6 @@ namespace OpenMS
     }
   }
 
-
   Size ModificationsDB::getNumberOfModifications() const
   {
     return mods_.size();
@@ -98,7 +97,7 @@ namespace OpenMS
     {
       throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, index, mods_.size());
     }
-    return *mods_.at(index);
+    return mods_.at(index);
   }
 
 

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -159,30 +159,30 @@ namespace OpenMS
     return **mods.begin();
   }
 
-
   bool ModificationsDB::has(String modification) const
   {
-    OPENMS_PRECONDITION(!modification_names_.has(modification) || (int)findModificationIndex(modification) >= 0,
+    OPENMS_PRECONDITION( modification_names_.find(modification) == modification_names_.end() || (int)findModificationIndex(modification) >= 0,
         "The modification being present implies that it can be found."); // NOTE: some very smart compilers may remove this statement ...
-    return modification_names_.has(modification);
+    return modification_names_.find(modification) != modification_names_.end();
   }
 
   Size ModificationsDB::findModificationIndex(const String & mod_name) const
   {
-    if (!modification_names_.has(mod_name))
+    if (modification_names_.find(mod_name) == modification_names_.end())
     {
       throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, mod_name);
     }
 
-    if (modification_names_[mod_name].size() > 1)
+    if (modification_names_.at(mod_name).size() > 1)
     {
-      throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "more than one element of name '" + mod_name + "' found!");
+      throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+                                       "More than one element of name '" + mod_name + "' found!");
     }
 
-    const ResidueModification* mod = *modification_names_[mod_name].begin();
+    auto mod = *modification_names_.at(mod_name).begin();
     for (Size i = 0; i != mods_.size(); ++i)
     {
-      if (mods_[i] == mod)
+      if (mods_.at(i) == mod)
       {
         return i;
       }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -275,7 +275,7 @@ namespace OpenMS
     vector<ResidueModification*> new_mods;
     UnimodXMLFile().load(filename, new_mods);
 
-    for (vector<ResidueModification*>::iterator it = new_mods.begin(); it != new_mods.end(); ++it)
+    for (auto it = new_mods.begin(); it != new_mods.end(); ++it)
     {
       // create full ID based on other information:
       (*it)->setFullId();
@@ -296,7 +296,9 @@ namespace OpenMS
   {
     if (has(new_mod->getFullId()))
     {
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Modification already exists in ModificationsDB.", String(new_mod->getFullId()));
+      throw Exception::InvalidValue(__FILE__, __LINE__,
+                                    OPENMS_PRETTY_FUNCTION,
+                                    "Modification already exists in ModificationsDB.", String(new_mod->getFullId()));
     }
     modification_names_[new_mod->getFullId()].insert(new_mod);
     modification_names_[new_mod->getId()].insert(new_mod);
@@ -568,8 +570,8 @@ namespace OpenMS
       if (it->second.getUniModRecordId() > 0)
       {
         //cerr << "Found UniMod PSI-MOD mapping: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
-        set<const ResidueModification*> mods = modification_names_[it->second.getUniModAccession()];
-        for (set<const ResidueModification*>::const_iterator mit = mods.begin(); mit != mods.end(); ++mit)
+        auto mods = modification_names_[it->second.getUniModAccession()];
+        for (auto mit = mods.begin(); mit != mods.end(); ++mit)
         {
           //cerr << "Adding PSIMOD accession: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
           modification_names_[it->second.getPSIMODAccession()].insert(*mit);
@@ -610,7 +612,7 @@ namespace OpenMS
   {
     modifications.clear();
 
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin(); it != mods_.end(); ++it)
+    for (auto it = mods_.begin(); it != mods_.end(); ++it)
     {
       if ((*it)->getUniModRecordId() > 0)
       {

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -314,9 +314,20 @@ namespace OpenMS
     }
   }
 
+
+  void ModificationsDB::ensureModificationIsAdded(ResidueModification* new_mod)
+  {
+    OPENMS_THREAD_CRITICAL(ModificationsDB)
+    {
+    if (!has(new_mod->getFullId()))
+    {
+      addModification_(new_mod);
+    }
+    }
+  }
   void ModificationsDB::addModification(ResidueModification* new_mod)
   {
-#pragma omp critical (MetaInfoRegistry)
+    OPENMS_THREAD_CRITICAL(ModificationsDB)
     {
     if (has(new_mod->getFullId()))
     {
@@ -324,14 +335,18 @@ namespace OpenMS
                                     OPENMS_PRETTY_FUNCTION,
                                     "Modification already exists in ModificationsDB.", String(new_mod->getFullId()));
     }
+    addModification_(new_mod);
+    }
+  }
 
+  void ModificationsDB::addModification_(ResidueModification* new_mod)
+  {
     modification_names_[new_mod->getFullId()].insert(new_mod);
     modification_names_[new_mod->getId()].insert(new_mod);
     modification_names_[new_mod->getFullName()].insert(new_mod);
     modification_names_[new_mod->getUniModAccession()].insert(new_mod);
 
     mods_.push_back(new_mod); // we probably want that
-    }
   }
 
   void ModificationsDB::readFromOBOFile(const String& filename)

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -106,15 +106,14 @@ namespace OpenMS
   {
     mods.clear();
 
-    if (!modification_names_.has(mod_name))
+    if (modification_names_.find(mod_name) == modification_names_.end())
     {
       throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                        mod_name);
     }
 
-    const set<const ResidueModification*>& temp = modification_names_[mod_name];
-    for (set<const ResidueModification*>::const_iterator it = temp.begin();
-         it != temp.end(); ++it)
+    auto temp = modification_names_.at(std::string(mod_name));
+    for (auto it = temp.begin(); it != temp.end(); ++it)
     {
       if (residuesMatch_(residue, (*it)->getOrigin()) &&
           (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY ||
@@ -141,11 +140,15 @@ namespace OpenMS
 
     if (mods.empty())
     {
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Retrieving the modification failed. It is not available for the residue '" + String(residue) + "' and term specificity " + String(Int(term_spec)) + ".", mod_name);
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
+          "Retrieving the modification failed. It is not available for the residue '" +
+          String(residue) + "' and term specificity " + String(Int(term_spec)) + ".", mod_name);
     }
     if (mods.size() > 1)
     {
-      LOG_WARN << "Warning (ModificationsDB::getModification): more than one modification with name '" + mod_name + "', residue '" + residue + "', specificity '" + String(Int(term_spec)) << "' found, picking the first one of:";
+      LOG_WARN << "Warning (ModificationsDB::getModification): more than one modification with name '" +
+        mod_name + "', residue '" + residue + "', specificity '" + String(Int(term_spec)) <<
+        "' found, picking the first one of:";
       for (set<const ResidueModification*>::const_iterator it = mods.begin();
            it != mods.end(); ++it)
       {

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -196,8 +196,8 @@ namespace OpenMS
   void ModificationsDB::searchModificationsByDiffMonoMass(vector<String>& mods, double mass, double max_error, const String& residue, ResidueModification::TermSpecificity term_spec)
   {
     mods.clear();
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin();
-         it != mods_.end(); ++it)
+
+    for (auto it = mods_.begin(); it != mods_.end(); ++it)
     {
       if ((fabs((*it)->getDiffMonoMass() - mass) <= max_error) &&
           residuesMatch_(residue, (*it)->getOrigin()) &&
@@ -216,8 +216,8 @@ namespace OpenMS
     double min_error = max_error;
     const ResidueModification* mod = nullptr;
     const Residue* residue_ = ResidueDB::getInstance()->getResidue(residue); // is NULL if not found
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin();
-         it != mods_.end(); ++it)
+
+    for (auto it = mods_.begin(); it != mods_.end(); ++it)
     {
       double mono_mass = (*it)->getMonoMass();
       if ((mono_mass <= 0) && !residue.empty())
@@ -252,8 +252,7 @@ namespace OpenMS
   {
     double min_error = max_error;
     const ResidueModification* mod = nullptr;
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin();
-         it != mods_.end(); ++it)
+    for (auto it = mods_.begin(); it != mods_.end(); ++it)
     {
       // using less instead of less-or-equal will pick the first matching
       // modification of equally heavy modifications (in our case this is the

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -98,7 +98,7 @@ namespace OpenMS
     {
       throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, index, mods_.size());
     }
-    return *mods_[index];
+    return *mods_.at(index);
   }
 
 

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -77,11 +77,10 @@ namespace OpenMS
     return is_instantiated_;
   }
 
-
   ModificationsDB::~ModificationsDB()
   {
     modification_names_.clear();
-    for (vector<ResidueModification*>::iterator it = mods_.begin(); it != mods_.end(); ++it)
+    for (auto it = mods_.begin(); it != mods_.end(); ++it)
     {
       delete *it;
     }
@@ -92,7 +91,6 @@ namespace OpenMS
   {
     return mods_.size();
   }
-
 
   const ResidueModification& ModificationsDB::getModification(Size index) const
   {

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -97,7 +97,7 @@ namespace OpenMS
     {
       throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, index, mods_.size());
     }
-    return mods_.at(index);
+    return *mods_.at(index);
   }
 
 

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -96,7 +96,7 @@ namespace OpenMS
     return modified_residues_.size();
   }
 
-  const set<const Residue*> ResidueDB::getResidues(const String& residue_set) const
+  const ResidueDB::ResidueConstSetT ResidueDB::getResidues(const String& residue_set) const
   {
     if (!residues_by_set_.has(residue_set))
     {
@@ -417,7 +417,7 @@ namespace OpenMS
     return res_ptr;
   }
 
-  const set<String>& ResidueDB::getResidueSets() const
+  const std::set<std::string>& ResidueDB::getResidueSets() const
   {
     return residue_sets_;
   }

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -44,23 +44,17 @@
 #include <OpenMS/FORMAT/ParamXMLFile.h>
 
 #include <OpenMS/CONCEPT/Macros.h>
+#include <OpenMS/CONCEPT/MultiThreading.h>
 #include <OpenMS/SYSTEM/File.h>
 
 #include <iostream>
-
-#ifdef _OPENMP
-#define _MULTITHREADING_ON
-#include <boost/thread.hpp>
-#endif
 
 using namespace std;
 
 namespace OpenMS
 {
 
-#ifdef _MULTITHREADING_ON
-  static boost::shared_mutex mutex;
-#endif
+  STATIC_LOCK(mutex) 
 
   ResidueDB::ResidueDB()
   {
@@ -74,9 +68,7 @@ namespace OpenMS
     static ResidueDB* db_ = nullptr;
 
     // unique lock (make sure we only create one instance)
-#ifdef _MULTITHREADING_ON
-    boost::unique_lock<boost::shared_mutex> lock{mutex};
-#endif
+    OPENMS_UNIQUELOCK(mutex, lock)
 
     if (db_ == nullptr)
     {
@@ -92,10 +84,7 @@ namespace OpenMS
 
   const Residue* ResidueDB::getResidue(const String& name) const
   {
-    // non-unique read lock
-#ifdef _MULTITHREADING_ON
-    boost::shared_lock<boost::shared_mutex> lock{mutex};
-#endif
+    OPENMS_NONUNIQUELOCK(mutex, lock)
 
     if (residue_names_.find(name) != residue_names_.end())
     {
@@ -106,41 +95,25 @@ namespace OpenMS
 
   const Residue* ResidueDB::getResidue(const unsigned char& one_letter_code) const
   {
-    // non-unique read lock
-#ifdef _MULTITHREADING_ON
-    boost::shared_lock<boost::shared_mutex> lock{mutex};
-#endif
-
+    OPENMS_NONUNIQUELOCK(mutex, lock)
     return residue_by_one_letter_code_[one_letter_code];
   }
 
   Size ResidueDB::getNumberOfResidues() const
   {
-    // non-unique read lock
-#ifdef _MULTITHREADING_ON
-    boost::shared_lock<boost::shared_mutex> lock{mutex};
-#endif
-
+    OPENMS_NONUNIQUELOCK(mutex, lock)
     return residues_.size();
   }
 
   Size ResidueDB::getNumberOfModifiedResidues() const
   {
-    // non-unique read lock
-#ifdef _MULTITHREADING_ON
-    boost::shared_lock<boost::shared_mutex> lock{mutex};
-#endif
-
+    OPENMS_NONUNIQUELOCK(mutex, lock)
     return modified_residues_.size();
   }
 
   const ResidueDB::ResidueConstSetT ResidueDB::getResidues(const String& residue_set) const
   {
-    // non-unique read lock
-#ifdef _MULTITHREADING_ON
-    boost::shared_lock<boost::shared_mutex> lock{mutex};
-#endif
-
+    OPENMS_NONUNIQUELOCK(mutex, lock)
     if (residues_by_set_.find(residue_set) == residues_by_set_.end())
     {
       throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Residue set cannot be found: '" + residue_set + "'");
@@ -151,11 +124,7 @@ namespace OpenMS
 
   void ResidueDB::setResidues(const String& file_name)
   {
-    // unique lock
-#ifdef _MULTITHREADING_ON
-    boost::unique_lock<boost::shared_mutex> lock{mutex};
-#endif
-
+    OPENMS_UNIQUELOCK(mutex, lock)
     clearResidues_();
     readResiduesFromFile_(file_name);
     buildResidueNames_();
@@ -163,11 +132,7 @@ namespace OpenMS
 
   void ResidueDB::addResidue(const Residue& residue)
   {
-    // unique lock
-#ifdef _MULTITHREADING_ON
-    boost::unique_lock<boost::shared_mutex> lock{mutex};
-#endif
-
+    OPENMS_UNIQUELOCK(mutex, lock)
     Residue* r = new Residue(residue);
     addResidue_(r);
   }
@@ -232,11 +197,7 @@ namespace OpenMS
 
   bool ResidueDB::hasResidue(const String& res_name) const
   {
-    // non-unique read lock
-#ifdef _MULTITHREADING_ON
-    boost::shared_lock<boost::shared_mutex> lock{mutex};
-#endif
-
+    OPENMS_NONUNIQUELOCK(mutex, lock)
     if (residue_names_.find(res_name) != residue_names_.end())
     {
       return true;
@@ -246,11 +207,7 @@ namespace OpenMS
 
   bool ResidueDB::hasResidue(const Residue* residue) const
   {
-    // non-unique read lock
-#ifdef _MULTITHREADING_ON
-    boost::shared_lock<boost::shared_mutex> lock{mutex};
-#endif
-
+    OPENMS_NONUNIQUELOCK(mutex, lock)
     if (const_residues_.find(residue) != const_residues_.end() ||
         const_modified_residues_.find(residue) != const_modified_residues_.end())
     {
@@ -524,10 +481,7 @@ namespace OpenMS
 
   const Residue* ResidueDB::getModifiedResidue(const String& modification)
   {
-    // non-unique read lock
-#ifdef _MULTITHREADING_ON
-    boost::shared_lock<boost::shared_mutex> lock{mutex};
-#endif
+    OPENMS_NONUNIQUELOCK(mutex, lock)
 
     // terminal mods. don't apply to residue (side chain), so don't consider them:
     const ResidueModification& mod = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::ANYWHERE);
@@ -537,9 +491,7 @@ namespace OpenMS
   const Residue* ResidueDB::getModifiedResidue(const Residue* residue, const String& modification)
   {
     // get upgradeable access (right now we dont need a unique lock)
-#ifdef _MULTITHREADING_ON
-    boost::upgrade_lock<boost::shared_mutex> lock{mutex};
-#endif
+    OPENMS_UPGRADEABLE_UNIQUELOCK(mutex, lock) 
 
     OPENMS_PRECONDITION(!modification.empty(), "Modification cannot be empty")
 
@@ -569,13 +521,10 @@ namespace OpenMS
     //res->setLossNames(vector<String>());
 
     // now we do need to have unique access
-#ifdef _MULTITHREADING_ON
-    boost::upgrade_to_unique_lock<boost::shared_mutex> uniqueLock(lock);
-#endif
-    {
-      // now register this modified residue
-      addResidue_(res);
-    }
+    OPENMS_UPGRADE_UNIQUELOCK(lock, uniqueLock)
+    // now register this modified residue
+    addResidue_(res);
+
     return res;
   }
 

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -57,6 +57,16 @@ namespace OpenMS
     buildResidueNames_();
   }
 
+  ResidueDB* ResidueDB::getInstance()
+  {
+    static ResidueDB* db_ = nullptr;
+    if (db_ == nullptr)
+    {
+      db_ = new ResidueDB;
+    }
+    return db_;
+  }
+
   ResidueDB::~ResidueDB()
   {
     clear_();

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -98,7 +98,7 @@ namespace OpenMS
 
   const ResidueDB::ResidueConstSetT ResidueDB::getResidues(const String& residue_set) const
   {
-    if (!residues_by_set_.has(residue_set))
+    if (residues_by_set_.find(residue_set) == residues_by_set_.end())
     {
       throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Residue set cannot be found: '" + residue_set + "'");
     }

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -103,7 +103,7 @@ namespace OpenMS
       throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Residue set cannot be found: '" + residue_set + "'");
     }
 
-    return residues_by_set_[residue_set];
+    return residues_by_set_.at(residue_set);
   }
 
   void ResidueDB::setResidues(const String& file_name)
@@ -256,8 +256,7 @@ namespace OpenMS
 
   void ResidueDB::clearResidues_()
   {
-    set<Residue*>::iterator it;
-    for (it = residues_.begin(); it != residues_.end(); ++it)
+    for (auto it = residues_.begin(); it != residues_.end(); ++it)
     {
       delete *it;
     }
@@ -409,7 +408,7 @@ namespace OpenMS
       res_ptr->setLowMassIons(low_mass_ions);
     }
 
-    for (set<String>::const_iterator it = res_ptr->getResidueSets().begin(); it != res_ptr->getResidueSets().end(); ++it)
+    for (auto it = res_ptr->getResidueSets().begin(); it != res_ptr->getResidueSets().end(); ++it)
     {
       residues_by_set_[*it].insert(res_ptr);
     }
@@ -417,7 +416,7 @@ namespace OpenMS
     return res_ptr;
   }
 
-  const std::set<std::string>& ResidueDB::getResidueSets() const
+  const ResidueDB::ResidueSetT& ResidueDB::getResidueSets() const
   {
     return residue_sets_;
   }
@@ -430,8 +429,7 @@ namespace OpenMS
       residue_by_one_letter_code_[i] = nullptr;
     }
 
-    set<Residue*>::iterator it;
-    for (it = residues_.begin(); it != residues_.end(); ++it)
+    for (auto it = residues_.begin(); it != residues_.end(); ++it)
     {
       residue_names_[(*it)->getName()] = *it;
       if ((*it)->getThreeLetterCode() != "")

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -54,7 +54,7 @@ using namespace std;
 namespace OpenMS
 {
 
-  STATIC_LOCK(mutex) 
+  STATIC_LOCK(mutex_rdb) 
 
   ResidueDB::ResidueDB()
   {
@@ -68,7 +68,7 @@ namespace OpenMS
     static ResidueDB* db_ = nullptr;
 
     // unique lock (make sure we only create one instance)
-    OPENMS_UNIQUELOCK(mutex, lock)
+    OPENMS_UNIQUELOCK(mutex_rdb, lock)
 
     if (db_ == nullptr)
     {
@@ -84,7 +84,7 @@ namespace OpenMS
 
   const Residue* ResidueDB::getResidue(const String& name) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_rdb, lock)
 
     if (residue_names_.find(name) != residue_names_.end())
     {
@@ -95,25 +95,25 @@ namespace OpenMS
 
   const Residue* ResidueDB::getResidue(const unsigned char& one_letter_code) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_rdb, lock)
     return residue_by_one_letter_code_[one_letter_code];
   }
 
   Size ResidueDB::getNumberOfResidues() const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_rdb, lock)
     return residues_.size();
   }
 
   Size ResidueDB::getNumberOfModifiedResidues() const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_rdb, lock)
     return modified_residues_.size();
   }
 
   const ResidueDB::ResidueConstSetT ResidueDB::getResidues(const String& residue_set) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_rdb, lock)
     if (residues_by_set_.find(residue_set) == residues_by_set_.end())
     {
       throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Residue set cannot be found: '" + residue_set + "'");
@@ -124,7 +124,7 @@ namespace OpenMS
 
   void ResidueDB::setResidues(const String& file_name)
   {
-    OPENMS_UNIQUELOCK(mutex, lock)
+    OPENMS_UNIQUELOCK(mutex_rdb, lock)
     clearResidues_();
     readResiduesFromFile_(file_name);
     buildResidueNames_();
@@ -132,7 +132,7 @@ namespace OpenMS
 
   void ResidueDB::addResidue(const Residue& residue)
   {
-    OPENMS_UNIQUELOCK(mutex, lock)
+    OPENMS_UNIQUELOCK(mutex_rdb, lock)
     Residue* r = new Residue(residue);
     addResidue_(r);
   }
@@ -197,7 +197,7 @@ namespace OpenMS
 
   bool ResidueDB::hasResidue(const String& res_name) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_rdb, lock)
     if (residue_names_.find(res_name) != residue_names_.end())
     {
       return true;
@@ -207,7 +207,7 @@ namespace OpenMS
 
   bool ResidueDB::hasResidue(const Residue* residue) const
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_rdb, lock)
     if (const_residues_.find(residue) != const_residues_.end() ||
         const_modified_residues_.find(residue) != const_modified_residues_.end())
     {
@@ -481,7 +481,7 @@ namespace OpenMS
 
   const Residue* ResidueDB::getModifiedResidue(const String& modification)
   {
-    OPENMS_NONUNIQUELOCK(mutex, lock)
+    OPENMS_NONUNIQUELOCK(mutex_rdb, lock)
 
     // terminal mods. don't apply to residue (side chain), so don't consider them:
     const ResidueModification& mod = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::ANYWHERE);
@@ -491,7 +491,7 @@ namespace OpenMS
   const Residue* ResidueDB::getModifiedResidue(const Residue* residue, const String& modification)
   {
     // get upgradeable access (right now we dont need a unique lock)
-    OPENMS_UPGRADEABLE_UNIQUELOCK(mutex, lock) 
+    OPENMS_UPGRADEABLE_UNIQUELOCK(mutex_rdb, lock) 
 
     OPENMS_PRECONDITION(!modification.empty(), "Modification cannot be empty")
 

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -474,15 +474,17 @@ namespace OpenMS
     if (residue_names_.find(res_name) == residue_names_.end())
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                       String("Residue with name " + res_name + " was not registered in residue DB, register first!").c_str());
+          String("Residue with name " + res_name + " was not registered in residue DB, register first!").c_str());
     }
 
     // terminal mods. don't apply to residue (side chain), so don't consider them:
-    const ResidueModification& mod = ModificationsDB::getInstance()->getModification(modification, residue->getOneLetterCode(), ResidueModification::ANYWHERE);
+    const ResidueModification& mod = ModificationsDB::getInstance()->getModification(
+        modification, residue->getOneLetterCode(), ResidueModification::ANYWHERE);
     String id = mod.getId();
     if (id.empty()) id = mod.getFullId();
 
-    if (residue_mod_names_.has(res_name) && residue_mod_names_[res_name].has(id))
+    if (residue_mod_names_.find(res_name) != residue_mod_names_.end() && 
+        residue_mod_names_[res_name].find(id) != residue_mod_names_[res_name].end())
     {
       return residue_mod_names_[res_name][id];
     }

--- a/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGenerator.cpp
@@ -81,10 +81,9 @@ namespace OpenMS
     {
       ResidueDB* res_db;
       res_db = ResidueDB::getInstance();
-      std::set<const Residue*> all_aa = res_db->getResidues("Natural20");
+      auto all_aa = res_db->getResidues("Natural20");
       std::set<String> residues;
-      std::set<const Residue*>::const_iterator aa_it;
-      for (aa_it = all_aa.begin(); aa_it != all_aa.end(); ++aa_it)
+      for (auto aa_it = all_aa.begin(); aa_it != all_aa.end(); ++aa_it)
       {
         residues.insert((*aa_it)->getOneLetterCode());
       }

--- a/src/pyOpenMS/pxds/ResidueDB.pxd
+++ b/src/pyOpenMS/pxds/ResidueDB.pxd
@@ -16,7 +16,7 @@ cdef extern from "<OpenMS/CHEMISTRY/ResidueDB.h>" namespace "OpenMS":
         const Residue * getModifiedResidue(String & name) nogil except +
         const Residue * getModifiedResidue(Residue * residue, String & name) nogil except +
         libcpp_set[ const Residue * ] getResidues(String & residue_set) nogil except +
-        libcpp_set[ String ] getResidueSets() nogil except +
+        libcpp_set[ libcpp_string ] getResidueSets() nogil except +
         void setResidues(String & filename) nogil except +
         void addResidue(Residue & residue) nogil except +
         bool hasResidue(String & name) nogil except +

--- a/src/tests/class_tests/openms/executables.cmake
+++ b/src/tests/class_tests/openms/executables.cmake
@@ -369,6 +369,7 @@ set(chemistry_executables_list
   ModificationsDB_test
   CrossLinksDB_test
   ProteaseDB_test
+  RNaseDB_test
   ProteaseDigestion_test
   ResidueDB_test
   ResidueModification_test

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -1167,8 +1167,6 @@ END_SECTION
 
 START_SECTION([EXTRA] multithreaded example)
 {
-  static ResidueDB* rdb = ResidueDB::getInstance();
-
   // All measurements are best of three (wall time, Linux, 8 threads)
   //
   // Serial execution of code:

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -1169,7 +1169,22 @@ START_SECTION([EXTRA] multithreaded example)
 {
   static ResidueDB* rdb = ResidueDB::getInstance();
 
-  int nr_iterations (5e3), test (0);
+  // All measurements are best of three (wall time, Linux, 8 threads)
+  //
+  // Serial execution of code:
+  // 5e4 iterations -> 5.42 seconds
+  //
+  // Parallel execution of code:
+  // original code:
+  // 5e4 iterations -> 4.01 seconds with boost::shared_mutex
+  // 5e4 iterations -> 8.05 seconds with std::mutex
+  //
+  // refactored code that throws exception outside block:
+  // 5e4 iterations -> 8.55 seconds with omp critical
+  // 5e4 iterations -> 8.59 seconds with std::mutex
+  // 5e4 iterations -> 3.94 seconds with boost::shared_mutex
+  int nr_iterations (5e4), test (0);
+
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
@@ -1181,11 +1196,6 @@ START_SECTION([EXTRA] multithreaded example)
 #pragma omp critical (add_test)
 #endif
     {
-// #ifdef _OPENMP
-//       std::cout << " thread " << omp_get_thread_num() << " work on " << k << std::endl;
-// #else
-//       std::cout << " no thread here, " << " work on " << k << " and add " << aa.size() << std::endl;
-// #endif
       test += aa.size();
     }
   }

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -38,6 +38,10 @@
 
 ///////////////////////////
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/CHEMISTRY/ResidueDB.h>
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
@@ -1158,6 +1162,34 @@ START_SECTION([EXTRA] testing terminal modifications)
   TEST_EQUAL(aaNoMod.getCTerminalModificationName(), "")
   TEST_EQUAL(aaNtermMod.getCTerminalModificationName(), "")
   TEST_EQUAL(aaCtermMod.getCTerminalModificationName(), "Label:18O(2)")
+}
+END_SECTION
+
+START_SECTION([EXTRA] multithreaded example)
+{
+  static ResidueDB* rdb = ResidueDB::getInstance();
+
+  int nr_iterations (5e3), test (0);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    auto aa = AASequence::fromString("TEST[" +  String(0.14*k) + "]PEPTIDE");
+
+#ifdef _OPENMP
+#pragma omp critical (add_test)
+#endif
+    {
+// #ifdef _OPENMP
+//       std::cout << " thread " << omp_get_thread_num() << " work on " << k << std::endl;
+// #else
+//       std::cout << " no thread here, " << " work on " << k << " and add " << aa.size() << std::endl;
+// #endif
+      test += aa.size();
+    }
+  }
+  TEST_EQUAL(test, nr_iterations*11)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -39,6 +39,7 @@
 ///////////////////////////
 
 #include <OpenMS/CHEMISTRY/ElementDB.h>
+#include <OpenMS/CHEMISTRY/Element.h>
 #include <OpenMS/DATASTRUCTURES/Map.h>
 
 using namespace OpenMS;
@@ -101,6 +102,29 @@ END_SECTION
 
 START_SECTION(bool hasElement(UInt atomic_number) const)
 	TEST_EQUAL(e_ptr->hasElement(6), true)
+END_SECTION
+
+START_SECTION([EXTRA] multithreaded example)
+{
+  int nr_iterations (100), test (0);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+
+    auto edb = ElementDB::getInstance();
+    const Element * e1 = edb->getElement("Carbon");
+
+#ifdef _OPENMP
+#pragma omp critical (add_test)
+#endif
+    {
+      test += e1->getAtomicNumber();
+    }
+  }
+  TEST_EQUAL(test, 6 * 100)
+}
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -55,6 +55,29 @@ const ElementDB* e_ptr = nullptr;
 const ElementDB* e_nullPointer = nullptr;
 const Element * elem_nullPointer = nullptr;
 
+START_SECTION([EXTRA] multithreaded example)
+{
+  int nr_iterations (100), test (0);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+
+    auto edb = ElementDB::getInstance();
+    const Element * e1 = edb->getElement("Carbon");
+
+#ifdef _OPENMP
+#pragma omp critical (add_test)
+#endif
+    {
+      test += e1->getAtomicNumber();
+    }
+  }
+  TEST_EQUAL(test, 6 * 100)
+}
+END_SECTION
+
 START_SECTION(static const ElementDB* getInstance())
 	e_ptr = ElementDB::getInstance();
 	TEST_NOT_EQUAL(e_ptr, e_nullPointer)
@@ -102,29 +125,6 @@ END_SECTION
 
 START_SECTION(bool hasElement(UInt atomic_number) const)
 	TEST_EQUAL(e_ptr->hasElement(6), true)
-END_SECTION
-
-START_SECTION([EXTRA] multithreaded example)
-{
-  int nr_iterations (100), test (0);
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
-  for (int k = 1; k < nr_iterations + 1; k++)
-  {
-
-    auto edb = ElementDB::getInstance();
-    const Element * e1 = edb->getElement("Carbon");
-
-#ifdef _OPENMP
-#pragma omp critical (add_test)
-#endif
-    {
-      test += e1->getAtomicNumber();
-    }
-  }
-  TEST_EQUAL(test, 6 * 100)
-}
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/FactoryBase_test.cpp
+++ b/src/tests/class_tests/openms/source/FactoryBase_test.cpp
@@ -51,14 +51,14 @@ FactoryBase* ptr = nullptr;
 FactoryBase* nullPointer = nullptr;
 START_SECTION(FactoryBase())
 {
-        ptr = new FactoryBase();
-	TEST_NOT_EQUAL(ptr, nullPointer)
+  ptr = new FactoryBase();
+  TEST_NOT_EQUAL(ptr, nullPointer)
 }
 END_SECTION
 
 START_SECTION(~FactoryBase())
 {
-        delete ptr;
+  delete ptr;
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Factory_test.cpp
+++ b/src/tests/class_tests/openms/source/Factory_test.cpp
@@ -51,6 +51,29 @@ START_TEST(<Factory>, "$Id$")
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
+START_SECTION([EXTRA] multithreaded example)
+{
+
+  int nr_iterations (1e2), test (0);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+	  FilterFunctor* p = Factory<FilterFunctor>::create("TICFilter");
+    TICFilter reducer;
+
+#ifdef _OPENMP
+#pragma omp critical (add_test)
+#endif
+    {
+      test += (*p==reducer);
+    }
+  }
+  TEST_EQUAL(test, nr_iterations)
+}
+END_SECTION
+
 // Factory is singleton, therefore we don't test the constructor
 START_SECTION(static FactoryProduct* create(const String& name))
 	FilterFunctor* p = Factory<FilterFunctor>::create("TICFilter");

--- a/src/tests/class_tests/openms/source/MetaInfoRegistry_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaInfoRegistry_test.cpp
@@ -180,13 +180,53 @@ END_SECTION
 
 START_SECTION([EXTRA] multithreaded example)
 {
-  int nr_iterations (1e5), test (0);
+  // All measurements are best of three (wall time, Linux, 8 threads)
+  //
+  // Serial execution of code:
+  // 1e7 iterations -> 1.10 seconds
+  // 1e6 iterations -> 0.31 seconds
+  //
+  // Parallel execution of code:
+  // 1e7 iterations -> 3.41 seconds with omp critical
+  // 1e7 iterations -> 4.30 seconds with std::mutex
+  // 1e7 iterations -> ???  seconds with boost::shared_mutex
+  //
+  // 1e6 iterations -> 0.36 seconds with omp critical
+  // 1e6 iterations -> 0.43 seconds with std::mutex
+  // 1e6 iterations -> 5.96 seconds with boost::shared_mutex
+
+
+  // 1e7 iterations with 1000 different values
+  // Serial execution of code:
+  // 1e7 iterations -> 6.84 seconds
+  // 1e6 iterations -> 0.91 seconds
+  //
+  // Parallel execution of code:
+  // 1e7 iterations -> 5.20 seconds with omp critical
+  // 1e7 iterations -> 7.44 seconds with std::mutex
+  // 1e7 iterations -> ???  seconds with boost::shared_mutex
+  //
+  // 1e6 iterations -> 0.55 seconds with omp critical
+  // 1e6 iterations -> 0.78 seconds with std::mutex
+  // 1e6 iterations -> 7.63 seconds with boost::shared_mutex
+
+  // Note how the omp critical is 3x slower for the "same value" code than
+  // serial code whereas it is slightly faster for the "1000 different values"
+  // code.
+  // The shared_mutex code is an order of magnitude slower (10-20x) for both
+  // cases. It seems for this case, most case is spent in locking / unlocking
+  // the mutex.
+  int nr_iterations (1e7), test (0);
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
   for (int k = 1; k < nr_iterations + 1; k++)
   {
+#if 0
+    std::string val = "newValue" + String(k%1000);
+#else
     std::string val = "newValue";
+#endif
     
     UInt index = mir.registerName(val);
     mir.setDescription(index, val);
@@ -198,7 +238,7 @@ START_SECTION([EXTRA] multithreaded example)
       test += index;
     }
   }
-  TEST_EQUAL(test, 1027 * 100)
+  TEST_EQUAL(test, 1027 * nr_iterations)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/MetaInfoRegistry_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaInfoRegistry_test.cpp
@@ -39,6 +39,10 @@
 
 #include <OpenMS/METADATA/MetaInfoRegistry.h>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 ///////////////////////////
 
 START_TEST(MetaInfoRegistry, "$Id$")
@@ -172,6 +176,30 @@ START_SECTION((MetaInfoRegistry& operator=(const MetaInfoRegistry& rhs)))
 	TEST_STRING_EQUAL(mir2.getUnit(1025), "sec")
 	TEST_STRING_EQUAL(mir2.getUnit("testname"), "")
 	TEST_STRING_EQUAL(mir2.getUnit("retention time"), "sec")
+END_SECTION
+
+START_SECTION([EXTRA] multithreaded example)
+{
+  int nr_iterations (1e5), test (0);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    std::string val = "newValue";
+    
+    UInt index = mir.registerName(val);
+    mir.setDescription(index, val);
+
+#ifdef _OPENMP
+#pragma omp critical (add_test)
+#endif
+    {
+      test += index;
+    }
+  }
+  TEST_EQUAL(test, 1027 * 100)
+}
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/MetaInfoRegistry_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaInfoRegistry_test.cpp
@@ -216,7 +216,7 @@ START_SECTION([EXTRA] multithreaded example)
   // The shared_mutex code is an order of magnitude slower (10-20x) for both
   // cases. It seems for this case, most case is spent in locking / unlocking
   // the mutex.
-  int nr_iterations (1e7), test (0);
+  int nr_iterations (1e6), test (0);
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif

--- a/src/tests/class_tests/openms/source/ProteaseDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDB_test.cpp
@@ -54,6 +54,34 @@ START_TEST(ProteaseDB, "$Id$")
 ProteaseDB* ptr = nullptr;
 ProteaseDB* nullPointer = nullptr;
 String RKP("(?<=R)(?!P)");
+
+START_SECTION([EXTRA] multithreaded example)
+{
+
+  int nr_iterations (1e2), test (0);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    auto p = ProteaseDB::getInstance();
+    int tmp (0);
+    if (p->hasEnzyme("Trypsin"), true)
+    {
+      tmp++;
+    }
+
+#ifdef _OPENMP
+#pragma omp critical (add_test)
+#endif
+    {
+      test += tmp;
+    }
+  }
+  TEST_EQUAL(test, nr_iterations)
+}
+END_SECTION
+
 START_SECTION(ProteaseDB* getInstance())
     ptr = ProteaseDB::getInstance();
     TEST_NOT_EQUAL(ptr, nullPointer)

--- a/src/tests/class_tests/openms/source/RNaseDB_test.cpp
+++ b/src/tests/class_tests/openms/source/RNaseDB_test.cpp
@@ -1,0 +1,132 @@
+// --------------------------------------------------------------------------
+//                   OpenMS -- Open-Source Mass Spectrometry
+// --------------------------------------------------------------------------
+// Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
+// ETH Zurich, and Freie Universitaet Berlin 2002-2017.
+//
+// This software is released under a three-clause BSD license:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
+//    without specific prior written permission.
+// For a full list of authors, refer to the file AUTHORS.
+// --------------------------------------------------------------------------
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// --------------------------------------------------------------------------
+// $Maintainer: Xiao Liang $
+// $Authors: Xiao Liang, Chris Bielow $
+// --------------------------------------------------------------------------
+//
+
+#include <OpenMS/CONCEPT/ClassTest.h>
+#include <OpenMS/test_config.h>
+
+///////////////////////////
+
+#include <OpenMS/CHEMISTRY/RNaseDB.h>
+#include <OpenMS/CHEMISTRY/DigestionEnzymeRNA.h>
+
+using namespace OpenMS;
+using namespace std;
+
+///////////////////////////
+
+START_TEST(RNaseDB, "$Id$")
+
+/////////////////////////////////////////////////////////////
+
+RNaseDB* ptr = nullptr;
+RNaseDB* nullPointer = nullptr;
+String t1_regex("(?<=G)");
+
+START_SECTION([EXTRA] multithreaded example)
+{
+
+  int nr_iterations (1e2), test (0);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    auto p = RNaseDB::getInstance();
+    int tmp (0);
+    if (p->hasEnzyme("Trypsin"), true)
+    {
+      tmp++;
+    }
+
+#ifdef _OPENMP
+#pragma omp critical (add_test)
+#endif
+    {
+      test += tmp;
+    }
+  }
+  TEST_EQUAL(test, nr_iterations)
+}
+END_SECTION
+
+START_SECTION(RNaseDB* getInstance())
+    ptr = RNaseDB::getInstance();
+    TEST_NOT_EQUAL(ptr, nullPointer)
+END_SECTION
+
+START_SECTION(virtual ~RNaseDB())
+    NOT_TESTABLE
+END_SECTION
+
+START_SECTION((bool hasEnzyme(const String &name) const))
+    TEST_EQUAL(ptr->hasEnzyme("RNAse"), false)
+    TEST_EQUAL(ptr->hasEnzyme("RNase_T1"), true)
+END_SECTION
+
+START_SECTION((const DigestionEnzymeProtein* getEnzyme(const String &name) const))
+    TEST_EQUAL(ptr->getEnzyme("RNase_T1")->getName(), "RNase_T1")
+END_SECTION
+
+START_SECTION((bool hasRegEx(const String& cleavage_regex) const))
+    TEST_EQUAL(ptr->hasRegEx("(?<=[P])(?!P)"), false)
+    TEST_EQUAL(ptr->hasRegEx(t1_regex), true)
+END_SECTION
+
+START_SECTION((const DigestionEnzymeRNA* getEnzymeByRegEx(const String& cleavage_regex) const))
+    TEST_EQUAL(ptr->getEnzymeByRegEx(t1_regex)->getName(), "RNase_T1")
+END_SECTION
+
+START_SECTION(bool hasEnzyme(const DigestionEnzymeProtein* enzyme) const)
+  TEST_EQUAL(ptr->hasEnzyme(ptr->getEnzyme("RNase_T1")), true)
+  DigestionEnzymeRNA myNewEnzyme("bla", "blubb");
+  TEST_EQUAL(ptr->hasEnzyme(&myNewEnzyme), false);
+END_SECTION
+
+START_SECTION(ConstEnzymeIterator beginEnzyme() const)
+    auto it = ptr->beginEnzyme();
+    Size count(0);
+    while (it != ptr->endEnzyme())
+    {
+      ++it;
+      ++count;
+    }
+    TEST_EQUAL(count >= 3, true)
+END_SECTION
+
+START_SECTION(ConstEnzymeIterator endEnzyme() const)
+    NOT_TESTABLE // tested above
+END_SECTION
+
+END_TEST

--- a/src/tests/class_tests/openms/source/RNaseDB_test.cpp
+++ b/src/tests/class_tests/openms/source/RNaseDB_test.cpp
@@ -65,7 +65,7 @@ START_SECTION([EXTRA] multithreaded example)
   {
     auto p = RNaseDB::getInstance();
     int tmp (0);
-    if (p->hasEnzyme("Trypsin"), true)
+    if (p->hasEnzyme("RNase_T1"))
     {
       tmp++;
     }

--- a/src/tests/class_tests/openms/source/ResidueDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueDB_test.cpp
@@ -53,12 +53,12 @@ START_TEST(ResidueDB, "$Id$")
 ResidueDB* ptr = nullptr;
 ResidueDB* nullPointer = nullptr;
 START_SECTION(ResidueDB* getInstance())
-	ptr = ResidueDB::getInstance();
-	TEST_NOT_EQUAL(ptr, nullPointer)
+  ptr = ResidueDB::getInstance();
+  TEST_NOT_EQUAL(ptr, nullPointer)
 END_SECTION
 
 START_SECTION(virtual ~ResidueDB())
-	NOT_TESTABLE
+  NOT_TESTABLE
 END_SECTION
 
 START_SECTION((const Residue* getResidue(const String& name) const))
@@ -71,111 +71,111 @@ END_SECTION
 
 START_SECTION((bool hasResidue(const String& name) const))
   TEST_EQUAL(ptr->hasResidue("BLUBB"), false)
-	TEST_EQUAL(ptr->hasResidue("LYS"), true)
-	TEST_EQUAL(ptr->hasResidue("K"), true)
+  TEST_EQUAL(ptr->hasResidue("LYS"), true)
+  TEST_EQUAL(ptr->hasResidue("K"), true)
 END_SECTION
 
 START_SECTION(bool hasResidue(const Residue* residue) const)
-	TEST_EQUAL(ptr->hasResidue(ptr->getResidue("BLUBB")), false)
-	TEST_EQUAL(ptr->hasResidue(ptr->getResidue("LYS")), true)
-	TEST_EQUAL(ptr->hasResidue(ptr->getResidue("K")), true)
+  TEST_EQUAL(ptr->hasResidue(ptr->getResidue("BLUBB")), false)
+  TEST_EQUAL(ptr->hasResidue(ptr->getResidue("LYS")), true)
+  TEST_EQUAL(ptr->hasResidue(ptr->getResidue("K")), true)
 END_SECTION
 
 START_SECTION(Size getNumberOfResidues() const)
-	TEST_EQUAL(ptr->getNumberOfResidues() >= 20 , true);
+  TEST_EQUAL(ptr->getNumberOfResidues() >= 20 , true);
 END_SECTION
 
 START_SECTION(const Residue* getModifiedResidue(const String& name))
-	const Residue* mod_res = ptr->getModifiedResidue("Oxidation (M)"); // ox methionine
-	TEST_STRING_EQUAL(mod_res->getOneLetterCode(), "M")
-	TEST_STRING_EQUAL(mod_res->getModificationName(), "Oxidation")
+  const Residue* mod_res = ptr->getModifiedResidue("Oxidation (M)"); // ox methionine
+  TEST_STRING_EQUAL(mod_res->getOneLetterCode(), "M")
+  TEST_STRING_EQUAL(mod_res->getModificationName(), "Oxidation")
 END_SECTION
 
 START_SECTION(const Residue* getModifiedResidue(const Residue* residue, const String& name))
-	const Residue* mod_res = ptr->getModifiedResidue(ptr->getResidue("M"), "Oxidation (M)");
-	TEST_STRING_EQUAL(mod_res->getOneLetterCode(), "M")
-	TEST_STRING_EQUAL(mod_res->getModificationName(), "Oxidation")
+  const Residue* mod_res = ptr->getModifiedResidue(ptr->getResidue("M"), "Oxidation (M)");
+  TEST_STRING_EQUAL(mod_res->getOneLetterCode(), "M")
+  TEST_STRING_EQUAL(mod_res->getModificationName(), "Oxidation")
 END_SECTION
 
 START_SECTION((const std::set<const Residue*> getResidues(const String& residue_set="All") const))
-	set<const Residue*> residues = ptr->getResidues("All");
-	TEST_EQUAL(residues.size() >= 21, true)
-	residues = ptr->getResidues("Natural20");
-	TEST_EQUAL(residues.size(), 20)
-	residues = ptr->getResidues("Natural19WithoutL");
-	TEST_EQUAL(residues.size(), 19)
+  set<const Residue*> residues = ptr->getResidues("All");
+  TEST_EQUAL(residues.size() >= 21, true)
+  residues = ptr->getResidues("Natural20");
+  TEST_EQUAL(residues.size(), 20)
+  residues = ptr->getResidues("Natural19WithoutL");
+  TEST_EQUAL(residues.size(), 19)
 END_SECTION
 
 START_SECTION((const std::set<String>& getResidueSets() const))
-	set<String> res_sets = ResidueDB::getInstance()->getResidueSets();
-	TEST_EQUAL(res_sets.find("All") != res_sets.end(), true)
-	TEST_EQUAL(res_sets.find("Natural20") != res_sets.end(), true)
-	TEST_EQUAL(res_sets.find("Natural19WithoutL") != res_sets.end(), true)
-	TEST_EQUAL(res_sets.find("Natural19WithoutI") != res_sets.end(), true)
+  set<std::string> res_sets = ResidueDB::getInstance()->getResidueSets();
+  TEST_EQUAL(res_sets.find("All") != res_sets.end(), true)
+  TEST_EQUAL(res_sets.find("Natural20") != res_sets.end(), true)
+  TEST_EQUAL(res_sets.find("Natural19WithoutL") != res_sets.end(), true)
+  TEST_EQUAL(res_sets.find("Natural19WithoutI") != res_sets.end(), true)
 END_SECTION
 
 
 START_SECTION(void setResidues(const String& filename))
-	NOT_TESTABLE // this method is hard to test, just provided for convenience
+  NOT_TESTABLE // this method is hard to test, just provided for convenience
 END_SECTION
 
 START_SECTION(void addResidue(const Residue& residue))
-	TEST_EQUAL(ptr->hasResidue("UGU"), false)
-	TEST_EQUAL(ptr->hasResidue("$"), false)
-	TEST_EQUAL(ptr->hasResidue("$hortName"), false)
-	TEST_EQUAL(ptr->hasResidue("MyLittleUGUResidue"), false)
-	Residue res;
-	res.setShortName("$hortName");
-	res.setOneLetterCode("$");
-	res.setThreeLetterCode("UGU");
-	res.setName("MyLittleUGUResidue");
-	res.setFormula(EmpiricalFormula("C3H4O4"));
-	ptr->addResidue(res);
-	TEST_EQUAL(ptr->hasResidue("UGU"), true)
-	TEST_EQUAL(ptr->hasResidue("$"), true)
-	TEST_EQUAL(ptr->hasResidue("$hortName"), true)
-	TEST_EQUAL(ptr->hasResidue("MyLittleUGUResidue"), true)
+  TEST_EQUAL(ptr->hasResidue("UGU"), false)
+  TEST_EQUAL(ptr->hasResidue("$"), false)
+  TEST_EQUAL(ptr->hasResidue("$hortName"), false)
+  TEST_EQUAL(ptr->hasResidue("MyLittleUGUResidue"), false)
+  Residue res;
+  res.setShortName("$hortName");
+  res.setOneLetterCode("$");
+  res.setThreeLetterCode("UGU");
+  res.setName("MyLittleUGUResidue");
+  res.setFormula(EmpiricalFormula("C3H4O4"));
+  ptr->addResidue(res);
+  TEST_EQUAL(ptr->hasResidue("UGU"), true)
+  TEST_EQUAL(ptr->hasResidue("$"), true)
+  TEST_EQUAL(ptr->hasResidue("$hortName"), true)
+  TEST_EQUAL(ptr->hasResidue("MyLittleUGUResidue"), true)
 END_SECTION
 
 START_SECTION(ResidueIterator beginResidue())
-	ResidueDB::ResidueIterator it = ptr->beginResidue();
-	Size count(0);
-	while (it != ptr->endResidue())
-	{
-		++it;
-		++count;
-	}
+  ResidueDB::ResidueIterator it = ptr->beginResidue();
+  Size count(0);
+  while (it != ptr->endResidue())
+  {
+    ++it;
+    ++count;
+  }
 
-	TEST_EQUAL(count >= 22, true)
+  TEST_EQUAL(count >= 22, true)
 END_SECTION
 
 START_SECTION(ResidueIterator endResidue())
-	NOT_TESTABLE // tested above
+  NOT_TESTABLE // tested above
 END_SECTION
 
 START_SECTION(ResidueConstIterator beginResidue() const)
-	const ResidueDB* const_ptr = ptr;
-	ResidueDB::ResidueConstIterator it = const_ptr->beginResidue();
-	Size count(0);
-	while (it != const_ptr->endResidue())
-	{
-		++it;
-		++count;
-	}
-	TEST_EQUAL(count >= 22, true)
+  const ResidueDB* const_ptr = ptr;
+  ResidueDB::ResidueConstIterator it = const_ptr->beginResidue();
+  Size count(0);
+  while (it != const_ptr->endResidue())
+  {
+    ++it;
+    ++count;
+  }
+  TEST_EQUAL(count >= 22, true)
 END_SECTION
 
 START_SECTION(ResidueConstIterator endResidue() const)
-	NOT_TESTABLE // tested above
+  NOT_TESTABLE // tested above
 END_SECTION
 
 START_SECTION(Size getNumberOfModifiedResidues() const)
-	TEST_EQUAL(ptr->getNumberOfModifiedResidues(), 1)
-	const Residue* mod_res = nullptr;
-    const Residue* mod_res_nullPointer = nullptr;
-	mod_res = ptr->getModifiedResidue("Carbamidomethyl (C)");
-    TEST_NOT_EQUAL(mod_res, mod_res_nullPointer)
-	TEST_EQUAL(ptr->getNumberOfModifiedResidues(), 2)
+  TEST_EQUAL(ptr->getNumberOfModifiedResidues(), 1)
+  const Residue* mod_res = nullptr;
+  const Residue* mod_res_nullPointer = nullptr;
+  mod_res = ptr->getModifiedResidue("Carbamidomethyl (C)");
+  TEST_NOT_EQUAL(mod_res, mod_res_nullPointer)
+  TEST_EQUAL(ptr->getNumberOfModifiedResidues(), 2)
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
@@ -57,6 +57,33 @@ unsigned nofIdsToGenerate = 100000;
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
+START_SECTION([EXTRA] multithreaded example)
+{
+
+  /* test for collisions, test will be different for every test execution */
+  OpenMS::UniqueIdGenerator::setSeed(std::time(nullptr));
+  std::vector<OpenMS::UInt64> ids;
+  ids.reserve(nofIdsToGenerate);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (unsigned i=0; i<nofIdsToGenerate; ++i)
+  {
+    OpenMS::UInt64 tmp = OpenMS::UniqueIdGenerator::getUniqueId();
+#ifdef _OPENMP
+#pragma omp critical (add_test)
+#endif
+    {
+      ids.push_back(tmp);
+    }
+  }
+  std::sort(ids.begin(), ids.end());
+  // check if the generated ids contain (at least) two equal ones
+  std::vector<OpenMS::UInt64>::iterator iter = std::adjacent_find(ids.begin(), ids.end());
+  TEST_EQUAL(iter == ids.end(), true);
+}
+END_SECTION
+
 START_SECTION((UniqueIdGenerator()))
 {
   // singleton has private ctor


### PR DESCRIPTION
- adds a common framework for managing concurrency in `CONCEPT/MultiThreading.h`
- implements a simple read-write lock using macros:
  - `OPENMS_UNIQUELOCK` indicates a section where only one (writer) thread can execute
  - `OPENMS_NONUNIQUELOCK` indicates a section where multiple (reader) threads can concurrently execute but not concurrently with a writer thread
- allows user to easily switch between different forms of mutexes (boost, STL)
- adds missing mutexes and adds multithreaded tests for several singletons:
  - ProteaseDB
  - RNaseDB
  - ModificationsDB
  - ElementDB
  - Factory
  - UniqueIdGenerator
  - MetaInfoRegistry
- fixes #905
- fixes #3431
- another step on the way to address #957

## Testing
while multithreading is pretty tough to test and debug, the following is a pretty straight forward approach:

```
while ctest -R Factory_test -V; do :; done
```

## Performance
Performance testing of a realistic sample is even harder, this PR basically just ensures that we wont produce any errors, unexpected segfaults etc when using the singletons above in a multithreaded environment. I did benchmark `boost::shared_mutex`, `std::mutex` and `pragma omp critical` against each other and it seems that for simple code where lots of code has a lock, `critical` performs best whereas for more complex code where only part of the code is locked, the `shared_mutex` performs best. Note there are some platform specific issues with `boost::shared_mutex`, see https://stackoverflow.com/questions/37303342/boostshared-mutex-slower-than-a-coarse-stdmutex-on-linux/37306432?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
