### PR TITLE
[FEATURE]/ PeptideIndexer auto mode for decoy string + position

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
@@ -55,7 +55,6 @@
 #include <atomic>
 #include <algorithm>
 #include <fstream>
-#include <boost/algorithm/string/find.hpp>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 
 namespace OpenMS
@@ -756,6 +755,7 @@ public:
                }
                else if (seq_lower.hasSuffix(pair.first))
                {
+                 // count observed (ignoring case)
                  decoy_count[pair.first].second++;
                  // store observed (case sensitive)
                  std::string seq_decoy = StringUtils::suffix(seq, pair.first.length());

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
@@ -202,7 +202,7 @@ public:
           return DECOYSTRING_EMPTY;
         }
 
-        proteins.reset(); // need to reset
+        proteins.reset(); // reset caching
       }
 
       //-------------------------------------------------------------
@@ -713,10 +713,10 @@ public:
        // Common decoy strings in fasta files. Used to determine if a protein is target/decoy automatically.
        // Note: decoy prefixes/suffices must be provided in lower case and must only contain alphanumeric characters
         MapDecoyStringToPrefixSuffixCount decoy_count = {{"decoy", {0,0}}, {"rev", {0,0}},
-                                                                 {"reverse", {0,0}}, {"dev", {0,0}},
-                                                                 {"iddecoy", {0,0}}, {"xxx", {0,0}},
-                                                                 {"shuffle", {0,0}}, {"shuffled", {0,0}},
-                                                                 {"random", {0,0}}};
+                                                          {"reverse", {0,0}}, {"dev", {0,0}},
+                                                          {"iddecoy", {0,0}}, {"xxx", {0,0}},
+                                                          {"shuffle", {0,0}}, {"shuffled", {0,0}},
+                                                          {"random", {0,0}}};
 
 
        // map case insensitive strings back to original case (as used in fasta)
@@ -728,7 +728,6 @@ public:
        {
          proteins.cacheChunk(PROTEIN_CACHE_SIZE);
          bool has_active_data = proteins.activateCache();
-
 
          if (!has_active_data) break;
          auto prot_count = (SignedSize)proteins.chunkSize();
@@ -768,7 +767,7 @@ public:
        }
 
        // DEBUG only: print counts of found decoys
-       for (auto & a : decoy_count) LOG_DEBUG << a.first << "\t" << a.second.first << "\t" << a.second.second << std::endl;
+       for (auto &a : decoy_count) LOG_DEBUG << a.first << "\t" << a.second.first << "\t" << a.second.second << std::endl;
 
        return determineDecoyStringFromCounts_(decoy_count, decoy_case_sensitive, decoy_string, is_prefix);
      }
@@ -794,7 +793,7 @@ public:
 
        if (all_prefix_occur == all_suffix_occur)
        {
-         LOG_ERROR << "Error: Unable to determine decoy string" << std::endl;
+         LOG_ERROR << "Unable to determine decoy string" << std::endl;
          return DECOYSTRING_EMPTY;
        }
 
@@ -816,7 +815,6 @@ public:
            }
 
          }
-
        }
 
        // if a decoy suffix occured at least 80% -> set it as suffix decoy
@@ -841,7 +839,7 @@ public:
 
        if (decoy_string.empty())
        {
-         LOG_ERROR << "Error: Unable to determine decoy string" << std::endl;
+         LOG_ERROR << "Unable to determine decoy string" << std::endl;
          return DECOYSTRING_EMPTY;
        }
 

--- a/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
@@ -198,7 +198,7 @@ public:
     return f_.atEnd() && offsets_.empty();
   }
 
-  /// reset
+  /// resets reading of the FASTA file, enables fresh reading of the FASTA from the beginning
   void reset()
   {
     f_.setPosition(0);
@@ -311,7 +311,7 @@ public:
     return data_.size();
   }
 
-  /// reset
+  /// required for template parameters!
   void reset()
   {
   }

--- a/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/FASTAContainer.h
@@ -198,6 +198,17 @@ public:
     return f_.atEnd() && offsets_.empty();
   }
 
+  /// reset
+  void reset()
+  {
+    f_.setPosition(0);
+    offsets_.clear();
+    data_fg_.clear();
+    data_bg_.clear();
+    chunk_offset_ = 0;
+  }
+
+
   /** @brief NOT the number of entries in the FASTA file, but merely the number of already read entries (since we do not know how many are still to come)
 
       @note Data in the background cache is included here, i.e. access to size()-1 using readAt() might be slow 
@@ -298,6 +309,11 @@ public:
   size_t size() const
   {
     return data_.size();
+  }
+
+  /// reset
+  void reset()
+  {
   }
 
 private:

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -43,7 +43,7 @@ using namespace std;
     : DefaultParamHandler("PeptideIndexing")
   {
 
-    defaults_.setValue("decoy_string", "", "String that was appended (or prefixed - see 'decoy_string_position' flag below) to the accessions in the protein database to indicate decoy proteins.");
+    defaults_.setValue("decoy_string", "", "String that was appended (or prefixed - see 'decoy_string_position' flag below) to the accessions in the protein database to indicate decoy proteins. Empty -> determined automatically");
 
     defaults_.setValue("decoy_string_position", "prefix", "Should the 'decoy_string' be prepended (prefix) or appended (suffix) to the protein accession?");
     defaults_.setValidStrings("decoy_string_position", ListUtils::create<String>("prefix,suffix"));

--- a/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideIndexing.cpp
@@ -43,7 +43,7 @@ using namespace std;
     : DefaultParamHandler("PeptideIndexing")
   {
 
-    defaults_.setValue("decoy_string", "DECOY_", "String that was appended (or prefixed - see 'decoy_string_position' flag below) to the accessions in the protein database to indicate decoy proteins.");
+    defaults_.setValue("decoy_string", "", "String that was appended (or prefixed - see 'decoy_string_position' flag below) to the accessions in the protein database to indicate decoy proteins.");
 
     defaults_.setValue("decoy_string_position", "prefix", "Should the 'decoy_string' be prepended (prefix) or appended (suffix) to the protein accession?");
     defaults_.setValidStrings("decoy_string_position", ListUtils::create<String>("prefix,suffix"));


### PR DESCRIPTION
Hey,

this PR introduces an automode for the PeptideIndexer. When no decoy string and/or prefix/suffix string is provided, then the decoy string + position will now be automatically determined. 

We scan the identifiers for a preset of decoy strings and increase each occurence.
If the occurence of a decoy string is >80% we'll use it as the decoy string, if it occured less than 100% we display a warning. 
Furthermore we determine whether the decoy string is prefix/suffix and set it accordingly. 

Up for discussion:
If you know any additional commonly or rarely used decoy strings, please tell me about them. I'll then happily add them.