### PR TITLE
Feature/gui

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
@@ -322,6 +322,8 @@ public slots:
     void showCurrentPeaksAs3D();
     /// Shows the current peak data of the active layer as ion mobility
     void showCurrentPeaksAsIonMobility();
+    /// Shows the current peak data of the active layer as DIA data
+    void showCurrentPeaksAsDIA();
     /// Shows the 'About' dialog
     void showAboutDialog();
     /// Saves the whole current layer data

--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
@@ -320,6 +320,8 @@ public slots:
     void showCurrentPeaksAs2D();
     /// Shows the current peak data of the active layer in 3D
     void showCurrentPeaksAs3D();
+    /// Shows the current peak data of the active layer as ion mobility
+    void showCurrentPeaksAsIonMobility();
     /// Shows the 'About' dialog
     void showAboutDialog();
     /// Saves the whole current layer data

--- a/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/APPLICATIONS/TOPPViewBase.h
@@ -578,6 +578,9 @@ public:
     /// Returns true if @p contains at least one MS1 spectrum
     static bool containsMS1Scans(const ExperimentType& exp);
 
+    /// Returns true if @p contains ion mobility data
+    static bool containsIMData(const MSSpectrum& s);
+
     /// Estimates the noise by evaluating n_scans random scans of MS level 1. Assumes that 4/5 of intensities is noise.
     float estimateNoiseFromRandomMS1Scans(const ExperimentType& exp, UInt n_scans = 10);
 

--- a/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPViewOpenDialog.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/DIALOGS/TOPPViewOpenDialog.h
@@ -72,8 +72,10 @@ public:
     bool viewMapAs2D() const;
     /// Returns true, if 1D mode is to be used for maps
     bool viewMapAs1D() const;
-    /// Returns of the low intensity peaks should be hidden
+    /// Returns if the low intensity peaks should be hidden
     bool isCutoffEnabled() const;
+    /// Returns if the data is DIA / SWATH-MS data
+    bool isDataDIA() const;
     /// Returns true, if the data should be opened in a new window
     bool openAsNewWindow() const;
     ///Returns the index of the selected merge layer. If the option is not selected -1 is returned.
@@ -86,7 +88,7 @@ public:
     /// Disables opening location section and sets the selected option
     void disableLocation(bool window);
     /**
-        @brief Sets the possible merge layers (index and name) and activates the the option
+        @brief Sets the possible merge layers (index and name) and activates the option
 
         It is deactivated by default and can be deactivated manually by passing an empty list.
     */

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -337,6 +337,20 @@ public:
       this->getPeakData()->setMetaValue("is_ion_mobility", "true");
     }
 
