### PR TITLE
[FEATURE] Integrate EMG into PeakIntegrator workflow

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -538,12 +538,12 @@ protected:
 
     template <typename PeakContainerT>
     PeakArea integratePeak_(
-      const PeakContainerT& pc, const double left, const double right
+      const PeakContainerT& pc, double left, double right
     ) const;
 
     template <typename PeakContainerT>
     PeakBackground estimateBackground_(
-      const PeakContainerT& pc, const double left, const double right,
+      const PeakContainerT& pc, double left, double right,
       const double peak_apex_pos
     ) const;
 
@@ -552,7 +552,7 @@ protected:
 
     template <typename PeakContainerT>
     PeakShapeMetrics calculatePeakShapeMetrics_(
-      const PeakContainerT& pc, const double left, const double right,
+      const PeakContainerT& pc, double left, double right,
       const double peak_height, const double peak_apex_pos
     ) const;
 
@@ -643,5 +643,26 @@ private:
     */
     double simpson(MSSpectrum::ConstIterator it_begin, MSSpectrum::ConstIterator it_end) const;
     ///@}
+
+    /**
+      @brief Fit the peak to the EMG model
+
+      The fitting process happens only if `fit_EMG_` is true. `left` and `right`
+      are updated accordingly.
+
+      @tparam PeakContainerT Either a MSChromatogram or a MSSpectrum
+      @param[in] pc Input peak
+      @param[out] emg_pc Will possibly contain the processed peak
+      @param[in] left RT or MZ value of the first point of interest
+      @param[in] right RT or MZ value of the first point of interest
+      @return A const reference to `emg_pc` if the fitting is executed, `pc` otherwise.
+    */
+    template <typename PeakContainerT>
+    const PeakContainerT& EMGPreProcess_(
+      const PeakContainerT& pc,
+      PeakContainerT& emg_pc,
+      double& left,
+      double& right
+    ) const;
   };
 }

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -45,7 +45,6 @@
 
 namespace OpenMS
 {
-
   /**
     @brief Compute the area, background and shape metrics of a peak.
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -41,6 +41,7 @@
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/KERNEL/MSChromatogram.h>
 #include <OpenMS/KERNEL/MSSpectrum.h>
+#include <OpenMS/MATH/MISC/EmgGradientDescent.h>
 
 namespace OpenMS
 {
@@ -537,12 +538,12 @@ protected:
 
     template <typename PeakContainerT>
     PeakArea integratePeak_(
-      const PeakContainerT& p, const double left, const double right
+      const PeakContainerT& pc, const double left, const double right
     ) const;
 
     template <typename PeakContainerT>
     PeakBackground estimateBackground_(
-      const PeakContainerT& p, const double left, const double right,
+      const PeakContainerT& pc, const double left, const double right,
       const double peak_apex_pos
     ) const;
 
@@ -551,7 +552,7 @@ protected:
 
     template <typename PeakContainerT>
     PeakShapeMetrics calculatePeakShapeMetrics_(
-      const PeakContainerT& p, const double left, const double right,
+      const PeakContainerT& pc, const double left, const double right,
       const double peak_height, const double peak_apex_pos
     ) const;
 
@@ -600,6 +601,10 @@ private:
     */
     String baseline_type_ = BASELINE_TYPE_BASETOBASE;
     ///@}
+
+    /// Enable/disable EMG peak model fitting
+    bool fit_EMG_;
+    EmgGradientDescent emg_;
 
     /** @name Helper methods
       The Simpson's rule implementations for an odd number of unequally spaced points.

--- a/src/openms/include/OpenMS/MATH/MISC/EmgGradientDescent.h
+++ b/src/openms/include/OpenMS/MATH/MISC/EmgGradientDescent.h
@@ -76,7 +76,7 @@ public:
     friend class EmgGradientDescent_friend;
 
     /**
-      @brief Fit the given peak (a MSChromatogram) to the EMG peak model
+      @brief Fit the given peak (either MSChromatogram or MSSpectrum) to the EMG peak model
 
       The method is able to recapitulate the actual peak area of saturated or cutoff peaks.
       In addition, the method is able to fine tune the peak area of well acquired peaks.
@@ -89,37 +89,8 @@ public:
       order (from index 0 to 3): amplitude `h`, mean `mu`, standard deviation `sigma`,
       exponent relaxation time `tau`.
 
-      @note All optimal gradient descent parameters are currently hard coded to allow for a simplified user interface
-
-      @note Cutoff peak: The intensities of the left and right baselines are not equal
-
-      @note Saturated peak: The maximum intensity of the peak is lower than expected due to saturation of the detector
-
-      Inspired by the results found in:
-      Yuri Kalambet, Yuri Kozmin, Ksenia Mikhailova, Igor Nagaev, Pavel Tikhonov
-      Reconstruction of chromatographic peaks using the exponentially modified Gaussian function
-
-      @param[in] input_peak Input peak
-      @param[out] output_peak Output peak
-    */
-    void fitEMGPeakModel(
-      const MSChromatogram& input_peak,
-      MSChromatogram& output_peak
-    ) const;
-
-    /**
-      @brief Fit the given peak (a MSSpectrum) to the EMG peak model
-
-      The method is able to recapitulate the actual peak area of saturated or cutoff peaks.
-      In addition, the method is able to fine tune the peak area of well acquired peaks.
-      The output is a reconstruction of the input peak. Additional points are often added
-      to produce a peak with similar intensities on boundaries' points.
-
-      Metadata will be added to the output peak, containing the optimal parameters
-      for the EMG peak model. This information will be found in a `FloatDataArray`
-      of name "emg_parameters", with the parameters being saved in the following
-      order (from index 0 to 3): amplitude `h`, mean `mu`, standard deviation `sigma`,
-      exponent relaxation time `tau`.
+      If `left_pos` and `right_pos` are passed, then only that part of the peak
+      is taken into consideration.
 
       @note All optimal gradient descent parameters are currently hard coded to allow for a simplified user interface
 
@@ -131,12 +102,18 @@ public:
       Yuri Kalambet, Yuri Kozmin, Ksenia Mikhailova, Igor Nagaev, Pavel Tikhonov
       Reconstruction of chromatographic peaks using the exponentially modified Gaussian function
 
+      @tparam PeakContainerT Either a MSChromatogram or a MSSpectrum
       @param[in] input_peak Input peak
       @param[out] output_peak Output peak
+      @param[in] left_pos RT or MZ value of the first point of interest
+      @param[in] right_pos RT or MZ value of the last point of interest
     */
+    template <typename PeakContainerT>
     void fitEMGPeakModel(
-      const MSSpectrum& input_peak,
-      MSSpectrum& output_peak
+      const PeakContainerT& input_peak,
+      PeakContainerT& output_peak,
+      const double left_pos = 0.0,
+      const double right_pos = 0.0
     ) const;
 
 protected:
@@ -440,12 +417,6 @@ private:
       const double mu,
       const double sigma,
       const double tau
-    ) const;
-
-    template <typename PeakContainerT>
-    void fitEMGPeakModel_(
-      const PeakContainerT& input_peak,
-      PeakContainerT& output_peak
     ) const;
 
     /// Alias for OpenMS::Constants:PI

