### PR TITLE
[FIX, API, TEST] mass calculations for isotope distributions

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -42,7 +42,6 @@
 #include <OpenMS/CONCEPT/Types.h>
 
 
-
 namespace OpenMS
 {
   class String;
@@ -50,6 +49,7 @@ namespace OpenMS
   class ElementDB;
   class IsotopeDistribution;
   class IsotopePatternGenerator;
+  class CoarseIsotopePatternGenerator;
   /**
     @ingroup Chemistry
 
@@ -175,15 +175,16 @@ public:
     IsotopeDistribution getIsotopeDistribution(const IsotopePatternGenerator& method) const;    
     
     /**
-      @brief returns the fragment iUsotope distribution of this given a precursor formula
+      @brief returns the fragment isotope distribution of this given a precursor formula
       and conditioned on a set of isolated precursor isotopes.
 
       The max_depth of the isotopic distribution is set to max(precursor_isotopes)+1.
       @param precursor: the empirical formula of the precursor
       @param precursor_isotopes: the precursor isotopes that were isolated
+      @param method: the method that will be used for the calculation of the IsotopeDistribution
       @return the conditional IsotopeDistribution of the fragment
     */
-    IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes) const;
+    IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes, const CoarseIsotopePatternGenerator& method) const;
 
     /// returns the number of atoms for a certain @p element (can be negative)
     SignedSize getNumberOf(const Element* element) const;

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h
@@ -75,6 +75,8 @@ namespace OpenMS
 
     CoarseIsotopePatternGenerator(const Size& max_isotope);
 
+    CoarseIsotopePatternGenerator(const Size& max_isotope, const bool calc_mass);
+
     virtual ~CoarseIsotopePatternGenerator();
 
     /// @name Accessors
@@ -87,8 +89,14 @@ namespace OpenMS
     */
     void setMaxIsotope(const Size& max_isotope);
 
+    /// sets the calc_mass_ flag to calculate and return expected masses (true) or atomic numbers (false).
+    void setCalcMass(const bool calc_mass);
+
     /// returns the currently set maximum isotope
     Size getMaxIsotope() const;
+
+    /// returns the current value of the flag to return expected masses (true) or atomic numbers (false).
+    bool getCalcMass() const;
     
     Size getMin() const;
     Size getMax() const;
@@ -269,8 +277,9 @@ namespace OpenMS
        @param fragment_isotope_dist the isotopic distribution of the fragment (as if it was a precursor).
        @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
        @param precursor_isotopes a list of which precursor isotopes were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
+       @param fragment_mono_mass the monoisotopic mass of the fragment. It is only used to compute masses if getCalcMass() is true.
     */
-    IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes);
+    IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes, const double fragment_mono_mass) const;
 
     CoarseIsotopePatternGenerator& operator=(const CoarseIsotopePatternGenerator& iso);
 
@@ -283,7 +292,10 @@ namespace OpenMS
     /// convolves the distribution @p input with itself and stores the result in @p result
     IsotopeDistribution::ContainerType convolveSquare_(const IsotopeDistribution::ContainerType & input) const;
 
-protected:
+    /// converts the masses of distribution @p input from atomic numbers to atomic masses
+    IsotopeDistribution::ContainerType correctMass_(const IsotopeDistribution::ContainerType & input, const double mono_weight) const;
+
+  protected:
 
     /** @brief calculates the fragment distribution for a fragment molecule and stores it in @p result.
 
@@ -291,7 +303,7 @@ protected:
         @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
         @param precursor_isotopes which precursor isotopes were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
     */
-    IsotopeDistribution calcFragmentIsotopeDist_(const IsotopeDistribution::ContainerType& fragment_isotope_dist, const IsotopeDistribution::ContainerType& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes);
+    IsotopeDistribution calcFragmentIsotopeDist_(const IsotopeDistribution::ContainerType& fragment_isotope_dist, const IsotopeDistribution::ContainerType& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes) const;
 
     /// fill a gapped isotope pattern (i.e. certain masses are missing), with zero probability masses
     IsotopeDistribution::ContainerType fillGaps_(const IsotopeDistribution::ContainerType& id) const;
@@ -299,6 +311,8 @@ protected:
  protected:
     /// maximal isotopes which is used to calculate the distribution
     Size max_isotope_;
+    /// flag to determine whether expected masses or atomic numbers are returned
+    bool calc_mass_;
 
   };
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h
@@ -53,6 +53,12 @@ namespace OpenMS
     *         For example for (13)Carbon it assumes that the mass of the isotope is 13Da
     *         instead of 13.0033548378
     *
+    *         The output is a list of nominal isotope probabilities
+    *         with either accurate or rounded masses. The accurate masses assume the
+    *         nominal isotopes are mostly due to (13)Carbon.
+    *         To return accurate vs rounded masses, use setRoundMasses accordingly.
+    *         The default is to return accurate masses.
+    *
     *         The most important value which should be set is the max isotope value.
     *         This value can be set using the setMaxIsotope method. It is an upper
     *         bound for the number of isotopes which are calculated
@@ -62,8 +68,6 @@ namespace OpenMS
     *         number of values, if the mass value is large!
     *
     *         See also method run()
-    *
-    *         Distributions can be added to one another or scaled by an integer.
     **/
 
   class OPENMS_DLLAPI CoarseIsotopePatternGenerator 
@@ -75,7 +79,7 @@ namespace OpenMS
 
     CoarseIsotopePatternGenerator(const Size& max_isotope);
 
-    CoarseIsotopePatternGenerator(const Size& max_isotope, const bool calc_mass);
+    CoarseIsotopePatternGenerator(const Size& max_isotope, const bool round_masses);
 
     virtual ~CoarseIsotopePatternGenerator();
 
@@ -89,14 +93,14 @@ namespace OpenMS
     */
     void setMaxIsotope(const Size& max_isotope);
 
-    /// sets the calc_mass_ flag to calculate and return expected masses (true) or atomic numbers (false).
-    void setCalcMass(const bool calc_mass);
+    /// sets the round_masses_ flag to round masses to integer values (true) or return accurate masses (false)
+    void setRoundMasses(const bool round_masses);
 
     /// returns the currently set maximum isotope
     Size getMaxIsotope() const;
 
     /// returns the current value of the flag to return expected masses (true) or atomic numbers (false).
