### PR TITLE
Fix/pyopenms str

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/XQuestResultXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/XQuestResultXMLFile.h
@@ -97,7 +97,11 @@ public:
       * @param CrossLinkSpectrumMatches, from which the IDs were generated. Only spectra with matches are written out.
       * @param The spectra, that were searched as a PeakMap. The indices in spectrum_pairs correspond to spectra in this map.
       */
-      static void writeXQuestXMLSpec(String out_file, String base_name, const OPXLDataStructs::PreprocessedPairSpectra& preprocessed_pair_spectra, const std::vector< std::pair<Size, Size> >& spectrum_pairs, const std::vector< std::vector< OPXLDataStructs::CrossLinkSpectrumMatch > >& all_top_csms, const PeakMap& spectra);
+    static void writeXQuestXMLSpec(const String& out_file, const String& base_name,
+                                   const OPXLDataStructs::PreprocessedPairSpectra& preprocessed_pair_spectra,
+                                   const std::vector< std::pair<Size, Size> >& spectrum_pairs,
+                                   const std::vector< std::vector< OPXLDataStructs::CrossLinkSpectrumMatch > >& all_top_csms,
+                                   const PeakMap& spectra);
 
      /**
       * @brief Writes spec.xml output containing spectra for visualization. This version of the function is meant to be used for label-free linkers.
@@ -106,7 +110,9 @@ public:
       * @param CrossLinkSpectrumMatches, from which the IDs were generated. Only spectra with matches are written out.
       * @param The spectra, that were searched as a PeakMap.
       */
-      static void writeXQuestXMLSpec(String out_file, String base_name, const std::vector< std::vector< OPXLDataStructs::CrossLinkSpectrumMatch > >& all_top_csms, const PeakMap& spectra);
+    static void writeXQuestXMLSpec(const String& out_file, const String& base_name,
+                                   const std::vector< std::vector< OPXLDataStructs::CrossLinkSpectrumMatch > >& all_top_csms,
+                                   const PeakMap& spectra);
 
 
 

--- a/src/openms/source/FORMAT/XQuestResultXMLFile.cpp
+++ b/src/openms/source/FORMAT/XQuestResultXMLFile.cpp
@@ -89,7 +89,7 @@ namespace OpenMS
   }
 
   // version for labeled linkers
-  void XQuestResultXMLFile::writeXQuestXMLSpec(String out_file, String base_name, const OPXLDataStructs::PreprocessedPairSpectra& preprocessed_pair_spectra, const std::vector< std::pair<Size, Size> >& spectrum_pairs, const std::vector< std::vector< OPXLDataStructs::CrossLinkSpectrumMatch > >& all_top_csms, const PeakMap& spectra)
+  void XQuestResultXMLFile::writeXQuestXMLSpec(const String& out_file, const String& base_name, const OPXLDataStructs::PreprocessedPairSpectra& preprocessed_pair_spectra, const std::vector< std::pair<Size, Size> >& spectrum_pairs, const std::vector< std::vector< OPXLDataStructs::CrossLinkSpectrumMatch > >& all_top_csms, const PeakMap& spectra)
   {
     // XML Header
     std::ofstream spec_xml_file;
@@ -158,7 +158,7 @@ namespace OpenMS
   }
 
   // version for label-free linkers
-  void XQuestResultXMLFile::writeXQuestXMLSpec(String out_file, String base_name, const std::vector< std::vector< OPXLDataStructs::CrossLinkSpectrumMatch > >& all_top_csms, const PeakMap& spectra)
+  void XQuestResultXMLFile::writeXQuestXMLSpec(const String& out_file, const String& base_name, const std::vector< std::vector< OPXLDataStructs::CrossLinkSpectrumMatch > >& all_top_csms, const PeakMap& spectra)
   {
     // String spec_xml_filename = base_name + "_matched.spec.xml";
     // XML Header

--- a/src/pyOpenMS/pxds/AbsoluteQuantitation.pxd
+++ b/src/pyOpenMS/pxds/AbsoluteQuantitation.pxd
@@ -18,17 +18,17 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitation.h>" namespa
 
         void setQuantMethods(libcpp_vector[ AbsoluteQuantitationMethod ]& quant_methods) nogil except +
         libcpp_vector[ AbsoluteQuantitationMethod ] getQuantMethods() nogil except +
-        double calculateRatio(Feature & component_1, Feature & component_2, String & feature_name) nogil except +
+        double calculateRatio(Feature & component_1, Feature & component_2, const String & feature_name) nogil except +
         # double calculateBias(double actual_concentration, double calculated_concentration) nogil except +
-        double applyCalibration(Feature & component, Feature & IS_component, String & feature_name, 
-                                String & transformation_model, Param & transformation_model_params) nogil except +
+        double applyCalibration(const Feature & component, const Feature & IS_component, const String & feature_name, 
+                                const String & transformation_model, const Param & transformation_model_params) nogil except +
         void quantifyComponents(FeatureMap& unknowns) nogil except +
 
         bool optimizeCalibrationCurveIterative(
             libcpp_vector[ AQS_featureConcentration ] & component_concentrations,
-            String & feature_name,
-            String & transformation_model,
-            Param & transformation_model_params,
+            const String & feature_name,
+            const String & transformation_model,
+            const Param & transformation_model_params,
             Param & optimized_params) nogil except +
 
         void optimizeSingleCalibrationCurve(

--- a/src/pyOpenMS/pxds/AbsoluteQuantitationMethod.pxd
+++ b/src/pyOpenMS/pxds/AbsoluteQuantitationMethod.pxd
@@ -23,17 +23,17 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h>" n
         void checkLOD(double value) nogil except +
         void checkLOQ(double value) nogil except +
         
-        void setComponentName(String& component_name) nogil except +
-        void setISName(String& IS_name) nogil except +
-        void setFeatureName(String& feature_name) nogil except +
+        void setComponentName(const String& component_name) nogil except +
+        void setISName(const String& IS_name) nogil except +
+        void setFeatureName(const String& feature_name) nogil except +
         String getComponentName() nogil except +
         String getISName() nogil except +
         String getFeatureName() nogil except +
 
-        void setConcentrationUnits(String& concentration_units) nogil except +
+        void setConcentrationUnits(const String& concentration_units) nogil except +
         String getConcentrationUnits() nogil except +
 
-        void setTransformationModel(String& transformation_model) nogil except +
+        void setTransformationModel(const String& transformation_model) nogil except +
         void setTransformationModelParams(Param transformation_model_param) nogil except +
         String getTransformationModel() nogil except +
         Param getTransformationModelParams() nogil except +

--- a/src/pyOpenMS/pxds/AccurateMassSearchResult.pxd
+++ b/src/pyOpenMS/pxds/AccurateMassSearchResult.pxd
@@ -31,9 +31,9 @@ cdef extern from "<OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h>" namespace "Op
         double getMatchingIndex() nogil except +
         void setMatchingIndex(double & idx) nogil except +
         String getFoundAdduct() nogil except +
-        void setFoundAdduct(String & add) nogil except +
+        void setFoundAdduct(const String & add) nogil except +
         String getFormulaString() nogil except +
-        void setEmpiricalFormula(String & ep) nogil except +
+        void setEmpiricalFormula(const String & ep) nogil except +
         libcpp_vector[ String ] getMatchingHMDBids() nogil except +
         void setMatchingHMDBids(libcpp_vector[ String ] & match_ids) nogil except +
         double getIsotopesSimScore() nogil except +

--- a/src/pyOpenMS/pxds/Acquisition.pxd
+++ b/src/pyOpenMS/pxds/Acquisition.pxd
@@ -8,6 +8,6 @@ cdef extern from "<OpenMS/METADATA/Acquisition.h>" namespace "OpenMS":
         Acquisition(Acquisition) nogil except +
         bool operator==(Acquisition &rhs) nogil except +
         bool operator!=(Acquisition &rhs) nogil except +
-        String  getIdentifier() nogil except +
-        void setIdentifier(String &identifier) nogil except +
+        String getIdentifier() nogil except +
+        void setIdentifier(const String &identifier) nogil except +
 

--- a/src/pyOpenMS/pxds/AdductInfo.pxd
+++ b/src/pyOpenMS/pxds/AdductInfo.pxd
@@ -14,12 +14,12 @@ cdef extern from "<OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h>" namespace "Op
     cdef cppclass AMSE_AdductInfo "OpenMS::AdductInfo":
 
         AMSE_AdductInfo(AMSE_AdductInfo) nogil except + #wrap-ignore
-        AMSE_AdductInfo(String & name, EmpiricalFormula & adduct, int charge, UInt mol_multiplier) nogil except +
+        AMSE_AdductInfo(const String & name, EmpiricalFormula & adduct, int charge, UInt mol_multiplier) nogil except +
 
         double getNeutralMass(double observed_mz) nogil except +
         double getMZ(double neutral_mass) nogil except +
         bool isCompatible(EmpiricalFormula db_entry) nogil except +
         int getCharge() nogil except +
         String getName() nogil except +
-        # AMSE_AdductInfo parseAdductString(String & adduct) nogil except +
+        # AMSE_AdductInfo parseAdductString(const String & adduct) nogil except +
 

--- a/src/pyOpenMS/pxds/Base64.pxd
+++ b/src/pyOpenMS/pxds/Base64.pxd
@@ -25,4 +25,3 @@ cdef extern from "<OpenMS/FORMAT/Base64.h>" namespace "OpenMS::Base64":
         #    Base64
         BYTEORDER_BIGENDIAN
         BYTEORDER_LITTLEENDIAN
-

--- a/src/pyOpenMS/pxds/Base64.pxd
+++ b/src/pyOpenMS/pxds/Base64.pxd
@@ -10,12 +10,12 @@ cdef extern from "<OpenMS/FORMAT/Base64.h>" namespace "OpenMS":
         Base64(Base64) nogil except + #wrap-ignore
 
         void encode(libcpp_vector[ double ] & in_, ByteOrder to_byte_order, String &out, bool zlib_compression) nogil except +
-        void decode(String & in_, ByteOrder from_byte_order, libcpp_vector[ double ] &out, bool zlib_compression) nogil except +
+        void decode(const String & in_, ByteOrder from_byte_order, libcpp_vector[ double ] &out, bool zlib_compression) nogil except +
         void encodeIntegers(libcpp_vector[ int ] & in_, ByteOrder to_byte_order, String &out, bool zlib_compression) nogil except +
-        void decodeIntegers(String & in_, ByteOrder from_byte_order, libcpp_vector[ int ] &out, bool zlib_compression) nogil except +
+        void decodeIntegers(const String & in_, ByteOrder from_byte_order, libcpp_vector[ int ] &out, bool zlib_compression) nogil except +
 
         void encodeStrings(libcpp_vector[ String ] & in_, String &out, bool zlib_compression) nogil except +
-        void decodeStrings(String & in_, libcpp_vector[ String ] &out, bool zlib_compression) nogil except +
+        void decodeStrings(const String & in_, libcpp_vector[ String ] &out, bool zlib_compression) nogil except +
 
         # void decodeSingleString(const String & in, QByteArray & base64_uncompressed, bool zlib_compression);
 

--- a/src/pyOpenMS/pxds/CVMappingFile.pxd
+++ b/src/pyOpenMS/pxds/CVMappingFile.pxd
@@ -9,5 +9,5 @@ cdef extern from "<OpenMS/FORMAT/CVMappingFile.h>" namespace "OpenMS":
 
         CVMappingFile() nogil except +
         # CVMappingFile(CVMappingFile) nogil except + # private
-        void load(String & filename, CVMappings & cv_mappings, bool strip_namespaces) nogil except +
+        void load(const String & filename, CVMappings & cv_mappings, bool strip_namespaces) nogil except +
 

--- a/src/pyOpenMS/pxds/CVMappings.pxd
+++ b/src/pyOpenMS/pxds/CVMappings.pxd
@@ -9,11 +9,11 @@ cdef extern from "<OpenMS/DATASTRUCTURES/CVMappings.h>" namespace "OpenMS":
 
         CVMappings() nogil except +
         CVMappings(CVMappings) nogil except +
-        void setMappingRules(libcpp_vector[ CVMappingRule ] &cv_mapping_rules) nogil except +
+        void setMappingRules(libcpp_vector[ CVMappingRule ]& cv_mapping_rules) nogil except +
         libcpp_vector[ CVMappingRule ]  getMappingRules() nogil except +
-        void addMappingRule(CVMappingRule &cv_mapping_rule) nogil except +
-        void setCVReferences(libcpp_vector[ CVReference ] &cv_references) nogil except +
-        libcpp_vector[ CVReference ]  getCVReferences() nogil except +
-        void addCVReference(CVReference &cv_reference) nogil except +
-        bool hasCVReference(String &identifier) nogil except +
+        void addMappingRule(CVMappingRule& cv_mapping_rule) nogil except +
+        void setCVReferences(libcpp_vector[ CVReference ]& cv_references) nogil except +
+        libcpp_vector[ CVReference ] getCVReferences() nogil except +
+        void addCVReference(CVReference& cv_reference) nogil except +
+        bool hasCVReference(const String& identifier) nogil except +
 

--- a/src/pyOpenMS/pxds/CVReference.pxd
+++ b/src/pyOpenMS/pxds/CVReference.pxd
@@ -7,10 +7,10 @@ cdef extern from "<OpenMS/DATASTRUCTURES/CVReference.h>" namespace "OpenMS":
     cdef cppclass CVReference "OpenMS::CVReference":
         CVReference() nogil except +
         CVReference(CVReference) nogil except +
-        void setName(String &name) nogil except +
-        String  getName() nogil except +
-        void setIdentifier(String &identifier) nogil except +
-        String  getIdentifier() nogil except +
+        void setName(const String &name) nogil except +
+        String getName() nogil except +
+        void setIdentifier(const String &identifier) nogil except +
+        String getIdentifier() nogil except +
         bool operator==(CVReference &rhs) nogil except +
         bool operator!=(CVReference &rhs) nogil except +
 

--- a/src/pyOpenMS/pxds/CVTerm.pxd
+++ b/src/pyOpenMS/pxds/CVTerm.pxd
@@ -36,7 +36,7 @@ cdef extern from "<OpenMS/METADATA/CVTerm.h>" namespace "OpenMS::CVTerm":
         String accession
         String name
         String cv_ref
-        Unit(String & p_accession, String & p_name, String & p_cv_ref) nogil except +
+        Unit(const String & p_accession, const String & p_name, const String & p_cv_ref) nogil except +
         bool operator==(Unit & rhs) nogil except +
         bool operator!=(Unit & rhs) nogil except +
 

--- a/src/pyOpenMS/pxds/CVTermListInterface.pxd
+++ b/src/pyOpenMS/pxds/CVTermListInterface.pxd
@@ -17,11 +17,11 @@ cdef extern from "<OpenMS/METADATA/CVTermListInterface.h>" namespace "OpenMS":
         void replaceCVTerms(Map[ String, libcpp_vector[ CVTerm ] ] & cv_terms) nogil except +
         void setCVTerms(libcpp_vector[ CVTerm ] & terms) nogil except +
         void replaceCVTerm(CVTerm & cv_term) nogil except +
-        void replaceCVTerms(libcpp_vector[ CVTerm ] & cv_terms, String & accession) nogil except +
+        void replaceCVTerms(libcpp_vector[ CVTerm ] & cv_terms, const String & accession) nogil except +
         # void replaceCVTerms(Map[ String, libcpp_vector[ CVTerm ] ] & cv_term_map) nogil except +
         void consumeCVTerms(Map[ String, libcpp_vector[ CVTerm ] ] & cv_term_map) nogil except +
         Map[ String, libcpp_vector[ CVTerm ] ]  getCVTerms() nogil except +
         void addCVTerm(CVTerm & term) nogil except +
-        bool hasCVTerm(String & accession) nogil except +
+        bool hasCVTerm(const String & accession) nogil except +
         bool empty() nogil except +
 

--- a/src/pyOpenMS/pxds/ConsensusMapNormalizerAlgorithmMedian.pxd
+++ b/src/pyOpenMS/pxds/ConsensusMapNormalizerAlgorithmMedian.pxd
@@ -14,5 +14,12 @@ cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmMe
         ConsensusMapNormalizerAlgorithmMedian() nogil except +
         ConsensusMapNormalizerAlgorithmMedian(ConsensusMapNormalizerAlgorithmMedian) nogil except + #wrap-ignore
 
-        Size computeMedians(ConsensusMap & input_map, libcpp_vector[double] & medians, String & acc_filter, String & desc_filter) nogil except +
-        void normalizeMaps(ConsensusMap & input_map, NormalizationMethod method, String & acc_filter, String & desc_filter) nogil except +
+        Size computeMedians(ConsensusMap & input_map,
+                            libcpp_vector[double] & medians,
+                            const String & acc_filter,
+                            const String & desc_filter) nogil except +
+
+        void normalizeMaps(ConsensusMap & input_map,
+                           NormalizationMethod method,
+                           const String & acc_filter,
+                           const String & desc_filter) nogil except +

--- a/src/pyOpenMS/pxds/ConsensusMapNormalizerAlgorithmThreshold.pxd
+++ b/src/pyOpenMS/pxds/ConsensusMapNormalizerAlgorithmThreshold.pxd
@@ -8,6 +8,11 @@ cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmTh
         ConsensusMapNormalizerAlgorithmThreshold() nogil except +
         ConsensusMapNormalizerAlgorithmThreshold(ConsensusMapNormalizerAlgorithmThreshold) nogil except + #wrap-ignore
 
-        libcpp_vector[double] computeCorrelation(ConsensusMap & input_map, double ratio_threshold, String & acc_filter, String & desc_filter) nogil except +
-        void normalizeMaps(ConsensusMap & input_map, libcpp_vector[double] & ratios) nogil except +
+        libcpp_vector[double] computeCorrelation(ConsensusMap & input_map,
+                                                 double ratio_threshold,
+                                                 const String & acc_filter,
+                                                 const String & desc_filter) nogil except +
+
+        void normalizeMaps(ConsensusMap & input_map,
+                           libcpp_vector[double] & ratios) nogil except +
 

--- a/src/pyOpenMS/pxds/CrossLinksDB.pxd
+++ b/src/pyOpenMS/pxds/CrossLinksDB.pxd
@@ -21,23 +21,23 @@ cdef extern from "<OpenMS/CHEMISTRY/CrossLinksDB.h>" namespace "OpenMS":
                                  String mod_name, String residue,
                                  TermSpecificity term_spec) nogil except +
 
-        ResidueModification getModification(String & mod_name, String & residue, TermSpecificity term_spec) nogil except +
+        ResidueModification getModification(const String & mod_name, const String & residue, TermSpecificity term_spec) nogil except +
 
         bool has(String modification) nogil except +
 
         void addModification(ResidueModification * new_mod) nogil except +
 
-        Size findModificationIndex(String & mod_name) nogil except +
+        Size findModificationIndex(const String & mod_name) nogil except +
 
         void searchModificationsByDiffMonoMass(libcpp_vector[ String ] & mods, double mass, double max_error,
-                                               String & residue, TermSpecificity term_spec) nogil except +
+                                               const String & residue, TermSpecificity term_spec) nogil except +
 
         const ResidueModification* getBestModificationByMonoMass(double mass, double max_error,
-                                                           String residue,
-                                                           TermSpecificity term_spec) nogil except +
+                                                                 const String residue,
+                                                                 TermSpecificity term_spec) nogil except +
 
         const ResidueModification* getBestModificationByDiffMonoMass(double mass, double max_error,
-                                                               String residue, TermSpecificity term_spec) nogil except +
+                                                                     const String residue, TermSpecificity term_spec) nogil except +
 
         void getAllSearchModifications(libcpp_vector[ String ] & modifications) nogil except +
 