+    /// Check whether the current layer contains DIA (SWATH-MS) data
+    bool isDIAData() const
+    {
+      return this->getPeakData()->size() > 0 &&
+             this->getPeakData()->metaValueExists("is_dia_data") &&
+             this->getPeakData()->getMetaValue("is_dia_data").toBool();
+    }
+
+    /// Label the current layer as DIA (SWATH-MS) data
+    void labelAsDIAData()
+    {
+      peaks->setMetaValue("is_dia_data", "true");
+    }
+
     /**
     @brief Check whether the current layer is a chromatogram
      

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -323,7 +323,20 @@ public:
       current_spectrum_ = index;
       updateCache_();
     }
-    
+
+    /// Check whether the current layer should be represented as ion mobility
+    bool isIonMobilityData() const
+    {
+      return this->getPeakData()->size() > 0 &&
+             this->getPeakData()->metaValueExists("is_ion_mobility") &&
+             this->getPeakData()->getMetaValue("is_ion_mobility").toBool();
+    }
+
+    void labelAsIonMobilityData() const
+    {
+      this->getPeakData()->setMetaValue("is_ion_mobility", "true");
+    }
+
     /**
     @brief Check whether the current layer is a chromatogram
      

--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -334,7 +334,7 @@ public:
 
     void labelAsIonMobilityData() const
     {
-      this->getPeakData()->setMetaValue("is_ion_mobility", "true");
+      peaks->setMetaValue("is_ion_mobility", "true");
     }
 
     /// Check whether the current layer contains DIA (SWATH-MS) data

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
@@ -172,8 +172,12 @@ public:
 signals:
     /// Requests to display all spectra in 2D plot
     void showCurrentPeaksAs2D();
+
     /// Requests to display all spectra in 3D plot
     void showCurrentPeaksAs3D();
+
+    /// Requests to display all spectra in ion mobility plot
+    void showCurrentPeaksAsIonMobility();
 
 public slots:
     // Docu in base class

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DCanvas.h
@@ -179,6 +179,9 @@ signals:
     /// Requests to display all spectra in ion mobility plot
     void showCurrentPeaksAsIonMobility();
 
+    /// Requests to display all spectra as DIA
+    void showCurrentPeaksAsDIA();
+
 public slots:
     // Docu in base class
     void activateLayer(Size layer_index) override;

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DWidget.h
@@ -113,6 +113,9 @@ signals:
     /// Requests to display the whole spectrum in ion mobility view
     void showCurrentPeaksAsIonMobility();
 
+    /// Requests to display a full DIA window
+    void showCurrentPeaksAsDIA();
+
 public slots:
     // Docu in base class
     void showGoToDialog() override;

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum1DWidget.h
@@ -110,6 +110,9 @@ signals:
     /// Requests to display the whole spectrum in 3D view
     void showCurrentPeaksAs3D();
 
+    /// Requests to display the whole spectrum in ion mobility view
+    void showCurrentPeaksAsIonMobility();
+
 public slots:
     // Docu in base class
     void showGoToDialog() override;

--- a/src/openms_gui/include/OpenMS/VISUAL/Spectrum3DOpenGLCanvas.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/Spectrum3DOpenGLCanvas.h
@@ -96,6 +96,10 @@ public:
     void mousePressEvent(QMouseEvent * e) override;
     void focusOutEvent(QFocusEvent * e) override;
     //@}
+
+    void setXLabel(const QString& l) { x_label_ = l; }
+    void setYLabel(const QString& l) { y_label_ = l; }
+    void setZLabel(const QString& l) { z_label_ = l; }
     
     /// updates the min and max values of the intensity
     void updateIntensityScale();
@@ -227,6 +231,10 @@ protected:
     double trans_x_;
     /// y_translation
     double trans_y_;
+
+    QString x_label_;
+    QString y_label_;
+    QString z_label_;
 
 protected slots:
     /// Slot that reacts on action mode changes

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPView.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPView.cpp
@@ -39,12 +39,12 @@
   and several other file formats. It also supports viewing data from an %OpenMS database.
   The following figure shows two instances of TOPPView displaying a HPLC-MS map and a MS raw spectrum:
 
-    @image html TOPPView.png
+  @image html TOPPView.png
 
-    More information about TOPPView can be found in the @ref TOPP_tutorial.
+  More information about TOPPView can be found in the @ref TOPP_tutorial.
 
-    <B>The command line parameters of this tool are:</B>
-    @verbinclude TOPP_TOPPView.cli
+  <B>The command line parameters of this tool are:</B>
+  @verbinclude TOPP_TOPPView.cli
 */
 
 //QT
@@ -101,7 +101,7 @@ void print_usage()
        << " - '@r'  after a map file displays the dots in red." << endl
        << " - '@g'  after a map file displays the dots in green." << endl
        << " - '@m'  after a map file displays the dots in magenta." << endl
-       << " - Example: 'TOPPView 1.mzML + 2.mzML @bw + 3.mzML @bg'" << endl
+       << " - Example: '" << tool_name << " 1.mzML + 2.mzML @bw + 3.mzML @bg'" << endl
        << endl;
 }
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -677,6 +677,15 @@ namespace OpenMS
   }
 
   // static
