### PR TITLE
[FIX] Fixing debug build, accessing const map key with .at instead of []

### DIFF
--- a/src/openms/include/OpenMS/KERNEL/MRMTransitionGroup.h
+++ b/src/openms/include/OpenMS/KERNEL/MRMTransitionGroup.h
@@ -255,7 +255,7 @@ public:
     inline const ChromatogramType & getPrecursorChromatogram(const String& key) const
     {
       OPENMS_PRECONDITION(hasPrecursorChromatogram(key), "Cannot retrieve precursor chromatogram that does not exist")
-      OPENMS_PRECONDITION(precursor_chromatograms_.size() > (size_t)precursor_chromatogram_map_[key], "Mapping needs to be accurate")
+      OPENMS_PRECONDITION(precursor_chromatograms_.size() > (size_t)precursor_chromatogram_map_.at(key), "Mapping needs to be accurate")
       return precursor_chromatograms_[precursor_chromatogram_map_.at(key)];
     }
     //@}


### PR DESCRIPTION
Hi,

I hope that this is not solely on my end, but rather a problem for everyone ;)

The following compiler error occurs when trying to build OpenMS in debug mode: /home/lheumos/CLionProjects/OpenMS/src/openms/include/OpenMS/KERNEL/MRMTransitionGroup.h:258:96: error: no match for 'operator[]' (operand types are 'const std::map<OpenMS::String, int>' and 'const OpenMS::String')

It is not allowed to access const maps keys with parentheses [], because values not present in the map will get inserted using the [] operator. Therefore, it is recommended to use .at, which checks whether or not the key is present in the map and does not insert any new keys.