### PR TITLE
[FEATURE] TargetedSpectraExtractor: "no feature" support for all methods

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
@@ -35,20 +35,10 @@
 #pragma once
 
 #include <OpenMS/config.h> // OPENMS_DLLAPI
-#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
 #include <OpenMS/ANALYSIS/TARGETED/TargetedExperiment.h>
-#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
-#include <OpenMS/FILTERING/SMOOTHING/GaussFilter.h>
-#include <OpenMS/FILTERING/SMOOTHING/SavitzkyGolayFilter.h>
-#include <OpenMS/FORMAT/MzMLFile.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
-#include <OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h>
-
-// TODO: move headers where they are necessary (cpp/h files)
-// TODO: update documentation about thrown exceptions
 
 namespace OpenMS
 {
@@ -79,9 +69,9 @@ namespace OpenMS
   {
 public:
     TargetedSpectraExtractor();
-    virtual ~TargetedSpectraExtractor();
+    virtual ~TargetedSpectraExtractor() = default;
 
-    void getDefaultParameters(Param& params);
+    void getDefaultParameters(Param& params) const;
 
     /**
       @brief Filters and annotates those spectra that could potentially match the
@@ -97,6 +87,7 @@ public:
       @param[in] targeted_exp The target list
       @param[out] annotated_spectra The spectra annotated with the related transition's name
       @param[out] features A FeatureMap which will contain informations about the name, precursor RT and precursor MZ of the matched transition
+      @param[in] compute_features If false, `features` will be ignored
     */
     void annotateSpectra(
       const std::vector<MSSpectrum>& spectra,
@@ -106,6 +97,20 @@ public:
       const bool compute_features = true
     ) const;
 
+    /**
+      @brief Filters and annotates those spectra that could potentially match the
+      transitions of the target list.
+
+      The spectra taken into account are those that fall within the precursor RT
+      window and MZ tolerance set by the user through the parameters "rt_window"
+      and "mz_tolerance". Default values are provided for both parameters.
+
+      @warning The picked spectrum could be empty, meaning no peaks were found.
+
+      @param[in] spectra The spectra to filter
+      @param[in] targeted_exp The target list
+      @param[out] annotated_spectra The spectra annotated with the related transition's name
+    */
     void annotateSpectra(
       const std::vector<MSSpectrum>& spectra,
       const TargetedExperiment& targeted_exp,
@@ -124,6 +129,8 @@ public:
       It is possible to set the peaks' limits through the parameters: "peak_height_min",
       "peak_height_max" and "fwhm_threshold".
 
+      @throw Exception::IllegalArgument If `spectrum` is not sorted by position (mz).
+
       @param[in] spectrum The input spectrum
       @param[out] picked_spectrum A spectrum containing only the picked peaks
     */
@@ -139,10 +146,13 @@ public:
       The FWHMs are computed only on picked peaks. Both SNR and FWHM are averaged values.
       The informations are added as FloatDataArray in scored_spectra and as MetaValue in features.
 
+      @throw Exception::InvalidSize If `features` and `annotated_spectra` sizes don't match.
+
       @param[in] annotated_spectra The annotated spectra to score (for TIC and SNR)
       @param[in] picked_spectra The picked peaks found on each of the annotated spectra (for FWHM)
       @param[in,out] features The score informations are also added to this FeatureMap. Picked peaks' FWHMs are saved in features' subordinates.
       @param[out] scored_spectra The scored spectra. Basically a copy of annotated_spectra with the added score informations
+      @param[in] compute_features If false, `features` will be ignored
     */
     void scoreSpectra(
       const std::vector<MSSpectrum>& annotated_spectra,
@@ -152,6 +162,19 @@ public:
       const bool compute_features = true
     ) const;
 
+    /**
+      @brief Assigns a score to the spectra given an input and saves them in scored_spectra.
+
+      Also add the informations to the FeatureMap first constructed in annotateSpectra().
+      The scores are based on total TIC, SNR and FWHM. It is possible to assign a
+      weight to these parameters using: "tic_weight", "fwhm_weight" and "snr_weight".
+      For each spectrum, the TIC and the SNR are computed on the entire spectrum.
+      The FWHMs are computed only on picked peaks. Both SNR and FWHM are averaged values.
+
+      @param[in] annotated_spectra The annotated spectra to score (for TIC and SNR)
+      @param[in] picked_spectra The picked peaks found on each of the annotated spectra (for FWHM)
+      @param[out] scored_spectra The scored spectra. Basically a copy of annotated_spectra with the added score informations
+    */
     void scoreSpectra(
       const std::vector<MSSpectrum>& annotated_spectra,
       const std::vector<MSSpectrum>& picked_spectra,
@@ -166,6 +189,7 @@ public:
       @param[in] features Input features
       @param[out] selected_spectra Output selected spectra
       @param[out] selected_features Output selected features
+      @param[in] compute_features If false, `selected_features` will be ignored
     */
     void selectSpectra(
       const std::vector<MSSpectrum>& scored_spectra,
@@ -201,6 +225,7 @@ public:
       @param[in] targeted_exp The target list
       @param[out] extracted_spectra The spectra related to the transitions
       @param[out] extracted_features The features related to the output spectra
+      @param[in] compute_features If false, `extracted_features` will be ignored
     */
     void extractSpectra(
       const MSExperiment& experiment,
@@ -210,6 +235,19 @@ public:
       const bool compute_features = true
     ) const;
 
+    /**
+      @brief Combines the functionalities given by all the other methods implemented
+      in this class.
+
+      The method expects an experiment and a target list in input,
+      and constructs the extracted spectra.
+      For each transition of the target list, the method tries to find its best
+      spectrum match.
+
+      @param[in] experiment The input experiment
+      @param[in] targeted_exp The target list
+      @param[out] extracted_spectra The spectra related to the transitions
+    */
     void extractSpectra(
       const MSExperiment& experiment,
       const TargetedExperiment& targeted_exp,

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
@@ -47,6 +47,9 @@
 #include <OpenMS/KERNEL/FeatureMap.h>
 #include <OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h>
 
+// TODO: move headers where they are necessary (cpp/h files)
+// TODO: update documentation about thrown exceptions
+
 namespace OpenMS
 {
   /**
@@ -100,7 +103,7 @@ public:
       const TargetedExperiment& targeted_exp,
       std::vector<MSSpectrum>& annotated_spectra,
       FeatureMap& features
-    );
+    ) const;
 
     /**
       @brief Picks a spectrum's peaks and saves them in picked_spectrum.
@@ -117,7 +120,7 @@ public:
       @param[in] spectrum The input spectrum
       @param[out] picked_spectrum A spectrum containing only the picked peaks
     */
-    void pickSpectrum(const MSSpectrum& spectrum, MSSpectrum& picked_spectrum);
+    void pickSpectrum(const MSSpectrum& spectrum, MSSpectrum& picked_spectrum) const;
 
     /**
       @brief Assigns a score to the spectra given an input and saves them in scored_spectra.
@@ -139,7 +142,7 @@ public:
       const std::vector<MSSpectrum>& picked_spectra,
       FeatureMap& features,
       std::vector<MSSpectrum>& scored_spectra
-    );
+    ) const;
 
     /**
       @brief The method selects the highest scoring spectrum for each possible
@@ -155,7 +158,7 @@ public:
       const FeatureMap& features,
       std::vector<MSSpectrum>& selected_spectra,
       FeatureMap& selected_features
-    );
+    ) const;
 
     /**
       @brief The method selects the highest scoring spectrum for each possible
@@ -167,7 +170,7 @@ public:
     void selectSpectra(
       const std::vector<MSSpectrum>& scored_spectra,
       std::vector<MSSpectrum>& selected_spectra
-    );
+    ) const;
 
     /**
       @brief Combines the functionalities given by all the other methods implemented
@@ -189,7 +192,7 @@ public:
       const TargetedExperiment& targeted_exp,
       std::vector<MSSpectrum>& extracted_spectra,
       FeatureMap& extracted_features
-    );
+    ) const;
 
 protected:
     /// Overridden function from DefaultParamHandler to keep members up to date, when a parameter is changed

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
@@ -102,7 +102,14 @@ public:
       const std::vector<MSSpectrum>& spectra,
       const TargetedExperiment& targeted_exp,
       std::vector<MSSpectrum>& annotated_spectra,
-      FeatureMap& features
+      FeatureMap& features,
+      const bool compute_features = true
+    ) const;
+
+    void annotateSpectra(
+      const std::vector<MSSpectrum>& spectra,
+      const TargetedExperiment& targeted_exp,
+      std::vector<MSSpectrum>& annotated_spectra
     ) const;
 
     /**
@@ -141,6 +148,13 @@ public:
       const std::vector<MSSpectrum>& annotated_spectra,
       const std::vector<MSSpectrum>& picked_spectra,
       FeatureMap& features,
+      std::vector<MSSpectrum>& scored_spectra,
+      const bool compute_features = true
+    ) const;
+
+    void scoreSpectra(
+      const std::vector<MSSpectrum>& annotated_spectra,
+      const std::vector<MSSpectrum>& picked_spectra,
       std::vector<MSSpectrum>& scored_spectra
     ) const;
 
@@ -157,7 +171,8 @@ public:
       const std::vector<MSSpectrum>& scored_spectra,
       const FeatureMap& features,
       std::vector<MSSpectrum>& selected_spectra,
-      FeatureMap& selected_features
+      FeatureMap& selected_features,
+      const bool compute_features = true
     ) const;
 
     /**
@@ -191,7 +206,14 @@ public:
       const MSExperiment& experiment,
       const TargetedExperiment& targeted_exp,
       std::vector<MSSpectrum>& extracted_spectra,
-      FeatureMap& extracted_features
+      FeatureMap& extracted_features,
+      const bool compute_features = true
+    ) const;
+
+    void extractSpectra(
+      const MSExperiment& experiment,
+      const TargetedExperiment& targeted_exp,
+      std::vector<MSSpectrum>& extracted_spectra
     ) const;
 
 protected:

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -33,8 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h>
-
-#include <boost/unordered_map.hpp> 
+#include <unordered_map>
 
 namespace OpenMS
 {
@@ -133,45 +132,48 @@ namespace OpenMS
     const TargetedExperiment& targeted_exp,
     std::vector<MSSpectrum>& annotated_spectra,
     FeatureMap& features
-  )
+  ) const
   {
     annotated_spectra.clear();
     features.clear(true);
-    const std::vector<ReactionMonitoringTransition> transitions = targeted_exp.getTransitions();
-    for (Size i=0; i<spectra.size(); ++i)
+    const std::vector<ReactionMonitoringTransition>& transitions = targeted_exp.getTransitions();
+    for (Size i = 0; i < spectra.size(); ++i)
     {
-      MSSpectrum spectrum = spectra[i];
+      const MSSpectrum& spectrum = spectra[i];
       const double spectrum_rt = spectrum.getRT();
       const double rt_left_lim = spectrum_rt - rt_window_ / 2.0;
       const double rt_right_lim = spectrum_rt + rt_window_ / 2.0;
-      const std::vector<Precursor> precursors = spectrum.getPrecursors();
-      if (precursors.size() < 1)
+      const std::vector<Precursor>& precursors = spectrum.getPrecursors();
+      if (precursors.empty())
       {
-        throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-                                         "Spectrum does not contain precursor info.");
+        LOG_WARN << "annotateSpectra(): No precursor MZ found. Setting spectrum_mz to 0." << std::endl;
       }
-      const double spectrum_mz = precursors[0].getMZ();
+      const double spectrum_mz = precursors.empty() ? 0.0 : precursors.front().getMZ();
       const double mz_tolerance = mz_unit_is_Da_ ? mz_tolerance_ : mz_tolerance_ / 1e6;
-      const double mz_left_lim = spectrum_mz - mz_tolerance;
-      const double mz_right_lim = spectrum_mz + mz_tolerance;
 
-      LOG_DEBUG << "[" << i << "]\trt: " << spectrum_rt << "\tmz: " << spectrum_mz << std::endl;
+      // When spectrum_mz is 0, the mz check on transitions is inhibited
+      const double mz_left_lim = spectrum_mz ? spectrum_mz - mz_tolerance : std::numeric_limits<double>::min();
+      const double mz_right_lim = spectrum_mz ? spectrum_mz + mz_tolerance : std::numeric_limits<double>::max();
 
-      for (Size j=0; j<transitions.size(); ++j)
+      LOG_DEBUG << "annotateSpectra(): [" << i << "] (RT: " << spectrum_rt << ") (MZ: " << spectrum_mz << ")" << std::endl;
+
+      for (Size j = 0; j < transitions.size(); ++j)
       {
-        const TargetedExperimentHelper::Peptide peptide = targeted_exp.getPeptideByRef(transitions[j].getPeptideRef());
+        const TargetedExperimentHelper::Peptide& peptide = targeted_exp.getPeptideByRef(transitions[j].getPeptideRef());
         double target_rt = peptide.getRetentionTime();
         if (peptide.getRetentionTimeUnit() == TargetedExperimentHelper::RetentionTime::RTUnit::MINUTE)
         {
           target_rt *= 60.0;
         }
         const double target_mz = transitions[j].getPrecursorMZ();
-        if (target_rt >= rt_left_lim && target_rt <= rt_right_lim && target_mz >= mz_left_lim && target_mz <= mz_right_lim)
+        if (target_rt >= rt_left_lim && target_rt <= rt_right_lim &&
+            target_mz >= mz_left_lim && target_mz <= mz_right_lim)
         {
-          LOG_DEBUG << "target_rt: " << target_rt << "\ttarget_mz: " << target_mz << std::endl;
-          LOG_DEBUG << "pushed thanks to transition: " << j << " with name: " << transitions[j].getPeptideRef() << std::endl << std::endl;
-          spectrum.setName(transitions[j].getPeptideRef());
-          annotated_spectra.push_back(spectrum);
+          LOG_DEBUG << "annotateSpectra(): [" << j << "][" << transitions[j].getPeptideRef() << "]";
+          LOG_DEBUG << " (target_rt: " << target_rt << ") (target_mz: " << target_mz << ")" << std::endl << std::endl;
+          MSSpectrum annotated_spectrum = spectrum;
+          annotated_spectrum.setName(transitions[j].getPeptideRef());
+          annotated_spectra.push_back(annotated_spectrum);
           Feature feature;
           feature.setRT(spectrum_rt);
           feature.setMZ(spectrum_mz);
@@ -181,24 +183,16 @@ namespace OpenMS
         }
       }
     }
-    LOG_DEBUG << "the annotated variable has " << annotated_spectra.size() << " elements instead of " << spectra.size() << std::endl;
+    LOG_DEBUG << "annotateSpectra(): (input size: " << spectra.size() << ") (annotated spectra: " << annotated_spectra.size() << ")\n" << std::endl;
   }
 
-  void TargetedSpectraExtractor::pickSpectrum(const MSSpectrum& spectrum, MSSpectrum& picked_spectrum)
+  void TargetedSpectraExtractor::pickSpectrum(const MSSpectrum& spectrum, MSSpectrum& picked_spectrum) const
   {
     if (!spectrum.isSorted())
     {
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                                        "Spectrum must be sorted by position");
     }
-
-    LOG_DEBUG << " ====  Picking spectrum " << spectrum.getNativeID() << " with " << spectrum.size() << " peaks ";
-    if (spectrum.empty())
-    {
-        LOG_DEBUG << std::endl << " - Error: spectrum is empty, abort picking." << std::endl;
-        return;
-    }
-    LOG_DEBUG << "(start at RT " << spectrum[0].getMZ() << " to RT " << spectrum[spectrum.size() - 1].getMZ() << ") " << std::endl;
 
     // Smooth the spectrum
     MSSpectrum smoothed_spectrum = spectrum;
@@ -232,9 +226,9 @@ namespace OpenMS
     pp.setParameters(pepi_param);
     pp.pick(smoothed_spectrum, picked_spectrum);
 
-    std::vector<UInt> peaks_pos_to_erase;
+    std::vector<Int> peaks_pos_to_erase;
     const double fwhm_threshold = mz_unit_is_Da_ ? fwhm_threshold_ : fwhm_threshold_ / 1e6;
-    for (Int i=picked_spectrum.size()-1; i>=0; --i)
+    for (Int i = picked_spectrum.size() - 1; i >= 0; --i)
     {
       if (picked_spectrum[i].getIntensity() < peak_height_min_ ||
           picked_spectrum[i].getIntensity() > peak_height_max_ ||
@@ -246,7 +240,7 @@ namespace OpenMS
 
     if (peaks_pos_to_erase.size() != picked_spectrum.size()) // if not all peaks are to be removed
     {
-      for (auto i : peaks_pos_to_erase) // then keep only the valid peaks (and fwhm)
+      for (Int i : peaks_pos_to_erase) // then keep only the valid peaks (and fwhm)
       {
         picked_spectrum.erase(picked_spectrum.begin() + i);
         picked_spectrum.getFloatDataArrays()[0].erase(picked_spectrum.getFloatDataArrays()[0].begin() + i);
@@ -257,7 +251,8 @@ namespace OpenMS
       picked_spectrum.clear(true);
     }
 
-    LOG_DEBUG << "Found " << picked_spectrum.size() << " peaks." << std::endl;
+    LOG_DEBUG << "pickSpectrum(): " << spectrum.getName() << " (input size: " <<
+      spectrum.size() << ") (picked: " << picked_spectrum.size() << ")\n" << std::endl;
   }
 
   void TargetedSpectraExtractor::scoreSpectra(
@@ -265,20 +260,24 @@ namespace OpenMS
     const std::vector<MSSpectrum>& picked_spectra,
     FeatureMap& features,
     std::vector<MSSpectrum>& scored_spectra
-  )
+  ) const
   {
     scored_spectra.clear();
     scored_spectra.resize(annotated_spectra.size());
-    for (Size i=0; i<annotated_spectra.size(); ++i)
+    if (scored_spectra.size() != features.size())
     {
-      double total_tic = 0;
-      for (Size j=0; j<annotated_spectra[i].size(); ++j)
+      throw Exception::InvalidSize(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+    }
+    for (Size i = 0; i < annotated_spectra.size(); ++i)
+    {
+      double total_tic { 0 };
+      for (Size j = 0; j < annotated_spectra[i].size(); ++j)
       {
         total_tic += annotated_spectra[i][j].getIntensity();
       }
 
-      double avgFWHM = 0;
-      for (Size j=0; j<picked_spectra[i].getFloatDataArrays()[0].size(); ++j)
+      double avgFWHM { 0 };
+      for (Size j = 0; j < picked_spectra[i].getFloatDataArrays()[0].size(); ++j)
       {
         avgFWHM += picked_spectra[i].getFloatDataArrays()[0][j];
       }
@@ -290,10 +289,11 @@ namespace OpenMS
       p.setValue("noise_for_empty_window", 2.0);
       p.setValue("min_required_elements", 10);
       sne.setParameters(p);
-      MSSpectrum::const_iterator it;
       sne.init(annotated_spectra[i].begin(), annotated_spectra[i].end());
-      double avgSNR = 0.0;
-      for (it=annotated_spectra[i].begin(); it!=annotated_spectra[i].end(); ++it)
+      double avgSNR { 0 };
+      for (MSSpectrum::const_iterator it = annotated_spectra[i].begin();
+           it != annotated_spectra[i].end();
+           ++it)
       {
         avgSNR += sne.getSignalToNoise(it);
       }
@@ -320,7 +320,7 @@ namespace OpenMS
       features[i].setMetaValue("avgSNR", avgSNR);
 
       std::vector<Feature> subordinates(picked_spectra[i].size());
-      for (Size j=0; j<picked_spectra[i].size(); ++j)
+      for (Size j = 0; j < picked_spectra[i].size(); ++j)
       {
         subordinates[j].setMZ(picked_spectra[i][j].getMZ());
         subordinates[j].setIntensity(picked_spectra[i][j].getIntensity());
@@ -335,22 +335,23 @@ namespace OpenMS
     const FeatureMap& features,
     std::vector<MSSpectrum>& selected_spectra,
     FeatureMap& selected_features
-  )
+  ) const
   {
-    boost::unordered_map<std::string,UInt> transition_best_spec;
-    for (Size i=0; i<scored_spectra.size(); ++i)
+    std::unordered_map<std::string,UInt> transition_best_spec;
+    for (UInt i = 0; i < scored_spectra.size(); ++i)
     {
       if (scored_spectra[i].getFloatDataArrays()[1][0] < min_score_)
       {
         continue;
       }
-      const std::string transition_name = scored_spectra[i].getName();
-      boost::unordered_map<std::string,UInt>::const_iterator it = transition_best_spec.find(transition_name);
-      if (it == transition_best_spec.end())
+      const std::string& transition_name = scored_spectra[i].getName();
+      std::unordered_map<std::string,UInt>::const_iterator it = transition_best_spec.find(transition_name);
+      if (it == transition_best_spec.cend())
       {
         transition_best_spec.insert({transition_name, i});
       }
-      else if (scored_spectra[it->second].getFloatDataArrays()[1][0] < scored_spectra[i].getFloatDataArrays()[1][0])
+      else if (scored_spectra[it->second].getFloatDataArrays()[1][0] <
+               scored_spectra[i].getFloatDataArrays()[1][0])
       {
         transition_best_spec.erase(transition_name);
         transition_best_spec.insert({transition_name, i});
@@ -380,7 +381,7 @@ namespace OpenMS
   void TargetedSpectraExtractor::selectSpectra(
     const std::vector<MSSpectrum>& scored_spectra,
     std::vector<MSSpectrum>& selected_spectra
-  )
+  ) const
   {
     FeatureMap dummy_features;
     FeatureMap dummy_selected_features;
@@ -392,10 +393,10 @@ namespace OpenMS
     const TargetedExperiment& targeted_exp,
     std::vector<MSSpectrum>& extracted_spectra,
     FeatureMap& extracted_features
-  )
+  ) const
   {
     // get the spectra from the experiment
-    const std::vector<MSSpectrum> spectra = experiment.getSpectra();
+    const std::vector<MSSpectrum>& spectra = experiment.getSpectra();
 
     // annotate spectra
     std::vector<MSSpectrum> annotated;
@@ -404,15 +405,15 @@ namespace OpenMS
 
     // pick peaks from annotate spectra
     std::vector<MSSpectrum> picked(annotated.size());
-    for (Size i=0; i<annotated.size(); ++i)
+    for (Size i = 0; i < annotated.size(); ++i)
     {
       pickSpectrum(annotated[i], picked[i]);
     }
 
     // remove empty picked<> spectra, and accordingly update annotated<> and features
-    for (Int i=annotated.size()-1; i>=0; --i)
+    for (Int i = annotated.size() - 1; i >= 0; --i)
     {
-      if (!picked[i].size())
+      if (picked[i].empty())
       {
         annotated.erase(annotated.begin() + i);
         picked.erase(picked.begin() + i);

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -33,6 +33,11 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h>
+#include <OpenMS/CONCEPT/LogStream.h>
+#include <OpenMS/DATASTRUCTURES/String.h>
+#include <OpenMS/FILTERING/SMOOTHING/GaussFilter.h>
+#include <OpenMS/FILTERING/SMOOTHING/SavitzkyGolayFilter.h>
+#include <OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h>
 #include <unordered_map>
 
 namespace OpenMS
@@ -55,8 +60,6 @@ namespace OpenMS
     defaultsToParam_(); // write defaults into Param object param_
   }
 
-  TargetedSpectraExtractor::~TargetedSpectraExtractor() {}
-
   void TargetedSpectraExtractor::updateMembers_()
   {
     rt_window_ = (double)param_.getValue("rt_window");
@@ -72,7 +75,7 @@ namespace OpenMS
     snr_weight_ = (double)param_.getValue("snr_weight");
   }
 
-  void TargetedSpectraExtractor::getDefaultParameters(Param& params)
+  void TargetedSpectraExtractor::getDefaultParameters(Param& params) const
   {
     params.clear();
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -397,7 +397,7 @@ namespace OpenMS
     selected_spectra.clear();
     selected_features.clear(true);
 
-    for (auto it = transition_best_spec.cbegin(); it!=transition_best_spec.cend(); ++it)
+    for (auto it = transition_best_spec.cbegin(); it != transition_best_spec.cend(); ++it)
     {
       selected_spectra.push_back(scored_spectra[it->second]);
       if (compute_features) selected_features.push_back(features[it->second]);

--- a/src/pyOpenMS/pxds/TargetedSpectraExtractor.pxd
+++ b/src/pyOpenMS/pxds/TargetedSpectraExtractor.pxd
@@ -23,13 +23,15 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h>" namesp
         void getDefaultParameters(Param) nogil except +
 
         void annotateSpectra(libcpp_vector[ MSSpectrum ], TargetedExperiment, libcpp_vector[ MSSpectrum ], FeatureMap) nogil except +
+        void annotateSpectra(libcpp_vector[ MSSpectrum ], TargetedExperiment, libcpp_vector[ MSSpectrum ]) nogil except +
 
         void pickSpectrum(MSSpectrum, MSSpectrum) nogil except +
 
         void scoreSpectra(libcpp_vector[ MSSpectrum ], libcpp_vector[ MSSpectrum ], FeatureMap, libcpp_vector[ MSSpectrum ]) nogil except +
+        void scoreSpectra(libcpp_vector[ MSSpectrum ], libcpp_vector[ MSSpectrum ], libcpp_vector[ MSSpectrum ]) nogil except +
 
         void selectSpectra(libcpp_vector[ MSSpectrum ], FeatureMap, libcpp_vector[ MSSpectrum ], FeatureMap) nogil except +
-
         void selectSpectra(libcpp_vector[ MSSpectrum ], libcpp_vector[ MSSpectrum ]) nogil except +
 
         void extractSpectra(MSExperiment, TargetedExperiment, libcpp_vector[ MSSpectrum ], FeatureMap) nogil except +
+        void extractSpectra(MSExperiment, TargetedExperiment, libcpp_vector[ MSSpectrum ]) nogil except +

--- a/src/tests/class_tests/openms/source/TargetedSpectraExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/TargetedSpectraExtractor_test.cpp
@@ -37,6 +37,8 @@
 
 ///////////////////////////
 #include <OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/TransitionTSVFile.h>
+#include <OpenMS/FORMAT/MzMLFile.h>
 ///////////////////////////
 
 using namespace OpenMS;
@@ -50,7 +52,7 @@ START_TEST(TargetedSpectraExtractor, "$Id$")
 // taken from E. coli grown on glucose M9 during steady-state
 // for flux analysis.
 
-vector<double> mz = {
+const vector<double> mz = {
   61.92, 68.88, 71.4, 79.56, 84.6, 84.72, 84.84, 84.96, 85.08, 85.2, 85.32,
   85.44, 85.68, 85.8, 85.92, 86.04, 86.16, 86.28, 86.4, 87.72, 87.96, 88.08,
   90.36, 94.44, 99.84, 100.8, 101.04, 101.88, 102, 102.96, 110.16, 110.88,
@@ -59,7 +61,7 @@ vector<double> mz = {
   130.2, 130.32, 130.44, 130.56, 132.12, 138, 139.08, 140.16, 144.12, 146.04,
   146.16, 156, 156.12, 156.36, 173.76, 174, 174.12, 174.24, 174.36, 174.6, 175.08
 };
-vector<double> intensity = {
+const vector<double> intensity = {
   6705.41660838088, 1676.35415209522, 1676.35415209522, 1676.35415209522, 3352.70830419044,
   5029.06245628566, 8381.7707604761, 53643.332867047, 51966.9787149518, 6705.41660838088,
   8381.7707604761, 1676.35415209522, 11734.4790646665, 25145.3122814283, 68730.520235904,
@@ -76,32 +78,18 @@ vector<double> intensity = {
   1676.35415209522, 1676.35415209522, 1676.35415209522, 6705.41660838088, 11734.4790646665,
   6705.41660838088, 1676.35415209522, 1676.35415209522
 };
-MSSpectrum spectrum;
+MSSpectrum s;
 for (Size i = 0; i != mz.size(); ++i)
 {
-  spectrum.push_back(Peak1D(mz[i],intensity[i]));
+  s.push_back(Peak1D(mz[i],intensity[i]));
 }
-
-START_SECTION(getMZ())
-{
-  TEST_EQUAL(spectrum[0].getMZ(), 61.92)
-  TEST_EQUAL(spectrum[0].getIntensity(), 6705.41660838088f)
-  TEST_EQUAL(spectrum[1].getMZ(), 68.88)
-  TEST_EQUAL(spectrum[1].getIntensity(), 1676.35415209522f)
-  TEST_EQUAL(spectrum[6].getMZ(), 84.84)
-  TEST_EQUAL(spectrum[6].getIntensity(), 8381.7707604761f)
-  TEST_EQUAL(spectrum[71].getMZ(), 174.6)
-  TEST_EQUAL(spectrum[71].getIntensity(), 1676.35415209522f)
-  TEST_EQUAL(spectrum[72].getMZ(), 175.08)
-  TEST_EQUAL(spectrum[72].getIntensity(), 1676.35415209522f)
-}
-END_SECTION
+const MSSpectrum spectrum = s;
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
-TargetedSpectraExtractor* ptr = 0;
-TargetedSpectraExtractor* null_ptr = 0;
+TargetedSpectraExtractor* ptr = nullptr;
+TargetedSpectraExtractor* null_ptr = nullptr;
 const String experiment_path = OPENMS_GET_TEST_DATA_PATH("TargetedSpectraExtractor_13C1_spectra0to100.mzML");
 const String target_list_path = OPENMS_GET_TEST_DATA_PATH("TargetedSpectraExtractor_13CFlux_TraML.csv");
 MzMLFile mzml;
@@ -127,11 +115,10 @@ START_SECTION(~TargetedSpectraExtractor())
 }
 END_SECTION
 
-ptr = new TargetedSpectraExtractor();
-
-START_SECTION(getParameters())
+START_SECTION(const Param& getParameters() const)
 {
-  Param params = ptr->getParameters();
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
   TEST_EQUAL(params.getValue("rt_window"), 30.0)
   TEST_EQUAL(params.getValue("min_score"), 0.7)
   TEST_EQUAL(params.getValue("mz_tolerance"), 0.1)
@@ -150,20 +137,46 @@ START_SECTION(getParameters())
 }
 END_SECTION
 
-START_SECTION(annotateSpectra())
+START_SECTION(void getDefaultParameters(Param& params) const)
 {
-  Param params = ptr->getParameters();
+  TargetedSpectraExtractor tse;
+  Param params;
+  tse.getDefaultParameters(params);
+  TEST_EQUAL(params.getValue("rt_window"), 30.0)
+  TEST_EQUAL(params.getValue("min_score"), 0.7)
+  TEST_EQUAL(params.getValue("mz_tolerance"), 0.1)
+  TEST_EQUAL(params.getValue("mz_unit_is_Da"), "true")
+  TEST_EQUAL(params.getValue("use_gauss"), "true")
+  TEST_EQUAL(params.getValue("peak_height_min"), 0.0)
+  TEST_EQUAL(params.getValue("peak_height_max"), 4e6)
+  TEST_EQUAL(params.getValue("fwhm_threshold"), 0.0)
+  TEST_EQUAL(params.getValue("tic_weight"), 1.0)
+  TEST_EQUAL(params.getValue("fwhm_weight"), 1.0)
+  TEST_EQUAL(params.getValue("snr_weight"), 1.0)
+}
+END_SECTION
+
+START_SECTION(void annotateSpectra(
+  const std::vector<MSSpectrum>& spectra,
+  const TargetedExperiment& targeted_exp,
+  std::vector<MSSpectrum>& annotated_spectra,
+  FeatureMap& features,
+  const bool compute_features = true
+) const)
+{
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
   params.setValue("GaussFilter:gaussian_width", 0.25);
   params.setValue("peak_height_min", 15000.0);
   params.setValue("peak_height_max", 110000.0);
   params.setValue("fwhm_threshold", 0.23);
-  ptr->setParameters(params);
+  tse.setParameters(params);
 
-  vector<MSSpectrum> spectra = experiment.getSpectra();
+  const vector<MSSpectrum>& spectra = experiment.getSpectra();
   vector<MSSpectrum> annotated_spectra;
   FeatureMap features;
 
-  ptr->annotateSpectra(spectra, targeted_exp, annotated_spectra, features);
+  tse.annotateSpectra(spectra, targeted_exp, annotated_spectra, features);
 
   TEST_EQUAL(annotated_spectra.size(), 21)
   TEST_EQUAL(annotated_spectra.size(), features.size())
@@ -199,32 +212,52 @@ START_SECTION(annotateSpectra())
   TEST_EQUAL(features[20].getMetaValue("transition_name"), "skm.skm_m4-3")
   TEST_REAL_SIMILAR(features[20].getRT(), 166.95400000002)
   TEST_REAL_SIMILAR(features[20].getMZ(), 177.057998657227)
-
-  STATUS("Annotated spectra from annotateSpectra():")
-  for (auto s : annotated_spectra)
-  {
-    STATUS("name: " << s.getName() << "\t peaks: " << s.size())
-  }
-  STATUS("Features from annotateSpectra():")
-  for (auto f : features)
-  {
-    STATUS("name: " << f.getMetaValue("transition_name") << "\t RT: " << f.getRT() << "\t MZ: " << f.getMZ())
-  }
 }
 END_SECTION
 
-START_SECTION(pickSpectrum())
+START_SECTION(void annotateSpectra(
+  const std::vector<MSSpectrum>& spectra,
+  const TargetedExperiment& targeted_exp,
+  std::vector<MSSpectrum>& annotated_spectra
+) const)
+{
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
+  params.setValue("GaussFilter:gaussian_width", 0.25);
+  params.setValue("peak_height_min", 15000.0);
+  params.setValue("peak_height_max", 110000.0);
+  params.setValue("fwhm_threshold", 0.23);
+  tse.setParameters(params);
+
+  const vector<MSSpectrum>& spectra = experiment.getSpectra();
+  vector<MSSpectrum> annotated_spectra;
+
+  tse.annotateSpectra(spectra, targeted_exp, annotated_spectra);
+
+  TEST_EQUAL(annotated_spectra.size(), 21)
+
+  TEST_EQUAL(annotated_spectra[0].getName(), "met-L.met-L_m0-0")
+  TEST_EQUAL(annotated_spectra[0].size(), 121)
+  TEST_EQUAL(annotated_spectra[4].getName(), "glu-L.glu-L_m4-4")
+  TEST_EQUAL(annotated_spectra[4].size(), 98)
+  TEST_EQUAL(annotated_spectra[20].getName(), "skm.skm_m4-3")
+  TEST_EQUAL(annotated_spectra[20].size(), 552)
+}
+END_SECTION
+
+START_SECTION(void pickSpectrum(const MSSpectrum& spectrum, MSSpectrum& picked_spectrum) const)
 {
   MSSpectrum picked_spectrum;
-  spectrum.sortByPosition();
-
-  Param params = ptr->getParameters();
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
   params.setValue("GaussFilter:gaussian_width", 0.25);
   params.setValue("peak_height_min", 0.0);
   params.setValue("peak_height_max", 200000.0);
   params.setValue("fwhm_threshold", 0.0);
-  ptr->setParameters(params);
-  ptr->pickSpectrum(spectrum, picked_spectrum);
+  tse.setParameters(params);
+
+  tse.pickSpectrum(spectrum, picked_spectrum);
+
   TEST_NOT_EQUAL(spectrum.size(), picked_spectrum.size())
   TEST_EQUAL(picked_spectrum.size(), 6)
   MSSpectrum::Iterator it = picked_spectrum.begin();
@@ -248,8 +281,10 @@ START_SECTION(pickSpectrum())
 
   params.setValue("peak_height_min", 15000.0);
   params.setValue("peak_height_max", 110000.0);
-  ptr->setParameters(params);
-  ptr->pickSpectrum(spectrum, picked_spectrum);
+  tse.setParameters(params);
+
+  tse.pickSpectrum(spectrum, picked_spectrum);
+
   // With the new filters on peaks' heights, less peaks get picked.
   TEST_EQUAL(picked_spectrum.size(), 3)
   it = picked_spectrum.begin();
@@ -263,8 +298,10 @@ START_SECTION(pickSpectrum())
   TEST_REAL_SIMILAR(it->getIntensity(), 31838.1)
 
   params.setValue("fwhm_threshold", 0.23);
-  ptr->setParameters(params);
-  ptr->pickSpectrum(spectrum, picked_spectrum);
+  tse.setParameters(params);
+
+  tse.pickSpectrum(spectrum, picked_spectrum);
+
   // Filtering also on fwhm, even less peaks get picked.
   TEST_EQUAL(picked_spectrum.size(), 2)
   it = picked_spectrum.begin();
@@ -276,32 +313,39 @@ START_SECTION(pickSpectrum())
 }
 END_SECTION
 
-START_SECTION(scoreSpectra())
+START_SECTION(void scoreSpectra(
+  const std::vector<MSSpectrum>& annotated_spectra,
+  const std::vector<MSSpectrum>& picked_spectra,
+  FeatureMap& features,
+  std::vector<MSSpectrum>& scored_spectra,
+  const bool compute_features = true
+) const)
 {
-  Param params = ptr->getParameters();
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
   params.setValue("GaussFilter:gaussian_width", 0.25);
   params.setValue("peak_height_min", 15000.0);
   params.setValue("peak_height_max", 110000.0);
   params.setValue("fwhm_threshold", 0.23);
-  ptr->setParameters(params);
+  tse.setParameters(params);
 
   vector<MSSpectrum> annotated_spectra;
   FeatureMap features;
-  const vector<MSSpectrum> spectra = experiment.getSpectra();
+  const vector<MSSpectrum>& spectra = experiment.getSpectra();
 
-  ptr->annotateSpectra(spectra, targeted_exp, annotated_spectra, features);
+  tse.annotateSpectra(spectra, targeted_exp, annotated_spectra, features);
   TEST_EQUAL(annotated_spectra.size(), features.size())
   TEST_EQUAL(annotated_spectra.size(), 21)
 
   vector<MSSpectrum> picked_spectra(annotated_spectra.size());
-  for (Size i=0; i<annotated_spectra.size(); ++i)
+  for (Size i = 0; i < annotated_spectra.size(); ++i)
   {
-    ptr->pickSpectrum(annotated_spectra[i], picked_spectra[i]);
+    tse.pickSpectrum(annotated_spectra[i], picked_spectra[i]);
   }
 
-  for (Int i=annotated_spectra.size()-1; i>=0; --i)
+  for (Int i = annotated_spectra.size() - 1; i >= 0; --i)
   {
-    if (!picked_spectra[i].size())
+    if (picked_spectra[i].empty())
     {
       annotated_spectra.erase(annotated_spectra.begin() + i);
       picked_spectra.erase(picked_spectra.begin() + i);
@@ -313,7 +357,7 @@ START_SECTION(scoreSpectra())
   TEST_EQUAL(picked_spectra.size(), features.size())
 
   vector<MSSpectrum> scored_spectra;
-  ptr->scoreSpectra(annotated_spectra, picked_spectra, features, scored_spectra);
+  tse.scoreSpectra(annotated_spectra, picked_spectra, features, scored_spectra);
 
   TEST_EQUAL(scored_spectra.size(), 12)
   TEST_EQUAL(scored_spectra.size(), annotated_spectra.size())
@@ -370,63 +414,107 @@ START_SECTION(scoreSpectra())
   TEST_REAL_SIMILAR(features[11].getMetaValue("inverse_avgFWHM"), 2.02868912178847)
   TEST_REAL_SIMILAR(features[11].getMetaValue("avgSNR"), 1.94235549504842)
   TEST_REAL_SIMILAR(features[11].getMetaValue("avgFWHM"), 0.492929147822516)
-
-  // sort(scored_spectra.begin(), scored_spectra.end(), [](MSSpectrum a, MSSpectrum b)
-  // {
-  //   return a.getFloatDataArrays()[1][0] > b.getFloatDataArrays()[1][0];
-  // });
-  // sort(scored_spectra.begin(), scored_spectra.end(), [](MSSpectrum a, MSSpectrum b)
-  // {
-  //   return a.getName().compare(b.getName()) < 0;
-  // });
-  // STATUS("Scored spectra have been sorted by name.")
-
-  STATUS("Info from scored spectra:")
-  for (auto s : scored_spectra)
-  {
-    STATUS(s.getName()
-    << "\t score: " << s.getFloatDataArrays()[1][0]
-    << "\t log10_tic: " << s.getFloatDataArrays()[2][0]
-    << "\t 1/fwhm: " << s.getFloatDataArrays()[3][0]
-    << "\t SNR: " << s.getFloatDataArrays()[4][0])
-  }
-
-  STATUS("Info from FeatureMap:")
-  for (auto f : features)
-  {
-    STATUS(f.getMetaValue("transition_name")
-    << "\t score: " << f.getIntensity()
-    << "\t log10_tic: " << f.getMetaValue("log10_total_tic")
-    << "\t 1/fwhm: " << f.getMetaValue("inverse_avgFWHM")
-    << "\t SNR: " << f.getMetaValue("avgSNR")
-    << "\t fwhm: " << f.getMetaValue("avgFWHM"))
-  }
 }
 END_SECTION
 
-START_SECTION(selectSpectra())
+START_SECTION(void scoreSpectra(
+  const std::vector<MSSpectrum>& annotated_spectra,
+  const std::vector<MSSpectrum>& picked_spectra,
+  std::vector<MSSpectrum>& scored_spectra
+) const)
+{
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
+  params.setValue("GaussFilter:gaussian_width", 0.25);
+  params.setValue("peak_height_min", 15000.0);
+  params.setValue("peak_height_max", 110000.0);
+  params.setValue("fwhm_threshold", 0.23);
+  tse.setParameters(params);
+
+  vector<MSSpectrum> annotated_spectra;
+  const vector<MSSpectrum>& spectra = experiment.getSpectra();
+
+  tse.annotateSpectra(spectra, targeted_exp, annotated_spectra);
+  TEST_EQUAL(annotated_spectra.size(), 21)
+
+  vector<MSSpectrum> picked_spectra(annotated_spectra.size());
+  for (Size i = 0; i < annotated_spectra.size(); ++i)
+  {
+    tse.pickSpectrum(annotated_spectra[i], picked_spectra[i]);
+  }
+
+  for (Int i = annotated_spectra.size() - 1; i >= 0; --i)
+  {
+    if (picked_spectra[i].empty())
+    {
+      annotated_spectra.erase(annotated_spectra.begin() + i);
+      picked_spectra.erase(picked_spectra.begin() + i);
+    }
+  }
+  TEST_EQUAL(annotated_spectra.size(), 12)
+
+  vector<MSSpectrum> scored_spectra;
+  tse.scoreSpectra(annotated_spectra, picked_spectra, scored_spectra);
+
+  TEST_EQUAL(scored_spectra.size(), 12)
+  TEST_EQUAL(scored_spectra.size(), annotated_spectra.size())
+
+  TEST_EQUAL(scored_spectra[0].getName(), "met-L.met-L_m0-0")
+  TEST_REAL_SIMILAR(scored_spectra[0].getFloatDataArrays()[1][0], 15.2046270370483) // score
+  TEST_REAL_SIMILAR(scored_spectra[0].getFloatDataArrays()[2][0], 5.3508939743042)  // total tic
+  TEST_REAL_SIMILAR(scored_spectra[0].getFloatDataArrays()[3][0], 3.96267318725586) // inverse average fwhm
+  TEST_REAL_SIMILAR(scored_spectra[0].getFloatDataArrays()[4][0], 5.89106035232544) // average snr
+
+  TEST_EQUAL(scored_spectra[4].getName(), "asp-L.asp-L_m1-0")
+  TEST_REAL_SIMILAR(scored_spectra[4].getFloatDataArrays()[1][0], 10.90163230896)
+  TEST_REAL_SIMILAR(scored_spectra[4].getFloatDataArrays()[2][0], 6.50192594528198)
+  TEST_REAL_SIMILAR(scored_spectra[4].getFloatDataArrays()[3][0], 2.14086890220642)
+  TEST_REAL_SIMILAR(scored_spectra[4].getFloatDataArrays()[4][0], 2.25883746147156)
+
+  TEST_EQUAL(scored_spectra[8].getName(), "glu-L.glu-L_m1-1")
+  TEST_REAL_SIMILAR(scored_spectra[8].getFloatDataArrays()[1][0], 13.7276296615601)
+  TEST_REAL_SIMILAR(scored_spectra[8].getFloatDataArrays()[2][0], 5.51675566061136)
+  TEST_REAL_SIMILAR(scored_spectra[8].getFloatDataArrays()[3][0], 3.46319246830875)
+  TEST_REAL_SIMILAR(scored_spectra[8].getFloatDataArrays()[4][0], 4.74768113612061)
+
+  TEST_EQUAL(scored_spectra[11].getName(), "skm.skm_m4-3")
+  TEST_REAL_SIMILAR(scored_spectra[11].getFloatDataArrays()[1][0], 10.5745859146118)
+  TEST_REAL_SIMILAR(scored_spectra[11].getFloatDataArrays()[2][0], 6.60354137420654)
+  TEST_REAL_SIMILAR(scored_spectra[11].getFloatDataArrays()[3][0], 2.02868914604187)
+  TEST_REAL_SIMILAR(scored_spectra[11].getFloatDataArrays()[4][0], 1.94235551357269)
+}
+END_SECTION
+
+START_SECTION(void selectSpectra(
+  const std::vector<MSSpectrum>& scored_spectra,
+  const FeatureMap& features,
+  std::vector<MSSpectrum>& selected_spectra,
+  FeatureMap& selected_features,
+  const bool compute_features = true
+) const)
 {
   const double min_score = 15.0;
-  Param params = ptr->getParameters();
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
   params.setValue("min_score", min_score);
   params.setValue("GaussFilter:gaussian_width", 0.25);
   params.setValue("peak_height_min", 15000.0);
   params.setValue("peak_height_max", 110000.0);
   params.setValue("fwhm_threshold", 0.23);
-  ptr->setParameters(params);
+  tse.setParameters(params);
 
-  const std::vector<MSSpectrum> spectra = experiment.getSpectra();
+  const std::vector<MSSpectrum>& spectra = experiment.getSpectra();
   std::vector<MSSpectrum> annotated;
   FeatureMap features;
-  ptr->annotateSpectra(spectra, targeted_exp, annotated, features);
+  tse.annotateSpectra(spectra, targeted_exp, annotated, features);
   std::vector<MSSpectrum> picked(annotated.size());
-  for (Size i=0; i<annotated.size(); ++i)
+  for (Size i = 0; i < annotated.size(); ++i)
   {
-    ptr->pickSpectrum(annotated[i], picked[i]);
+    tse.pickSpectrum(annotated[i], picked[i]);
   }
-  for (Int i=annotated.size()-1; i>=0; --i)
+  for (Int i = annotated.size() - 1; i >= 0; --i)
   {
-    if (!picked[i].size())
+    if (picked[i].empty())
     {
       annotated.erase(annotated.begin() + i);
       picked.erase(picked.begin() + i);
@@ -434,21 +522,15 @@ START_SECTION(selectSpectra())
     }
   }
   std::vector<MSSpectrum> scored;
-  ptr->scoreSpectra(annotated, picked, features, scored);
-
-  STATUS("Scored spectra and their score:")
-  for (auto s : scored)
-  {
-    STATUS(s.getName() << "\t" << s.getFloatDataArrays()[1][0])
-  }
+  tse.scoreSpectra(annotated, picked, features, scored);
 
   std::vector<MSSpectrum> selected_spectra;
   FeatureMap selected_features;
 
-  ptr->selectSpectra(scored, features, selected_spectra, selected_features);
+  tse.selectSpectra(scored, features, selected_spectra, selected_features);
   TEST_EQUAL(selected_spectra.size(), 2)
   TEST_EQUAL(selected_spectra.size(), selected_features.size())
-  for (Size i=0; i<selected_spectra.size(); ++i)
+  for (Size i = 0; i < selected_spectra.size(); ++i)
   {
     TEST_NOT_EQUAL(selected_spectra[i].getName(), "")
     TEST_EQUAL(selected_spectra[i].getName(), selected_features[i].getMetaValue("transition_name"))
@@ -456,9 +538,9 @@ START_SECTION(selectSpectra())
     TEST_EQUAL(selected_spectra[i].getFloatDataArrays()[1][0] >= min_score, true)
   }
 
-  ptr->selectSpectra(scored, selected_spectra);
+  tse.selectSpectra(scored, selected_spectra);
   TEST_EQUAL(selected_spectra.size(), 2)
-  for (Size i=0; i<selected_spectra.size(); ++i)
+  for (Size i = 0; i < selected_spectra.size(); ++i)
   {
     TEST_NOT_EQUAL(selected_spectra[i].getName(), "")
     TEST_EQUAL(selected_spectra[i].getFloatDataArrays()[1][0] >= min_score, true)
@@ -470,19 +552,84 @@ START_SECTION(selectSpectra())
 }
 END_SECTION
 
-START_SECTION(extractSpectra())
+START_SECTION(void selectSpectra(
+  const std::vector<MSSpectrum>& scored_spectra,
+  std::vector<MSSpectrum>& selected_spectra
+) const)
 {
-  Param params = ptr->getParameters();
+  const double min_score = 15.0;
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
+  params.setValue("min_score", min_score);
+  params.setValue("GaussFilter:gaussian_width", 0.25);
+  params.setValue("peak_height_min", 15000.0);
+  params.setValue("peak_height_max", 110000.0);
+  params.setValue("fwhm_threshold", 0.23);
+  tse.setParameters(params);
+
+  const std::vector<MSSpectrum>& spectra = experiment.getSpectra();
+  std::vector<MSSpectrum> annotated;
+  tse.annotateSpectra(spectra, targeted_exp, annotated);
+  std::vector<MSSpectrum> picked(annotated.size());
+  for (Size i = 0; i < annotated.size(); ++i)
+  {
+    tse.pickSpectrum(annotated[i], picked[i]);
+  }
+  for (Int i = annotated.size() - 1; i >= 0; --i)
+  {
+    if (picked[i].empty())
+    {
+      annotated.erase(annotated.begin() + i);
+      picked.erase(picked.begin() + i);
+    }
+  }
+  std::vector<MSSpectrum> scored;
+  tse.scoreSpectra(annotated, picked, scored);
+
+  std::vector<MSSpectrum> selected_spectra;
+
+  tse.selectSpectra(scored, selected_spectra);
+  TEST_EQUAL(selected_spectra.size(), 2)
+  for (Size i = 0; i < selected_spectra.size(); ++i)
+  {
+    TEST_NOT_EQUAL(selected_spectra[i].getName(), "")
+    TEST_EQUAL(selected_spectra[i].getFloatDataArrays()[1][0] >= min_score, true)
+  }
+
+  tse.selectSpectra(scored, selected_spectra);
+  TEST_EQUAL(selected_spectra.size(), 2)
+  for (Size i = 0; i < selected_spectra.size(); ++i)
+  {
+    TEST_NOT_EQUAL(selected_spectra[i].getName(), "")
+    TEST_EQUAL(selected_spectra[i].getFloatDataArrays()[1][0] >= min_score, true)
+  }
+  TEST_EQUAL(selected_spectra[0].getName(), "asp-L.asp-L_m2-1")
+  TEST_REAL_SIMILAR(selected_spectra[0].getFloatDataArrays()[1][0], 17.4552230834961)
+  TEST_EQUAL(selected_spectra[1].getName(), "met-L.met-L_m0-0")
+  TEST_REAL_SIMILAR(selected_spectra[1].getFloatDataArrays()[1][0], 16.0294418334961)
+}
+END_SECTION
+
+START_SECTION(void extractSpectra(
+  const MSExperiment& experiment,
+  const TargetedExperiment& targeted_exp,
+  std::vector<MSSpectrum>& extracted_spectra,
+  FeatureMap& extracted_features,
+  const bool compute_features = true
+) const)
+{
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
   params.setValue("min_score", 15.0);
   params.setValue("GaussFilter:gaussian_width", 0.25);
   params.setValue("peak_height_min", 15000.0);
   params.setValue("peak_height_max", 110000.0);
   params.setValue("fwhm_threshold", 0.23);
-  ptr->setParameters(params);
+  tse.setParameters(params);
 
   vector<MSSpectrum> extracted_spectra;
   FeatureMap extracted_features;
-  ptr->extractSpectra(experiment, targeted_exp, extracted_spectra, extracted_features);
+  tse.extractSpectra(experiment, targeted_exp, extracted_spectra, extracted_features);
 
   TEST_EQUAL(extracted_spectra.size(), extracted_features.size())
   TEST_EQUAL(extracted_spectra.size(), 2)
@@ -491,16 +638,35 @@ START_SECTION(extractSpectra())
   TEST_REAL_SIMILAR(extracted_spectra[0].getFloatDataArrays()[1][0], 17.4552230834961)
   TEST_EQUAL(extracted_spectra[1].getName(), "met-L.met-L_m0-0")
   TEST_REAL_SIMILAR(extracted_spectra[1].getFloatDataArrays()[1][0], 16.0294418334961)
-
-  STATUS("Printing mapping of transition -> best spectrum:")
-  for (Size i=0; i<extracted_spectra.size(); ++i)
-  {
-    STATUS(extracted_spectra[i].getName() << "\t" << extracted_features[i].getIntensity())
-  }
 }
 END_SECTION
 
-delete ptr;
+START_SECTION(void extractSpectra(
+  const MSExperiment& experiment,
+  const TargetedExperiment& targeted_exp,
+  std::vector<MSSpectrum>& extracted_spectra
+) const)
+{
+  TargetedSpectraExtractor tse;
+  Param params = tse.getParameters();
+  params.setValue("min_score", 15.0);
+  params.setValue("GaussFilter:gaussian_width", 0.25);
+  params.setValue("peak_height_min", 15000.0);
+  params.setValue("peak_height_max", 110000.0);
+  params.setValue("fwhm_threshold", 0.23);
+  tse.setParameters(params);
+
+  vector<MSSpectrum> extracted_spectra;
+  tse.extractSpectra(experiment, targeted_exp, extracted_spectra);
+
+  TEST_EQUAL(extracted_spectra.size(), 2)
+
+  TEST_EQUAL(extracted_spectra[0].getName(), "asp-L.asp-L_m2-1")
+  TEST_REAL_SIMILAR(extracted_spectra[0].getFloatDataArrays()[1][0], 17.4552230834961)
+  TEST_EQUAL(extracted_spectra[1].getName(), "met-L.met-L_m0-0")
+  TEST_REAL_SIMILAR(extracted_spectra[1].getFloatDataArrays()[1][0], 16.0294418334961)
+}
+END_SECTION
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/TargetedSpectraExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/TargetedSpectraExtractor_test.cpp
@@ -44,7 +44,7 @@
 using namespace OpenMS;
 using namespace std;
 
-vector<MSSpectrum>::const_iterator find_spectrum_by_name(const vector<MSSpectrum>& spectra, const String& name)
+vector<MSSpectrum>::const_iterator findSpectrumByName(const vector<MSSpectrum>& spectra, const String& name)
 {
   vector<MSSpectrum>::const_iterator it;
   it = std::find_if(spectra.cbegin(), spectra.cend(), [&name] (const MSSpectrum& s)
@@ -561,9 +561,9 @@ START_SECTION(void selectSpectra(
   }
 
   vector<MSSpectrum>::const_iterator it;
-  it = find_spectrum_by_name(selected_spectra, "asp-L.asp-L_m2-1");
+  it = findSpectrumByName(selected_spectra, "asp-L.asp-L_m2-1");
   TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 17.4552230834961)
-  it = find_spectrum_by_name(selected_spectra, "met-L.met-L_m0-0");
+  it = findSpectrumByName(selected_spectra, "met-L.met-L_m0-0");
   TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 16.0294418334961)
 }
 END_SECTION
@@ -621,9 +621,9 @@ START_SECTION(void selectSpectra(
   }
 
   vector<MSSpectrum>::const_iterator it;
-  it = find_spectrum_by_name(selected_spectra, "asp-L.asp-L_m2-1");
+  it = findSpectrumByName(selected_spectra, "asp-L.asp-L_m2-1");
   TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 17.4552230834961)
-  it = find_spectrum_by_name(selected_spectra, "met-L.met-L_m0-0");
+  it = findSpectrumByName(selected_spectra, "met-L.met-L_m0-0");
   TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 16.0294418334961)
 }
 END_SECTION
@@ -653,9 +653,9 @@ START_SECTION(void extractSpectra(
   TEST_EQUAL(extracted_spectra.size(), 2)
 
   vector<MSSpectrum>::const_iterator it;
-  it = find_spectrum_by_name(extracted_spectra, "asp-L.asp-L_m2-1");
+  it = findSpectrumByName(extracted_spectra, "asp-L.asp-L_m2-1");
   TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 17.4552230834961)
-  it = find_spectrum_by_name(extracted_spectra, "met-L.met-L_m0-0");
+  it = findSpectrumByName(extracted_spectra, "met-L.met-L_m0-0");
   TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 16.0294418334961)
 }
 END_SECTION
@@ -681,9 +681,9 @@ START_SECTION(void extractSpectra(
   TEST_EQUAL(extracted_spectra.size(), 2)
 
   vector<MSSpectrum>::const_iterator it;
-  it = find_spectrum_by_name(extracted_spectra, "asp-L.asp-L_m2-1");
+  it = findSpectrumByName(extracted_spectra, "asp-L.asp-L_m2-1");
   TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 17.4552230834961)
-  it = find_spectrum_by_name(extracted_spectra, "met-L.met-L_m0-0");
+  it = findSpectrumByName(extracted_spectra, "met-L.met-L_m0-0");
   TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 16.0294418334961)
 }
 END_SECTION

--- a/src/tests/class_tests/openms/source/TargetedSpectraExtractor_test.cpp
+++ b/src/tests/class_tests/openms/source/TargetedSpectraExtractor_test.cpp
@@ -44,6 +44,20 @@
 using namespace OpenMS;
 using namespace std;
 
+vector<MSSpectrum>::const_iterator find_spectrum_by_name(const vector<MSSpectrum>& spectra, const String& name)
+{
+  vector<MSSpectrum>::const_iterator it;
+  it = std::find_if(spectra.cbegin(), spectra.cend(), [&name] (const MSSpectrum& s)
+    {
+      return s.getName() == name;
+    });
+  if (it == spectra.cend())
+  {
+    throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, name);
+  }
+  return it;
+}
+
 START_TEST(TargetedSpectraExtractor, "$Id$")
 
 /////////////////////////////////////////////////////////////
@@ -545,10 +559,12 @@ START_SECTION(void selectSpectra(
     TEST_NOT_EQUAL(selected_spectra[i].getName(), "")
     TEST_EQUAL(selected_spectra[i].getFloatDataArrays()[1][0] >= min_score, true)
   }
-  TEST_EQUAL(selected_spectra[0].getName(), "asp-L.asp-L_m2-1")
-  TEST_REAL_SIMILAR(selected_spectra[0].getFloatDataArrays()[1][0], 17.4552230834961)
-  TEST_EQUAL(selected_spectra[1].getName(), "met-L.met-L_m0-0")
-  TEST_REAL_SIMILAR(selected_spectra[1].getFloatDataArrays()[1][0], 16.0294418334961)
+
+  vector<MSSpectrum>::const_iterator it;
+  it = find_spectrum_by_name(selected_spectra, "asp-L.asp-L_m2-1");
+  TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 17.4552230834961)
+  it = find_spectrum_by_name(selected_spectra, "met-L.met-L_m0-0");
+  TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 16.0294418334961)
 }
 END_SECTION
 
@@ -603,10 +619,12 @@ START_SECTION(void selectSpectra(
     TEST_NOT_EQUAL(selected_spectra[i].getName(), "")
     TEST_EQUAL(selected_spectra[i].getFloatDataArrays()[1][0] >= min_score, true)
   }
-  TEST_EQUAL(selected_spectra[0].getName(), "asp-L.asp-L_m2-1")
-  TEST_REAL_SIMILAR(selected_spectra[0].getFloatDataArrays()[1][0], 17.4552230834961)
-  TEST_EQUAL(selected_spectra[1].getName(), "met-L.met-L_m0-0")
-  TEST_REAL_SIMILAR(selected_spectra[1].getFloatDataArrays()[1][0], 16.0294418334961)
+
+  vector<MSSpectrum>::const_iterator it;
+  it = find_spectrum_by_name(selected_spectra, "asp-L.asp-L_m2-1");
+  TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 17.4552230834961)
+  it = find_spectrum_by_name(selected_spectra, "met-L.met-L_m0-0");
+  TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 16.0294418334961)
 }
 END_SECTION
 
@@ -634,10 +652,11 @@ START_SECTION(void extractSpectra(
   TEST_EQUAL(extracted_spectra.size(), extracted_features.size())
   TEST_EQUAL(extracted_spectra.size(), 2)
 
-  TEST_EQUAL(extracted_spectra[0].getName(), "asp-L.asp-L_m2-1")
-  TEST_REAL_SIMILAR(extracted_spectra[0].getFloatDataArrays()[1][0], 17.4552230834961)
-  TEST_EQUAL(extracted_spectra[1].getName(), "met-L.met-L_m0-0")
-  TEST_REAL_SIMILAR(extracted_spectra[1].getFloatDataArrays()[1][0], 16.0294418334961)
+  vector<MSSpectrum>::const_iterator it;
+  it = find_spectrum_by_name(extracted_spectra, "asp-L.asp-L_m2-1");
+  TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 17.4552230834961)
+  it = find_spectrum_by_name(extracted_spectra, "met-L.met-L_m0-0");
+  TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 16.0294418334961)
 }
 END_SECTION
 
@@ -661,10 +680,11 @@ START_SECTION(void extractSpectra(
 
   TEST_EQUAL(extracted_spectra.size(), 2)
 
-  TEST_EQUAL(extracted_spectra[0].getName(), "asp-L.asp-L_m2-1")
-  TEST_REAL_SIMILAR(extracted_spectra[0].getFloatDataArrays()[1][0], 17.4552230834961)
-  TEST_EQUAL(extracted_spectra[1].getName(), "met-L.met-L_m0-0")
-  TEST_REAL_SIMILAR(extracted_spectra[1].getFloatDataArrays()[1][0], 16.0294418334961)
+  vector<MSSpectrum>::const_iterator it;
+  it = find_spectrum_by_name(extracted_spectra, "asp-L.asp-L_m2-1");
+  TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 17.4552230834961)
+  it = find_spectrum_by_name(extracted_spectra, "met-L.met-L_m0-0");
+  TEST_REAL_SIMILAR(it->getFloatDataArrays()[1][0], 16.0294418334961)
 }
 END_SECTION
 


### PR DESCRIPTION
This PR implements a way to fully support usage of each of the class' methods without relying on the presence of a `FeatureMap` in input/output.

To avoid duplicating code, I decided to add a `bool` argument `compute_features` to existing methods, which decides on the computation of the `FeatureMap` in input.

I found some small details that I could improve on (like avoiding copying variables when references `&` could be used, or postponing copy of data only when really it is necessary).

In tests, I avoid the use of a global pointer and I instantiate a new `TargetedSpectraExtractor` object for each test.