### PR TITLE
Update MSGFPlusAdapter.cpp

### DIFF
--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -299,6 +299,11 @@ protected:
       f.getOptions().addMSLevel(2);
       f.load(exp_name, exp);
       exp.getPrimaryMSRunPath(primary_ms_run_path_);
+      // if no primary run is assigned, the mzML file is the (unprocessed) primary file
+      if (primary_ms_run_path_.empty())
+      {
+        primary_ms_run_path_.push_back(exp_name);
+      }
 
       if (exp.getSpectra().empty())
       {


### PR DESCRIPTION
if the mzML file was directly fed into MSGFPlus, the primary run is not annotated in the ID file