### PR TITLE
[FIX] Include instead of forward declare QStringList

### DIFF
--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -54,7 +54,8 @@
 
 #include <fstream>
 
-class QStringList;
+#include <QStringList>
+
 
 namespace OpenMS
 {


### PR DESCRIPTION
Seems to fail on some compilers otherwise.