### PR TITLE
[FIX] Correction of the observed mass if isotope error is given

### DIFF
--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -418,12 +418,17 @@ protected:
         double calc_mass = hit.getSequence().getMonoWeight(Residue::Full, charge)/charge;
         hit.setMetaValue("CalcMass", calc_mass);
 
-        if (hit.metaValueExists("IsotopeError"))
+        if (hit.metaValueExists("IsotopeError"))  // MSGFPlus
         {
-          float isoErr = stof(hit.getMetaValue("IsotopeError").toString());
+          float isoErr = hit.getMetaValue("IsotopeError").toString().toFloat();
           exp_mass = exp_mass - (isoErr * Constants::C13C12_MASSDIFF_U) / charge;
         }
-        
+        else if (hit.metaValueExists("isotope_error")) // e.g. SimpleSearchEngine /RNPxlSearch
+        {
+          float isoErr = hit.getMetaValue("isotope_error").toString().toFloat();
+          exp_mass = exp_mass - (isoErr * Constants::C13C12_MASSDIFF_U) / charge;
+        }
+                
         hit.setMetaValue("ExpMass", exp_mass);
         hit.setMetaValue("mass", exp_mass);
         

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -416,12 +416,13 @@ protected:
         String unmodified_sequence = hit.getSequence().toUnmodifiedString();
         
         double calc_mass = hit.getSequence().getMonoWeight(Residue::Full, charge)/charge;
-        if (hit.metaValueExists("IsotopeError")) {
-          float isoErr = hit.getMetaValue("IsotopeError");
-          calc_mass = calc_mass - (isoErr * Constants::PROTON_MASS_U) / charge;
-        }
         hit.setMetaValue("CalcMass", calc_mass);
-        
+
+        if (hit.metaValueExists("IsotopeError"))
+        {
+          float isoErr = stof(hit.getMetaValue("IsotopeError").toString());
+          exp_mass = exp_mass - (isoErr * Constants::C13C12_MASSDIFF_U) / charge;
+        }
         
         hit.setMetaValue("ExpMass", exp_mass);
         hit.setMetaValue("mass", exp_mass);

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -43,6 +43,7 @@
 #include <OpenMS/FORMAT/MzIdentMLFile.h>
 #include <OpenMS/FORMAT/OSWFile.h>
 #include <OpenMS/SYSTEM/File.h>
+#include <OpenMS/CONCEPT/Constants.h>
 
 #include <iostream>
 #include <cmath>
@@ -415,6 +416,10 @@ protected:
         String unmodified_sequence = hit.getSequence().toUnmodifiedString();
         
         double calc_mass = hit.getSequence().getMonoWeight(Residue::Full, charge)/charge;
+        if (hit.metaValueExists("IsotopeError")) {
+          float isoErr = hit.getMetaValue("IsotopeError");
+          calc_mass = calc_mass - (isoErr * Constants::PROTON_MASS_U) / charge;
+        }
         hit.setMetaValue("CalcMass", calc_mass);
         
         


### PR DESCRIPTION
If an isotope error is given (e.g. when using the search engine MSGF+), the calulated mass is corrected by subtracting `(isotopeError * protonMass) / charge`. 