### PR TITLE
[FIX] repair broken links, add Gitter+Github

### DIFF
--- a/doc/doxygen/public/Main.doxygen
+++ b/doc/doxygen/public/Main.doxygen
@@ -71,7 +71,10 @@
 
 				Misc:
 				<UL>
-				  <LI> <a class="el" href="http://www.OpenMS.de/support/bugs" target="_blank">Support</a>
+				  <LI> <a class="el" href="https://github.com/OpenMS/OpenMS/wiki#contact" target="_blank">Support</a>
+				  <LI> <a class="el" href="https://github.com/OpenMS/OpenMS" target="_blank">Github</a>
+				  <LI> <a class="el" href="https://gitter.im/OpenMS/OpenMS" target="_blank">Gitter chat</a>
+				  <LI> <a class="el" href="https://sourceforge.net/projects/open-ms/lists/open-ms-general" target="_blank">Mailing List</a>
 					<LI> @subpage FAQ
 					<LI> @subpage ChangeLog
 				</UL>
@@ -91,7 +94,7 @@
 				<UL>
                                   <LI> <a class="el" href="https://github.com/OpenMS/OpenMS/wiki/Coding-conventions" target="_blank">Coding conventions (online)</a>
                                   <LI> <a class="el" href="https://github.com/OpenMS/OpenMS/wiki/Developer-FAQ" target="_blank">Developer FAQ (online)</a>
-                                  <LI> <a class="el" href="https://github.com/OpenMS/OpenMS/wiki/C&%2343;&%2343;-Guide" target="_blank">CPP Guide (online)</a>
+                                  <LI> <a class="el" href="https://github.com/OpenMS/OpenMS/wiki/Cpp-Guide" target="_blank">CPP Guide (online)</a>
 				</UL>
 
 				Documentation:


### PR DESCRIPTION
some quite embarrassing fixes - some links were dead and others were missing, e.g. no link to gitter or github