### PR TITLE
Feature/pyopenms perf

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h
@@ -62,8 +62,13 @@ public:
     /// Convert a ChromatogramPtr to an OpenMS Chromatogram
     static void convertToOpenMSChromatogram(const OpenSwath::ChromatogramPtr cptr, OpenMS::MSChromatogram & chromatogram);
 
-    static void convertToOpenMSChromatogramFilter(OpenMS::MSChromatogram & chromatogram, const OpenSwath::ChromatogramPtr cptr,
-                                                  double rt_min, double rt_max);
+    /// Convert an OpenMS Chromatogram to an ChromatogramPtr
+    static OpenSwath::ChromatogramPtr convertToChromatogramPtr(const OpenMS::MSChromatogram & chromatogram);
+
+    static void convertToOpenMSChromatogramFilter(OpenMS::MSChromatogram & chromatogram,
+                                                  const OpenSwath::ChromatogramPtr cptr,
+                                                  double rt_min,
+                                                  double rt_max);
 
     /// convert from the OpenMS TargetedExperiment to the LightTargetedExperiment
     static void convertTargetedExp(const OpenMS::TargetedExperiment & transition_exp_, OpenSwath::LightTargetedExperiment & transition_exp);

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -38,6 +38,7 @@
 
 namespace OpenMS
 {
+
   void OpenSwathDataAccessHelper::convertToOpenMSSpectrum(const OpenSwath::SpectrumPtr sptr, OpenMS::MSSpectrum & spectrum)
   {
     spectrum.reserve(sptr->getMZArray()->data.size());
@@ -57,6 +58,8 @@ namespace OpenMS
   {
     OpenSwath::BinaryDataArrayPtr intensity_array(new OpenSwath::BinaryDataArray);
     OpenSwath::BinaryDataArrayPtr mz_array(new OpenSwath::BinaryDataArray);
+    mz_array->data.reserve(spectrum.size());
+    intensity_array->data.reserve(spectrum.size());
     for (MSSpectrum::const_iterator it = spectrum.begin(); it != spectrum.end(); ++it)
     {
       mz_array->data.push_back(it->getMZ());
@@ -67,6 +70,24 @@ namespace OpenMS
     sptr->setMZArray(mz_array);
     sptr->setIntensityArray(intensity_array);
     return sptr;
+  }
+
+  OpenSwath::ChromatogramPtr OpenSwathDataAccessHelper::convertToChromatogramPtr(const OpenMS::MSChromatogram & chromatogram)
+  {
+    OpenSwath::BinaryDataArrayPtr intensity_array(new OpenSwath::BinaryDataArray);
+    OpenSwath::BinaryDataArrayPtr rt_array(new OpenSwath::BinaryDataArray);
+    rt_array->data.reserve(chromatogram.size());
+    intensity_array->data.reserve(chromatogram.size());
+    for (MSChromatogram::const_iterator it = chromatogram.begin(); it != chromatogram.end(); ++it)
+    {
+      rt_array->data.push_back(it->getRT());
+      intensity_array->data.push_back(it->getIntensity());
+    }
+
+    OpenSwath::ChromatogramPtr cptr(new OpenSwath::Chromatogram);
+    cptr->setTimeArray(rt_array);
+    cptr->setIntensityArray(intensity_array);
+    return cptr;
   }
 
   void OpenSwathDataAccessHelper::convertToOpenMSChromatogram(const OpenSwath::ChromatogramPtr cptr, OpenMS::MSChromatogram & chromatogram)
@@ -84,8 +105,10 @@ namespace OpenMS
     }
   }
 
-  void OpenSwathDataAccessHelper::convertToOpenMSChromatogramFilter(OpenMS::MSChromatogram & chromatogram, const OpenSwath::ChromatogramPtr cptr,
-                                                                    double rt_min, double rt_max)
+  void OpenSwathDataAccessHelper::convertToOpenMSChromatogramFilter(OpenMS::MSChromatogram & chromatogram,
+                                                                    const OpenSwath::ChromatogramPtr cptr,
+                                                                    double rt_min,
+                                                                    double rt_max)
   {
     chromatogram.reserve(cptr->getTimeArray()->data.size());
 
@@ -303,6 +326,5 @@ namespace OpenMS
                                                 "UniMod:" + String(it->unimod_id), aa_sequence);
     }
   }
