### PR TITLE
[FIX] reduce size of meta data

### DIFF
--- a/src/openms/include/OpenMS/METADATA/MetaInfo.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfo.h
@@ -40,6 +40,8 @@
 #include <OpenMS/METADATA/MetaInfoRegistry.h>
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
 
+#include <boost/container/flat_map.hpp>
+
 namespace OpenMS
 {
   class String;
@@ -119,7 +121,7 @@ public:
     void clear();
 
 private:
-    using MapType = std::map<UInt, DataValue>;
+    using MapType = boost::container::flat_map<UInt, DataValue>;
     /// Static MetaInfoRegistry
     static MetaInfoRegistry registry_;
     /// The actual mapping of indexes to values


### PR DESCRIPTION
Small change to reduce the size of meta info interface
before:
Memory usage (loading consensusXML): 2205 MB (working set delta)
FileInfo took 02:41 m (wall), 02:41 m (CPU), 2.10 s (system), 02:39 m (user).
after:
Memory usage (loading consensusXML): 1638 MB (working set delta)
FileInfo took 02:32 m (wall), 02:32 m (CPU), 1.72 s (system), 02:30 m (user).
