### PR TITLE
[FIX] CsiFingerIdMzTAbWriter, SiriusMzTabWriter 

### DIFF
--- a/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
@@ -56,7 +56,6 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & sirius_output_path
 
   for (std::vector<String>::const_iterator it = sirius_output_paths.begin(); it != sirius_output_paths.end(); ++it)
   {
-
     const std::string pathtocsicsv = *it + "/summary_csi_fingerid.csv";
 
     ifstream file(pathtocsicsv);
@@ -68,7 +67,8 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & sirius_output_path
     
       if (rowcount > 1)
       {
-        
+        const UInt top_n_hits_cor = (top_n_hits >= rowcount) ? rowcount : top_n_hits;
+
         // fill identification structure containing all candidate hits for a single spectrum
         CsiFingerIdMzTabWriter::CsiAdapterIdentification csi_id;
 
@@ -89,7 +89,6 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & sirius_output_path
         // results from scan were not assigned to a feautre
         if (feature_id == "id_0") {feature_id = "null";}
 
-        const UInt top_n_hits_cor = (top_n_hits > rowcount) ? rowcount : top_n_hits;
         for (Size j = 1; j < top_n_hits_cor; ++j)
         {
           
@@ -138,7 +137,8 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & sirius_output_path
             const CsiFingerIdMzTabWriter::CsiAdapterHit &hit = id.hits[j];
             MzTabSmallMoleculeSectionRow smsr;
 
-            map <Size, MzTabDouble> engine_score = {{1, MzTabDouble(hit.score)}};
+            map <Size, MzTabDouble> engine_score;
+            engine_score[1] = MzTabDouble(hit.score);
             smsr.best_search_engine_score = engine_score;
 
             smsr.chemical_formula = MzTabString(hit.molecular_formula);
@@ -171,7 +171,7 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & sirius_output_path
 
             MzTabOptionalColumnEntry featureId;
             featureId.first = "featureId";
-            featureId.second = MzTabString(csi_id.feature_id);
+            featureId.second = MzTabString(id.feature_id);
 
             smsr.opt_.push_back(rank);
             smsr.opt_.push_back(compoundId);

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
@@ -71,7 +71,10 @@ void SiriusMzTabWriter::read(const std::vector<String> & sirius_output_paths,
 
       if (rowcount > 1)
       {
-        const UInt top_n_hits_cor = (top_n_hits >= rowcount) ? rowcount : top_n_hits;
+        // correction if the rowcount is smaller than the number of hits used as parameter
+        // rowcount-1 because the csv header will be skipped in the loop later on.
+        int header = 1;
+        const UInt top_n_hits_cor = (top_n_hits >= rowcount) ? rowcount-header : top_n_hits;
         
         // fill identification structure containing all candidate hits for a single spectrum
         SiriusMzTabWriter::SiriusAdapterIdentification sirius_id;
@@ -90,12 +93,11 @@ void SiriusMzTabWriter::read(const std::vector<String> & sirius_output_paths,
         boost::regex regexp_feature("_(?<SCAN>\\d+)-");
         bool found = boost::regex_search(str, match, regexp_feature);
         if (found && match["SCAN"].matched) {feature_id = "id_" + match["SCAN"].str();}
-        // results from scan were not assigned to a feautre
-        if (feature_id == "id_0") {feature_id = "null";}
+        String unassigned = "null";
 
-        for (Size j = 1; j < top_n_hits_cor; ++j)
+        // j = 1 because of .csv file format (header)
+        for (Size j = 1; j <= top_n_hits_cor; ++j)
         {
-          
           StringList sl;
           compounds.getRow(j, sl);
           SiriusMzTabWriter::SiriusAdapterHit sirius_hit;
@@ -115,7 +117,15 @@ void SiriusMzTabWriter::read(const std::vector<String> & sirius_output_paths,
 
         sirius_id.scan_index = scan_index;
         sirius_id.scan_number = scan_number;
-        sirius_id.feature_id = feature_id;
+        // check if results were assigned to a feature
+        if (feature_id != "id_0")
+        {
+          sirius_id.feature_id = feature_id;
+        }
+        else
+        {
+          sirius_id.feature_id = unassigned;
+        }
         sirius_result.identifications.push_back(sirius_id);
 
         // write metadata to mzTab file

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
@@ -60,14 +60,12 @@ void SiriusMzTabWriter::read(const std::vector<String> & sirius_output_paths,
 
   for (std::vector<String>::const_iterator it = sirius_output_paths.begin(); it != sirius_output_paths.end(); ++it)
   {
-
     const std::string pathtosiriuscsv = *it + "/summary_sirius.csv";
 
     ifstream file(pathtosiriuscsv);
 
     if (file) 
     {
-      
       CsvFile compounds(pathtosiriuscsv, '\t');
       const UInt rowcount = compounds.rowCount();
 
@@ -96,7 +94,6 @@ void SiriusMzTabWriter::read(const std::vector<String> & sirius_output_paths,
         if (feature_id == "id_0") {feature_id = "null";}
 
         for (Size j = 1; j < top_n_hits_cor; ++j)
-
         {
           
           StringList sl;

--- a/src/tests/topp/THIRDPARTY/SiriusAdapter_4_foutput.mzTab
+++ b/src/tests/topp/THIRDPARTY/SiriusAdapter_4_foutput.mzTab
@@ -3,7 +3,7 @@ MTD	mzTab-mode	null
 MTD	mzTab-type	null
 MTD	description	CSI:FingerID-4.0
 MTD	smallmolecule_search_engine_score[1]	[, , score, ]
-MTD	ms_run[1]-location	/Users/alka/Documents/work/software/openms_oa_1/OpenMS/src/tests/topp/THIRDPARTY/SiriusAdapter_2_input.mzML
+MTD	ms_run[1]-location	/Users/alka/Documents/work/software/openms_oa/OpenMS/src/tests/topp/THIRDPARTY/SiriusAdapter_2_input.mzML
 
 SMH	identifier	chemical_formula	smiles	inchi_key	description	exp_mass_to_charge	calc_mass_to_charge	charge	retention_time	taxid	species	database	database_version	spectra_ref	search_engine	best_search_engine_score[1]	modifications	rank	compoundId	compoundScanNumber	featureId
 SML	55574	C21H10O	C1=CC2=C3C(=C1)C=CC4=CC5=CC=CC6=C5C(=C43)C(=C2)C6=O	HIHHXINILQCLMA	""	null	null	null	null	null	null	null	null	null	null	-117.640158756418	null	1	79	6	null
@@ -15,3 +15,4 @@ SML	12103331	C21H10O	C1=CC2=C3C4=C5C(=CC=C14)C=CC6=C(C=C(C=C2)C3=C65)C=O	MQUYWEK
 SML	13734048	C23H11N	C1=C2C=CC3=CC=C4C=NC5=CC=C6C=CC(=C1)C7=C6C5=C4C3=C27	QLZKBLCYIJHNPV	""	null	null	null	null	null	null	null	null	null	null	-143.453380351929	null	7	79	6	null
 SML	101127729	C23H10O	C1=CC2=CC=C3C=C4C(=O)C=C5C=CC6=CC=C1C7=C6C5=C4C3=C27	LSZAGAQJGCTDPH	""	null	null	null	null	null	null	null	null	null	null	-147.406650862968	null	8	79	6	null
 SML	11550864	C21H10O	C#CC1=CC(=CC(=C1)C#C)C(=O)C2=CC(=CC(=C2)C#C)C#C	WRSJHHGCOHFRKW	Bis(3,5-diethynylphenyl)methanone	null	null	null	null	null	null	null	null	null	null	-148.948965097184	null	9	79	6	null
+SML	60036939	C21H10O	C#CC1=CC=C(C(=C1)C#C)C(=O)C2=CC=C(C#C)C=C2C#C	NHPOZYDWIPXQSI	bis(2,4-diethynylphenyl)methanone	null	null	null	null	null	null	null	null	null	null	-151.501121054042	null	10	79	6	null

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -151,7 +151,7 @@ protected:
     // internal sirius parameters
     registerStringOption_("profile", "<choice>", "qtof", "Specify the used analysis profile", false);
     setValidStrings_("profile", ListUtils::create<String>("qtof,orbitrap,fticr"));
-    registerIntOption_("candidates", "<num>", 5, "The number of candidates in the sirius output.", false);
+    registerIntOption_("candidates", "<num>", 5, "The number of candidates in the SIRIUS output.", false);
     registerStringOption_("database", "<choice>", "all", "search formulas in given database", false);
     setValidStrings_("database", ListUtils::create<String>("all,chebi,custom,kegg,bio,natural products,pubmed,hmdb,biocyc,hsdb,knapsack,biological,zinc bio,gnps,pubchem,mesh,maconda"));
     registerIntOption_("noise", "<num>", 0, "median intensity of noise peaks", false);
@@ -161,12 +161,12 @@ protected:
     registerStringOption_("elements", "<choice>", "CHNOP[5]S[8]Cl[1]", "The allowed elements. Write CHNOPSCl to allow the elements C, H, N, O, P, S and Cl. Add numbers in brackets to restrict the maximal allowed occurrence of these elements: CHNOP[5]S[8]Cl[1].", false);
     registerIntOption_("compound_timeout", "<num>", 10, "Time out in seconds per compound. To disable the timeout set the value to 0", false);
     registerIntOption_("tree_timeout", "<num>", 0, "Time out in seconds per fragmentation tree computation.", false);
-    registerIntOption_("top_n_hits", "<num>", 10, "The top_n_hit for each compound written to the CSI:FingerID output", false);
+    registerIntOption_("top_n_hits", "<num>", 10, "The number of top hits for each compound written to the CSI:FingerID output", false);
 
     registerFlag_("auto_charge", "Use this option if the charge of your compounds is unknown and you do not want to assume [M+H]+ as default. With the auto charge option SIRIUS will not care about charges and allow arbitrary adducts for the precursor peak.", false);
     registerFlag_("ion_tree", "Print molecular formulas and node labels with the ion formula instead of the neutral formula", false);
     registerFlag_("no_recalibration", "If this option is set, SIRIUS will not recalibrate the spectrum during the analysis.", false);
-    registerFlag_("most_intense_ms2", "Sirius uses the fragmentation spectrum with the most intense precursor peak (for each spectrum)", false);
+    registerFlag_("most_intense_ms2", "SIRIUS uses the fragmentation spectrum with the most intense precursor peak (for each spectrum)", false);
   }
 
   ExitCodes main_(int, const char **) override
@@ -179,8 +179,6 @@ protected:
     String out_sirius = getStringOption_("out_sirius");
     String out_csifingerid = getStringOption_("out_fingerid");
     String featureinfo = getStringOption_("in_featureinfo");
-
-    std::cout << "option" << featureinfo.empty() << std::endl;
 
     // parameter for SiriusAdapter
     bool feature_only = getFlag_("feature_only");
@@ -199,7 +197,7 @@ protected:
     bool no_mt_info = getFlag_("no_masstrace_info_isotope_pattern");
 
     // needed for counting
-    int top_n_hits = getIntOption_("top_n_hits") + 1;
+    int top_n_hits = getIntOption_("top_n_hits");
 
     // parameter for Sirius
     QString executable = getStringOption_("executable").toQString();
@@ -209,7 +207,7 @@ protected:
     const QString isotope = getStringOption_("isotope").toQString();
     const QString noise = QString::number(getIntOption_("noise"));
     const QString ppm_max = QString::number(getIntOption_("ppm_max"));
-    const QString candidates = QString::number(getIntOption_("candidates")+1);
+    const Size candidates = getIntOption_("candidates");
     const QString compound_timeout = QString::number(getIntOption_("compound_timeout"));
     const QString tree_timeout = QString::number(getIntOption_("tree_timeout"));
 
@@ -308,7 +306,7 @@ protected:
                    << "-d" << database
                    << "-s" << isotope
                    << "--noise" << noise
-                   << "--candidates" << candidates
+                   << "--candidates" << QString::number(candidates)
                    << "--ppm-max" << ppm_max
                    << "--compound-timeout" << compound_timeout
                    << "--tree-timeout" << tree_timeout 
@@ -384,7 +382,7 @@ protected:
     // convert sirius_output to mztab and store file
     MzTab sirius_result;
     MzTabFile siriusfile;
-    SiriusMzTabWriter::read(subdirs, in, candidates.toLong(), sirius_result);
+    SiriusMzTabWriter::read(subdirs, in, candidates, sirius_result);
     siriusfile.store(out_sirius, sirius_result);
 
     // convert sirius_output to mztab and store file

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -151,7 +151,7 @@ protected:
     // internal sirius parameters
     registerStringOption_("profile", "<choice>", "qtof", "Specify the used analysis profile", false);
     setValidStrings_("profile", ListUtils::create<String>("qtof,orbitrap,fticr"));
-    registerIntOption_("candidates", "<num>", 5, "The number of candidates in the output.", false);
+    registerIntOption_("candidates", "<num>", 5, "The number of candidates in the sirius output.", false);
     registerStringOption_("database", "<choice>", "all", "search formulas in given database", false);
     setValidStrings_("database", ListUtils::create<String>("all,chebi,custom,kegg,bio,natural products,pubmed,hmdb,biocyc,hsdb,knapsack,biological,zinc bio,gnps,pubchem,mesh,maconda"));
     registerIntOption_("noise", "<num>", 0, "median intensity of noise peaks", false);
@@ -161,7 +161,7 @@ protected:
     registerStringOption_("elements", "<choice>", "CHNOP[5]S[8]Cl[1]", "The allowed elements. Write CHNOPSCl to allow the elements C, H, N, O, P, S and Cl. Add numbers in brackets to restrict the maximal allowed occurrence of these elements: CHNOP[5]S[8]Cl[1].", false);
     registerIntOption_("compound_timeout", "<num>", 10, "Time out in seconds per compound. To disable the timeout set the value to 0", false);
     registerIntOption_("tree_timeout", "<num>", 0, "Time out in seconds per fragmentation tree computation.", false);
-    registerIntOption_("top_n_hits", "<num>", 10, "The top_n_hit for each compound written to the output", false);
+    registerIntOption_("top_n_hits", "<num>", 10, "The top_n_hit for each compound written to the CSI:FingerID output", false);
 
     registerFlag_("auto_charge", "Use this option if the charge of your compounds is unknown and you do not want to assume [M+H]+ as default. With the auto charge option SIRIUS will not care about charges and allow arbitrary adducts for the precursor peak.", false);
     registerFlag_("ion_tree", "Print molecular formulas and node labels with the ion formula instead of the neutral formula", false);
@@ -199,7 +199,7 @@ protected:
     bool no_mt_info = getFlag_("no_masstrace_info_isotope_pattern");
 
     // needed for counting
-    int top_n_hits = getIntOption_("top_n_hits"); 
+    int top_n_hits = getIntOption_("top_n_hits") + 1;
 
     // parameter for Sirius
     QString executable = getStringOption_("executable").toQString();
@@ -209,7 +209,7 @@ protected:
     const QString isotope = getStringOption_("isotope").toQString();
     const QString noise = QString::number(getIntOption_("noise"));
     const QString ppm_max = QString::number(getIntOption_("ppm_max"));
-    const QString candidates = QString::number(getIntOption_("candidates"));
+    const QString candidates = QString::number(getIntOption_("candidates")+1);
     const QString compound_timeout = QString::number(getIntOption_("compound_timeout"));
     const QString tree_timeout = QString::number(getIntOption_("tree_timeout"));
 
@@ -384,7 +384,7 @@ protected:
     // convert sirius_output to mztab and store file
     MzTab sirius_result;
     MzTabFile siriusfile;
-    SiriusMzTabWriter::read(subdirs, in, top_n_hits, sirius_result);
+    SiriusMzTabWriter::read(subdirs, in, candidates.toLong(), sirius_result);
     siriusfile.store(out_sirius, sirius_result);
 
     // convert sirius_output to mztab and store file


### PR DESCRIPTION
Feature_id was not reported correctly in the CsiFingerIdMzTabWriter.

Use the number of candidates for Sirius Output.
Use the number of top hits for CSIFingerID Output.

Fix corresponding CSIFingerID-test.