--- a/src/pyOpenMS/pxds/DataFilters.pxd
+++ b/src/pyOpenMS/pxds/DataFilters.pxd
@@ -34,7 +34,7 @@ cdef extern from "<OpenMS/FILTERING/DATAREDUCTION/DataFilters.h>" namespace "Ope
         String meta_name
         bool value_is_numerical
         String toString() nogil except +
-        void fromString(String & filter_) nogil except +
+        void fromString(const String & filter_) nogil except +
         bool operator==(DataFilter & rhs) nogil except +
         bool operator!=(DataFilter & rhs) nogil except +
 

--- a/src/pyOpenMS/pxds/DataValue.pxd
+++ b/src/pyOpenMS/pxds/DataValue.pxd
@@ -33,7 +33,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/DataValue.h>" namespace "OpenMS":
          bool toBool() nogil except +
          bool hasUnit() nogil except +
          String  getUnit() nogil except +
-         void setUnit(String & unit) nogil except +
+         void setUnit(const String & unit) nogil except +
 
 cdef extern from "<OpenMS/DATASTRUCTURES/DataValue.h>" namespace "OpenMS::DataValue":
 

--- a/src/pyOpenMS/pxds/Date.pxd
+++ b/src/pyOpenMS/pxds/Date.pxd
@@ -8,7 +8,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/Date.h>" namespace "OpenMS":
         Date() nogil except +
         Date(Date) nogil except + # wrap-ignore
 
-        void set(String & date) nogil except +
+        void set(const String & date) nogil except +
         # void set(UInt month, UInt day, UInt year);
 
         Date today() nogil except +

--- a/src/pyOpenMS/pxds/DefaultParamHandler.pxd
+++ b/src/pyOpenMS/pxds/DefaultParamHandler.pxd
@@ -8,7 +8,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/DefaultParamHandler.h>" namespace "Open
         #wrap-ignore
         #no-pxd-import
 
-        # DefaultParamHandler(String & name) nogil except +
+        # DefaultParamHandler(const String & name) nogil except +
         # DefaultParamHandler(DefaultParamHandler & rhs) nogil except +
         # libcpp_vector[ String ] getSubsections() nogil except +
 
@@ -16,4 +16,4 @@ cdef extern from "<OpenMS/DATASTRUCTURES/DefaultParamHandler.h>" namespace "Open
         Param getParameters()  nogil except +
         Param getDefaults()  nogil except +
         String getName()  nogil except +
-        void setName(String)  nogil except +
+        void setName(const String&)  nogil except +

--- a/src/pyOpenMS/pxds/Digestion.pxd
+++ b/src/pyOpenMS/pxds/Digestion.pxd
@@ -11,7 +11,7 @@ cdef extern from "<OpenMS/METADATA/Digestion.h>" namespace "OpenMS":
         # bool operator==(SampleTreatment &rhs) nogil except +
         # SampleTreatment * clone() nogil except +
         String  getEnzyme() nogil except +
-        void setEnzyme(String &enzyme) nogil except +
+        void setEnzyme(const String& enzyme) nogil except +
         double getDigestionTime() nogil except +
         void setDigestionTime(double digestion_time) nogil except +
         double getTemperature() nogil except +

--- a/src/pyOpenMS/pxds/ElementDB.pxd
+++ b/src/pyOpenMS/pxds/ElementDB.pxd
@@ -17,9 +17,9 @@ cdef extern from "<OpenMS/CHEMISTRY/ElementDB.h>" namespace "OpenMS":
         # const Map[ String, Element * ]  getNames() nogil except +
         # const Map[ String, Element * ] getSymbols() nogil except +
         # const Map[unsigned int, Element * ] getAtomicNumbers() nogil except +
-        const Element * getElement(String & name) nogil except +
+        const Element * getElement(const String & name) nogil except +
         const Element * getElement(UInt atomic_number) nogil except +
-        bool hasElement(String & name) nogil except +
+        bool hasElement(const String & name) nogil except +
         bool hasElement(UInt atomic_number) nogil except +
 
 ## wrap static methods

--- a/src/pyOpenMS/pxds/EnzymaticDigestionLogModel.pxd
+++ b/src/pyOpenMS/pxds/EnzymaticDigestionLogModel.pxd
@@ -12,7 +12,7 @@ cdef extern from "<OpenMS/CHEMISTRY/EnzymaticDigestionLogModel.h>" namespace "Op
       # not wrapped due to name clash with Enzyme.h
       # Enzyme getEnzyme()  nogil except +
       # void setEnzyme(Enzyme enzyme) nogil except +
-      # Enzyme getEnzymeByName(String & name) nogil except +
+      # Enzyme getEnzymeByName(String name) nogil except +
 
       String getEnzymeName() nogil except +
       void setEnzyme(String name) nogil except +

--- a/src/pyOpenMS/pxds/ExperimentalDesign.pxd
+++ b/src/pyOpenMS/pxds/ExperimentalDesign.pxd
@@ -8,7 +8,7 @@ cdef extern from "<OpenMS/METADATA/ExperimentalDesign.h>" namespace "OpenMS":
         libcpp_vector[ ExperimentalDesign_MSRun] runs
         # libcpp_map[ unsigned, libcpp_set[unsigned] ] getFractionToRunsMapping() nogil except +
         bool sameNrOfRunsPerFraction() nogil except +
-        void load(String & tsv_file, ExperimentalDesign & design) nogil except +
+        void load(const String & tsv_file, ExperimentalDesign & design) nogil except +
 
 cdef extern from "<OpenMS/METADATA/ExperimentalDesign.h>" namespace "OpenMS::ExperimentalDesign":
     

