### PR TITLE
[FIX] annotate "spectra_data"

### DIFF
--- a/src/tests/topp/FeatureFinderMetabo_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderMetabo_1_output.featureXML
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.9" id="fm_7459857709672936328" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.9" id="fm_7459857709672936328" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<UserParam type="stringList" name="spectra_data" value="[file://./EU_Gliadinextrakt_100ng_25bis40in90min2.RAW]"/>
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderMetabo" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureFinderMetabo_2_noEPD_output.featureXML
+++ b/src/tests/topp/FeatureFinderMetabo_2_noEPD_output.featureXML
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.9" id="fm_2927519776102075938" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.9" id="fm_2927519776102075938" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<UserParam type="stringList" name="spectra_data" value="[file:///M:/projects/LipidsQuant/identifyByFullScan/results/20150225_QExactiveNanoMate_testSeries/20150224_e11_blank_WAT_280k.mzML]"/>
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderMetabo" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/tests/topp/FeatureFinderMetabo_4_output.featureXML
+++ b/src/tests/topp/FeatureFinderMetabo_4_output.featureXML
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.9" id="fm_15004869347769368353" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.9" id="fm_15004869347769368353" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<UserParam type="stringList" name="spectra_data" value="[file:///Y:\AG backups\licha\20160215 Metabo Extraktionsmethoden\Analytisch\RP\TOP 5\Metaboextraction pos/005_DaLi_H9M9_Pool_MeOH_1_pos_08.raw]"/>
 	<dataProcessing completion_time="1999-12-31T23:59:59">
 		<software name="FeatureFinderMetabo" version="version_string" />
 		<processingAction name="Quantitation" />

--- a/src/topp/FeatureFinderMetabo.cpp
+++ b/src/topp/FeatureFinderMetabo.cpp
@@ -285,12 +285,7 @@ protected:
     ffm_param.setValue("report_chromatograms", report_chromatograms);
 
     FeatureMap feat_map;
-    StringList ms_runs;
-    ms_peakmap.getPrimaryMSRunPath(ms_runs);
-    feat_map.setPrimaryMSRunPath(ms_runs);
-
     std::vector< std::vector< OpenMS::MSChromatogram > > feat_chromatograms;
-
     FeatureFindingMetabo ffmet;
     ffmet.setParameters(ffm_param);
     ffmet.run(m_traces_final, feat_map, feat_chromatograms);
@@ -366,10 +361,15 @@ protected:
     // annotate output with data processing info
     addDataProcessing_(feat_map, getProcessingInfo_(DataProcessing::QUANTITATION));
 
+    // annotate "spectra_data" metavalue
+    StringList ms_runs;
+    ms_peakmap.getPrimaryMSRunPath(ms_runs);
+    feat_map.setPrimaryMSRunPath(ms_runs);
+
     FeatureXMLFile feature_xml_file;
     feature_xml_file.setLogType(log_type_);
     feature_xml_file.store(out, feat_map);
-
+  
     return EXECUTION_OK;
   }
 


### PR DESCRIPTION
Annotation was set beforehand but lost on the way.

This will fix the issue. The fix is critical for the Release 2.4.0, since the Pipeline using the FeautreFinderMetabo will otherwise not annotate the filenames correctly.
The tools used further downstream will use "UNKOWN" instead.

(cheery-picked commit 35caee889efd87002dbb1243e1d3c9b9e769c772)

@hroest thank you for the suggestion