### PR TITLE
[FEATURE] TOPPView column showing peak annotations as text

### DIFF
--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -130,11 +130,27 @@ public:
 
     bool operator==(const PeptideHit::PeakAnnotation& other) const
     {
-      if (charge != other.charge || mz != other.mz || 
+      if (charge != other.charge || mz != other.mz ||
           intensity != other.intensity || annotation != other.annotation) return false;
       return true;
     }
-};
+
+    static void writePeakAnnotationsString_(String& annotation_string, std::vector<PeptideHit::PeakAnnotation> annotations)
+    {
+      if (annotations.empty()) { return; }
+
+      // sort by mz, charge, ...
+      stable_sort(annotations.begin(), annotations.end());
+
+      String val;
+      for (auto& a : annotations)
+      {
+        annotation_string += String(a.mz) + "," + String(a.intensity) + "," + String(a.charge) + "," + String(a.annotation).quote();
+        if (&a != &annotations.back()) { annotation_string += "|"; }
+      }
+    }
+
+  };
 
 public:
 
@@ -177,7 +193,7 @@ public:
     };
     //@}
 
-    
+
     /// Lesser predicate for (modified) sequence of hits
     class OPENMS_DLLAPI SequenceLessComparator
     {
@@ -201,7 +217,7 @@ public:
 
       bool operator==(const PepXMLAnalysisResult& rhs) const
       {
-        return score_type == rhs.score_type 
+        return score_type == rhs.score_type
           && higher_is_better == rhs.higher_is_better
           && main_score == rhs.main_score
           && sub_scores == rhs.sub_scores;
@@ -325,4 +341,3 @@ protected:
   };
 
 } // namespace OpenMS
-

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -90,7 +90,7 @@ namespace OpenMS
     prot_hit_ = ProteinHit();
     pep_hit_ = PeptideHit();
     proteinid_to_accession_.clear();
-    
+
     endProgress();
   }
 
@@ -389,7 +389,7 @@ namespace OpenMS
       if (count_wrong_id && protein_ids.size() == 1) LOG_WARN << "Omitted writing of " << count_wrong_id << " peptide identifications due to wrong protein mapping." << std::endl;
       if (count_empty) LOG_WARN << "Omitted writing of " << count_empty << " peptide identifications due to empty hits." << std::endl;
     }
-    
+
     // empty protein ids  parameters
     if (protein_ids.empty())
     {
@@ -1053,23 +1053,14 @@ namespace OpenMS
     return aa_string;
   }
 
-  void IdXMLFile::writeFragmentAnnotations_(const String & tag_name, std::ostream & os, 
+  void IdXMLFile::writeFragmentAnnotations_(const String & tag_name, std::ostream & os,
                                             std::vector<PeptideHit::PeakAnnotation> annotations, UInt indent)
   {
-    if (annotations.empty()) { return; } 
-
-    // sort by mz, charge, ...
-    stable_sort(annotations.begin(), annotations.end());
-
     String val;
-    for (auto& a : annotations)
-    {
-      val += String(a.mz) + "," + String(a.intensity) + "," + String(a.charge) + "," + String(a.annotation).quote();
-      if (&a != &annotations.back()) { val += "|"; }     
-    }
+    PeptideHit::PeakAnnotation::writePeakAnnotationsString_(val, annotations);
     os << String(indent, '\t') << "<" << writeXMLEscape(tag_name) << " type=\"string\" name=\"fragment_annotation\" value=\"" << writeXMLEscape(val) << "\"/>" << "\n";
   }
- 
+
   void IdXMLFile::parseFragmentAnnotation_(const String& s, std::vector<PeptideHit::PeakAnnotation> & annotations)
   {
     if (s.empty()) { return; }
@@ -1081,7 +1072,7 @@ namespace OpenMS
     {
       StringList fields;
       pa.split_quoted(',', fields);
-      if (fields.size() != 4) 
+      if (fields.size() != 4)
       {
         throw Exception::InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
                 "Invalid fragment annotation. Four comma-separated fields required. String is: '" + pa + "'");

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -1058,7 +1058,10 @@ namespace OpenMS
   {
     String val;
     PeptideHit::PeakAnnotation::writePeakAnnotationsString_(val, annotations);
-    os << String(indent, '\t') << "<" << writeXMLEscape(tag_name) << " type=\"string\" name=\"fragment_annotation\" value=\"" << writeXMLEscape(val) << "\"/>" << "\n";
+    if (!val.empty())
+    {
+      os << String(indent, '\t') << "<" << writeXMLEscape(tag_name) << " type=\"string\" name=\"fragment_annotation\" value=\"" << writeXMLEscape(val) << "\"/>" << "\n";
+    }
   }
 
   void IdXMLFile::parseFragmentAnnotation_(const String& s, std::vector<PeptideHit::PeakAnnotation> & annotations)

--- a/src/openms_gui/include/OpenMS/VISUAL/SpectraIdentificationViewWidget.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/SpectraIdentificationViewWidget.h
@@ -91,6 +91,7 @@ private:
     QCheckBox* create_rows_for_commmon_metavalue_;
     QTableWidget* table_widget_;
     bool is_ms1_shown_;
+    QTableWidget* fragment_window_;
 private slots:
     /// Emits spectrumSelected with the current spectrum index
     void spectrumSelectionChange_(QTableWidgetItem*, QTableWidgetItem*);
@@ -106,4 +107,3 @@ private slots:
     void cellClicked_(int row, int column);
   };
 }
-


### PR DESCRIPTION
The column appears when "Show advanced annotations" is ticked and `PeakAnnotations` exist in the `PeptideHits`.
Adresses #3588 .

For me it looks like the resizing of the column may not work correctly, it resizes to the longest annotation for one dataset with shorter annotations, but not for another with some much longer strings.
There may be a maximal limit to the automatic resizing with `table_widget_->resizeColumnsToContents()`

Also the horizontal scrolling method that sticks to columns makes it difficult to scroll this wide column.

At least exporting the table as .csv exports all the annotations correctly, regardless of the column size.