### PR TITLE
Feature/move semantics

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -46,7 +46,7 @@
 namespace OpenMS
 {
 
-  //forward declarations
+  // forward declarations
   class ResidueModification;
 
   /**
@@ -112,7 +112,7 @@ public:
 
     /** @brief ConstIterator for AASequence
 
-               AASequence constant iterator
+        AASequence constant iterator
     */
     class OPENMS_DLLAPI ConstIterator
     {
@@ -247,7 +247,7 @@ protected:
 
     /** @brief Iterator class for AASequence
 
-            Mutable iterator for AASequence
+        Mutable iterator for AASequence
     */
     class OPENMS_DLLAPI Iterator
     {
@@ -379,18 +379,25 @@ protected:
     /** @name Constructors and Destructors
     */
     //@{
-    /// default constructor
+
+    /// Default constructor
     AASequence();
 
-    /// copy constructor
-    AASequence(const AASequence& rhs);
+    /// Copy constructor
+    AASequence(const AASequence& rhs) = default;
 
-    /// destructor
+    /// Move constructor
+    AASequence(AASequence&&) = default;
+
+    /// Destructor
     virtual ~AASequence();
     //@}
 
-    /// assignment operator
-    AASequence& operator=(const AASequence& rhs);
+    /// Assignment operator
+    AASequence& operator=(const AASequence& rhs) = default;
+
+    /// Move assignment operator
+    AASequence& operator=(AASequence&&) & = default;
 
     /// check if sequence is empty
     bool empty() const;
@@ -582,6 +589,7 @@ protected:
                                  bool permissive = true);
 
   protected:
+
     std::vector<const Residue*> peptide_;
 
     const ResidueModification* n_term_mod_;

--- a/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzyme.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzyme.h
@@ -56,24 +56,30 @@ namespace OpenMS
     /** @name Constructors
     */
     //@{
-    /// copy constructor
-    DigestionEnzyme(const DigestionEnzyme& enzyme);
+    /// Copy constructor
+    DigestionEnzyme(const DigestionEnzyme& enzyme) = default;
 
-    /// detailed constructor
+    /// Move constructor
+    DigestionEnzyme(DigestionEnzyme&&) = default;
+
+    /// Detailed constructor
     explicit DigestionEnzyme(const String& name,
                              const String& cleavage_regex,
                              const std::set<String>& synonyms = std::set<String>(),
                              String regex_description = "");
 
-    /// destructor
+    /// Destructor
     virtual ~DigestionEnzyme();
     //@}
 
     /** @name Assignment
      */
     //@{
-    /// assignment operator
-    DigestionEnzyme& operator=(const DigestionEnzyme& enzyme);
+    /// Assignment operator
+    DigestionEnzyme& operator=(const DigestionEnzyme& enzyme) = default;
+
+    /// Move assignment operator
+    DigestionEnzyme& operator=(DigestionEnzyme&&) & = default;
     //@}
 
     /** Accessors
@@ -137,6 +143,7 @@ namespace OpenMS
     friend OPENMS_DLLAPI std::ostream& operator<<(std::ostream& os, const DigestionEnzyme& enzyme);
 
   protected:
+
     /// default constructor
     DigestionEnzyme();
 

--- a/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeProtein.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeProtein.h
@@ -45,20 +45,25 @@ namespace OpenMS
 
       @brief Representation of a digestion enzyme for proteins (protease)
   */
-  class OPENMS_DLLAPI DigestionEnzymeProtein: public DigestionEnzyme
+  class OPENMS_DLLAPI DigestionEnzymeProtein :
+    public DigestionEnzyme
   {
   public:
 
     /** @name Constructors
     */
     //@{
-    /// default constructor
+
+    /// Default constructor
     DigestionEnzymeProtein();
 
-    /// copy constructor
-    DigestionEnzymeProtein(const DigestionEnzymeProtein& enzyme);
+    /// Copy constructor
+    DigestionEnzymeProtein(const DigestionEnzymeProtein& enzyme) = default;
 
-    /// detailed constructor
+    /// Move constructor
+    DigestionEnzymeProtein(DigestionEnzymeProtein&&) = default;
+
+    /// Detailed constructor
     explicit DigestionEnzymeProtein(const String& name,
                                     const String& cleavage_regex,
                                     const std::set<String>& synonyms = std::set<String>(),
@@ -72,15 +77,18 @@ namespace OpenMS
                                     Int msgf_id = -1,
                                     Int omssa_id = -1);
 
-    /// destructor
+    /// Destructor
     ~DigestionEnzymeProtein() override;
     //@}
 
     /** @name Assignment
      */
     //@{
-    /// assignment operator
-    DigestionEnzymeProtein& operator=(const DigestionEnzymeProtein& enzyme);
+    /// Assignment operator
+    DigestionEnzymeProtein& operator=(const DigestionEnzymeProtein& enzyme) = default;
+
+    /// Move assignment operator
+    DigestionEnzymeProtein& operator=(DigestionEnzymeProtein&&) & = default;
     //@}
 
     /** Accessors

--- a/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/EmpiricalFormula.h
@@ -41,7 +41,6 @@
 
 #include <OpenMS/CONCEPT/Types.h>
 
-
 namespace OpenMS
 {
   class String;
@@ -50,6 +49,7 @@ namespace OpenMS
   class IsotopeDistribution;
   class IsotopePatternGenerator;
   class CoarseIsotopePatternGenerator;
+
   /**
     @ingroup Chemistry
 
@@ -99,11 +99,14 @@ public:
     /** @name Constructors and Destructors
     */
     //@{
-    /// default constructor
+    /// Default constructor
     EmpiricalFormula();
 
-    /// copy constructor
-    EmpiricalFormula(const EmpiricalFormula& rhs);
+    /// Copy constructor
+    EmpiricalFormula(const EmpiricalFormula& rhs) = default;
+
+    /// Move constructor
+    EmpiricalFormula(EmpiricalFormula&&) = default;
 
     /**
       Constructor from an OpenMS String
@@ -112,14 +115,12 @@ public:
     */
     explicit EmpiricalFormula(const String& rhs);
 
-    /// constructor with element pointer and number
+    /// Constructor with element pointer and number
     EmpiricalFormula(SignedSize number, const Element* element, SignedSize charge = 0);
 
-    /// destructor
+    /// Destructor
     virtual ~EmpiricalFormula();
     //@}
-
-
 
     /** @name Accessors
     */
@@ -184,7 +185,9 @@ public:
       @param method: the method that will be used for the calculation of the IsotopeDistribution
       @return the conditional IsotopeDistribution of the fragment
     */
-    IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes, const CoarseIsotopePatternGenerator& method) const;
+    IsotopeDistribution getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor,
+                                                          const std::set<UInt>& precursor_isotopes,
+                                                          const CoarseIsotopePatternGenerator& method) const;
 
     /// returns the number of atoms for a certain @p element (can be negative)
     SignedSize getNumberOf(const Element* element) const;
@@ -208,8 +211,12 @@ public:
     /** Assignment
     */
     //@{
-    /// assignment operator
-    EmpiricalFormula& operator=(const EmpiricalFormula& rhs);
+
+    /// Assignment operator
+    EmpiricalFormula& operator=(const EmpiricalFormula& rhs) = default;
+
+    /// Move assignment operator
+    EmpiricalFormula& operator=(EmpiricalFormula&&) & = default;
 
     /// adds the elements of the given formula
     EmpiricalFormula& operator+=(const EmpiricalFormula& rhs);

--- a/src/openms/include/OpenMS/CHEMISTRY/Residue.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/Residue.h
@@ -177,27 +177,35 @@ public:
     /** @name Constructors
     */
     //@{
-    /// default constructor
+
+    /// Default constructor
     Residue();
 
-    /// copy constructor
-    Residue(const Residue& residue);
+    /// Copy constructor
+    Residue(const Residue& residue) = default;
 
-    /// detailed constructor
+    /// Move constructor
+    Residue(Residue&&) = default;
+
+    /// Detailed constructor
     Residue(const String& name,
             const String& three_letter_code,
             const String& one_letter_code,
             const EmpiricalFormula& formula);
 
-    /// destructor
+    /// Destructor
     virtual ~Residue();
     //@}
 
     /** @name Assignment
      */
     //@{
-    /// assignment operator
-    Residue& operator=(const Residue& residue);
+
+    /// Assignment operator
+    Residue& operator=(const Residue& residue) = default;
+
+    /// Move assignment operator
+    Residue& operator=(Residue&&) & = default;
     //@}
 
     /** @name Accessors

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueModification.h
@@ -129,21 +129,29 @@ public:
     /** @name Constructors and Destructors
     */
     //@{
-    /// default constructor
+
+    /// Default constructor
     ResidueModification();
 
-    /// copy constructor
-    ResidueModification(const ResidueModification& modification);
+    /// Copy constructor
+    ResidueModification(const ResidueModification& modification) = default;
 
-    /// destructor
+    /// Move constructor
+    ResidueModification(ResidueModification&&) = default;
+
+    /// Destructor
     virtual ~ResidueModification();
     //@}
 
     /** @name Assignment operator
     */
     //@{
-    /// assignment operator
-    ResidueModification& operator=(const ResidueModification& modification);
+
+    /// Assignment operator
+    ResidueModification& operator=(const ResidueModification& modification) = default;
+
+    /// Move assignment operator
+    ResidueModification& operator=(ResidueModification&&) & = default;
     //@}
 
     /** @name Accessors

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Date.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Date.h
@@ -60,14 +60,18 @@ public:
 
         Fills the object with an undefined date: 00/00/0000
     */
-    Date();
+    Date() = default;
     /// Copy constructor
-    Date(const Date& date);
+    Date(const Date& date) = default;
     /// Copy constructor from Qt base class
     Date(const QDate& date);
+    /// Move constructor
+    Date(Date&&) = default;
 
     /// Assignment operator
-    Date& operator=(const Date& source);
+    Date& operator=(const Date& source) = default;
+    /// Move assignment operator
+    Date& operator=(Date&&) & = default;
 
     /**
         @brief sets data from a string

--- a/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DateTime.h
@@ -66,9 +66,13 @@ public:
     DateTime(const DateTime& date);
     /// Copy constructor from Qt base class
     DateTime(const QDateTime& date);
+    /// Move constructor
+    DateTime(DateTime&&) = default;
 
     /// Assignment operator
     DateTime& operator=(const DateTime& source);
+    /// Move assignment operator
+    DateTime& operator=(DateTime&&) & = default;
 
     /**
         @brief sets date from a string

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Map.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Map.h
@@ -120,7 +120,6 @@ public:
     /// Return a mutable reference to the element whose key is @p key. If an element with the key @p key does not exist, it is inserted.
     T& operator[](const Key& key);
 
-
     inline bool equals(const Map<Key, T>& other) const
     {
       return operator==(

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors:  Marc Sturm, Clemens Groepl $
+// $Authors: Marc Sturm, Clemens Groepl $
 // --------------------------------------------------------------------------
 
 #pragma once
@@ -83,9 +83,16 @@ public:
       /// Constructor with name, description, value and advanced flag
       ParamEntry(const String& n, const DataValue& v, const String& d, const StringList& t = StringList());
       /// Copy constructor
-      ParamEntry(const ParamEntry& other);
+      ParamEntry(const ParamEntry& other) = default;
+      /// Move constructor
+      ParamEntry(ParamEntry&&) = default;
       /// Destructor
       ~ParamEntry();
+
+      /// Assignment operator
+      ParamEntry& operator=(const ParamEntry& rhs) = default;
+      /// Move assignment operator
+      ParamEntry& operator=(ParamEntry&&) & = default;
 
       /// Check if 'value' fulfills restrictions
       bool isValid(String& message) const;
@@ -122,13 +129,23 @@ public:
       ///Iterator for entries
       typedef std::vector<ParamEntry>::const_iterator ConstEntryIterator;
 
-      ///Default constructor
+      /// Default constructor
       ParamNode();
-      ///Constructor with name and description
+      /// Constructor with name and description
       ParamNode(const String& n, const String& d);
+      /// Copy constructor
+      ParamNode(const ParamNode& other) = default;
+      /// Move constructor
+      ParamNode(ParamNode&&) = default;
       /// Destructor
       ~ParamNode();
-      ///Equality operator (name, entries and subnodes are compared)
+
+      /// Assignment operator
+      ParamNode& operator=(const ParamNode& rhs) = default;
+      /// Move assignment operator
+      ParamNode& operator=(ParamNode&&) & = default;
+
+      /// Equality operator (name, entries and subnodes are compared)
       bool operator==(const ParamNode& rhs) const;
 
       /**
@@ -239,13 +256,19 @@ protected:
     Param();
 
     /// Copy constructor
-    Param(const Param& rhs);
+    Param(const Param& rhs) = default;
+
+    /// Move constructor
+    Param(Param&&) = default;
 
     /// Destructor
     ~Param();
 
     /// Assignment operator
-    Param& operator=(const Param& rhs);
+    Param& operator=(const Param& rhs) = default;
+
+    /// Move assignment operator
+    Param& operator=(Param&&) & = default;
 
     /// Equality operator
     bool operator==(const Param& rhs) const;
@@ -307,9 +330,6 @@ protected:
       @return Returns end() if leaf does not exist.
     */
     ParamIterator findNext(const String& leaf, const ParamIterator& start_leaf) const;
-
-
-
     //@}
 
     ///@name Tags handling
@@ -611,6 +631,7 @@ protected:
     //@}
 
 protected:
+
     /**
       @brief Returns a mutable reference to a parameter entry.
 

--- a/src/openms/include/OpenMS/DATASTRUCTURES/String.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/String.h
@@ -86,6 +86,10 @@ public:
     //@{
     /// Default constructor
     OPENMS_DLLAPI String();
+    /// Copy constructor
+    OPENMS_DLLAPI String(const String&) = default;
+    /// Move constructor
+    OPENMS_DLLAPI String(String&&) = default;
     /// Constructor from std::string
     OPENMS_DLLAPI String(const std::string& s);
     /// Constructor from Qt QString
@@ -149,6 +153,10 @@ public:
     OPENMS_DLLAPI bool has(Byte byte) const;
     //@}
 
+    /// Assignment operator
+    OPENMS_DLLAPI String& operator=(const String& source) = default;
+    /// Move assignment operator
+    OPENMS_DLLAPI String& operator=(String&&) & = default;
 
     /** @name Accessors
     */

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -453,7 +453,6 @@ protected:
         std::vector<BinaryData> data;
         Size default_array_length;
         SpectrumType spectrum;
-        bool skip_data;
       };
 
       /// Vector of spectrum data stored for later parallel processing

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
@@ -70,15 +70,15 @@ namespace OpenMS
 
         enum {
           PRE_NONE, ///< unknown precision
-          PRE_32, ///< 32bit precision
-          PRE_64 ///< 64bit precision
+          PRE_32,   ///< 32bit precision
+          PRE_64    ///< 64bit precision
         } precision;
 
         enum {
-          DT_NONE, ///< unknown data type
-          DT_FLOAT, ///< float data type
-          DT_INT, ///< integer data type
-          DT_STRING ///< string data type
+          DT_NONE,    ///< unknown data type
+          DT_FLOAT,   ///< float data type
+          DT_INT,     ///< integer data type
+          DT_STRING   ///< string data type
         } data_type;
 
         MSNumpressCoder::NumpressCompression np_compression; ///< numpress options
@@ -114,12 +114,21 @@ namespace OpenMS
         {
         }
 
+        BinaryData(const BinaryData&) = default;               // Copy constructor
+        BinaryData(BinaryData&&) = default;                    // Move constructor
+        BinaryData& operator=(const BinaryData&) & = default;  // Copy assignment operator
+        BinaryData& operator=(BinaryData&&) & = default;       // Move assignment operator
+        ~BinaryData() = default;                               // Destructor
+
       };
 
       /**
         @brief Returns the appropriate compression term given the PeakFileOptions and the NumpressConfig
       */
-      static String getCompressionTerm_(const PeakFileOptions& opt, MSNumpressCoder::NumpressConfig np_compression, String indent = "", bool use_numpress = false);
+      static String getCompressionTerm_(const PeakFileOptions& opt,
+                                        MSNumpressCoder::NumpressConfig np_compression,
+                                        String indent = "",
+                                        bool use_numpress = false);
 
       /**
         @brief Write the indexed mzML footer the appropriate compression term given the PeakFileOptions and the NumpressConfig

--- a/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
+++ b/src/openms/include/OpenMS/KERNEL/MSChromatogram.h
@@ -127,26 +127,13 @@ public:
     //@}
 
     /// Constructor
-    MSChromatogram() :
-      ContainerType(),
-      RangeManager<1>(),
-      ChromatogramSettings(),
-      name_(),
-      float_data_arrays_(),
-      string_data_arrays_(),
-      integer_data_arrays_()
-    {}
+    MSChromatogram() = default;
 
     /// Copy constructor
-    MSChromatogram(const MSChromatogram& source) :
-      ContainerType(source),
-      RangeManager<1>(source),
-      ChromatogramSettings(source),
-      name_(source.name_),
-      float_data_arrays_(source.float_data_arrays_),
-      string_data_arrays_(source.string_data_arrays_),
-      integer_data_arrays_(source.integer_data_arrays_)
-    {}
+    MSChromatogram(const MSChromatogram& source) = default;
+
+    /// Move constructor
+    MSChromatogram(MSChromatogram&&) = default;
 
     /// Destructor
     ~MSChromatogram() override
@@ -154,6 +141,9 @@ public:
 
     /// Assignment operator
     MSChromatogram& operator=(const MSChromatogram& source);
+
+    /// Move assignment operator
+    MSChromatogram& operator=(MSChromatogram&&) & = default;
 
     /// Equality operator
     bool operator==(const MSChromatogram& rhs) const;

--- a/src/openms/include/OpenMS/KERNEL/MSExperiment.h
+++ b/src/openms/include/OpenMS/KERNEL/MSExperiment.h
@@ -185,8 +185,14 @@ public:
     /// Copy constructor
     MSExperiment(const MSExperiment & source);
 
+    /// Move constructor
+    MSExperiment(MSExperiment&&) = default;
+
     /// Assignment operator
     MSExperiment & operator=(const MSExperiment & source);
+
+    /// Move assignment operator
+    MSExperiment& operator=(MSExperiment&&) & = default;
 
     /// Assignment operator
     MSExperiment & operator=(const ExperimentalSettings & source);
@@ -479,6 +485,11 @@ public:
     /// adds a spectrum to the list
     void addSpectrum(const MSSpectrum & spectrum);
 
+    void addSpectrum(MSSpectrum&& spectrum)
+    {
+      spectra_.push_back(std::forward<MSSpectrum>(spectrum));
+    }
+
     /// returns the spectrum list
     const std::vector<MSSpectrum> & getSpectra() const;
 
@@ -490,6 +501,11 @@ public:
 
     /// adds a chromatogram to the list
     void addChromatogram(const MSChromatogram & chromatogram);
+
+    void addChromatogram(MSChromatogram&& chrom)
+    {
+      chromatograms_.push_back(std::forward<MSChromatogram>(chrom));
+    }
 
     /// returns the chromatogram list
     const std::vector<MSChromatogram > & getChromatograms() const;

--- a/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
+++ b/src/openms/include/OpenMS/KERNEL/MSSpectrum.h
@@ -144,12 +144,18 @@ public:
     /// Copy constructor
     MSSpectrum(const MSSpectrum& source);
 
+    /// Move constructor
+    MSSpectrum(MSSpectrum&&) = default;
+
     /// Destructor
     ~MSSpectrum() override
     {}
 
     /// Assignment operator
     MSSpectrum& operator=(const MSSpectrum& source);
+
+    /// Move assignment operator
+    MSSpectrum& operator=(MSSpectrum&&) & = default;
 
     /// Assignment operator
     MSSpectrum& operator=(const SpectrumSettings & source);

--- a/src/openms/include/OpenMS/METADATA/AbsoluteQuantitationStandards.h
+++ b/src/openms/include/OpenMS/METADATA/AbsoluteQuantitationStandards.h
@@ -131,3 +131,4 @@ private:
     ) const;
   };
 }
+

--- a/src/openms/include/OpenMS/METADATA/Acquisition.h
+++ b/src/openms/include/OpenMS/METADATA/Acquisition.h
@@ -51,16 +51,16 @@ namespace OpenMS
   {
 public:
     /// Constructor
-    Acquisition();
+    Acquisition() = default;
     /// Copy constructor
-    Acquisition(const Acquisition & source);
+    Acquisition(const Acquisition & source) = default;
     /// Move constructor
     Acquisition(Acquisition&&) = default;
     /// Destructor
-    ~Acquisition();
+    ~Acquisition() = default;
 
     /// Assignment operator
-    Acquisition & operator=(const Acquisition & source);
+    Acquisition & operator=(const Acquisition & source) = default;
     /// Move assignment operator
     Acquisition& operator=(Acquisition&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/Acquisition.h
+++ b/src/openms/include/OpenMS/METADATA/Acquisition.h
@@ -54,11 +54,15 @@ public:
     Acquisition();
     /// Copy constructor
     Acquisition(const Acquisition & source);
+    /// Move constructor
+    Acquisition(Acquisition&&) = default;
     /// Destructor
     ~Acquisition();
 
     /// Assignment operator
     Acquisition & operator=(const Acquisition & source);
+    /// Move assignment operator
+    Acquisition& operator=(Acquisition&&) & = default;
 
     /// Equality operator
     bool operator==(const Acquisition & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/AcquisitionInfo.h
+++ b/src/openms/include/OpenMS/METADATA/AcquisitionInfo.h
@@ -58,16 +58,16 @@ private:
 
 public:
     /// Constructor
-    AcquisitionInfo();
+    AcquisitionInfo() = default;
     /// Copy constructor
-    AcquisitionInfo(const AcquisitionInfo& source);
+    AcquisitionInfo(const AcquisitionInfo& source) = default;
     /// Move constructor
     AcquisitionInfo(AcquisitionInfo&&) = default;
     /// Destructor
-    ~AcquisitionInfo();
+    ~AcquisitionInfo() = default;
 
     /// Assignment operator
-    AcquisitionInfo& operator=(const AcquisitionInfo& source);
+    AcquisitionInfo& operator=(const AcquisitionInfo& source) = default;
     /// Move assignment operator
     AcquisitionInfo& operator=(AcquisitionInfo&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/AcquisitionInfo.h
+++ b/src/openms/include/OpenMS/METADATA/AcquisitionInfo.h
@@ -61,11 +61,15 @@ public:
     AcquisitionInfo();
     /// Copy constructor
     AcquisitionInfo(const AcquisitionInfo& source);
+    /// Move constructor
+    AcquisitionInfo(AcquisitionInfo&&) = default;
     /// Destructor
     ~AcquisitionInfo();
 
     /// Assignment operator
     AcquisitionInfo& operator=(const AcquisitionInfo& source);
+    /// Move assignment operator
+    AcquisitionInfo& operator=(AcquisitionInfo&&) & = default;
 
     /// Equality operator
     bool operator==(const AcquisitionInfo& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/CVTerm.h
+++ b/src/openms/include/OpenMS/METADATA/CVTerm.h
@@ -100,13 +100,13 @@ public:
     };
 
     /// Default constructor
-    CVTerm();
+    CVTerm() = default;
 
     /// Detailed constructor
     CVTerm(const String & accession, const String & name, const String & cv_identifier_ref, const String & value, const Unit & unit);
 
     /// Copy constructor
-    CVTerm(const CVTerm & rhs);
+    CVTerm(const CVTerm & rhs) = default;
 
     /// Move constructor
     CVTerm(CVTerm&&) = default;
@@ -115,7 +115,7 @@ public:
     virtual ~CVTerm();
 
     /// Assignment operator
-    CVTerm & operator=(const CVTerm & rhs);
+    CVTerm & operator=(const CVTerm & rhs) = default;
 
     /// Move assignment operator
     CVTerm& operator=(CVTerm&&) & = default;

--- a/src/openms/include/OpenMS/METADATA/CVTerm.h
+++ b/src/openms/include/OpenMS/METADATA/CVTerm.h
@@ -39,24 +39,25 @@
 
 namespace OpenMS
 {
+
   /**
       @brief Representation of controlled vocabulary term
 
       This class simply stores a CV term, its value and unit if necessary.
 
+      Representation of a CV term used by CVMappings
+
       @ingroup Metadata
   */