+  bool TOPPViewBase::containsIMData(const MSSpectrum& s)
+  {
+    if (s.getFloatDataArrays().empty() || s.getFloatDataArrays()[0].getName() != "Ion Mobility")
+    {
+      return false;
+    }
+    return true;
+  }
+
   float TOPPViewBase::estimateNoiseFromRandomMS1Scans(const ExperimentType& exp, UInt n_scans)
   {
     if (!TOPPViewBase::containsMS1Scans(exp))
@@ -3455,7 +3464,7 @@ namespace OpenMS
     auto spidx = layer.getCurrentSpectrumIndex();
     MSSpectrum tmps = exp_sptr->getSpectrum(spidx);
 
-    if (tmps.getFloatDataArrays().empty() || tmps.getFloatDataArrays()[0].getName() != "Ion Mobility")
+    if (!containsIMData(tmps))
     {
       std::cout << "Cannot display ion mobility data, no float array with the correct name 'Ion Mobility' available." <<
         " Number of float arrays: " << tmps.getFloatDataArrays().size() << std::endl;
@@ -3464,7 +3473,7 @@ namespace OpenMS
 
     // Fill temporary spectral map (mobility -> Spectrum) with data from current spectrum
     std::map< int, boost::shared_ptr<MSSpectrum> > im_map;
-    auto im_arr = tmps.getFloatDataArrays()[0];
+    auto im_arr = tmps.getFloatDataArrays()[0]; // the first array should be the IM array (see containsIMData)
     for (Size k = 0;  k < tmps.size(); k++)
     {
       double im = im_arr[ k ];

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -85,7 +85,8 @@
 #include <OpenMS/VISUAL/DIALOGS/TOPPViewPrefDialog.h>
 #include <OpenMS/VISUAL/DIALOGS/SpectrumAlignmentDialog.h>
 #include <OpenMS/VISUAL/MISC/GUIHelpers.h>
-
+#include <OpenMS/VISUAL/AxisWidget.h>
+#include <OpenMS/VISUAL/Spectrum3DOpenGLCanvas.h>
 
 //Qt
 #include <QtCore/QSettings>
@@ -3495,6 +3496,7 @@ namespace OpenMS
     }
     tmpe->sortSpectra();
     tmpe->updateRanges();
+    tmpe->setMetaValue("is_ion_mobility", "true");
 
     // open new 2D widget
     Spectrum2DWidget* w = new Spectrum2DWidget(getSpectrumParameters(2), ws_);
@@ -3504,6 +3506,7 @@ namespace OpenMS
     {
       return;
     }
+    w->xAxis()->setLegend(String("Ion Mobility [ms]"));
 
     String caption = layer.name;
     caption += " (Ion Mobility Scan " + String(spidx) + ")";
@@ -3560,6 +3563,11 @@ namespace OpenMS
       Spectrum3DWidget* w = new Spectrum3DWidget(getSpectrumParameters(3), ws_);
 
       ExperimentSharedPtrType exp_sptr = layer.getPeakDataMuteable();
+
+      if (layer.isIonMobilityData())
+      {
+        w->canvas()->openglwidget()->setYLabel("Ion Mobility [ms]");
+      }
 
       if (!w->canvas()->addLayer(exp_sptr, SpectrumCanvas::ODExperimentSharedPtrType(new OnDiscMSExperiment()), layer.filename))
       {

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -3473,11 +3473,10 @@ namespace OpenMS
     double IM_BINNING = 1e5;
 
     const LayerData& layer = getActiveCanvas()->getCurrentLayer();
-    ExperimentSharedPtrType exp_sptr = layer.getPeakData();
 
     // Get current spectrum
     auto spidx = layer.getCurrentSpectrumIndex();
-    MSSpectrum tmps = exp_sptr->getSpectrum(spidx);
+    MSSpectrum tmps = layer.getCurrentSpectrum();
 
     if (!containsIMData(tmps))
     {
@@ -3516,7 +3515,7 @@ namespace OpenMS
     Spectrum2DWidget* w = new Spectrum2DWidget(getSpectrumParameters(2), ws_);
 
     // add data
-    if (!w->canvas()->addLayer(tmpe, layer.filename))
+    if (!w->canvas()->addLayer(tmpe, SpectrumCanvas::ODExperimentSharedPtrType(new OnDiscMSExperiment()), layer.filename))
     {
       return;
     }

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewOpenDialog.cpp
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewOpenDialog.cpp
@@ -60,10 +60,6 @@ namespace OpenMS
     ui_->setupUi(this);
 
     //init map view
-    QButtonGroup * button_group = new QButtonGroup(this);
-    button_group->addButton(ui_->d1_);
-    button_group->addButton(ui_->d2_);
-    button_group->addButton(ui_->d3_);
     if (!as_2d)
     {
       ui_->d1_->setChecked(true);
@@ -76,26 +72,12 @@ namespace OpenMS
     }
 
     //init intensity cutoff
-    button_group = new QButtonGroup(this);
-    button_group->addButton(ui_->cutoff_);
-    button_group->addButton(ui_->nocutoff_);
-    if (!cutoff)
+    if (cutoff)
     {
-      ui_->nocutoff_->setChecked(true);
-      ui_->nocutoff_->setFocus();
-    }
-    else
-    {
-      ui_->cutoff_->setChecked(true);
-      ui_->cutoff_->setFocus();
+      ui_->intensity_cutoff_->setChecked(true);
     }
 
     //init open as
-    button_group = new QButtonGroup(this);
-    button_group->addButton(ui_->window_);
-    button_group->addButton(ui_->layer_);
-    button_group->addButton(ui_->merge_);
-    connect(button_group, SIGNAL(buttonClicked(QAbstractButton *)), this, SLOT(updateViewMode_(QAbstractButton *)));
     if (!as_window)
     {
       ui_->layer_->setChecked(true);
@@ -119,34 +101,27 @@ namespace OpenMS
 
   bool TOPPViewOpenDialog::viewMapAs2D() const
   {
-    if (ui_->d2_->isChecked())
-      return true;
-
-    return false;
+    return ui_->d2_->isChecked();
   }
 
   bool TOPPViewOpenDialog::viewMapAs1D() const
   {
-    if (ui_->d1_->isChecked())
-      return true;
-
-    return false;
+    return ui_->d1_->isChecked();
   }
 
   bool TOPPViewOpenDialog::isCutoffEnabled() const
   {
-    if (ui_->cutoff_->isChecked())
-      return true;
+    return ui_->intensity_cutoff_->isChecked();
+  }
 
-    return false;
+  bool TOPPViewOpenDialog::isDataDIA() const
+  {
+    return ui_->dia_data_->isChecked();
   }
 
   bool TOPPViewOpenDialog::openAsNewWindow() const
   {
-    if (ui_->window_->isChecked())
-      return true;
-
-    return false;
+    return ui_->window_->isChecked();
   }
 
   void TOPPViewOpenDialog::disableDimension(bool as_2d)
@@ -161,9 +136,7 @@ namespace OpenMS
 
   void TOPPViewOpenDialog::disableCutoff(bool cutoff_on)
   {
-    ui_->cutoff_->setChecked(cutoff_on);
-    ui_->cutoff_->setEnabled(false);
-    ui_->nocutoff_->setEnabled(false);
+    ui_->intensity_cutoff_->setChecked(false);
   }
 
   void TOPPViewOpenDialog::disableLocation(bool as_window)
@@ -200,7 +173,7 @@ namespace OpenMS
 
   void TOPPViewOpenDialog::setMergeLayers(const Map<Size, String> & layers)
   {
-    //remove all items
+    // remove all items
     ui_->merge_combo_->clear();
 
     if (layers.size() != 0)

--- a/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewOpenDialog.ui
+++ b/src/openms_gui/source/VISUAL/DIALOGS/TOPPViewOpenDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>485</width>
-    <height>220</height>
+    <width>570</width>
+    <height>224</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -55,7 +55,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>new window                                </string>
+           <string>&amp;new window                                </string>
           </property>
           <property name="checked">
            <bool>false</bool>
@@ -68,7 +68,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>new layer                                    </string>
+           <string>new &amp;layer                                    </string>
           </property>
          </widget>
         </item>
@@ -81,7 +81,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>merge into layer                           </string>
+           <string>&amp;merge into layer                           </string>
           </property>
          </widget>
         </item>
@@ -119,7 +119,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>1D            </string>
+           <string>&amp;1D            </string>
           </property>
          </widget>
         </item>
@@ -129,7 +129,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>2D            </string>
+           <string>&amp;2D            </string>
           </property>
           <property name="checked">
            <bool>false</bool>
@@ -142,7 +142,7 @@
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>3D            </string>
+           <string>&amp;3D            </string>
           </property>
          </widget>
         </item>
@@ -165,32 +165,20 @@
      <item>
       <widget class="QGroupBox" name="groupBox_3">
        <property name="title">
-        <string>Low intensity cutoff</string>
+        <string>Display Option</string>
        </property>
        <layout class="QVBoxLayout">
         <item>
-         <widget class="QRadioButton" name="cutoff_">
-          <property name="mouseTracking">
-           <bool>false</bool>
-          </property>
+         <widget class="QCheckBox" name="dia_data_">
           <property name="text">
-           <string>on                    </string>
+           <string>DIA / SWATH data</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="nocutoff_">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="mouseTracking">
-           <bool>false</bool>
-          </property>
+         <widget class="QCheckBox" name="intensity_cutoff_">
           <property name="text">
-           <string>off                    </string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
+           <string>Low intensity cutoff</string>
           </property>
          </widget>
         </item>
@@ -282,8 +270,6 @@
   <tabstop>layer_</tabstop>
   <tabstop>d2_</tabstop>
   <tabstop>d3_</tabstop>
-  <tabstop>nocutoff_</tabstop>
-  <tabstop>cutoff_</tabstop>
   <tabstop>cancel_</tabstop>
   <tabstop>ok_</tabstop>
  </tabstops>

--- a/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraViewWidget.cpp
@@ -66,7 +66,7 @@ namespace OpenMS
     ///@improvement write the visibility-status of the columns in toppview.ini and read at start
 
     QStringList qsl; // names of searchable columns
-    qsl << "index" << "RT" << "PC m/z" << "dissociation" << "scan" << "zoom";
+    qsl << "index" << "RT" << "precursor m/z" << "dissociation" << "scan" << "zoom";
 
     QStringList header_labels; /// @improvement make this global to change only once (otherwise changes must be applied in several slots too!)
     header_labels.append(QString("MS level"));
@@ -314,6 +314,20 @@ namespace OpenMS
       parent_stack.push_back(nullptr);
       bool fail = false;
 
+      if (cl.isIonMobilityData())
+      {
+        // replace RT with Ion Mobility as a header
+        QStringList header_labels;
+        header_labels.append(QString("MS level"));
+        header_labels.append(QString("index"));
+        header_labels.append(QString("Ion Mobility"));
+        header_labels.append(QString("precursor m/z"));
+        header_labels.append(QString("dissociation"));
+        header_labels.append(QString("scan type"));
+        header_labels.append(QString("zoom"));
+        spectra_treewidget_->setHeaderLabels(header_labels);
+      }
+
       for (Size i = 0; i < cl.getPeakData()->size(); ++i)
       {
         const MSSpectrum& current_spec = (*cl.getPeakData())[i];
@@ -382,16 +396,16 @@ namespace OpenMS
 
         if (!current_precursors.empty() || current_spec.metaValueExists("analyzer scan offset"))
         {
-          double pc_val;
+          double precursor_mz;
           if (current_spec.metaValueExists("analyzer scan offset"))
           {
-            pc_val = current_spec.getMetaValue("analyzer scan offset");
+            precursor_mz = current_spec.getMetaValue("analyzer scan offset");
             item->setText(4, "-");
           }
           else 
           {
             const Precursor& current_pc = current_precursors[0];
-            pc_val = current_pc.getMZ();
+            precursor_mz = current_pc.getMZ();
             if (!current_pc.getActivationMethods().empty())
             {
               QString t;
@@ -410,7 +424,7 @@ namespace OpenMS
               item->setText(4, "-");
             }
           }
-          item->setText(3, QString::number(pc_val));
+          item->setText(3, QString::number(precursor_mz));
         }
         else
         {

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1426,7 +1426,6 @@ namespace OpenMS
         context_menu->addAction("Switch to 3D view");
       }
 
-      // TODO only if its im data!!!
       if (TOPPViewBase::containsIMData(getCurrentLayer().getPeakData()->getSpectrum( 
               getCurrentLayer().getCurrentSpectrumIndex() ) ))
       {

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1426,8 +1426,7 @@ namespace OpenMS
         context_menu->addAction("Switch to 3D view");
       }
 
-      if (TOPPViewBase::containsIMData(getCurrentLayer().getPeakData()->getSpectrum( 
-              getCurrentLayer().getCurrentSpectrumIndex() ) ))
+      if (TOPPViewBase::containsIMData(getCurrentLayer().getCurrentSpectrum()))
       {
         context_menu->addAction("Switch to ion mobility view");
       }

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1425,6 +1425,7 @@ namespace OpenMS
         context_menu->addAction("Switch to 2D view");
         context_menu->addAction("Switch to 3D view");
       }
+      context_menu->addAction("Switch to ion mobility view");
 
       //add external context menu
       if (context_add_)
@@ -1506,6 +1507,10 @@ namespace OpenMS
         else if (result->text() == "Switch to 3D view")
         {
           emit showCurrentPeaksAs3D();
+        }
+        else if (result->text() == "Switch to ion mobility view")
+        {
+          emit showCurrentPeaksAsIonMobility();
         }
       }
     }

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1425,7 +1425,13 @@ namespace OpenMS
         context_menu->addAction("Switch to 2D view");
         context_menu->addAction("Switch to 3D view");
       }
-      context_menu->addAction("Switch to ion mobility view");
+
+      // TODO only if its im data!!!
+      if (TOPPViewBase::containsIMData(getCurrentLayer().getPeakData()->getSpectrum( 
+              getCurrentLayer().getCurrentSpectrumIndex() ) ))
+      {
+        context_menu->addAction("Switch to ion mobility view");
+      }
 
       //add external context menu
       if (context_add_)

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -1431,6 +1431,11 @@ namespace OpenMS
         context_menu->addAction("Switch to ion mobility view");
       }
 
+      if (getCurrentLayer().isDIAData())
+      {
+        context_menu->addAction("Switch to DIA-MS view");
+      }
+
       //add external context menu
       if (context_add_)
       {
@@ -1515,6 +1520,10 @@ namespace OpenMS
         else if (result->text() == "Switch to ion mobility view")
         {
           emit showCurrentPeaksAsIonMobility();
+        }
+        else if (result->text() == "Switch to DIA-MS view")
+        {
+          emit showCurrentPeaksAsDIA();
         }
       }
     }

--- a/src/openms_gui/source/VISUAL/Spectrum1DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DWidget.cpp
@@ -74,6 +74,7 @@ namespace OpenMS
     //Delegate signals
     connect(canvas(), SIGNAL(showCurrentPeaksAs2D()), this, SIGNAL(showCurrentPeaksAs2D()));
     connect(canvas(), SIGNAL(showCurrentPeaksAs3D()), this, SIGNAL(showCurrentPeaksAs3D()));
+    connect(canvas(), SIGNAL(showCurrentPeaksAsIonMobility()), this, SIGNAL(showCurrentPeaksAsIonMobility()));
   }
 
   void Spectrum1DWidget::recalculateAxes_()

