### PR TITLE
Fix segfaults & other issues

### DIFF
--- a/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDConflictResolverAlgorithm.cpp
@@ -105,8 +105,11 @@ namespace OpenMS
   {
     // if any of them is empty, the other is considered "greater"
     // independent of the score in the first hit
-    if (left.getHits().empty()) return true;
-    if (right.getHits().empty()) return false;
+    if (left.getHits().empty() || right.getHits().empty()) 
+    { // also: for strict weak ordering, comp(x,x) needs to be false
+      return left.getHits().size() < right.getHits().size();
+    }
+
     if (left.getHits()[0].getScore() < right.getHits()[0].getScore())
     {
       return true;

--- a/src/openms/source/ANALYSIS/TARGETED/PSLPFormulation.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/PSLPFormulation.cpp
@@ -250,8 +250,11 @@ namespace OpenMS
 #ifdef DEBUG_OPS
       std::cout << "\nadd row " << std::endl;
 #endif
-      model_->addRow(indices, entries, (String("PREC_ACQU_LIMIT_") + i), 0, param_.getValue("feature_based:max_number_precursors_per_feature"),
-                     LPWrapper::UPPER_BOUND_ONLY); // only upper bounded problem -> lower bound is ignored
+      if (!indices.empty())
+      {
+        model_->addRow(indices, entries, (String("PREC_ACQU_LIMIT_") + i), 0, param_.getValue("feature_based:max_number_precursors_per_feature"),
+                       LPWrapper::UPPER_BOUND_ONLY); // only upper bounded problem -> lower bound is ignored
+      }
 
 #ifdef DEBUG_OPS
       std::cout << stop - start << " PREC_ACQU_LIMIT_" << String(i) << std::endl;

--- a/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
+++ b/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
@@ -129,8 +129,14 @@ namespace OpenMS
 
   Int LPWrapper::addColumn(std::vector<Int> column_indices, std::vector<double> column_values, const String& name)
   {
+    if (column_indices.empty())
+    {
+      throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Column indices for Row are empty");
+    }
     if (column_indices.size() != column_values.size())
+    {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Indices and values vectors differ in size");
+    }
     if (solver_ == SOLVER_GLPK)
     {
       Int index = glp_add_cols(lp_problem_, 1);

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -339,6 +339,8 @@ namespace OpenMS
            groups.begin(); group_it != groups.end(); ++group_it)
     {
       ProteinIdentification::ProteinGroup filtered;
+      // sort group accessions (required for 'set_intersection' operation)
+      sort(group_it->accessions.begin(), group_it->accessions.end());
       set_intersection(group_it->accessions.begin(), group_it->accessions.end(),
                        valid_accessions.begin(), valid_accessions.end(),
                        inserter(filtered.accessions,

--- a/src/tests/class_tests/openms/data/AbsoluteQuantitationMethodFile_out.csv
+++ b/src/tests/class_tests/openms/data/AbsoluteQuantitationMethodFile_out.csv
@@ -1,9 +1,0 @@
-IS_name,component_name,feature_name,concentration_units,llod,ulod,lloq,uloq,correlation_coefficient,n_points,transformation_model,transformation_model_param_slope,transformation_model_param_intercept
-IS1,component1,feature1,uM,0,10,2,8,0.99,5,TransformationModelLinear,2,1
-IS2,component2,feature2,uM,1,9,3,7,0.98,4,TransformationModelLinear,2,2
-IS3,component3,feature3,uM,2,8,4,6,0.97,3,TransformationModelLinear,1,2
-,component4,feature4,uM,3,7,5,5,0.96,2,TransformationModelLinear,2,2
-IS5,,feature5,uM,4,6,6,4,0.95,1,TransformationModelLinear,2,1
-IS6,component6,feature6,uM,5,5,7,3,0.94,2,TransformationModelLinear,2,2
-,component 7,feature 7,,0,0,0,0,0,0,,0,2
-IS8,component8,feature8,uM,7,3,0,1,0.92,1,TransformationModelLinear,1,2

--- a/src/tests/class_tests/openms/data/CsvFile_3.csv
+++ b/src/tests/class_tests/openms/data/CsvFile_3.csv
@@ -1,3 +1,0 @@
-"hello"	"world"
-"the"	"dude"
-"spectral"	"search"

--- a/src/tests/class_tests/openms/data/CsvFile_4.csv
+++ b/src/tests/class_tests/openms/data/CsvFile_4.csv
@@ -1,2 +1,0 @@
-first,second,third
-4,5,6

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitationMethodFile_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitationMethodFile_test.cpp
@@ -63,7 +63,7 @@ AbsoluteQuantitationMethodFile* ptr = nullptr;
 AbsoluteQuantitationMethodFile* nullPointer = nullptr;
 const String in_file_1 = OPENMS_GET_TEST_DATA_PATH("AbsoluteQuantitationMethodFile_in_1.csv");
 const String in_file_2 = OPENMS_GET_TEST_DATA_PATH("AbsoluteQuantitationMethodFile_in_2.csv");
-const String out_file = OPENMS_GET_TEST_DATA_PATH("AbsoluteQuantitationMethodFile_out.csv");
+const String out_file = File::getTemporaryFile();
 
 START_SECTION((AbsoluteQuantitationMethodFile()))
 	ptr = new AbsoluteQuantitationMethodFile();

--- a/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
@@ -51,7 +51,6 @@ START_TEST(ChromeleonFile, "$Id$")
 ChromeleonFile* ptr = 0;
 ChromeleonFile* null_ptr = 0;
 const String input_filepath = OPENMS_GET_TEST_DATA_PATH("20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2.txt");
-const String output_filepath = OPENMS_GET_TEST_DATA_PATH("20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2.mzML");
 
 START_SECTION(ChromeleonFile())
 {
@@ -99,6 +98,7 @@ START_SECTION(void load(const String& filename, MSExperiment& experiment) const)
   TEST_REAL_SIMILAR(c[3300].getIntensity(), -0.130904)
 
   MzMLFile mzml;
+  const String output_filepath = File::getTemporaryFile();
   mzml.store(output_filepath, experiment);
   MSExperiment read_exp;
   mzml.load(output_filepath, read_exp);

--- a/src/tests/class_tests/openms/source/CsvFile_test.cpp
+++ b/src/tests/class_tests/openms/source/CsvFile_test.cpp
@@ -114,9 +114,10 @@ START_SECTION(void store(const String& filename))
 	CsvFile f1,f2;
 	StringList list;
 
-	f1.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_2.csv"),'\t',true); // load from a file
-	f1.store(OPENMS_GET_TEST_DATA_PATH("CsvFile_3.csv"));          // store into a new one
-	f2.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_3.csv"),'\t',true); // load the new one
+	f1.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_2.csv"), '\t', true); // load from a file
+	String tmpfile = File::getTemporaryFile();
+  f1.store(tmpfile);          // store into a new one
+	f2.load(tmpfile, '\t', true); // load the new one
 	f2.getRow(0,list);
 	TEST_EQUAL(list,ListUtils::create<String>("hello,world"))
 	f2.getRow(1,list);
@@ -131,9 +132,10 @@ START_SECTION(void addRow(const StringList& list))
 
 	f1.addRow(ListUtils::create<String>("first,second,third"));
 	f1.addRow(ListUtils::create<String>("4,5,6"));
-
-	f1.store(OPENMS_GET_TEST_DATA_PATH("CsvFile_4.csv"));
-	f2.load(OPENMS_GET_TEST_DATA_PATH("CsvFile_4.csv"), ',', false);
+  
+  String tmpfile = File::getTemporaryFile();
+	f1.store(tmpfile);
+	f2.load(tmpfile, ',', false);
 	f2.getRow(0,list);
 	TEST_EQUAL(list, ListUtils::create<String>("first,second,third"))
 	f2.getRow(1,list);

--- a/src/tests/topp/IDConflictResolver_3_output.consensusXML
+++ b/src/tests/topp/IDConflictResolver_3_output.consensusXML
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<?xml-stylesheet type="text/xsl" href="file:////nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/share/OpenMS/XSL/ConsensusXML.xsl"?>
+<?xml-stylesheet type="text/xsl" href="file:///C:/dev/openmsqt5/share/OpenMS/XSL/ConsensusXML.xsl"?>
 <consensusXML version="1.7" id="cm_6888843767287282833" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<dataProcessing completion_time="2017-04-21T15:32:16">
 		<software name="FeatureLinkerUnlabeledQT" version="2.1.0" />
@@ -403,11 +403,6 @@
 		</PeptideHit>
 		<UserParam type="string" name="feature_id" value="not mapped"/>
 	</UnassignedPeptideIdentification>
-	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75" RT="1586.72680664062" spectrum_reference="spectrum=2385" >
-		<UserParam type="int" name="spectrum_index" value="599"/>
-		<UserParam type="int" name="map_index" value="4"/>
-		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
-	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75048828125" RT="1525.90893554688" spectrum_reference="spectrum=2321" >
 		<UserParam type="int" name="spectrum_index" value="540"/>
 		<UserParam type="int" name="map_index" value="2"/>
@@ -426,6 +421,11 @@
 	<UnassignedPeptideIdentification identification_run_ref="PI_15" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75" RT="1586.72680664062" spectrum_reference="spectrum=2385" >
 		<UserParam type="int" name="spectrum_index" value="599"/>
 		<UserParam type="int" name="map_index" value="5"/>
+		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
+	</UnassignedPeptideIdentification>
+	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.749572753906" RT="1571.3095703125" spectrum_reference="spectrum=2463" >
+		<UserParam type="int" name="spectrum_index" value="585"/>
+		<UserParam type="int" name="map_index" value="0"/>
 		<UserParam type="string" name="feature_id" value="17962861576887891871"/>
 	</UnassignedPeptideIdentification>
 	<UnassignedPeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="531.220703125" RT="2365.1015625" spectrum_reference="spectrum=3126" >
@@ -529,9 +529,9 @@
 				<element map="4" id="5197685355969128079" rt="1595.95941974638" mz="763.749333898306" it="210602" charge="2"/>
 				<element map="5" id="17450310248252634930" rt="1595.95941974638" mz="763.749333898306" it="210602" charge="2"/>
 			</groupedElementList>
-			<PeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.749572753906" RT="1571.3095703125" spectrum_reference="spectrum=2463" >
-				<UserParam type="int" name="spectrum_index" value="585"/>
-				<UserParam type="int" name="map_index" value="0"/>
+			<PeptideIdentification identification_run_ref="PI_12" score_type="" higher_score_better="true" significance_threshold="0" MZ="763.75" RT="1586.72680664062" spectrum_reference="spectrum=2385" >
+				<UserParam type="int" name="spectrum_index" value="599"/>
+				<UserParam type="int" name="map_index" value="4"/>
 				<UserParam type="string" name="feature_id" value="17962861576887891871"/>
 			</PeptideIdentification>
 			<UserParam type="string" name="feature_id" value="17962861576887891871"/>

--- a/src/utils/XFDR.cpp
+++ b/src/utils/XFDR.cpp
@@ -793,6 +793,7 @@ protected:
       // Extract required attributes of the peptide_identification (filter criteria)
       PeptideIdentification & pep_id = all_ids[rank_one_ids[order_score[i]]];
 
+      assert(delta_scores.size() > rank_one_ids[order_score[i]]);
       double delta_score = delta_scores[rank_one_ids[order_score[i]]];
       Size ions_matched = n_min_ions_matched[order_score[i]];
 

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -54,7 +54,7 @@ echo.
 
 if not exist %SLN% (
   ECHO.
-  ECHO The .sln file '%SLN%' was not found. This script should be invoked from the root of the build tree after configuring with cmake (make sure you use one of the Visual Studio Generators and *not* the nmake Generator). Change CWD and try again!
+  ECHO The .sln file '%SLN%' was not found. This script should be invoked from the root of the build tree after configuring with cmake ^(make sure you use one of the Visual Studio Generators and *not* the nmake Generator^). Change CWD and try again!
   goto end
 )
 


### PR DESCRIPTION
I've been running the tests on Visual Studio in debug mode, and it found some quite alarming bugs, which are not caught by our CI/nightlies. We should think about running VS debug builds from time to time....
I fixed most things except for: This PR will make XFDR tests fail, but it only exposes the problem. 

 - fixes #3345 (temp test files in source tree)
 - fix less-operator in IDConflictResolver (needs to be strict weak ordering) @hendrikweisser: can you please verify it still does the right thing f762051 ?
 - fix segfault in LPWrapper (when adding empty row, the first element is accessed)
 - fix invalid set operation (intersection input needs to be sorted)
 - add assert (this will lead to failing XFDR tests, but highlights the issue) @lukaszimmermann: fb31e6f now exposes the segfaults, so XFDR tests will fail. Can you fix?
 - augments #3408 (which broke the script), not escaping special chars "()<>|"