--- a/src/openms/source/MATH/MISC/EmgGradientDescent.cpp
+++ b/src/openms/source/MATH/MISC/EmgGradientDescent.cpp
@@ -741,34 +741,22 @@ namespace OpenMS
     return iter_idx;
   }
 
-  void EmgGradientDescent::fitEMGPeakModel(
-    const MSChromatogram& input_peak,
-    MSChromatogram& output_peak
-  ) const
-  {
-    fitEMGPeakModel_(input_peak, output_peak);
-  }
-
-  void EmgGradientDescent::fitEMGPeakModel(
-    const MSSpectrum& input_peak,
-    MSSpectrum& output_peak
-  ) const
-  {
-    fitEMGPeakModel_(input_peak, output_peak);
-  }
-
   template <typename PeakContainerT>
-  void EmgGradientDescent::fitEMGPeakModel_(
+  void EmgGradientDescent::fitEMGPeakModel(
     const PeakContainerT& input_peak,
-    PeakContainerT& output_peak
+    PeakContainerT& output_peak,
+    const double left_pos,
+    const double right_pos
   ) const
   {
     // Extract points
+    typename PeakContainerT::const_iterator start_it = left_pos ? input_peak.PosBegin(left_pos) : input_peak.begin();
+    typename PeakContainerT::const_iterator end_it = right_pos ? input_peak.PosEnd(right_pos) : input_peak.end();
     std::vector<double> xs, ys;
-    for (const typename PeakContainerT::PeakType& point : input_peak)
+    for (typename PeakContainerT::const_iterator it = start_it; it != end_it; ++it)
     {
-      xs.push_back(point.getPos());
-      ys.push_back(point.getIntensity());
+      xs.push_back(it->getPos());
+      ys.push_back(it->getIntensity());
     }
 
     // EMG parameter estimation with gradient descent
@@ -807,4 +795,18 @@ namespace OpenMS
       std::cout << "Number of additional points: " << (output_peak.size() - input_peak.size()) << "\n\n" << std::endl;
     }
   }
+
+  template void EmgGradientDescent::fitEMGPeakModel<MSChromatogram>(
+    const MSChromatogram& input_peak,
+    MSChromatogram& output_peak,
+    const double left_pos,
+    const double right_pos
+  ) const;
+
+  template void EmgGradientDescent::fitEMGPeakModel<MSSpectrum>(
+    const MSSpectrum& input_peak,
+    MSSpectrum& output_peak,
+    const double left_pos,
+    const double right_pos
+  ) const;
 }