--- a/src/pyOpenMS/pxds/FASTAFile.pxd
+++ b/src/pyOpenMS/pxds/FASTAFile.pxd
@@ -15,8 +15,8 @@ cdef extern from "<OpenMS/FORMAT/FASTAFile.h>" namespace "OpenMS":
         FASTAFile() nogil except +
         FASTAFile(FASTAFile) nogil except + #wrap-ignore
 
-        void load(String& filename, libcpp_vector[FASTAEntry] & data) nogil except +
-        void store(String& filename, libcpp_vector[FASTAEntry] & data) nogil except +
+        void load(const String& filename, libcpp_vector[FASTAEntry] & data) nogil except +
+        void store(const String& filename, libcpp_vector[FASTAEntry] & data) nogil except +
 
 
 cdef extern from "<OpenMS/FORMAT/FASTAFile.h>" namespace "OpenMS::FASTAFile":

--- a/src/pyOpenMS/pxds/File.pxd
+++ b/src/pyOpenMS/pxds/File.pxd
@@ -79,7 +79,7 @@ cdef extern from "<OpenMS/SYSTEM/File.h>" namespace "OpenMS::File":
     # Searchs for an executable with the given name.
     String findExecutable(String toolName) nogil except + # wrap-attach:File
 
-    String getTemporaryFile(String & alternative_file) nogil except + # wrap-attach:File
+    String getTemporaryFile(const String & alternative_file) nogil except + # wrap-attach:File
 
     # Resolves a partial file name to a documentation file in the doc-folder.
     String findDoc(String filename) nogil except + # wrap-attach:File

--- a/src/pyOpenMS/pxds/FileHandler.pxd
+++ b/src/pyOpenMS/pxds/FileHandler.pxd
@@ -24,10 +24,10 @@ cdef extern from "<OpenMS/FORMAT/FileHandler.h>" namespace "OpenMS":
 #
 cdef extern from "<OpenMS/FORMAT/FileHandler.h>" namespace "OpenMS::FileHandler":
 
-    int getType(String filename) nogil except + # wrap-attach:FileHandler
-    FileType getTypeByFileName(String & filename) nogil except + # wrap-attach:FileHandler 
-    FileType getTypeByContent(String & filename) nogil except + # wrap-attach:FileHandler 
-    String computeFileHash(String & filename) nogil except + # wrap-attach:FileHandler 
+    int getType(const String& filename) nogil except + # wrap-attach:FileHandler
+    FileType getTypeByFileName(const String & filename) nogil except + # wrap-attach:FileHandler 
+    FileType getTypeByContent(const String & filename) nogil except + # wrap-attach:FileHandler 
+    String computeFileHash(const String & filename) nogil except + # wrap-attach:FileHandler 
     bool isSupported(FileType type_) nogil except + # wrap-attach:FileHandler 
-    bool hasValidExtension(String & filename, FileType type_) nogil except + # wrap-attach:FileHandler 
+    bool hasValidExtension(const String & filename, FileType type_) nogil except + # wrap-attach:FileHandler 
 

--- a/src/pyOpenMS/pxds/HiddenMarkovModel.pxd
+++ b/src/pyOpenMS/pxds/HiddenMarkovModel.pxd
@@ -9,28 +9,28 @@ cdef extern from "<OpenMS/ANALYSIS/ID/HiddenMarkovModel.h>" namespace "OpenMS":
     cdef cppclass HiddenMarkovModel "OpenMS::HiddenMarkovModel":
         HiddenMarkovModel() nogil except +
         HiddenMarkovModel(HiddenMarkovModel) nogil except +
-        void writeGraphMLFile(String & filename) nogil except +
+        void writeGraphMLFile(const String & filename) nogil except +
         # NAMESPACE # void write(std::ostream & out) nogil except +
-        double getTransitionProbability(String & s1, String & s2) nogil except +
-        void setTransitionProbability(String & s1, String & s2, double prob) nogil except +
+        double getTransitionProbability(const String & s1, const String & s2) nogil except +
+        void setTransitionProbability(const String & s1, const String & s2, double prob) nogil except +
         Size getNumberOfStates() nogil except +
         void addNewState(HMMState * state) nogil except +
-        void addNewState(String & name) nogil except +
-        void addSynonymTransition(String & name1, String & name2, String & synonym1, String & synonym2) nogil except +
+        void addNewState(const String & name) nogil except +
+        void addSynonymTransition(const String & name1, const String & name2, const String & synonym1, const String & synonym2) nogil except +
         void evaluate() nogil except +
         void train() nogil except +
-        void setInitialTransitionProbability(String & state, double prob) nogil except +
+        void setInitialTransitionProbability(const String & state, double prob) nogil except +
         void clearInitialTransitionProbabilities() nogil except +
-        void setTrainingEmissionProbability(String & state, double prob) nogil except +
+        void setTrainingEmissionProbability(const String & state, double prob) nogil except +
         void clearTrainingEmissionProbabilities() nogil except +
-        void enableTransition(String & s1, String & s2) nogil except +
-        void disableTransition(String & s1, String & s2) nogil except +
+        void enableTransition(const String & s1, const String & s2) nogil except +
+        void disableTransition(const String & s1, const String & s2) nogil except +
         void disableTransitions() nogil except +
         # POINTER # void calculateEmissionProbabilities(Map[ HMMState *, double ] & emission_probs) nogil except +
         void dump() nogil except +
         void forwardDump() nogil except +
         void estimateUntrainedTransitions() nogil except +
-        HMMState * getState(String & name) nogil except +
+        HMMState * getState(const String & name) nogil except +
         void clear() nogil except +
         void setPseudoCounts(double pseudo_counts) nogil except +
         double getPseudoCounts() nogil except +
@@ -41,14 +41,14 @@ cdef extern from "<OpenMS/ANALYSIS/ID/HiddenMarkovModel.h>" namespace "OpenMS":
     cdef cppclass HMMState "OpenMS::HMMState":
         HMMState() nogil except +
         HMMState(HMMState) nogil except +
-        HMMState(String & name, bool hidden) nogil except +
+        HMMState(const String & name, bool hidden) nogil except +
 
         # They dont exist ...
         # bool operator==(HMMState) nogil except +
         # bool operator!=(HMMState) nogil except +
 
-        void setName(String & name) nogil except +
-        String  getName() nogil except +
+        void setName(const String & name) nogil except +
+        String getName() nogil except +
         void setHidden(bool hidden) nogil except +
         bool isHidden() nogil except +
         void addPredecessorState(HMMState * state) nogil except +

--- a/src/pyOpenMS/pxds/IBSpectraFile.pxd
+++ b/src/pyOpenMS/pxds/IBSpectraFile.pxd
@@ -7,4 +7,4 @@ cdef extern from "<OpenMS/FORMAT/IBSpectraFile.h>" namespace "OpenMS":
     cdef cppclass IBSpectraFile "OpenMS::IBSpectraFile":
         IBSpectraFile() nogil except +
         IBSpectraFile(IBSpectraFile) nogil except +
-        void store(String & filename, ConsensusMap & cm) nogil except +
+        void store(const String & filename, ConsensusMap & cm) nogil except +

--- a/src/pyOpenMS/pxds/IDFilter.pxd
+++ b/src/pyOpenMS/pxds/IDFilter.pxd
@@ -75,7 +75,7 @@ cdef extern from "<OpenMS/FILTERING/ID/IDFilter.h>" namespace "OpenMS":
 
         void filterPeptidesByMZError(libcpp_vector[PeptideIdentification]& peptides, double mass_error, bool unit_ppm) nogil except +
 
-        void filterPeptidesByRTPredictPValue(libcpp_vector[PeptideIdentification]& peptides, String& metavalue_key, double threshold) nogil except +
+        void filterPeptidesByRTPredictPValue(libcpp_vector[PeptideIdentification]& peptides, const String& metavalue_key, double threshold) nogil except +
 
         void removePeptidesWithMatchingModifications(libcpp_vector[PeptideIdentification]& peptides, libcpp_set[String]& modifications) nogil except +
 

--- a/src/pyOpenMS/pxds/IncludeExcludeTarget.pxd
+++ b/src/pyOpenMS/pxds/IncludeExcludeTarget.pxd
@@ -9,11 +9,11 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/IncludeExcludeTarget.h>" namespace "
     cdef cppclass IncludeExcludeTarget :
         IncludeExcludeTarget() nogil except +
         IncludeExcludeTarget(IncludeExcludeTarget) nogil except +
-        void setName(String & name) nogil except +
+        void setName(const String & name) nogil except +
         String  getName() nogil except +
-        void setPeptideRef(String & peptide_ref) nogil except +
+        void setPeptideRef(const String & peptide_ref) nogil except +
         String  getPeptideRef() nogil except +
-        void setCompoundRef(String & compound_ref) nogil except +
+        void setCompoundRef(const String & compound_ref) nogil except +
         String  getCompoundRef() nogil except +
         void setPrecursorMZ(double mz) nogil except +
         double getPrecursorMZ() nogil except +

--- a/src/pyOpenMS/pxds/InclusionExclusionList.pxd
+++ b/src/pyOpenMS/pxds/InclusionExclusionList.pxd
@@ -13,7 +13,7 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/InclusionExclusionList.h>" namespace
         #  DefaultParamHandler
         InclusionExclusionList() nogil except +
         InclusionExclusionList(InclusionExclusionList) nogil except + #wrap-ignore
-        void writeTargets(libcpp_vector[ FASTAEntry ] & fasta_entries, String & out_path, IntList & charges, String rt_model_path) nogil except +
-        void writeTargets(FeatureMap & map_, String & out_path) nogil except +
-        void writeTargets(libcpp_vector[ PeptideIdentification ] & pep_ids, String & out_path, IntList & charges) nogil except +
+        void writeTargets(libcpp_vector[ FASTAEntry ] & fasta_entries, const String & out_path, IntList & charges, const String rt_model_path) nogil except +
+        void writeTargets(FeatureMap & map_, const String & out_path) nogil except +
+        void writeTargets(libcpp_vector[ PeptideIdentification ] & pep_ids, const String & out_path, IntList & charges) nogil except +
 

--- a/src/pyOpenMS/pxds/InspectInfile.pxd
+++ b/src/pyOpenMS/pxds/InspectInfile.pxd
@@ -12,14 +12,14 @@ cdef extern from "<OpenMS/FORMAT/InspectInfile.h>" namespace "OpenMS":
         InspectInfile(InspectInfile) nogil except +
 
         bool operator==(InspectInfile & inspect_infile) nogil except +
-        void store(String & filename) nogil except +
-        void handlePTMs(String & modification_line, String & modifications_filename, bool monoisotopic) nogil except +
+        void store(const String & filename) nogil except +
+        void handlePTMs(const String & modification_line, const String & modifications_filename, bool monoisotopic) nogil except +
         String  getSpectra() nogil except +
-        void setSpectra(String & spectra) nogil except +
+        void setSpectra(const String & spectra) nogil except +
         String  getDb() nogil except +
-        void setDb(String & db) nogil except +
+        void setDb(const String & db) nogil except +
         String  getEnzyme() nogil except +
-        void setEnzyme(String & enzyme) nogil except +
+        void setEnzyme(const String & enzyme) nogil except +
         Int getModificationsPerPeptide() nogil except +
         void setModificationsPerPeptide(Int modifications_per_peptide) nogil except +
         UInt getBlind() nogil except +
@@ -33,7 +33,7 @@ cdef extern from "<OpenMS/FORMAT/InspectInfile.h>" namespace "OpenMS":
         UInt getMulticharge() nogil except +
         void setMulticharge(UInt multicharge) nogil except +
         String  getInstrument() nogil except +
-        void setInstrument(String & instrument) nogil except +
+        void setInstrument(const String & instrument) nogil except +
         Int getTagCount() nogil except +
         void setTagCount(Int TagCount) nogil except +
 

--- a/src/pyOpenMS/pxds/InspectOutfile.pxd
+++ b/src/pyOpenMS/pxds/InspectOutfile.pxd
@@ -16,41 +16,58 @@ cdef extern from "<OpenMS/FORMAT/InspectOutfile.h>" namespace "OpenMS":
 
         bool operator==(InspectOutfile & inspect_outfile) nogil except +
 
-        libcpp_vector[ size_t ] load(String & result_filename, 
+        libcpp_vector[ size_t ] load(const String & result_filename, 
                                      libcpp_vector[ PeptideIdentification ] & peptide_identifications,
                                      ProteinIdentification & protein_identification, double
-                                     p_value_threshold, String & database_filename) nogil except +
+                                     p_value_threshold, const String & database_filename) nogil except +
 
