### PR TITLE
[FEATURE] Compute Percolator features across replicates

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/PercolatorFeatureSetHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PercolatorFeatureSetHelper.h
@@ -157,6 +157,15 @@ namespace OpenMS
         static void addCONCATSEFeatures(std::vector<PeptideIdentification>& peptide_id_list, StringList& search_engines_used, StringList& feature_set);
 
         /**
+         * @brief addREPLICATEFeatures
+         * @param peptide_id_list PeptideIdentification vector to create Percolator features in
+         * @param feature_set register of added features
+         *
+         * Creates and adds Percolator features across replicates and registers them in feature_set
+         */
+        static void addREPLICATEFeatures(std::vector<PeptideIdentification>& peptide_id_list, StringList& feature_set);
+
+        /**
          * @brief checkExtraFeatures
          * @param psms the vector of PeptideHit to be checked
          * @param extra_features the list of requested extra features

--- a/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
+++ b/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
@@ -405,11 +405,11 @@ namespace OpenMS
                   double score = inner_pep->getScore();
                   if (is_e_value) score = -log(score + 0.0001);
 
-                  if (outer_pep->getMetaValue("TMP:sources") == inner_pep->getMetaValue("TMP:sources"))  // PSMs from different runs
+                  if (outer_pep->getMetaValue("TMP:sources") == inner_pep->getMetaValue("TMP:sources"))  // PSMs from the same run
                   {
                     replicate_spectra += score;
                   }
-                  else  // PSMs from the same run
+                  else  // PSMs from different runs
                   {
                     sibling_experiments += score;
                   }

--- a/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
+++ b/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
@@ -316,7 +316,7 @@ namespace OpenMS
         for (vector<PeptideHit>::iterator hit = it->getHits().begin(); hit != it->getHits().end(); ++hit)
         {
           String sequence = hit->getSequence().toUnmodifiedString();
-          String sources = hit->getMetaValue("TMP:sources").toString();
+          String sources = hit->getMetaValue("TMP:sources");
           matches[sequence][sources].push_back(*hit);
         }
       }
@@ -336,7 +336,7 @@ namespace OpenMS
           for (std::map<String, vector<PeptideHit>>::iterator item = match_group.begin(); item != match_group.end(); ++item)
           {
             String sources = item->first;
-            if (sources != hit->getMetaValue("TMP:sources").toString())
+            if (sources != hit->getMetaValue("TMP:sources"))
             {
               vector<PeptideHit> peptide_matches = item->second;
 
@@ -421,7 +421,7 @@ namespace OpenMS
                   double score = inner_pep->getScore();
                   if (is_e_value) score = -log(score + 0.0001);
 
-                  if (outer_pep->getMetaValue("TMP:sources").toString() == inner_pep->getMetaValue("TMP:sources").toString())  // PSMs from different runs
+                  if (outer_pep->getMetaValue("TMP:sources") == inner_pep->getMetaValue("TMP:sources"))  // PSMs from different runs
                   {
                     replicate_spectra += score;
                   }

--- a/src/pyOpenMS/pxds/PercolatorFeatureSetHelper.pxd
+++ b/src/pyOpenMS/pxds/PercolatorFeatureSetHelper.pxd
@@ -22,5 +22,6 @@ cdef extern from "<OpenMS/ANALYSIS/ID/PercolatorFeatureSetHelper.h>" namespace "
         void addMASCOTFeatures(libcpp_vector[ PeptideIdentification ] & peptide_ids, StringList & feature_set) nogil except +
         void addMULTISEFeatures(libcpp_vector[ PeptideIdentification ] & peptide_ids, StringList & search_engines_used, StringList & feature_set, bool complete_only, bool limits_imputation) nogil except +
         void addCONCATSEFeatures(libcpp_vector[ PeptideIdentification ] & peptide_id_list, StringList & search_engines_used, StringList & feature_set) nogil except +
+        void addREPLICATEFeatures(libcpp_vector[ PeptideIdentification ] & peptide_ids, StringList & feature_set) nogil except +
         void checkExtraFeatures(libcpp_vector[ PeptideHit ] & psms, StringList & extra_features) nogil except +
 

--- a/src/utils/PSMFeatureExtractor.cpp
+++ b/src/utils/PSMFeatureExtractor.cpp
@@ -113,7 +113,7 @@ protected:
   {
     registerInputFileList_("in", "<files>", StringList(), "Input file(s)", true);
     setValidFormats_("in", ListUtils::create<String>("mzid,idXML"));
-    registerOutputFile_("out", "<file>", "", "Output file in mzid or idXML format", true);
+    registerOutputFileList_("out", "<files>", StringList(), "Output file(s)", true);
     setValidFormats_("out", ListUtils::create<String>("mzid,idXML"));
     registerStringList_("extra", "<MetaData parameter>", vector<String>(), "List of the MetaData parameters to be included in a feature set for precolator.", false, false);
     // setValidStrings_("extra", ?);
@@ -124,8 +124,32 @@ protected:
     registerFlag_("concat", "Naive merging of PSMs from different search engines: concatenate multiple search results instead of merging on scan level. Only valid together with -multiple_search_engines flag.", true);
     registerFlag_("impute", "Will instead of discarding all PSM not unanimously detected by all SE, impute missing values by their respective scores min/max observed. Only valid together with -multiple_search_engines flag.", true);
     registerFlag_("limit_imputation", "Will impute missing scores with the worst numerical limit (instead of min/max observed) of the respective score. Only valid together with -multiple_search_engines flag.", true);
+    registerFlag_("replicates", "Add features across multiple replicate runs analysed using the same search engine. Cannot be combined with -multiple_search_engines.", false);
   }
-  
+
+  void writeOutputToFile_(const String out, vector<PeptideIdentification>& peptide_ids, vector<ProteinIdentification>& protein_ids, StringList& feature_set, StringList& extra_features)
+  {
+    ProteinIdentification::SearchParameters search_parameters = protein_ids.front().getSearchParameters();
+    search_parameters.setMetaValue("feature_extractor", "TOPP_PSMFeatureExtractor");
+    feature_set.insert(feature_set.end(), extra_features.begin(), extra_features.end());
+    search_parameters.setMetaValue("extra_features", ListUtils::concatenate(feature_set, ","));
+    protein_ids.front().setSearchParameters(search_parameters);
+
+    // Storing the PeptideHits with calculated q-value, pep and svm score
+    FileTypes::Type out_type = FileHandler::getType(out);
+
+    LOG_INFO << "writing output file: " << out << endl;
+
+    if (out_type == FileTypes::IDXML)
+    {
+      IdXMLFile().store(out, protein_ids, peptide_ids);
+    }
+    else if (out_type == FileTypes::MZIDENTML)
+    {
+      MzIdentMLFile().store(out, protein_ids, peptide_ids);
+    }
+  }
+
   ExitCodes main_(int, const char**) override
   {
     //-------------------------------------------------------------
@@ -138,16 +162,36 @@ protected:
     // parsing parameters
     //-------------------------------------------------------------
     const StringList in_list = getStringList_("in");
+    const StringList out_list = getStringList_("out");
     bool multiple_search_engines = getFlag_("multiple_search_engines");
+    bool replicates = getFlag_("replicates");
     LOG_DEBUG << "Input file (of target?): " << ListUtils::concatenate(in_list, ",") << endl;
-    if (in_list.size() > 1 && !multiple_search_engines)
+
+    if (in_list.size() > 1 && !multiple_search_engines && !replicates)
     {
-      writeLog_("Fatal error: multiple input files given for -in, but -multiple_search_engines flag not specified. If the same search engine was used, feed the input files into PSMFeatureExtractor one by one.");
+      writeLog_("Fatal error: multiple input files given for -in, but -multiple_search_engines or -replicates flag not specified.");
       printUsage_();
       return ILLEGAL_PARAMETERS;
     }
-    
-    const String out(getStringOption_("out"));
+
+    if (multiple_search_engines && replicates)
+    {
+      writeLog_("Fatal error: both -multiple_search_engines and -replicates flag specified.");
+      printUsage_();
+      return ILLEGAL_PARAMETERS;
+    }
+
+    if (replicates && in_list.size() != out_list.size())
+    {
+      writeLog_("Fatal error: If -replicates flag is specified, please provide one output file for each input file.");
+      printUsage_();
+      return ILLEGAL_PARAMETERS;
+    }
+
+    if (!replicates && out_list.size() > 1)
+    {
+      LOG_WARN << "Multiple output files given for -out, but -replicates flag not specified. Output files other than the first one will be ignored." << endl;
+    }
 
     //-------------------------------------------------------------
     // read input
@@ -155,6 +199,7 @@ protected:
     bool skip_db_check = getFlag_("skip_db_check");
     bool concatenate = getFlag_("concat");
     StringList search_engines_used;
+    vector<Int> peptide_ids_range {0};
     for (StringList::const_iterator fit = in_list.begin(); fit != in_list.end(); ++fit)
     {
       vector<PeptideIdentification> peptide_ids;
@@ -175,7 +220,7 @@ protected:
       //else caught by TOPPBase:registerInput being mandatory mzid or idxml
 
       // will check if all ProteinIdentifications have the same search db unless it is the first, in which case all_protein_ids is empty yet.
-      if (multiple_search_engines && !skip_db_check && !all_protein_ids.empty())
+      if ((multiple_search_engines || replicates) && !skip_db_check && !all_protein_ids.empty())
       {
         ProteinIdentification::SearchParameters all_search_parameters = all_protein_ids.front().getSearchParameters();
         ProteinIdentification::SearchParameters search_parameters = protein_ids.front().getSearchParameters();
@@ -185,10 +230,31 @@ protected:
           return INCOMPATIBLE_INPUT_DATA;
         }
       }
-      
+
+      if (replicates)
+      {
+        // for each peptide hit, remember the file it originated from (will be removed after processing)
+        StringList sources;
+        protein_ids.front().getPrimaryMSRunPath(sources);
+        for (vector<PeptideIdentification>::iterator it = peptide_ids.begin(); it != peptide_ids.end(); ++it)
+        {
+          for (vector<PeptideHit>::iterator hit = it->getHits().begin(); hit != it->getHits().end(); ++hit)
+          {
+            hit->setMetaValue("TMP:sources", sources);
+          }
+        }
+
+        all_protein_ids.insert(all_protein_ids.end(), protein_ids.begin(), protein_ids.end());
+      }
+      else
+      {
+        PercolatorFeatureSetHelper::mergeMULTISEProteinIds(all_protein_ids, protein_ids);
+      }
+
       if (!multiple_search_engines)
       {
         all_peptide_ids.insert(all_peptide_ids.end(), peptide_ids.begin(), peptide_ids.end());
+        peptide_ids_range.push_back(all_peptide_ids.size());
       }
       else
       {
@@ -209,7 +275,6 @@ protected:
           PercolatorFeatureSetHelper::mergeMULTISEPeptideIds(all_peptide_ids, peptide_ids, search_engine);
         }
       }
-      PercolatorFeatureSetHelper::mergeMULTISEProteinIds(all_protein_ids, protein_ids);
     }
     
     if (all_protein_ids.empty())
@@ -252,40 +317,61 @@ protected:
       return INCOMPATIBLE_INPUT_DATA;
     }
 
-    String run_identifier = all_protein_ids.front().getIdentifier();
-    for (vector<PeptideIdentification>::iterator it = all_peptide_ids.begin(); it != all_peptide_ids.end(); ++it)
+    if (replicates)
     {
-      it->setIdentifier(run_identifier);
-      PercolatorFeatureSetHelper::checkExtraFeatures(it->getHits(), extra_features);  // will remove inconsistently available features
+      PercolatorFeatureSetHelper::addREPLICATEFeatures(all_peptide_ids, feature_set);
+
+      // remove temporary meta value storing a peptide hit's source
+      for (vector<PeptideIdentification>::iterator it = all_peptide_ids.begin(); it != all_peptide_ids.end(); ++it)
+      {
+        for (vector<PeptideHit>::iterator hit = it->getHits().begin(); hit != it->getHits().end(); ++hit)
+        {
+          hit->removeMetaValue("TMP:sources");
+        }
+      }
+
+      for (string::size_type i = 0; i < in_list.size(); ++i)
+      {
+        ProteinIdentification p = all_protein_ids[i];
+        vector<PeptideIdentification> peptide_ids(all_peptide_ids.begin() + peptide_ids_range[i], all_peptide_ids.begin() + peptide_ids_range[i + 1]);
+
+        String run_identifier = p.getIdentifier();
+        for (vector<PeptideIdentification>::iterator it = peptide_ids.begin(); it != peptide_ids.end(); ++it)
+        {
+          it->setIdentifier(run_identifier);
+          PercolatorFeatureSetHelper::checkExtraFeatures(it->getHits(), extra_features);  // will remove inconsistently available features
+        }
+      }
     }
-    
-    if (all_protein_ids.size() > 1)
+    else
+    {
+      String run_identifier = all_protein_ids.front().getIdentifier();
+      for (vector<PeptideIdentification>::iterator it = all_peptide_ids.begin(); it != all_peptide_ids.end(); ++it)
+      {
+        it->setIdentifier(run_identifier);
+        PercolatorFeatureSetHelper::checkExtraFeatures(it->getHits(), extra_features);  // will remove inconsistently available features
+      }
+    }
+
+    if ((!replicates && all_protein_ids.size() > 1) || (replicates && all_protein_ids.size() != in_list.size()))
     {
       LOG_ERROR << "Multiple identifications in one file are not supported. Please resume with separate input files. Quitting." << std::endl;
       return INCOMPATIBLE_INPUT_DATA;
     }
+
+    if (replicates)
+    {
+      for (string::size_type i = 0; i < out_list.size(); ++i)
+      {
+        vector<PeptideIdentification> peptide_ids(all_peptide_ids.begin() + peptide_ids_range[i], all_peptide_ids.begin() + peptide_ids_range[i + 1]);
+        vector<ProteinIdentification> protein_ids(1, all_protein_ids[i]);
+
+        writeOutputToFile_(out_list[i], peptide_ids, protein_ids, feature_set, extra_features);
+      }
+    }
     else
     {
-      ProteinIdentification::SearchParameters search_parameters = all_protein_ids.front().getSearchParameters();
-      
-      search_parameters.setMetaValue("feature_extractor", "TOPP_PSMFeatureExtractor");
-      feature_set.insert(feature_set.end(), extra_features.begin(), extra_features.end());
-      search_parameters.setMetaValue("extra_features", ListUtils::concatenate(feature_set, ","));
-      all_protein_ids.front().setSearchParameters(search_parameters);
-    }
-    
-    // Storing the PeptideHits with calculated q-value, pep and svm score
-    FileTypes::Type out_type = FileHandler::getType(out);
-    
-    LOG_INFO << "writing output file: " << out << endl;
-    
-    if (out_type == FileTypes::IDXML)
-    {
-      IdXMLFile().store(out, all_protein_ids, all_peptide_ids);
-    }
-    else if (out_type == FileTypes::MZIDENTML)
-    {
-      MzIdentMLFile().store(out, all_protein_ids, all_peptide_ids);
+      writeOutputToFile_(out_list[0], all_peptide_ids, all_protein_ids, feature_set, extra_features);
     }
 
     writeLog_("PSMFeatureExtractor finished successfully!");

--- a/src/utils/PSMFeatureExtractor.cpp
+++ b/src/utils/PSMFeatureExtractor.cpp
@@ -200,6 +200,7 @@ protected:
     bool concatenate = getFlag_("concat");
     StringList search_engines_used;
     vector<Int> peptide_ids_range {0};
+    int file_count = 0;
     for (StringList::const_iterator fit = in_list.begin(); fit != in_list.end(); ++fit)
     {
       vector<PeptideIdentification> peptide_ids;
@@ -233,6 +234,9 @@ protected:
 
       if (replicates)
       {
+        // update file count (serves as identifier)
+        file_count += 1;
+
         // for each peptide hit, remember the file it originated from (will be removed after processing)
         StringList sources;
         protein_ids.front().getPrimaryMSRunPath(sources);
@@ -241,6 +245,15 @@ protected:
           for (vector<PeptideHit>::iterator hit = it->getHits().begin(); hit != it->getHits().end(); ++hit)
           {
             hit->setMetaValue("TMP:sources", sources);
+
+            if (sources.empty())
+            {
+              hit->setMetaValue("TMP:sources", "file_" + to_string(file_count));
+            }
+            else
+            {
+              hit->setMetaValue("TMP:sources", hit->getMetaValue("TMP:sources").toString());
+            }
           }
         }
 


### PR DESCRIPTION
Add an option in `PSMFeatureExtractor` to compute Percolator features across multiple replicate runs (i.e. the same sample analysed multiple times). For each given input file, one output file is produced.  

Currently implemented features are more like suggestions / examples and include:
- identical unmodified peptide found in the same or other runs (bool)
- number of identical unmodified peptides found in the same and other runs
- same peptide with different modification found in the same or other runs (bool)
- number of different peptide modifications found in the same and other runs
- identical unmodified peptide found in other runs (bool)
- number of identical unmodified peptides found in other runs
- same peptide with different modification found in other runs (bool)
- number of different peptide modifications found in other runs