### PR TITLE
Feature/sse peptide motif

### DIFF
--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -312,7 +312,7 @@ namespace OpenMS
         const Size right = std::min(i + max_length, sequence.size());
         for (Size j = i + min_length; j <= right; ++j)
         {
-          output.push_back(sequence.substr(i, j - 1));
+          output.emplace_back(sequence.substr(i, j - i));
         }
       }
       return 0;

--- a/src/tests/class_tests/openms/source/EnzymaticDigestion_test.cpp
+++ b/src/tests/class_tests/openms/source/EnzymaticDigestion_test.cpp
@@ -291,6 +291,15 @@ START_SECTION((Size digestUnmodified(const StringView sequence, std::vector<Stri
     ed.setEnzyme(ProteaseDB::getInstance()->getEnzyme("unspecific cleavage"));
     ed.digestUnmodified(s, out);
     TEST_EQUAL(out.size(), 11 * 10 / 2)
+
+    // digest with min/max length
+    ed.digestUnmodified(s, out, 5, 6);
+    for (auto & a : out)
+    {
+      TEST_EQUAL(a.getString().size() == 5 
+      || a.getString().size() == 6, true)    
+    }
+
     s = "ABC";
     ed.digestUnmodified(s, out);
     TEST_EQUAL(out.size(), 4 * 3 / 2);

--- a/src/utils/SimpleSearchEngine.cpp
+++ b/src/utils/SimpleSearchEngine.cpp
@@ -78,24 +78,6 @@
 using namespace OpenMS;
 using namespace std;
 
-/*
-  TODO:
-   - proper C-term N-term handling of terminal modifications that can be at every amino acid
-
-        // should be something like this: check if AA of modification and peptide match
-        if (origin != aa_seq[pos].getOneLetterCode() && origin != "C-term" && origin != "N-term")
-        {
-          continue;
-        }
-
-  // check for common annotation error in unimod
-  if ((origin == "C-term" || origin == "N-term") && term_specifity == ResidueModification::ANYWHERE)
-        {
-          continue;
-        }
-
-*/
-
 class SimpleSearchEngine :
     public TOPPBase
 {
@@ -115,7 +97,9 @@ class SimpleSearchEngine :
 
   public:
     SimpleSearchEngine() :
-      TOPPBase("SimpleSearchEngine", "Annotates MS/MS spectra using SimpleSearchEngine.", false)
+      TOPPBase("SimpleSearchEngine", 
+        "Annotates MS/MS spectra using SimpleSearchEngine.", 
+        false)
     {
     }
 
@@ -463,7 +447,6 @@ class SimpleSearchEngine :
       // set minimum / maximum size of peptide after digestion
       Size min_peptide_length = getIntOption_("peptide:min_size");
       Size max_peptide_length = getIntOption_("peptide:max_size");
-
       Size count_proteins(0), count_peptides(0);
 
 #ifdef _OPENMP
@@ -485,7 +468,7 @@ class SimpleSearchEngine :
         digestor.digestUnmodified(fasta_db[fasta_index].sequence, current_digest, min_peptide_length, max_peptide_length);
 
         for (auto const & c : current_digest)
-        {
+        { 
           if (c.getString().has('X')) { continue; }
         
           bool already_processed = false;
@@ -628,7 +611,6 @@ class SimpleSearchEngine :
       param_pi.setValue("enzyme:name", getStringOption_("enzyme"));
       param_pi.setValue("enzyme:specificity", "full");
       param_pi.setValue("missing_decoy_action", "silent");
-      param_pi.setValue("log", getStringOption_("log"));
       indexer.setParameters(param_pi);
 
       PeptideIndexing::ExitCodes indexer_exit = indexer.run(fasta_db, protein_ids, peptide_ids);

--- a/src/utils/SimpleSearchEngine.cpp
+++ b/src/utils/SimpleSearchEngine.cpp
@@ -160,6 +160,7 @@ class SimpleSearchEngine :
       registerIntOption_("peptide:min_size", "<num>", 7, "Minimum size a peptide must have after digestion to be considered in the search.", false, true);
       registerIntOption_("peptide:max_size", "<num>", 40, "Maximum size a peptide must have after digestion to be considered in the search (0 = disabled).", false, true);
       registerIntOption_("peptide:missed_cleavages", "<num>", 1, "Number of missed cleavages.", false, false);
+      registerStringOption_("peptide:motif", "<regex>", "", "If set, only peptides that contain this motif (provided as RegEx) will be considered.", false);
 
       registerTOPPSubsection_("report", "Reporting Options");
       registerIntOption_("report:top_hits", "<num>", 1, "Maximum number of top scoring hits per spectrum that are reported.", false, true);
@@ -328,6 +329,8 @@ class SimpleSearchEngine :
       String in_mzml = getStringOption_("in");
       String in_db = getStringOption_("database");
       String out_idxml = getStringOption_("out");
+      const String peptide_motif = getStringOption_("peptide:motif");      
+      boost::regex peptide_motif_regex(peptide_motif);
 
       Int min_precursor_charge = getIntOption_("precursor:min_charge");
       Int max_precursor_charge = getIntOption_("precursor:max_charge");
@@ -470,6 +473,9 @@ class SimpleSearchEngine :
         for (auto const & c : current_digest)
         { 
           if (c.getString().has('X')) { continue; }
+
+          // if a peptide motif is provided skip all peptides without match
+          if (!peptide_motif.empty() && !boost::regex_match(c.getString(), peptide_motif_regex)) { continue; }          
         
           bool already_processed = false;
 #ifdef _OPENMP


### PR DESCRIPTION
Only consider peptides that match a regular expression:
e.g., -peptide:motif "FV.*" will match all peptides starting with FV