-    bool getCalcMass() const;
+    bool getRoundMasses() const;
     
     Size getMin() const;
     Size getMax() const;
@@ -277,7 +281,8 @@ namespace OpenMS
        @param fragment_isotope_dist the isotopic distribution of the fragment (as if it was a precursor).
        @param comp_fragment_isotope_dist the isotopic distribution of the complementary fragment (as if it was a precursor).
        @param precursor_isotopes a list of which precursor isotopes were isolated. 0 corresponds to the mono-isotopic molecule (M0), 1->M1, etc.
-       @param fragment_mono_mass the monoisotopic mass of the fragment. It is only used to compute masses if getCalcMass() is true.
+       @param fragment_mono_mass the monoisotopic mass of the fragment.
+       @pre fragment_isotope_dist and comp_fragment_isotope_dist are gapless (no missing isotopes between the min/max isotopes of the dist)
     */
     IsotopeDistribution calcFragmentIsotopeDist(const IsotopeDistribution& fragment_isotope_dist, const IsotopeDistribution& comp_fragment_isotope_dist, const std::set<UInt>& precursor_isotopes, const double fragment_mono_mass) const;
 
@@ -292,7 +297,7 @@ namespace OpenMS
     /// convolves the distribution @p input with itself and stores the result in @p result
     IsotopeDistribution::ContainerType convolveSquare_(const IsotopeDistribution::ContainerType & input) const;
 
-    /// converts the masses of distribution @p input from atomic numbers to atomic masses
+    /// converts the masses of distribution @p input from atomic numbers to accurate masses
     IsotopeDistribution::ContainerType correctMass_(const IsotopeDistribution::ContainerType & input, const double mono_weight) const;
 
   protected:
@@ -311,8 +316,8 @@ namespace OpenMS
  protected:
     /// maximal isotopes which is used to calculate the distribution
     Size max_isotope_;
-    /// flag to determine whether expected masses or atomic numbers are returned
-    bool calc_mass_;
+    /// flag to determine whether masses should be rounded or not
+    bool round_masses_;
 
   };
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
@@ -64,7 +64,7 @@ namespace OpenMS
         atomic masses.
         The CoarseIsotopePatternGenerator solver quantizes the atomic masses to integer 
         numbers that correspond to the atomic number. Then the calculation of the 
-        IsotopeDistribution produces only atomic numbers.
+        IsotopeDistribution can produce nominal isotopes with accurate or rounded masses
 
     */
   class Element; 

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
@@ -121,6 +121,9 @@ public:
     /// returns the minimal weight isotope which is stored in the distribution
     Peak1D::CoordinateType getMin() const;
 
+    /// returns the most abundant isotope which is stored in the distribution
+    Peak1D getMostAbundant() const;
+
     /// returns the size of the distribution which is the number of isotopes in the distribution
     Size size() const;
 

--- a/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
+++ b/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
@@ -205,8 +205,7 @@ namespace OpenMS
     IsotopeDistribution fragment_isotope_dist = getIsotopeDistribution(CoarseIsotopePatternGenerator(max_depth));
     IsotopeDistribution comp_fragment_isotope_dist = complementary_fragment.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_depth));
 
-    IsotopeDistribution result;
-    result = solver.calcFragmentIsotopeDist(fragment_isotope_dist, comp_fragment_isotope_dist, precursor_isotopes, getMonoWeight());
+    IsotopeDistribution result = solver.calcFragmentIsotopeDist(fragment_isotope_dist, comp_fragment_isotope_dist, precursor_isotopes, getMonoWeight());
 
     // Renormalize to make these conditional probabilities (conditioned on the isolated precursor isotopes)
     result.renormalize();

--- a/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
+++ b/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
@@ -194,7 +194,7 @@ namespace OpenMS
   }
 
 
-  IsotopeDistribution EmpiricalFormula::getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes) const
+  IsotopeDistribution EmpiricalFormula::getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes, const CoarseIsotopePatternGenerator& solver) const
   {
     // A fragment's isotopes can only be as high as the largest isolated precursor isotope.
     UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end())+1;
@@ -206,8 +206,7 @@ namespace OpenMS
     IsotopeDistribution comp_fragment_isotope_dist = complementary_fragment.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_depth));
 
     IsotopeDistribution result;
-    CoarseIsotopePatternGenerator solver;
-    result = solver.calcFragmentIsotopeDist(fragment_isotope_dist, comp_fragment_isotope_dist, precursor_isotopes);
+    result = solver.calcFragmentIsotopeDist(fragment_isotope_dist, comp_fragment_isotope_dist, precursor_isotopes, getMonoWeight());
 
     // Renormalize to make these conditional probabilities (conditioned on the isolated precursor isotopes)
     result.renormalize();

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.cpp
@@ -110,6 +110,10 @@ namespace OpenMS
 
   Peak1D IsotopeDistribution::getMostAbundant() const
   {
+      if (distribution_.empty())
+      {
+          return Peak1D(0, 1);
+      }
       return *std::max_element(begin(), end(), MassAbundance::IntensityLess());
   }
 

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.cpp
@@ -108,6 +108,10 @@ namespace OpenMS
     return distribution_[0].getMZ();
   }
 
+  Peak1D IsotopeDistribution::getMostAbundant() const
+  {
+      return *std::max_element(begin(), end(), MassAbundance::IntensityLess());
+  }
 
   Size IsotopeDistribution::size() const
   {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/IsotopeModel.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/IsotopeModel.cpp
@@ -127,7 +127,7 @@ namespace OpenMS
     typedef std::vector<double> ContainerType;
     ContainerType isotopes_exact;
 
-    isotope_distribution_ = formula.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_));
+    isotope_distribution_ = formula.getIsotopeDistribution(CoarseIsotopePatternGenerator(max_isotope_, true));
 
     isotope_distribution_.trimRight(trim_right_cutoff_);
     isotope_distribution_.renormalize();

--- a/src/pyOpenMS/pxds/EmpiricalFormula.pxd
+++ b/src/pyOpenMS/pxds/EmpiricalFormula.pxd
@@ -33,11 +33,12 @@ cdef extern from "<OpenMS/CHEMISTRY/EmpiricalFormula.h>" namespace "OpenMS":
         #  Computes the isotope distribution of an empirical formula using the CoarseIsotopePatternGenerator method
         IsotopeDistribution getIsotopeDistribution(CoarseIsotopePatternGenerator) nogil except +
 