--- a/src/openms_gui/source/VISUAL/Spectrum1DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DWidget.cpp
@@ -75,6 +75,7 @@ namespace OpenMS
     connect(canvas(), SIGNAL(showCurrentPeaksAs2D()), this, SIGNAL(showCurrentPeaksAs2D()));
     connect(canvas(), SIGNAL(showCurrentPeaksAs3D()), this, SIGNAL(showCurrentPeaksAs3D()));
     connect(canvas(), SIGNAL(showCurrentPeaksAsIonMobility()), this, SIGNAL(showCurrentPeaksAsIonMobility()));
+    connect(canvas(), SIGNAL(showCurrentPeaksAsDIA()), this, SIGNAL(showCurrentPeaksAsDIA()));
   }
 
   void Spectrum1DWidget::recalculateAxes_()

--- a/src/openms_gui/source/VISUAL/Spectrum3DOpenGLCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum3DOpenGLCanvas.cpp
@@ -53,6 +53,9 @@ namespace OpenMS
   {
     canvas_3d.rubber_band_.setParent(this);
 
+    x_label_ = (String(Peak2D::shortDimensionName(Peak2D::MZ)) + " [" + String(Peak2D::shortDimensionUnit(Peak2D::MZ)) + "]").toQString();
+    y_label_ = (String(Peak2D::shortDimensionName(Peak2D::RT)) + " [" + String(Peak2D::shortDimensionUnit(Peak2D::RT)) + "]").toQString();
+
     //Set focus policy and mouse tracking in order to get keyboard events
     setMouseTracking(true);
     setFocusPolicy(Qt::StrongFocus);
@@ -323,73 +326,72 @@ namespace OpenMS
     QString text;
     qglColor_(Qt::black);
 
-    //RT axis legend
+    // Draw x and y axis legend
     if (canvas_3d_.legend_shown_)
     {
       font.setPixelSize(12);
-
-      static QString mz_label = (String(Peak2D::shortDimensionName(Peak2D::MZ)) + " [" + String(Peak2D::shortDimensionUnit(Peak2D::MZ)) + "]").toQString();
-      renderText_(0.0, -corner_ - 20.0, -near_ - 2 * corner_ + 20.0, mz_label);
-
-      static QString rt_label = (String(Peak2D::shortDimensionName(Peak2D::RT)) + " [" + String(Peak2D::shortDimensionUnit(Peak2D::RT)) + "]").toQString();
-      renderText_(-corner_ - 20.0, -corner_ - 20.0, -near_ - 3 * corner_, rt_label);
-
+      renderText_(0.0, -corner_ - 20.0, -near_ - 2 * corner_ + 20.0, x_label_);
+      renderText_(-corner_ - 20.0, -corner_ - 20.0, -near_ - 3 * corner_, y_label_);
       font.setPixelSize(10);
     }
 
-    //RT numbers
-    if (grid_rt_.size() > 0)
+    // RT tick labels
     {
-      for (Size i = 0; i < grid_rt_[0].size(); i++)
+      if (grid_rt_.size() > 0)
       {
-        text = QString::number(grid_rt_[0][i]);
-        renderText_(-corner_ - 15.0, -corner_ - 5.0, -near_ - 2 * corner_ - scaledRT_(grid_rt_[0][i]), text);
+        for (Size i = 0; i < grid_rt_[0].size(); i++)
+        {
+          text = QString::number(grid_rt_[0][i]);
+          renderText_(-corner_ - 15.0, -corner_ - 5.0, -near_ - 2 * corner_ - scaledRT_(grid_rt_[0][i]), text);
+        }
       }
-    }
-    if (zoom_ < 3.0 && grid_rt_.size() >= 2)
-    {
-      for (Size i = 0; i < grid_rt_[1].size(); i++)
+      if (zoom_ < 3.0 && grid_rt_.size() >= 2)
       {
-        text = QString::number(grid_rt_[1][i]);
-        renderText_(-corner_ - 15.0, -corner_ - 5.0, -near_ - 2 * corner_ - scaledRT_(grid_rt_[1][i]), text);
+        for (Size i = 0; i < grid_rt_[1].size(); i++)
+        {
+          text = QString::number(grid_rt_[1][i]);
+          renderText_(-corner_ - 15.0, -corner_ - 5.0, -near_ - 2 * corner_ - scaledRT_(grid_rt_[1][i]), text);
+        }
       }
-    }
-    if (zoom_ < 2.0 && grid_rt_.size() >= 3)
-    {
-      for (Size i = 0; i < grid_rt_[2].size(); i++)
+      if (zoom_ < 2.0 && grid_rt_.size() >= 3)
       {
-        text = QString::number(grid_rt_[2][i]);
-        renderText_(-corner_ - 15.0, -corner_ - 5.0, -near_ - 2 * corner_ - scaledRT_(grid_rt_[2][i]), text);
-      }
-    }
-
-    //m/z numbers
-    if (grid_mz_.size() > 0)
-    {
-      for (Size i = 0; i < grid_mz_[0].size(); i++)
-      {
-        text = QString::number(grid_mz_[0][i]);
-        renderText_(-corner_ - text.length() + scaledMZ_(grid_mz_[0][i]), -corner_ - 5.0, -near_ - 2 * corner_ + 15.0, text);
-      }
-    }
-    if (zoom_ < 3.0 && grid_mz_.size() >= 2)
-    {
-      for (Size i = 0; i < grid_mz_[1].size(); i++)
-      {
-        text = QString::number(grid_mz_[1][i]);
-        renderText_(-corner_ - text.length() + scaledMZ_(grid_mz_[1][i]), -corner_ - 5.0, -near_ - 2 * corner_ + 15.0, text);
-      }
-    }
-    if (zoom_ < 2.0 && grid_mz_.size() >= 3)
-    {
-      for (Size i = 0; i < grid_mz_[2].size(); i++)
-      {
-        text = QString::number(grid_mz_[2][i]);
-        renderText_(-corner_ - text.length() + scaledMZ_(grid_mz_[2][i]), -corner_ - 5.0, -near_ - 2 * corner_ + 15.0, text);
+        for (Size i = 0; i < grid_rt_[2].size(); i++)
+        {
+          text = QString::number(grid_rt_[2][i]);
+          renderText_(-corner_ - 15.0, -corner_ - 5.0, -near_ - 2 * corner_ - scaledRT_(grid_rt_[2][i]), text);
+        }
       }
     }
 
-    //draw intensity legend if not in zoom mode
+    // m/z tick labels
+    {
+      if (grid_mz_.size() > 0)
+      {
+        for (Size i = 0; i < grid_mz_[0].size(); i++)
+        {
+          text = QString::number(grid_mz_[0][i]);
+          renderText_(-corner_ - text.length() + scaledMZ_(grid_mz_[0][i]), -corner_ - 5.0, -near_ - 2 * corner_ + 15.0, text);
+        }
+      }
+      if (zoom_ < 3.0 && grid_mz_.size() >= 2)
+      {
+        for (Size i = 0; i < grid_mz_[1].size(); i++)
+        {
+          text = QString::number(grid_mz_[1][i]);
+          renderText_(-corner_ - text.length() + scaledMZ_(grid_mz_[1][i]), -corner_ - 5.0, -near_ - 2 * corner_ + 15.0, text);
+        }
+      }
+      if (zoom_ < 2.0 && grid_mz_.size() >= 3)
+      {
+        for (Size i = 0; i < grid_mz_[2].size(); i++)
+        {
+          text = QString::number(grid_mz_[2][i]);
+          renderText_(-corner_ - text.length() + scaledMZ_(grid_mz_[2][i]), -corner_ - 5.0, -near_ - 2 * corner_ + 15.0, text);
+        }
+      }
+    }
+
+    // draw intensity legend if not in zoom mode
     if (canvas_3d_.action_mode_ != SpectrumCanvas::AM_ZOOM)
     {
       switch (canvas_3d_.intensity_mode_)

--- a/tools/scripts/create_im.py
+++ b/tools/scripts/create_im.py
@@ -54,11 +54,36 @@ for rt_idx in range(NR_RT_SAMPLES):
     sp = MSSpectrum()
     sp.setRT(rt_idx)
     sp.setMSLevel(1)
+
+    base_int = 100 - abs(20 - rt_idx)*(100)/25.0  # shift the precursor slightly
+    base_int = max(5, base_int)
+
+    fda = pyopenms.FloatDataArray()
+    fda.setName("Ion Mobility")
+    fda.resize(100)
+
     for i in range(100):
         p = Peak1D()
         p.setMZ(100+i)
-        p.setIntensity(100+i)
+        p.setIntensity(base_int+i)
         sp.push_back(p)
+        fda[i] = 10
+
+    for i in range(10):
+        p = Peak1D()
+        p.setMZ(412.502)
+        p.setIntensity(base_int+ (i-5))
+        sp.push_back(p)
+        fda.push_back( 99 + (i-5) )
+
+    for i in range(10):
+        p = Peak1D()
+        p.setMZ(417.502)
+        p.setIntensity(base_int+ (i-5))
+        sp.push_back(p)
+        fda.push_back( 152 + (i-5) )
+
+    sp.setFloatDataArrays([fda])
     exp.addSpectrum(sp)
 
 # Create MS2 spectra
@@ -74,7 +99,6 @@ for rt_idx in range(NR_RT_SAMPLES):
     allim = []
 
     for im_idx in range(NR_IM_BINS):
-        # print("======================================= ion mobility", im_idx)
         sp = MSSpectrum()
         p = pyopenms.Precursor()
         p.setIsolationWindowLowerOffset(12)


### PR DESCRIPTION
- display Ion Mobility data in TOPPView
- display SWATH-MS / PRM / DIA data in TOPPView

this works through an addition option when right-clicking on the 1D spectrum view to either enter Ion Mobility view (if present) or SWATH-MS view (if selected when loading the file). Works well together with the cached MS1 / MS2 spectra from previous PR.

Ion mobility data can be visualized in the m/z *vs* Ion Mobility domain from a 1D spectrum:

![screenshot from 2018-04-25 14-06-27](https://user-images.githubusercontent.com/464014/40339849-3cbc561a-5d4a-11e8-895b-4109db3f48aa.png)

![screenshot from 2018-04-25 14-11-20](https://user-images.githubusercontent.com/464014/40339859-48fe0072-5d4a-11e8-9e46-b126388b7aa2.png)

this works to visualize individual scans in 2D, 3D as well as 1D (again). 

For the SWATH-MS / DIA part:

Allows loading of full SWATH-MS data files in ca 20 seconds (full file is ca 40-50 GB raw data in memory, 75k spectra) with less than 300 MB of RAM usage. Loading of individual SWATH-MS slices takes about 10 seconds during which ca 2300 spectra are loaded into memory and need to be decompressed (1.5 GB of memory). This allows users to explore individual SWATH-MS windows with the whole data on disk using IndexedMzML.

![screenshot from 2018-05-21 22-58-52](https://user-images.githubusercontent.com/464014/40339933-93352e9a-5d4a-11e8-8938-532fa99063c5.png)

![screenshot from 2018-05-21 22-58-02](https://user-images.githubusercontent.com/464014/40339885-6ea1dce0-5d4a-11e8-8e0a-75209fe7c9bd.png)

note how all the scans have the same precursor in the above screenshot since they are all from the same SWATH-MS window. This should also work with spectrum-level SRM data, with PRM data, DIA data etc. 

Finally, this PR modifies the loading TOPPViewOpenDialog to the following:

![screenshot from 2018-05-21 23-00-56](https://user-images.githubusercontent.com/464014/40339994-d8381c3c-5d4a-11e8-8c64-d15f7313abae.png)

in order to make space (low intensity cutoff does not need 2 boxes) and allow user to specify loading data in DIA / SWATH-MS mode.