-        libcpp_vector[ size_t ] getWantedRecords(String & result_filename,
+        libcpp_vector[ size_t ] getWantedRecords(const String & result_filename,
                                                  double p_value_threshold) nogil except +
 
-        void compressTrieDB(String & database_filename, String &
+        void compressTrieDB(const String & database_filename, const String &
                             index_filename, libcpp_vector[ size_t ] &
-                            wanted_records, String & snd_database_filename,
-                            String & snd_index_filename, bool append) nogil except +
+                            wanted_records, const String & snd_database_filename,
+                            const String & snd_index_filename, bool append) nogil except +
 
-        void generateTrieDB(String & source_database_filename, String &
-                            database_filename, String & index_filename, bool
-                            append, String species) nogil except +
+        void generateTrieDB(const String & source_database_filename, const String &
+                            database_filename, const String & index_filename, bool
+                            append, const String species) nogil except +
 
-        void getACAndACType(String line, String & accession, String & accession_type) nogil except +
+        void getACAndACType(String line,
+                            String & accession,
+                            String & accession_type) nogil except +
 
         # TODO mixed, nested STL
         void getPrecursorRTandMZ(
             libcpp_vector[ libcpp_pair[ String, libcpp_vector[ libcpp_pair[ size_t, size_t ] ] ] ] & files_and_peptide_identification_with_scan_number,
             libcpp_vector[ PeptideIdentification ] & ids) nogil except + # wrap-ignore
 
-        void getLabels(String & source_database_filename, String & ac_label,
-                       String & sequence_start_label, String & sequence_end_label,
-                       String & comment_label, String & species_label) nogil except +
+        void getLabels(const String & source_database_filename,
+                       String & ac_label,
+                       String & sequence_start_label,
+                       String & sequence_end_label,
+                       String & comment_label,
+                       String & species_label) nogil except +
 
-        libcpp_vector[ size_t ] getSequences(String & database_filename,
+        libcpp_vector[ size_t ] getSequences(const String & database_filename,
                                              libcpp_map[ size_t, size_t ] & wanted_records,
                                              libcpp_vector[ String ] & sequences) nogil except +
 
-        void getExperiment(MSExperiment & exp, String & type_, String & in_filename) nogil except +
+        void getExperiment(MSExperiment & exp, String & type_, const String & in_filename) nogil except +
 
-        bool getSearchEngineAndVersion(String & cmd_output, ProteinIdentification & protein_identification) nogil except +
+        bool getSearchEngineAndVersion(const String & cmd_output, ProteinIdentification & protein_identification) nogil except +
 
-        void readOutHeader(String & filename, String & header_line, Int & spectrum_file_column, Int & scan_column, Int & peptide_column, Int & protein_column, Int & charge_column, Int & MQ_score_column, Int & p_value_column, Int & record_number_column, Int & DB_file_pos_column, Int & spec_file_pos_column, Size & number_of_columns) nogil except +
+        void readOutHeader(const String & filename,
+                           const String & header_line,
+                           Int & spectrum_file_column,
+                           Int & scan_column,
+                           Int & peptide_column,
+                           Int & protein_column,
+                           Int & charge_column,
+                           Int & MQ_score_column,
+                           Int & p_value_column,
+                           Int & record_number_column,
+                           Int & DB_file_pos_column,
+                           Int & spec_file_pos_column,
+                           Size & number_of_columns) nogil except +
 

--- a/src/pyOpenMS/pxds/LPWrapper.pxd
+++ b/src/pyOpenMS/pxds/LPWrapper.pxd
@@ -7,22 +7,22 @@ cdef extern from "<OpenMS/DATASTRUCTURES/LPWrapper.h>" namespace "OpenMS":
     cdef cppclass LPWrapper "OpenMS::LPWrapper":
         LPWrapper() nogil except +
         LPWrapper(LPWrapper) nogil except + #wrap-ignore
-        Int addRow(libcpp_vector[ int ] row_indices, libcpp_vector[ double ] row_values, String & name) nogil except +
+        Int addRow(libcpp_vector[ int ] row_indices, libcpp_vector[ double ] row_values, const String & name) nogil except +
         Int addColumn() nogil except +
-        Int addColumn(libcpp_vector[ int ] column_indices, libcpp_vector[ double ] column_values, String & name) nogil except +
-        Int addRow(libcpp_vector[ int ] & row_indices, libcpp_vector[ double ] & row_values, String & name, double lower_bound, double upper_bound, LPWrapper_Type type_) nogil except +
-        Int addColumn(libcpp_vector[ int ] & column_indices, libcpp_vector[ double ] & column_values, String & name, double lower_bound, double upper_bound, LPWrapper_Type type_) nogil except +
+        Int addColumn(libcpp_vector[ int ] column_indices, libcpp_vector[ double ] column_values, const String & name) nogil except +
+        Int addRow(libcpp_vector[ int ] & row_indices, libcpp_vector[ double ] & row_values, const String & name, double lower_bound, double upper_bound, LPWrapper_Type type_) nogil except +
+        Int addColumn(libcpp_vector[ int ] & column_indices, libcpp_vector[ double ] & column_values, const String & name, double lower_bound, double upper_bound, LPWrapper_Type type_) nogil except +
         void deleteRow(Int index) nogil except +
-        void setColumnName(Int index, String & name) nogil except +
+        void setColumnName(Int index, const String & name) nogil except +
         String getColumnName(Int index) nogil except +
         String getRowName(Int index) nogil except +
-        Int getRowIndex(String & name) nogil except +
-        Int getColumnIndex(String & name) nogil except +
+        Int getRowIndex(const String & name) nogil except +
+        Int getColumnIndex(const String & name) nogil except +
         double getColumnUpperBound(Int index) nogil except +
         double getColumnLowerBound(Int index) nogil except +
         double getRowUpperBound(Int index) nogil except +
         double getRowLowerBound(Int index) nogil except +
-        void setRowName(Int index, String & name) nogil except +
+        void setRowName(Int index, const String & name) nogil except +
         void setColumnBounds(Int index, double lower_bound, double upper_bound, LPWrapper_Type type_) nogil except +
         void setRowBounds(Int index, double lower_bound, double upper_bound, LPWrapper_Type type_) nogil except +
         void setColumnType(Int index, VariableType type_) nogil except +
@@ -36,7 +36,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/LPWrapper.h>" namespace "OpenMS":
         void setElement(Int row_index, Int column_index, double value) nogil except +
         double getElement(Int row_index, Int column_index) nogil except +
         void readProblem(String filename, String format_) nogil except +
-        void writeProblem(String & filename, WriteFormat format_) nogil except +
+        void writeProblem(const String & filename, WriteFormat format_) nogil except +
         Int solve(SolverParam & solver_param, Size verbose_level) nogil except +
         SolverStatus getStatus() nogil except +
         double getObjectiveValue() nogil except +

--- a/src/pyOpenMS/pxds/MS2File.pxd
+++ b/src/pyOpenMS/pxds/MS2File.pxd
@@ -10,5 +10,5 @@ cdef extern from "<OpenMS/FORMAT/MS2File.h>" namespace "OpenMS":
         #  ProgressLogger
         MS2File() nogil except +
         MS2File(MS2File) nogil except + #wrap-ignore
-        void load(String & filename, MSExperiment & exp) nogil except +
+        void load(const String & filename, MSExperiment & exp) nogil except +
 

--- a/src/pyOpenMS/pxds/MSNumpressCoder.pxd
+++ b/src/pyOpenMS/pxds/MSNumpressCoder.pxd
@@ -11,7 +11,7 @@ cdef extern from "<OpenMS/FORMAT/MSNumpressCoder.h>" namespace "OpenMS":
         void encodeNP(libcpp_vector[double] in_, String & result,
                 bool zlib_compression, NumpressConfig config) nogil except +
 
-        void decodeNP(String in_, libcpp_vector[double] & out,
+        void decodeNP(const String& in_, libcpp_vector[double] & out,
                 bool zlib_compression, NumpressConfig config) nogil except +
 
 cdef extern from "<OpenMS/FORMAT/MSNumpressCoder.h>" namespace "OpenMS::MSNumpressCoder":

--- a/src/pyOpenMS/pxds/MascotGenericFile.pxd
+++ b/src/pyOpenMS/pxds/MascotGenericFile.pxd
@@ -13,9 +13,9 @@ cdef extern from "<OpenMS/FORMAT/MascotGenericFile.h>" namespace "OpenMS":
         #  DefaultParamHandler
         MascotGenericFile() nogil except +
         MascotGenericFile(MascotGenericFile) nogil except + #wrap-ignore
-        void store(String & filename, MSExperiment & experiment) nogil except +
-        # NAMESPACE # void store(std::ostream & os, String & filename, MSExperiment & experiment) nogil except +
-        void load(String & filename, MSExperiment & exp) nogil except +
-        libcpp_pair[ String, String ] getHTTPPeakListEnclosure(String & filename) nogil except +
+        void store(const String & filename, MSExperiment & experiment) nogil except +
+        # NAMESPACE # void store(std::ostream & os, const String & filename, MSExperiment & experiment) nogil except +
+        void load(const String & filename, MSExperiment & exp) nogil except +
+        libcpp_pair[ String, String ] getHTTPPeakListEnclosure(const String & filename) nogil except +
         void updateMembers_() nogil except +
 

--- a/src/pyOpenMS/pxds/MascotInfile.pxd
+++ b/src/pyOpenMS/pxds/MascotInfile.pxd
@@ -14,27 +14,27 @@ cdef extern from "<OpenMS/FORMAT/MascotInfile.h>" namespace "OpenMS":
         #  ProgressLogger
         MascotInfile() nogil except +
         MascotInfile(MascotInfile) nogil except + #wrap-ignore
-        void store(String & filename, MSSpectrum & spec, double mz, double retention_time, String search_title) nogil except +
-        void store(String & filename, MSExperiment & experiment, String search_title) nogil except +
-        void load(String & filename, MSExperiment & exp) nogil except +
+        void store(const String & filename, MSSpectrum & spec, double mz, double retention_time, String search_title) nogil except +
+        void store(const String & filename, MSExperiment & experiment, String search_title) nogil except +
+        void load(const String & filename, MSExperiment & exp) nogil except +
         String  getBoundary() nogil except +
-        void setBoundary(String & boundary) nogil except +
+        void setBoundary(const String & boundary) nogil except +
         String  getDB() nogil except +
-        void setDB(String & db) nogil except +
+        void setDB(const String & db) nogil except +
         String  getSearchType() nogil except +
-        void setSearchType(String & search_type) nogil except +
+        void setSearchType(const String & search_type) nogil except +
         String  getHits() nogil except +
-        void setHits(String & hits) nogil except +
+        void setHits(const String & hits) nogil except +
         String  getCleavage() nogil except +
-        void setCleavage(String & cleavage) nogil except +
+        void setCleavage(const String & cleavage) nogil except +
         String  getMassType() nogil except +
-        void setMassType(String & mass_type) nogil except +
+        void setMassType(const String & mass_type) nogil except +
         libcpp_vector[ String ]  getModifications() nogil except +
         void setModifications(libcpp_vector[ String ] & mods) nogil except +
         libcpp_vector[ String ]  getVariableModifications() nogil except +
         void setVariableModifications(libcpp_vector[ String ] & mods) nogil except +
         String  getInstrument() nogil except +
-        void setInstrument(String & instrument) nogil except +
+        void setInstrument(const String & instrument) nogil except +
         UInt getMissedCleavages() nogil except +
         void setMissedCleavages(UInt missed_cleavages) nogil except +
         float getPrecursorMassTolerance() nogil except +
@@ -42,9 +42,9 @@ cdef extern from "<OpenMS/FORMAT/MascotInfile.h>" namespace "OpenMS":
         float getPeakMassTolerance() nogil except +
         void setPeakMassTolerance(float ion_mass_tolerance) nogil except +
         String  getTaxonomy() nogil except +
-        void setTaxonomy(String & taxonomy) nogil except +
+        void setTaxonomy(const String & taxonomy) nogil except +
         String  getFormVersion() nogil except +
-        void setFormVersion(String & form_version) nogil except +
+        void setFormVersion(const String & form_version) nogil except +
         String  getCharges() nogil except +
         void setCharges(libcpp_vector[ int ] & charges) nogil except +
 

--- a/src/pyOpenMS/pxds/MascotXMLFile.pxd
+++ b/src/pyOpenMS/pxds/MascotXMLFile.pxd
@@ -16,17 +16,17 @@ cdef extern from "<OpenMS/FORMAT/MascotXMLFile.h>" namespace "OpenMS":
         MascotXMLFile() nogil except +
         MascotXMLFile(MascotXMLFile) nogil except + #wrap-ignore
 
-        void load(String & filename,
+        void load(const String & filename,
                   ProteinIdentification & protein_identification,
                   libcpp_vector[ PeptideIdentification ] & id_data,
                   SpectrumMetaDataLookup & rt_mapping) nogil except +
 
         # TODO fix
-        # void load(String & filename,
+        # void load(const String & filename,
         #           ProteinIdentification & protein_identification,
         #           libcpp_vector[ PeptideIdentification ] & id_data,
         #           libcpp_map[ String, libcpp_vector[ AASequence ] ] & peptides,
         #           SpectrumMetaDataLookup & rt_mapping) nogil except +
 
-        void initializeLookup(SpectrumMetaDataLookup & lookup, MSExperiment& experiment, String & scan_regex) nogil except +
+        void initializeLookup(SpectrumMetaDataLookup & lookup, MSExperiment& experiment, const String & scan_regex) nogil except +
 

--- a/src/pyOpenMS/pxds/MassDecomposition.pxd
+++ b/src/pyOpenMS/pxds/MassDecomposition.pxd
@@ -8,14 +8,14 @@ cdef extern from "<OpenMS/CHEMISTRY/MASSDECOMPOSITION/MassDecomposition.h>" name
     cdef cppclass MassDecomposition "OpenMS::MassDecomposition":
         MassDecomposition() nogil except +
         MassDecomposition(MassDecomposition) nogil except +
-        MassDecomposition(String & deco) nogil except +
+        MassDecomposition(const String & deco) nogil except +
         # MassDecomposition  operator+=(MassDecomposition & d) nogil except +
         String toString() nogil except +
         String toExpandedString() nogil except +
         # MassDecomposition operator+(MassDecomposition & rhs) nogil except +
         Size getNumberOfMaxAA() nogil except +
         # bool operator<(MassDecomposition & rhs) nogil except +
-        # bool operator==(String & deco) nogil except +
-        bool containsTag(String & tag) nogil except +
+        # bool operator==(const String & deco) nogil except +
+        bool containsTag(const String & tag) nogil except +
         bool compatible(MassDecomposition & deco) nogil except +
 

--- a/src/pyOpenMS/pxds/MetaInfoRegistry.pxd
+++ b/src/pyOpenMS/pxds/MetaInfoRegistry.pxd
@@ -6,15 +6,15 @@ cdef extern from "<OpenMS/METADATA/MetaInfoRegistry.h>" namespace "OpenMS":
     cdef cppclass MetaInfoRegistry "OpenMS::MetaInfoRegistry":
         MetaInfoRegistry() nogil except +
         MetaInfoRegistry(MetaInfoRegistry) nogil except +
-        UInt registerName(String & name, String & description, String & unit) nogil except +
-        void setDescription(UInt index, String & description) nogil except +
-        void setDescription(String & name, String & description) nogil except +
-        void setUnit(UInt index, String & unit) nogil except +
-        void setUnit(String & name, String & unit) nogil except +
-        UInt getIndex(String & name) nogil except +
+        UInt registerName(const String & name, const String & description, const String & unit) nogil except +
+        void setDescription(UInt index, const String & description) nogil except +
+        void setDescription(const String & name, const String & description) nogil except +
+        void setUnit(UInt index, const String & unit) nogil except +
+        void setUnit(const String & name, const String & unit) nogil except +
+        UInt getIndex(const String & name) nogil except +
         String getName(UInt index) nogil except +
         String getDescription(UInt index) nogil except +
-        String getDescription(String & name) nogil except +
+        String getDescription(const String & name) nogil except +
         String getUnit(UInt index) nogil except +
-        String getUnit(String & name) nogil except +
+        String getUnit(const String & name) nogil except +
 

--- a/src/pyOpenMS/pxds/Modification.pxd
+++ b/src/pyOpenMS/pxds/Modification.pxd
@@ -15,7 +15,7 @@ cdef extern from "<OpenMS/METADATA/Modification.h>" namespace "OpenMS":
         # SampleTreatment * clone() nogil except +
 
         String getReagentName() nogil except +
-        void setReagentName(String & reagent_name) nogil except +
+        void setReagentName(const String & reagent_name) nogil except +
 
         double getMass() nogil except +
         void setMass(double mass) nogil except +
@@ -24,7 +24,7 @@ cdef extern from "<OpenMS/METADATA/Modification.h>" namespace "OpenMS":
         void setSpecificityType(Modification_SpecificityType & specificity_type) nogil except +
 
         String getAffectedAminoAcids() nogil except +
-        void setAffectedAminoAcids(String & affected_amino_acids) nogil except +
+        void setAffectedAminoAcids(const String & affected_amino_acids) nogil except +
 
 cdef extern from "<OpenMS/METADATA/Modification.h>" namespace "OpenMS::Modification":
     cdef enum Modification_SpecificityType "OpenMS::Modification::SpecificityType":

--- a/src/pyOpenMS/pxds/ModificationDefinition.pxd
+++ b/src/pyOpenMS/pxds/ModificationDefinition.pxd
@@ -11,9 +11,9 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationDefinition.h>" namespace "OpenMS
 
         ModificationDefinition() nogil except +
         ModificationDefinition(ModificationDefinition) nogil except +
-        ModificationDefinition(String &mod) nogil except +
-        ModificationDefinition(String &mod, bool fixed) nogil except +
-        ModificationDefinition(String &mod, bool fixed, UInt max_occur) nogil except +
+        ModificationDefinition(const String &mod) nogil except +
+        ModificationDefinition(const String &mod, bool fixed) nogil except +
+        ModificationDefinition(const String &mod, bool fixed, UInt max_occur) nogil except +
         ModificationDefinition(ResidueModification &mod) nogil except +
         ModificationDefinition(ResidueModification &mod, bool fixed) nogil except +
         ModificationDefinition(ResidueModification &mod, bool fixed, UInt max_occur) nogil except +
@@ -27,7 +27,7 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationDefinition.h>" namespace "OpenMS
         void setMaxOccurrences(UInt num) nogil except +
         UInt getMaxOccurrences() nogil except +
         String getModificationName() nogil except +
-        void setModification(String &modification) nogil except +
+        void setModification(const String &modification) nogil except +
 
         ResidueModification getModification() nogil except +
 

--- a/src/pyOpenMS/pxds/ModificationDefinitionsSet.pxd
+++ b/src/pyOpenMS/pxds/ModificationDefinitionsSet.pxd
@@ -23,7 +23,7 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>" namespace "Op
         Size getNumberOfVariableModifications() nogil except +
         void addModification(ModificationDefinition &mod_def) nogil except +
         void setModifications(libcpp_set[ ModificationDefinition ] &mod_defs) nogil except +
-        void setModifications(String &fixed_modifications, String &variable_modifications) nogil except +
+        void setModifications(const String &fixed_modifications, String &variable_modifications) nogil except +
         void setModifications(StringList &fixed_modifications, StringList &variable_modifications) nogil except +
         libcpp_set[ ModificationDefinition ] getModifications() nogil except +
         libcpp_set[ ModificationDefinition ]  getFixedModifications() nogil except +

--- a/src/pyOpenMS/pxds/ModificationsDB.pxd
+++ b/src/pyOpenMS/pxds/ModificationsDB.pxd
@@ -16,26 +16,29 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationsDB.h>" namespace "OpenMS":
         ResidueModification getModification(Size index) nogil except +
 
         void searchModifications(libcpp_set[ const ResidueModification * ] & mods,
-                                 String mod_name, String residue,
+                                 const String& mod_name,
+                                 const String& residue,
                                  TermSpecificity term_spec) nogil except +
 
-        ResidueModification getModification(String & mod_name, String & residue, TermSpecificity term_spec) nogil except +
+        ResidueModification getModification(const String & mod_name,
+                                            const String & residue,
+                                            TermSpecificity term_spec) nogil except +
 
         bool has(String modification) nogil except +
 
         void addModification(ResidueModification * new_mod) nogil except +
 
-        Size findModificationIndex(String & mod_name) nogil except +
+        Size findModificationIndex(const String & mod_name) nogil except +
 
         void searchModificationsByDiffMonoMass(libcpp_vector[ String ] & mods, double mass, double max_error,
-                                               String & residue, TermSpecificity term_spec) nogil except +
+                                               const String & residue, TermSpecificity term_spec) nogil except +
 
         const ResidueModification* getBestModificationByMonoMass(double mass, double max_error,
-                                                           String residue,
-                                                           TermSpecificity term_spec) nogil except +
+                                                                 const String& residue,
+                                                                 TermSpecificity term_spec) nogil except +
 
         const ResidueModification* getBestModificationByDiffMonoMass(double mass, double max_error,
-                                                               String residue, TermSpecificity term_spec) nogil except +
+                                                                     const String& residue, TermSpecificity term_spec) nogil except +
 
         void getAllSearchModifications(libcpp_vector[ String ] & modifications) nogil except +
 
@@ -47,3 +50,4 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationsDB.h>" namespace "OpenMS::Modif
     ModificationsDB* getInstance(String unimod_file, 
                                  String psimod_file,
                                  String xlmod_file) nogil except + # wrap-ignore
+

--- a/src/pyOpenMS/pxds/MsInspectFile.pxd
+++ b/src/pyOpenMS/pxds/MsInspectFile.pxd
@@ -9,6 +9,6 @@ cdef extern from "<OpenMS/FORMAT/MsInspectFile.h>" namespace "OpenMS":
     cdef cppclass MsInspectFile "OpenMS::MsInspectFile":
         MsInspectFile() nogil except +
         MsInspectFile(MsInspectFile) nogil except + #wrap-ignore
-        void load(String & filename, FeatureMap & feature_map) nogil except +
-        void store(String & filename, MSSpectrum & spectrum) nogil except +
+        void load(const String & filename, FeatureMap & feature_map) nogil except +
+        void store(const String & filename, MSSpectrum & spectrum) nogil except +
 

--- a/src/pyOpenMS/pxds/MzDataFile.pxd
+++ b/src/pyOpenMS/pxds/MzDataFile.pxd
@@ -15,11 +15,11 @@ cdef extern from "<OpenMS/FORMAT/MzDataFile.h>" namespace "OpenMS":
 
         MzDataFile() nogil except +
 
-        void load(String, MSExperiment &) nogil except+
-        void store(String, MSExperiment &) nogil except+
+        void load(const String&, MSExperiment &) nogil except+
+        void store(const String&, MSExperiment &) nogil except+
 
         PeakFileOptions getOptions() nogil except +
         void setOptions(PeakFileOptions) nogil except +
 
-        bool isSemanticallyValid(String & filename, StringList & errors, StringList & warnings) nogil except +
+        bool isSemanticallyValid(const String& filename, StringList & errors, StringList & warnings) nogil except +
 

--- a/src/pyOpenMS/pxds/MzMLFile.pxd
+++ b/src/pyOpenMS/pxds/MzMLFile.pxd
@@ -14,16 +14,16 @@ cdef extern from "<OpenMS/FORMAT/MzMLFile.h>" namespace "OpenMS":
 
         MzMLFile() nogil except +
 
-        void load(String, MSExperiment &) nogil except+
-        void store(String, MSExperiment &) nogil except+
+        void load(const String&, MSExperiment &) nogil except+
+        void store(const String&, MSExperiment &) nogil except+
 
-        void transform(String, IMSDataConsumer[Peak1D, ChromatogramPeak] *) nogil except + # wrap-ignore
+        void transform(const String&, IMSDataConsumer[Peak1D, ChromatogramPeak] *) nogil except + # wrap-ignore
 
         PeakFileOptions getOptions() nogil except +
         void setOptions(PeakFileOptions) nogil except +
 
-        bool isSemanticallyValid(String & filename, StringList & errors, StringList & warnings) nogil except +
+        bool isSemanticallyValid(const String & filename, StringList & errors, StringList & warnings) nogil except +
 
-        # NAMESPACE # bool isValid(String & filename, std::ostream & os)
+        # NAMESPACE # bool isValid(const String & filename, std::ostream & os)
 
-        # void loadSize(String & filename, Size & scount, Size & ccount) 
+        # void loadSize(const String & filename, Size & scount, Size & ccount) 

--- a/src/pyOpenMS/pxds/OMSSACSVFile.pxd
+++ b/src/pyOpenMS/pxds/OMSSACSVFile.pxd
@@ -8,7 +8,7 @@ cdef extern from "<OpenMS/FORMAT/OMSSACSVFile.h>" namespace "OpenMS":
         OMSSACSVFile() nogil except +
         OMSSACSVFile(OMSSACSVFile) nogil except + #wrap-ignore
 
-        void load(String & filename,
+        void load(const String & filename,
                   ProteinIdentification & protein_identification,
                   libcpp_vector[ PeptideIdentification ] & id_data) nogil except +
 

--- a/src/pyOpenMS/pxds/OMSSAXMLFile.pxd
+++ b/src/pyOpenMS/pxds/OMSSAXMLFile.pxd
@@ -14,7 +14,7 @@ cdef extern from "<OpenMS/FORMAT/OMSSAXMLFile.h>" namespace "OpenMS":
         OMSSAXMLFile() nogil except +
         OMSSAXMLFile(OMSSAXMLFile) nogil except + #wrap-ignore
 
-        void load(String & filename,
+        void load(const String & filename,
                   ProteinIdentification & protein_identification,
                   libcpp_vector[ PeptideIdentification ] & id_data,
                   bool load_proteins,

--- a/src/pyOpenMS/pxds/PSProteinInference.pxd
+++ b/src/pyOpenMS/pxds/PSProteinInference.pxd
@@ -13,8 +13,8 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/PSProteinInference.h>" namespace "Op
         PSProteinInference(PSProteinInference) nogil except + #wrap-ignore
         Size findMinimalProteinList(libcpp_vector[ PeptideIdentification ] & peptide_ids) nogil except +
         void calculateProteinProbabilities(libcpp_vector[ PeptideIdentification ] & ids) nogil except +
-        double getProteinProbability(String & acc) nogil except +
-        bool isProteinInMinimalList(String & acc) nogil except +
+        double getProteinProbability(const String & acc) nogil except +
+        bool isProteinInMinimalList(const String & acc) nogil except +
         Int getNumberOfProtIds(double protein_id_threshold) nogil except +
         # TODO nested STL
         # Int getNumberOfProtIdsPeptideRule(Int min_peptides, libcpp_map[ String, libcpp_set[ String ] ] & prot_id_counter) nogil except +

--- a/src/pyOpenMS/pxds/ParamNode.pxd
+++ b/src/pyOpenMS/pxds/ParamNode.pxd
@@ -16,14 +16,14 @@ cdef extern from "<OpenMS/DATASTRUCTURES/Param.h>" namespace "OpenMS::Param":
         String description
         libcpp_vector[ ParamEntry ] entries
         libcpp_vector[ ParamNode ] nodes
-        ParamNode(String & n, String & d) nogil except +
+        ParamNode(const String & n, const String & d) nogil except +
         bool operator==(ParamNode & rhs) nogil except +
-        # EntryIterator findEntry(String & name) nogil except +
-        # NodeIterator findNode(String & name) nogil except +
-        ParamNode * findParentOf(String & name) nogil except +
-        ParamEntry * findEntryRecursive(String & name) nogil except +
-        void insert(ParamNode & node, String & prefix) nogil except +
-        void insert(ParamEntry & entry, String & prefix) nogil except +
+        # EntryIterator findEntry(const String & name) nogil except +
+        # NodeIterator findNode(const String & name) nogil except +
+        ParamNode * findParentOf(const String & name) nogil except +
+        ParamEntry * findEntryRecursive(const String & name) nogil except +
+        void insert(ParamNode & node, const String & prefix) nogil except +
+        void insert(ParamEntry & entry, const String & prefix) nogil except +
         Size size() nogil except +
-        String suffix(String & key) nogil except +
+        String suffix(const String & key) nogil except +
 

--- a/src/pyOpenMS/pxds/PepXMLFileMascot.pxd
+++ b/src/pyOpenMS/pxds/PepXMLFileMascot.pxd
@@ -15,5 +15,5 @@ cdef extern from "<OpenMS/FORMAT/PepXMLFileMascot.h>" namespace "OpenMS":
         PepXMLFileMascot(PepXMLFileMascot) nogil except + #wrap-ignore
 
         # TODO map
-        # void load(String & filename, libcpp_map[ String, libcpp_vector[ AASequence ] ] & peptides) nogil except +
+        # void load(const String & filename, libcpp_map[ String, libcpp_vector[ AASequence ] ] & peptides) nogil except +
 

--- a/src/pyOpenMS/pxds/PercolatorOutfile.pxd
+++ b/src/pyOpenMS/pxds/PercolatorOutfile.pxd
@@ -13,7 +13,7 @@ cdef extern from "<OpenMS/FORMAT/PercolatorOutfile.h>" namespace "OpenMS":
         # libcpp_string score_type_names()
         PercolatorOutfile_ScoreType getScoreType(String score_type_name) nogil except +
 
-        void load(String & filename, ProteinIdentification & proteins,
+        void load(const String & filename, ProteinIdentification & proteins,
                   libcpp_vector[ PeptideIdentification ] & peptides,
                   SpectrumMetaDataLookup & lookup, 
                   PercolatorOutfile_ScoreType output_score) nogil except +

--- a/src/pyOpenMS/pxds/PosteriorErrorProbabilityModel.pxd
+++ b/src/pyOpenMS/pxds/PosteriorErrorProbabilityModel.pxd
@@ -80,5 +80,5 @@ cdef extern from "<OpenMS/MATH/STATISTICS/PosteriorErrorProbabilityModel.h>" nam
         # returns the smallest score used in the last fit
         double getSmallestScore() nogil except +
 
-        void tryGnuplot(String & gp_file) nogil except +
+        void tryGnuplot(const String & gp_file) nogil except +
 

--- a/src/pyOpenMS/pxds/ProteaseDB.pxd
+++ b/src/pyOpenMS/pxds/ProteaseDB.pxd
@@ -11,14 +11,14 @@ cdef extern from "<OpenMS/CHEMISTRY/ProteaseDB.h>" namespace "OpenMS":
         ProteaseDB() nogil except + #wrap-ignore
         ProteaseDB(ProteaseDB) nogil except + #wrap-ignore
 
-        const DigestionEnzymeProtein* getEnzyme(String& name) nogil except +
-        const DigestionEnzymeProtein* getEnzymeByRegEx(String& cleavage_regex) nogil except +
+        const DigestionEnzymeProtein* getEnzyme(const String& name) nogil except +
+        const DigestionEnzymeProtein* getEnzymeByRegEx(const String& cleavage_regex) nogil except +
         void getAllNames(libcpp_vector[ String ]& all_names) nogil except +
         void getAllXTandemNames(libcpp_vector[ String ]& all_names) nogil except +
         void getAllOMSSANames(libcpp_vector[ String ]& all_names) nogil except +
         void getAllCometNames(libcpp_vector[ String ]& all_names) nogil except +
-        bool hasEnzyme(String& name) nogil except +
-        bool hasRegEx(String& cleavage_regex) nogil except +
+        bool hasEnzyme(const String& name) nogil except +
+        bool hasRegEx(const String& cleavage_regex) nogil except +
         # bool hasEnzyme(DigestionEnzymeProtein* enzyme) nogil except + # does not make sense as the ptr wont match
 
         # ConstEnzymeIterator beginEnzyme() nogil except +

--- a/src/pyOpenMS/pxds/QcMLFile.pxd
+++ b/src/pyOpenMS/pxds/QcMLFile.pxd
@@ -15,8 +15,8 @@ cdef extern from "<OpenMS/FORMAT/QcMLFile.h>" namespace "OpenMS":
         #  ProgressLogger
         QcMLFile() nogil except +
         QcMLFile(QcMLFile) nogil except + #wrap-ignore
-        String map2csv(libcpp_map[ String, libcpp_map[ String, String ] ] & cvs_table, String & separator) nogil except + # wrap-ignore
-        String exportIDstats(String & filename) nogil except +
+        String map2csv(libcpp_map[ String, libcpp_map[ String, String ] ] & cvs_table, const String & separator) nogil except + # wrap-ignore
+        String exportIDstats(const String & filename) nogil except +
         void addRunQualityParameter(String r, QualityParameter qp) nogil except +
         void addRunAttachment(String r, Attachment at) nogil except +
         void addSetQualityParameter(String r, QualityParameter qp) nogil except +
@@ -33,8 +33,8 @@ cdef extern from "<OpenMS/FORMAT/QcMLFile.h>" namespace "OpenMS":
         bool existsSet(String filename) nogil except +
         void existsRunQualityParameter(String filename, String qpname, libcpp_vector[ String ] & ids) nogil except +
         void existsSetQualityParameter(String filename, String qpname, libcpp_vector[ String ] & ids) nogil except +
-        void store(String & filename) nogil except +
-        void load(String & filename) nogil except +
+        void store(const String & filename) nogil except +
+        void load(const String & filename) nogil except +
 
         void registerRun(String id_, String name) nogil except +
         void registerSet(String id_, String name, libcpp_set[ String ] & names) nogil except +

--- a/src/pyOpenMS/pxds/RNPxlReport.pxd
+++ b/src/pyOpenMS/pxds/RNPxlReport.pxd
@@ -19,7 +19,7 @@ cdef extern from "<OpenMS/ANALYSIS/RNPXL/RNPxlReport.h>" namespace "OpenMS":
     
     cdef cppclass RNPxlReportRowHeader "OpenMS::RNPxlReportRowHeader":
         RNPxlReportRowHeader(RNPxlReportRowHeader) nogil except + #wrap-ignore
-        String getString(String & separator) nogil except +
+        String getString(const String & separator) nogil except +
 
 cdef extern from "<OpenMS/ANALYSIS/RNPXL/RNPxlReport.h>" namespace "OpenMS":
     
@@ -48,5 +48,5 @@ cdef extern from "<OpenMS/ANALYSIS/RNPXL/RNPxlReport.h>" namespace "OpenMS":
         double m_3H
         double m_4H
         String fragment_annotation_string
-        String getString(String & separator) nogil except +
+        String getString(const String & separator) nogil except +
 

--- a/src/pyOpenMS/pxds/RNaseDB.pxd
+++ b/src/pyOpenMS/pxds/RNaseDB.pxd
@@ -11,11 +11,11 @@ cdef extern from "<OpenMS/CHEMISTRY/RNaseDB.h>" namespace "OpenMS":
         RNaseDB() nogil except + #wrap-ignore
         RNaseDB(RNaseDB) nogil except + #wrap-ignore
 
-        const DigestionEnzymeRNA* getEnzyme(String& name) nogil except +
-        const DigestionEnzymeRNA* getEnzymeByRegEx(String& cleavage_regex) nogil except +
+        const DigestionEnzymeRNA* getEnzyme(const String& name) nogil except +
+        const DigestionEnzymeRNA* getEnzymeByRegEx(const String& cleavage_regex) nogil except +
         void getAllNames(libcpp_vector[ String ]& all_names) nogil except +
-        bool hasEnzyme(String& name) nogil except +
-        bool hasRegEx(String& cleavage_regex) nogil except +
+        bool hasEnzyme(const String& name) nogil except +
+        bool hasRegEx(const String& cleavage_regex) nogil except +
         # bool hasEnzyme(DigestionEnzymeRNA* enzyme) nogil except + # does not make sense as the ptr wont match
 
         # ConstEnzymeIterator beginEnzyme() nogil except +

--- a/src/pyOpenMS/pxds/ReactionMonitoringTransition.pxd
+++ b/src/pyOpenMS/pxds/ReactionMonitoringTransition.pxd
@@ -24,7 +24,7 @@ cdef extern from "<OpenMS/ANALYSIS/MRM/ReactionMonitoringTransition.h>" namespac
       
         DecoyTransitionType getDecoyTransitionType() nogil except +
 
-        void setCompoundRef(String & compound_ref)nogil except +
+        void setCompoundRef(const String & compound_ref)nogil except +
         String  getCompoundRef()nogil except +
 
         bool hasPrecursorCVTerms() nogil except +

--- a/src/pyOpenMS/pxds/ResidueDB.pxd
+++ b/src/pyOpenMS/pxds/ResidueDB.pxd
@@ -12,14 +12,14 @@ cdef extern from "<OpenMS/CHEMISTRY/ResidueDB.h>" namespace "OpenMS":
 
         Size getNumberOfResidues() nogil except +
         Size getNumberOfModifiedResidues() nogil except +
-        const Residue * getResidue(String & name) nogil except +
-        const Residue * getModifiedResidue(String & name) nogil except +
-        const Residue * getModifiedResidue(Residue * residue, String & name) nogil except +
-        libcpp_set[ const Residue * ] getResidues(String & residue_set) nogil except +
+        const Residue * getResidue(const String & name) nogil except +
+        const Residue * getModifiedResidue(const String & name) nogil except +
+        const Residue * getModifiedResidue(Residue * residue, const String & name) nogil except +
+        libcpp_set[ const Residue * ] getResidues(const String & residue_set) nogil except +
         libcpp_set[ String ] getResidueSets() nogil except +
-        void setResidues(String & filename) nogil except +
+        void setResidues(const String & filename) nogil except +
         void addResidue(Residue & residue) nogil except +
-        bool hasResidue(String & name) nogil except +
+        bool hasResidue(const String & name) nogil except +
         # bool hasResidue(Residue * residue) nogil except + # does not really work as the ptr is different
 
 # COMMENT: wrap static methods

--- a/src/pyOpenMS/pxds/ResidueModification.pxd
+++ b/src/pyOpenMS/pxds/ResidueModification.pxd
@@ -16,30 +16,30 @@ cdef extern from "<OpenMS/CHEMISTRY/ResidueModification.h>" namespace "OpenMS":
         bool operator==(ResidueModification & modification) nogil except +
         bool operator!=(ResidueModification & modification) nogil except +
 
-        void setId(String & id_) nogil except +
+        void setId(const String & id_) nogil except +
         String  getId() nogil except +
-        void setFullId(String & full_id) nogil except +
+        void setFullId(const String & full_id) nogil except +
         String  getFullId() nogil except +
 
         Int getUniModRecordId() nogil except +
         void setUniModRecordId(Int id_) nogil except +
         String  getUniModAccession() nogil except +
 
-        void setPSIMODAccession(String & id_) nogil except +
+        void setPSIMODAccession(const String & id_) nogil except +
         String getPSIMODAccession() nogil except +
-        void setFullName(String & full_name) nogil except +
+        void setFullName(const String & full_name) nogil except +
         String getFullName() nogil except +
-        void setName(String & name) nogil except +
+        void setName(const String & name) nogil except +
         String getName() nogil except +
         void setTermSpecificity(TermSpecificity term_spec) nogil except +
-        void setTermSpecificity(String & name) nogil except +
+        void setTermSpecificity(const String & name) nogil except +
 
         TermSpecificity getTermSpecificity() nogil except +
         String getTermSpecificityName(TermSpecificity ) nogil except +
         void setOrigin(char origin) nogil except +
         char  getOrigin() nogil except +
 
-        void setSourceClassification(String & classification) nogil except +
+        void setSourceClassification(const String & classification) nogil except +
         void setSourceClassification(SourceClassification classification) nogil except +
         SourceClassification getSourceClassification() nogil except +
         String getSourceClassificationName(SourceClassification classification) nogil except +
@@ -53,13 +53,13 @@ cdef extern from "<OpenMS/CHEMISTRY/ResidueModification.h>" namespace "OpenMS":
         void setDiffMonoMass(double mass) nogil except +
         double getDiffMonoMass() nogil except +
 
-        void setFormula(String & composition) nogil except +
+        void setFormula(const String & composition) nogil except +
         String  getFormula() nogil except +
         void setDiffFormula(EmpiricalFormula & diff_formula) nogil except +
         EmpiricalFormula  getDiffFormula() nogil except +
 
         void setSynonyms(libcpp_set[ String ] & synonyms) nogil except +
-        void addSynonym(String & synonym) nogil except +
+        void addSynonym(const String & synonym) nogil except +
         libcpp_set[ String ] getSynonyms() nogil except +
 
         void setNeutralLossDiffFormula(EmpiricalFormula & loss) nogil except +

--- a/src/pyOpenMS/pxds/SVMWrapper.pxd
+++ b/src/pyOpenMS/pxds/SVMWrapper.pxd
@@ -58,8 +58,8 @@ cdef extern from "<OpenMS/ANALYSIS/SVM/SVMWrapper.h>" namespace "OpenMS":
         # TODO nested STL
         # SVMData(libcpp_vector[ libcpp_vector[ libcpp_pair[ Int, double ] ] ] &seqs, libcpp_vector[ double ] &lbls) nogil except +
         bool operator==(SVMData &rhs) nogil except +
-        bool store(String &filename) nogil except +
-        bool load(String &filename) nogil except +
+        bool store(const String &filename) nogil except +
+        bool load(const String &filename) nogil except +
 
 
 cdef extern from "<OpenMS/ANALYSIS/SVM/SVMWrapper.h>" namespace "OpenMS::SVMWrapper":

--- a/src/pyOpenMS/pxds/SampleTreatment.pxd
+++ b/src/pyOpenMS/pxds/SampleTreatment.pxd
@@ -13,12 +13,12 @@ cdef extern from "<OpenMS/METADATA/SampleTreatment.h>" namespace "OpenMS":
         # wrap-inherits:
         #  MetaInfoInterface
         SampleTreatment(SampleTreatment) nogil except +
-        SampleTreatment(String & type_) nogil except +
+        SampleTreatment(const String & type_) nogil except +
 
         bool operator==(SampleTreatment & rhs) nogil except +
-        String  getType() nogil except +
-        String  getComment() nogil except +
-        void setComment(String & comment) nogil except +
+        String getType() nogil except +
+        String getComment() nogil except +
+        void setComment(const String & comment) nogil except +
         # POINTER # SampleTreatment * clone() nogil except +
 
 

--- a/src/pyOpenMS/pxds/SequestInfile.pxd
+++ b/src/pyOpenMS/pxds/SequestInfile.pxd
@@ -10,20 +10,20 @@ cdef extern from "<OpenMS/FORMAT/SequestInfile.h>" namespace "OpenMS":
         SequestInfile() nogil except +
         SequestInfile(SequestInfile) nogil except +
         bool operator==(SequestInfile &sequest_infile) nogil except +
-        void store(String &filename) nogil except +
+        void store(const String &filename) nogil except +
         String getEnzymeInfoAsString() nogil except +
         String  getDatabase() nogil except +
-        void setDatabase(String &database) nogil except +
+        void setDatabase(const String &database) nogil except +
         String  getNeutralLossesForIons() nogil except +
-        void setNeutralLossesForIons(String &neutral_losses_for_ions) nogil except +
+        void setNeutralLossesForIons(const String &neutral_losses_for_ions) nogil except +
         String  getIonSeriesWeights() nogil except +
-        void setIonSeriesWeights(String &ion_series_weights) nogil except +
+        void setIonSeriesWeights(const String &ion_series_weights) nogil except +
         String  getPartialSequence() nogil except +
-        void setPartialSequence(String &partial_sequence) nogil except +
+        void setPartialSequence(const String &partial_sequence) nogil except +
         String  getSequenceHeaderFilter() nogil except +
-        void setSequenceHeaderFilter(String &sequence_header_filter) nogil except +
+        void setSequenceHeaderFilter(const String &sequence_header_filter) nogil except +
         String  getProteinMassFilter() nogil except +
-        void setProteinMassFilter(String &protein_mass_filter) nogil except +
+        void setProteinMassFilter(const String &protein_mass_filter) nogil except +
         float getPeakMassTolerance() nogil except +
         void setPeakMassTolerance(float peak_mass_tolerance) nogil except +
         float getPrecursorMassTolerance() nogil except +
@@ -68,5 +68,5 @@ cdef extern from "<OpenMS/FORMAT/SequestInfile.h>" namespace "OpenMS":
         void addEnzymeInfo(libcpp_vector[ String ] &enzyme_info) nogil except +
 
         libcpp_map[ String, libcpp_vector[ String ] ]  getModifications() nogil except + # wrap-ignore
-        void handlePTMs(String &modification_line, String &modifications_filename, bool monoisotopic) nogil except +
+        void handlePTMs(const String &modification_line, const String &modifications_filename, bool monoisotopic) nogil except +
 

--- a/src/pyOpenMS/pxds/SequestOutfile.pxd
+++ b/src/pyOpenMS/pxds/SequestOutfile.pxd
@@ -14,9 +14,15 @@ cdef extern from "<OpenMS/FORMAT/SequestOutfile.h>" namespace "OpenMS":
         SequestOutfile(SequestOutfile) nogil except +
 
         bool operator==(SequestOutfile &sequest_outfile) nogil except +
-        void load(String &result_filename, libcpp_vector[ PeptideIdentification ] &peptide_identifications, ProteinIdentification &protein_identification, double p_value_threshold, libcpp_vector[ double ] &pvalues, String &database, bool ignore_proteins_per_peptide) nogil except +
-        bool getColumns(String &line, libcpp_vector[ String ] &substrings, Size number_of_columns, Size reference_column) nogil except +
-        void getSequences(String &database_filename,
+        void load(const String &result_filename,
+                  libcpp_vector[ PeptideIdentification ] &peptide_identifications,
+                  ProteinIdentification &protein_identification,
+                  double p_value_threshold,
+                  libcpp_vector[ double ] &pvalues,
+                  const String &database,
+                  bool ignore_proteins_per_peptide) nogil except +
+        bool getColumns(const String &line, libcpp_vector[ String ] &substrings, Size number_of_columns, Size reference_column) nogil except +
+        void getSequences(const String &database_filename,
                           libcpp_map[ String, size_t ] &ac_position_map,
                           libcpp_vector[ String ] &sequences,
                           libcpp_vector[ libcpp_pair[ String, size_t ] ] &found,
@@ -24,5 +30,13 @@ cdef extern from "<OpenMS/FORMAT/SequestOutfile.h>" namespace "OpenMS":
         void getACAndACType(String line, String &accession, String &accession_type) nogil except +
 
         # TODO immutable types by reference
-        # void readOutHeader(String &result_filename, DateTime &datetime, double &precursor_mz_value, Int &charge, Size &precursor_mass_type, Size &ion_mass_type, Size &displayed_peptides, String &sequest, String &sequest_version, String &database_type, Int &number_column, Int &rank_sp_column, Int &id_column, Int &mh_column, Int &delta_cn_column, Int &xcorr_column, Int &sp_column, Int &sf_column, Int &ions_column, Int &reference_column, Int &peptide_column, Int &score_column, Size &number_of_columns) nogil except +
+        # 
+        # void readOutHeader(String &result_filename, DateTime &datetime,
+        # double &precursor_mz_value, Int &charge, Size &precursor_mass_type,
+        # Size &ion_mass_type, Size &displayed_peptides, String &sequest,
+        # String &sequest_version, String &database_type, Int &number_column,
+        # Int &rank_sp_column, Int &id_column, Int &mh_column, Int
+        # &delta_cn_column, Int &xcorr_column, Int &sp_column, Int &sf_column,
+        # Int &ions_column, Int &reference_column, Int &peptide_column, Int
+        # &score_column, Size &number_of_columns) nogil except +
 

--- a/src/pyOpenMS/pxds/SimpleSVM.pxd
+++ b/src/pyOpenMS/pxds/SimpleSVM.pxd
@@ -18,7 +18,7 @@ cdef extern from "<OpenMS/ANALYSIS/SVM/SimpleSVM.h>" namespace "OpenMS":
         # void setup(libcpp_map[String, libcpp_vector[double] ]& predictors, libcpp_map[ Size, Int ] & labels) nogil except +
         void predict(libcpp_vector[ SVMPrediction ] & predictions, libcpp_vector[ size_t ] indexes) nogil except +
         void getFeatureWeights(libcpp_map[ String, double ] & feature_weights) nogil except +
-        void writeXvalResults(String & path) nogil except +
+        void writeXvalResults(const String & path) nogil except +
 
 
 cdef extern from "<OpenMS/ANALYSIS/SVM/SimpleSVM.h>" namespace "OpenMS::SimpleSVM":

--- a/src/pyOpenMS/pxds/SiriusMzTabWriter.pxd
+++ b/src/pyOpenMS/pxds/SiriusMzTabWriter.pxd
@@ -9,7 +9,7 @@ cdef extern from "<OpenMS/FORMAT/DATAACCESS/SiriusMzTabWriter.h>" namespace "Ope
     cdef cppclass SiriusMzTabWriter "OpenMS::SiriusMzTabWriter":
         SiriusMzTabWriter() nogil except + 
         SiriusMzTabWriter(SiriusMzTabWriter) nogil except + #wrap-ignore
-        String extract_scan_index(String & path) nogil except +
+        String extract_scan_index(const String & path) nogil except +
         void read(libcpp_vector[String] sirius_output_paths, String original_input_mzml, Size top_n_hits, MzTab & result) nogil except +
 
 

--- a/src/pyOpenMS/pxds/SpectrumLookup.pxd
+++ b/src/pyOpenMS/pxds/SpectrumLookup.pxd
@@ -35,5 +35,5 @@ cdef extern from "<OpenMS/METADATA/SpectrumLookup.h>" namespace "OpenMS":
 
         void addReferenceFormat(String regexp) nogil except +
 
-        # # NAMESPACE # Int extractScanNumber(String & native_id, boost::regex & scan_regexp, bool no_error) nogil except +
+        # # NAMESPACE # Int extractScanNumber(const String & native_id, boost::regex & scan_regexp, bool no_error) nogil except +
 

--- a/src/pyOpenMS/pxds/SqMassFile.pxd
+++ b/src/pyOpenMS/pxds/SqMassFile.pxd
@@ -1,11 +1,19 @@
 from Types cimport *
 from MSExperiment cimport *
+from IMSDataConsumer cimport *
+from ChromatogramPeak cimport *
+from Peak1D cimport *
 
 cdef extern from "<OpenMS/FORMAT/SqMassFile.h>" namespace "OpenMS":
     
     cdef cppclass SqMassFile "OpenMS::SqMassFile":
         SqMassFile() nogil except +
         SqMassFile(SqMassFile) nogil except + #wrap-ignore
-        void load(String & filename, MSExperiment & map_) nogil except +
-        void store(String & filename, MSExperiment & map_) nogil except +
+        void load(const String & filename, MSExperiment & map_) nogil except +
+        void store(const String & filename, MSExperiment & map_) nogil except +
+        # TODO !
+        void transform(const String&,
+                       IMSDataConsumer[Peak1D, ChromatogramPeak] *,
+                       bool skip_full_count,
+                       bool skip_first_pass) nogil except + # wrap-ignore
 

--- a/src/pyOpenMS/pxds/TextFile.pxd
+++ b/src/pyOpenMS/pxds/TextFile.pxd
@@ -7,7 +7,7 @@ cdef extern from "<OpenMS/FORMAT/TextFile.h>" namespace "OpenMS":
     cdef cppclass TextFile "OpenMS::TextFile":
         TextFile() nogil except +
         TextFile(TextFile) nogil except + #wrap-ignore
-        TextFile(String &filename, bool trim_linesalse, Int first_n1) nogil except +
-        void load(String &filename, bool trim_linesalse, Int first_n1) nogil except +
-        void store(String &filename) nogil except +
-        void addLine(String line) nogil except +
+        TextFile(const String &filename, bool trim_linesalse, Int first_n1) nogil except +
+        void load(const String &filename, bool trim_linesalse, Int first_n1) nogil except +
+        void store(const String &filename) nogil except +
+        void addLine(const String line) nogil except +

--- a/src/pyOpenMS/pxds/TransformationModel.pxd
+++ b/src/pyOpenMS/pxds/TransformationModel.pxd
@@ -7,7 +7,7 @@ cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>" namespace
     cdef cppclass TM_DataPoint "OpenMS::TransformationModel::DataPoint":
         TM_DataPoint() nogil except +
         TM_DataPoint(double, double) nogil except +
-        TM_DataPoint(double, double, String&) nogil except +
+        TM_DataPoint(double, double, const String&) nogil except +
         TM_DataPoint(TM_DataPoint) nogil except + #wrap-ignore
         bool operator<(TM_DataPoint&) nogil except +
         bool operator==(TM_DataPoint&) nogil except +
@@ -31,8 +31,8 @@ cdef extern from "<OpenMS/ANALYSIS/MAPMATCHING/TransformationModel.h>" namespace
         
         void weightData(libcpp_vector[TM_DataPoint]& data) nogil except +
         void weightData(libcpp_vector[TM_DataPoint]& data) nogil except +
-        bool checkValidWeight(String& weight, libcpp_vector[String]& valid_weights) nogil except +
-        double weightDatum(double& datum, String& weight) nogil except +
-        double unWeightDatum(double& datum, String& weight) nogil except +
+        bool checkValidWeight(const String& weight, libcpp_vector[String]& valid_weights) nogil except +
+        double weightDatum(double& datum, const String& weight) nogil except +
+        double unWeightDatum(double& datum, const String& weight) nogil except +
         # String getValidXWeights() nogil except +
         # String getValidYWeights() nogil except +

--- a/src/pyOpenMS/pxds/UnimodXMLFile.pxd
+++ b/src/pyOpenMS/pxds/UnimodXMLFile.pxd
@@ -12,5 +12,5 @@ cdef extern from "<OpenMS/FORMAT/UnimodXMLFile.h>" namespace "OpenMS":
         UnimodXMLFile(UnimodXMLFile) nogil except + #wrap-ignore
 
         # TODO raw ptr in vector
-        # void load(String & filename, libcpp_vector[ ResidueModification * ] & modifications) nogil except +
+        # void load(const String & filename, libcpp_vector[ ResidueModification * ] & modifications) nogil except +
 

--- a/src/pyOpenMS/pxds/UniqueIdInterface.pxd
+++ b/src/pyOpenMS/pxds/UniqueIdInterface.pxd
@@ -21,7 +21,7 @@ cdef extern from "<OpenMS/CONCEPT/UniqueIdInterface.h>" namespace "OpenMS":
         # overloading Cython Issue
         # TODO: Mismatch between C++ return type ([u'Size']) and Python return type (['void']) in function public setUniqueId:
         # Size setUniqueId() nogil except +
-        # void setUniqueId(String & rhs) nogil except +
+        # void setUniqueId(const String & rhs) nogil except +
 
         bool isValid(UInt64 unique_id) nogil except +
 

--- a/src/pyOpenMS/pxds/XMLFile.pxd
+++ b/src/pyOpenMS/pxds/XMLFile.pxd
@@ -8,7 +8,7 @@ cdef extern from "<OpenMS/FORMAT/XMLFile.h>" namespace "OpenMS::Internal":
         XMLFile() nogil except +
         XMLFile(XMLFile) nogil except + #wrap-ignore
 
-        XMLFile(String & schema_location, String & version) nogil except +
-        # NAMESPACE # bool isValid(String & filename, std::ostream & os) nogil except +
+        XMLFile(const String & schema_location, const String & version) nogil except +
+        # NAMESPACE # bool isValid(const String & filename, std::ostream & os) nogil except +
         String getVersion() nogil except +
 

--- a/src/pyOpenMS/pxds/XMLHandler.pxd
+++ b/src/pyOpenMS/pxds/XMLHandler.pxd
@@ -13,13 +13,13 @@ cdef extern from "<OpenMS/FORMAT/HANDLERS/XMLHandler.h>" namespace "OpenMS::Inte
         # NAMESPACE # void fatalError(xercesc::SAXParseException & exception) nogil except +
         # NAMESPACE # void error(xercesc::SAXParseException & exception) nogil except +
         # NAMESPACE # void warning(xercesc::SAXParseException & exception) nogil except +
-        XMLHandler(String & filename, String & version) nogil except +
+        XMLHandler(const String & filename, const String & version) nogil except +
         void reset() nogil except +
         # TODO cdash might parse out "fatalError" statements and interpret them
         # as compilation failure...
-        # void fatalError(ActionMode mode, String & msg, UInt line, UInt column) nogil except +
-        void error(ActionMode mode, String & msg, UInt line, UInt column) nogil except +
-        void warning(ActionMode mode, String & msg, UInt line, UInt column) nogil except +
+        # void fatalError(ActionMode mode, const String & msg, UInt line, UInt column) nogil except +
+        void error(ActionMode mode, const String & msg, UInt line, UInt column) nogil except +
+        void warning(ActionMode mode, const String & msg, UInt line, UInt column) nogil except +
         # POINTER # void characters(XMLCh *chars, XMLSize_t length) nogil except +
         # NAMESPACE # # POINTER # void startElement(XMLCh *uri, XMLCh *localname, XMLCh *qname, xercesc::Attributes & attrs) nogil except +
         # POINTER # void endElement(XMLCh *uri, XMLCh *localname, XMLCh *qname) nogil except +

--- a/src/pyOpenMS/pxds/XQuestResultXMLFile.pxd
+++ b/src/pyOpenMS/pxds/XQuestResultXMLFile.pxd
@@ -18,11 +18,11 @@ cdef extern from "<OpenMS/FORMAT/XQuestResultXMLFile.h>" namespace "OpenMS":
         XQuestResultXMLFile() nogil except +
         XQuestResultXMLFile(XQuestResultXMLFile) nogil except + #wrap-ignore
 
-        void load(String & filename,
+        void load(const String & filename,
                 libcpp_vector[ PeptideIdentification ] & pep_ids,
                 libcpp_vector[ ProteinIdentification ] & prot_ids) nogil except +
 
-        void store(String & filename,
+        void store(const String & filename,
                 libcpp_vector[ ProteinIdentification ] & poid,
                 libcpp_vector[ PeptideIdentification ] & peid) nogil except +
 
@@ -30,12 +30,12 @@ cdef extern from "<OpenMS/FORMAT/XQuestResultXMLFile.h>" namespace "OpenMS":
         double getMinScore() nogil except +
         double getMaxScore() nogil except +
 
-        void writeXQuestXMLSpec(String out_file, String base_name,
+        void writeXQuestXMLSpec(const String& out_file, const String& base_name,
                                 OPXL_PreprocessedPairSpectra & preprocessed_pair_spectra,
                                 libcpp_vector[ libcpp_pair[ size_t, size_t ] ] & spectrum_pairs,
                                 libcpp_vector[ libcpp_vector[ OPXL_CrossLinkSpectrumMatch ] ] & all_top_csms,
                                 MSExperiment & spectra) nogil except +
 
-        void writeXQuestXMLSpec(String out_file, String base_name,
+        void writeXQuestXMLSpec(const String& out_file, const String& base_name,
                                 libcpp_vector[ libcpp_vector[ OPXL_CrossLinkSpectrumMatch] ] & all_top_csms,
                                 MSExperiment & spectra) nogil except +

--- a/src/pyOpenMS/pxds/XTandemInfile.pxd
+++ b/src/pyOpenMS/pxds/XTandemInfile.pxd
@@ -32,16 +32,16 @@ cdef extern from "<OpenMS/FORMAT/XTandemInfile.h>" namespace "OpenMS":
         void setModifications(ModificationDefinitionsSet & mods) nogil except +
         ModificationDefinitionsSet  getModifications() nogil except +
 
-        void setOutputFilename(String & output) nogil except +
+        void setOutputFilename(const String & output) nogil except +
         String getOutputFilename() nogil except +
-        void setInputFilename(String & input_file) nogil except +
+        void setInputFilename(const String & input_file) nogil except +
         String getInputFilename() nogil except +
-        void setTaxonomyFilename(String & filename) nogil except +
+        void setTaxonomyFilename(const String & filename) nogil except +
         String getTaxonomyFilename() nogil except +
-        void setDefaultParametersFilename(String & filename) nogil except +
+        void setDefaultParametersFilename(const String & filename) nogil except +
         String getDefaultParametersFilename() nogil except +
 
-        void setTaxon(String & taxon) nogil except +
+        void setTaxon(const String & taxon) nogil except +
         String getTaxon() nogil except +
 
         void setMaxPrecursorCharge(Int max_charge) nogil except +

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -3389,6 +3389,71 @@ def testPeak():
 
 
 @report
+def testNumpressCoder():
+    """
+    """
+
+    np = pyopenms.MSNumpressCoder()
+
+    nc = pyopenms.NumpressConfig()
+    nc.np_compression = np.NumpressCompression.LINEAR
+    nc.estimate_fixed_point = True
+    tmp = pyopenms.String()
+    out = []
+    inp =  [1.0, 2.0, 3.0]
+    np.encodeNP(inp, tmp, True, nc)
+
+    res = str(tmp)
+    assert len(res) != 0, len(res)
+    assert res != "", res
+    np.decodeNP(res, out, True, nc)
+    assert len(out) == 3, (out, res)
+    assert out == inp, out
+
+    # Now try to use a simple Python string as input -> this will fail as we
+    # cannot pass this by reference in C++
+    res = ""
+    try:
+        np.encodeNP(inp, res, True, nc)
+        has_error = False
+    except AssertionError:
+        has_error = True
+
+    assert has_error
+
+@report
+def testNumpressConfig():
+    """
+    """
+
+    n = pyopenms.MSNumpressCoder()
+    np = pyopenms.NumpressConfig()
+    np.np_compression = n.NumpressCompression.LINEAR
+    assert np.np_compression == n.NumpressCompression.LINEAR
+    np.numpressFixedPoint = 4.2
+    np.numpressErrorTolerance = 4.2
+    np.estimate_fixed_point = True
+    np.linear_fp_mass_acc = 4.2
+    np.setCompression("linear")
+
+@report
+def testBase64():
+    """
+    """
+
+    b = pyopenms.Base64()
+    out = pyopenms.String()
+    inp =  [1.0, 2.0, 3.0]
+    b.encode(inp, b.ByteOrder.BYTEORDER_LITTLEENDIAN, out, False)
+    res = str(out)
+    assert len(res) != 0
+    assert res != ""
+
+    convBack = []
+    b.decode(res, b.ByteOrder.BYTEORDER_LITTLEENDIAN, convBack, False)
+    assert convBack == inp, convBack
+
+@report
 def testPeakFileOptions():
     """
     @tests: PeakFileOptions


### PR DESCRIPTION
fixes a bug where Strings cannot be passed by reference in pyOpenMS

- allow passing of Strings in pyOpenMS
- differentiate between `const String&`, `String` and `String&` arguments which all require special treatments
- add tests for numpress and base64 which return String objects through passing by reference