### PR TITLE
[INTERNAL] Removed namespace std header declaration

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/IDConflictResolverAlgorithm.h
@@ -45,7 +45,7 @@
 #include <algorithm>
 
 using namespace OpenMS;
-using namespace std;
+using std::vector;
 
 //-------------------------------------------------------------
 // Doxygen docu


### PR DESCRIPTION
As accordance to section: [Coding conventions - Coding Style - General Rules - Namespaces](https://github.com/OpenMS/OpenMS/wiki/Coding-conventions#gen_rules).
.