--- a/src/pyOpenMS/pxds/EmgGradientDescent.pxd
+++ b/src/pyOpenMS/pxds/EmgGradientDescent.pxd
@@ -15,3 +15,5 @@ cdef extern from "<OpenMS/MATH/MISC/EmgGradientDescent.h>" namespace "OpenMS":
 
         void fitEMGPeakModel(MSChromatogram input_peak, MSChromatogram& output_peak) nogil except +
         void fitEMGPeakModel(MSSpectrum input_peak, MSSpectrum& output_peak) nogil except +
+        void fitEMGPeakModel(MSChromatogram input_peak, MSChromatogram& output_peak, double left_pos, double right_pos) nogil except +
+        void fitEMGPeakModel(MSSpectrum input_peak, MSSpectrum& output_peak, double left_pos, double right_pos) nogil except +

--- a/src/pyOpenMS/pxds/EmgGradientDescent.pxd
+++ b/src/pyOpenMS/pxds/EmgGradientDescent.pxd
@@ -13,7 +13,7 @@ cdef extern from "<OpenMS/MATH/MISC/EmgGradientDescent.h>" namespace "OpenMS":
 
         void getDefaultParameters(Param&) nogil except +
 
-        void fitEMGPeakModel(MSChromatogram input_peak, MSChromatogram& output_peak) nogil except +
-        void fitEMGPeakModel(MSSpectrum input_peak, MSSpectrum& output_peak) nogil except +
-        void fitEMGPeakModel(MSChromatogram input_peak, MSChromatogram& output_peak, double left_pos, double right_pos) nogil except +
-        void fitEMGPeakModel(MSSpectrum input_peak, MSSpectrum& output_peak, double left_pos, double right_pos) nogil except +
+        void fitEMGPeakModel(MSChromatogram& input_peak, MSChromatogram& output_peak) nogil except +
+        void fitEMGPeakModel(MSSpectrum& input_peak, MSSpectrum& output_peak) nogil except +
+        void fitEMGPeakModel(MSChromatogram& input_peak, MSChromatogram& output_peak, double left_pos, double right_pos) nogil except +
+        void fitEMGPeakModel(MSSpectrum& input_peak, MSSpectrum& output_peak, double left_pos, double right_pos) nogil except +

--- a/src/pyOpenMS/pxds/PeakIntegrator.pxd
+++ b/src/pyOpenMS/pxds/PeakIntegrator.pxd
@@ -15,14 +15,14 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h>" namespace "OpenM
 
         void getDefaultParameters(Param) nogil except +
 
-        PI_PeakArea integratePeak(MSChromatogram chromatogram, double left, double right) nogil except +
-        PI_PeakArea integratePeak(MSSpectrum spectrum, double left, double right) nogil except +
+        PI_PeakArea integratePeak(MSChromatogram& chromatogram, double left, double right) nogil except +
+        PI_PeakArea integratePeak(MSSpectrum& spectrum, double left, double right) nogil except +
 
-        PI_PeakBackground estimateBackground(MSChromatogram chromatogram, double left, double right, double peak_apex_pos) nogil except +
-        PI_PeakBackground estimateBackground(MSSpectrum spectrum, double left, double right, double peak_apex_pos) nogil except +
+        PI_PeakBackground estimateBackground(MSChromatogram& chromatogram, double left, double right, double peak_apex_pos) nogil except +
+        PI_PeakBackground estimateBackground(MSSpectrum& spectrum, double left, double right, double peak_apex_pos) nogil except +
 
-        PI_PeakShapeMetrics calculatePeakShapeMetrics(MSChromatogram chromatogram, double left, double right, double peak_height, double peak_apex_pos) nogil except +
-        PI_PeakShapeMetrics calculatePeakShapeMetrics(MSSpectrum spectrum, double left, double right, double peak_height, double peak_apex_pos) nogil except +
+        PI_PeakShapeMetrics calculatePeakShapeMetrics(MSChromatogram& chromatogram, double left, double right, double peak_height, double peak_apex_pos) nogil except +
+        PI_PeakShapeMetrics calculatePeakShapeMetrics(MSSpectrum& spectrum, double left, double right, double peak_height, double peak_apex_pos) nogil except +
 
 
 cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h>" namespace "OpenMS::PeakIntegrator":


### PR DESCRIPTION
_EmgGradientDescent_ now supports `left` and `right` arguments.
_PeakIntegrator_ has a `"fit_EMG"` parameter that, if `true`, fits the EMG peak model to the interested peak part. The integration/bg_estimation/metrics computation continues on the interested part.