### PR TITLE
[FIX] MSPGenericFile: Assume one metadatum per line

### DIFF
--- a/src/openms/source/FORMAT/MSPGenericFile.cpp
+++ b/src/openms/source/FORMAT/MSPGenericFile.cpp
@@ -90,7 +90,8 @@ namespace OpenMS
     boost::regex re_synon("^synon(?:yms?)?: (.+)", boost::regex::no_mod_s | boost::regex::icase);
     boost::regex re_points_line("^\\d");
     boost::regex re_point("(\\d+(?:\\.\\d+)?)[: ](\\d+(?:\\.\\d+)?);? ?");
-    boost::regex re_metadatum(" *([^;\r\n]+): ([^;\r\n]+)");
+    boost::regex re_cas_nist("^CAS#: ([\\d-]+);  NIST#: (\\d+)"); // specific to NIST db
+    boost::regex re_metadatum("^(.+): (.+)", boost::regex::no_mod_s);
 
     LOG_INFO << "\nLoading spectra from .msp file. Please wait." << std::endl;
 
@@ -126,14 +127,18 @@ namespace OpenMS
         spectrum.setName( String(m[1]) );
         spectrum.setMetaValue("is_valid", 1);
       }
+      // Specific case of NIST's exported msp
+      else if (boost::regex_search(line, m, re_cas_nist))
+      {
+        // LOG_DEBUG << "CAS#: " << m[1] << "; NIST#: " << m[2] << "\n";
+        spectrum.setMetaValue(String("CAS#"), String(m[1]));
+        spectrum.setMetaValue(String("NIST#"), String(m[2]));
+      }
       // Other metadata
       else if (boost::regex_search(line, m, re_metadatum))
       {
-        do {
-          // LOG_DEBUG << m[1] << m[2] << "\n";
-          spectrum.setMetaValue(String(m[1]), String(m[2]));
-        }
-        while (boost::regex_search(m[0].second, m, re_metadatum));
+        // LOG_DEBUG << m[1] << m[2] << "\n";
+        spectrum.setMetaValue(String(m[1]), String(m[2]));
       }
     }
     // To make sure a spectrum is added even if no empty line is present before EOF


### PR DESCRIPTION
The `develop` version of this class parses multiple metadata on the same line, assuming they are separated by a `;`.

I noticed that some libraries use the character `;` within the `Comments` metadatum, and that breaks the implementation.

If one exports the NIST library to msp format (demo: https://chemdata.nist.gov/dokuwiki/doku.php?id=chemdata:nist17), he/she'll find that `CAS#` and `NIST#` are on the same line, separated by a `;`.

It is nice to support an important library as NIST's, therefore I went for a simple solution: keep supporting the above line, but do not assume multiple metadata on a single line anywhere else, because character `;` is not universally used as a separator for metadata.