### PR TITLE
[INTERNAL, FEATURE] Refactor of SvmTheoreticalSpectrumGeneratorSet

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.h
@@ -61,29 +61,7 @@ namespace OpenMS
   class OPENMS_DLLAPI SvmTheoreticalSpectrumGeneratorSet
   {
 public:
-
-    /** @name Constructors and Destructors
-     */
-    //@{
-    /// Default constructor
-    SvmTheoreticalSpectrumGeneratorSet();
-
-    /// Copy constructor
-    SvmTheoreticalSpectrumGeneratorSet(const SvmTheoreticalSpectrumGeneratorSet & source);
-
-    /// Move Constructor
-    SvmTheoreticalSpectrumGeneratorSet(SvmTheoreticalSpectrumGeneratorSet&& source) noexcept;
-
-    /// Destructor
-    virtual ~SvmTheoreticalSpectrumGeneratorSet();
-    //@}
-
-    /// Assignment operator
-    SvmTheoreticalSpectrumGeneratorSet & operator=(const SvmTheoreticalSpectrumGeneratorSet & tsg);
-
-    /// Move Assignment operator
-    SvmTheoreticalSpectrumGeneratorSet & operator=(SvmTheoreticalSpectrumGeneratorSet&& tsg) noexcept;
-
+    // Rule of Zero in effect for this class.
 
     /// Generate the MS/MS according to the model for the given precursor_charge
     void simulate(PeakSpectrum & spectrum, const AASequence & peptide, boost::random::mt19937_64& rng, Size precursor_charge);

--- a/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.h
@@ -82,7 +82,7 @@ public:
     void simulate(PeakSpectrum & spectrum, const AASequence & peptide, boost::random::mt19937_64& rng, Size precursor_charge);
 
     ///Load a trained Svm and Prob. models
-    void load(String);
+    void load(String filename);
 
     ///Return precursor charges for which a model is contained in the set
     void getSupportedCharges(std::set<Size> & charges);

--- a/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.h
@@ -71,12 +71,19 @@ public:
     /// Copy constructor
     SvmTheoreticalSpectrumGeneratorSet(const SvmTheoreticalSpectrumGeneratorSet & source);
 
+    /// Move Constructor
+    SvmTheoreticalSpectrumGeneratorSet(SvmTheoreticalSpectrumGeneratorSet&& source) noexcept;
+
     /// Destructor
     virtual ~SvmTheoreticalSpectrumGeneratorSet();
     //@}
 
     /// Assignment operator
     SvmTheoreticalSpectrumGeneratorSet & operator=(const SvmTheoreticalSpectrumGeneratorSet & tsg);
+
+    /// Move Assignment operator
+    SvmTheoreticalSpectrumGeneratorSet & operator=(SvmTheoreticalSpectrumGeneratorSet&& tsg) noexcept;
+
 
     /// Generate the MS/MS according to the model for the given precursor_charge
     void simulate(PeakSpectrum & spectrum, const AASequence & peptide, boost::random::mt19937_64& rng, Size precursor_charge);

--- a/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.cpp
+++ b/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.cpp
@@ -67,8 +67,8 @@ namespace OpenMS
   // Generate the MS/MS according to the given probabilistic model
   void SvmTheoreticalSpectrumGeneratorSet::simulate(PeakSpectrum& spectrum, const AASequence& peptide, boost::random::mt19937_64& rng, Size precursor_charge)
   {
-    std::map<Size, SvmTheoreticalSpectrumGenerator>::iterator it = simulators_.find(precursor_charge);
-    if (it != simulators_.end())
+    auto it = simulators_.find(precursor_charge);
+    if (it != std::end(simulators_))
     {
       it->second.simulate(spectrum, peptide, rng, precursor_charge);
     }
@@ -127,12 +127,13 @@ namespace OpenMS
   //return a modifiable reference to the SVM model with given charge. If charge is not supported throw exception
   SvmTheoreticalSpectrumGenerator& SvmTheoreticalSpectrumGeneratorSet::getSvmModel(Size prec_charge)
   {
-    std::map<Size, SvmTheoreticalSpectrumGenerator>::iterator it = simulators_.find(prec_charge);
-    if (it == simulators_.end())
+    auto it = simulators_.find(prec_charge);
+    if (it != std::end(simulators_))
     {
-      throw OpenMS::Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Invalid Precursor charge, no Model available", String(prec_charge));
+      return it->second;
     }
-    return it->second;
+
+    throw OpenMS::Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Invalid Precursor charge, no Model available", String(prec_charge));
   }
 
 }

--- a/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.cpp
+++ b/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.cpp
@@ -118,11 +118,10 @@ namespace OpenMS
   void SvmTheoreticalSpectrumGeneratorSet::getSupportedCharges(std::set<Size>& charges)
   {
     charges.clear();
-    std::map<Size, SvmTheoreticalSpectrumGenerator>::const_iterator it;
-    for (it = simulators_.begin(); it != simulators_.end(); ++it)
-    {
-      charges.insert(it->first);
-    }
+
+    std::transform(std::begin(simulators_), std::end(simulators_),
+                   std::inserter(charges, std::begin(charges)),
+                   [] (std::pair<Size, SvmTheoreticalSpectrumGenerator> it) { return it.first; });
   }
 
   //return a modifiable reference to the SVM model with given charge. If charge is not supported throw exception

--- a/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.cpp
+++ b/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.cpp
@@ -39,30 +39,18 @@ namespace OpenMS
 {
 
   // Default constructor
-  SvmTheoreticalSpectrumGeneratorSet::SvmTheoreticalSpectrumGeneratorSet()
-  {
-  }
-
+  SvmTheoreticalSpectrumGeneratorSet::SvmTheoreticalSpectrumGeneratorSet() = default;
   // Copy constructor
-  SvmTheoreticalSpectrumGeneratorSet::SvmTheoreticalSpectrumGeneratorSet(const SvmTheoreticalSpectrumGeneratorSet& source) :
-    simulators_(source.simulators_)
-  {
-  }
-
+  SvmTheoreticalSpectrumGeneratorSet::SvmTheoreticalSpectrumGeneratorSet(const SvmTheoreticalSpectrumGeneratorSet&) = default;
+  // Move constructor
+  SvmTheoreticalSpectrumGeneratorSet::SvmTheoreticalSpectrumGeneratorSet(SvmTheoreticalSpectrumGeneratorSet&&) noexcept = default;
   //Destructor
-  SvmTheoreticalSpectrumGeneratorSet::~SvmTheoreticalSpectrumGeneratorSet()
-  {
-  }
+  SvmTheoreticalSpectrumGeneratorSet::~SvmTheoreticalSpectrumGeneratorSet() = default;
 
   // Assignment operator
-  SvmTheoreticalSpectrumGeneratorSet& SvmTheoreticalSpectrumGeneratorSet::operator=(const SvmTheoreticalSpectrumGeneratorSet& rhs)
-  {
-    if (this != &rhs)
-    {
-      simulators_ = rhs.simulators_;
-    }
-    return *this;
-  }
+  SvmTheoreticalSpectrumGeneratorSet& SvmTheoreticalSpectrumGeneratorSet::operator=(const SvmTheoreticalSpectrumGeneratorSet&) = default;
+  // Move Assignment operator
+  SvmTheoreticalSpectrumGeneratorSet& SvmTheoreticalSpectrumGeneratorSet::operator=(SvmTheoreticalSpectrumGeneratorSet&&) noexcept = default;
 
   // Generate the MS/MS according to the given probabilistic model
   void SvmTheoreticalSpectrumGeneratorSet::simulate(PeakSpectrum& spectrum, const AASequence& peptide, boost::random::mt19937_64& rng, Size precursor_charge)

--- a/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.cpp
+++ b/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGeneratorSet.cpp
@@ -37,21 +37,6 @@
 
 namespace OpenMS
 {
-
-  // Default constructor
-  SvmTheoreticalSpectrumGeneratorSet::SvmTheoreticalSpectrumGeneratorSet() = default;
-  // Copy constructor
-  SvmTheoreticalSpectrumGeneratorSet::SvmTheoreticalSpectrumGeneratorSet(const SvmTheoreticalSpectrumGeneratorSet&) = default;
-  // Move constructor
-  SvmTheoreticalSpectrumGeneratorSet::SvmTheoreticalSpectrumGeneratorSet(SvmTheoreticalSpectrumGeneratorSet&&) noexcept = default;
-  //Destructor
-  SvmTheoreticalSpectrumGeneratorSet::~SvmTheoreticalSpectrumGeneratorSet() = default;
-
-  // Assignment operator
-  SvmTheoreticalSpectrumGeneratorSet& SvmTheoreticalSpectrumGeneratorSet::operator=(const SvmTheoreticalSpectrumGeneratorSet&) = default;
-  // Move Assignment operator
-  SvmTheoreticalSpectrumGeneratorSet& SvmTheoreticalSpectrumGeneratorSet::operator=(SvmTheoreticalSpectrumGeneratorSet&&) noexcept = default;
-
   // Generate the MS/MS according to the given probabilistic model
   void SvmTheoreticalSpectrumGeneratorSet::simulate(PeakSpectrum& spectrum, const AASequence& peptide, boost::random::mt19937_64& rng, Size precursor_charge)
   {

--- a/src/tests/class_tests/openms/source/SvmTheoreticalSpectrumGeneratorSet_test.cpp
+++ b/src/tests/class_tests/openms/source/SvmTheoreticalSpectrumGeneratorSet_test.cpp
@@ -65,8 +65,16 @@ START_SECTION(SvmTheoreticalSpectrumGeneratorSet(const SvmTheoreticalSpectrumGen
   NOT_TESTABLE //is tested in getSupportedCharges test
 END_SECTION
 
+START_SECTION(SvmTheoreticalSpectrumGeneratorSet(SvmTheoreticalSpectrumGeneratorSet&& source))
+  NOT_TESTABLE
+END_SECTION
+
 START_SECTION(SvmTheoreticalSpectrumGeneratorSet& operator =(const SvmTheoreticalSpectrumGeneratorSet& tsg))
   NOT_TESTABLE //is tested in getSupportedCharges test
+END_SECTION
+
+START_SECTION(SvmTheoreticalSpectrumGeneratorSet& operator =(SvmTheoreticalSpectrumGeneratorSet&& tsg))
+  NOT_TESTABLE
 END_SECTION
 
 START_SECTION(~SvmTheoreticalSpectrumGeneratorSet())

--- a/src/tests/class_tests/openms/source/SvmTheoreticalSpectrumGeneratorSet_test.cpp
+++ b/src/tests/class_tests/openms/source/SvmTheoreticalSpectrumGeneratorSet_test.cpp
@@ -75,7 +75,7 @@ END_SECTION
 
 SvmTheoreticalSpectrumGeneratorSet gen_set;
 
-START_SECTION(void load(String))
+START_SECTION(void load(String filename))
     gen_set.load("examples/simulation/SvmModelSet.model");
     NOT_TESTABLE //is implicitly tested by the following two tests
 END_SECTION


### PR DESCRIPTION
As according to:
C++ Core Guidelines:
* [C.defop.20 - If you can avoid defining default operations, do.](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-zero)
* [C.copy.62 - Make copy assignment safe for self-assignment.](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-copy-self)
* [P.3 - Express intent.](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rp-what)
* [P.13 - Use support libraries as appropriate.](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rp-lib)
* [F.def.1 - "Package" meaningful operations as carefully named functions.](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-package)

Clang-Tidy:  
* [modernize-use-auto](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html#iterators)

Notes / Observations:
* [N4165 - Unified Call Syntax](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4165.pdf)
