### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -98,7 +98,8 @@ Major changes in functionality:
   - OpenSWATH:
     - RT normalization now allows more models
     - Add S/N ratio for each ion trace
-    
+  - Support for C++11 (requires a compiler that supports C++11)
+
 Library:
   - TOPP tools report their peak memory usage when using -debug 1 (or higher)
   - idXML files can now be written faster (about 10%)


### PR DESCRIPTION
this was introduced with OpenMS 2.3 if I am not mistaken, see #2734 and

```
$ git log Release2.1.0 | grep -c 21ca45b2a90d853488938e945405ae26fc24d13c 
0
$ git log Release2.2.0 | grep -c 21ca45b2a90d853488938e945405ae26fc24d13c 
0
$ git log Release2.3.0 | grep -c 21ca45b2a90d853488938e945405ae26fc24d13c 
1
```