-        # @brief returns the fragment isotope distribution of this conditioned
+        # returns the fragment isotope distribution of this conditioned
         # on a precursor formula and a list of isolated precursor isotopes.
-        # @param precursor: the empirical formula of the precursor
-        # @param precursor_isotopes: the set of precursor isotopes that were isolated
-        IsotopeDistribution getConditionalFragmentIsotopeDist(EmpiricalFormula& precursor, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
+        # precursor: the empirical formula of the precursor
+        # precursor_isotopes: the set of precursor isotopes that were isolated
+        # method: the method that will be used for the calculation of the IsotopeDistribution
+        IsotopeDistribution getConditionalFragmentIsotopeDist(EmpiricalFormula& precursor, libcpp_set[ unsigned int ]& precursor_isotopes, CoarseIsotopePatternGenerator method) nogil except +
 
         # returns the number of atoms
         # doesnt work!

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -53,15 +53,15 @@ cdef extern from "<OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGene
 
         CoarseIsotopePatternGenerator() nogil except + 
         CoarseIsotopePatternGenerator(Size max_isotope) nogil except +
-        CoarseIsotopePatternGenerator(Size max_isotope, bool calc_mass) nogil except +
+        CoarseIsotopePatternGenerator(Size max_isotope, bool round_masses) nogil except +
 
         IsotopeDistribution run(EmpiricalFormula) nogil except +
 
-        # returns the current value of the flag to return expected masses (true) or atomic numbers (false)
-        bool getCalcMass() nogil except +
+        # returns the current value of the flag to round masses to integer values (true) or return accurate masses (false)
+        bool getRoundMasses() nogil except +
 
-        # sets the calc_mass_ flag to calculate and return expected masses (true) or atomic numbers (false)
-        void setCalcMass(Size max_isotope) nogil except +
+        /// sets the round_masses_ flag to round masses to integer values (true) or return accurate masses (false)
+        void setRoundMasses(bool round_masses_) nogil except +
 
         # returns the currently set maximum isotope
         Size getMaxIsotope() nogil except +

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -23,6 +23,9 @@ cdef extern from "<OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>" 
         # returns the minimal weight isotope which is stored in the distribution
         Size getMin() nogil except +
 
+        # returns the most abundant isotope which is stored in the distribution
+        Peak1D getMostAbundant() nogil except +
+
         # returns the size of the distribution which is the number of isotopes in the distribution
         Size size() nogil except +
 

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -53,10 +53,16 @@ cdef extern from "<OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGene
 
         CoarseIsotopePatternGenerator() nogil except + 
         CoarseIsotopePatternGenerator(Size max_isotope) nogil except +
-
+        CoarseIsotopePatternGenerator(Size max_isotope, bool calc_mass) nogil except +
 
         IsotopeDistribution run(EmpiricalFormula) nogil except +
-        
+
+        # returns the current value of the flag to return expected masses (true) or atomic numbers (false)
+        bool getCalcMass() nogil except +
+
+        # sets the calc_mass_ flag to calculate and return expected masses (true) or atomic numbers (false)
+        void setCalcMass(Size max_isotope) nogil except +
+
         # returns the currently set maximum isotope
         Size getMaxIsotope() nogil except +
         
@@ -103,5 +109,4 @@ cdef extern from "<OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGene
         IsotopeDistribution estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes, double C, double H, double N, double O, double S, double P) nogil except +
 
         # Calculate isotopic distribution for a fragment molecule
-
-        IsotopeDistribution calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
+        IsotopeDistribution calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_set[ unsigned int ]& precursor_isotopes, double fragment_mono_mass) nogil except +

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -29,12 +29,6 @@ cdef extern from "<OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>" 
         # clears the distribution and resets max isotope to 0
         void clear() nogil except +
 
-        # Estimate Peptide Isotopedistribution from weight and number of isotopes that should be reported
-        #   Implementation using the averagine model proposed by Senko et al. in
-
-        # Estimate Isotopedistribution from weight, average composition, and number of isotopes that should be reported
-
-
         # renormalizes the sum of the probabilities of the isotopes to 1
         void renormalize() nogil except +
 
@@ -60,7 +54,7 @@ cdef extern from "<OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGene
         # returns the current value of the flag to round masses to integer values (true) or return accurate masses (false)
         bool getRoundMasses() nogil except +
 
-        /// sets the round_masses_ flag to round masses to integer values (true) or return accurate masses (false)
+        # sets the round_masses_ flag to round masses to integer values (true) or return accurate masses (false)
         void setRoundMasses(bool round_masses_) nogil except +
 
         # returns the currently set maximum isotope
@@ -82,31 +76,59 @@ cdef extern from "<OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGene
         # Estimate Nucleotide Isotopedistribution from weight
         IsotopeDistribution estimateFromDNAWeight(double average_weight) nogil except +
 
-        IsotopeDistribution estimateFromWeightAndComp(double average_weight, double C, double H, double N, double O, double S, double P) nogil except +
+        IsotopeDistribution estimateFromWeightAndComp(double average_weight,
+                                                      double C, double H,
+                                                      double N, double O,
+                                                      double S, double P) nogil except +
 
         # Estimate IsotopeDistribution from weight, exact number of sulfurs, and average remaining composition
-        IsotopeDistribution estimateFromWeightAndCompAndS(double average_weight, UInt S, double C, double H, double N, double O, double P);
+        IsotopeDistribution estimateFromWeightAndCompAndS(double average_weight,
+                                                          UInt S, double C,
+                                                          double H, double N,
+                                                          double O, double P) nogil except +
 
         # Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
         # fragment's average weight, and a set of isolated precursor isotopes.