-
 
 }

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -41,13 +41,15 @@ namespace OpenMS
 
   void OpenSwathDataAccessHelper::convertToOpenMSSpectrum(const OpenSwath::SpectrumPtr sptr, OpenMS::MSSpectrum & spectrum)
   {
-    spectrum.reserve(sptr->getMZArray()->data.size());
 
     std::vector<double>::const_iterator mz_it = sptr->getMZArray()->data.begin();
     std::vector<double>::const_iterator int_it = sptr->getIntensityArray()->data.begin();
+
+    Peak1D p;
+    spectrum.clear(false);
+    spectrum.reserve(sptr->getMZArray()->data.size());
     for (; mz_it != sptr->getMZArray()->data.end(); ++mz_it, ++int_it)
     {
-      Peak1D p;
       p.setMZ(*mz_it);
       p.setIntensity(*int_it);
       spectrum.push_back(p);
@@ -56,8 +58,9 @@ namespace OpenMS
 
   OpenSwath::SpectrumPtr OpenSwathDataAccessHelper::convertToSpectrumPtr(const OpenMS::MSSpectrum & spectrum)
   {
-    OpenSwath::BinaryDataArrayPtr intensity_array(new OpenSwath::BinaryDataArray);
-    OpenSwath::BinaryDataArrayPtr mz_array(new OpenSwath::BinaryDataArray);
+    OpenSwath::SpectrumPtr sptr(new OpenSwath::Spectrum);
+    OpenSwath::BinaryDataArrayPtr intensity_array = sptr->getIntensityArray();
+    OpenSwath::BinaryDataArrayPtr mz_array = sptr->getMZArray();
     mz_array->data.reserve(spectrum.size());
     intensity_array->data.reserve(spectrum.size());
     for (MSSpectrum::const_iterator it = spectrum.begin(); it != spectrum.end(); ++it)
@@ -65,17 +68,14 @@ namespace OpenMS
       mz_array->data.push_back(it->getMZ());
       intensity_array->data.push_back(it->getIntensity());
     }
-
-    OpenSwath::SpectrumPtr sptr(new OpenSwath::Spectrum);
-    sptr->setMZArray(mz_array);
-    sptr->setIntensityArray(intensity_array);
     return sptr;
   }
 
   OpenSwath::ChromatogramPtr OpenSwathDataAccessHelper::convertToChromatogramPtr(const OpenMS::MSChromatogram & chromatogram)
   {
-    OpenSwath::BinaryDataArrayPtr intensity_array(new OpenSwath::BinaryDataArray);
-    OpenSwath::BinaryDataArrayPtr rt_array(new OpenSwath::BinaryDataArray);
+    OpenSwath::ChromatogramPtr cptr(new OpenSwath::Chromatogram);
+    OpenSwath::BinaryDataArrayPtr intensity_array = cptr->getIntensityArray();
+    OpenSwath::BinaryDataArrayPtr rt_array = cptr->getTimeArray();
     rt_array->data.reserve(chromatogram.size());
     intensity_array->data.reserve(chromatogram.size());
     for (MSChromatogram::const_iterator it = chromatogram.begin(); it != chromatogram.end(); ++it)
@@ -83,22 +83,19 @@ namespace OpenMS
       rt_array->data.push_back(it->getRT());
       intensity_array->data.push_back(it->getIntensity());
     }
-
-    OpenSwath::ChromatogramPtr cptr(new OpenSwath::Chromatogram);
-    cptr->setTimeArray(rt_array);
-    cptr->setIntensityArray(intensity_array);
     return cptr;
   }
 
   void OpenSwathDataAccessHelper::convertToOpenMSChromatogram(const OpenSwath::ChromatogramPtr cptr, OpenMS::MSChromatogram & chromatogram)
   {
-    chromatogram.reserve(cptr->getTimeArray()->data.size());
-
     std::vector<double>::const_iterator rt_it = cptr->getTimeArray()->data.begin();
     std::vector<double>::const_iterator int_it = cptr->getIntensityArray()->data.begin();
+
+    ChromatogramPeak peak;
+    chromatogram.clear(false);
+    chromatogram.reserve(cptr->getTimeArray()->data.size());
     for (; rt_it != cptr->getTimeArray()->data.end(); ++rt_it, ++int_it)
     {
-      ChromatogramPeak peak;
       peak.setRT(*rt_it);
       peak.setIntensity(*int_it);
       chromatogram.push_back(peak);
@@ -110,17 +107,18 @@ namespace OpenMS
                                                                     double rt_min,
                                                                     double rt_max)
   {
-    chromatogram.reserve(cptr->getTimeArray()->data.size());
-
     std::vector<double>::const_iterator rt_it = cptr->getTimeArray()->data.begin();
     std::vector<double>::const_iterator int_it = cptr->getIntensityArray()->data.begin();
+
+    ChromatogramPeak peak;
+    chromatogram.clear(false);
+    chromatogram.reserve(cptr->getTimeArray()->data.size());
     for (; rt_it != cptr->getTimeArray()->data.end(); ++rt_it, ++int_it)
     {
       if (*rt_it < rt_min || *rt_it > rt_max)
       {
         continue;
       }
-      ChromatogramPeak peak;
       peak.setRT(*rt_it);
       peak.setIntensity(*int_it);
       chromatogram.push_back(peak);

--- a/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp
@@ -41,12 +41,12 @@ namespace OpenMS
 
   void OpenSwathDataAccessHelper::convertToOpenMSSpectrum(const OpenSwath::SpectrumPtr sptr, OpenMS::MSSpectrum & spectrum)
   {
-
     std::vector<double>::const_iterator mz_it = sptr->getMZArray()->data.begin();
     std::vector<double>::const_iterator int_it = sptr->getIntensityArray()->data.begin();
 
+    if (!spectrum.empty()) spectrum.clear(false);
+
     Peak1D p;
-    spectrum.clear(false);
     spectrum.reserve(sptr->getMZArray()->data.size());
     for (; mz_it != sptr->getMZArray()->data.end(); ++mz_it, ++int_it)
     {
@@ -91,8 +91,9 @@ namespace OpenMS
     std::vector<double>::const_iterator rt_it = cptr->getTimeArray()->data.begin();
     std::vector<double>::const_iterator int_it = cptr->getIntensityArray()->data.begin();
 
+    if (!chromatogram.empty()) chromatogram.clear(false);
+
     ChromatogramPeak peak;
-    chromatogram.clear(false);
     chromatogram.reserve(cptr->getTimeArray()->data.size());
     for (; rt_it != cptr->getTimeArray()->data.end(); ++rt_it, ++int_it)
     {

--- a/src/pyOpenMS/addons/MSChromatogram.pyx
+++ b/src/pyOpenMS/addons/MSChromatogram.pyx
@@ -54,7 +54,7 @@ import numpy as np
 
         chrom_.clear(0) # empty vector , keep meta data
         chrom_.reserve(<int>len(data_rt)) # allocate space for incoming data
-        cdef _Peak1D p = _Peak1D()
+        cdef _ChromatogramPeak p = _ChromatogramPeak()
         cdef double rt
         cdef double intensity
         cdef int N
@@ -76,7 +76,7 @@ import numpy as np
 
         chrom_.clear(0) # empty vector , keep meta data
         chrom_.reserve(<int>len(data_rt)) # allocate space for incoming data
-        cdef _Peak1D p = _Peak1D()
+        cdef _ChromatogramPeak p = _ChromatogramPeak()
         cdef double rt
         cdef float intensity
         cdef int N
@@ -99,7 +99,7 @@ import numpy as np
 
         chrom_.clear(0) # empty vector , keep meta data
         chrom_.reserve(<int>len(rts)) # allocate space for incoming data
-        cdef _Peak1D p = _Peak1D()
+        cdef _ChromatogramPeak p = _ChromatogramPeak()
         cdef double rt
         cdef float intensity
         cdef int N

--- a/src/pyOpenMS/addons/MSChromatogram.pyx
+++ b/src/pyOpenMS/addons/MSChromatogram.pyx
@@ -2,6 +2,8 @@ cimport numpy as np
 import numpy as np
 
 
+
+
     def get_peaks(self):
 
         cdef _MSChromatogram * chrom_ = self.inst.get()
@@ -31,23 +33,84 @@ import numpy as np
         rts, intensities = peaks
         assert len(rts) == len(intensities), "Input vectors for set_peaks need to have the same length (rt and intensity vector)"
 
+        # Select which function to use for set_peaks:
+        # If we have numpy arrays, it helps to use optimized functions
+        if isinstance(rts, np.ndarray) and isinstance(intensities, np.ndarray) and \
+          rts.dtype == np.float64 and intensities.dtype == np.float32 and \
+          rts.flags["C_CONTIGUOUS"] and intensities.flags["C_CONTIGUOUS"]  :
+            self._set_peaks_fast_df(rts, intensities)
+        elif isinstance(rts, np.ndarray) and isinstance(intensities, np.ndarray) and \
+          rts.dtype == np.float64 and intensities.dtype == np.float64 and \
+          rts.flags["C_CONTIGUOUS"] and intensities.flags["C_CONTIGUOUS"]  :
+            self._set_peaks_fast_dd(rts, intensities)
+        else:
+            self._set_peaks_orig(rts, intensities)
+
+
+
+    def _set_peaks_fast_dd(self, np.ndarray[double, ndim=1, mode="c"] data_rt not None, np.ndarray[double, ndim=1, mode="c"] data_i not None):
+
         cdef _MSChromatogram * chrom_ = self.inst.get()
 
-        chrom_.clear(0) # empty vector, keep meta data
-        # chrom_.reserve(<int>len(rts)) # allocate space for incoming data
-        cdef _ChromatogramPeak p = _ChromatogramPeak()
+        chrom_.clear(0) # empty vector , keep meta data
+        chrom_.reserve(<int>len(data_rt)) # allocate space for incoming data
+        cdef _Peak1D p = _Peak1D()
         cdef double rt
-        cdef float I
+        cdef double intensity
         cdef int N
-        N = len(rts)
+        N = len(data_rt)
 
         for i in range(N):
-            rt = rts[i]
-            intensity  = intensities[i]
+            rt = data_rt[i]
+            intensity = data_i[i]
             p.setRT(<double>rt)
             p.setIntensity(<float>intensity)
             chrom_.push_back(p)
 
         chrom_.updateRanges()
 
+
+    def _set_peaks_fast_df(self, np.ndarray[double, ndim=1, mode="c"] data_rt not None, np.ndarray[float, ndim=1, mode="c"] data_i not None):
+
+        cdef _MSChromatogram * chrom_ = self.inst.get()
+
+        chrom_.clear(0) # empty vector , keep meta data
+        chrom_.reserve(<int>len(data_rt)) # allocate space for incoming data
+        cdef _Peak1D p = _Peak1D()
+        cdef double rt
+        cdef float intensity
+        cdef int N
+        N = len(data_rt)
+
+        for i in range(N):
+            rt = data_rt[i]
+            intensity = data_i[i]
+            p.setRT(<double>rt)
+            p.setIntensity(<float>intensity)
+            chrom_.push_back(p)
+
+        chrom_.updateRanges()
+
+
+    def _set_peaks_orig(self, rts, intensities):
+
+
+        cdef _MSChromatogram * chrom_ = self.inst.get()
+
+        chrom_.clear(0) # empty vector , keep meta data
+        chrom_.reserve(<int>len(rts)) # allocate space for incoming data
+        cdef _Peak1D p = _Peak1D()
+        cdef double rt
+        cdef float intensity
+        cdef int N
+        N = len(rts)
+
+        for i in range(N):
+            rt = rts[i]
+            intensity = intensities[i]
+            p.setRT(<double>rt)
+            p.setIntensity(<float>intensity)
+            chrom_.push_back(p)
+
+        chrom_.updateRanges()
 

--- a/src/pyOpenMS/addons/MSSpectrum.pyx
+++ b/src/pyOpenMS/addons/MSSpectrum.pyx
@@ -94,6 +94,9 @@ import numpy as np
 
     def _set_peaks_orig(self, mzs, intensities):
 
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+
         spec_.clear(0) # empty vector , keep meta data
         spec_.reserve(<int>len(mzs)) # allocate space for incoming data
         cdef _Peak1D p = _Peak1D()

--- a/src/pyOpenMS/addons/MSSpectrum.pyx
+++ b/src/pyOpenMS/addons/MSSpectrum.pyx
@@ -2,6 +2,123 @@ cimport numpy as np
 import numpy as np
 
 
+
+
+    def get_peaks_newx(self):
+
+        # 's.get_peaks_newx()'
+        # 1000 loops, best of 3: 399 usec per loop
+        # with reserve: 1000 loops, best of 3: 315 usec per loop
+
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+        cdef _OpenSwathDataAccessHelper tmp
+        cdef shared_ptr[_OSSpectrum] tmp_s
+
+        tmp_s = tmp.convertToSpectrumPtr( deref(spec_) )
+
+        cdef unsigned int n = spec_.size()
+        cdef shared_ptr[_OSBinaryDataArray] qq1 = tmp_s.get().getIntensityArray()
+        cdef shared_ptr[_OSBinaryDataArray] qq2 = tmp_s.get().getMZArray()
+
+        return qq1.get().data.size()
+
+
+    def get_peaks_new3(self):
+        # 's.get_peaks_new3()'
+        # 1000 loops, best of 3: 410 usec per loop
+
+        # 
+
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+        cdef _OpenSwathDataAccessHelper tmp
+        cdef shared_ptr[_OSSpectrum] tmp_s
+
+        tmp_s = tmp.convertToSpectrumPtr( deref(spec_) )
+
+        cdef unsigned int n = spec_.size()
+        cdef shared_ptr[_OSBinaryDataArray] qq1 = tmp_s.get().getIntensityArray()
+        cdef shared_ptr[_OSBinaryDataArray] qq2 = tmp_s.get().getMZArray()
+
+        ## # We use a memory view to get the data from the raw data
+        ## # See https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html 
+        ## # See https://stackoverflow.com/questions/43021574/cast-c-array-into-numpy-array-cython-typed-memoryview-in-cython-code
+        cdef double * raw_ptr = address(qq1.get().data[0]) 
+        cdef double[:] fda_view = <double[:n]>raw_ptr # cast to memoryview, refer to the underlying buffer without copy
+        xarr = np.asarray(fda_view) # numpy array refer to the underlying buffer without copy
+        cdef double * raw_ptr2 = address(qq2.get().data[0]) 
+        cdef double[:] xx = <double[:n]>raw_ptr2 # cast to memoryview, refer to the underlying buffer without copy
+        xarr2 = np.asarray(xx) # numpy array refer to the underlying buffer without copy
+        return xarr, xarr2
+
+
+
+    def get_peaks_new2(self):
+
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+
+        cdef unsigned int n = spec_.size()
+
+        cdef libcpp_vector[float] intensities
+        cdef libcpp_vector[double] mzs
+
+        cdef libcpp_vector[_Peak1D].iterator it = spec_.begin()
+        while it != spec_.end():
+            mzs.push_back( deref(it).getMZ() )
+            intensities.push_back( deref(it).getIntensity() )
+            inc(it)
+
+        # return mzs, intensities
+
+
+
+        ## # We use a memory view to get the data from the raw data
+        ## # See https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html 
+        ## # See https://stackoverflow.com/questions/43021574/cast-c-array-into-numpy-array-cython-typed-memoryview-in-cython-code
+        cdef float * raw_ptr = address(intensities[0]) 
+        cdef float[:] fda_view = <float[:n]>raw_ptr # cast to memoryview, refer to the underlying buffer without copy
+        xarr = np.asarray(fda_view) # numpy array refer to the underlying buffer without copy
+        cdef double * raw_ptr2 = address(mzs[0]) 
+        cdef double[:] xx = <double[:n]>raw_ptr2 # cast to memoryview, refer to the underlying buffer without copy
+        xarr2 = np.asarray(xx) # numpy array refer to the underlying buffer without copy
+        return xarr, xarr2
+
+    def get_peaks_new(self):
+
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+
+        cdef unsigned int n = spec_.size()
+
+        cdef libcpp_vector[float] intensities
+        cdef libcpp_vector[double] mzs
+
+        cdef libcpp_vector[_Peak1D].iterator it = spec_.begin()
+        while it != spec_.end():
+            mzs.push_back( deref(it).getMZ() )
+            intensities.push_back( deref(it).getIntensity() )
+            inc(it)
+
+        return mzs, intensities
+
+
+
+        ## cdef _FloatDataArray * fda_ = self.inst.get()
+        ## cdef unsigned int n = fda_.size()
+        ##  
+        ## # Obtain a raw ptr to the beginning of the C++ array
+        ## cdef libcpp_vector[float] * vec_ptr = <libcpp_vector[float]*> fda_
+        ## cdef float * raw_ptr =  address(deref(vec_ptr)[0]) 
+
+        ## # We use a memory view to get the data from the raw data
+        ## # See https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html 
+        ## # See https://stackoverflow.com/questions/43021574/cast-c-array-into-numpy-array-cython-typed-memoryview-in-cython-code
+        ## cdef float[:] fda_view = <float[:n]>raw_ptr # cast to memoryview, refer to the underlying buffer without copy
+        ## xarr = np.asarray(fda_view) # numpy array refer to the underlying buffer without copy
+        ## return xarr
+
     def get_peaks(self):
 
         cdef _MSSpectrum * spec_ = self.inst.get()
@@ -23,7 +140,83 @@ import numpy as np
 
         return mzs, intensities
 
-    def set_peaks(self, peaks):
+    def set_peaks_fast2(self, np.ndarray[double, ndim=1, mode="c"] data_mz not None, np.ndarray[double, ndim=1, mode="c"] data_i not None):
+        # 1000 loops, best of 3: 1.8 msec per loop
+
+        cdef _OSSpectrum * _s = new _OSSpectrum()
+        cdef shared_ptr[_OSSpectrum] tmp_s = shared_ptr[_OSSpectrum](_s)
+        cdef shared_ptr[_OSBinaryDataArray] int_arr = tmp_s.get().getIntensityArray()
+        cdef shared_ptr[_OSBinaryDataArray] mz_arr = tmp_s.get().getMZArray()
+
+        cdef int N
+        N = data_mz.size
+
+        cdef libcpp_vector[double] * int_data = & int_arr.get().data
+        cdef libcpp_vector[double] * mz_data = & mz_arr.get().data
+
+        # We use "assign" to directly to copy the numpy array
+        cdef double * array_start_mz = <double*>data_mz.data
+        mz_data.assign(array_start_mz, array_start_mz + N)
+        cdef double * array_start_int = <double*>data_i.data
+        int_data.assign(array_start_int, array_start_int + N)
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+        spec_.clear(False)
+
+        cdef _OpenSwathDataAccessHelper tmp
+        tmp.convertToOpenMSSpectrum(tmp_s, deref(spec_) )
+        spec_.updateRanges()
+
+
+    def set_peaks_fast_dd(self, np.ndarray[double, ndim=1, mode="c"] data_mz not None, np.ndarray[double, ndim=1, mode="c"] data_i not None):
+        # 1000 loops, best of 3: 1.09 msec per loop
+        # 1000 loops, best of 3: 781 usec per loop
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+
+        spec_.clear(0) # empty vector , keep meta data
+        spec_.reserve(<int>len(data_mz)) # allocate space for incoming data
+        cdef _Peak1D p = _Peak1D()
+        cdef double mz
+        cdef double intensity
+        cdef int N
+        N = len(data_mz)
+
+        for i in range(N):
+            mz = data_mz[i]
+            intensity = data_i[i]
+            p.setMZ(<double>mz)
+            p.setIntensity(<float>intensity)
+            spec_.push_back(p)
+
+        spec_.updateRanges()
+
+
+    def set_peaks_fast_df(self, np.ndarray[double, ndim=1, mode="c"] data_mz not None, np.ndarray[float, ndim=1, mode="c"] data_i not None):
+        # 1000 loops, best of 3: 1.09 msec per loop
+        # 1000 loops, best of 3: 657 usec per loop
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+
+        spec_.clear(0) # empty vector , keep meta data
+        spec_.reserve(<int>len(data_mz)) # allocate space for incoming data
+        cdef _Peak1D p = _Peak1D()
+        cdef double mz
+        cdef float intensity
+        cdef int N
+        N = len(data_mz)
+
+        for i in range(N):
+            mz = data_mz[i]
+            intensity = data_i[i]
+            p.setMZ(<double>mz)
+            p.setIntensity(<float>intensity)
+            spec_.push_back(p)
+
+        spec_.updateRanges()
+
+
+    def set_peaks_x(self, peaks):
 
         assert isinstance(peaks, (tuple, list)), "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
         assert len(peaks) == 2, "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
@@ -31,10 +224,24 @@ import numpy as np
         mzs, intensities = peaks
         assert len(mzs) == len(intensities), "Input vectors for set_peaks need to have the same length (mz and intensity vector)"
 
+        if isinstance(mzs, np.ndarray) and isinstance(intensities, np.ndarray) and \
+                      mzs.dtype == np.float64 and intensities.dtype == np.float32 and \
+                      mzs.flags["C_CONTIGUOUS"] and intensities.flags["C_CONTIGUOUS"]  :
+
+                        self.set_peaks_fast_df(mzs, intensities)
+                        return
+
+        elif isinstance(mzs, np.ndarray) and isinstance(intensities, np.ndarray) and \
+                        mzs.dtype == np.float64 and intensities.dtype == np.float64 and \
+                        mzs.flags["C_CONTIGUOUS"] and intensities.flags["C_CONTIGUOUS"]  :
+
+                        self.set_peaks_fast_dd(mzs, intensities)
+                        return
+
         cdef _MSSpectrum * spec_ = self.inst.get()
 
         spec_.clear(0) # empty vector , keep meta data
-        # spec_.reserve(<int>len(mzs)) # allocate space for incoming data
+        spec_.reserve(<int>len(mzs)) # allocate space for incoming data
         cdef _Peak1D p = _Peak1D()
         cdef double mz
         cdef float I
@@ -49,6 +256,37 @@ import numpy as np
             spec_.push_back(p)
 
         spec_.updateRanges()
+
+    def set_peaks(self, peaks):
+        # 100 loops, best of 3: 6.22 msec per loop
+        # python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand(100000); s=pyopenms.MSSpectrum(); p=pyopenms.Peak1D()' 'for val in d: p.setMZ(val); p.setIntensity(val); s.push_back(p)'
+        # 100 loops, best of 3: 17.3 msec per loop
+
+        assert isinstance(peaks, (tuple, list)), "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
+        assert len(peaks) == 2, "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
+
+        mzs, intensities = peaks
+        assert len(mzs) == len(intensities), "Input vectors for set_peaks need to have the same length (mz and intensity vector)"
+
+        cdef _MSSpectrum * spec_ = self.inst.get()
+
+        spec_.clear(0) # empty vector , keep meta data
+        spec_.reserve(<int>len(mzs)) # allocate space for incoming data
+        cdef _Peak1D p = _Peak1D()
+        cdef double mz
+        cdef float intensity
+        cdef int N
+        N = len(mzs)
+
+        for i in range(N):
+            mz = mzs[i]
+            intensity  = intensities[i]
+            p.setMZ(<double>mz)
+            p.setIntensity(<float>intensity)
+            spec_.push_back(p)
+
+        spec_.updateRanges()
+
 
     def intensityInRange(self, float mzmin, float mzmax):
 

--- a/src/pyOpenMS/addons/MSSpectrum.pyx
+++ b/src/pyOpenMS/addons/MSSpectrum.pyx
@@ -4,121 +4,6 @@ import numpy as np
 
 
 
-    def get_peaks_newx(self):
-
-        # 's.get_peaks_newx()'
-        # 1000 loops, best of 3: 399 usec per loop
-        # with reserve: 1000 loops, best of 3: 315 usec per loop
-
-
-        cdef _MSSpectrum * spec_ = self.inst.get()
-        cdef _OpenSwathDataAccessHelper tmp
-        cdef shared_ptr[_OSSpectrum] tmp_s
-
-        tmp_s = tmp.convertToSpectrumPtr( deref(spec_) )
-
-        cdef unsigned int n = spec_.size()
-        cdef shared_ptr[_OSBinaryDataArray] qq1 = tmp_s.get().getIntensityArray()
-        cdef shared_ptr[_OSBinaryDataArray] qq2 = tmp_s.get().getMZArray()
-
-        return qq1.get().data.size()
-
-
-    def get_peaks_new3(self):
-        # 's.get_peaks_new3()'
-        # 1000 loops, best of 3: 410 usec per loop
-
-        # 
-
-
-        cdef _MSSpectrum * spec_ = self.inst.get()
-        cdef _OpenSwathDataAccessHelper tmp
-        cdef shared_ptr[_OSSpectrum] tmp_s
-
-        tmp_s = tmp.convertToSpectrumPtr( deref(spec_) )
-
-        cdef unsigned int n = spec_.size()
-        cdef shared_ptr[_OSBinaryDataArray] qq1 = tmp_s.get().getIntensityArray()
-        cdef shared_ptr[_OSBinaryDataArray] qq2 = tmp_s.get().getMZArray()
-
-        ## # We use a memory view to get the data from the raw data
-        ## # See https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html 
-        ## # See https://stackoverflow.com/questions/43021574/cast-c-array-into-numpy-array-cython-typed-memoryview-in-cython-code
-        cdef double * raw_ptr = address(qq1.get().data[0]) 
-        cdef double[:] fda_view = <double[:n]>raw_ptr # cast to memoryview, refer to the underlying buffer without copy
-        xarr = np.asarray(fda_view) # numpy array refer to the underlying buffer without copy
-        cdef double * raw_ptr2 = address(qq2.get().data[0]) 
-        cdef double[:] xx = <double[:n]>raw_ptr2 # cast to memoryview, refer to the underlying buffer without copy
-        xarr2 = np.asarray(xx) # numpy array refer to the underlying buffer without copy
-        return xarr, xarr2
-
-
-
-    def get_peaks_new2(self):
-
-
-        cdef _MSSpectrum * spec_ = self.inst.get()
-
-        cdef unsigned int n = spec_.size()
-
-        cdef libcpp_vector[float] intensities
-        cdef libcpp_vector[double] mzs
-
-        cdef libcpp_vector[_Peak1D].iterator it = spec_.begin()
-        while it != spec_.end():
-            mzs.push_back( deref(it).getMZ() )
-            intensities.push_back( deref(it).getIntensity() )
-            inc(it)
-
-        # return mzs, intensities
-
-
-
-        ## # We use a memory view to get the data from the raw data
-        ## # See https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html 
-        ## # See https://stackoverflow.com/questions/43021574/cast-c-array-into-numpy-array-cython-typed-memoryview-in-cython-code
-        cdef float * raw_ptr = address(intensities[0]) 
-        cdef float[:] fda_view = <float[:n]>raw_ptr # cast to memoryview, refer to the underlying buffer without copy
-        xarr = np.asarray(fda_view) # numpy array refer to the underlying buffer without copy
-        cdef double * raw_ptr2 = address(mzs[0]) 
-        cdef double[:] xx = <double[:n]>raw_ptr2 # cast to memoryview, refer to the underlying buffer without copy
-        xarr2 = np.asarray(xx) # numpy array refer to the underlying buffer without copy
-        return xarr, xarr2
-
-    def get_peaks_new(self):
-
-
-        cdef _MSSpectrum * spec_ = self.inst.get()
-
-        cdef unsigned int n = spec_.size()
-
-        cdef libcpp_vector[float] intensities
-        cdef libcpp_vector[double] mzs
-
-        cdef libcpp_vector[_Peak1D].iterator it = spec_.begin()
-        while it != spec_.end():
-            mzs.push_back( deref(it).getMZ() )
-            intensities.push_back( deref(it).getIntensity() )
-            inc(it)
-
-        return mzs, intensities
-
-
-
-        ## cdef _FloatDataArray * fda_ = self.inst.get()
-        ## cdef unsigned int n = fda_.size()
-        ##  
-        ## # Obtain a raw ptr to the beginning of the C++ array
-        ## cdef libcpp_vector[float] * vec_ptr = <libcpp_vector[float]*> fda_
-        ## cdef float * raw_ptr =  address(deref(vec_ptr)[0]) 
-
-        ## # We use a memory view to get the data from the raw data
-        ## # See https://cython.readthedocs.io/en/latest/src/userguide/memoryviews.html 
-        ## # See https://stackoverflow.com/questions/43021574/cast-c-array-into-numpy-array-cython-typed-memoryview-in-cython-code
-        ## cdef float[:] fda_view = <float[:n]>raw_ptr # cast to memoryview, refer to the underlying buffer without copy
-        ## xarr = np.asarray(fda_view) # numpy array refer to the underlying buffer without copy
-        ## return xarr
-
     def get_peaks(self):
 
         cdef _MSSpectrum * spec_ = self.inst.get()
@@ -140,37 +25,30 @@ import numpy as np
 
         return mzs, intensities
 
-    def set_peaks_fast2(self, np.ndarray[double, ndim=1, mode="c"] data_mz not None, np.ndarray[double, ndim=1, mode="c"] data_i not None):
-        # 1000 loops, best of 3: 1.8 msec per loop
+    def set_peaks(self, peaks):
 
-        cdef _OSSpectrum * _s = new _OSSpectrum()
-        cdef shared_ptr[_OSSpectrum] tmp_s = shared_ptr[_OSSpectrum](_s)
-        cdef shared_ptr[_OSBinaryDataArray] int_arr = tmp_s.get().getIntensityArray()
-        cdef shared_ptr[_OSBinaryDataArray] mz_arr = tmp_s.get().getMZArray()
+        assert isinstance(peaks, (tuple, list)), "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
+        assert len(peaks) == 2, "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
 
-        cdef int N
-        N = data_mz.size
+        mzs, intensities = peaks
+        assert len(mzs) == len(intensities), "Input vectors for set_peaks need to have the same length (mz and intensity vector)"
 
-        cdef libcpp_vector[double] * int_data = & int_arr.get().data
-        cdef libcpp_vector[double] * mz_data = & mz_arr.get().data
-
-        # We use "assign" to directly to copy the numpy array
-        cdef double * array_start_mz = <double*>data_mz.data
-        mz_data.assign(array_start_mz, array_start_mz + N)
-        cdef double * array_start_int = <double*>data_i.data
-        int_data.assign(array_start_int, array_start_int + N)
-
-        cdef _MSSpectrum * spec_ = self.inst.get()
-        spec_.clear(False)
-
-        cdef _OpenSwathDataAccessHelper tmp
-        tmp.convertToOpenMSSpectrum(tmp_s, deref(spec_) )
-        spec_.updateRanges()
+        # Select which function to use for set_peaks:
+        # If we have numpy arrays, it helps to use optimized functions
+        if isinstance(mzs, np.ndarray) and isinstance(intensities, np.ndarray) and \
+          mzs.dtype == np.float64 and intensities.dtype == np.float32 and \
+          mzs.flags["C_CONTIGUOUS"] and intensities.flags["C_CONTIGUOUS"]  :
+            self._set_peaks_fast_df(mzs, intensities)
+        elif isinstance(mzs, np.ndarray) and isinstance(intensities, np.ndarray) and \
+          mzs.dtype == np.float64 and intensities.dtype == np.float64 and \
+          mzs.flags["C_CONTIGUOUS"] and intensities.flags["C_CONTIGUOUS"]  :
+            self._set_peaks_fast_dd(mzs, intensities)
+        else:
+            self._set_peaks_orig(mzs, intensities)
 
 
-    def set_peaks_fast_dd(self, np.ndarray[double, ndim=1, mode="c"] data_mz not None, np.ndarray[double, ndim=1, mode="c"] data_i not None):
-        # 1000 loops, best of 3: 1.09 msec per loop
-        # 1000 loops, best of 3: 781 usec per loop
+
+    def _set_peaks_fast_dd(self, np.ndarray[double, ndim=1, mode="c"] data_mz not None, np.ndarray[double, ndim=1, mode="c"] data_i not None):
 
         cdef _MSSpectrum * spec_ = self.inst.get()
 
@@ -192,9 +70,7 @@ import numpy as np
         spec_.updateRanges()
 
 
-    def set_peaks_fast_df(self, np.ndarray[double, ndim=1, mode="c"] data_mz not None, np.ndarray[float, ndim=1, mode="c"] data_i not None):
-        # 1000 loops, best of 3: 1.09 msec per loop
-        # 1000 loops, best of 3: 657 usec per loop
+    def _set_peaks_fast_df(self, np.ndarray[double, ndim=1, mode="c"] data_mz not None, np.ndarray[float, ndim=1, mode="c"] data_i not None):
 
         cdef _MSSpectrum * spec_ = self.inst.get()
 
@@ -216,59 +92,7 @@ import numpy as np
         spec_.updateRanges()
 
 
-    def set_peaks_x(self, peaks):
-
-        assert isinstance(peaks, (tuple, list)), "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
-        assert len(peaks) == 2, "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
-
-        mzs, intensities = peaks
-        assert len(mzs) == len(intensities), "Input vectors for set_peaks need to have the same length (mz and intensity vector)"
-
-        if isinstance(mzs, np.ndarray) and isinstance(intensities, np.ndarray) and \
-                      mzs.dtype == np.float64 and intensities.dtype == np.float32 and \
-                      mzs.flags["C_CONTIGUOUS"] and intensities.flags["C_CONTIGUOUS"]  :
-
-                        self.set_peaks_fast_df(mzs, intensities)
-                        return
-
-        elif isinstance(mzs, np.ndarray) and isinstance(intensities, np.ndarray) and \
-                        mzs.dtype == np.float64 and intensities.dtype == np.float64 and \
-                        mzs.flags["C_CONTIGUOUS"] and intensities.flags["C_CONTIGUOUS"]  :
-
-                        self.set_peaks_fast_dd(mzs, intensities)
-                        return
-
-        cdef _MSSpectrum * spec_ = self.inst.get()
-
-        spec_.clear(0) # empty vector , keep meta data
-        spec_.reserve(<int>len(mzs)) # allocate space for incoming data
-        cdef _Peak1D p = _Peak1D()
-        cdef double mz
-        cdef float I
-        cdef int N
-        N = len(mzs)
-
-        for i in range(N):
-            mz = mzs[i]
-            intensity  = intensities[i]
-            p.setMZ(<double>mz)
-            p.setIntensity(<float>intensity)
-            spec_.push_back(p)
-
-        spec_.updateRanges()
-
-    def set_peaks(self, peaks):
-        # 100 loops, best of 3: 6.22 msec per loop
-        # python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand(100000); s=pyopenms.MSSpectrum(); p=pyopenms.Peak1D()' 'for val in d: p.setMZ(val); p.setIntensity(val); s.push_back(p)'
-        # 100 loops, best of 3: 17.3 msec per loop
-
-        assert isinstance(peaks, (tuple, list)), "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
-        assert len(peaks) == 2, "Input for set_peaks needs to be a tuple or a list of size 2 (mz and intensity vector)"
-
-        mzs, intensities = peaks
-        assert len(mzs) == len(intensities), "Input vectors for set_peaks need to have the same length (mz and intensity vector)"
-
-        cdef _MSSpectrum * spec_ = self.inst.get()
+    def _set_peaks_orig(self, mzs, intensities):
 
         spec_.clear(0) # empty vector , keep meta data
         spec_.reserve(<int>len(mzs)) # allocate space for incoming data
@@ -280,13 +104,12 @@ import numpy as np
 
         for i in range(N):
             mz = mzs[i]
-            intensity  = intensities[i]
+            intensity = intensities[i]
             p.setMZ(<double>mz)
             p.setIntensity(<float>intensity)
             spec_.push_back(p)
 
         spec_.updateRanges()
-
 
     def intensityInRange(self, float mzmin, float mzmax):
 

--- a/src/pyOpenMS/addons/OpenSwathDataAccessHelper.pyx
+++ b/src/pyOpenMS/addons/OpenSwathDataAccessHelper.pyx
@@ -3,10 +3,18 @@
     def convertToSpectrumPtr(self, MSSpectrum spectrum):
         assert isinstance(spectrum, MSSpectrum), 'arg spec wrong type'
 
-
         _r = self.inst.get().convertToSpectrumPtr((deref(spectrum.inst.get())))
-        cdef shared_ptr[_OSSpectrum] py_result = _r
+        # cdef shared_ptr[_OSSpectrum] py_result = _r
         spec = OSSpectrum()
         spec.inst = _r
         return spec
+
+    def convertToChromatogramPtr(self, MSChromatogram chrom):
+        assert isinstance(chrom, MSChromatogram), 'arg spec wrong type'
+
+        _r = self.inst.get().convertToChromatogramPtr((deref(chrom.inst.get())))
+        # cdef shared_ptr[_OSChromatogram] py_result = _r
+        ch = OSChromatogram()
+        ch.inst = _r
+        return ch
 

--- a/src/pyOpenMS/performance.rst
+++ b/src/pyOpenMS/performance.rst
@@ -1,0 +1,85 @@
+Performance Measurements
+========================
+
+FloatDataArray
+--------------
+
+Raw conversions of floating point data (arrays):
+
+.. code-block:: bash
+
+    python -m timeit -s 'import pyopenms as p, numpy as np;d=np.random.rand(100000).astype(np.float32);f=p.FloatDataArray();f.set_data(d)' 'f.get_data()'
+    1000000 loops, best of 3: 1.42 usec per loop
+
+    python -m timeit -s 'import pyopenms as p, numpy as np;d=np.random.rand(100000).astype(np.float32);f=p.FloatDataArray();f.set_data(d)' 'q = [val for val in d]'
+    100 loops, best of 3: 3.93 msec per loop
+
+    python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand( 100000).astype(numpy.float32); f = pyopenms.FloatDataArray();' 'f.set_data(d)'    
+    100000 loops, best of 3: 13.6 usec per loop
+
+    python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand( 100000).astype(numpy.float32); f = pyopenms.FloatDataArray();' 'for val in d: f.push_back(val)'
+    100 loops, best of 3: 8.5 msec per loop
+
+OpenSwath Spectrum
+------------------
+
+Spectral conversion to OpenSwath Spectrum:
+
+.. code-block:: bash
+
+  python -m timeit -s 'import pyopenms as p, numpy as np;d=np.random.rand(100000);s=p.MSSpectrum();s.set_peaks((d,d));sa=p.OpenSwathDataAccessHelper()' 'sa.convertToSpectrumPtr(s)'
+
+  1000 loops, best of 3: 413 usec per loop -- version 2.3.0.4
+  1000 loops, best of 3: 321 usec per loop
+
+Spectral conversion from OpenSwath Spectrum:
+
+.. code-block:: bash
+
+  python -m timeit -s 'import pyopenms as p, numpy as np;d=np.random.rand(100000);s=p.MSSpectrum();s.set_peaks((d,d));sa=p.OpenSwathDataAccessHelper();sptr=sa.convertToSpectrumPtr(s)' 's.clear(False); sa.convertToOpenMSSpectrum(sptr, s)'
+
+  1000 loops, best of 3: 1.45 msec per loop -- version 2.3.0.4
+  1000 loops, best of 3: 1.21 msec per loop
+
+MSSpectrum
+----------
+
+Spectral data setting:
+
+.. code-block:: bash
+
+  python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand(100000); s=pyopenms.MSSpectrum(); p=pyopenms.Peak1D()' 'for val in d: p.setMZ(val); p.setIntensity(val); s.push_back(p)'
+  100 loops, best of 3: 16.8 msec per loop
+
+  python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand( 100000).astype(numpy.float32); s=pyopenms.MSSpectrum();d=list(d)' 's.set_peaks([d,d])'
+  100 loops, best of 3: 2.7 msec per loop -- version 2.3.0.4
+  100 loops, best of 3: 2.48 msec per loop
+
+  python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand( 100000).astype(numpy.float64); df = d.astype(numpy.float32); s=pyopenms.MSSpectrum();' 's._set_peaks_fast_dd( d,d )' 
+  1000 loops, best of 3: 792 usec per loop
+
+  python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand( 100000).astype(numpy.float64); df = d.astype(numpy.float32); s=pyopenms.MSSpectrum();' 's._set_peaks_fast_df( d,df )' 
+  1000 loops, best of 3: 662 usec per loop
+
+Strangely, using numpy arrays to set data is considerably slower when using the list interface:
+
+
+.. code-block:: bash
+
+  python -m timeit -s 'import pyopenms, numpy; d = numpy.random.rand( 100000).astype(numpy.float64); df = d.astype(numpy.float32); s=pyopenms.MSSpectrum();' 's._set_peaks_orig(d,df)'
+
+  100 loops, best of 3: 6.46 msec per loop -- version 2.3.0.4 [use 's.set_peaks([d,df])']
+  100 loops, best of 3: 6.23 msec per loop
+
+
+Spectral data access:
+
+
+.. code-block:: bash
+
+  python -m timeit -r 3 -s 'import pyopenms, numpy; d = numpy.random.rand( 100000).astype(numpy.float32); s=pyopenms.MSSpectrum(); s.set_peaks([d,d])' 's.get_peaks()'
+
+  1000 loops, best of 3: 207 usec per loop -- version 2.3.0.4
+  10000 loops, best of 3: 168 usec per loop
+
+

--- a/src/pyOpenMS/pxds/ChromatogramPeak.pxd
+++ b/src/pyOpenMS/pxds/ChromatogramPeak.pxd
@@ -18,18 +18,22 @@ cdef extern from "<OpenMS/KERNEL/ChromatogramPeak.h>" namespace "OpenMS":
         bool operator==(ChromatogramPeak) nogil except +
         bool operator!=(ChromatogramPeak) nogil except +
 
-        IntensityType getIntensity() nogil except +
-        void setIntensity(IntensityType) nogil except +
+        # We will not catch C++ exceptions for get/set methods for performance
+        # reasons (no memory allocation is involved).
 
-        DPosition1 getPosition() nogil except +
-        void setPosition(DPosition1) nogil except +
+        IntensityType getIntensity() nogil 
+        void setIntensity(IntensityType) nogil 
 
-        CoordinateType getRT() nogil except +
-        void setRT(CoordinateType) nogil except +
+        DPosition1 getPosition() nogil 
+        void setPosition(DPosition1) nogil 
 
-        CoordinateType getPos() nogil except +
-        void setPos(CoordinateType) nogil except +
+        CoordinateType getRT() nogil 
+        void setRT(CoordinateType) nogil 
+
+        CoordinateType getPos() nogil 
+        void setPos(CoordinateType) nogil 
 
         # alias for getRT 
-        CoordinateType getMZ() nogil except +
-        void setMZ(CoordinateType) nogil except +
+        CoordinateType getMZ() nogil 
+        void setMZ(CoordinateType) nogil 
+

--- a/src/pyOpenMS/pxds/MSChromatogram.pxd
+++ b/src/pyOpenMS/pxds/MSChromatogram.pxd
@@ -33,6 +33,8 @@ cdef extern from "<OpenMS/KERNEL/MSChromatogram.h>" namespace "OpenMS":
         void setName(libcpp_string) nogil except +
 
         Size size() nogil except +
+        void reserve(size_t n) nogil except + 
+
         ChromatogramPeak operator[](int) nogil except +
 
         void updateRanges() nogil except +

--- a/src/pyOpenMS/pxds/MSSpectrum.pxd
+++ b/src/pyOpenMS/pxds/MSSpectrum.pxd
@@ -37,6 +37,7 @@ cdef extern from "<OpenMS/KERNEL/MSSpectrum.h>" namespace "OpenMS":
         void setName(libcpp_string) nogil except +
 
         Size size() nogil except +
+        void reserve(size_t n) nogil except + 
 
         Peak1D operator[](int) nogil except + # wrap-upper-limit:size()
 

--- a/src/pyOpenMS/pxds/OpenSwathDataAccessHelper.pxd
+++ b/src/pyOpenMS/pxds/OpenSwathDataAccessHelper.pxd
@@ -10,6 +10,8 @@ from MSChromatogram cimport *
 from ChromatogramPeak cimport *
 from AASequence cimport *
 
+# this class has addons, see the ./addons folder (../addons/OpenSwathDataAccessHelper.pyx)
+
 cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>" namespace "OpenMS":
 
     cdef cppclass OpenSwathDataAccessHelper:
@@ -22,6 +24,9 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.h>" nam
 
         # Convert an OpenMS Spectrum to an SpectrumPtr
         shared_ptr[OSSpectrum] convertToSpectrumPtr(MSSpectrum spectrum) nogil except + # wrap-ignore
+
+        # Convert an OpenMS Chromatogram to an ChromatogramPtr
+        shared_ptr[OSChromatogram] convertToChromatogramPtr(MSChromatogram chromatogram) nogil except + # wrap-ignore
 
         # Convert a ChromatogramPtr to an OpenMS Chromatogram
         void convertToOpenMSChromatogram(shared_ptr[OSChromatogram] cptr, MSChromatogram & chromatogram) nogil except +

--- a/src/pyOpenMS/pxds/OpenSwathDataStructures.pxd
+++ b/src/pyOpenMS/pxds/OpenSwathDataStructures.pxd
@@ -10,7 +10,7 @@ cdef extern from "<OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h>" namespace 
       
   ctypedef shared_ptr[OSBinaryDataArray] OSBinaryDataArrayPtr
 
-  # See addons/OSSpectrum.pyx
+  # See ../addons/OSSpectrum.pyx
   cdef cppclass OSSpectrum:
         OSSpectrum() nogil except +
         OSSpectrum(OSSpectrum) nogil except +
@@ -22,7 +22,7 @@ cdef extern from "<OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h>" namespace 
   # boost::shared_ptr<OpenSwath::Spectrum> OpenSwath::SpectrumPtr;
   ctypedef shared_ptr[OSSpectrum] OSSpectrumPtr
 
-  # See addons/OSChromatogram.pyx
+  # See ../addons/OSChromatogram.pyx
   cdef cppclass OSChromatogram:
         OSChromatogram() nogil except +
         OSChromatogram(OSChromatogram) nogil except +

--- a/src/pyOpenMS/pxds/Peak1D.pxd
+++ b/src/pyOpenMS/pxds/Peak1D.pxd
@@ -8,14 +8,16 @@ cdef extern from "<OpenMS/KERNEL/Peak1D.h>" namespace "OpenMS":
         Peak1D() nogil except +
         Peak1D(Peak1D &) nogil except +
 
+        # We will not catch C++ exceptions for get/set methods for performance
+        # reasons (no memory allocation is involved).
         float getIntensity() nogil 
         double getMZ() nogil 
         void setMZ(double) nogil 
         void setIntensity(float) nogil 
         bool operator==(Peak1D) nogil except +
         bool operator!=(Peak1D) nogil except +
-        double getPos() nogil except +
-        void setPos(double pos) nogil except +
+        double getPos() nogil 
+        void setPos(double pos) nogil 
         # DPosition1 getPosition() nogil except + # wrap-ignore
         # void setPosition(DPosition1 position) nogil except + # wrap-ignore
     

--- a/src/pyOpenMS/pxds/Peak1D.pxd
+++ b/src/pyOpenMS/pxds/Peak1D.pxd
@@ -8,10 +8,10 @@ cdef extern from "<OpenMS/KERNEL/Peak1D.h>" namespace "OpenMS":
         Peak1D() nogil except +
         Peak1D(Peak1D &) nogil except +
 
-        float getIntensity() nogil except +
-        double getMZ() nogil except +
-        void setMZ(double) nogil except +
-        void setIntensity(float) nogil except +
+        float getIntensity() nogil 
+        double getMZ() nogil 
+        void setMZ(double) nogil 
+        void setIntensity(float) nogil 
         bool operator==(Peak1D) nogil except +
         bool operator!=(Peak1D) nogil except +
         double getPos() nogil except +

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -2927,8 +2927,8 @@ def testMSSpectrum():
     p = pyopenms.Peak1D()
     p.setMZ(1000.0)
     p.setIntensity(200.0)
-
     spec.push_back(p)
+
     assert spec.size() == 1
     assert spec[0] == p
 
@@ -2952,9 +2952,78 @@ def testMSSpectrum():
     assert mz0 == mz
     assert ii0 == ii
 
-    assert int(spec.isSorted()) in  (0,1)
+    assert int(spec.isSorted()) in (0,1)
 
+    spec.clear(False)
+    p = pyopenms.Peak1D()
+    p.setMZ(1000.0)
+    p.setIntensity(200.0)
+    spec.push_back(p)
+    p = pyopenms.Peak1D()
+    p.setMZ(2000.0)
+    p.setIntensity(400.0)
+    spec.push_back(p)
+
+    mz, ii = spec.get_peaks()
+    assert spec[0].getMZ() == 1000.0
+    assert spec[1].getMZ() == 2000.0
+    assert spec[0].getIntensity() == 200.0
+    assert spec[1].getIntensity() == 400.0
+    assert mz[0] == 1000.0
+    assert mz[1] == 2000.0
+    assert ii[0] == 200.0
+    assert ii[1] == 400.0
+
+    spec.clear(False)
+    data_mz = np.array( [5.0, 8.0] ).astype(np.float64)
+    data_i = np.array( [50.0, 80.0] ).astype(np.float32)
+    spec.set_peaks( [data_mz,data_i] )
+
+    mz, ii = spec.get_peaks()
+    assert spec[0].getMZ() == 5.0
+    assert spec[1].getMZ() == 8.0
+    assert spec[0].getIntensity() == 50.0
+    assert spec[1].getIntensity() == 80.0
+    assert mz[0] == 5.0
+    assert mz[1] == 8.0
+    assert ii[0] == 50.0
+    assert ii[1] == 80.0
+
+    # Fast
+    spec.clear(False)
+    data_mz = np.array( [5.0, 8.0] ).astype(np.float64)
+    data_i = np.array( [50.0, 80.0] ).astype(np.float64)
+    spec.set_peaks( [data_mz,data_i] )
+
+    mz, ii = spec.get_peaks()
+    assert spec[0].getMZ() == 5.0
+    assert spec[1].getMZ() == 8.0
+    assert spec[0].getIntensity() == 50.0
+    assert spec[1].getIntensity() == 80.0
+    assert mz[0] == 5.0
+    assert mz[1] == 8.0
+    assert ii[0] == 50.0
+    assert ii[1] == 80.0
+
+    # Slow
+    spec.clear(False)
+    data_mz = np.array( [5.0, 8.0] ).astype(np.float32)
+    data_i = np.array( [50.0, 80.0] ).astype(np.float32)
+    spec.set_peaks( [data_mz,data_i] )
+
+    mz, ii = spec.get_peaks()
+    assert spec[0].getMZ() == 5.0
+    assert spec[1].getMZ() == 8.0
+    assert spec[0].getIntensity() == 50.0
+    assert spec[1].getIntensity() == 80.0
+    assert mz[0] == 5.0
+    assert mz[1] == 8.0
+    assert ii[0] == 50.0
+    assert ii[1] == 80.0
+
+    ###################################
     # get data arrays
+    ###################################
     assert len(spec.getStringDataArrays()) == 0
     string_da = [ pyopenms.StringDataArray() ]
     string_da[0].push_back("hello")

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -3212,6 +3212,73 @@ def testMSChromatogram():
 
     assert int(chrom.isSorted()) in  (0,1)
 
+    chrom.clear(False)
+    p = pyopenms.ChromatogramPeak()
+    p.setRT(1000.0)
+    p.setIntensity(200.0)
+    chrom.push_back(p)
+    p = pyopenms.ChromatogramPeak()
+    p.setRT(2000.0)
+    p.setIntensity(400.0)
+    chrom.push_back(p)
+
+    mz, ii = chrom.get_peaks()
+    assert chrom[0].getRT() == 1000.0
+    assert chrom[1].getRT() == 2000.0
+    assert chrom[0].getIntensity() == 200.0
+    assert chrom[1].getIntensity() == 400.0
+    assert mz[0] == 1000.0
+    assert mz[1] == 2000.0
+    assert ii[0] == 200.0
+    assert ii[1] == 400.0
+
+    chrom.clear(False)
+    data_mz = np.array( [5.0, 8.0] ).astype(np.float64)
+    data_i = np.array( [50.0, 80.0] ).astype(np.float32)
+    chrom.set_peaks( [data_mz,data_i] )
+
+    mz, ii = chrom.get_peaks()
+    assert chrom[0].getRT() == 5.0
+    assert chrom[1].getRT() == 8.0
+    assert chrom[0].getIntensity() == 50.0
+    assert chrom[1].getIntensity() == 80.0
+    assert mz[0] == 5.0
+    assert mz[1] == 8.0
+    assert ii[0] == 50.0
+    assert ii[1] == 80.0
+
+    # Fast
+    chrom.clear(False)
+    data_mz = np.array( [5.0, 8.0] ).astype(np.float64)
+    data_i = np.array( [50.0, 80.0] ).astype(np.float64)
+    chrom.set_peaks( [data_mz,data_i] )
+
+    mz, ii = chrom.get_peaks()
+    assert chrom[0].getRT() == 5.0
+    assert chrom[1].getRT() == 8.0
+    assert chrom[0].getIntensity() == 50.0
+    assert chrom[1].getIntensity() == 80.0
+    assert mz[0] == 5.0
+    assert mz[1] == 8.0
+    assert ii[0] == 50.0
+    assert ii[1] == 80.0
+
+    # Slow
+    chrom.clear(False)
+    data_mz = np.array( [5.0, 8.0] ).astype(np.float32)
+    data_i = np.array( [50.0, 80.0] ).astype(np.float32)
+    chrom.set_peaks( [data_mz,data_i] )
+
+    mz, ii = chrom.get_peaks()
+    assert chrom[0].getRT() == 5.0
+    assert chrom[1].getRT() == 8.0
+    assert chrom[0].getIntensity() == 50.0
+    assert chrom[1].getIntensity() == 80.0
+    assert mz[0] == 5.0
+    assert mz[1] == 8.0
+    assert ii[0] == 50.0
+    assert ii[1] == 80.0
+
 @report
 def testMRMFeature():
     """


### PR DESCRIPTION
some performance improvements when shuttling data between C++ and Python. Specifically when using numpy arrays instead of Python lists we get improvements:

```
  -- with list:
  100 loops, best of 3: 2.7 msec per loop -- version 2.3.0.4
  100 loops, best of 3: 2.48 msec per loop
  -- with numpy arrays:
  1000 loops, best of 3: 662 usec per loop
```