### PR TITLE
[FIX] make `knime_package_support.cmake`  reissue `find_package` for QT to reload variables

### DIFF
--- a/cmake/knime_package_support.cmake
+++ b/cmake/knime_package_support.cmake
@@ -88,6 +88,10 @@ set(CTD_executables ${TOPP_TOOLS} ${UTILS_TOOLS})
 # remove tools that do not produce CTDs or should not be shipped (because of dependencies or specifics that can not be resolved in KNIME)
 list(REMOVE_ITEM CTD_executables OpenMSInfo ExecutePipeline INIUpdater ImageCreator GenericWrapper InspectAdapter MascotAdapter SvmTheoreticalSpectrumGeneratorTrainer OpenSwathMzMLFileCacher PepNovoAdapter)
 
+## we have to find again so the target variables are reloaded (on linux)
+set(PACKAGE_QT_COMPONENTS "${OpenMS_QT_COMPONENTS};${OpenMS_GUI_QT_COMPONENTS}")
+find_package(Qt5 COMPONENTS ${PACKAGE_QT_COMPONENTS}) 
+
 # pseudo-ctd target
 add_custom_target(
   create_ctds


### PR DESCRIPTION
Necessary on Ubuntu Xenial (16.04) to avoid QT errors when building custom KNIME
plugins for OpenMS. See also: https://gitter.im/OpenMS/OpenMS?at=5b2bba007da8cd7c8c60a5d5