-        IsotopeDistribution estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
+        IsotopeDistribution estimateForFragmentFromPeptideWeight(double average_weight_precursor,
+                                                                 double average_weight_fragment,
+                                                                 libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # Estimate peptide fragment IsotopeDistribution from the precursor's average weight,
         # number of sulfurs in the precursor, fragment's average weight, number of sulfurs in the fragment,
         # and a set of isolated precursor isotopes.
-        IsotopeDistribution estimateForFragmentFromPeptideWeightAndS(double average_weight_precursor, UInt S_precursor, double average_weight_fragment, UInt S_fragment, libcpp_set[ unsigned int ]& precursor_isotopes);
+        IsotopeDistribution estimateForFragmentFromPeptideWeightAndS(double average_weight_precursor,
+                                                                     UInt S_precursor,
+                                                                     double average_weight_fragment,
+                                                                     UInt S_fragment,
+                                                                     libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # Estimate RNA fragment IsotopeDistribution from the precursor's average weight,
         # fragment's average weight, and a set of isolated precursor isotopes.
-        IsotopeDistribution estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
+        IsotopeDistribution estimateForFragmentFromRNAWeight(double average_weight_precursor,
+                                                             double average_weight_fragment,
+                                                             libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # Estimate DNA fragment IsotopeDistribution from the precursor's average weight,
         # fragment's average weight, and a set of isolated precursor isotopes.
-        IsotopeDistribution estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
+        IsotopeDistribution estimateForFragmentFromDNAWeight(double average_weight_precursor,
+                                                             double average_weight_fragment,
+                                                             libcpp_set[ unsigned int ]& precursor_isotopes) nogil except +
 
         # Estimate fragment IsotopeDistribution from the precursor's average weight,
         # fragment's average weight, a set of isolated precursor isotopes, and average composition
-        IsotopeDistribution estimateForFragmentFromWeightAndComp(double average_weight_precursor, double average_weight_fragment, libcpp_set[ unsigned int ]& precursor_isotopes, double C, double H, double N, double O, double S, double P) nogil except +
+        IsotopeDistribution estimateForFragmentFromWeightAndComp(double average_weight_precursor,
+                                                                 double average_weight_fragment,
+                                                                 libcpp_set[ unsigned int ]& precursor_isotopes,
+                                                                 double C,
+                                                                 double H,
+                                                                 double N,
+                                                                 double O,
+                                                                 double S,
+                                                                 double P) nogil except +
 
         # Calculate isotopic distribution for a fragment molecule
-        IsotopeDistribution calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist, IsotopeDistribution& comp_fragment_isotope_dist, libcpp_set[ unsigned int ]& precursor_isotopes, double fragment_mono_mass) nogil except +
+        IsotopeDistribution calcFragmentIsotopeDist(IsotopeDistribution& fragment_isotope_dist,
+                                                    IsotopeDistribution& comp_fragment_isotope_dist,
+                                                    libcpp_set[ unsigned int ]& precursor_isotopes,
+                                                    double fragment_mono_mass) nogil except +
+

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -356,7 +356,7 @@ def testCoarseIsotopePatternGenerator():
     iso = pyopenms.CoarseIsotopePatternGenerator(10)
     isod = iso.run(methanol)
     assert len(isod.getContainer()) == 10, len(isod.getContainer()) 
-    assert isod.getContainer()[0].getMZ() == 32.0, isod.getContainer()[0].getMZ()
+    assert abs(isod.getContainer()[0].getMZ() - 32.0262151276) < 1e-5
     assert isod.getContainer()[0].getIntensity() - 0.986442089081 < 1e-5
     
 @report

--- a/src/tests/class_tests/openms/source/CoarseIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/CoarseIsotopeDistribution_test.cpp
@@ -69,7 +69,8 @@ START_SECTION(CoarseIsotopePatternGenerator())
 	CoarseIsotopePatternGenerator* ptr = nullptr;
 	ptr = new CoarseIsotopePatternGenerator();
 	Size max_isotope = ptr->getMaxIsotope();
-  TEST_EQUAL(max_isotope, 0)
+    TEST_EQUAL(max_isotope, 0)
+	TEST_EQUAL(ptr->getCalcMass(), true)
 	TEST_NOT_EQUAL(ptr, nullPointer)
 	delete ptr;
 END_SECTION
@@ -79,7 +80,17 @@ END_SECTION
 START_SECTION(CoarseIsotopePatternGenerator(Size max_isotope))
 	CoarseIsotopePatternGenerator* ptr = new CoarseIsotopePatternGenerator(117);
 	Size max_isotope = ptr->getMaxIsotope();
-  TEST_EQUAL(max_isotope, 117)
+    TEST_EQUAL(max_isotope, 117)
+	TEST_EQUAL(ptr->getCalcMass(), true)
+	TEST_NOT_EQUAL(ptr, nullPointer)
+	delete ptr;
+END_SECTION
+
+START_SECTION(CoarseIsotopePatternGenerator(Size max_isotope, bool calc_mass))
+	CoarseIsotopePatternGenerator* ptr = new CoarseIsotopePatternGenerator(117, false);
+	Size max_isotope = ptr->getMaxIsotope();
+	TEST_EQUAL(max_isotope, 117)
+	TEST_EQUAL(ptr->getCalcMass(), false)
 	TEST_NOT_EQUAL(ptr, nullPointer)
 	delete ptr;
 END_SECTION
@@ -92,6 +103,16 @@ START_SECTION(~CoarseIsotopePatternGenerator())
 	delete ptr;
 END_SECTION
 
+START_SECTION(void setCalcMass(bool calc_mass))
+    CoarseIsotopePatternGenerator solver2 = CoarseIsotopePatternGenerator();
+    TEST_EQUAL(solver2.getCalcMass(), true)
+    solver2.setCalcMass(false);
+    TEST_EQUAL(solver2.getCalcMass(), false)
+END_SECTION
+
+START_SECTION(bool getCalcMass() const)
+    NOT_TESTABLE
+END_SECTION
 
 START_SECTION(void setMaxIsotope(Size max_isotope))
   IsotopeDistribution iso = solver->estimateFromPeptideWeight(1234.2);
@@ -197,21 +218,37 @@ START_SECTION(IsotopeDistribution estimateFromWeightAndComp(double average_weigh
     iso = solver->estimateFromWeightAndComp(1000.0, 4.9384, 7.7583, 1.3577, 1.4773, 0.0417, 0.0);
     iso2 = solver->estimateFromPeptideWeight(1000.0);
     TEST_EQUAL(iso.begin()->getIntensity(),iso2.begin()->getIntensity());
+    TEST_EQUAL(iso.begin()->getMZ(),iso2.begin()->getMZ());
 END_SECTION
 
 
 START_SECTION(IsotopeDitribution CoarseIsotopePatternGenerator::estimateFromPeptideWeight(double average_weight))
 	// hard to test as this is an rough estimate
 	IsotopeDistribution iso;
-  solver->setMaxIsotope(3);
+    solver->setMaxIsotope(3);
 	iso = solver->estimateFromPeptideWeight(100.0);
 	TEST_REAL_SIMILAR(iso.begin()->getIntensity(), 0.949735)
+    TEST_REAL_SIMILAR(iso.begin()->getMZ(), 100.170);
 
 	iso = solver->estimateFromPeptideWeight(1000.0);
 	TEST_REAL_SIMILAR(iso.begin()->getIntensity(), 0.586906)
+    TEST_REAL_SIMILAR(iso.begin()->getMZ(), 999.714);
 
 	iso = solver->estimateFromPeptideWeight(10000.0);
 	TEST_REAL_SIMILAR(iso.begin()->getIntensity(), 0.046495)
+    TEST_REAL_SIMILAR(iso.begin()->getMZ(), 9994.041);
+
+    solver->setCalcMass(false);
+    iso = solver->estimateFromPeptideWeight(100.0);
+    TEST_REAL_SIMILAR(iso.begin()->getMZ(), 100);
+
+    iso = solver->estimateFromPeptideWeight(1000.0);
+    TEST_REAL_SIMILAR(iso.begin()->getMZ(), 999);
+
+    iso = solver->estimateFromPeptideWeight(10000.0);
+    TEST_REAL_SIMILAR(iso.begin()->getMZ(), 9989);
+
+    solver->setCalcMass(true);
 END_SECTION
 
 
@@ -220,7 +257,7 @@ START_SECTION(IsotopeDistribution CoarseIsotopePatternGenerator::estimateForFrag
 	IsotopeDistribution iso;
 	IsotopeDistribution iso2;
 	std::set<UInt> precursor_isotopes;
-  solver->setMaxIsotope(0);
+    solver->setMaxIsotope(0);
 	// We're isolating the M+2 precursor isotopes
 	precursor_isotopes.insert(2);
 	// These are regression tests, but the results also follow an expected pattern.
@@ -336,7 +373,7 @@ END_SECTION
 
 START_SECTION(IsotopeDistribution estimateForFragmentFromPeptideWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes))
 	IsotopeDistribution iso;
-  solver->setMaxIsotope(0);
+    solver->setMaxIsotope(0);
 	std::set<UInt> precursor_isotopes;
 	// We're isolating the M0 and M+1 precursor isotopes
 	precursor_isotopes.insert(0);
@@ -351,6 +388,7 @@ START_SECTION(IsotopeDistribution estimateForFragmentFromPeptideWeight(double av
 	iso = solver->estimateForFragmentFromPeptideWeight(200.0, 100.0, precursor_isotopes);
 	iso.renormalize();
 	TEST_REAL_SIMILAR(iso.begin()->getIntensity(), 0.954654801320083)
+	TEST_REAL_SIMILAR(iso.begin()->getMZ(), 100.170);
 
 	// This peptide is large enough that the M0 and M+1 precursors are similar in abundance.
 	// However, since the fragment is only 1/20th the mass of the precursor, it's
@@ -359,6 +397,8 @@ START_SECTION(IsotopeDistribution estimateForFragmentFromPeptideWeight(double av
 	iso = solver->estimateForFragmentFromPeptideWeight(2000.0, 100.0, precursor_isotopes);
 	iso.renormalize();
 	TEST_REAL_SIMILAR(iso.begin()->getIntensity(), 0.975984866212216)
+    // The size of the precursor should have no effect on the mass of the fragment
+	TEST_REAL_SIMILAR(iso.begin()->getMZ(), 100.170);
 
 	// Same explanation as the previous example.
 	iso = solver->estimateForFragmentFromPeptideWeight(20000.0, 100.0, precursor_isotopes);
@@ -375,6 +415,7 @@ START_SECTION(IsotopeDistribution estimateForFragmentFromPeptideWeight(double av
 	iso = solver->estimateForFragmentFromPeptideWeight(2000.0, 1000.0, precursor_isotopes);
 	iso.renormalize();
 	TEST_REAL_SIMILAR(iso.begin()->getIntensity(), 0.741290977639283)
+	TEST_REAL_SIMILAR(iso.begin()->getMZ(), 999.714);
 
 	// Same explanation as the second example, except now the M+1 precursor is
 	// more abundant than the M0 precursor. But, the fragment is so small that
@@ -392,7 +433,6 @@ START_SECTION(IsotopeDistribution estimateForFragmentFromPeptideWeight(double av
 	// should be the same as if it was just a precursor that wasn't isolated.
 	iso = solver->estimateForFragmentFromPeptideWeight(200.0, 200.0, precursor_isotopes);
 	IsotopeDistribution iso_precursor;
-  solver->setMaxIsotope(2);
 	iso_precursor = solver->estimateFromPeptideWeight(200.0);
 	IsotopeDistribution::ConstIterator it1(iso.begin()), it2(iso_precursor.begin());
 
@@ -402,12 +442,20 @@ START_SECTION(IsotopeDistribution estimateForFragmentFromPeptideWeight(double av
 		TEST_REAL_SIMILAR(it2->getIntensity(), it2->getIntensity())
 	}
 
+	solver->setCalcMass(false);
+
+    // Calculating atomic number instead of expected mass
+    iso = solver->estimateForFragmentFromPeptideWeight(200.0, 100.0, precursor_isotopes);
+    TEST_EQUAL(iso.begin()->getMZ(), 100);
+
+	solver->setCalcMass(true);
+
 END_SECTION
 
 
 START_SECTION(IsotopeDistribution CoarseIsotopePatternGenerator::estimateForFragmentFromDNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes))
 	IsotopeDistribution iso;
-  solver->setMaxIsotope(0);
+    solver->setMaxIsotope(0);
 	std::set<UInt> precursor_isotopes;
 	// We're isolating the M0 and M+1 precursor isotopes
 	precursor_isotopes.insert(0);
@@ -440,8 +488,8 @@ START_SECTION(IsotopeDistribution CoarseIsotopePatternGenerator::estimateForFrag
 	TEST_REAL_SIMILAR(iso.begin()->getIntensity(), 0.555730613643729)
 
 	iso = solver->estimateForFragmentFromDNAWeight(200.0, 200.0, precursor_isotopes);
-  IsotopeDistribution iso_precursor;
-  solver->setMaxIsotope(2);
+    IsotopeDistribution iso_precursor;
+    solver->setMaxIsotope(2);
 	iso_precursor = solver->estimateFromDNAWeight(200.0);
 	IsotopeDistribution::ConstIterator it1(iso.begin()), it2(iso_precursor.begin());
 
@@ -456,7 +504,7 @@ END_SECTION
 
 START_SECTION(IsotopeDistribution CoarseIsotopePatternGenerator::estimateForFragmentFromRNAWeight(double average_weight_precursor, double average_weight_fragment, const std::set<UInt>& precursor_isotopes))
 	IsotopeDistribution iso;
-  solver->setMaxIsotope(0);
+    solver->setMaxIsotope(0);
 	std::set<UInt> precursor_isotopes;
 	// We're isolating the M0 and M+1 precursor isotopes
 	precursor_isotopes.insert(0);
@@ -489,8 +537,8 @@ START_SECTION(IsotopeDistribution CoarseIsotopePatternGenerator::estimateForFrag
 	TEST_REAL_SIMILAR(iso.begin()->getIntensity(), 0.558201381343203)
 
 	iso = solver->estimateForFragmentFromRNAWeight(200.0, 200.0, precursor_isotopes);
-  IsotopeDistribution iso_precursor;
-  solver->setMaxIsotope(2);
+    IsotopeDistribution iso_precursor;
+    solver->setMaxIsotope(2);
 	iso_precursor = solver->estimateFromRNAWeight(200.0);
 	IsotopeDistribution::ConstIterator it1(iso.begin()), it2(iso_precursor.begin());
 
@@ -502,9 +550,13 @@ START_SECTION(IsotopeDistribution CoarseIsotopePatternGenerator::estimateForFrag
 
 END_SECTION
 
-START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const CoarseIsotopePatternGenerator & comp_fragment_isotope_distribution, const std::set<UInt>& precursor_isotopes))
-  IsotopeDistribution iso1(EmpiricalFormula("C1").getIsotopeDistribution(CoarseIsotopePatternGenerator(11))); // fragment
-  IsotopeDistribution iso2(EmpiricalFormula("C2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11))); // complementary fragment
+START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const CoarseIsotopePatternGenerator & comp_fragment_isotope_distribution, const std::set<UInt>& precursor_isotopes, const double fragment_mono_mass))
+  EmpiricalFormula ef_complementary_fragment = EmpiricalFormula("C2");
+  EmpiricalFormula ef_fragment = EmpiricalFormula("C1");
+  // The input to calcFragmentIsotopeDist should be isotope distributions
+  // where the solver used atomic numbers for the mass field
+  IsotopeDistribution iso1(ef_fragment.getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false))); // fragment
+  IsotopeDistribution iso2(ef_complementary_fragment.getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false))); // complementary fragment
 
   std::set<UInt> precursor_isotopes;
   precursor_isotopes.insert(0);
@@ -513,28 +565,31 @@ START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const CoarseIsotopePat
   precursor_isotopes.insert(2);
   IsotopeDistribution iso3;
   solver->setMaxIsotope(0);
-  iso3 = solver->calcFragmentIsotopeDist(iso1,iso2,precursor_isotopes);
+  iso3 = solver->calcFragmentIsotopeDist(iso1, iso2, precursor_isotopes, ef_fragment.getMonoWeight());
   iso3.renormalize();
 
-  IsotopeDistribution::ConstIterator it1(iso1.begin()), it2(iso3.begin());
+  // Need the distribution with expected masses for the next comparison
+  // because that's what the solver used for the fragment distribution
+  IsotopeDistribution iso1_calc_mass(ef_fragment.getIsotopeDistribution(CoarseIsotopePatternGenerator(11))); // fragment
+
+  IsotopeDistribution::ConstIterator it1(iso1_calc_mass.begin()), it2(iso3.begin());
   // By isolating all the precursor isotopes, the fragment isotopic distribution of a fragment molecule
   // should be the same as if it was the precursor. The probabilities can be slightly different due to
   // numerical issues.
-  for (; it1 != iso1.end(); ++it1, ++it2)
+  for (; it1 != iso1_calc_mass.end(); ++it1, ++it2)
   {
 	TEST_EQUAL(it1->getMZ(), it2->getMZ())
 	TEST_REAL_SIMILAR(it1->getIntensity(), it2->getIntensity())
   }
 
   precursor_isotopes.erase(precursor_isotopes.find(2));
-  IsotopeDistribution iso4;
   solver->setMaxIsotope(0);
-  iso4 = solver->calcFragmentIsotopeDist(iso1, iso2, precursor_isotopes);
+  IsotopeDistribution iso4 = solver->calcFragmentIsotopeDist(iso1, iso2, precursor_isotopes, ef_fragment.getMonoWeight());
   iso4.renormalize();
 
 
-  TEST_EQUAL(iso1.getContainer()[0].getMZ(), iso4.getContainer()[0].getMZ())
-  TEST_EQUAL(iso1.getContainer()[1].getMZ(), iso4.getContainer()[1].getMZ())
+  TEST_EQUAL(iso1_calc_mass.getContainer()[0].getMZ(), iso4.getContainer()[0].getMZ())
+  TEST_EQUAL(iso1_calc_mass.getContainer()[1].getMZ(), iso4.getContainer()[1].getMZ())
   // Now that we're not isolating every precursor isotope, the probabilities should NOT be similar.
   // Since there's no TEST_REAL_NOT_SIMILAR, we test their similarity to the values they should be
   TEST_REAL_SIMILAR(iso1.getContainer()[0].getIntensity(), 0.989300)
@@ -542,6 +597,21 @@ START_SECTION(IsotopeDistribution calcFragmentIsotopeDist(const CoarseIsotopePat
 
   TEST_REAL_SIMILAR(iso4.getContainer()[0].getIntensity(), 0.989524)
   TEST_REAL_SIMILAR(iso4.getContainer()[1].getIntensity(), 0.010479)
+
+  solver->setCalcMass(false);
+  IsotopeDistribution iso5 = solver->calcFragmentIsotopeDist(iso1, iso2, precursor_isotopes, ef_fragment.getMonoWeight());
+  double result_expected_mass[] = { 12.0, 13.0033548378 };
+  double result_atomic_number[] = { 12, 13 };
+  Size i = 0;
+  // making sure that the masses are correct depending on whether we asked the IsotopeDistribution solver
+  // to return atomic numbers or expected masses
+  for (it1 = iso3.begin(), it2 = iso5.begin(); it1 != iso3.end(); ++it1, ++it2, ++i)
+  {
+    TEST_REAL_SIMILAR(it1->getMZ(), result_expected_mass[i])
+    TEST_EQUAL(it2->getMZ(), result_atomic_number[i])
+  }
+  solver->setCalcMass(true);
+
 END_SECTION
 
 

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -387,15 +387,30 @@ START_SECTION(IsotopeDistribution getIsotopeDistribution(UInt max_depth) const)
     TEST_REAL_SIMILAR(it->getMZ(), result_rounded_mass[i])
   }
 
-  // Formula of Bovine Serum Albumin (BSA) that is has been processed and is missing the first 24 AA
+  // Formula of Bovine Serum Albumin (BSA) that has been processed and is missing the first 24 AA
   EmpiricalFormula ef2("C2934H4615N781O897S39");
-  IsotopeDistribution iso3 = ef2.getIsotopeDistribution(CoarseIsotopePatternGenerator(20));
+  IsotopeDistribution iso3 = ef2.getIsotopeDistribution(CoarseIsotopePatternGenerator(100));
   // monoisotopic mass
   TEST_REAL_SIMILAR(iso3.begin()->getMZ(), 66389.863)
+  // the average mass of the IsotopeDistribution is computed from its masses and probabilities
+  // and should be extremely close to the result from the EmpiricalFormula which uses the
+  // average weights of each atom.
+  TEST_REAL_SIMILAR(iso3.averageMass(), ef2.getAverageWeight())
 
-  IsotopeDistribution iso4 = ef2.getIsotopeDistribution(CoarseIsotopePatternGenerator(20, true));
+  Peak1D most_abundant = iso3.getMostAbundant();
+  // Partially a regression test. For such a large molecule, consecutive isotopes have very similar probabilities
+  // and a small change could change the result by 1Da (e.g. numerical error, elemental isotope probabilities)
+  TEST_REAL_SIMILAR(most_abundant.getMZ(), 66432.0037);
+  TEST_REAL_SIMILAR(most_abundant.getIntensity(), 0.057);
+
+  IsotopeDistribution iso4 = ef2.getIsotopeDistribution(CoarseIsotopePatternGenerator(100, true));
   // rounded monoisotopic mass
-  TEST_REAL_SIMILAR(iso4.begin()->getMZ(), 66390)
+  TEST_EQUAL(iso4.begin()->getMZ(), 66390)
+  TEST_REAL_SIMILAR(iso4.averageMass(), ef2.getAverageWeight())
+
+  most_abundant = iso4.getMostAbundant();
+  TEST_EQUAL(most_abundant.getMZ(), 66432);
+  TEST_REAL_SIMILAR(most_abundant.getIntensity(), 0.057);
 
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -118,6 +118,11 @@ START_SECTION(IsotopeDistribution& operator < (const CoarseIsotopePatternGenerat
 	IsotopeDistribution iso5(EmpiricalFormula("C5").getIsotopeDistribution(CoarseIsotopePatternGenerator(1)));
     IsotopeDistribution iso6(EmpiricalFormula("C5").getIsotopeDistribution(CoarseIsotopePatternGenerator(1000)));
 	TEST_EQUAL(iso5 < iso6, true)
+
+    IsotopeDistribution iso7(EmpiricalFormula("C5").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false)));
+    IsotopeDistribution iso8(EmpiricalFormula("C5").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
+    // iso7 should be less because its second isotope's mass is 61 (atomic number), while for iso8 it is 61.003 (expected mass)
+    TEST_EQUAL(iso7 < iso8, true)
 END_SECTION
 
 
@@ -127,6 +132,11 @@ START_SECTION(bool operator==(const IsotopeDistribution &isotope_distribution) c
 	IsotopeDistribution iso3(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11))),
     iso4(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
 	TEST_EQUAL(iso3 == iso4, true)
+
+    IsotopeDistribution iso5(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false))),
+    iso6(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
+    // the masses should be different
+    TEST_EQUAL(iso5 == iso6, false)
 END_SECTION
 
 START_SECTION(void set(const ContainerType &distribution))
@@ -144,14 +154,20 @@ END_SECTION
 
 START_SECTION(Size getMax() const)
 	IsotopeDistribution iso(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
-	TEST_EQUAL(iso.getMax(), 6)
+	TEST_REAL_SIMILAR(iso.getMax(), 6.02907)
+	IsotopeDistribution iso2(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false)));
+	TEST_EQUAL(iso2.getMax(), 6)
 END_SECTION
 
 START_SECTION(Size getMin() const)
 	IsotopeDistribution iso(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
-	TEST_EQUAL(iso.getMin(), 2)
-	IsotopeDistribution iso2(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
-	TEST_EQUAL(iso2.getMin(), 48)
+	TEST_REAL_SIMILAR(iso.getMin(), 2.01565)
+	IsotopeDistribution iso2(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false)));
+	TEST_EQUAL(iso2.getMin(), 2)
+	IsotopeDistribution iso3(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
+	TEST_REAL_SIMILAR(iso3.getMin(), 48)
+	IsotopeDistribution iso4(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false)));
+	TEST_EQUAL(iso4.getMin(), 48)
 END_SECTION
 
 START_SECTION(Size size() const)

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -170,6 +170,18 @@ START_SECTION(Size getMin() const)
 	TEST_EQUAL(iso4.getMin(), 48)
 END_SECTION
 
+START_SECTION(Size getMostAbundant() const)
+	IsotopeDistribution iso(EmpiricalFormula("C1").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true)));
+    // The most abundant isotope is the monoisotope
+	TEST_EQUAL(iso.getMostAbundant().getMZ(), 12)
+	IsotopeDistribution iso2(EmpiricalFormula("C100").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true)));
+    // In this case, the most abundant isotope isn't the monoisotope
+	TEST_EQUAL(iso2.getMostAbundant().getMZ(), 1201)
+	IsotopeDistribution iso3;
+    // Making sure an empty distribution doesn't crash it.
+    TEST_EQUAL(iso3.getMostAbundant().getMZ(), 0);
+END_SECTION
+
 START_SECTION(Size size() const)
 	IsotopeDistribution iso1, iso2(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
 	TEST_EQUAL(iso1.size(), 1)

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -177,9 +177,10 @@ START_SECTION(Size getMostAbundant() const)
 	IsotopeDistribution iso2(EmpiricalFormula("C100").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true)));
     // In this case, the most abundant isotope isn't the monoisotope
 	TEST_EQUAL(iso2.getMostAbundant().getMZ(), 1201)
-	IsotopeDistribution iso3;
-    // Making sure an empty distribution doesn't crash it.
-    TEST_EQUAL(iso3.getMostAbundant().getMZ(), 0);
+    // Empty distribution
+    iso2.clear();
+    TEST_EQUAL(iso2.getMostAbundant().getMZ(), 0);
+	TEST_EQUAL(iso2.getMostAbundant().getIntensity(), 1);
 END_SECTION
 
 START_SECTION(Size size() const)

--- a/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistribution_test.cpp
@@ -119,7 +119,7 @@ START_SECTION(IsotopeDistribution& operator < (const CoarseIsotopePatternGenerat
     IsotopeDistribution iso6(EmpiricalFormula("C5").getIsotopeDistribution(CoarseIsotopePatternGenerator(1000)));
 	TEST_EQUAL(iso5 < iso6, true)
 
-    IsotopeDistribution iso7(EmpiricalFormula("C5").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false)));
+    IsotopeDistribution iso7(EmpiricalFormula("C5").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true)));
     IsotopeDistribution iso8(EmpiricalFormula("C5").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
     // iso7 should be less because its second isotope's mass is 61 (atomic number), while for iso8 it is 61.003 (expected mass)
     TEST_EQUAL(iso7 < iso8, true)
@@ -133,7 +133,7 @@ START_SECTION(bool operator==(const IsotopeDistribution &isotope_distribution) c
     iso4(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
 	TEST_EQUAL(iso3 == iso4, true)
 
-    IsotopeDistribution iso5(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false))),
+    IsotopeDistribution iso5(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true))),
     iso6(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
     // the masses should be different
     TEST_EQUAL(iso5 == iso6, false)
@@ -155,18 +155,18 @@ END_SECTION
 START_SECTION(Size getMax() const)
 	IsotopeDistribution iso(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
 	TEST_REAL_SIMILAR(iso.getMax(), 6.02907)
-	IsotopeDistribution iso2(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false)));
+	IsotopeDistribution iso2(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true)));
 	TEST_EQUAL(iso2.getMax(), 6)
 END_SECTION
 
 START_SECTION(Size getMin() const)
 	IsotopeDistribution iso(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
 	TEST_REAL_SIMILAR(iso.getMin(), 2.01565)
-	IsotopeDistribution iso2(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false)));
+	IsotopeDistribution iso2(EmpiricalFormula("H2").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true)));
 	TEST_EQUAL(iso2.getMin(), 2)
 	IsotopeDistribution iso3(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11)));
 	TEST_REAL_SIMILAR(iso3.getMin(), 48)
