### PR TITLE
small tool for git diffs

### DIFF
--- a/tools/scripts/git_showdiff.sh
+++ b/tools/scripts/git_showdiff.sh
@@ -1,0 +1,15 @@
+
+echo "Usage: git_showdiff.sh REV1 REV2"
+
+git diff $1 $2 --name-only \
+  | grep -v '^src/tests/topp/' \
+  | grep -v '^share/OpenMS' \
+  | grep -v '^src/tests/class_tests/openms/data/' \
+  | grep -v '^cmake/modules/'  \
+  | grep -v '^cmake/'  \
+  | grep -v '^src/openswathalgo/thirdparty' \
+  | grep -v '^src/openms/thirdparty/' \
+  | grep -v '^tools'  \
+  | xargs git diff --shortstat $1 $2 --
+
+


### PR DESCRIPTION
small tool that allows calculation of line changes between releases:
```
$ bash tools/scripts/git_showdiff.sh Release2.0.0 Release2.0.1
Usage: git_showdiff.sh REV1 REV2
 2207 files changed, 43543 insertions(+), 19816 deletions(-)
 182 files changed, 9660 insertions(+), 4476 deletions(-)
$ bash tools/scripts/git_showdiff.sh Release2.0.1 Release2.1.0
Usage: git_showdiff.sh REV1 REV2
 1651 files changed, 21921 insertions(+), 25841 deletions(-)
$ bash tools/scripts/git_showdiff.sh  Release2.1.0 Release2.2.0
Usage: git_showdiff.sh REV1 REV2
 2257 files changed, 42708 insertions(+), 22749 deletions(-)
 281 files changed, 8931 insertions(+), 4911 deletions(-)
$ bash tools/scripts/git_showdiff.sh  Release2.2.0 Release2.3.0
Usage: git_showdiff.sh REV1 REV2
 750 files changed, 29401 insertions(+), 8575 deletions(-)
$ bash tools/scripts/git_showdiff.sh  Release2.3.0 develop
Usage: git_showdiff.sh REV1 REV2
 2237 files changed, 78427 insertions(+), 46682 deletions(-)
 330 files changed, 17911 insertions(+), 11824 deletions(-)
```