### PR TITLE
 Fix/fuzzy

### DIFF
--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -398,18 +398,19 @@ namespace OpenMS
                   {
                     ratio = 1.0 / ratio;
                   }
+
                   // by now, we are sure that ratio >= 1
                   if (ratio > ratio_max_) // update running max
                   {
-                    ratio_max_ = ratio;
                     line_num_1_max_ = line_num_1_;
                     line_num_2_max_ = line_num_2_;
                     line_str_1_max_ = line_str_1;
                     line_str_2_max_ = line_str_2;
-                    if (ratio_max_ > ratio_max_allowed_)
+                    if (ratio > ratio_max_allowed_)
                     {
                       if (!is_absdiff_small_)
                       {
+                        ratio_max_ = ratio;
                         reportFailure_("ratio of numbers is too large");
                         continue;
                       }
@@ -506,6 +507,7 @@ namespace OpenMS
           );
 
       } // while ( input_line_1_ || input_line_2_ )
+
       if (input_line_1_.ok() && !input_line_2_.ok())
       {
         reportFailure_("line from input_2 is shorter than line from input_1");

--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -39,7 +39,7 @@
 #include <iomanip>
 #include <iostream>
 
-#define DEBUG_FUZZY
+// #define DEBUG_FUZZY
 
 namespace OpenMS
 {

--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -39,6 +39,8 @@
 #include <iomanip>
 #include <iostream>
 
+#define DEBUG_FUZZY
+
 namespace OpenMS
 {
 
@@ -84,8 +86,9 @@ namespace OpenMS
   {
     this->ratio_max_allowed_ = rhs;
     if (ratio_max_allowed_ < 1.0)
-      ratio_max_allowed_ = 1
-                           / ratio_max_allowed_;
+    {
+      ratio_max_allowed_ = 1 / ratio_max_allowed_;
+    }
 
   }
 
@@ -98,8 +101,9 @@ namespace OpenMS
   {
     this->absdiff_max_allowed_ = rhs;
     if (absdiff_max_allowed_ < 0.0)
-      absdiff_max_allowed_
-        = -absdiff_max_allowed_;
+    {
+      absdiff_max_allowed_ = -absdiff_max_allowed_;
+    }
   }
 
   const StringList& FuzzyStringComparator::getWhitelist() const
@@ -291,15 +295,11 @@ namespace OpenMS
 
   bool FuzzyStringComparator::compareLines_(std::string const& line_str_1, std::string const& line_str_2)
   {
-
     for (StringList::const_iterator slit = whitelist_.begin();
-         slit != whitelist_.end();
-         ++slit
-         )
+         slit != whitelist_.end(); ++slit)
     {
       if (line_str_1.find(*slit) != String::npos &&
-          line_str_2.find(*slit) != String::npos
-          )
+          line_str_2.find(*slit) != String::npos)
       {
         ++whitelist_cases_[*slit];
         // *log_dest_ << "whitelist_ case: " << *slit << '\n';
@@ -339,7 +339,12 @@ namespace OpenMS
         if (element_1_.is_number)
         {
           if (element_2_.is_number) // we are comparing numbers
-          { // check if absolute difference is small
+          {
+#ifdef DEBUG_FUZZY
+            std::cout << "cmp number: " << String(element_1_.number) << " : " << String(element_2_.number) << std::endl;
+#endif
+
+            // check if absolute difference is small
             double absdiff = element_1_.number - element_2_.number;
             if (absdiff < 0)
             {
@@ -398,6 +403,9 @@ namespace OpenMS
                   {
                     ratio = 1.0 / ratio;
                   }
+#ifdef DEBUG_FUZZY
+                  std::cout << " check ratio:  " << ratio << " vs " << ratio_max_ << std::endl;
+#endif
 
                   // by now, we are sure that ratio >= 1
                   if (ratio > ratio_max_) // update running max
@@ -408,6 +416,9 @@ namespace OpenMS
                     line_str_2_max_ = line_str_2;
                     if (ratio > ratio_max_allowed_)
                     {
+#ifdef DEBUG_FUZZY
+                      std::cout << "Ratio test failed: is larger than ratio_max " << std::endl;
+#endif
                       if (!is_absdiff_small_)
                       {
                         ratio_max_ = ratio;
@@ -546,14 +557,20 @@ namespace OpenMS
     {
 
       readNextLine_(input_1, line_str_1, line_num_1_);
-      //std::cout << "eof: " << input_1.eof() << " failbit: " << input_1.fail() << " badbit: " << input_1.bad() << " reading " << input_1.tellg () << "chars\n";
+#ifdef DEBUG_FUZZY
+      std::cout << "eof: " << input_1.eof() << " failbit: " << input_1.fail() << " badbit: " << input_1.bad() << " reading " << input_1.tellg () << "chars\n";
+#endif
 
       readNextLine_(input_2, line_str_2, line_num_2_);
-      //std::cout << "eof: " << input_2.eof() << " failbit: " << input_2.fail() << " badbit: " << input_2.bad() << " reading " << input_2.tellg () << "chars\n";
-
+#ifdef DEBUG_FUZZY
+      std::cout << "eof: " << input_2.eof() << " failbit: " << input_2.fail() << " badbit: " << input_2.bad() << " reading " << input_2.tellg () << "chars\n";
+      std::cout << line_str_1 << "\n" << line_str_2 << std::endl;
+#endif
       // compare the two lines of input
       if (!compareLines_(line_str_1, line_str_2) && verbose_level_ < 3)
+      {
         break;
+      }
 
     } // while ( input_1 || input_2 )
 
@@ -568,14 +585,18 @@ namespace OpenMS
     for (line_string.clear(); static_cast<void>(++line_number), std::getline(input_stream, line_string); )
     {
       if (line_string.empty())
+      {
         continue; // shortcut
+      }
       std::string::const_iterator iter = line_string.begin(); // loop initialization
       for (; iter != line_string.end() && isspace((unsigned char)*iter); ++iter)
       {
       }
       // skip over whitespace
       if (iter != line_string.end())
+      {
         break; // line is not empty or whitespace only
+      }
     }
   }
 
@@ -592,11 +613,15 @@ namespace OpenMS
 
     std::ifstream input_1_f;
     if (!openInputFileStream_(input_1_name_, input_1_f))
+    {
       return false;
+    }
 
     std::ifstream input_2_f;
     if (!openInputFileStream_(input_2_name_, input_2_f))
+    {
       return false;
+    }
 
     //------------------------------------------------------------
     // main loop
@@ -627,16 +652,14 @@ namespace OpenMS
         prefix << '\n' <<
         prefix << "  whitelist cases:\n";
       Size length = 0;
-      for (std::map<String, UInt>::const_iterator wlcit =
-             whitelist_cases_.begin(); wlcit != whitelist_cases_.end();
-           ++wlcit)
+      for (std::map<String, UInt>::const_iterator wlcit = whitelist_cases_.begin();
+           wlcit != whitelist_cases_.end(); ++wlcit)
       {
         if (wlcit->first.size() > length)
           length = wlcit->first.size();
       }
-      for (std::map<String, UInt>::const_iterator wlcit =
-             whitelist_cases_.begin(); wlcit != whitelist_cases_.end();
-           ++wlcit)
+      for (std::map<String, UInt>::const_iterator wlcit = whitelist_cases_.begin();
+           wlcit != whitelist_cases_.end(); ++wlcit)
       {
         *log_dest_ <<
           prefix << "    " << std::setw(length + 3) << std::left <<
@@ -686,7 +709,9 @@ namespace OpenMS
     std::string buffer;
 
     if (input_line.line_.eof())
+    {
       return false;
+    }
 
     c_peek = input_line.line_.peek();
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -1168,7 +1168,7 @@ namespace OpenMS
         }
         spec_id_++;
 
-        if (sql_it > sql_batch_size_) // flush as sqlite can only handle so many bind_blob statments
+        if (sql_it > sql_batch_size_) // flush as sqlite can only handle so many bind_blob statements
         {
           // prevent writing of empty data which would throw an SQL exception
           if (!data.empty())
@@ -1363,7 +1363,7 @@ namespace OpenMS
         }
         chrom_id_++;
 
-        if (sql_it > sql_batch_size_) // flush as sqlite can only handle so many bind_blob statments
+        if (sql_it > sql_batch_size_) // flush as sqlite can only handle so many bind_blob statements
         {
           // prevent writing of empty data which would throw an SQL exception
           if (!data.empty())

--- a/src/tests/class_tests/openms/source/ProtXMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ProtXMLFile_test.cpp
@@ -67,7 +67,7 @@ START_SECTION(void load(const String &filename, ProteinIdentification &protein_i
   PeptideIdentification peptides;
   String prot_file;
 
-        StringList ids = ListUtils::create<String>("16627578304933075941,13229490167902618598");
+  StringList ids = ListUtils::create<String>("16627578304933075941,13229490167902618598");
   // we do this twice, just to check that members are correctly reset etc..
   for (Int i=0;i<2;++i)
   {

--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -166,6 +166,15 @@ set_tests_properties("TOPP_CLI_INVALIDNAME" PROPERTIES WILL_FAIL 1)
 # TOPP tests
 #------------------------------------------------------------------------------
 
+# FuzzyDiff tests
+add_test("UTILS_FuzzyDiff_1" ${TOPP_BIN_PATH}/FuzzyDiff -test -ini ${DATA_DIR_TOPP}/FuzzyDiff.ini -in1 ${DATA_DIR_TOPP}/FuzzyDiff_1_in1.featureXML -in2 ${DATA_DIR_TOPP}/FuzzyDiff_1_in1.featureXML)
+add_test("UTILS_FuzzyDiff_2" ${TOPP_BIN_PATH}/FuzzyDiff -test -ini ${DATA_DIR_TOPP}/FuzzyDiff.ini -in1 ${DATA_DIR_TOPP}/FuzzyDiff_1_in1.featureXML -in2 ${DATA_DIR_TOPP}/FuzzyDiff_1_in2.featureXML)
+add_test("UTILS_FuzzyDiff_3" ${TOPP_BIN_PATH}/FuzzyDiff -test -ini ${DATA_DIR_TOPP}/FuzzyDiff.ini -in1 ${DATA_DIR_TOPP}/FuzzyDiff_3_in1.featureXML -in2 ${DATA_DIR_TOPP}/FuzzyDiff_3_in2.featureXML)
+add_test("UTILS_FuzzyDiff_4" ${TOPP_BIN_PATH}/FuzzyDiff -test -ini ${DATA_DIR_TOPP}/FuzzyDiff.ini -in1 ${DATA_DIR_TOPP}/lorem_ipsum.featureXML -in2 ${DATA_DIR_TOPP}/FuzzyDiff_3_in2.featureXML)
+set_tests_properties("UTILS_FuzzyDiff_1" PROPERTIES WILL_FAIL 1) ## needs to fail due to different numbers
+set_tests_properties("UTILS_FuzzyDiff_2" PROPERTIES WILL_FAIL 1) ## needs to fail (cheating)
+set_tests_properties("UTILS_FuzzyDiff_4" PROPERTIES WILL_FAIL 1) ## needs to fail (file does not exist)
+
 #------------------------------------------------------------------------------
 # IDMerger tests
 add_test("TOPP_IDMerger_1" ${TOPP_BIN_PATH}/IDMerger -test -in ${DATA_DIR_TOPP}/IDMerger_1_input1.idXML ${DATA_DIR_TOPP}/IDMerger_1_input2.idXML -out IDMerger_1_output.tmp -annotate_file_origin)

--- a/src/tests/topp/FuzzyDiff_1_in1.featureXML
+++ b/src/tests/topp/FuzzyDiff_1_in1.featureXML
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.9" id="fm_14509930621887606273" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<dataProcessing completion_time="1999-12-31T23:59:59">
+		<software name="OpenSwathWorkflow" version="version_string" />
+		<processingAction name="Quantitation" />
+		<UserParam type="string" name="parameter: mode" value="test_mode"/>
+	</dataProcessing>
+	<featureList count="6">
+		<feature id="f_4835329514588776807">
+			<position dim="0">100.999999701977</position>
+			<position dim="1">412.5</position>
+			<intensity>25944.8</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>2.27157</overallquality>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.865706760687806"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.181819841265678"/>
+			<UserParam type="float" name="var_massdev_score" value="3.78948546767785e-11"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="2.10526970426547e-11"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.773737603010274"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.706588316825436"/>
+			<UserParam type="float" name="var_ms1_xcorr_shape" value="0"/>
+			<UserParam type="float" name="var_ms1_xcorr_coelution" value="19"/>
+			<UserParam type="float" name="var_ms1_ppm_diff" value="50"/>
+			<UserParam type="float" name="var_ms1_isotope_correlation" value="0"/>
+			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.27157274651"/>
+			<UserParam type="float" name="PrecursorMZ" value="412.5"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+		</feature>
+	</featureList>
+</featureMap>

--- a/src/tests/topp/FuzzyDiff_1_in2.featureXML
+++ b/src/tests/topp/FuzzyDiff_1_in2.featureXML
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.9" id="fm_14509930621887606273" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<dataProcessing completion_time="1999-12-31T23:59:59">
+		<software name="OpenSwathWorkflow" version="version_string" />
+		<processingAction name="Quantitation" />
+		<UserParam type="string" name="parameter: mode" value="test_mode"/>
+	</dataProcessing>
+	<featureList count="6">
+		<feature id="f_4835329514588776807">
+			<position dim="0">100.999999701977</position>
+			<position dim="1">412.5</position>
+			<intensity>25944.8</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>2.27157</overallquality>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.865706760687806"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.181819841265678"/>
+			<UserParam type="float" name="var_massdev_score" value="3.78948546767785e-11"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="6.31580911279641e-11"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.569372277937119"/>
+			<UserParam type="float" name="var_manhatt_score" value="1.41687881616726"/>
+			<UserParam type="float" name="var_ms1_xcorr_shape" value="0"/>
+			<UserParam type="float" name="var_ms1_xcorr_coelution" value="19"/>
+			<UserParam type="float" name="var_ms1_ppm_diff" value="121.212121212121"/>
+			<UserParam type="float" name="var_ms1_isotope_correlation" value="0"/>
+			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.27157274651"/>
+			<UserParam type="float" name="PrecursorMZ" value="412.5"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+		</feature>
+	</featureList>
+</featureMap>

--- a/src/tests/topp/FuzzyDiff_3_in1.featureXML
+++ b/src/tests/topp/FuzzyDiff_3_in1.featureXML
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.9" id="fm_14509930621887606273" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<dataProcessing completion_time="1999-12-31T23:59:59">
+		<software name="OpenSwathWorkflow" version="version_string" />
+		<processingAction name="Quantitation" />
+		<UserParam type="string" name="parameter: mode" value="test_mode"/>
+	</dataProcessing>
+	<featureList count="6">
+		<feature id="f_4835329514588776807">
+			<position dim="0">100.999999701977</position>
+			<position dim="1">412.5</position>
+			<intensity>25944.8</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>2.27157</overallquality>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.865706760687806"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.181819841265678"/>
+			<UserParam type="float" name="var_massdev_score" value="3.78948546767785e-11"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="2.10526970426547e-11"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.773737603010274"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.706588316825436"/>
+			<UserParam type="float" name="var_ms1_xcorr_shape" value="0"/>
+			<UserParam type="float" name="var_ms1_xcorr_coelution" value="19"/>
+			<UserParam type="float" name="var_ms1_ppm_diff" value="50"/>
+			<UserParam type="float" name="var_ms1_isotope_correlation" value="0"/>
+			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.27157274651"/>
+			<UserParam type="float" name="PrecursorMZ" value="412.5"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+		</feature>
+	</featureList>
+</featureMap>

--- a/src/tests/topp/FuzzyDiff_3_in2.featureXML
+++ b/src/tests/topp/FuzzyDiff_3_in2.featureXML
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.9" id="fm_14509930621887606273" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<dataProcessing completion_time="1999-12-31T23:59:59">
+		<software name="OpenSwathWorkflow" version="version_string" />
+		<processingAction name="Quantitation" />
+		<UserParam type="string" name="parameter: mode" value="test_mode"/>
+	</dataProcessing>
+	<featureList count="6">
+		<feature id="f_4835329514588776807">
+			<position dim="0">100.999999701977</position>
+			<position dim="1">412.5</position>
+			<intensity>25944.8</intensity>
+			<quality dim="0">0</quality>
+			<quality dim="1">0</quality>
+			<overallquality>2.27157</overallquality>
+			<UserParam type="float" name="var_isotope_correlation_score" value="0.865706760687806"/>
+			<UserParam type="float" name="var_isotope_overlap_score" value="0.181819841265678"/>
+			<UserParam type="float" name="var_massdev_score" value="3.78948546767785e-11"/>
+			<UserParam type="float" name="var_massdev_score_weighted" value="2.10526970426547e-11"/>
+			<UserParam type="float" name="var_bseries_score" value="0"/>
+			<UserParam type="float" name="var_yseries_score" value="0"/>
+			<UserParam type="float" name="var_dotprod_score" value="0.773737603010274"/>
+			<UserParam type="float" name="var_manhatt_score" value="0.706588316825436"/>
+			<UserParam type="float" name="var_ms1_xcorr_shape" value="0"/>
+			<UserParam type="float" name="var_ms1_xcorr_coelution" value="19"/>
+			<UserParam type="float" name="var_ms1_ppm_diff" value="50"/>
+			<UserParam type="float" name="var_ms1_isotope_correlation" value="0"/>
+			<UserParam type="float" name="var_ms1_isotope_overlap" value="0"/>
+			<UserParam type="float" name="main_var_xx_swath_prelim_score" value="2.27157274651"/>
+			<UserParam type="float" name="PrecursorMZ" value="412.5"/>
+			<UserParam type="float" name="xx_swath_prelim_score" value="0"/>
+		</feature>
+	</featureList>
+</featureMap>


### PR DESCRIPTION
fixes a pretty serious bug in FuzzyDiff:

- Fixes the following bug: when a large ratio was found but does not
  lead to failure (due to small absolute difference) then smaller ratios
  than the original one that *should* lead to failure are ignored.
- adds tests for FuzzyDiff (really, we did not have tests so far?)