-	IsotopeDistribution iso4(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, false)));
+	IsotopeDistribution iso4(EmpiricalFormula("C4").getIsotopeDistribution(CoarseIsotopePatternGenerator(11, true)));
 	TEST_EQUAL(iso4.getMin(), 48)
 END_SECTION
 


### PR DESCRIPTION
fixes #3589

CoarseIsotopePatternGenerator used to output atomic numbers (# protons + # neutrons) for the mass of each isotope. This can be quite different from the rounded mass of an isotope (see #3589)

I added a calc_mass_ flag that can be set during initialization of the CoarseIsotopePatternGenerator or afterwards. It determines if the expected masses (new functionality) or atomic numbers (old functionality) should be returned. By default, the calc_mass_ is set to true. The previous behavior can be achieved by setting calc_mass_ to false.

Expected masses are the monoisotopic mass of the molecule + (C13_C12_MASS_DIFFERENCE * isotope number). I'm assuming that most of a coarse isotopic peak is due to C13 molecules.

Currently, OpenMS has the following capabilities:

- With a known EmpiricalFormula
  - Precursor isotope distribution
    - Compute fine isotope probabilities and mass
    - Compute coarse isotope probabilities and atomic numbers for the mass
    - Compute coarse isotope probabilities and expected mass
  - Fragment isotope distribution
    - Compute coarse isotope probabilities and atomic numbers for the mass
    - Compute coarse isotope probabilities and expected mass
- With unknown EmpiricalFormula (using observed masses instead)
  - Precursor isotope distribution
    - Compute fine isotope probabilities and mass
    - Compute coarse isotope probabilities and atomic numbers for the mass
    - Compute coarse isotope probabilities and expected mass
  - Fragment isotope distribution
    - Compute coarse isotope probabilities and atomic numbers for the mass
    - Compute coarse isotope probabilities and expected mass

These changes only broke a handful of unit tests (because default is now to return expected mass) and they have been updated. I looked for tools that used the returned masses but it seems like they re-compute the masses themselves. I need to look more thoroughly.

Examples:
https://github.com/OpenMS/OpenMS/blob/5a70018d9e03ce32e64fcbb1c985b7a1256efc7a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp#L487-L491 

https://github.com/OpenMS/OpenMS/blob/5a70018d9e03ce32e64fcbb1c985b7a1256efc7a/src/openms/source/ANALYSIS/OPENSWATH/DIAHelper.cpp#L115-L122

Note that for the FeatureFinder, it doesn't use C13_C12_MASS_DIFFERENCE. I'm going to try changing this later to see if the number features increases/decreases. I haven't gone through the openSWATH code yet.

I can also add functionality to return the rounded expected masses. I would probably replace the bool calc_mass_ variable with an enum {ROUND, EXPECTED_MASS, ATOMIC_NUMBER}.

Thoughts and advice are welcome!

