### PR TITLE
[FIX] allow multiple array names for IM

### DIFF
--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -681,11 +681,15 @@ namespace OpenMS
   // static
   bool TOPPViewBase::containsIMData(const MSSpectrum& s)
   {
-    if (s.getFloatDataArrays().empty() || s.getFloatDataArrays()[0].getName() != "Ion Mobility")
+    if (!s.getFloatDataArrays().empty() &&
+        (s.getFloatDataArrays()[0].getName() == "Ion Mobility" ||
+         s.getFloatDataArrays()[0].getName() == "ion mobility array" ||
+         s.getFloatDataArrays()[0].getName() == "ion mobility drift time")
+        )
     {
-      return false;
+      return true;
     }
-    return true;
+    return false;
   }
 
   float TOPPViewBase::estimateNoiseFromRandomMS1Scans(const ExperimentType& exp, UInt n_scans)


### PR DESCRIPTION
allow multiple different values for the ion mobility array, including 

```
[Term]
id: MS:1002893
name: ion mobility array
def: "An array of ion mobility data." [PSI:PI]
is_a: MS:1000513 ! binary data array
```