### PR TITLE
[FIX] OpenSWATH: OSW transition-level reports without MI scores

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
@@ -392,7 +392,6 @@ namespace OpenMS
           std::vector<double> id_target_area_intensity = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_area_intensity"),';');
           std::vector<double> id_target_total_area_intensity = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_total_area_intensity"),';');
           std::vector<double> id_target_apex_intensity = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_apex_intensity"),';');
-          std::vector<double> id_target_total_mi = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_total_mi"),';');
           std::vector<double> id_target_intensity_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_intensity_score"),';');
           std::vector<double> id_target_intensity_ratio_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_intensity_ratio_score"),';');
           std::vector<double> id_target_log_intensity = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_ind_log_intensity"),';');
@@ -400,15 +399,43 @@ namespace OpenMS
           std::vector<double> id_target_ind_xcorr_shape = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_ind_xcorr_shape"),';');
           std::vector<double> id_target_ind_log_sn_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_ind_log_sn_score"),';');
           std::vector<double> id_target_ind_massdev_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_ind_massdev_score"),';');
-          std::vector<double> id_target_ind_mi_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_ind_mi_score"),';');
-          std::vector<double> id_target_ind_mi_ratio_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_ind_mi_ratio_score"),';');
           std::vector<double> id_target_ind_isotope_correlation = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_ind_isotope_correlation"),';');
           std::vector<double> id_target_ind_isotope_overlap = ListUtils::create<double>((String)feature_it->getMetaValue("id_target_ind_isotope_overlap"),';');
 
           if ((String)feature_it->getMetaValue("id_target_num_transitions") != "")
           {
-            for (int i = 0; i < feature_it->getMetaValue("id_target_num_transitions").toString().toInt(); ++i)
+            int id_target_num_transitions = feature_it->getMetaValue("id_target_num_transitions").toString().toInt();
+
+            std::vector<std::string> id_target_total_mi(id_target_num_transitions, "NULL");
+            if (!feature_it->getMetaValue("id_target_total_mi").isEmpty())
             {
+              id_target_total_mi = ListUtils::create<std::string>((String)feature_it->getMetaValue("id_target_total_mi"),';');
+            }
+
+            std::vector<std::string> id_target_ind_mi_score(id_target_num_transitions, "NULL");
+            if (!feature_it->getMetaValue("id_target_ind_mi_score").isEmpty() && feature_it->getMetaValue("id_target_ind_mi_score") != "")
+            {
+              id_target_ind_mi_score = ListUtils::create<std::string>((String)feature_it->getMetaValue("id_target_ind_mi_score"),';');
+            }
+
+            std::vector<std::string> id_target_ind_mi_ratio_score(id_target_num_transitions, "NULL");
+            if (!feature_it->getMetaValue("id_target_ind_mi_ratio_score").isEmpty())
+            {
+              id_target_ind_mi_ratio_score = ListUtils::create<std::string>((String)feature_it->getMetaValue("id_target_ind_mi_ratio_score"),';');
+            }
+
+            for (int i = 0; i < id_target_num_transitions; ++i)
+            {
+              if (id_target_total_mi[i] == "") {
+                id_target_total_mi[i] = "NULL";
+              }
+              if (id_target_ind_mi_score[i] == "") {
+                id_target_ind_mi_score[i] = "NULL";
+              }
+              if (id_target_ind_mi_ratio_score[i] == "") {
+                id_target_ind_mi_ratio_score[i] = "NULL";
+              }
+
               sql_feature_uis_transition  << "INSERT INTO FEATURE_TRANSITION (FEATURE_ID, TRANSITION_ID, AREA_INTENSITY, TOTAL_AREA_INTENSITY, APEX_INTENSITY, TOTAL_MI, VAR_INTENSITY_SCORE, VAR_INTENSITY_RATIO_SCORE, VAR_LOG_INTENSITY, VAR_XCORR_COELUTION, VAR_XCORR_SHAPE, VAR_LOG_SN_SCORE, VAR_MASSDEV_SCORE, VAR_MI_SCORE, VAR_MI_RATIO_SCORE, VAR_ISOTOPE_CORRELATION_SCORE, VAR_ISOTOPE_OVERLAP_SCORE) VALUES (" 
                                           << feature_id << ", " 
                                           << id_target_transition_names[i] << ", " 
@@ -434,7 +461,6 @@ namespace OpenMS
           std::vector<double> id_decoy_area_intensity = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_area_intensity"),';');
           std::vector<double> id_decoy_total_area_intensity = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_total_area_intensity"),';');
           std::vector<double> id_decoy_apex_intensity = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_apex_intensity"),';');
-          std::vector<double> id_decoy_total_mi = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_total_mi"),';');
           std::vector<double> id_decoy_intensity_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_intensity_score"),';');
           std::vector<double> id_decoy_intensity_ratio_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_intensity_ratio_score"),';');
           std::vector<double> id_decoy_log_intensity = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_ind_log_intensity"),';');
@@ -442,15 +468,43 @@ namespace OpenMS
           std::vector<double> id_decoy_ind_xcorr_shape = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_ind_xcorr_shape"),';');
           std::vector<double> id_decoy_ind_log_sn_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_ind_log_sn_score"),';');
           std::vector<double> id_decoy_ind_massdev_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_ind_massdev_score"),';');
-          std::vector<double> id_decoy_ind_mi_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_ind_mi_score"),';');
-          std::vector<double> id_decoy_ind_mi_ratio_score = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_ind_mi_ratio_score"),';');
           std::vector<double> id_decoy_ind_isotope_correlation = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_ind_isotope_correlation"),';');
           std::vector<double> id_decoy_ind_isotope_overlap = ListUtils::create<double>((String)feature_it->getMetaValue("id_decoy_ind_isotope_overlap"),';');
 
           if ((String)feature_it->getMetaValue("id_decoy_num_transitions") != "")
           {
+            int id_decoy_num_transitions = feature_it->getMetaValue("id_decoy_num_transitions").toString().toInt();
+
+            std::vector<std::string> id_decoy_total_mi(id_decoy_num_transitions, "NULL");
+            if (!feature_it->getMetaValue("id_decoy_total_mi").isEmpty())
+            {
+              id_decoy_total_mi = ListUtils::create<std::string>((String)feature_it->getMetaValue("id_decoy_total_mi"),';');
+            }
+
+            std::vector<std::string> id_decoy_ind_mi_score(id_decoy_num_transitions, "NULL");
+            if (!feature_it->getMetaValue("id_decoy_ind_mi_score").isEmpty() && feature_it->getMetaValue("id_decoy_ind_mi_score") != "")
+            {
+              id_decoy_ind_mi_score = ListUtils::create<std::string>((String)feature_it->getMetaValue("id_decoy_ind_mi_score"),';');
+            }
+
+            std::vector<std::string> id_decoy_ind_mi_ratio_score(id_decoy_num_transitions, "NULL");
+            if (!feature_it->getMetaValue("id_decoy_ind_mi_ratio_score").isEmpty())
+            {
+              id_decoy_ind_mi_ratio_score = ListUtils::create<std::string>((String)feature_it->getMetaValue("id_decoy_ind_mi_ratio_score"),';');
+            }
+
             for (int i = 0; i < feature_it->getMetaValue("id_decoy_num_transitions").toString().toInt(); ++i)
             {
+              if (id_decoy_total_mi[i] == "") {
+                id_decoy_total_mi[i] = "NULL";
+              }
+              if (id_decoy_ind_mi_score[i] == "") {
+                id_decoy_ind_mi_score[i] = "NULL";
+              }
+              if (id_decoy_ind_mi_ratio_score[i] == "") {
+                id_decoy_ind_mi_ratio_score[i] = "NULL";
+              }
+
               sql_feature_uis_transition  << "INSERT INTO FEATURE_TRANSITION (FEATURE_ID, TRANSITION_ID, AREA_INTENSITY, TOTAL_AREA_INTENSITY, APEX_INTENSITY, TOTAL_MI, VAR_INTENSITY_SCORE, VAR_INTENSITY_RATIO_SCORE, VAR_LOG_INTENSITY, VAR_XCORR_COELUTION, VAR_XCORR_SHAPE, VAR_LOG_SN_SCORE, VAR_MASSDEV_SCORE, VAR_MI_SCORE, VAR_MI_RATIO_SCORE, VAR_ISOTOPE_CORRELATION_SCORE, VAR_ISOTOPE_OVERLAP_SCORE) VALUES (" 
                                           << feature_id << ", " 
                                           << id_decoy_transition_names[i] << ", " 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.h
@@ -426,13 +426,16 @@ namespace OpenMS
 
             for (int i = 0; i < id_target_num_transitions; ++i)
             {
-              if (id_target_total_mi[i] == "") {
+              if (id_target_total_mi[i] == "")
+              {
                 id_target_total_mi[i] = "NULL";
               }
-              if (id_target_ind_mi_score[i] == "") {
+              if (id_target_ind_mi_score[i] == "")
+              {
                 id_target_ind_mi_score[i] = "NULL";
               }
-              if (id_target_ind_mi_ratio_score[i] == "") {
+              if (id_target_ind_mi_ratio_score[i] == "")
+              {
                 id_target_ind_mi_ratio_score[i] = "NULL";
               }
 
@@ -495,13 +498,16 @@ namespace OpenMS
 
             for (int i = 0; i < feature_it->getMetaValue("id_decoy_num_transitions").toString().toInt(); ++i)
             {
-              if (id_decoy_total_mi[i] == "") {
+              if (id_decoy_total_mi[i] == "")
+              {
                 id_decoy_total_mi[i] = "NULL";
               }
-              if (id_decoy_ind_mi_score[i] == "") {
+              if (id_decoy_ind_mi_score[i] == "")
+              {
                 id_decoy_ind_mi_score[i] = "NULL";
               }
-              if (id_decoy_ind_mi_ratio_score[i] == "") {
+              if (id_decoy_ind_mi_ratio_score[i] == "")
+              {
                 id_decoy_ind_mi_ratio_score[i] = "NULL";
               }
 


### PR DESCRIPTION
This PR fixes a bug in the OSW export functionality if transition-level scoring is enabled but MI scores are not used.