-  ///Representation of a CV term used by CVMappings
   class OPENMS_DLLAPI CVTerm
   {
 public:
 
-
     struct Unit
     {
-      Unit()
-      {
-      }
+
+      /// Default constructor
+      Unit() = default;
 
       Unit(const String & p_accession, const String & p_name, const String & p_cv_ref) :
         accession(p_accession),
@@ -65,27 +66,21 @@ public:
       {
       }
 
-      Unit(const Unit & rhs) :
-        accession(rhs.accession),
-        name(rhs.name),
-        cv_ref(rhs.cv_ref)
-      {
-      }
+      /// Copy constructor
+      Unit(const Unit & rhs) = default;
+      
+      /// Move constructor
+      Unit(Unit&&) = default;
 
+      /// Destructor
       virtual ~Unit()
       {
       }
 
-      Unit & operator=(const Unit & rhs)
-      {
-        if (this != &rhs)
-        {
-          accession = rhs.accession;
-          name = rhs.name;
-          cv_ref = rhs.cv_ref;
-        }
-        return *this;
-      }
+      /// Assignment operator
+      Unit & operator=(const Unit & source) = default;
+      /// Move assignment operator
+      Unit& operator=(Unit&&) & = default;
 
       bool operator==(const Unit & rhs) const
       {
@@ -104,7 +99,6 @@ public:
       String cv_ref;
     };
 
-
     /// Default constructor
     CVTerm();
 
@@ -114,11 +108,17 @@ public:
     /// Copy constructor
     CVTerm(const CVTerm & rhs);
 
+    /// Move constructor
+    CVTerm(CVTerm&&) = default;
+
     /// Destructor
     virtual ~CVTerm();
 
     /// Assignment operator
     CVTerm & operator=(const CVTerm & rhs);
+
+    /// Move assignment operator
+    CVTerm& operator=(CVTerm&&) & = default;
 
     /** @name Accessors
     */

--- a/src/openms/include/OpenMS/METADATA/CVTermList.h
+++ b/src/openms/include/OpenMS/METADATA/CVTermList.h
@@ -60,11 +60,17 @@ public:
     /// Copy constructor
     CVTermList(const CVTermList& rhs);
 
+    /// Move constructor
+    CVTermList(CVTermList&&) = default;
+
     /// Destructor
     virtual ~CVTermList();
 
     /// Assignment operator
     CVTermList& operator=(const CVTermList& rhs);
+
+    /// Move assignment operator
+    CVTermList& operator=(CVTermList&&) & = default;
 
     /** @name Accessors
     */

--- a/src/openms/include/OpenMS/METADATA/CVTermList.h
+++ b/src/openms/include/OpenMS/METADATA/CVTermList.h
@@ -55,10 +55,10 @@ namespace OpenMS
 public:
 
     /// Defaults constructor
-    CVTermList();
+    CVTermList() = default;
 
     /// Copy constructor
-    CVTermList(const CVTermList& rhs);
+    CVTermList(const CVTermList& rhs) = default;
 
     /// Move constructor
     CVTermList(CVTermList&&) = default;
@@ -67,7 +67,7 @@ public:
     virtual ~CVTermList();
 
     /// Assignment operator
-    CVTermList& operator=(const CVTermList& rhs);
+    CVTermList& operator=(const CVTermList& rhs) = default;
 
     /// Move assignment operator
     CVTermList& operator=(CVTermList&&) & = default;

--- a/src/openms/include/OpenMS/METADATA/CVTermListInterface.h
+++ b/src/openms/include/OpenMS/METADATA/CVTermListInterface.h
@@ -54,22 +54,27 @@ namespace OpenMS
 
       @ingroup Metadata
   */
-  ///Representation of a CV term used by CVMappings
   class OPENMS_DLLAPI CVTermListInterface :
     public MetaInfoInterface
   {
 
   public:
 
+    // Constructor
     CVTermListInterface();
 
+    /// Copy constructor
     CVTermListInterface(const CVTermListInterface & rhs);
+    /// Move constructor
+    CVTermListInterface(CVTermListInterface&&);
 
     // Destructor (non virtual)
     ~CVTermListInterface();
 
     /// Assignment operator
     CVTermListInterface & operator=(const CVTermListInterface & rhs);
+    /// Move assignment operator
+    CVTermListInterface& operator=(CVTermListInterface&&);
 
     /// equality operator
     bool operator==(const CVTermListInterface& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/CVTermListInterface.h
+++ b/src/openms/include/OpenMS/METADATA/CVTermListInterface.h
@@ -119,4 +119,3 @@ namespace OpenMS
 
 } // namespace OpenMS
 
-

--- a/src/openms/include/OpenMS/METADATA/ChromatogramSettings.h
+++ b/src/openms/include/OpenMS/METADATA/ChromatogramSettings.h
@@ -47,6 +47,7 @@
 
 namespace OpenMS
 {
+
   /**
       @brief Representation of chromatogram settings, e.g. SRM/MRM chromatograms
 
@@ -83,18 +84,21 @@ public:
     /// Constructor
     ChromatogramSettings();
     /// Copy constructor
-    ChromatogramSettings(const ChromatogramSettings & source);
+    ChromatogramSettings(const ChromatogramSettings & source) = default;
+    /// Move constructor
+    ChromatogramSettings(ChromatogramSettings&&) = default;
     /// Destructor
     virtual ~ChromatogramSettings();
 
     // Assignment operator
-    ChromatogramSettings & operator=(const ChromatogramSettings & source);
+    ChromatogramSettings & operator=(const ChromatogramSettings & source) = default;
+    /// Move assignment operator
+    ChromatogramSettings& operator=(ChromatogramSettings&&) & = default;
 
     /// Equality operator
     bool operator==(const ChromatogramSettings & rhs) const;
     /// Equality operator
     bool operator!=(const ChromatogramSettings & rhs) const;
-
 
     /// returns the native identifier for the spectrum, used by the acquisition software.
     const String & getNativeID() const;

--- a/src/openms/include/OpenMS/METADATA/ContactPerson.h
+++ b/src/openms/include/OpenMS/METADATA/ContactPerson.h
@@ -42,23 +42,26 @@ namespace OpenMS
   /**
       @brief Contact person information
 
-
-
       @ingroup Metadata
   */
   class OPENMS_DLLAPI ContactPerson :
     public MetaInfoInterface
   {
 public:
+
     /// Constructor
     ContactPerson();
     /// Copy constructor
     ContactPerson(const ContactPerson & source);
+    /// Move constructor
+    ContactPerson(ContactPerson&&) = default;
     /// Destructor
     ~ContactPerson();
 
     /// Assignment operator
     ContactPerson & operator=(const ContactPerson & source);
+    /// Move assignment operator
+    ContactPerson& operator=(ContactPerson&&) & = default;
 
     /// Equality operator
     bool operator==(const ContactPerson & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/ContactPerson.h
+++ b/src/openms/include/OpenMS/METADATA/ContactPerson.h
@@ -50,16 +50,16 @@ namespace OpenMS
 public:
 
     /// Constructor
-    ContactPerson();
+    ContactPerson() = default;
     /// Copy constructor
-    ContactPerson(const ContactPerson & source);
+    ContactPerson(const ContactPerson & source) = default;
     /// Move constructor
     ContactPerson(ContactPerson&&) = default;
     /// Destructor
-    ~ContactPerson();
+    ~ContactPerson() = default;
 
     /// Assignment operator
-    ContactPerson & operator=(const ContactPerson & source);
+    ContactPerson & operator=(const ContactPerson & source) = default;
     /// Move assignment operator
     ContactPerson& operator=(ContactPerson&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/DataArrays.h
+++ b/src/openms/include/OpenMS/METADATA/DataArrays.h
@@ -43,23 +43,25 @@ namespace OpenMS
 
     /// Float data array class
     class FloatDataArray :
-    public MetaInfoDescription,
-    public std::vector<float>
-    {};
+      public MetaInfoDescription,
+      public std::vector<float>
+    {
+    };
 
     /// Integer data array class
     class IntegerDataArray :
-    public MetaInfoDescription,
-    public std::vector<Int>
-    {};
+      public MetaInfoDescription,
+      public std::vector<Int>
+    {
+    };
 
     /// String data array class
     class StringDataArray :
-    public MetaInfoDescription,
-    public std::vector<String>
-    {};
+      public MetaInfoDescription,
+      public std::vector<String>
+    {
+    };
 
   }
 } // namespace OpenMS
-
 

--- a/src/openms/include/OpenMS/METADATA/DataProcessing.h
+++ b/src/openms/include/OpenMS/METADATA/DataProcessing.h
@@ -86,11 +86,15 @@ public:
     DataProcessing();
     /// Copy constructor
     DataProcessing(const DataProcessing & source);
+    /// Move constructor
+    DataProcessing(DataProcessing&&) = default;
     /// Destructor
     ~DataProcessing();
 
     /// Assignment operator
     DataProcessing & operator=(const DataProcessing & source);
+    /// Move assignment operator
+    DataProcessing& operator=(DataProcessing&&) & = default;
 
     /// Equality operator
     bool operator==(const DataProcessing & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/DataProcessing.h
+++ b/src/openms/include/OpenMS/METADATA/DataProcessing.h
@@ -83,16 +83,16 @@ public:
     static const std::string NamesOfProcessingAction[SIZE_OF_PROCESSINGACTION];
 
     /// Constructor
-    DataProcessing();
+    DataProcessing() = default;
     /// Copy constructor
-    DataProcessing(const DataProcessing & source);
+    DataProcessing(const DataProcessing & source) = default;
     /// Move constructor
     DataProcessing(DataProcessing&&) = default;
     /// Destructor
     ~DataProcessing();
 
     /// Assignment operator
-    DataProcessing & operator=(const DataProcessing & source);
+    DataProcessing & operator=(const DataProcessing & source) = default;
     /// Move assignment operator
     DataProcessing& operator=(DataProcessing&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/Digestion.h
+++ b/src/openms/include/OpenMS/METADATA/Digestion.h
@@ -53,19 +53,19 @@ public:
     /// Default constructor
     Digestion();
     /// Copy constructor
-    Digestion(const Digestion &);
+    Digestion(const Digestion &) = default;
     /// Move constructor
     Digestion(Digestion&&) = default;
     /// Destructor
     ~Digestion() override;
 
     /// Assignment operator
-    Digestion & operator=(const Digestion &);
+    Digestion & operator=(const Digestion &) = default;
     /// Move assignment operator
     Digestion& operator=(Digestion&&) & = default;
 
     /**
-        @brief Equality operator
+      @brief Equality operator
 
       Although this operator takes a reference to a SampleTreatment as argument
       it tests for the equality of Tagging instances!

--- a/src/openms/include/OpenMS/METADATA/Digestion.h
+++ b/src/openms/include/OpenMS/METADATA/Digestion.h
@@ -50,22 +50,26 @@ namespace OpenMS
     public SampleTreatment
   {
 public:
-    /// default constructor
+    /// Default constructor
     Digestion();
-    /// copy constructor
+    /// Copy constructor
     Digestion(const Digestion &);
-    /// destructor
+    /// Move constructor
+    Digestion(Digestion&&) = default;
+    /// Destructor
     ~Digestion() override;
 
-    /// assignment operator
+    /// Assignment operator
     Digestion & operator=(const Digestion &);
+    /// Move assignment operator
+    Digestion& operator=(Digestion&&) & = default;
 
     /**
         @brief Equality operator
 
-    Although this operator takes a reference to a SampleTreatment as argument
-    it tests for the equality of Tagging instances!
-  */
+      Although this operator takes a reference to a SampleTreatment as argument
+      it tests for the equality of Tagging instances!
+    */
     bool operator==(const SampleTreatment & rhs) const override;
 
     /// clone method. See SampleTreatment

--- a/src/openms/include/OpenMS/METADATA/DocumentIDTagger.h
+++ b/src/openms/include/OpenMS/METADATA/DocumentIDTagger.h
@@ -75,12 +75,12 @@ public:
     /// Constructor
     DocumentIDTagger(String toolname);
     /// Copy constructor
-    DocumentIDTagger(const DocumentIDTagger & source);
+    DocumentIDTagger(const DocumentIDTagger & source) = default;
     /// Destructor
     ~DocumentIDTagger();
 
     /// Assignment operator
-    DocumentIDTagger & operator=(const DocumentIDTagger & source);
+    DocumentIDTagger & operator=(const DocumentIDTagger & source) = default;
 
     /// Equality operator
     bool operator==(const DocumentIDTagger & source) const;

--- a/src/openms/include/OpenMS/METADATA/DocumentIdentifier.h
+++ b/src/openms/include/OpenMS/METADATA/DocumentIdentifier.h
@@ -63,7 +63,7 @@ public:
     DocumentIdentifier();
 
     /// Copy constructor
-    DocumentIdentifier(const DocumentIdentifier & source);
+    DocumentIdentifier(const DocumentIdentifier & source) = default;
 
     /// Move constructor
     DocumentIdentifier(DocumentIdentifier&&) = default;
@@ -72,7 +72,7 @@ public:
     virtual ~DocumentIdentifier();
 
     /// Assignment operator
-    DocumentIdentifier & operator=(const DocumentIdentifier & source);
+    DocumentIdentifier & operator=(const DocumentIdentifier & source) = default;
 
     /// Move assignment operator
     DocumentIdentifier& operator=(DocumentIdentifier&&) & = default;

--- a/src/openms/include/OpenMS/METADATA/DocumentIdentifier.h
+++ b/src/openms/include/OpenMS/METADATA/DocumentIdentifier.h
@@ -58,20 +58,28 @@ public:
     /** @name Constructors and Destructors
     */
     //@{
-    /// default constructor
+
+    /// Default constructor
     DocumentIdentifier();
 
     /// Copy constructor
     DocumentIdentifier(const DocumentIdentifier & source);
 
+    /// Move constructor
+    DocumentIdentifier(DocumentIdentifier&&) = default;
+
+    /// Destructor
+    virtual ~DocumentIdentifier();
+
     /// Assignment operator
     DocumentIdentifier & operator=(const DocumentIdentifier & source);
+
+    /// Move assignment operator
+    DocumentIdentifier& operator=(DocumentIdentifier&&) & = default;
 
     /// Equality operator
     bool operator==(const DocumentIdentifier & rhs) const;
 
-    /// destructor
-    virtual ~DocumentIdentifier();
     //@}
 
     /** @name Acessors

--- a/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalDesign.h
@@ -84,6 +84,7 @@ namespace OpenMS
 
   class OPENMS_DLLAPI ExperimentalDesign
   {
+
   public:
     /// MSFileSectionEntry links single quant. values back the MS file
     /// It supports:
@@ -159,7 +160,6 @@ namespace OpenMS
     const ExperimentalDesign::SampleSection& getSampleSection() const;
 
     void setSampleSection(const SampleSection& sample_section);
-
 
     /// return fraction index to file paths (ordered by fraction_group)
     std::map<unsigned int, std::vector<String> > getFractionToMSFilesMapping() const;

--- a/src/openms/include/OpenMS/METADATA/ExperimentalSettings.h
+++ b/src/openms/include/OpenMS/METADATA/ExperimentalSettings.h
@@ -51,7 +51,8 @@ namespace OpenMS
       @brief Description of the experimental settings
 
       These settings are valid for the whole experiment.
-      See SpectrumSettings for settings which are spectrum specific.
+      See SpectrumSettings for settings which are specific to an MSSpectrum.
+      See ChromatogramSettings for settings which are specific to an MSChromatogram.
 
       @ingroup Metadata
   */
@@ -60,15 +61,20 @@ namespace OpenMS
     public DocumentIdentifier
   {
 public:
-    ///Constructor
-    ExperimentalSettings();
-    ///Copy constructor
-    ExperimentalSettings(const ExperimentalSettings & source);
-    ///Destructor
+
+    /// Constructor
+    ExperimentalSettings() = default;
+    /// Copy constructor
+    ExperimentalSettings(const ExperimentalSettings & source) = default;
+    /// Move constructor
+    ExperimentalSettings(ExperimentalSettings&&) = default;
+    /// Destructor
     ~ExperimentalSettings() override;
 
-    ///Assignment operator
-    ExperimentalSettings & operator=(const ExperimentalSettings & source);
+    /// Assignment operator
+    ExperimentalSettings & operator=(const ExperimentalSettings & source) = default;
+    /// Move assignment operator
+    ExperimentalSettings& operator=(ExperimentalSettings&&) & = default;
 
     /// Equality operator
     bool operator==(const ExperimentalSettings & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/Gradient.h
+++ b/src/openms/include/OpenMS/METADATA/Gradient.h
@@ -47,7 +47,7 @@ namespace OpenMS
     It consists of several eluents and timepoints.
     Linear behaviour between timepoints is assumed.
 
-        @ingroup Metadata
+    @ingroup Metadata
   */
   class OPENMS_DLLAPI Gradient
   {
@@ -56,11 +56,15 @@ public:
     Gradient();
     /// Copy constructor
     Gradient(const Gradient & source);
+    /// Move constructor
+    Gradient(Gradient&&) = default;
     /// Destructor
     ~Gradient();
 
     /// Assignment operator
     Gradient & operator=(const Gradient & source);
+    /// Move assignment operator
+    Gradient& operator=(Gradient&&) & = default;
 
     /// Equality operator
     bool operator==(const Gradient & source) const;

--- a/src/openms/include/OpenMS/METADATA/Gradient.h
+++ b/src/openms/include/OpenMS/METADATA/Gradient.h
@@ -53,16 +53,16 @@ namespace OpenMS
   {
 public:
     /// Constructor
-    Gradient();
+    Gradient() = default;
     /// Copy constructor
-    Gradient(const Gradient & source);
+    Gradient(const Gradient & source) = default;
     /// Move constructor
     Gradient(Gradient&&) = default;
     /// Destructor
     ~Gradient();
 
     /// Assignment operator
-    Gradient & operator=(const Gradient & source);
+    Gradient & operator=(const Gradient & source) = default;
     /// Move assignment operator
     Gradient& operator=(Gradient&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/HPLC.h
+++ b/src/openms/include/OpenMS/METADATA/HPLC.h
@@ -45,7 +45,7 @@ namespace OpenMS
 
     It contains the description of instrument, the settings and the gradient.
 
-        @ingroup Metadata
+    @ingroup Metadata
   */
   class OPENMS_DLLAPI HPLC
   {
@@ -54,11 +54,15 @@ public:
     HPLC();
     /// Copy constructor
     HPLC(const HPLC & source);
+    /// Move constructor
+    HPLC(HPLC&&) = default;
     /// Destructor
     ~HPLC();
 
     /// Assignment operator
     HPLC & operator=(const HPLC & source);
+    /// Move assignment operator
+    HPLC& operator=(HPLC&&) & = default;
 
     /// Equality operator
     bool operator==(const HPLC & source) const;

--- a/src/openms/include/OpenMS/METADATA/HPLC.h
+++ b/src/openms/include/OpenMS/METADATA/HPLC.h
@@ -53,14 +53,14 @@ public:
     /// Constructor
     HPLC();
     /// Copy constructor
-    HPLC(const HPLC & source);
+    HPLC(const HPLC & source) = default;
     /// Move constructor
     HPLC(HPLC&&) = default;
     /// Destructor
     ~HPLC();
 
     /// Assignment operator
-    HPLC & operator=(const HPLC & source);
+    HPLC & operator=(const HPLC & source) = default;
     /// Move assignment operator
     HPLC& operator=(HPLC&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/Identification.h
+++ b/src/openms/include/OpenMS/METADATA/Identification.h
@@ -56,14 +56,21 @@ public:
 
     /// @name constructors,destructors,assignment operator
     //@{
-    /// default constructor
+
+    /// Default constructor
     Identification();
-    /// destructor
-    virtual ~Identification();
-    /// copy constructor
+    /// Copy constructor
     Identification(const Identification & source);
-    /// assignment operator
+    /// Move constructor
+    Identification(Identification&&) = default;
+    /// Destructor
+    virtual ~Identification();
+
+    /// Assignment operator
     Identification & operator=(const Identification & source);
+    /// Move assignment operator
+    Identification& operator=(Identification&&) & = default;
+
     /// Equality operator
     bool operator==(const Identification & rhs) const;
     /// Inequality operator
@@ -89,10 +96,11 @@ public:
     //@}
 protected:
 
-    String id_;                                     ///< Identifier
-    DateTime creation_date_;            ///< Date and time the search was performed
+    String id_; ///< Identifier
+    DateTime creation_date_; ///< Date and time the search was performed
     std::vector<SpectrumIdentification> spectrum_identifications_;
 
   };
 
 } //namespace OpenMS
+

--- a/src/openms/include/OpenMS/METADATA/Identification.h
+++ b/src/openms/include/OpenMS/METADATA/Identification.h
@@ -58,16 +58,16 @@ public:
     //@{
 
     /// Default constructor
-    Identification();
+    Identification() = default;
     /// Copy constructor
-    Identification(const Identification & source);
+    Identification(const Identification & source) = default;
     /// Move constructor
     Identification(Identification&&) = default;
     /// Destructor
     virtual ~Identification();
 
     /// Assignment operator
-    Identification & operator=(const Identification & source);
+    Identification & operator=(const Identification & source) = default;
     /// Move assignment operator
     Identification& operator=(Identification&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/IdentificationHit.h
+++ b/src/openms/include/OpenMS/METADATA/IdentificationHit.h
@@ -41,9 +41,9 @@ namespace OpenMS
   /**
     @brief Represents a object which can store the information of an analysisXML instance
 
-        //@todo docu (Andreas)
+    //@todo docu (Andreas)
 
-        @ingroup Metadata
+    @ingroup Metadata
   */
   class OPENMS_DLLAPI IdentificationHit :
     public MetaInfoInterface
@@ -52,14 +52,21 @@ public:
 
     /// @name constructors,destructors,assignment operator
     //@{
-    /// default constructor
+
+    /// Default constructor
     IdentificationHit();
-    /// destructor
+    /// Destructor
     virtual ~IdentificationHit();
-    /// copy constructor
+    /// Copy constructor
     IdentificationHit(const IdentificationHit & source);
-    /// assignment operator
+    /// Move constructor
+    IdentificationHit(IdentificationHit&&) = default;
+
+    /// Assignment operator
     IdentificationHit & operator=(const IdentificationHit & source);
+    /// Move assignment operator
+    IdentificationHit& operator=(IdentificationHit&&) & = default;
+
     /// Equality operator
     bool operator==(const IdentificationHit & rhs) const;
     /// Inequality operator
@@ -124,3 +131,4 @@ protected:
   };
 
 } //namespace OpenMS
+

--- a/src/openms/include/OpenMS/METADATA/IdentificationHit.h
+++ b/src/openms/include/OpenMS/METADATA/IdentificationHit.h
@@ -55,15 +55,15 @@ public:
 
     /// Default constructor
     IdentificationHit();
+    /// Copy constructor
+    IdentificationHit(const IdentificationHit & source) = default;
     /// Destructor
     virtual ~IdentificationHit();
-    /// Copy constructor
-    IdentificationHit(const IdentificationHit & source);
     /// Move constructor
     IdentificationHit(IdentificationHit&&) = default;
 
     /// Assignment operator
-    IdentificationHit & operator=(const IdentificationHit & source);
+    IdentificationHit & operator=(const IdentificationHit & source) = default;
     /// Move assignment operator
     IdentificationHit& operator=(IdentificationHit&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/Instrument.h
+++ b/src/openms/include/OpenMS/METADATA/Instrument.h
@@ -69,20 +69,21 @@ public:
     /// ion optics type
     enum IonOpticsType
     {
-      UNKNOWN,                                          ///< unknown
-      MAGNETIC_DEFLECTION,                      ///< magnetic deflection
-      DELAYED_EXTRACTION,                       ///< delayed extraction
-      COLLISION_QUADRUPOLE,                 ///< collision quadrupole
-      SELECTED_ION_FLOW_TUBE,               ///< selected ion flow tube
-      TIME_LAG_FOCUSING,                        ///< time lag focusing
-      REFLECTRON,                                       ///< reflectron
-      EINZEL_LENS,                                      ///< einzel lens
-      FIRST_STABILITY_REGION,               ///< first stability region
-      FRINGING_FIELD,                               ///< fringing field
-      KINETIC_ENERGY_ANALYZER,              ///< kinetic energy analyzer
-      STATIC_FIELD,                                     ///< static field
+      UNKNOWN,                  ///< unknown
+      MAGNETIC_DEFLECTION,      ///< magnetic deflection
+      DELAYED_EXTRACTION,       ///< delayed extraction
+      COLLISION_QUADRUPOLE,     ///< collision quadrupole
+      SELECTED_ION_FLOW_TUBE,   ///< selected ion flow tube
+      TIME_LAG_FOCUSING,        ///< time lag focusing
+      REFLECTRON,               ///< reflectron
+      EINZEL_LENS,              ///< einzel lens
+      FIRST_STABILITY_REGION,   ///< first stability region
+      FRINGING_FIELD,           ///< fringing field
+      KINETIC_ENERGY_ANALYZER,  ///< kinetic energy analyzer
+      STATIC_FIELD,             ///< static field
       SIZE_OF_IONOPTICSTYPE
     };
+
     /// Names of inlet types
     static const std::string NamesOfIonOpticsType[SIZE_OF_IONOPTICSTYPE];
 
@@ -90,11 +91,15 @@ public:
     Instrument();
     /// Copy constructor
     Instrument(const Instrument & source);
+    /// Move constructor
+    Instrument(Instrument&&) = default;
     /// Destructor
     ~Instrument();
 
     /// Assignment operator
     Instrument & operator=(const Instrument & source);
+    /// Move assignment operator
+    Instrument& operator=(Instrument&&) & = default;
 
     /// Equality operator
     bool operator==(const Instrument & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/Instrument.h
+++ b/src/openms/include/OpenMS/METADATA/Instrument.h
@@ -90,14 +90,14 @@ public:
     /// Constructor
     Instrument();
     /// Copy constructor
-    Instrument(const Instrument & source);
+    Instrument(const Instrument & source) = default;
     /// Move constructor
     Instrument(Instrument&&) = default;
     /// Destructor
     ~Instrument();
 
     /// Assignment operator
-    Instrument & operator=(const Instrument & source);
+    Instrument & operator=(const Instrument & source) = default;
     /// Move assignment operator
     Instrument& operator=(Instrument&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/InstrumentSettings.h
+++ b/src/openms/include/OpenMS/METADATA/InstrumentSettings.h
@@ -51,21 +51,21 @@ public:
     /// scan mode
     enum ScanMode
     {
-      UNKNOWN,                      ///< Unknown scan method
-      MASSSPECTRUM,       ///< general spectrum type
-      MS1SPECTRUM,              ///< full scan mass spectrum, is a "mass spectrum" @n Synonyms: 'full spectrum', 'Q1 spectrum', 'Q3 spectrum', 'Single-Stage Mass Spectrometry'
-      MSNSPECTRUM,        ///< MS2+ mass spectrum, is a "mass spectrum"
-      SIM,                              ///< Selected ion monitoring scan @n Synonyms: 'Multiple ion monitoring scan', 'SIM scan', 'MIM scan'
-      SRM,                              ///< Selected reaction monitoring scan @n Synonyms: 'Multiple reaction monitoring scan', 'SRM scan', 'MRM scan'
-      CRM,                              ///< Consecutive reaction monitoring scan @n Synonyms: 'CRM scan'
-      CNG,                              ///< Constant neutral gain scan @n Synonyms: 'CNG scan'
-      CNL,                              ///< Constant neutral loss scan @n Synonyms: 'CNG scan'
-      PRECURSOR,                ///< Precursor ion scan
-      EMC,                              ///< Enhanced multiply charged scan
-      TDF,                              ///< Time-delayed fragmentation scan
-      EMR,                              ///< Electromagnetic radiation scan @n Synonyms: 'EMR spectrum'
-      EMISSION,                     ///< Emission scan
-      ABSORPTION,               ///< Absorption scan
+      UNKNOWN,          ///< Unknown scan method
+      MASSSPECTRUM,     ///< general spectrum type
+      MS1SPECTRUM,      ///< full scan mass spectrum, is a "mass spectrum" @n Synonyms: 'full spectrum', 'Q1 spectrum', 'Q3 spectrum', 'Single-Stage Mass Spectrometry'
+      MSNSPECTRUM,      ///< MS2+ mass spectrum, is a "mass spectrum"
+      SIM,              ///< Selected ion monitoring scan @n Synonyms: 'Multiple ion monitoring scan', 'SIM scan', 'MIM scan'
+      SRM,              ///< Selected reaction monitoring scan @n Synonyms: 'Multiple reaction monitoring scan', 'SRM scan', 'MRM scan'
+      CRM,              ///< Consecutive reaction monitoring scan @n Synonyms: 'CRM scan'
+      CNG,              ///< Constant neutral gain scan @n Synonyms: 'CNG scan'
+      CNL,              ///< Constant neutral loss scan @n Synonyms: 'CNG scan'
+      PRECURSOR,        ///< Precursor ion scan
+      EMC,              ///< Enhanced multiply charged scan
+      TDF,              ///< Time-delayed fragmentation scan
+      EMR,              ///< Electromagnetic radiation scan @n Synonyms: 'EMR spectrum'
+      EMISSION,         ///< Emission scan
+      ABSORPTION,       ///< Absorption scan
       SIZE_OF_SCANMODE
     };
 
@@ -75,12 +75,16 @@ public:
     /// Constructor
     InstrumentSettings();
     /// Copy constructor
-    InstrumentSettings(const InstrumentSettings & source);
+    InstrumentSettings(const InstrumentSettings & source) = default;
+    /// Move constructor
+    InstrumentSettings(InstrumentSettings&&) = default;
     /// Destructor
     ~InstrumentSettings();
 
     /// Assignment operator
-    InstrumentSettings & operator=(const InstrumentSettings & source);
+    InstrumentSettings & operator=(const InstrumentSettings & source) = default;
+    /// Move assignment operator
+    InstrumentSettings& operator=(InstrumentSettings&&) & = default;
 
     /// Equality operator
     bool operator==(const InstrumentSettings & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/IonDetector.h
+++ b/src/openms/include/OpenMS/METADATA/IonDetector.h
@@ -50,28 +50,28 @@ public:
     /// Detector type
     enum Type
     {
-      TYPENULL,                                                                 ///< Unknown
-      ELECTRONMULTIPLIER,                                           ///< Electron multiplier
-      PHOTOMULTIPLIER,                                                  ///< Photo multiplier
-      FOCALPLANEARRAY,                                                  ///< Focal plane array
-      FARADAYCUP,                                                           ///< Faraday cup
-      CONVERSIONDYNODEELECTRONMULTIPLIER,           ///< Conversion dynode electron multiplier
-      CONVERSIONDYNODEPHOTOMULTIPLIER,                  ///< Conversion dynode photo multiplier
-      MULTICOLLECTOR,                                                   ///< Multi-collector
-      CHANNELELECTRONMULTIPLIER,                            ///< Channel electron multiplier
-      CHANNELTRON,                                                          ///< channeltron
-      DALYDETECTOR,                                                         ///< daly detector
-      MICROCHANNELPLATEDETECTOR,                            ///< microchannel plate detector
-      ARRAYDETECTOR,                                                    ///< array detector
-      CONVERSIONDYNODE,                                                 ///< conversion dynode
-      DYNODE,                                                                   ///< dynode
-      FOCALPLANECOLLECTOR,                                          ///< focal plane collector
-      IONTOPHOTONDETECTOR,                                          ///< ion-to-photon detector
-      POINTCOLLECTOR,                                                   ///< point collector
-      POSTACCELERATIONDETECTOR,                                 ///< postacceleration detector
-      PHOTODIODEARRAYDETECTOR,                                  ///< photodiode array detector
-      INDUCTIVEDETECTOR,                                            ///< inductive detector
-      ELECTRONMULTIPLIERTUBE,                                   ///< electron multiplier tube
+      TYPENULL,                                  ///< Unknown
+      ELECTRONMULTIPLIER,                        ///< Electron multiplier
+      PHOTOMULTIPLIER,                           ///< Photo multiplier
+      FOCALPLANEARRAY,                           ///< Focal plane array
+      FARADAYCUP,                                ///< Faraday cup
+      CONVERSIONDYNODEELECTRONMULTIPLIER,        ///< Conversion dynode electron multiplier
+      CONVERSIONDYNODEPHOTOMULTIPLIER,           ///< Conversion dynode photo multiplier
+      MULTICOLLECTOR,                            ///< Multi-collector
+      CHANNELELECTRONMULTIPLIER,                 ///< Channel electron multiplier
+      CHANNELTRON,                               ///< channeltron
+      DALYDETECTOR,                              ///< daly detector
+      MICROCHANNELPLATEDETECTOR,                 ///< microchannel plate detector
+      ARRAYDETECTOR,                             ///< array detector
+      CONVERSIONDYNODE,                          ///< conversion dynode
+      DYNODE,                                    ///< dynode
+      FOCALPLANECOLLECTOR,                       ///< focal plane collector
+      IONTOPHOTONDETECTOR,                       ///< ion-to-photon detector
+      POINTCOLLECTOR,                            ///< point collector
+      POSTACCELERATIONDETECTOR,                  ///< postacceleration detector
+      PHOTODIODEARRAYDETECTOR,                   ///< photodiode array detector
+      INDUCTIVEDETECTOR,                         ///< inductive detector
+      ELECTRONMULTIPLIERTUBE,                    ///< electron multiplier tube
       SIZE_OF_TYPE
     };
     /// Names of detector types
@@ -80,11 +80,11 @@ public:
     /// Acquisition mode
     enum AcquisitionMode
     {
-      ACQMODENULL,                          ///< Unknown
-      PULSECOUNTING,                    ///< Pulse counting
-      ADC,                                          ///< Analog-digital converter
-      TDC,                                          ///< Time-digital converter
-      TRANSIENTRECORDER,            ///< Transient recorder
+      ACQMODENULL,             ///< Unknown
+      PULSECOUNTING,           ///< Pulse counting
+      ADC,                     ///< Analog-digital converter
+      TDC,                     ///< Time-digital converter
+      TRANSIENTRECORDER,       ///< Transient recorder
       SIZE_OF_ACQUISITIONMODE
     };
     /// Names of acquisition modes
@@ -94,11 +94,15 @@ public:
     IonDetector();
     /// Copy constructor
     IonDetector(const IonDetector & source);
+    /// Move constructor
+    IonDetector(IonDetector&&) = default;
     /// Destructor
     ~IonDetector();
 
     /// Assignment operator
     IonDetector & operator=(const IonDetector & source);
+    /// Move assignment operator
+    IonDetector& operator=(IonDetector&&) & = default;
 
     /// Equality operator
     bool operator==(const IonDetector & rhs) const;
@@ -134,7 +138,7 @@ public:
         - one ion detector
 
         For more complex instruments, the order should be defined.
-*/
+    */
     Int getOrder() const;
     /// sets the order
     void setOrder(Int order);

--- a/src/openms/include/OpenMS/METADATA/IonDetector.h
+++ b/src/openms/include/OpenMS/METADATA/IonDetector.h
@@ -93,14 +93,14 @@ public:
     /// Constructor
     IonDetector();
     /// Copy constructor
-    IonDetector(const IonDetector & source);
+    IonDetector(const IonDetector & source) = default;
     /// Move constructor
     IonDetector(IonDetector&&) = default;
     /// Destructor
     ~IonDetector();
 
     /// Assignment operator
-    IonDetector & operator=(const IonDetector & source);
+    IonDetector & operator=(const IonDetector & source) = default;
     /// Move assignment operator
     IonDetector& operator=(IonDetector&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/IonSource.h
+++ b/src/openms/include/OpenMS/METADATA/IonSource.h
@@ -150,14 +150,14 @@ public:
     /// Constructor
     IonSource();
     /// Copy constructor
-    IonSource(const IonSource & source);
+    IonSource(const IonSource & source) = default;
     /// Move constructor
     IonSource(IonSource&&) = default;
     /// Destructor
     ~IonSource();
 
     /// Assignment operator
-    IonSource & operator=(const IonSource & source);
+    IonSource & operator=(const IonSource & source) = default;
     /// Move assignment operator
     IonSource& operator=(IonSource&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/IonSource.h
+++ b/src/openms/include/OpenMS/METADATA/IonSource.h
@@ -38,6 +38,7 @@
 
 namespace OpenMS
 {
+
   /**
       @brief Description of an ion source (part of a MS Instrument)
 
@@ -50,26 +51,26 @@ public:
     /// inlet type
     enum InletType
     {
-      INLETNULL,                                                        ///< Unknown
-      DIRECT,                                                               ///< Direct
-      BATCH,                                                                ///< Batch (e.g. in MALDI)
-      CHROMATOGRAPHY,                                               ///< Chromatography (liquid)
-      PARTICLEBEAM,                                                     ///< Particle beam
-      MEMBRANESEPARATOR,                                        ///< Membrane separator
-      OPENSPLIT,                                                        ///< Open split
-      JETSEPARATOR,                                                     ///< Jet separator
-      SEPTUM,                                                               ///< Septum
-      RESERVOIR,                                                        ///< Reservoir
-      MOVINGBELT,                                                       ///< Moving belt
-      MOVINGWIRE,                                                       ///< Moving wire
-      FLOWINJECTIONANALYSIS,                                ///< Flow injection analysis
-      ELECTROSPRAYINLET,                                        ///< Electro spray
-      THERMOSPRAYINLET,                                             ///< Thermo spray
-      INFUSION,                                                             ///< Infusion
-      CONTINUOUSFLOWFASTATOMBOMBARDMENT,        ///< Continuous flow fast atom bombardment
-      INDUCTIVELYCOUPLEDPLASMA,                             ///< Inductively coupled plasma
-      MEMBRANE,                                                             ///< Membrane inlet
-      NANOSPRAY,                                                        ///< Nanospray inlet
+      INLETNULL,                           ///< Unknown
+      DIRECT,                              ///< Direct
+      BATCH,                               ///< Batch (e.g. in MALDI)
+      CHROMATOGRAPHY,                      ///< Chromatography (liquid)
+      PARTICLEBEAM,                        ///< Particle beam
+      MEMBRANESEPARATOR,                   ///< Membrane separator
+      OPENSPLIT,                           ///< Open split
+      JETSEPARATOR,                        ///< Jet separator
+      SEPTUM,                              ///< Septum
+      RESERVOIR,                           ///< Reservoir
+      MOVINGBELT,                          ///< Moving belt
+      MOVINGWIRE,                          ///< Moving wire
+      FLOWINJECTIONANALYSIS,               ///< Flow injection analysis
+      ELECTROSPRAYINLET,                   ///< Electro spray
+      THERMOSPRAYINLET,                    ///< Thermo spray
+      INFUSION,                            ///< Infusion
+      CONTINUOUSFLOWFASTATOMBOMBARDMENT,   ///< Continuous flow fast atom bombardment
+      INDUCTIVELYCOUPLEDPLASMA,            ///< Inductively coupled plasma
+      MEMBRANE,                            ///< Membrane inlet
+      NANOSPRAY,                           ///< Nanospray inlet
       SIZE_OF_INLETTYPE
     };
     /// Names of inlet types
@@ -78,58 +79,58 @@ public:
     /// ionization method
     enum IonizationMethod
     {
-      IONMETHODNULL,        ///< Unknown
-      ESI,                              ///< electrospray ionisation
-      EI,                               ///< electron ionization
-      CI,                               ///< chemical ionisation
-      FAB,                              ///< fast atom bombardment
-      TSP,                              ///< thermospray
-      LD,                               ///< laser desorption
-      FD,                               ///< field desorption
-      FI,                               ///< flame ionization
-      PD,                               ///< plasma desorption
-      SI,                               ///< secondary ion MS
-      TI,                               ///< thermal ionization
-      API,                              ///< atmospheric pressure ionisation
-      ISI,                              ///<
-      CID,                              ///< collision induced decomposition
-      CAD,                              ///< collision activated decomposition
-      HN,                               ///<
-      APCI,                             ///< atmospheric pressure chemical ionization
-      APPI,                             ///< atmospheric pressure photo ionization
-      ICP,                              ///< inductively coupled plasma
-      NESI,                             ///< Nano electrospray ionization
-      MESI,                             ///< Micro electrospray ionization
-      SELDI,                        ///< Surface enhanced laser desorption ionization
-      SEND,                             ///< Surface enhanced neat desorption
-      FIB,                              ///< Fast ion bombardment
-      MALDI,                        ///< Matrix-assisted laser desorption ionization
-      MPI,                              ///< Multiphoton ionization
-      DI,                               ///< desorption ionization
-      FA,                               ///< flowing afterglow
-      FII,                              ///< field ionization
-      GD_MS,                        ///< glow discharge ionization
-      NICI,                             ///< negative ion chemical ionization
-      NRMS,                             ///< neutralization reionization mass spectrometry
-      PI,                               ///< photoionization
-      PYMS,                             ///< pyrolysis mass spectrometry
-      REMPI,                        ///< resonance enhanced multiphoton ionization
-      AI,                               ///< adiabatic ionization
-      ASI,                              ///< associative ionization
-      AD,                               ///< autodetachment
-      AUI,                              ///< autoionization
-      CEI,                              ///< charge exchange ionization
-      CHEMI,                        ///< chemi-ionization
-      DISSI,                        ///< dissociative ionization
-      LSI,                              ///< liquid secondary ionization
-      PEI,                              ///< penning ionization
-      SOI,                              ///< soft ionization
-      SPI,                              ///< spark ionization
-      SUI,                              ///< surface ionization
-      VI,                               ///< vertical ionization
-      AP_MALDI,                     ///< atmospheric pressure matrix-assisted laser desorption ionization
-      SILI,                             ///< desorption/ionization on silicon
-      SALDI,                        ///< surface-assisted laser desorption ionization
+      IONMETHODNULL,           ///< Unknown
+      ESI,                     ///< electrospray ionisation
+      EI,                      ///< electron ionization
+      CI,                      ///< chemical ionisation
+      FAB,                     ///< fast atom bombardment
+      TSP,                     ///< thermospray
+      LD,                      ///< laser desorption
+      FD,                      ///< field desorption
+      FI,                      ///< flame ionization
+      PD,                      ///< plasma desorption
+      SI,                      ///< secondary ion MS
+      TI,                      ///< thermal ionization
+      API,                     ///< atmospheric pressure ionisation
+      ISI,                     ///<
+      CID,                     ///< collision induced decomposition
+      CAD,                     ///< collision activated decomposition
+      HN,                      ///<
+      APCI,                    ///< atmospheric pressure chemical ionization
+      APPI,                    ///< atmospheric pressure photo ionization
+      ICP,                     ///< inductively coupled plasma
+      NESI,                    ///< Nano electrospray ionization
+      MESI,                    ///< Micro electrospray ionization
+      SELDI,                   ///< Surface enhanced laser desorption ionization
+      SEND,                    ///< Surface enhanced neat desorption
+      FIB,                     ///< Fast ion bombardment
+      MALDI,                   ///< Matrix-assisted laser desorption ionization
+      MPI,                     ///< Multiphoton ionization
+      DI,                      ///< desorption ionization
+      FA,                      ///< flowing afterglow
+      FII,                     ///< field ionization
+      GD_MS,                   ///< glow discharge ionization
+      NICI,                    ///< negative ion chemical ionization
+      NRMS,                    ///< neutralization reionization mass spectrometry
+      PI,                      ///< photoionization
+      PYMS,                    ///< pyrolysis mass spectrometry
+      REMPI,                   ///< resonance enhanced multiphoton ionization
+      AI,                      ///< adiabatic ionization
+      ASI,                     ///< associative ionization
+      AD,                      ///< autodetachment
+      AUI,                     ///< autoionization
+      CEI,                     ///< charge exchange ionization
+      CHEMI,                   ///< chemi-ionization
+      DISSI,                   ///< dissociative ionization
+      LSI,                     ///< liquid secondary ionization
+      PEI,                     ///< penning ionization
+      SOI,                     ///< soft ionization
+      SPI,                     ///< spark ionization
+      SUI,                     ///< surface ionization
+      VI,                      ///< vertical ionization
+      AP_MALDI,                ///< atmospheric pressure matrix-assisted laser desorption ionization
+      SILI,                    ///< desorption/ionization on silicon
+      SALDI,                   ///< surface-assisted laser desorption ionization
       SIZE_OF_IONIZATIONMETHOD
     };
     /// Names of ionization methods
@@ -138,9 +139,9 @@ public:
     /// Polarity of the ion source
     enum Polarity
     {
-      POLNULL,      ///< Unknown
-      POSITIVE,   ///< Positive polarity
-      NEGATIVE,   ///< Negative polarity
+      POLNULL,          ///< Unknown
+      POSITIVE,         ///< Positive polarity
+      NEGATIVE,         ///< Negative polarity
       SIZE_OF_POLARITY
     };
     /// Names of polarity of the ion source
@@ -150,11 +151,15 @@ public:
     IonSource();
     /// Copy constructor
     IonSource(const IonSource & source);
+    /// Move constructor
+    IonSource(IonSource&&) = default;
     /// Destructor
     ~IonSource();
 
     /// Assignment operator
     IonSource & operator=(const IonSource & source);
+    /// Move assignment operator
+    IonSource& operator=(IonSource&&) & = default;
 
     /// Equality operator
     bool operator==(const IonSource & rhs) const;
@@ -185,7 +190,7 @@ public:
         - one ion detector
 
         For more complex instruments, the order should be defined.
-*/
+    */
     Int getOrder() const;
     /// sets the order
     void setOrder(Int order);

--- a/src/openms/include/OpenMS/METADATA/MSQuantifications.h
+++ b/src/openms/include/OpenMS/METADATA/MSQuantifications.h
@@ -182,22 +182,23 @@ public:
     //~ QUANT_TYPES experiment_type = MS1LABEL;
 
     /// Constructor
-    MSQuantifications();
+    MSQuantifications() = default;
 
     /// Detailed Constructor
     MSQuantifications(FeatureMap fm, ExperimentalSettings& es, std::vector<DataProcessing>& dps, std::vector<std::vector<std::pair<String, double> > > labels = (std::vector<std::vector<std::pair<String, double> > >()));
 
-    /// Destructor
-    ~MSQuantifications() override;
-
     /// Copy constructor
-    MSQuantifications(const MSQuantifications & source);
+    MSQuantifications(const MSQuantifications & source) = default;
 
     /// Move constructor
     MSQuantifications(MSQuantifications&&) = default;
 
+    /// Destructor
+    ~MSQuantifications() override;
+
     /// Assignment operator
-    MSQuantifications & operator=(const MSQuantifications & source);
+    MSQuantifications & operator=(const MSQuantifications & source) = default;
+
     /// Move assignment operator
     MSQuantifications& operator=(MSQuantifications&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/MSQuantifications.h
+++ b/src/openms/include/OpenMS/METADATA/MSQuantifications.h
@@ -193,8 +193,13 @@ public:
     /// Copy constructor
     MSQuantifications(const MSQuantifications & source);
 
+    /// Move constructor
+    MSQuantifications(MSQuantifications&&) = default;
+
     /// Assignment operator
     MSQuantifications & operator=(const MSQuantifications & source);
+    /// Move assignment operator
+    MSQuantifications& operator=(MSQuantifications&&) & = default;
 
     /// Equality operator
     bool operator==(const MSQuantifications & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/MassAnalyzer.h
+++ b/src/openms/include/OpenMS/METADATA/MassAnalyzer.h
@@ -51,21 +51,21 @@ public:
     /// analyzer type
     enum AnalyzerType
     {
-      ANALYZERNULL,                                         ///< Unknown
-      QUADRUPOLE,                                           ///< Quadrupole
-      PAULIONTRAP,                                          ///< Quadrupole ion trap / Paul ion trap
-      RADIALEJECTIONLINEARIONTRAP,          ///< Radial ejection linear ion trap
-      AXIALEJECTIONLINEARIONTRAP,           ///< Axial ejection linear ion trap
-      TOF,                                                          ///< Time-of-flight
-      SECTOR,                                                   ///< Magnetic sector
-      FOURIERTRANSFORM,                                 ///< Fourier transform ion cyclotron resonance mass spectrometer
-      IONSTORAGE,                                           ///< Ion storage
-      ESA,                                                          ///< Electrostatic energy analyzer
-      IT,                                                           ///< Ion trap
-      SWIFT,                                                    ///< Stored waveform inverse fourier transform
-      CYCLOTRON,                                            ///< Cyclotron
-      ORBITRAP,                                                 ///< Orbitrap
-      LIT,                                                          ///< Linear ion trap
+      ANALYZERNULL,                 ///< Unknown
+      QUADRUPOLE,                   ///< Quadrupole
+      PAULIONTRAP,                  ///< Quadrupole ion trap / Paul ion trap
+      RADIALEJECTIONLINEARIONTRAP,  ///< Radial ejection linear ion trap
+      AXIALEJECTIONLINEARIONTRAP,   ///< Axial ejection linear ion trap
+      TOF,                          ///< Time-of-flight
+      SECTOR,                       ///< Magnetic sector
+      FOURIERTRANSFORM,             ///< Fourier transform ion cyclotron resonance mass spectrometer
+      IONSTORAGE,                   ///< Ion storage
+      ESA,                          ///< Electrostatic energy analyzer
+      IT,                           ///< Ion trap
+      SWIFT,                        ///< Stored waveform inverse fourier transform
+      CYCLOTRON,                    ///< Cyclotron
+      ORBITRAP,                     ///< Orbitrap
+      LIT,                          ///< Linear ion trap
       SIZE_OF_ANALYZERTYPE
     };
     /// Names of the analyzer types
@@ -78,10 +78,10 @@ public:
     */
     enum ResolutionMethod
     {
-      RESMETHNULL,                      ///< Unknown
-      FWHM,                                     ///< Full width at half max
+      RESMETHNULL,                  ///< Unknown
+      FWHM,                         ///< Full width at half max
       TENPERCENTVALLEY,             ///< Ten percent valley
-      BASELINE,                             ///< Baseline
+      BASELINE,                     ///< Baseline
       SIZE_OF_RESOLUTIONMETHOD
     };
     /// Names of resolution methods
@@ -91,7 +91,7 @@ public:
     enum ResolutionType
     {
       RESTYPENULL,              ///< Unknown
-      CONSTANT,                     ///< Constant
+      CONSTANT,                 ///< Constant
       PROPORTIONAL,             ///< Proportional
       SIZE_OF_RESOLUTIONTYPE
     };
@@ -102,8 +102,8 @@ public:
     enum ScanDirection
     {
       SCANDIRNULL,              ///< Unknown
-      UP,                               ///< Up
-      DOWN,                             ///< Down
+      UP,                       ///< Up
+      DOWN,                     ///< Down
       SIZE_OF_SCANDIRECTION
     };
     /// Names of direction of scanning
@@ -114,7 +114,7 @@ public:
     {
       SCANLAWNULL,              ///< Unknown
       EXPONENTIAL,              ///< Unknown
-      LINEAR,                       ///< Linear
+      LINEAR,                   ///< Linear
       QUADRATIC,                ///< Quadratic
       SIZE_OF_SCANLAW
     };
@@ -125,9 +125,9 @@ public:
     enum ReflectronState
     {
       REFLSTATENULL,            ///< Unknown
-      ON,                                   ///< On
-      OFF,                                  ///< Off
-      NONE,                                 ///< None
+      ON,                       ///< On
+      OFF,                      ///< Off
+      NONE,                     ///< None
       SIZE_OF_REFLECTRONSTATE
     };
     /// Names of reflectron states
@@ -137,11 +137,15 @@ public:
     MassAnalyzer();
     /// Copy constructor
     MassAnalyzer(const MassAnalyzer & source);
+    /// Move constructor
+    MassAnalyzer(MassAnalyzer&&) = default;
     /// Destructor
     ~MassAnalyzer();
 
     /// Assignment operator
     MassAnalyzer & operator=(const MassAnalyzer & source);
+    /// Move assignment operator
+    MassAnalyzer& operator=(MassAnalyzer&&) & = default;
 
     /// Equality operator
     bool operator==(const MassAnalyzer & rhs) const;
@@ -231,7 +235,7 @@ public:
         - one ion detector
 
         For more complex instruments, the order should be defined.
-*/
+    */
     Int getOrder() const;
     /// sets the order
     void setOrder(Int order);

--- a/src/openms/include/OpenMS/METADATA/MassAnalyzer.h
+++ b/src/openms/include/OpenMS/METADATA/MassAnalyzer.h
@@ -136,14 +136,14 @@ public:
     /// Constructor
     MassAnalyzer();
     /// Copy constructor
-    MassAnalyzer(const MassAnalyzer & source);
+    MassAnalyzer(const MassAnalyzer & source) = default;
     /// Move constructor
     MassAnalyzer(MassAnalyzer&&) = default;
     /// Destructor
     ~MassAnalyzer();
 
     /// Assignment operator
-    MassAnalyzer & operator=(const MassAnalyzer & source);
+    MassAnalyzer & operator=(const MassAnalyzer & source) = default;
     /// Move assignment operator
     MassAnalyzer& operator=(MassAnalyzer&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/MetaInfo.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfo.h
@@ -74,11 +74,16 @@ public:
     /// Copy constructor
     MetaInfo(const MetaInfo& rhs);
 
+    /// Move constructor
+    MetaInfo(MetaInfo&&) = default;
+
     /// Destructor
     ~MetaInfo();
 
     /// Assignment operator
     MetaInfo& operator=(const MetaInfo& rhs);
+    /// Move assignment operator
+    MetaInfo& operator=(MetaInfo&&) & = default;
 
     /// Equality operator
     bool operator==(const MetaInfo& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/MetaInfo.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfo.h
@@ -69,10 +69,10 @@ namespace OpenMS
   {
 public:
     /// Constructor
-    MetaInfo();
+    MetaInfo() = default;
 
     /// Copy constructor
-    MetaInfo(const MetaInfo& rhs);
+    MetaInfo(const MetaInfo& rhs) = default;
 
     /// Move constructor
     MetaInfo(MetaInfo&&) = default;
@@ -81,7 +81,7 @@ public:
     ~MetaInfo();
 
     /// Assignment operator
-    MetaInfo& operator=(const MetaInfo& rhs);
+    MetaInfo& operator=(const MetaInfo& rhs) = default;
     /// Move assignment operator
     MetaInfo& operator=(MetaInfo&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
@@ -50,16 +50,16 @@ namespace OpenMS
   {
 public:
     /// Constructor
-    MetaInfoDescription();
+    MetaInfoDescription() = default;
     /// Copy constructor
-    MetaInfoDescription(const MetaInfoDescription & source);
+    MetaInfoDescription(const MetaInfoDescription & source) = default;
     /// Move constructor
     MetaInfoDescription(MetaInfoDescription&&) = default;
     /// Destructor
     ~MetaInfoDescription();
 
     /// Assignment operator
-    MetaInfoDescription & operator=(const MetaInfoDescription & source);
+    MetaInfoDescription & operator=(const MetaInfoDescription & source) = default;
     /// Move assignment operator
     MetaInfoDescription& operator=(MetaInfoDescription&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoDescription.h
@@ -53,11 +53,15 @@ public:
     MetaInfoDescription();
     /// Copy constructor
     MetaInfoDescription(const MetaInfoDescription & source);
+    /// Move constructor
+    MetaInfoDescription(MetaInfoDescription&&) = default;
     /// Destructor
     ~MetaInfoDescription();
 
     /// Assignment operator
     MetaInfoDescription & operator=(const MetaInfoDescription & source);
+    /// Move assignment operator
+    MetaInfoDescription& operator=(MetaInfoDescription&&) & = default;
 
     /// Equality operator
     bool operator==(const MetaInfoDescription & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/MetaInfoInterface.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoInterface.h
@@ -60,11 +60,15 @@ public:
     MetaInfoInterface();
     /// Copy constructor
     MetaInfoInterface(const MetaInfoInterface& rhs);
+    /// Move constructor
+    MetaInfoInterface(MetaInfoInterface&&);
     /// Destructor
     ~MetaInfoInterface();
 
     /// Assignment operator
     MetaInfoInterface& operator=(const MetaInfoInterface& rhs);
+    /// Move assignment operator
+    MetaInfoInterface& operator=(MetaInfoInterface&&);
 
     /// Equality operator
     bool operator==(const MetaInfoInterface& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoInterfaceUtils.h
@@ -105,6 +105,7 @@ private:
     MetaInfoInterfaceUtils();
     MetaInfoInterfaceUtils(const MetaInfoInterfaceUtils&);
     MetaInfoInterfaceUtils& operator=(MetaInfoInterfaceUtils&);
+    // no Move semantics for utils class
   
   }; // class
 

--- a/src/openms/include/OpenMS/METADATA/MetaInfoRegistry.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoRegistry.h
@@ -73,16 +73,16 @@ namespace OpenMS
   class OPENMS_DLLAPI MetaInfoRegistry
   {
 public:
-    ///default constructor
+    /// Default constructor
     MetaInfoRegistry();
 
-    ///copy constructor
+    /// Copy constructor
     MetaInfoRegistry(const MetaInfoRegistry& rhs);
 
-    ///destructor
+    /// Destructor
     ~MetaInfoRegistry();
 
-    ///assignment operator
+    /// Assignment operator
     MetaInfoRegistry& operator=(const MetaInfoRegistry& rhs);
 
     /**

--- a/src/openms/include/OpenMS/METADATA/Modification.h
+++ b/src/openms/include/OpenMS/METADATA/Modification.h
@@ -68,14 +68,14 @@ public:
     /// Default constructor
     Modification();
     /// Copy constructor
-    Modification(const Modification &);
+    Modification(const Modification &) = default;
     /// Move constructor
     Modification(Modification&&) = default;
     /// Destructor
     ~Modification() override;
 
     /// Assignment operator
-    Modification & operator=(const Modification &);
+    Modification & operator=(const Modification &) = default;
     /// Move assignment operator
     Modification& operator=(Modification&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/Modification.h
+++ b/src/openms/include/OpenMS/METADATA/Modification.h
@@ -65,15 +65,19 @@ public:
     /// Names of specificity types
     static const std::string NamesOfSpecificityType[SIZE_OF_SPECIFICITYTYPE];
 
-    /// default constructor
+    /// Default constructor
     Modification();
-    /// copy constructor
+    /// Copy constructor
     Modification(const Modification &);
-    /// destructor
+    /// Move constructor
+    Modification(Modification&&) = default;
+    /// Destructor
     ~Modification() override;
 
-    /// assignment operator
+    /// Assignment operator
     Modification & operator=(const Modification &);
+    /// Move assignment operator
+    Modification& operator=(Modification&&) & = default;
 
     /**
         @brief Equality operator
@@ -96,9 +100,9 @@ public:
     /// sets the mass change
     void setMass(double mass);
 
-    /// returns the specificity of the the reagent (default: AA)
+    /// returns the specificity of the reagent (default: AA)
     const SpecificityType & getSpecificityType() const;
-    /// sets the specificity of the the reagent
+    /// sets the specificity of the reagent
     void setSpecificityType(const SpecificityType & specificity_type);
 
     /// returns a string containing the one letter code of the amino acids that are affected by the reagent. (default: "")

--- a/src/openms/include/OpenMS/METADATA/PeptideEvidence.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideEvidence.h
@@ -67,7 +67,7 @@ public:
     PeptideEvidence(const String& accession, Int start, Int end, char aa_before, char aa_after);
 
     /// Copy constructor
-    PeptideEvidence(const PeptideEvidence& source);
+    PeptideEvidence(const PeptideEvidence& source) = default;
 
     /// Move constructor
     PeptideEvidence(PeptideEvidence&&) = default;
@@ -77,7 +77,7 @@ public:
     //@}
 
     /// Assignment operator
-    PeptideEvidence& operator=(const PeptideEvidence& source);
+    PeptideEvidence& operator=(const PeptideEvidence& source) = default;
     /// Move assignment operator
     PeptideEvidence& operator=(PeptideEvidence&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/PeptideEvidence.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideEvidence.h
@@ -60,21 +60,26 @@ public:
     static const char N_TERMINAL_AA;
     static const char C_TERMINAL_AA;
 
-    /// constructor
+    /// Constructor
     PeptideEvidence();
 
-    /// constructor
+    /// Constructor
     PeptideEvidence(const String& accession, Int start, Int end, char aa_before, char aa_after);
 
-    /// copy constructor
+    /// Copy constructor
     PeptideEvidence(const PeptideEvidence& source);
 
-    /// destructor
+    /// Move constructor
+    PeptideEvidence(PeptideEvidence&&) = default;
+
+    /// Destructor
     ~PeptideEvidence() {}
     //@}
 
-    /// assignment operator
+    /// Assignment operator
     PeptideEvidence& operator=(const PeptideEvidence& source);
+    /// Move assignment operator
+    PeptideEvidence& operator=(PeptideEvidence&&) & = default;
 
     /// Equality operator
     bool operator==(const PeptideEvidence& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -49,7 +49,7 @@ namespace OpenMS
 
     It contains the fields score, score_type, rank, and sequence.
 
-        @ingroup Metadata
+    @ingroup Metadata
   */
   class OPENMS_DLLAPI PeptideHit :
     public MetaInfoInterface
@@ -237,24 +237,31 @@ public:
 
     /** @name Constructors and Destructor */
     //@{
-    /// default constructor
+
+    /// Default constructor
     PeptideHit();
 
-    /// values constructor
+    /// Values constructor
     PeptideHit(double score,
                UInt rank,
                Int charge,
                const AASequence& sequence);
 
-    /// copy constructor
+    /// Copy constructor
     PeptideHit(const PeptideHit& source);
 
-    /// destructor
+    /// Move constructor
+    PeptideHit(PeptideHit&&);
+
+    /// Destructor
     virtual ~PeptideHit();
     //@}
 
-    /// assignment operator
+    /// Assignment operator
     PeptideHit& operator=(const PeptideHit& source);
+
+    /// Move assignment operator
+    PeptideHit& operator=(PeptideHit&&);
 
     /// Equality operator
     bool operator==(const PeptideHit& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -222,17 +222,6 @@ public:
           && main_score == rhs.main_score
           && sub_scores == rhs.sub_scores;
       }
-
-      PepXMLAnalysisResult& operator=(const PepXMLAnalysisResult& source)
-      {
-        if (this == &source) return *this;
-        score_type = source.score_type;
-        higher_is_better = source.higher_is_better;
-        main_score = source.main_score;
-        sub_scores = source.sub_scores;
-        return *this;
-      }
-
     };
 
     /** @name Constructors and Destructor */

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -74,12 +74,12 @@ public:
     /// destructor
     virtual ~PeptideIdentification();
     /// copy constructor
-    PeptideIdentification(const PeptideIdentification& source);
+    PeptideIdentification(const PeptideIdentification& source) = default;
     /// Move constructor
     PeptideIdentification(PeptideIdentification&&) = default;
 
     /// Assignment operator
-    PeptideIdentification& operator=(const PeptideIdentification& source);
+    PeptideIdentification& operator=(const PeptideIdentification& source) = default;
     /// Move assignment operator
     PeptideIdentification& operator=(PeptideIdentification&&) & = default;
     /// Equality operator

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -75,8 +75,13 @@ public:
     virtual ~PeptideIdentification();
     /// copy constructor
     PeptideIdentification(const PeptideIdentification& source);
-    /// assignment operator
+    /// Move constructor
+    PeptideIdentification(PeptideIdentification&&) = default;
+
+    /// Assignment operator
     PeptideIdentification& operator=(const PeptideIdentification& source);
+    /// Move assignment operator
+    PeptideIdentification& operator=(PeptideIdentification&&) & = default;
     /// Equality operator
     bool operator==(const PeptideIdentification& rhs) const;
     /// Inequality operator

--- a/src/openms/include/OpenMS/METADATA/Precursor.h
+++ b/src/openms/include/OpenMS/METADATA/Precursor.h
@@ -87,14 +87,14 @@ public:
     /// Constructor
     Precursor();
     /// Copy constructor
-    Precursor(const Precursor & source);
+    Precursor(const Precursor & source) = default;
     /// Move constructor
     Precursor(Precursor&&) = default;
     /// Destructor
     ~Precursor() override;
 
     /// Assignment operator
-    Precursor & operator=(const Precursor & source);
+    Precursor & operator=(const Precursor & source) = default;
     /// Move assignment operator
     Precursor& operator=(Precursor&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/Precursor.h
+++ b/src/openms/include/OpenMS/METADATA/Precursor.h
@@ -68,15 +68,15 @@ public:
       PSD,                      ///< Post-source decay
       PD,                       ///< Plasma desorption
       SID,                      ///< Surface-induced dissociation
-      BIRD,                             ///< Blackbody infrared radiative dissociation
-      ECD,                              ///< Electron capture dissociation
-      IMD,                              ///< Infrared multiphoton dissociation
-      SORI,                             ///< Sustained off-resonance irradiation
-      HCID,                             ///< High-energy collision-induced dissociation
-      LCID,                             ///< Low-energy collision-induced dissociation
-      PHD,                              ///< Photodissociation
-      ETD,                              ///< Electron transfer dissociation
-      PQD,                              ///< Pulsed q dissociation
+      BIRD,                     ///< Blackbody infrared radiative dissociation
+      ECD,                      ///< Electron capture dissociation
+      IMD,                      ///< Infrared multiphoton dissociation
+      SORI,                     ///< Sustained off-resonance irradiation
+      HCID,                     ///< High-energy collision-induced dissociation
+      LCID,                     ///< Low-energy collision-induced dissociation
+      PHD,                      ///< Photodissociation
+      ETD,                      ///< Electron transfer dissociation
+      PQD,                      ///< Pulsed q dissociation
       SIZE_OF_ACTIVATIONMETHOD
     };
 
@@ -88,11 +88,15 @@ public:
     Precursor();
     /// Copy constructor
     Precursor(const Precursor & source);
+    /// Move constructor
+    Precursor(Precursor&&) = default;
     /// Destructor
     ~Precursor() override;
 
     /// Assignment operator
     Precursor & operator=(const Precursor & source);
+    /// Move assignment operator
+    Precursor& operator=(Precursor&&) & = default;
 
     /// Equality operator
     bool operator==(const Precursor & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/Product.h
+++ b/src/openms/include/OpenMS/METADATA/Product.h
@@ -52,16 +52,16 @@ namespace OpenMS
 public:
 
     /// Constructor
-    Product();
+    Product() = default;
     /// Copy constructor
-    Product(const Product & source);
+    Product(const Product & source) = default;
     /// Move constructor
     Product(Product&&) = default;
     /// Destructor
-    ~Product() override;
+    ~Product() override = default;
 
     /// Assignment operator
-    Product & operator=(const Product & source);
+    Product & operator=(const Product & source) = default;
     /// Move assignment operator
     Product& operator=(Product&&) & = default;
 
@@ -87,9 +87,9 @@ public:
 
 protected:
 
-    double mz_;
-    double window_low_;
-    double window_up_;
+    double mz_ = 0.0;
+    double window_low_ = 0.0;
+    double window_up_ = 0.0;
   };
 } // namespace OpenMS
 

--- a/src/openms/include/OpenMS/METADATA/Product.h
+++ b/src/openms/include/OpenMS/METADATA/Product.h
@@ -55,11 +55,15 @@ public:
     Product();
     /// Copy constructor
     Product(const Product & source);
+    /// Move constructor
+    Product(Product&&) = default;
     /// Destructor
     ~Product() override;
 
     /// Assignment operator
     Product & operator=(const Product & source);
+    /// Move assignment operator
+    Product& operator=(Product&&) & = default;
 
     /// Equality operator
     bool operator==(const Product & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/ProteinHit.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinHit.h
@@ -107,7 +107,7 @@ public:
     ProteinHit(double score, UInt rank, String accession, String sequence);
 
     /// Copy constructor
-    ProteinHit(const ProteinHit & source);
+    ProteinHit(const ProteinHit & source) = default;
 
     /// Move constructor
     ProteinHit(ProteinHit&&) = default;
@@ -117,7 +117,7 @@ public:
     //@}
 
     /// Assignment operator
-    ProteinHit & operator=(const ProteinHit & source);
+    ProteinHit & operator=(const ProteinHit & source) = default;
 
     /// Move assignment operator
     ProteinHit& operator=(ProteinHit&&) & = default;

--- a/src/openms/include/OpenMS/METADATA/ProteinHit.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinHit.h
@@ -48,7 +48,7 @@ namespace OpenMS
     It contains the fields score, score_type, rank, accession,
     sequence and coverage.
 
-        @ingroup Metadata
+    @ingroup Metadata
   */
   class OPENMS_DLLAPI ProteinHit :
     public MetaInfoInterface
@@ -100,23 +100,29 @@ public:
     /** @name Constructors and Destructor */
     //@{
 
-    /// default constructor
+    /// Default constructor
     ProteinHit();
 
-    /// values constructor
+    /// Values constructor
     ProteinHit(double score, UInt rank, String accession, String sequence);
 
-    /// copy constructor
+    /// Copy constructor
     ProteinHit(const ProteinHit & source);
 
-    /// destructor
+    /// Move constructor
+    ProteinHit(ProteinHit&&) = default;
+
+    /// Destructor
     virtual ~ProteinHit();
     //@}
 
-    /// assignment operator
+    /// Assignment operator
     ProteinHit & operator=(const ProteinHit & source);
 
-    /// assignment for MetaInfo
+    /// Move assignment operator
+    ProteinHit& operator=(ProteinHit&&) & = default;
+
+    /// Assignment for MetaInfo
     ProteinHit & operator=(const MetaInfoInterface & source);
 
     /// Equality operator
@@ -168,11 +174,11 @@ public:
     //@}
 
 protected:
-    float score_;                        ///< the score of the protein hit
-    UInt rank_;                         ///< the position(rank) where the hit appeared in the hit list
-    String accession_;          ///< the protein identifier
-    String sequence_;               ///< the amino acid sequence of the protein hit
-    double coverage_;         ///< coverage of the protein based upon the matched peptide sequences
+    float score_;        ///< the score of the protein hit
+    UInt rank_;          ///< the position(rank) where the hit appeared in the hit list
+    String accession_;   ///< the protein identifier
+    String sequence_;    ///< the amino acid sequence of the protein hit
+    double coverage_;    ///< coverage of the protein based upon the matched peptide sequences
 
   };
 

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -51,12 +51,17 @@ namespace OpenMS
 
     The actual peptide hits are stored in PeptideIdentification instances that are part of spectra or features.
 
-    In order to be able to connect the ProteinIdentification and the corresponding peptide identifications, both classes have a string identifier. We recommend using the search engine name and the date as identifier.
-    Setting this identifier is especially important when there are several protein identification runs for a map, i.e. several ProteinIdentification instances.
+    In order to be able to connect the ProteinIdentification and the
+    corresponding peptide identifications, both classes have a string
+    identifier. We recommend using the search engine name and the date as
+    identifier.
+    Setting this identifier is especially important when there are several
+    protein identification runs for a map, i.e. several ProteinIdentification
+    instances.
 
     @todo Add MetaInfoInterface to modifications => update IdXMLFile and ProteinIdentificationVisualizer (Andreas)
 
-        @ingroup Metadata
+    @ingroup Metadata
   */
   class OPENMS_DLLAPI ProteinIdentification :
     public MetaInfoInterface
@@ -84,7 +89,10 @@ public:
       /*
         @brief Comparison operator (for sorting)
 
-        This operator is intended for sorting protein groups in a "best first" manner. That means higher probabilities are "less" than lower probabilities (!); smaller groups are "less" than larger groups; everything else being equal, accessions are compared lexicographically.
+        This operator is intended for sorting protein groups in a "best first"
+        manner. That means higher probabilities are "less" than lower
+        probabilities (!); smaller groups are "less" than larger groups;
+        everything else being equal, accessions are compared lexicographically.
       */
       bool operator<(const ProteinGroup& rhs) const;
     };
@@ -118,6 +126,17 @@ public:
       Protease digestion_enzyme; ///< The cleavage site information in details (from ProteaseDB)
 
       SearchParameters();
+      /// Copy constructor
+      SearchParameters(const SearchParameters & source) = default;
+      /// Move constructor
+      SearchParameters(SearchParameters&&) = default;
+      /// Destructor
+      ~SearchParameters() = default;
+
+      /// Assignment operator
+      SearchParameters & operator=(const SearchParameters & source) = default;
+      /// Move assignment operator
+      SearchParameters& operator=(SearchParameters&&) & = default;
 
       bool operator==(const SearchParameters& rhs) const;
 
@@ -125,17 +144,22 @@ public:
 
     };
 
-
     /** @name Constructors, destructors, assignment operator <br> */
     //@{
     /// Default constructor
     ProteinIdentification();
-    /// Destructor
-    virtual ~ProteinIdentification();
     /// Copy constructor
     ProteinIdentification(const ProteinIdentification& source);
+    /// Move constructor
+    ProteinIdentification(ProteinIdentification&&) = default;
+    /// Destructor
+    virtual ~ProteinIdentification();
+
     /// Assignment operator
     ProteinIdentification& operator=(const ProteinIdentification& source);
+    /// Move assignment operator
+    ProteinIdentification& operator=(ProteinIdentification&&) & = default;
+
     /// Equality operator
     bool operator==(const ProteinIdentification& rhs) const;
     /// Inequality operator

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -149,14 +149,14 @@ public:
     /// Default constructor
     ProteinIdentification();
     /// Copy constructor
-    ProteinIdentification(const ProteinIdentification& source);
+    ProteinIdentification(const ProteinIdentification& source) = default;
     /// Move constructor
     ProteinIdentification(ProteinIdentification&&) = default;
     /// Destructor
     virtual ~ProteinIdentification();
 
     /// Assignment operator
-    ProteinIdentification& operator=(const ProteinIdentification& source);
+    ProteinIdentification& operator=(const ProteinIdentification& source) = default;
     /// Move assignment operator
     ProteinIdentification& operator=(ProteinIdentification&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/Sample.h
+++ b/src/openms/include/OpenMS/METADATA/Sample.h
@@ -65,27 +65,31 @@ public:
     /// Names of sample states
     static const std::string NamesOfSampleState[SIZE_OF_SAMPLESTATE];
 
-    ///default constructor
+    /// Default constructor
     Sample();
-    ///copy constructor
+    /// Copy constructor
     Sample(const Sample & source);
-    ///destructor
+    /// Move constructor
+    Sample(Sample&&) = default;
+    /// Destructor
     ~Sample();
 
-    ///assignment operator
+    /// Assignment operator
     Sample & operator=(const Sample & source);
+    /// Move assignment operator
+    Sample& operator=(Sample&&) & = default;
 
     /// Equality operator
     bool operator==(const Sample & rhs) const;
 
-    ///returns the sample name (default: "")
+    /// returns the sample name (default: "")
     const String & getName() const;
-    ///sets the sample name
+    /// sets the sample name
     void setName(const String & name);
 
-    ///returns the sample name (default: "")
+    /// returns the sample name (default: "")
     const String & getOrganism() const;
-    ///sets the sample name
+    /// sets the sample name
     void setOrganism(const String & organism);
 
     /// returns the sample number (default: "")
@@ -126,29 +130,36 @@ public:
     void setSubsamples(const std::vector<Sample> & subsamples);
 
     /**
-        @brief adds a sample treatment before the given position (default is the end of the list). Sample treatments are ordered in the order of application to the sample. If before_position is smaller than 0, the sample treatment is appended to the list.
+        @brief adds a sample treatment before the given position (default is
+        the end of the list). Sample treatments are ordered in the order of
+        application to the sample. If before_position is smaller than 0, the
+        sample treatment is appended to the list.
 
-    @exception Exception::IndexOverflow is thrown if the position is invalid.
-  */
+        @exception Exception::IndexOverflow is thrown if the position is invalid.
+    */
     void addTreatment(const SampleTreatment & treatment, Int before_position = -1);
+
     /**
         @brief returns a mutable reference to the sample treatment at the given position
 
-    @exception Exception::IndexOverflow is thrown if the position is invalid.
-  */
+        @exception Exception::IndexOverflow is thrown if the position is invalid.
+    */
     SampleTreatment & getTreatment(UInt position);
+
     /**
         @brief returns a const reference to the sample treatment at the given position
 
-    @exception Exception::IndexOverflow is thrown if the position is invalid.
-  */
+        @exception Exception::IndexOverflow is thrown if the position is invalid.
+    */
     const SampleTreatment & getTreatment(UInt position) const;
+
     /**
         @brief removes the sample treatment at the given position
 
-    @exception Exception::IndexOverflow is thrown if the position is invalid.
-  */
+        @exception Exception::IndexOverflow is thrown if the position is invalid.
+    */
     void removeTreatment(UInt position);
+
     /// returns the number of sample treatments
     Int countTreatments() const;
 

--- a/src/openms/include/OpenMS/METADATA/Sample.h
+++ b/src/openms/include/OpenMS/METADATA/Sample.h
@@ -173,6 +173,10 @@ protected:
     double volume_;
     double concentration_;
     std::vector<Sample> subsamples_;
+
+    // note: default move constructor / assignment operator will work on this,
+    // since it will move the whole vector over to the new object who will then
+    // own the memory.
     std::list<SampleTreatment *> treatments_;
 
   };

--- a/src/openms/include/OpenMS/METADATA/SampleTreatment.h
+++ b/src/openms/include/OpenMS/METADATA/SampleTreatment.h
@@ -58,14 +58,14 @@ public:
 
         Use a unique type string for each treatment type
     */
-    SampleTreatment(const String & type);
+    explicit SampleTreatment(const String & type);
 
     /**
         @brief Copy constructor
 
         @note Do not forget to call it when you derive a class from SampleTreatment!
     */
-    SampleTreatment(const SampleTreatment &);
+    SampleTreatment(const SampleTreatment &) = default;
 
     /// Move constructor
     SampleTreatment(SampleTreatment&&) = default;
@@ -78,11 +78,10 @@ public:
 
         @note Do not forget to call it when you derive a class from SampleTreatment!
     */
-    SampleTreatment & operator=(const SampleTreatment &);
+    SampleTreatment & operator=(const SampleTreatment &) = default;
 
     /// Move assignment operator
     SampleTreatment& operator=(SampleTreatment&&) & = default;
-
 
     /**
         @brief Equality operator

--- a/src/openms/include/OpenMS/METADATA/SampleTreatment.h
+++ b/src/openms/include/OpenMS/METADATA/SampleTreatment.h
@@ -52,19 +52,25 @@ namespace OpenMS
     public MetaInfoInterface
   {
 public:
+
     /**
         @brief Constructor.
 
         Use a unique type string for each treatment type
     */
     SampleTreatment(const String & type);
+
     /**
         @brief Copy constructor
 
         @note Do not forget to call it when you derive a class from SampleTreatment!
     */
     SampleTreatment(const SampleTreatment &);
-    /// destructor
+
+    /// Move constructor
+    SampleTreatment(SampleTreatment&&) = default;
+
+    /// Destructor
     virtual ~SampleTreatment();
 
     /**
@@ -74,6 +80,10 @@ public:
     */
     SampleTreatment & operator=(const SampleTreatment &);
 
+    /// Move assignment operator
+    SampleTreatment& operator=(SampleTreatment&&) & = default;
+
+
     /**
         @brief Equality operator
 
@@ -81,7 +91,7 @@ public:
         They check the type and cast the reference to the right type if the type matches.
 
     @note Do not forget to call it when you derive a class from SampleTreatment!
-  */
+    */
     virtual bool operator==(const SampleTreatment & rhs) const;
 
     /**
@@ -89,7 +99,7 @@ public:
 
         The type_ has to be set in the default constructor.
         It is used to determine the kind of sample treatment, when only a pointer to this base class is available.
-        */
+    */
     const String & getType() const;
 
     /// returns the description of the sample treatment

--- a/src/openms/include/OpenMS/METADATA/ScanWindow.h
+++ b/src/openms/include/OpenMS/METADATA/ScanWindow.h
@@ -46,20 +46,28 @@ namespace OpenMS
   struct OPENMS_DLLAPI ScanWindow :
     public MetaInfoInterface
   {
-    ///Default constructor
+    /// Default constructor
     ScanWindow();
-    ///Copy constructor
+    /// Copy constructor
     ScanWindow(const ScanWindow & source);
-    ///Equality operator
-    bool operator==(const ScanWindow & source) const;
-    ///Equality operator
-    bool operator!=(const ScanWindow & source) const;
-    ///Assignment operator
-    ScanWindow & operator=(const ScanWindow & source);
+    /// Move constructor
+    ScanWindow(ScanWindow&&) = default;
+    /// Destructor
+    ~ScanWindow() {}
 
-    ///Begin of the window
+    /// Equality operator
+    bool operator==(const ScanWindow & source) const;
+    /// Equality operator
+    bool operator!=(const ScanWindow & source) const;
+
+    /// Assignment operator
+    ScanWindow & operator=(const ScanWindow & source);
+    /// Move assignment operator
+    ScanWindow& operator=(ScanWindow&&) & = default;
+
+    /// Begin of the window
     double begin;
-    ///End of the window
+    /// End of the window
     double end;
   };
 

--- a/src/openms/include/OpenMS/METADATA/ScanWindow.h
+++ b/src/openms/include/OpenMS/METADATA/ScanWindow.h
@@ -47,9 +47,9 @@ namespace OpenMS
     public MetaInfoInterface
   {
     /// Default constructor
-    ScanWindow();
+    ScanWindow() = default;
     /// Copy constructor
-    ScanWindow(const ScanWindow & source);
+    ScanWindow(const ScanWindow & source) = default;
     /// Move constructor
     ScanWindow(ScanWindow&&) = default;
     /// Destructor
@@ -61,14 +61,14 @@ namespace OpenMS
     bool operator!=(const ScanWindow & source) const;
 
     /// Assignment operator
-    ScanWindow & operator=(const ScanWindow & source);
+    ScanWindow & operator=(const ScanWindow & source) = default;
     /// Move assignment operator
     ScanWindow& operator=(ScanWindow&&) & = default;
 
     /// Begin of the window
-    double begin;
+    double begin = 0.0;
     /// End of the window
-    double end;
+    double end = 0.0;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/METADATA/Software.h
+++ b/src/openms/include/OpenMS/METADATA/Software.h
@@ -50,16 +50,16 @@ namespace OpenMS
   {
 public:
     /// Constructor
-    Software();
+    Software() = default;
     /// Copy constructor
-    Software(const Software & source);
+    Software(const Software & source) = default;
     /// Move constructor
     Software(Software&&) = default;
     /// Destructor
     ~Software() override;
 
     /// Assignment operator
-    Software & operator=(const Software & source);
+    Software & operator=(const Software & source) = default;
     /// Move assignment operator
     Software& operator=(Software&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/Software.h
+++ b/src/openms/include/OpenMS/METADATA/Software.h
@@ -53,11 +53,15 @@ public:
     Software();
     /// Copy constructor
     Software(const Software & source);
+    /// Move constructor
+    Software(Software&&) = default;
     /// Destructor
     ~Software() override;
 
     /// Assignment operator
     Software & operator=(const Software & source);
+    /// Move assignment operator
+    Software& operator=(Software&&) & = default;
 
     /// Equality operator
     bool operator==(const Software & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/SourceFile.h
+++ b/src/openms/include/OpenMS/METADATA/SourceFile.h
@@ -62,14 +62,14 @@ public:
     /// Constructor
     SourceFile();
     /// Copy constructor
-    SourceFile(const SourceFile& source);
+    SourceFile(const SourceFile& source) = default;
     /// Move constructor
     SourceFile(SourceFile&&) = default;
     /// Destructor
     ~SourceFile() override;
 
     /// Assignment operator
-    SourceFile& operator=(const SourceFile& source);
+    SourceFile& operator=(const SourceFile& source) = default;
     /// Move assignment operator
     SourceFile& operator=(SourceFile&&) & = default;
 
@@ -121,7 +121,7 @@ protected:
     double file_size_;
     String file_type_;
     String checksum_;
-    ChecksumType checksum_type_;
+    ChecksumType checksum_type_ = SourceFile::ChecksumType::UNKNOWN_CHECKSUM;
     String native_id_type_;
     String native_id_type_accession_;
   };

--- a/src/openms/include/OpenMS/METADATA/SourceFile.h
+++ b/src/openms/include/OpenMS/METADATA/SourceFile.h
@@ -55,6 +55,7 @@ public:
       MD5, ///< Message-Digest algorithm 5
       SIZE_OF_CHECKSUMTYPE
     };
+
     /// Names of checksum types
     static const std::string NamesOfChecksumType[SIZE_OF_CHECKSUMTYPE];
 
@@ -62,10 +63,15 @@ public:
     SourceFile();
     /// Copy constructor
     SourceFile(const SourceFile& source);
+    /// Move constructor
+    SourceFile(SourceFile&&) = default;
     /// Destructor
     ~SourceFile() override;
+
     /// Assignment operator
     SourceFile& operator=(const SourceFile& source);
+    /// Move assignment operator
+    SourceFile& operator=(SourceFile&&) & = default;
 
     /// Equality operator
     bool operator==(const SourceFile& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/SpectrumIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumIdentification.h
@@ -53,14 +53,18 @@ public:
 
     /// @name constructors,destructors,assignment operator
     //@{
-    /// default constructor
-    SpectrumIdentification();
-    /// destructor
+    /// Default constructor
+    SpectrumIdentification() = default;
+    /// Destructor
     virtual ~SpectrumIdentification();
-    /// copy constructor
-    SpectrumIdentification(const SpectrumIdentification & source);
-    /// assignment operator
-    SpectrumIdentification & operator=(const SpectrumIdentification & source);
+    /// Copy constructor
+    SpectrumIdentification(const SpectrumIdentification & source) = default;
+    /// Move constructor
+    SpectrumIdentification(SpectrumIdentification&&) = default;
+    /// Assignment operator
+    SpectrumIdentification & operator=(const SpectrumIdentification & source) = default;
+    /// Move assignment operator
+    SpectrumIdentification& operator=(SpectrumIdentification&&) & = default;
     /// Equality operator
     bool operator==(const SpectrumIdentification & rhs) const;
     /// Inequality operator
@@ -81,8 +85,8 @@ public:
 
 protected:
 
-    String id_;                                                                     ///< Identifier
-    std::vector<IdentificationHit> hits_;               ///< Single peptide hits
+    String id_; ///< Identifier
+    std::vector<IdentificationHit> hits_; ///< Single peptide hits
   };
 
 } //namespace OpenMS

--- a/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumMetaDataLookup.h
@@ -45,6 +45,7 @@
 
 namespace OpenMS
 {
+
   /**
     @brief Helper class for looking up spectrum meta data
 
@@ -176,6 +177,18 @@ namespace OpenMS
         precursor_charge(0), ms_level(0), scan_number(-1), native_id("")
       {
       }
+
+      /// Copy constructor
+      SpectrumMetaData(const SpectrumMetaData & source) = default;
+      /// Move constructor
+      SpectrumMetaData(SpectrumMetaData&&) = default;
+      /// Destructor
+      ~SpectrumMetaData() = default;
+
+      /// Assignment operator
+      SpectrumMetaData & operator=(const SpectrumMetaData & source) = default;
+      /// Move assignment operator
+      SpectrumMetaData& operator=(SpectrumMetaData&&) & = default;
     };
 
     /// Constructor

--- a/src/openms/include/OpenMS/METADATA/SpectrumSettings.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumSettings.h
@@ -80,14 +80,14 @@ public:
     /// Constructor
     SpectrumSettings();
     /// Copy constructor
-    SpectrumSettings(const SpectrumSettings & source);
+    SpectrumSettings(const SpectrumSettings & source) = default;
     /// Move constructor
     SpectrumSettings(SpectrumSettings&&) = default;
     /// Destructor
     ~SpectrumSettings();
 
     // Assignment operator
-    SpectrumSettings & operator=(const SpectrumSettings & source);
+    SpectrumSettings & operator=(const SpectrumSettings & source) = default;
     /// Move assignment operator
     SpectrumSettings& operator=(SpectrumSettings&&) & = default;
 

--- a/src/openms/include/OpenMS/METADATA/SpectrumSettings.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumSettings.h
@@ -81,11 +81,15 @@ public:
     SpectrumSettings();
     /// Copy constructor
     SpectrumSettings(const SpectrumSettings & source);
+    /// Move constructor
+    SpectrumSettings(SpectrumSettings&&) = default;
     /// Destructor
     ~SpectrumSettings();
 
     // Assignment operator
     SpectrumSettings & operator=(const SpectrumSettings & source);
+    /// Move assignment operator
+    SpectrumSettings& operator=(SpectrumSettings&&) & = default;
 
     /// Equality operator
     bool operator==(const SpectrumSettings & rhs) const;

--- a/src/openms/include/OpenMS/METADATA/Tagging.h
+++ b/src/openms/include/OpenMS/METADATA/Tagging.h
@@ -55,22 +55,26 @@ public:
     /// Names of isotope variants
     static const std::string NamesOfIsotopeVariant[SIZE_OF_ISOTOPEVARIANT];
 
-    /// default constructor
+    /// Default constructor
     Tagging();
-    /// copy constructor
+    /// Copy constructor
     Tagging(const Tagging &);
-    /// destructor
+    /// Move constructor
+    Tagging(Tagging&&) = default;
+    /// Destructor
     ~Tagging() override;
 
-    /// assignment operator
+    /// Assignment operator
     Tagging & operator=(const Tagging &);
+    /// Move assignment operator
+    Tagging& operator=(Tagging&&) & = default;
 
     /**
         @brief Equality operator
 
-    Although this operator takes a reference to a SampleTreatment as argument
-    it tests for the equality of Tagging instances!
-  */
+        Although this operator takes a reference to a SampleTreatment as argument
+        it tests for the equality of Tagging instances!
+    */
     bool operator==(const SampleTreatment & rhs) const override;
 
     /// clone method. See SampleTreatment

--- a/src/openms/include/OpenMS/METADATA/Tagging.h
+++ b/src/openms/include/OpenMS/METADATA/Tagging.h
@@ -58,14 +58,14 @@ public:
     /// Default constructor
     Tagging();
     /// Copy constructor
-    Tagging(const Tagging &);
+    Tagging(const Tagging &) = default;
     /// Move constructor
     Tagging(Tagging&&) = default;
     /// Destructor
     ~Tagging() override;
 
     /// Assignment operator
-    Tagging & operator=(const Tagging &);
+    Tagging & operator=(const Tagging &) = default;
     /// Move assignment operator
     Tagging& operator=(Tagging&&) & = default;
 

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -52,26 +52,8 @@ namespace OpenMS
   {
   }
 
-  AASequence::AASequence(const AASequence& rhs) :
-    peptide_(rhs.peptide_),
-    n_term_mod_(rhs.n_term_mod_),
-    c_term_mod_(rhs.c_term_mod_)
-  {
-  }
-
   AASequence::~AASequence()
   {
-  }
-
-  AASequence& AASequence::operator=(const AASequence& rhs)
-  {
-    if (this != &rhs)
-    {
-      peptide_ = rhs.peptide_;
-      n_term_mod_ = rhs.n_term_mod_;
-      c_term_mod_ = rhs.c_term_mod_;
-    }
-    return *this;
   }
 
   const Residue& AASequence::getResidue(Size index) const

--- a/src/openms/source/CHEMISTRY/DigestionEnzyme.cpp
+++ b/src/openms/source/CHEMISTRY/DigestionEnzyme.cpp
@@ -34,6 +34,7 @@
 //
 
 #include <OpenMS/CHEMISTRY/DigestionEnzyme.h>
+
 #include <iostream>
 
 using namespace std;
@@ -45,14 +46,6 @@ namespace OpenMS
     cleavage_regex_(""),
     synonyms_(),
     regex_description_("")
-  {
-  }
-
-  DigestionEnzyme::DigestionEnzyme(const DigestionEnzyme& enzyme) :
-    name_(enzyme.name_),
-    cleavage_regex_(enzyme.cleavage_regex_),
-    synonyms_(enzyme.synonyms_),
-    regex_description_(enzyme.regex_description_)
   {
   }
 
@@ -69,18 +62,6 @@ namespace OpenMS
 
   DigestionEnzyme::~DigestionEnzyme()
   {
-  }
-
-  DigestionEnzyme& DigestionEnzyme::operator=(const DigestionEnzyme& enzyme)
-  {
-    if (this != &enzyme)
-    {
-      name_ = enzyme.name_;
-      cleavage_regex_ = enzyme.cleavage_regex_;
-      synonyms_ = enzyme.synonyms_;
-      regex_description_ = enzyme.regex_description_;
-    }
-    return *this;
   }
 
   void DigestionEnzyme::setName(const String& name)
@@ -189,3 +170,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/CHEMISTRY/DigestionEnzymeProtein.cpp
+++ b/src/openms/source/CHEMISTRY/DigestionEnzymeProtein.cpp
@@ -34,6 +34,7 @@
 //
 
 #include <OpenMS/CHEMISTRY/DigestionEnzymeProtein.h>
+
 #include <iostream>
 
 using namespace std;
@@ -50,19 +51,6 @@ namespace OpenMS
     crux_id_(""),
     msgf_id_(-1),
     omssa_id_(-1)
-  {
-  }
-
-  DigestionEnzymeProtein::DigestionEnzymeProtein(const DigestionEnzymeProtein& enzyme) :
-    DigestionEnzyme(enzyme),
-    n_term_gain_(enzyme.n_term_gain_),
-    c_term_gain_(enzyme.c_term_gain_),
-    psi_id_(enzyme.psi_id_),
-    xtandem_id_(enzyme.xtandem_id_),
-    comet_id_(enzyme.comet_id_),
-    crux_id_(enzyme.crux_id_),
-    msgf_id_(enzyme.msgf_id_),
-    omssa_id_(enzyme.omssa_id_)
   {
   }
 
@@ -92,23 +80,6 @@ namespace OpenMS
 
   DigestionEnzymeProtein::~DigestionEnzymeProtein()
   {
-  }
-
-  DigestionEnzymeProtein& DigestionEnzymeProtein::operator=(const DigestionEnzymeProtein& enzyme)
-  {
-    if (this != &enzyme)
-    {
-      DigestionEnzyme::operator=(enzyme);
-      n_term_gain_ = enzyme.n_term_gain_;
-      c_term_gain_ = enzyme.c_term_gain_;
-      psi_id_ = enzyme.psi_id_;
-      xtandem_id_ = enzyme.xtandem_id_;
-      comet_id_ = enzyme.comet_id_;
-      crux_id_ = enzyme.crux_id_;
-      omssa_id_ = enzyme.omssa_id_;
-      msgf_id_ = enzyme.msgf_id_;
-    }
-    return *this;
   }
 
   void DigestionEnzymeProtein::setNTermGain(EmpiricalFormula value)
@@ -281,3 +252,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
+++ b/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
@@ -48,7 +48,6 @@
 
 #include <iostream>
 
-
 using namespace std;
 
 namespace OpenMS
@@ -56,12 +55,6 @@ namespace OpenMS
   EmpiricalFormula::EmpiricalFormula() :
     charge_(0)
   {}
-
-  EmpiricalFormula::EmpiricalFormula(const EmpiricalFormula& formula) :
-    formula_(formula.formula_),
-    charge_(formula.charge_)
-  {
-  }
 
   EmpiricalFormula::EmpiricalFormula(const String& formula)
   {
@@ -74,7 +67,6 @@ namespace OpenMS
     charge_ = charge;
   }
 
-
   EmpiricalFormula::~EmpiricalFormula()
   {
   }
@@ -86,10 +78,9 @@ namespace OpenMS
     {
       weight += Constants::PROTON_MASS_U * charge_;
     }
-    MapType_::const_iterator it = formula_.begin();
-    for (; it != formula_.end(); ++it)
+    for (const auto& it : formula_)
     {
-      weight += it->first->getMonoWeight() * (double)it->second;
+      weight += it.first->getMonoWeight() * (double)it.second;
     }
     return weight;
   }
@@ -101,10 +92,9 @@ namespace OpenMS
     {
       weight += Constants::PROTON_MASS_U * charge_;
     }
-    MapType_::const_iterator it = formula_.begin();
-    for (; it != formula_.end(); ++it)
+    for (const auto& it : formula_)
     {
-      weight += it->first->getAverageWeight() * (double)it->second;
+      weight += it.first->getAverageWeight() * (double)it.second;
     }
     return weight;
   }
@@ -193,8 +183,9 @@ namespace OpenMS
     return solver.run(*this);
   }
 
-
-  IsotopeDistribution EmpiricalFormula::getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor, const std::set<UInt>& precursor_isotopes, const CoarseIsotopePatternGenerator& solver) const
+  IsotopeDistribution EmpiricalFormula::getConditionalFragmentIsotopeDist(const EmpiricalFormula& precursor,
+                                                                          const std::set<UInt>& precursor_isotopes,
+                                                                          const CoarseIsotopePatternGenerator& solver) const
   {
     // A fragment's isotopes can only be as high as the largest isolated precursor isotope.
     UInt max_depth = *std::max_element(precursor_isotopes.begin(), precursor_isotopes.end())+1;
@@ -215,7 +206,7 @@ namespace OpenMS
 
   SignedSize EmpiricalFormula::getNumberOf(const Element* element) const
   {
-    MapType_::const_iterator it  = formula_.find(element);
+    const auto& it  = formula_.find(element);
     if (it != formula_.end())
     {
       return it->second;
@@ -226,11 +217,7 @@ namespace OpenMS
   SignedSize EmpiricalFormula::getNumberOfAtoms() const
   {
     SignedSize num_atoms(0);
-    MapType_::const_iterator it = formula_.begin();
-    for (; it != formula_.end(); ++it)
-    {
-      num_atoms += it->second;
-    }
+    for (const auto& it : formula_) num_atoms += it.second;
     return num_atoms;
   }
 
@@ -249,14 +236,14 @@ namespace OpenMS
     String formula;
     std::map<String, SignedSize> new_formula;
 
-    for (MapType_::const_iterator it = formula_.begin(); it != formula_.end(); ++it)
+    for (const auto& it : formula_) 
     {
-      new_formula[it->first->getSymbol()] = it->second;
+      new_formula[it.first->getSymbol()] = it.second;
     }
 
-    for (std::map<String, SignedSize>::const_iterator it = new_formula.begin(); it != new_formula.end(); ++it)
+    for (const auto& it : new_formula) 
     {
-      formula += it->first + String(it->second);
+      formula += it.first + String(it.second);
     }
     return formula;
   }
@@ -272,24 +259,10 @@ namespace OpenMS
     return new_formula;
   }
 
-  EmpiricalFormula& EmpiricalFormula::operator=(const EmpiricalFormula& formula)
-  {
-    if (this != &formula)
-    {
-      formula_ = formula.formula_;
-      charge_ = formula.charge_;
-    }
-    return *this;
-  }
-
   EmpiricalFormula EmpiricalFormula::operator*(const SignedSize& times) const
   {
     EmpiricalFormula ef(*this);
-    MapType_::const_iterator it = formula_.begin();
-    for (; it != formula_.end(); ++it)
-    {
-      ef.formula_[it->first] *= times;
-    }
+    for (const auto& it : formula_) ef.formula_[it.first] *= times;
     ef.charge_ *= times;
     ef.removeZeroedElements_();
     return ef;
@@ -299,17 +272,16 @@ namespace OpenMS
   {
     EmpiricalFormula ef;
     ef.formula_ = formula.formula_;
-    MapType_::const_iterator it = formula_.begin();
-    for (; it != formula_.end(); ++it)
+    for (const auto& it : formula_) 
     {
-      MapType_::iterator ef_it  = ef.formula_.find(it->first);
+      auto ef_it  = ef.formula_.find(it.first);
       if (ef_it != ef.formula_.end())
       {
-        ef_it->second += it->second;
+        ef_it->second += it.second;
       }
       else
       {
-        ef.formula_.insert(*it);
+        ef.formula_.insert(it);
       }
     }
     ef.charge_ = charge_ + formula.charge_;
@@ -319,17 +291,16 @@ namespace OpenMS
 
   EmpiricalFormula& EmpiricalFormula::operator+=(const EmpiricalFormula& formula)
   {
-    MapType_::const_iterator it = formula.formula_.begin();
-    for (; it != formula.formula_.end(); ++it)
+    for (const auto& it : formula.formula_) 
     {
-      MapType_::iterator f_it  = formula_.find(it->first);
+      auto f_it  = formula_.find(it.first);
       if (f_it != formula_.end())
       {
-        f_it->second += it->second;
+        f_it->second += it.second;
       }
       else
       {
-        formula_.insert(*it);
+        formula_.insert(it);
       }
     }
     charge_ += formula.charge_;
@@ -340,12 +311,11 @@ namespace OpenMS
   EmpiricalFormula EmpiricalFormula::operator-(const EmpiricalFormula& formula) const
   {
     EmpiricalFormula ef(*this);
-    MapType_::const_iterator it = formula.formula_.begin();
-    for (; it != formula.formula_.end(); ++it)
+    for (const auto& it : formula.formula_) 
     {
-      const Element* e = it->first;
-      SignedSize num = it->second;
-      MapType_::iterator ef_it  = ef.formula_.find(e);
+      const Element* e = it.first;
+      SignedSize num = it.second;
+      auto ef_it  = ef.formula_.find(e);
       if (ef_it != ef.formula_.end())
       {
         ef_it->second -= num;
@@ -363,17 +333,16 @@ namespace OpenMS
 
   EmpiricalFormula& EmpiricalFormula::operator-=(const EmpiricalFormula& formula)
   {
-    MapType_::const_iterator it = formula.formula_.begin();
-    for (; it != formula.formula_.end(); ++it)
+    for (const auto& it : formula.formula_) 
     {
-      MapType_::iterator f_it  = formula_.find(it->first);
+      auto f_it  = formula_.find(it.first);
       if (f_it != formula_.end())
       {
-        f_it->second -= it->second;
+        f_it->second -= it.second;
       }
       else
       {
-        formula_[it->first] = -it->second;
+        formula_[it.first] = -it.second;
       }
     }
     charge_ -= formula.charge_;
@@ -398,9 +367,9 @@ namespace OpenMS
 
   bool EmpiricalFormula::contains(const EmpiricalFormula& ef)
   {
-    for (EmpiricalFormula::const_iterator it = ef.begin(); it != ef.end(); ++it)
+    for (const auto& it : ef) 
     {
-      if (this->getNumberOf(it->first) < it->second)
+      if (this->getNumberOf(it.first) < it.second)
       {
         return false;
       }
@@ -421,18 +390,15 @@ namespace OpenMS
   ostream& operator<<(ostream& os, const EmpiricalFormula& formula)
   {
     std::map<String, SignedSize> new_formula;
-    for (Map<const Element*, SignedSize>::const_iterator it = formula.formula_.begin(); it != formula.formula_.end(); ++it)
+    for (const auto& it : formula.formula_) 
     {
-      new_formula[it->first->getSymbol()] = it->second;
+      new_formula[it.first->getSymbol()] = it.second;
     }
 
-    for (std::map<String, SignedSize>::const_iterator it = new_formula.begin(); it != new_formula.end(); ++it)
+    for (const auto& it : new_formula)
     {
-      os << it->first;
-      if (it->second > 1)
-      {
-        os << it->second;
-      }
+      os << it.first;
+      if (it.second > 1) os << it.second;
     }
     if (formula.charge_ == 0)
     {

--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -42,7 +42,6 @@ using namespace std;
 
 namespace OpenMS
 {
-  // residue
   Residue::Residue() :
     name_("unknown"),
     average_weight_(0.0f),
@@ -82,68 +81,8 @@ namespace OpenMS
     }
   }
 
-  Residue::Residue(const Residue& residue) :
-    name_(residue.name_),
-    short_name_(residue.short_name_),
-    synonyms_(residue.synonyms_),
-    three_letter_code_(residue.three_letter_code_),
-    one_letter_code_(residue.one_letter_code_),
-    formula_(residue.formula_),
-    internal_formula_(residue.internal_formula_),
-    average_weight_(residue.average_weight_),
-    mono_weight_(residue.mono_weight_),
-    modification_(residue.modification_),
-    loss_names_(residue.loss_names_),
-    loss_formulas_(residue.loss_formulas_),
-    NTerm_loss_names_(residue.NTerm_loss_names_),
-    NTerm_loss_formulas_(residue.NTerm_loss_formulas_),
-    loss_average_weight_(residue.loss_average_weight_),
-    loss_mono_weight_(residue.loss_mono_weight_),
-    low_mass_ions_(residue.low_mass_ions_),
-    pka_(residue.pka_),
-    pkb_(residue.pkb_),
-    pkc_(residue.pkc_),
-    gb_sc_(residue.gb_sc_),
-    gb_bb_l_(residue.gb_bb_l_),
-    gb_bb_r_(residue.gb_bb_r_),
-    residue_sets_(residue.residue_sets_)
-  {
-  }
-
   Residue::~Residue()
   {
-  }
-
-  Residue& Residue::operator=(const Residue& residue)
-  {
-    if (this != &residue)
-    {
-      name_ = residue.name_;
-      short_name_ = residue.short_name_;
-      synonyms_ = residue.synonyms_;
-      three_letter_code_ = residue.three_letter_code_;
-      one_letter_code_ = residue.one_letter_code_;
-      formula_ = residue.formula_;
-      internal_formula_ = residue.internal_formula_;
-      average_weight_ = residue.average_weight_;
-      mono_weight_ = residue.mono_weight_;
-      modification_ = residue.modification_;
-      loss_names_ = residue.loss_names_;
-      loss_formulas_ = residue.loss_formulas_;
-      NTerm_loss_names_ = residue.NTerm_loss_names_;
-      NTerm_loss_formulas_ = residue.NTerm_loss_formulas_;
-      loss_average_weight_ = residue.loss_average_weight_;
-      loss_mono_weight_ = residue.loss_mono_weight_;
-      low_mass_ions_ = residue.low_mass_ions_;
-      pka_ = residue.pka_;
-      pkb_ = residue.pkb_;
-      pkc_ = residue.pkc_;
-      gb_sc_ = residue.gb_sc_;
-      gb_bb_l_ = residue.gb_bb_l_;
-      gb_bb_r_ = residue.gb_bb_r_;
-      residue_sets_ = residue.residue_sets_;
-    }
-    return *this;
   }
 
   void Residue::setName(const String& name)
@@ -704,3 +643,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/CHEMISTRY/ResidueModification.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueModification.cpp
@@ -58,57 +58,6 @@ namespace OpenMS
   {
   }
 
-  ResidueModification::ResidueModification(const ResidueModification& rhs) :
-    id_(rhs.id_),
-    full_id_(rhs.full_id_),
-    psi_mod_accession_(rhs.psi_mod_accession_),
-    unimod_record_id_(rhs.unimod_record_id_),
-    full_name_(rhs.full_name_),
-    name_(rhs.name_),
-    term_spec_(rhs.term_spec_),
-    origin_(rhs.origin_),
-    classification_(rhs.classification_),
-    average_mass_(rhs.average_mass_),
-    mono_mass_(rhs.mono_mass_),
-    diff_average_mass_(rhs.diff_average_mass_),
-    diff_mono_mass_(rhs.diff_mono_mass_),
-    formula_(rhs.formula_),
-    diff_formula_(rhs.diff_formula_),
-    synonyms_(rhs.synonyms_),
-    neutral_loss_diff_formula_(rhs.neutral_loss_diff_formula_),
-    neutral_loss_mono_mass_(rhs.neutral_loss_mono_mass_),
-    neutral_loss_average_mass_(rhs.neutral_loss_average_mass_)
-  {
-  }
-
-  ResidueModification & ResidueModification::operator=(const ResidueModification& rhs)
-  {
-    if (this != &rhs)
-    {
-      id_ = rhs.id_;
-      full_id_ = rhs.full_id_;
-      psi_mod_accession_ = rhs.psi_mod_accession_;
-      unimod_record_id_ = rhs.unimod_record_id_;
-      full_name_ = rhs.full_name_;
-      name_ = rhs.name_;
-      term_spec_ = rhs.term_spec_;
-      origin_ = rhs.origin_;
-      classification_ = rhs.classification_;
-      average_mass_ = rhs.average_mass_;
-      mono_mass_ = rhs.mono_mass_;
-      diff_average_mass_ = rhs.diff_average_mass_;
-      diff_mono_mass_ = rhs.diff_mono_mass_;
-      formula_ = rhs.formula_;
-      diff_formula_ = rhs.diff_formula_;
-      synonyms_ = rhs.synonyms_;
-      neutral_loss_diff_formula_ = rhs.neutral_loss_diff_formula_;
-      neutral_loss_mono_mass_ = rhs.neutral_loss_mono_mass_;
-      neutral_loss_average_mass_ = rhs.neutral_loss_average_mass_;
-    }
-
-    return *this;
-  }
-
   bool ResidueModification::operator<(const ResidueModification& rhs) const
   {
     return std::tie(
@@ -609,3 +558,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/DATASTRUCTURES/DataValue.cpp
+++ b/src/openms/source/DATASTRUCTURES/DataValue.cpp
@@ -261,7 +261,8 @@ namespace OpenMS
     // copy unit if necessary
     if (p.hasUnit())
     {
-      unit_ = p.unit_;
+      //unit_ = p.unit_;
+      setUnit(p.getUnit());
     }
 
     return *this;

--- a/src/openms/source/DATASTRUCTURES/Date.cpp
+++ b/src/openms/source/DATASTRUCTURES/Date.cpp
@@ -40,31 +40,10 @@ using namespace std;
 
 namespace OpenMS
 {
-  Date::Date() :
-    QDate()
-  {
-
-  }
-
-  Date::Date(const Date& date) :
-    QDate(date)
-  {
-  }
 
   Date::Date(const QDate& date) :
     QDate(date)
   {
-  }
-
-  Date& Date::operator=(const Date& source)
-  {
-    if (&source == this)
-    {
-      return *this;
-    }
-    QDate::operator=(source);
-
-    return *this;
   }
 
   void Date::set(const String& date)
@@ -126,3 +105,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/DATASTRUCTURES/Map.cpp
+++ b/src/openms/source/DATASTRUCTURES/Map.cpp
@@ -32,6 +32,8 @@
 // $Authors: Marc Sturm $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/DATASTRUCTURES/Map.h>
+
 namespace OpenMS
 {
 }

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -32,8 +32,9 @@
 // $Authors: Marc Sturm, Clemens Groepl $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/DATASTRUCTURES/Param.h>
+
+#include <OpenMS/CONCEPT/LogStream.h>
 
 #include <OpenMS/DATASTRUCTURES/Map.h>
 
@@ -54,19 +55,6 @@ namespace OpenMS
     min_int(-std::numeric_limits<Int>::max()),
     max_int(std::numeric_limits<Int>::max()),
     valid_strings()
-  {
-  }
-
-  Param::ParamEntry::ParamEntry(const ParamEntry& other) :
-    name(other.name),
-    description(other.description),
-    value(other.value),
-    tags(other.tags),
-    min_float(other.min_float),
-    max_float(other.max_float),
-    min_int(other.min_int),
-    max_int(other.max_int),
-    valid_strings(other.valid_strings)
   {
   }
 
@@ -451,19 +439,8 @@ namespace OpenMS
   {
   }
 
-  Param::Param(const Param& rhs) :
-    root_(rhs.root_)
-  {
-  }
-
   Param::~Param()
   {
-  }
-
-  Param& Param::operator=(const Param& rhs)
-  {
-    root_ = rhs.root_;
-    return *this;
   }
 
   Param::Param(const ParamNode& node) :

--- a/src/openms/source/DATASTRUCTURES/String.cpp
+++ b/src/openms/source/DATASTRUCTURES/String.cpp
@@ -32,6 +32,8 @@
 // $Authors: Marc Sturm $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/DATASTRUCTURES/String.h>
+
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
 #include <OpenMS/DATASTRUCTURES/StringUtils.h>
 

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -185,12 +185,12 @@ namespace OpenMS
           consumer_->consumeSpectrum(spectrum_data_[i].spectrum);
           if (options_.getAlwaysAppendData())
           {
-            exp_->addSpectrum(spectrum_data_[i].spectrum);
+            exp_->addSpectrum(std::move(spectrum_data_[i].spectrum));
           }
         }
         else
         {
-          exp_->addSpectrum(spectrum_data_[i].spectrum);
+          exp_->addSpectrum(std::move(spectrum_data_[i].spectrum));
         }
       }
 
@@ -239,12 +239,12 @@ namespace OpenMS
           consumer_->consumeChromatogram(chromatogram_data_[i].chromatogram);
           if (options_.getAlwaysAppendData())
           {
-            exp_->addChromatogram(chromatogram_data_[i].chromatogram);
+            exp_->addChromatogram(std::move(chromatogram_data_[i].chromatogram));
           }
         }
         else
         {
-          exp_->addChromatogram(chromatogram_data_[i].chromatogram);
+          exp_->addChromatogram(std::move(chromatogram_data_[i].chromatogram));
         }
       }
 
@@ -706,10 +706,14 @@ namespace OpenMS
       //determine parent tag
       String parent_tag;
       if (open_tags_.size() > 1)
+      {
         parent_tag = *(open_tags_.end() - 2);
+      }
       String parent_parent_tag;
       if (open_tags_.size() > 2)
+      {
         parent_parent_tag = *(open_tags_.end() - 3);
+      }
 
       if (tag == "spectrum")
       {
@@ -831,12 +835,12 @@ namespace OpenMS
         bin_data_.back().np_compression = MSNumpressCoder::NONE; // ensure that numpress compression is initially set to none ...
         bin_data_.back().compression = false; // ensure that zlib compression is initially set to none ...
 
-        //array length
+        // array length
         Int array_length = (Int) default_array_length_;
         optionalAttributeAsInt_(array_length, attributes, s_array_length);
         bin_data_.back().size = array_length;
 
-        //data processing
+        // data processing
         String data_processing_ref;
         if (optionalAttributeAsString_(data_processing_ref, attributes, s_data_processing_ref))
         {
@@ -945,7 +949,7 @@ namespace OpenMS
           warning(LOAD, "Unhandled attribute 'instrumentConfigurationRef' in 'scan' tag.");
         }
 
-        spec_.getAcquisitionInfo().push_back(tmp);
+        spec_.getAcquisitionInfo().push_back(std::move(tmp));
       }
       else if (tag == "mzML")
       {
@@ -1043,7 +1047,7 @@ namespace OpenMS
       else if (tag == "processingMethod")
       {
         DataProcessingPtr dp(new DataProcessing);
-        // See ticket 452: Do NOT remove  this try/catch block until foreign
+        // See ticket 452: Do NOT remove this try/catch block until foreign
         // software (e.g. ProteoWizard msconvert.exe) produces valid mzML.
         try
         {
@@ -1189,13 +1193,17 @@ namespace OpenMS
           }
           */
           
-          spectrum_data_.push_back(SpectrumData());
-          spectrum_data_.back().default_array_length = default_array_length_;
-          spectrum_data_.back().spectrum = spec_;
+          // Move current data to (temporary) spectral data object
+          SpectrumData tmp;
+          tmp.spectrum = std::move(spec_);
+          tmp.default_array_length = default_array_length_;
           if (options_.getFillData())
           {
-            spectrum_data_.back().data = bin_data_;
+            tmp.data = std::move(bin_data_);
           }
+          // append current spectral data to buffer
+          spectrum_data_.push_back(std::move(tmp));
+
           if (spectrum_data_.size() >= options_.getMaxDataPoolSize())
           {
             populateSpectraWithData_();
@@ -1206,7 +1214,7 @@ namespace OpenMS
         {
           case XMLHandler::LD_ALLDATA:
           case XMLHandler::LD_COUNTS_WITHOPTIONS:
-            skip_spectrum_ = false; // dont skip the next spectrum (unless via options later)
+            skip_spectrum_ = false; // don't skip the next spectrum (unless via options later)
             break;
           case XMLHandler::LD_RAWCOUNTS:
             skip_spectrum_ = true; // we always skip spectra; we only need the outer <spectrumList/chromatogramList count=...>
@@ -1222,13 +1230,18 @@ namespace OpenMS
       {
         if (!skip_chromatogram_)
         {
-          chromatogram_data_.push_back(ChromatogramData());
-          chromatogram_data_.back().default_array_length = default_array_length_;
-          chromatogram_data_.back().chromatogram = chromatogram_;
+
+          // Move current data to (temporary) spectral data object
+          ChromatogramData tmp;
+          tmp.default_array_length = default_array_length_;
+          tmp.chromatogram = std::move(chromatogram_);
           if (options_.getFillData())
           {
-            chromatogram_data_.back().data = bin_data_;
+            tmp.data = std::move(bin_data_);
           }
+          // append current spectral data to buffer
+          chromatogram_data_.push_back(std::move(tmp));
+
           if (chromatogram_data_.size() >= options_.getMaxDataPoolSize())
           {
             populateChromatogramsWithData_();
@@ -1601,7 +1614,7 @@ namespace OpenMS
         term.name = name;
         term.value = value;
         term.unit_accession = unit_accession;
-        ref_param_[current_id_].push_back(term);
+        ref_param_[current_id_].push_back(std::move(term));
       }
       //------------------------- selectedIon ----------------------------
       else if (parent_tag == "selectedIon")
@@ -3324,7 +3337,7 @@ namespace OpenMS
               userParam += "xsd:string";
             }
             userParam += "\" value=\"" + writeXMLEscape(d.toString()) + "\"/>" + "\n";
-            userParams.push_back(userParam);
+            userParams.push_back(std::move(userParam));
           }
         }
       }

--- a/src/openms/source/METADATA/Acquisition.cpp
+++ b/src/openms/source/METADATA/Acquisition.cpp
@@ -38,32 +38,6 @@ using namespace std;
 
 namespace OpenMS
 {
-  Acquisition::Acquisition() :
-    MetaInfoInterface(),
-    identifier_()
-  {
-  }
-
-  Acquisition::Acquisition(const Acquisition & source) :
-    MetaInfoInterface(source),
-    identifier_(source.identifier_)
-  {
-  }
-
-  Acquisition::~Acquisition()
-  {
-  }
-
-  Acquisition & Acquisition::operator=(const Acquisition & source)
-  {
-    if (&source == this)
-      return *this;
-
-    identifier_ = source.identifier_;
-    MetaInfoInterface::operator=(source);
-
-    return *this;
-  }
 
   bool Acquisition::operator==(const Acquisition & rhs) const
   {
@@ -86,3 +60,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/AcquisitionInfo.cpp
+++ b/src/openms/source/METADATA/AcquisitionInfo.cpp
@@ -39,36 +39,6 @@ using namespace std;
 namespace OpenMS
 {
 
-  AcquisitionInfo::AcquisitionInfo() :
-    vector<Acquisition>(),
-    MetaInfoInterface()
-  {
-  }
-
-  AcquisitionInfo::AcquisitionInfo(const AcquisitionInfo & source) :
-    vector<Acquisition>(source),
-    MetaInfoInterface(source),
-    method_of_combination_(source.method_of_combination_)
-  {
-
-  }
-
-  AcquisitionInfo::~AcquisitionInfo()
-  {
-  }
-
-  AcquisitionInfo & AcquisitionInfo::operator=(const AcquisitionInfo & source)
-  {
-    if (&source == this)
-      return *this;
-
-    vector<Acquisition>::operator=(source);
-    MetaInfoInterface::operator=(source);
-    method_of_combination_ = source.method_of_combination_;
-
-    return *this;
-  }
-
   bool AcquisitionInfo::operator==(const AcquisitionInfo & rhs) const
   {
     return method_of_combination_ == rhs.method_of_combination_ &&
@@ -92,3 +62,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/CVTerm.cpp
+++ b/src/openms/source/METADATA/CVTerm.cpp
@@ -38,10 +38,6 @@ using namespace std;
 
 namespace OpenMS
 {
-  // CV term implementation
-  CVTerm::CVTerm()
-  {
-  }
 
   CVTerm::CVTerm(const String & accession, const String & name, const String & cv_identifier_ref, const String & value, const Unit & unit) :
     accession_(accession),
@@ -52,30 +48,8 @@ namespace OpenMS
   {
   }
 
-  CVTerm::CVTerm(const CVTerm & rhs) :
-    accession_(rhs.accession_),
-    name_(rhs.name_),
-    cv_identifier_ref_(rhs.cv_identifier_ref_),
-    unit_(rhs.unit_),
-    value_(rhs.value_)
-  {
-  }
-
   CVTerm::~CVTerm()
   {
-  }
-
-  CVTerm & CVTerm::operator=(const CVTerm & rhs)
-  {
-    if (this != &rhs)
-    {
-      accession_ = rhs.accession_;
-      name_ = rhs.name_;
-      cv_identifier_ref_ = rhs.cv_identifier_ref_;
-      unit_ = rhs.unit_;
-      value_ = rhs.value_;
-    }
-    return *this;
   }
 
   bool CVTerm::operator==(const CVTerm & rhs) const
@@ -153,3 +127,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/CVTermList.cpp
+++ b/src/openms/source/METADATA/CVTermList.cpp
@@ -40,30 +40,9 @@ using namespace std;
 
 namespace OpenMS
 {
-  // CV term implementation
-  CVTermList::CVTermList() :
-    MetaInfoInterface()
-  {
-  }
-
-  CVTermList::CVTermList(const CVTermList& rhs) :
-    MetaInfoInterface(rhs),
-    cv_terms_(rhs.cv_terms_)
-  {
-  }
 
   CVTermList::~CVTermList()
   {
-  }
-
-  CVTermList& CVTermList::operator=(const CVTermList& rhs)
-  {
-    if (this != &rhs)
-    {
-      MetaInfoInterface::operator=(rhs);
-      cv_terms_ = rhs.cv_terms_;
-    }
-    return *this;
   }
 
   void CVTermList::addCVTerm(const CVTerm& cv_term)
@@ -132,3 +111,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/CVTermListInterface.cpp
+++ b/src/openms/source/METADATA/CVTermListInterface.cpp
@@ -47,7 +47,6 @@ namespace OpenMS
       cvt_ptr_(nullptr)
     {}
 
-
   CVTermListInterface::CVTermListInterface(const CVTermListInterface & rhs) :
     MetaInfoInterface(rhs),
     cvt_ptr_(nullptr)

--- a/src/openms/source/METADATA/CVTermListInterface.cpp
+++ b/src/openms/source/METADATA/CVTermListInterface.cpp
@@ -52,52 +52,75 @@ namespace OpenMS
     MetaInfoInterface(rhs),
     cvt_ptr_(nullptr)
   {
-    MetaInfoInterface::operator=(rhs);
-
     if (rhs.cvt_ptr_ != nullptr)
     {
       cvt_ptr_ = new CVTermList(*rhs.cvt_ptr_);
     }
   }
 
-    // Destructor (non virtual)
-    CVTermListInterface::~CVTermListInterface() 
+  // http://thbecker.net/articles/rvalue_references/section_05.html
+  CVTermListInterface::CVTermListInterface(CVTermListInterface&& rhs) :
+    MetaInfoInterface(std::move(rhs)), // NOTE: rhs itself is an lvalue
+    cvt_ptr_(rhs.cvt_ptr_)
+  {
+    // take ownership
+    rhs.cvt_ptr_ = nullptr;
+  }
+
+  CVTermListInterface::~CVTermListInterface() 
+  {
+    delete cvt_ptr_;
+  }
+
+  CVTermListInterface & CVTermListInterface::operator=(const CVTermListInterface & rhs)
+  {
+    if (this != &rhs)
     {
+      MetaInfoInterface::operator=(rhs);
+
       delete cvt_ptr_;
-    }
-
-    CVTermListInterface & CVTermListInterface::operator=(const CVTermListInterface & rhs)
-    {
-      if (this != &rhs)
+      cvt_ptr_ = nullptr;
+      if (rhs.cvt_ptr_ != nullptr)
       {
-        MetaInfoInterface::operator=(rhs);
-
-        delete cvt_ptr_;
-        cvt_ptr_ = nullptr;
-        if (rhs.cvt_ptr_ != nullptr)
-        {
-          cvt_ptr_ = new CVTermList(*rhs.cvt_ptr_);
-        }
+        cvt_ptr_ = new CVTermList(*rhs.cvt_ptr_);
       }
+    }
+    return *this;
+  }
+
+  CVTermListInterface& CVTermListInterface::operator=(CVTermListInterface&& rhs)
+  {
+    if (&rhs == this)
+    {
       return *this;
     }
 
-    bool CVTermListInterface::operator==(const CVTermListInterface& rhs) const
-    {
-      return MetaInfoInterface::operator==(rhs) &&
-             Helpers::cmpPtrSafe<CVTermList*>(cvt_ptr_, rhs.cvt_ptr_);
-    }
+    MetaInfoInterface::operator=(rhs);
 
-    bool CVTermListInterface::operator!=(const CVTermListInterface& rhs) const
-    {
-      return !(*this == rhs);
-    }
+    // free memory and assign rhs memory
+    delete cvt_ptr_;
+    cvt_ptr_ = rhs.cvt_ptr_;
+    rhs.cvt_ptr_ = nullptr;
 
-    void CVTermListInterface::replaceCVTerms(Map<String, std::vector<CVTerm> > & cv_terms)
-    {
-      createIfNotExists_();
-      cvt_ptr_->replaceCVTerms(cv_terms);
-    }
+    return *this;
+  }
+
+  bool CVTermListInterface::operator==(const CVTermListInterface& rhs) const
+  {
+    return MetaInfoInterface::operator==(rhs) &&
+           Helpers::cmpPtrSafe<CVTermList*>(cvt_ptr_, rhs.cvt_ptr_);
+  }
+
+  bool CVTermListInterface::operator!=(const CVTermListInterface& rhs) const
+  {
+    return !(*this == rhs);
+  }
+
+  void CVTermListInterface::replaceCVTerms(Map<String, std::vector<CVTerm> > & cv_terms)
+  {
+    createIfNotExists_();
+    cvt_ptr_->replaceCVTerms(cv_terms);
+  }
 
   void CVTermListInterface::createIfNotExists_()
   {
@@ -174,5 +197,5 @@ namespace OpenMS
     }
   }
 
-
 }
+

--- a/src/openms/source/METADATA/ChromatogramSettings.cpp
+++ b/src/openms/source/METADATA/ChromatogramSettings.cpp
@@ -61,41 +61,8 @@ namespace OpenMS
   {
   }
 
-  ChromatogramSettings::ChromatogramSettings(const ChromatogramSettings & source) :
-    MetaInfoInterface(source),
-    native_id_(source.native_id_),
-    comment_(source.comment_),
-    instrument_settings_(source.instrument_settings_),
-    source_file_(source.source_file_),
-    acquisition_info_(source.acquisition_info_),
-    precursor_(source.precursor_),
-    product_(source.product_),
-    data_processing_(source.data_processing_),
-    type_(source.type_)
-  {
-  }
-
   ChromatogramSettings::~ChromatogramSettings()
   {
-  }
-
-  ChromatogramSettings & ChromatogramSettings::operator=(const ChromatogramSettings & source)
-  {
-    if (&source == this)
-      return *this;
-
-    MetaInfoInterface::operator=(source);
-    native_id_ = source.native_id_;
-    comment_ = source.comment_;
-    instrument_settings_ = source.instrument_settings_;
-    acquisition_info_ = source.acquisition_info_;
-    source_file_ = source.source_file_;
-    precursor_ = source.precursor_;
-    product_ = source.product_;
-    data_processing_ = source.data_processing_;
-    type_ = source.type_;
-
-    return *this;
   }
 
   bool ChromatogramSettings::operator==(const ChromatogramSettings & rhs) const

--- a/src/openms/source/METADATA/ContactPerson.cpp
+++ b/src/openms/source/METADATA/ContactPerson.cpp
@@ -39,54 +39,6 @@ using namespace std;
 namespace OpenMS
 {
 
-  ContactPerson::ContactPerson() :
-    MetaInfoInterface(),
-    first_name_(),
-    last_name_(),
-    institution_(),
-    email_(),
-    contact_info_(),
-    url_(),
-    address_()
-  {
-
-  }
-
-  ContactPerson::ContactPerson(const ContactPerson & source) :
-    MetaInfoInterface(source),
-    first_name_(source.first_name_),
-    last_name_(source.last_name_),
-    institution_(source.institution_),
-    email_(source.email_),
-    contact_info_(source.contact_info_),
-    url_(source.url_),
-    address_(source.address_)
-  {
-
-  }
-
-  ContactPerson::~ContactPerson()
-  {
-
-  }
-
-  ContactPerson & ContactPerson::operator=(const ContactPerson & source)
-  {
-    if (&source == this)
-      return *this;
-
-    first_name_ = source.first_name_;
-    last_name_ = source.last_name_;
-    institution_ = source.institution_;
-    email_ = source.email_;
-    contact_info_ = source.contact_info_;
-    url_ = source.url_;
-    address_ = source.address_;
-    MetaInfoInterface::operator=(source);
-
-    return *this;
-  }
-
   bool ContactPerson::operator==(const ContactPerson & rhs) const
   {
     return first_name_ == rhs.first_name_ &&
@@ -197,3 +149,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/DataArrays.cpp
+++ b/src/openms/source/METADATA/DataArrays.cpp
@@ -32,6 +32,8 @@
 // $Authors: Andreas Bertsch $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/METADATA/DataArrays.h>
+
 namespace OpenMS
 {
 

--- a/src/openms/source/METADATA/DataProcessing.cpp
+++ b/src/openms/source/METADATA/DataProcessing.cpp
@@ -34,7 +34,6 @@
 
 #include <OpenMS/METADATA/DataProcessing.h>
 
-
 using namespace std;
 
 namespace OpenMS
@@ -63,40 +62,9 @@ namespace OpenMS
     "Conversion to DTA format"
   };
 
-  DataProcessing::DataProcessing() :
-    MetaInfoInterface(),
-    software_(),
-    processing_actions_(),
-    completion_time_()
-  {
-
-  }
-
-  DataProcessing::DataProcessing(const DataProcessing & rhs) :
-    MetaInfoInterface(rhs),
-    software_(rhs.software_),
-    processing_actions_(rhs.processing_actions_),
-    completion_time_(rhs.completion_time_)
-  {
-
-  }
-
   DataProcessing::~DataProcessing()
   {
 
-  }
-
-  DataProcessing & DataProcessing::operator=(const DataProcessing & rhs)
-  {
-    if (&rhs == this)
-      return *this;
-
-    MetaInfoInterface::operator=(rhs);
-    software_ = rhs.software_;
-    processing_actions_ = rhs.processing_actions_;
-    completion_time_ = rhs.completion_time_;
-
-    return *this;
   }
 
   bool DataProcessing::operator==(const DataProcessing & rhs) const
@@ -153,3 +121,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/Digestion.cpp
+++ b/src/openms/source/METADATA/Digestion.cpp
@@ -50,16 +50,6 @@ namespace OpenMS
 
   }
 
-  Digestion::Digestion(const Digestion & source) :
-    SampleTreatment(source),
-    enzyme_(source.enzyme_),
-    digestion_time_(source.digestion_time_),
-    temperature_(source.temperature_),
-    ph_(source.ph_)
-  {
-
-  }
-
   Digestion::~Digestion()
   {
 
@@ -69,20 +59,6 @@ namespace OpenMS
   {
     SampleTreatment * tmp = new Digestion(*this);
     return tmp;
-  }
-
-  Digestion & Digestion::operator=(const Digestion & source)
-  {
-    if (&source == this)
-      return *this;
-
-    SampleTreatment::operator=(source);
-    enzyme_ = source.enzyme_;
-    digestion_time_ = source.digestion_time_;
-    temperature_ = source.temperature_;
-    ph_ = source.ph_;
-
-    return *this;
   }
 
   bool Digestion::operator==(const SampleTreatment & rhs) const
@@ -139,3 +115,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/DocumentIDTagger.cpp
+++ b/src/openms/source/METADATA/DocumentIDTagger.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/METADATA/DocumentIDTagger.h>
+
 #include <OpenMS/SYSTEM/File.h>
 #include <QDir>
 
@@ -60,24 +61,8 @@ namespace OpenMS
     pool_file_ = File::getOpenMSDataPath() + ("/IDPool/IDPool.txt");
   }
 
-  DocumentIDTagger::DocumentIDTagger(const DocumentIDTagger & source) :
-    toolname_(source.toolname_),
-    pool_file_(source.pool_file_)
-  {
-  }
-
   DocumentIDTagger::~DocumentIDTagger()
   {
-  }
-
-  DocumentIDTagger & DocumentIDTagger::operator=(const DocumentIDTagger & source)
-  {
-    if (source == *this)
-      return *this;
-
-    toolname_ = source.toolname_;
-    pool_file_ = source.pool_file_;
-    return *this;
   }
 
   bool DocumentIDTagger::operator==(const DocumentIDTagger & rhs) const
@@ -254,3 +239,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/DocumentIdentifier.cpp
+++ b/src/openms/source/METADATA/DocumentIdentifier.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/METADATA/DocumentIdentifier.h>
+
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/FileHandler.h>
 
@@ -46,27 +47,6 @@ namespace OpenMS
     file_path_(),
     file_type_(FileTypes::UNKNOWN)
   {
-  }
-
-  DocumentIdentifier::DocumentIdentifier(const DocumentIdentifier & source) :
-    id_(source.id_),
-    file_path_(source.file_path_),
-    file_type_(source.file_type_)
-  {
-  }
-
-  DocumentIdentifier & DocumentIdentifier::operator=(const DocumentIdentifier & source)
-  {
-    if (&source == this)
-    {
-      return *this;
-    }
-
-    id_ = source.id_;
-    file_type_ = source.file_type_;
-    file_path_ = source.file_path_;
-
-    return *this;
   }
 
   DocumentIdentifier::~DocumentIdentifier()
@@ -127,3 +107,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -32,9 +32,9 @@
 // $Authors: Timo Sachsenberg $
 // --------------------------------------------------------------------------
 
-#include <OpenMS/KERNEL/StandardTypes.h>
-
 #include <OpenMS/METADATA/ExperimentalDesign.h>
+
+#include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>

--- a/src/openms/source/METADATA/ExperimentalSettings.cpp
+++ b/src/openms/source/METADATA/ExperimentalSettings.cpp
@@ -39,58 +39,8 @@ using namespace std;
 namespace OpenMS
 {
 
-  ExperimentalSettings::ExperimentalSettings() :
-    MetaInfoInterface(),
-    DocumentIdentifier(),
-    sample_(),
-    source_files_(),
-    contacts_(),
-    instrument_(),
-    hplc_(),
-    datetime_(),
-    comment_(),
-    protein_identifications_(),
-    fraction_identifier_()
-  {
-  }
-
-  ExperimentalSettings::ExperimentalSettings(const ExperimentalSettings & source) :
-    MetaInfoInterface(source),
-    DocumentIdentifier(source),
-    sample_(source.sample_),
-    source_files_(source.source_files_),
-    contacts_(source.contacts_),
-    instrument_(source.instrument_),
-    hplc_(source.hplc_),
-    datetime_(source.datetime_),
-    comment_(source.comment_),
-    protein_identifications_(source.protein_identifications_),
-    fraction_identifier_(source.fraction_identifier_)
-  {
-  }
-
   ExperimentalSettings::~ExperimentalSettings()
   {
-  }
-
-  ExperimentalSettings & ExperimentalSettings::operator=(const ExperimentalSettings & source)
-  {
-    if (&source == this)
-      return *this;
-
-    sample_ = source.sample_;
-    source_files_ = source.source_files_;
-    contacts_ = source.contacts_;
-    instrument_ = source.instrument_;
-    hplc_ = source.hplc_;
-    datetime_ = source.datetime_;
-    comment_ = source.comment_;
-    protein_identifications_ = source.protein_identifications_;
-    fraction_identifier_ = source.fraction_identifier_;
-    MetaInfoInterface::operator=(source);
-    DocumentIdentifier::operator=(source);
-
-    return *this;
   }
 
   bool ExperimentalSettings::operator==(const ExperimentalSettings & rhs) const

--- a/src/openms/source/METADATA/Gradient.cpp
+++ b/src/openms/source/METADATA/Gradient.cpp
@@ -40,37 +40,10 @@ using namespace std;
 
 namespace OpenMS
 {
-  Gradient::Gradient() :
-    eluents_(),
-    times_(),
-    percentages_()
-  {
-
-  }
-
-  Gradient::Gradient(const Gradient & source) :
-    eluents_(source.eluents_),
-    times_(source.times_),
-    percentages_(source.percentages_)
-  {
-
-  }
 
   Gradient::~Gradient()
   {
 
-  }
-
-  Gradient & Gradient::operator=(const Gradient & source)
-  {
-    if (source == *this)
-      return *this;
-
-    eluents_ = source.eluents_;
-    times_ = source.times_;
-    percentages_ = source.percentages_;
-
-    return *this;
   }
 
   bool Gradient::operator==(const Gradient & rhs) const

--- a/src/openms/source/METADATA/HPLC.cpp
+++ b/src/openms/source/METADATA/HPLC.cpp
@@ -38,6 +38,7 @@ using namespace std;
 
 namespace OpenMS
 {
+
   HPLC::HPLC() :
     instrument_(),
     column_(),
@@ -47,40 +48,10 @@ namespace OpenMS
     comment_(),
     gradient_()
   {
-
-  }
-
-  HPLC::HPLC(const HPLC & source) :
-    instrument_(source.instrument_),
-    column_(source.column_),
-    temperature_(source.temperature_),
-    pressure_(source.pressure_),
-    flux_(source.flux_),
-    comment_(source.comment_),
-    gradient_(source.gradient_)
-  {
-
   }
 
   HPLC::~HPLC()
   {
-
-  }
-
-  HPLC & HPLC::operator=(const HPLC & source)
-  {
-    if (source == *this)
-      return *this;
-
-    instrument_ = source.instrument_;
-    column_ = source.column_;
-    temperature_ = source.temperature_;
-    pressure_ = source.pressure_;
-    flux_ = source.flux_;
-    comment_ = source.comment_;
-    gradient_ = source.gradient_;
-
-    return *this;
   }
 
   bool HPLC::operator==(const HPLC & rhs) const
@@ -175,3 +146,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/Identification.cpp
+++ b/src/openms/source/METADATA/Identification.cpp
@@ -39,38 +39,8 @@ using namespace std;
 namespace OpenMS
 {
 
-  Identification::Identification() :
-    MetaInfoInterface(),
-    id_(),
-    creation_date_()
-  {
-  }
-
-  Identification::Identification(const Identification & rhs) :
-    MetaInfoInterface(rhs),
-    id_(rhs.id_),
-    creation_date_(rhs.creation_date_),
-    spectrum_identifications_(rhs.spectrum_identifications_)
-  {
-  }
-
   Identification::~Identification()
   {
-  }
-
-  Identification & Identification::operator=(const Identification & rhs)
-  {
-    if (this == &rhs)
-    {
-      return *this;
-    }
-
-    MetaInfoInterface::operator=(rhs);
-    id_ = rhs.id_;
-    creation_date_ = rhs.creation_date_;
-    spectrum_identifications_ = rhs.spectrum_identifications_;
-
-    return *this;
   }
 
   // Equality operator
@@ -114,3 +84,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/IdentificationHit.cpp
+++ b/src/openms/source/METADATA/IdentificationHit.cpp
@@ -50,39 +50,8 @@ namespace OpenMS
   {
   }
 
-  IdentificationHit::IdentificationHit(const IdentificationHit & rhs) :
-    MetaInfoInterface(rhs),
-    id_(rhs.id_),
-    charge_(rhs.charge_),
-    calculated_mass_to_charge_(rhs.calculated_mass_to_charge_),
-    experimental_mass_to_charge_(rhs.experimental_mass_to_charge_),
-    name_(rhs.name_),
-    pass_threshold_(rhs.pass_threshold_),
-    rank_(rhs.rank_)
-  {
-  }
-
   IdentificationHit::~IdentificationHit()
   {
-  }
-
-  IdentificationHit & IdentificationHit::operator=(const IdentificationHit & rhs)
-  {
-    if (this == &rhs)
-    {
-      return *this;
-    }
-
-    MetaInfoInterface::operator=(rhs);
-    id_ = rhs.id_;
-    charge_ = rhs.charge_;
-    calculated_mass_to_charge_ = rhs.calculated_mass_to_charge_;
-    experimental_mass_to_charge_ = rhs.experimental_mass_to_charge_;
-    name_ = rhs.name_;
-    pass_threshold_ = rhs.pass_threshold_;
-    rank_ = rhs.rank_;
-
-    return *this;
   }
 
   // Equality operator
@@ -175,3 +144,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/Instrument.cpp
+++ b/src/openms/source/METADATA/Instrument.cpp
@@ -71,7 +71,9 @@ namespace OpenMS
   Instrument & Instrument::operator=(const Instrument & source)
   {
     if (&source == this)
+    {
       return *this;
+    }
 
     MetaInfoInterface::operator=(source);
     software_ = source.software_;
@@ -89,17 +91,6 @@ namespace OpenMS
 
   bool Instrument::operator==(const Instrument & rhs) const
   {
-//if (software_ != rhs.software_) cout << "Instrument - " << __LINE__ << endl;
-//if (name_ != rhs.name_) cout << "Instrument - " << __LINE__ << endl;
-//if (vendor_ != rhs.vendor_) cout << "Instrument - " << __LINE__ << endl;
-//if (model_ != rhs.model_) cout << "Instrument - " << __LINE__ << endl;
-//if (customizations_ != rhs.customizations_) cout << "Instrument - " << __LINE__ << endl;
-//if (ion_sources_ != rhs.ion_sources_) cout << "Instrument - " << __LINE__ << endl;
-//if (mass_analyzers_ != rhs.mass_analyzers_) cout << "Instrument - " << __LINE__ << endl;
-//if (ion_detectors_ != rhs.ion_detectors_) cout << "Instrument - " << __LINE__ << endl;
-//if (ion_optics_ != rhs.ion_optics_) cout << "Instrument - " << __LINE__ << endl;
-//if (MetaInfoInterface::operator!=(rhs)) cout << "Instrument - " << __LINE__ << endl;
-
     return software_ == rhs.software_ &&
            name_ == rhs.name_ &&
            vendor_ == rhs.vendor_ &&
@@ -228,3 +219,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/Instrument.cpp
+++ b/src/openms/source/METADATA/Instrument.cpp
@@ -48,45 +48,9 @@ namespace OpenMS
 
   }
 
-  Instrument::Instrument(const Instrument & source) :
-    MetaInfoInterface(source),
-    name_(source.name_),
-    vendor_(source.vendor_),
-    model_(source.model_),
-    customizations_(source.customizations_),
-    ion_sources_(source.ion_sources_),
-    mass_analyzers_(source.mass_analyzers_),
-    ion_detectors_(source.ion_detectors_),
-    software_(source.software_),
-    ion_optics_(source.ion_optics_)
-  {
-
-  }
-
   Instrument::~Instrument()
   {
 
-  }
-
-  Instrument & Instrument::operator=(const Instrument & source)
-  {
-    if (&source == this)
-    {
-      return *this;
-    }
-
-    MetaInfoInterface::operator=(source);
-    software_ = source.software_;
-    name_ = source.name_;
-    vendor_ = source.vendor_;
-    model_ = source.model_;
-    customizations_ = source.customizations_;
-    ion_sources_ = source.ion_sources_;
-    mass_analyzers_ = source.mass_analyzers_;
-    ion_detectors_ = source.ion_detectors_;
-    ion_optics_ = source.ion_optics_;
-
-    return *this;
   }
 
   bool Instrument::operator==(const Instrument & rhs) const

--- a/src/openms/source/METADATA/InstrumentSettings.cpp
+++ b/src/openms/source/METADATA/InstrumentSettings.cpp
@@ -113,3 +113,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/InstrumentSettings.cpp
+++ b/src/openms/source/METADATA/InstrumentSettings.cpp
@@ -49,31 +49,8 @@ namespace OpenMS
   {
   }
 
-  InstrumentSettings::InstrumentSettings(const InstrumentSettings & source) :
-    MetaInfoInterface(source),
-    scan_mode_(source.scan_mode_),
-    zoom_scan_(source.zoom_scan_),
-    polarity_(source.polarity_),
-    scan_windows_(source.scan_windows_)
-  {
-  }
-
   InstrumentSettings::~InstrumentSettings()
   {
-  }
-
-  InstrumentSettings & InstrumentSettings::operator=(const InstrumentSettings & source)
-  {
-    if (&source == this)
-      return *this;
-
-    scan_mode_ = source.scan_mode_;
-    zoom_scan_  = source.zoom_scan_;
-    polarity_ = source.polarity_;
-    scan_windows_ = source.scan_windows_;
-    MetaInfoInterface::operator=(source);
-
-    return *this;
   }
 
   bool InstrumentSettings::operator==(const InstrumentSettings & rhs) const

--- a/src/openms/source/METADATA/IonDetector.cpp
+++ b/src/openms/source/METADATA/IonDetector.cpp
@@ -54,35 +54,9 @@ namespace OpenMS
 
   }
 
-  IonDetector::IonDetector(const IonDetector & source) :
-    MetaInfoInterface(source),
-    type_(source.type_),
-    acquisition_mode_(source.acquisition_mode_),
-    resolution_(source.resolution_),
-    ADC_sampling_frequency_(source.ADC_sampling_frequency_),
-    order_(source.order_)
-  {
-
-  }
-
   IonDetector::~IonDetector()
   {
 
-  }
-
-  IonDetector & IonDetector::operator=(const IonDetector & source)
-  {
-    if (&source == this)
-      return *this;
-
-    order_ = source.order_;
-    type_ = source.type_;
-    acquisition_mode_ = source.acquisition_mode_;
-    resolution_ = source.resolution_;
-    ADC_sampling_frequency_ = source.ADC_sampling_frequency_;
-    MetaInfoInterface::operator=(source);
-
-    return *this;
   }
 
   bool IonDetector::operator==(const IonDetector & rhs) const
@@ -151,3 +125,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/IonSource.cpp
+++ b/src/openms/source/METADATA/IonSource.cpp
@@ -54,31 +54,8 @@ namespace OpenMS
   {
   }
 
-  IonSource::IonSource(const IonSource & source) :
-    MetaInfoInterface(source),
-    inlet_type_(source.inlet_type_),
-    ionization_method_(source.ionization_method_),
-    polarity_(source.polarity_),
-    order_(source.order_)
-  {
-  }
-
   IonSource::~IonSource()
   {
-  }
-
-  IonSource & IonSource::operator=(const IonSource & source)
-  {
-    if (&source == this)
-      return *this;
-
-    order_ = source.order_;
-    inlet_type_ = source.inlet_type_;
-    ionization_method_ = source.ionization_method_;
-    polarity_ = source.polarity_;
-    MetaInfoInterface::operator=(source);
-
-    return *this;
   }
 
   bool IonSource::operator==(const IonSource & rhs) const
@@ -136,3 +113,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/MSQuantifications.cpp
+++ b/src/openms/source/METADATA/MSQuantifications.cpp
@@ -40,12 +40,6 @@ namespace OpenMS
 {
   const std::string MSQuantifications::NamesOfQuantTypes[] = {"MS1LABEL", "MS2LABEL", "LABELFREE"};
 
-  /// Constructor
-  MSQuantifications::MSQuantifications() :
-    ExperimentalSettings()
-  {
-  }  
-  
   /// Detailed Constructor
   MSQuantifications::MSQuantifications(FeatureMap fm, ExperimentalSettings& es, std::vector<DataProcessing>& dps, std::vector<std::vector<std::pair<String, double> > > label) :
     ExperimentalSettings()
@@ -61,27 +55,8 @@ namespace OpenMS
     feature_maps_  = std::vector<FeatureMap > (1,fm);
   }
 
-  /// Copy constructor
-  MSQuantifications::MSQuantifications(const MSQuantifications & source) :
-    ExperimentalSettings(source)
-  {
-  }
-
   MSQuantifications::~MSQuantifications()
   {
-  }
-
-  /// Assignment operator
-  MSQuantifications & MSQuantifications::operator=(const MSQuantifications & source)
-  {
-    if (&source == this)
-      return *this;
-
-    ExperimentalSettings::operator=(source);
-
-    //~ reassign members
-
-    return *this;
   }
 
   /// Equality operator
@@ -222,3 +197,4 @@ namespace OpenMS
   }
 
 } //namespace OpenMS
+

--- a/src/openms/source/METADATA/MassAnalyzer.cpp
+++ b/src/openms/source/METADATA/MassAnalyzer.cpp
@@ -72,55 +72,9 @@ namespace OpenMS
 
   }
 
-  MassAnalyzer::MassAnalyzer(const MassAnalyzer & source) :
-    MetaInfoInterface(source),
-    type_(source.type_),
-    resolution_method_(source.resolution_method_),
-    resolution_type_(source.resolution_type_),
-    scan_direction_(source.scan_direction_),
-    scan_law_(source.scan_law_),
-    reflectron_state_(source.reflectron_state_),
-    resolution_(source.resolution_),
-    accuracy_(source.accuracy_),
-    scan_rate_(source.scan_rate_),
-    scan_time_(source.scan_time_),
-    TOF_total_path_length_(source.TOF_total_path_length_),
-    isolation_width_(source.isolation_width_),
-    final_MS_exponent_(source.final_MS_exponent_),
-    magnetic_field_strength_(source.magnetic_field_strength_),
-    order_(source.order_)
-  {
-
-  }
-
   MassAnalyzer::~MassAnalyzer()
   {
 
-  }
-
-  MassAnalyzer & MassAnalyzer::operator=(const MassAnalyzer & source)
-  {
-    if (&source == this)
-      return *this;
-
-    order_ = source.order_;
-    type_ = source.type_;
-    resolution_method_ = source.resolution_method_;
-    resolution_type_ = source.resolution_type_;
-    scan_direction_ = source.scan_direction_;
-    scan_law_ = source.scan_law_;
-    reflectron_state_ = source.reflectron_state_;
-    resolution_ = source.resolution_;
-    accuracy_ = source.accuracy_;
-    scan_rate_ = source.scan_rate_;
-    scan_time_ = source.scan_time_;
-    TOF_total_path_length_ = source.TOF_total_path_length_;
-    isolation_width_ = source.isolation_width_;
-    final_MS_exponent_ = source.final_MS_exponent_;
-    magnetic_field_strength_ = source.magnetic_field_strength_;
-    MetaInfoInterface::operator=(source);
-
-    return *this;
   }
 
   bool MassAnalyzer::operator==(const MassAnalyzer & rhs) const
@@ -299,3 +253,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/MetaInfo.cpp
+++ b/src/openms/source/METADATA/MetaInfo.cpp
@@ -41,27 +41,8 @@ namespace OpenMS
 
   MetaInfoRegistry MetaInfo::registry_ = MetaInfoRegistry();
 
-  MetaInfo::MetaInfo()
-  {
-  }
-
-  MetaInfo::MetaInfo(const MetaInfo & rhs)
-  {
-    *this = rhs;
-  }
-
   MetaInfo::~MetaInfo()
   {
-  }
-
-  MetaInfo & MetaInfo::operator=(const MetaInfo & rhs)
-  {
-    if (this == &rhs)
-      return *this;
-
-    index_to_value_ = rhs.index_to_value_;
-
-    return *this;
   }
 
   bool MetaInfo::operator==(const MetaInfo & rhs) const
@@ -175,3 +156,4 @@ namespace OpenMS
   }
 
 } //namespace
+

--- a/src/openms/source/METADATA/MetaInfoDescription.cpp
+++ b/src/openms/source/METADATA/MetaInfoDescription.cpp
@@ -41,40 +41,8 @@ using namespace std;
 namespace OpenMS
 {
 
-  MetaInfoDescription::MetaInfoDescription() :
-    MetaInfoInterface(),
-    comment_(),
-    name_(),
-    data_processing_()
-  {
-
-  }
-
-  MetaInfoDescription::MetaInfoDescription(const MetaInfoDescription & source) :
-    MetaInfoInterface(source),
-    comment_(source.comment_),
-    name_(source.name_),
-    data_processing_(source.data_processing_)
-  {
-
-  }
-
   MetaInfoDescription::~MetaInfoDescription()
   {
-
-  }
-
-  MetaInfoDescription & MetaInfoDescription::operator=(const MetaInfoDescription & source)
-  {
-    if (&source == this)
-      return *this;
-
-    MetaInfoInterface::operator=(source);
-    comment_ = source.comment_;
-    name_ = source.name_;
-    data_processing_ = source.data_processing_;
-
-    return *this;
   }
 
   bool MetaInfoDescription::operator==(const MetaInfoDescription & rhs) const
@@ -115,3 +83,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/MetaInfoInterface.cpp
+++ b/src/openms/source/METADATA/MetaInfoInterface.cpp
@@ -44,15 +44,12 @@ namespace OpenMS
   {
   }
 
-  MetaInfoInterface::MetaInfoInterface(const MetaInfoInterface & rhs)
+  MetaInfoInterface::MetaInfoInterface(const MetaInfoInterface & rhs) :
+    meta_(nullptr)
   {
     if (rhs.meta_ != nullptr)
     {
       meta_ = new MetaInfo(*(rhs.meta_));
-    }
-    else
-    {
-      meta_ = nullptr;
     }
   }
 
@@ -244,3 +241,4 @@ namespace OpenMS
   }
 
 } //namespace
+

--- a/src/openms/source/METADATA/MetaInfoInterface.cpp
+++ b/src/openms/source/METADATA/MetaInfoInterface.cpp
@@ -42,7 +42,6 @@ namespace OpenMS
   MetaInfoInterface::MetaInfoInterface() :
     meta_(nullptr)
   {
-
   }
 
   MetaInfoInterface::MetaInfoInterface(const MetaInfoInterface & rhs)
@@ -57,6 +56,13 @@ namespace OpenMS
     }
   }
 
+  MetaInfoInterface::MetaInfoInterface(MetaInfoInterface&& rhs) :
+    meta_(rhs.meta_)
+  {
+    // take ownership
+    rhs.meta_ = nullptr;
+  }
+
   MetaInfoInterface::~MetaInfoInterface()
   {
     delete(meta_);
@@ -65,11 +71,9 @@ namespace OpenMS
   MetaInfoInterface & MetaInfoInterface::operator=(const MetaInfoInterface & rhs)
   {
     if (this == &rhs)
+    {
       return *this;
-
-//      std::cout << meta_ << std::endl;
-//      std::cout << rhs.meta_ << std::endl;
-//      std::cout << " " << std::endl;
+    }
 
     if (rhs.meta_ != nullptr && meta_ != nullptr)
     {
@@ -84,6 +88,21 @@ namespace OpenMS
     {
       meta_ = new MetaInfo(*(rhs.meta_));
     }
+
+    return *this;
+  }
+
+  MetaInfoInterface& MetaInfoInterface::operator=(MetaInfoInterface&& rhs)
+  {
+    if (this == &rhs)
+    {
+      return *this;
+    }
+
+    // free memory and assign rhs memory
+    delete(meta_);
+    meta_ = rhs.meta_;
+    rhs.meta_ = nullptr;
 
     return *this;
   }

--- a/src/openms/source/METADATA/MetaInfoRegistry.cpp
+++ b/src/openms/source/METADATA/MetaInfoRegistry.cpp
@@ -327,3 +327,4 @@ namespace OpenMS
   }
 
 } //namespace
+

--- a/src/openms/source/METADATA/Modification.cpp
+++ b/src/openms/source/METADATA/Modification.cpp
@@ -48,42 +48,18 @@ namespace OpenMS
     specificity_type_(AA),
     affected_amino_acids_("")
   {
-
-  }
-
-  Modification::Modification(const Modification & source) :
-    SampleTreatment(source),
-    reagent_name_(source.reagent_name_),
-    mass_(source.mass_),
-    specificity_type_(source.specificity_type_),
-    affected_amino_acids_(source.affected_amino_acids_)
-  {
-
   }
 
   Modification::~Modification()
   {
-
-  }
-
-  Modification & Modification::operator=(const Modification & source)
-  {
-    if (&source == this)
-      return *this;
-
-    SampleTreatment::operator=(source);
-    reagent_name_ = source.reagent_name_;
-    mass_ = source.mass_;
-    specificity_type_ = source.specificity_type_;
-    affected_amino_acids_ = source.affected_amino_acids_;
-
-    return *this;
   }
 
   bool Modification::operator==(const SampleTreatment & rhs) const
   {
     if (type_ != rhs.getType())
+    {
       return false;
+    }
 
     const Modification * tmp = dynamic_cast<const Modification *>(&rhs);
     return SampleTreatment::operator==(* tmp) &&
@@ -140,3 +116,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/PeptideEvidence.cpp
+++ b/src/openms/source/METADATA/PeptideEvidence.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/METADATA/PeptideEvidence.h>
+
 #include <OpenMS/CHEMISTRY/AASequence.h>
 
 namespace OpenMS
@@ -53,32 +54,13 @@ namespace OpenMS
   {
   }
 
-  PeptideEvidence::PeptideEvidence(const String& accession, Int start, Int end, char aa_before, char aa_after)
-    : accession_(accession),
+  PeptideEvidence::PeptideEvidence(const String& accession, Int start, Int end, char aa_before, char aa_after) :
+      accession_(accession),
       start_(start),
       end_(end),
       aa_before_(aa_before),
       aa_after_(aa_after)
   {
-  }
-
-  PeptideEvidence::PeptideEvidence(const PeptideEvidence& rhs)
-  {
-    accession_ = rhs.accession_;
-    start_ = rhs.start_;
-    end_ = rhs.end_;
-    aa_before_ = rhs.aa_before_;
-    aa_after_ = rhs.aa_after_;
-  }
-
-  PeptideEvidence& PeptideEvidence::operator=(const PeptideEvidence& rhs)
-  {
-    accession_ = rhs.accession_;
-    start_ = rhs.start_;
-    end_ = rhs.end_;
-    aa_before_ = rhs.aa_before_;
-    aa_after_ = rhs.aa_after_;
-    return *this;
   }
 
   bool PeptideEvidence::operator==(const PeptideEvidence& rhs) const
@@ -165,3 +147,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -118,8 +118,8 @@ namespace OpenMS
       delete analysis_results_;
       analysis_results_ = new std::vector<PepXMLAnalysisResult>(*source.analysis_results_);
     }
-    charge_ = source.charge_;
     rank_ = source.rank_;
+    charge_ = source.charge_;
     peptide_evidences_ = source.peptide_evidences_;
     fragment_annotations_ = source.fragment_annotations_;
     return *this;
@@ -141,8 +141,8 @@ namespace OpenMS
     analysis_results_ = source.analysis_results_;
     source.analysis_results_ = nullptr;
 
-    charge_ = source.charge_;
     rank_ = source.rank_;
+    charge_ = source.charge_;
     peptide_evidences_ = source.peptide_evidences_;
     fragment_annotations_ = source.fragment_annotations_;
 

--- a/src/openms/source/METADATA/PeptideIdentification.cpp
+++ b/src/openms/source/METADATA/PeptideIdentification.cpp
@@ -52,43 +52,8 @@ namespace OpenMS
   {
   }
 
-  PeptideIdentification::PeptideIdentification(const PeptideIdentification& rhs) :
-    MetaInfoInterface(rhs),
-    id_(rhs.id_),
-    hits_(rhs.hits_),
-    significance_threshold_(rhs.significance_threshold_),
-    score_type_(rhs.score_type_),
-    higher_score_better_(rhs.higher_score_better_),
-    base_name_(rhs.base_name_),
-    mz_(rhs.mz_),
-    rt_(rhs.rt_)
-  {
-    setExperimentLabel( rhs.getExperimentLabel() );
-  }
-
   PeptideIdentification::~PeptideIdentification()
   {
-  }
-
-  PeptideIdentification& PeptideIdentification::operator=(const PeptideIdentification& rhs)
-  {
-    if (this == &rhs)
-    {
-      return *this;
-    }
-
-    MetaInfoInterface::operator=(rhs);
-    id_ = rhs.id_;
-    hits_ = rhs.hits_;
-    significance_threshold_ = rhs.significance_threshold_;
-    score_type_ = rhs.score_type_;
-    higher_score_better_ = rhs.higher_score_better_;
-    setExperimentLabel( rhs.getExperimentLabel() );
-    base_name_ = rhs.base_name_;
-    mz_ = rhs.mz_;
-    rt_ = rhs.rt_;
-
-    return *this;
   }
 
   // Equality operator
@@ -301,3 +266,4 @@ namespace OpenMS
   }
   
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/Precursor.cpp
+++ b/src/openms/source/METADATA/Precursor.cpp
@@ -57,43 +57,8 @@ namespace OpenMS
   {
   }
 
-  Precursor::Precursor(const Precursor & source) :
-    CVTermList(source),
-    Peak1D(source),
-    activation_methods_(source.activation_methods_),
-    activation_energy_(source.activation_energy_),
-    window_low_(source.window_low_),
-    window_up_(source.window_up_),
-    drift_time_(source.drift_time_),
-    drift_window_low_(source.drift_window_low_),
-    drift_window_up_(source.drift_window_up_),
-    charge_(source.charge_),
-    possible_charge_states_(source.possible_charge_states_)
-  {
-  }
-
   Precursor::~Precursor()
   {
-  }
-
-  Precursor & Precursor::operator=(const Precursor & source)
-  {
-    if (&source == this)
-      return *this;
-
-    CVTermList::operator=(source);
-    Peak1D::operator=(source);
-    activation_methods_ = source.activation_methods_;
-    activation_energy_ = source.activation_energy_;
-    window_low_ = source.window_low_;
-    window_up_ = source.window_up_;
-    drift_time_ = source.drift_time_;
-    drift_window_low_ = source.drift_window_low_;
-    drift_window_up_ = source.drift_window_up_;
-    charge_ = source.charge_;
-    possible_charge_states_ = source.possible_charge_states_;
-
-    return *this;
   }
 
   bool Precursor::operator==(const Precursor & rhs) const
@@ -222,3 +187,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/Product.cpp
+++ b/src/openms/source/METADATA/Product.cpp
@@ -39,39 +39,6 @@ using namespace std;
 namespace OpenMS
 {
 
-  Product::Product() :
-    CVTermList(),
-    mz_(0.0),
-    window_low_(0.0),
-    window_up_(0.0)
-  {
-  }
-
-  Product::Product(const Product & source) :
-    CVTermList(source),
-    mz_(source.mz_),
-    window_low_(source.window_low_),
-    window_up_(source.window_up_)
-  {
-  }
-
-  Product::~Product()
-  {
-  }
-
-  Product & Product::operator=(const Product & source)
-  {
-    if (&source == this)
-      return *this;
-
-    CVTermList::operator=(source);
-    mz_ = source.mz_;
-    window_low_ = source.window_low_;
-    window_up_ = source.window_up_;
-
-    return *this;
-  }
-
   bool Product::operator==(const Product & rhs) const
   {
     return mz_ == rhs.mz_ &&

--- a/src/openms/source/METADATA/ProteinHit.cpp
+++ b/src/openms/source/METADATA/ProteinHit.cpp
@@ -62,38 +62,9 @@ namespace OpenMS
   {
   }
 
-  // copy constructor
-  ProteinHit::ProteinHit(const ProteinHit & source) :
-    MetaInfoInterface(source),
-    score_(source.score_),
-    rank_(source.rank_),
-    accession_(source.accession_),
-    sequence_(source.sequence_),
-    coverage_(source.coverage_)
-  {
-  }
-
   // destructor
   ProteinHit::~ProteinHit()
   {
-  }
-
-  // assignment operator
-  ProteinHit & ProteinHit::operator=(const ProteinHit & source)
-  {
-    if (this == &source)
-    {
-      return *this;
-    }
-
-    MetaInfoInterface::operator=(source);
-    score_ = source.score_;
-    rank_  = source.rank_;
-    sequence_ = source.sequence_;
-    accession_ = source.accession_;
-    coverage_ = source.coverage_;
-
-    return *this;
   }
 
   // assignment operator for MetaInfoInterface
@@ -195,3 +166,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/ProteinIdentification.cpp
+++ b/src/openms/source/METADATA/ProteinIdentification.cpp
@@ -36,7 +36,6 @@
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <numeric>
 
-
 using namespace std;
 
 namespace OpenMS

--- a/src/openms/source/METADATA/ProteinIdentification.cpp
+++ b/src/openms/source/METADATA/ProteinIdentification.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/METADATA/ProteinIdentification.h>
+
 #include <OpenMS/METADATA/PeptideIdentification.h>
 #include <numeric>
 
@@ -115,22 +116,6 @@ namespace OpenMS
     protein_groups_(),
     indistinguishable_proteins_(),
     protein_significance_threshold_(0.0)
-  {
-  }
-
-  ProteinIdentification::ProteinIdentification(const ProteinIdentification& source) :
-    MetaInfoInterface(source),
-    id_(source.id_),
-    search_engine_(source.search_engine_),
-    search_engine_version_(source.search_engine_version_),
-    search_parameters_(source.search_parameters_),
-    date_(source.date_),
-    protein_score_type_(source.protein_score_type_),
-    higher_score_better_(source.higher_score_better_),
-    protein_hits_(source.protein_hits_),
-    protein_groups_(source.protein_groups_),
-    indistinguishable_proteins_(source.indistinguishable_proteins_),
-    protein_significance_threshold_(source.protein_significance_threshold_)
   {
   }
 
@@ -250,27 +235,6 @@ namespace OpenMS
     {
       toFill = this->getMetaValue("spectra_data");
     }
-  }
-
-  ProteinIdentification& ProteinIdentification::operator=(const ProteinIdentification& source)
-  {
-    if (this == &source)
-    {
-      return *this;
-    }
-    MetaInfoInterface::operator=(source);
-    id_ = source.id_;
-    search_engine_ = source.search_engine_;
-    search_engine_version_ = source.search_engine_version_;
-    search_parameters_ = source.search_parameters_;
-    date_ = source.date_;
-    protein_hits_ = source.protein_hits_;
-    protein_groups_ = source.protein_groups_;
-    indistinguishable_proteins_ = source.indistinguishable_proteins_;
-    protein_score_type_ = source.protein_score_type_;
-    protein_significance_threshold_ = source.protein_significance_threshold_;
-    higher_score_better_ = source.higher_score_better_;
-    return *this;
   }
 
   // Equality operator
@@ -452,3 +416,4 @@ namespace OpenMS
 
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/Sample.cpp
+++ b/src/openms/source/METADATA/Sample.cpp
@@ -63,31 +63,24 @@ namespace OpenMS
     concentration_(source.concentration_),
     subsamples_(source.subsamples_)
   {
-    //delete old treatments
-    for (list<SampleTreatment *>::iterator it = treatments_.begin(); it != treatments_.end(); ++it)
-    {
-      delete(*it);
-    }
+    // delete old treatments
+    for (auto& it : treatments_) delete it;
     treatments_.clear();
-    //copy treatments
-    for (list<SampleTreatment *>::const_iterator it = source.treatments_.begin(); it != source.treatments_.end(); ++it)
-    {
-      treatments_.push_back((*it)->clone());
-    }
+    // copy treatments
+    for (const auto & it : source.treatments_) treatments_.push_back(it->clone());
   }
 
   Sample::~Sample()
   {
-    for (list<SampleTreatment *>::iterator it = treatments_.begin(); it != treatments_.end(); ++it)
-    {
-      delete(*it);
-    }
+    for (auto& it : treatments_) delete it;
   }
 
   Sample & Sample::operator=(const Sample & source)
   {
     if (&source == this)
+    {
       return *this;
+    }
 
     name_ = source.name_;
     number_ = source.number_;
@@ -99,17 +92,12 @@ namespace OpenMS
     concentration_ = source.concentration_;
     subsamples_ = source.subsamples_;
     MetaInfoInterface::operator=(source);
-    //delete old treatments
-    for (list<SampleTreatment *>::iterator it = treatments_.begin(); it != treatments_.end(); ++it)
-    {
-      delete(*it);
-    }
+
+    // delete old treatments
+    for (auto& it : treatments_) delete it;
     treatments_.clear();
-    //copy treatments
-    for (list<SampleTreatment *>::const_iterator it = source.treatments_.begin(); it != source.treatments_.end(); ++it)
-    {
-      treatments_.push_back((*it)->clone());
-    }
+    // copy treatments
+    for (const auto & it : source.treatments_) treatments_.push_back(it->clone());
 
     return *this;
   }
@@ -133,12 +121,14 @@ namespace OpenMS
       return false;
     }
 
-    //treatments
-    list<SampleTreatment *>::const_iterator it2 = rhs.treatments_.begin();
-    for (list<SampleTreatment *>::const_iterator it = treatments_.begin(); it != treatments_.end(); ++it, ++it2)
+    // treatments
+    auto it2 = rhs.treatments_.begin();
+    for (auto it = treatments_.begin(); it != treatments_.end(); ++it, ++it2)
     {
       if (*it != *it2)
+      {
         return false;
+      }
     }
     return true;
   }

--- a/src/openms/source/METADATA/Sample.cpp
+++ b/src/openms/source/METADATA/Sample.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/METADATA/Sample.h>
+
 #include <OpenMS/METADATA/SampleTreatment.h>
 
 using namespace std;
@@ -300,3 +301,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/SampleTreatment.cpp
+++ b/src/openms/source/METADATA/SampleTreatment.cpp
@@ -39,43 +39,15 @@ using namespace std;
 namespace OpenMS
 {
 
-  SampleTreatment::SampleTreatment() :
-    MetaInfoInterface(),
-    comment_()
-  {
-
-  }
-
   SampleTreatment::SampleTreatment(const String & type) :
     MetaInfoInterface(),
     type_(type),
     comment_()
   {
-
-  }
-
-  SampleTreatment::SampleTreatment(const SampleTreatment & source) :
-    MetaInfoInterface(source),
-    type_(source.type_),
-    comment_(source.comment_)
-  {
-
   }
 
   SampleTreatment::~SampleTreatment()
   {
-
-  }
-
-  SampleTreatment & SampleTreatment::operator=(const SampleTreatment & source)
-  {
-    if (&source == this)
-      return *this;
-
-    MetaInfoInterface::operator=(source);
-    comment_ = source.comment_;
-
-    return *this;
   }
 
   const String & SampleTreatment::getType() const

--- a/src/openms/source/METADATA/ScanWindow.cpp
+++ b/src/openms/source/METADATA/ScanWindow.cpp
@@ -38,20 +38,6 @@ using namespace std;
 
 namespace OpenMS
 {
-  //--------------------------- ScanWindow ----------------------------
-  ScanWindow::ScanWindow() :
-    MetaInfoInterface(),
-    begin(0.0),
-    end(0.0)
-  {
-  }
-
-  ScanWindow::ScanWindow(const ScanWindow & source) :
-    MetaInfoInterface(source),
-    begin(source.begin),
-    end(source.end)
-  {
-  }
 
   bool ScanWindow::operator==(const ScanWindow & source) const
   {
@@ -65,16 +51,5 @@ namespace OpenMS
     return !(operator==(source));
   }
 
-  ScanWindow & ScanWindow::operator=(const ScanWindow & source)
-  {
-    if (&source == this)
-      return *this;
-
-    MetaInfoInterface::operator=(source);
-    begin = source.begin;
-    end = source.end;
-
-    return *this;
-  }
-
 }
+

--- a/src/openms/source/METADATA/Software.cpp
+++ b/src/openms/source/METADATA/Software.cpp
@@ -39,34 +39,8 @@ using namespace std;
 namespace OpenMS
 {
 
-  Software::Software() :
-    CVTermList(),
-    name_(),
-    version_()
-  {
-  }
-
-  Software::Software(const Software & rhs) :
-    CVTermList(rhs),
-    name_(rhs.name_),
-    version_(rhs.version_)
-  {
-  }
-
   Software::~Software()
   {
-  }
-
-  Software & Software::operator=(const Software & rhs)
-  {
-    if (&rhs == this)
-      return *this;
-
-    CVTermList::operator=(rhs);
-    name_ = rhs.name_;
-    version_ = rhs.version_;
-
-    return *this;
   }
 
   bool Software::operator==(const Software & rhs) const
@@ -102,3 +76,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/SourceFile.cpp
+++ b/src/openms/source/METADATA/SourceFile.cpp
@@ -51,42 +51,10 @@ namespace OpenMS
     native_id_type_(""),
     native_id_type_accession_("")
   {
-
-  }
-
-  SourceFile::SourceFile(const SourceFile& source) :
-    CVTermList(source),
-    name_of_file_(source.name_of_file_),
-    path_to_file_(source.path_to_file_),
-    file_size_(source.file_size_),
-    file_type_(source.file_type_),
-    checksum_(source.checksum_),
-    checksum_type_(source.checksum_type_),
-    native_id_type_(source.native_id_type_),
-    native_id_type_accession_(source.native_id_type_accession_)
-  {
   }
 
   SourceFile::~SourceFile()
   {
-  }
-
-  SourceFile& SourceFile::operator=(const SourceFile& source)
-  {
-    if (&source == this)
-      return *this;
-
-    CVTermList::operator=(source);
-    name_of_file_ = source.name_of_file_;
-    path_to_file_ = source.path_to_file_;
-    file_size_ = source.file_size_;
-    file_type_ = source.file_type_;
-    checksum_ = source.checksum_;
-    checksum_type_ = source.checksum_type_;
-    native_id_type_ = source.native_id_type_;
-    native_id_type_accession_ = source.native_id_type_accession_;
-
-    return *this;
   }
 
   bool SourceFile::operator==(const SourceFile& rhs) const
@@ -184,3 +152,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/SpectrumIdentification.cpp
+++ b/src/openms/source/METADATA/SpectrumIdentification.cpp
@@ -39,35 +39,8 @@ using namespace std;
 namespace OpenMS
 {
 
-  SpectrumIdentification::SpectrumIdentification() :
-    MetaInfoInterface(),
-    id_()
-  {
-  }
-
-  SpectrumIdentification::SpectrumIdentification(const SpectrumIdentification & rhs) :
-    MetaInfoInterface(rhs),
-    id_(rhs.id_),
-    hits_(rhs.hits_)
-  {
-  }
-
   SpectrumIdentification::~SpectrumIdentification()
   {
-  }
-
-  SpectrumIdentification & SpectrumIdentification::operator=(const SpectrumIdentification & rhs)
-  {
-    if (this == &rhs)
-    {
-      return *this;
-    }
-
-    MetaInfoInterface::operator=(rhs);
-    id_ = rhs.id_;
-    hits_ = rhs.hits_;
-
-    return *this;
   }
 
   // Equality operator
@@ -100,3 +73,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/SpectrumLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumLookup.cpp
@@ -340,3 +340,4 @@ namespace OpenMS
   }
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
@@ -257,3 +257,4 @@ namespace OpenMS
 
 
 } // namespace OpenMS
+

--- a/src/openms/source/METADATA/SpectrumSettings.cpp
+++ b/src/openms/source/METADATA/SpectrumSettings.cpp
@@ -59,43 +59,8 @@ namespace OpenMS
   {
   }
 
-  SpectrumSettings::SpectrumSettings(const SpectrumSettings & source) :
-    MetaInfoInterface(source),
-    type_(source.type_),
-    native_id_(source.native_id_),
-    comment_(source.comment_),
-    instrument_settings_(source.instrument_settings_),
-    source_file_(source.source_file_),
-    acquisition_info_(source.acquisition_info_),
-    precursors_(source.precursors_),
-    products_(source.products_),
-    identification_(source.identification_),
-    data_processing_(source.data_processing_)
-  {
-  }
-
   SpectrumSettings::~SpectrumSettings()
   {
-  }
-
-  SpectrumSettings & SpectrumSettings::operator=(const SpectrumSettings & source)
-  {
-    if (&source == this)
-      return *this;
-
-    MetaInfoInterface::operator=(source);
-    type_ = source.type_;
-    native_id_ = source.native_id_;
-    comment_ = source.comment_;
-    instrument_settings_ = source.instrument_settings_;
-    acquisition_info_ = source.acquisition_info_;
-    source_file_ = source.source_file_;
-    precursors_ = source.precursors_;
-    products_ = source.products_;
-    identification_ = source.identification_;
-    data_processing_ = source.data_processing_;
-
-    return *this;
   }
 
   bool SpectrumSettings::operator==(const SpectrumSettings & rhs) const
@@ -287,3 +252,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/source/METADATA/Tagging.cpp
+++ b/src/openms/source/METADATA/Tagging.cpp
@@ -48,35 +48,16 @@ namespace OpenMS
     type_ = "Tagging";
   }
 
-  Tagging::Tagging(const Tagging & source) :
-    Modification(source),
-    mass_shift_(source.mass_shift_),
-    variant_(source.variant_)
-  {
-    //????
-  }
-
   Tagging::~Tagging()
   {
-    //????
-  }
-
-  Tagging & Tagging::operator=(const Tagging & source)
-  {
-    if (&source == this)
-      return *this;
-
-    Modification::operator=(source);
-    mass_shift_ = source.mass_shift_;
-    variant_ = source.variant_;
-
-    return *this;
   }
 
   bool Tagging::operator==(const SampleTreatment & rhs) const
   {
     if (type_ != rhs.getType())
+    {
       return false;
+    }
 
     const Tagging * tmp = dynamic_cast<const Tagging *>(&rhs);
     return Modification::operator==(rhs)
@@ -111,3 +92,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/tests/class_tests/openms/source/Acquisition_test.cpp
+++ b/src/tests/class_tests/openms/source/Acquisition_test.cpp
@@ -78,6 +78,22 @@ START_SECTION(Acquisition(const Acquisition& source))
 	TEST_EQUAL((String)(tmp2.getMetaValue("label")), "label");
 END_SECTION
 
+START_SECTION(Acquisition(Acquisition&&) = default)
+  Acquisition e, empty;
+  e.setIdentifier("Ident");
+
+  Acquisition ef(e);
+  Acquisition ef2(e);
+
+  TEST_EQUAL(ef != empty, true)
+
+  // the move target should be equal, while the move source should be empty
+  Acquisition ef_mv(std::move(ef));
+  TEST_EQUAL(ef_mv == ef2, true)
+  TEST_EQUAL(ef == empty, true)
+  TEST_EQUAL(ef.getIdentifier() == "", true)
+END_SECTION
+
 START_SECTION(Acquisition& operator= (const Acquisition& source))
 	Acquisition tmp,tmp2,tmp3;
 	// assignment of a modified object

--- a/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
+++ b/src/tests/class_tests/openms/source/EmpiricalFormula_test.cpp
@@ -37,8 +37,10 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
 #include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+///////////////////////////
+
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
 #include <OpenMS/CHEMISTRY/Element.h>
 #include <OpenMS/CHEMISTRY/ElementDB.h>
 
@@ -55,6 +57,8 @@ EmpiricalFormula* e_ptr = nullptr;
 EmpiricalFormula* e_nullPointer = nullptr;
 const ElementDB * db = ElementDB::getInstance();
 
+EmpiricalFormula ef_empty;
+
 START_SECTION(EmpiricalFormula())
   e_ptr = new EmpiricalFormula;
   TEST_NOT_EQUAL(e_ptr, e_nullPointer)
@@ -67,18 +71,33 @@ END_SECTION
 START_SECTION(EmpiricalFormula(const String& rhs))
   e_ptr = new EmpiricalFormula("C4");
   TEST_NOT_EQUAL(e_ptr, e_nullPointer)
-        EmpiricalFormula e0("C5(13)C4H2");
-        EmpiricalFormula e1("C5(13)C4");
-        EmpiricalFormula e2("(12)C5(13)C4");
-        EmpiricalFormula e3("C9");
+  EmpiricalFormula e0("C5(13)C4H2");
+  EmpiricalFormula e1("C5(13)C4");
+  EmpiricalFormula e2("(12)C5(13)C4");
+  EmpiricalFormula e3("C9");
   TEST_REAL_SIMILAR(e1.getMonoWeight(), e2.getMonoWeight())
   TEST_REAL_SIMILAR(e1.getMonoWeight(), 112.013419)
   TEST_REAL_SIMILAR(e2.getMonoWeight(), 112.013419)
 END_SECTION
 
+
 START_SECTION(EmpiricalFormula(const EmpiricalFormula& rhs))
   EmpiricalFormula ef(*e_ptr);
   TEST_EQUAL(ef == *e_ptr, true)
+END_SECTION
+
+START_SECTION(EmpiricalFormula(EmpiricalFormula&&) = default)
+  EmpiricalFormula e = EmpiricalFormula("C4");
+
+  EmpiricalFormula ef(e);
+  EmpiricalFormula ef2(e);
+
+  TEST_NOT_EQUAL(ef, ef_empty)
+
+  // the move target should be equal, while the move source should be empty
+  EmpiricalFormula ef_mv(std::move(ef));
+  TEST_EQUAL(ef_mv, ef2)
+  TEST_EQUAL(ef, ef_empty)
 END_SECTION
 
 START_SECTION((EmpiricalFormula(SignedSize number, const Element* element, SignedSize charge=0)))
@@ -125,6 +144,21 @@ START_SECTION(EmpiricalFormula& operator = (const EmpiricalFormula& rhs))
   TEST_EQUAL(*e_ptr == ef, true)
 END_SECTION
 
+    
+START_SECTION(EmpiricalFormula& operator=(EmpiricalFormula&&) & = default)
+  EmpiricalFormula e = EmpiricalFormula("C4");
+
+  EmpiricalFormula ef(e);
+  EmpiricalFormula ef2(e);
+  TEST_NOT_EQUAL(ef, ef_empty)
+
+  // the move target should be equal, while the move source should be empty
+  EmpiricalFormula ef_mv;
+  ef_mv = std::move(ef);
+  TEST_EQUAL(ef_mv, ef2)
+  TEST_EQUAL(ef, ef_empty)
+END_SECTION
+
 START_SECTION(EmpiricalFormula operator * (const SignedSize& times) const)
   EmpiricalFormula ef("C3H8");
   ef = ef * 3;
@@ -133,6 +167,7 @@ END_SECTION
 
 START_SECTION(EmpiricalFormula& operator += (const EmpiricalFormula& rhs))
   EmpiricalFormula ef("C3");
+  TEST_EQUAL(ef, "C3")
   ef += ef;
   TEST_EQUAL(ef, "C6")
   EmpiricalFormula ef2("C-6H2");


### PR DESCRIPTION
First step towards move semantics in OpenMS

- implementations for MSSpectrum, MSChromatogram, MSExperiment
- implementations for METADATA
- implementations for some data structurs, such as `String`
- add `std::move` semantics to the MzMLHandler which should reduce copying while reading

in the long term, this should reduce extra code and simplify our code base while making it faster at the same time