### PR TITLE
[FIX] FalseDiscoveryRate.cpp: fixed a bug where having decoy hits but…

### DIFF
--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -681,7 +681,18 @@ namespace OpenMS
       }
 
       // corner cases
-      if (k == 0) { score_to_fdr[ds] = score_to_fdr[target_scores[0]]; continue; }
+      if (k == 0)
+      {
+        if (target_scores.size() != 0)
+        {
+          score_to_fdr[ds] = score_to_fdr[target_scores[0]];
+          continue;
+        }
+        else
+        {
+          score_to_fdr[ds] = 1.0;
+        }
+      }
 
       if (k == target_scores.size()) { score_to_fdr[ds] = score_to_fdr[target_scores.back()]; continue; }
       


### PR DESCRIPTION
… no actual hits would cause a seg fault