### PR TITLE
Feature/move semantics

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -387,7 +387,7 @@ protected:
     AASequence(const AASequence& rhs) = default;
 
     /// Move constructor
-    AASequence(AASequence&&) = default;
+    AASequence(AASequence&&) noexcept = default;
 
     /// Destructor
     virtual ~AASequence();
@@ -397,7 +397,7 @@ protected:
     AASequence& operator=(const AASequence& rhs) = default;
 
     /// Move assignment operator
-    AASequence& operator=(AASequence&&) & = default;
+    AASequence& operator=(AASequence&&) noexcept = default;
 
     /// check if sequence is empty
     bool empty() const;

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -397,7 +397,7 @@ protected:
     AASequence& operator=(const AASequence& rhs) = default;
 
     /// Move assignment operator
-    AASequence& operator=(AASequence&&) noexcept = default;
+    AASequence& operator=(AASequence&&) = default; // TODO: add noexcept (gcc 4.8 bug)
 
     /// check if sequence is empty
     bool empty() const;

--- a/src/openms/include/OpenMS/DATASTRUCTURES/DataValue.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DataValue.h
@@ -83,8 +83,12 @@ public:
 
     /// @name Constructors and destructors
     //@{
-    /// default constructor
+    /// Default constructor
     DataValue();
+    /// Copy constructor
+    DataValue(const DataValue&);
+    /// Move constructor
+    DataValue(DataValue&&) noexcept;
     /// specific constructor for char* (converted to string)
     DataValue(const char*);
     /// specific constructor for std::string values
@@ -121,9 +125,7 @@ public:
     DataValue(long long);
     /// specific constructor for unsigned long long int values (note: the implementation uses SignedSize)
     DataValue(unsigned long long);
-    /// copy constructor
-    DataValue(const DataValue&);
-    /// destructor
+    /// Destructor
     ~DataValue();
     //@}
 
@@ -302,8 +304,10 @@ public:
     ///@name Assignment operators
     ///These methods are used to assign supported types directly to a DataValue object.
     //@{
-    /// assignment operator
+    /// Assignment operator
     DataValue& operator=(const DataValue&);
+    /// Move assignment operator
+    DataValue& operator=(DataValue&&) noexcept;
     /// specific assignment for char* (converted to string)
     DataValue& operator=(const char*);
     /// specific assignment for std::string values
@@ -439,7 +443,7 @@ protected:
 private:
 
     /// Clears the current state of the DataValue and release every used memory.
-    void clear_();
+    void clear_() noexcept;
   };
 }
 

--- a/src/openms/include/OpenMS/METADATA/MetaInfoInterface.h
+++ b/src/openms/include/OpenMS/METADATA/MetaInfoInterface.h
@@ -61,14 +61,14 @@ public:
     /// Copy constructor
     MetaInfoInterface(const MetaInfoInterface& rhs);
     /// Move constructor
-    MetaInfoInterface(MetaInfoInterface&&);
+    MetaInfoInterface(MetaInfoInterface&&) noexcept;
     /// Destructor
     ~MetaInfoInterface();
 
     /// Assignment operator
     MetaInfoInterface& operator=(const MetaInfoInterface& rhs);
     /// Move assignment operator
-    MetaInfoInterface& operator=(MetaInfoInterface&&);
+    MetaInfoInterface& operator=(MetaInfoInterface&&) noexcept;
 
     /// Equality operator
     bool operator==(const MetaInfoInterface& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/PeptideEvidence.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideEvidence.h
@@ -70,7 +70,7 @@ public:
     PeptideEvidence(const PeptideEvidence& source) = default;
 
     /// Move constructor
-    PeptideEvidence(PeptideEvidence&&) = default;
+    PeptideEvidence(PeptideEvidence&&) noexcept = default;
 
     /// Destructor
     ~PeptideEvidence() {}
@@ -79,7 +79,7 @@ public:
     /// Assignment operator
     PeptideEvidence& operator=(const PeptideEvidence& source) = default;
     /// Move assignment operator
-    PeptideEvidence& operator=(PeptideEvidence&&) & = default;
+    PeptideEvidence& operator=(PeptideEvidence&&) noexcept = default;
 
     /// Equality operator
     bool operator==(const PeptideEvidence& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/PeptideEvidence.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideEvidence.h
@@ -79,7 +79,7 @@ public:
     /// Assignment operator
     PeptideEvidence& operator=(const PeptideEvidence& source) = default;
     /// Move assignment operator
-    PeptideEvidence& operator=(PeptideEvidence&&) noexcept = default;
+    PeptideEvidence& operator=(PeptideEvidence&&) = default; // TODO: add noexcept (gcc 4.8 bug)
 
     /// Equality operator
     bool operator==(const PeptideEvidence& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/PeptideHit.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideHit.h
@@ -240,7 +240,7 @@ public:
     PeptideHit(const PeptideHit& source);
 
     /// Move constructor
-    PeptideHit(PeptideHit&&);
+    PeptideHit(PeptideHit&&) noexcept;
 
     /// Destructor
     virtual ~PeptideHit();
@@ -250,7 +250,7 @@ public:
     PeptideHit& operator=(const PeptideHit& source);
 
     /// Move assignment operator
-    PeptideHit& operator=(PeptideHit&&);
+    PeptideHit& operator=(PeptideHit&&) noexcept;
 
     /// Equality operator
     bool operator==(const PeptideHit& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -108,6 +108,8 @@ public:
     std::vector<PeptideHit>& getHits();
     /// Appends a peptide hit
     void insertHit(const PeptideHit& hit);
+    /// Appends a peptide hit
+    void insertHit(PeptideHit&& hit);
     /// Sets the peptide hits
     void setHits(const std::vector<PeptideHit>& hits);
 

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -72,16 +72,16 @@ public:
     /// default constructor
     PeptideIdentification();
     /// destructor
-    virtual ~PeptideIdentification();
+    virtual ~PeptideIdentification() noexcept;
     /// copy constructor
     PeptideIdentification(const PeptideIdentification& source) = default;
     /// Move constructor
-    PeptideIdentification(PeptideIdentification&&) = default;
+    PeptideIdentification(PeptideIdentification&&) noexcept = default;
 
     /// Assignment operator
     PeptideIdentification& operator=(const PeptideIdentification& source) = default;
     /// Move assignment operator
-    PeptideIdentification& operator=(PeptideIdentification&&) & = default;
+    PeptideIdentification& operator=(PeptideIdentification&&) noexcept = default;
     /// Equality operator
     bool operator==(const PeptideIdentification& rhs) const;
     /// Inequality operator

--- a/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/PeptideIdentification.h
@@ -81,7 +81,7 @@ public:
     /// Assignment operator
     PeptideIdentification& operator=(const PeptideIdentification& source) = default;
     /// Move assignment operator
-    PeptideIdentification& operator=(PeptideIdentification&&) noexcept = default;
+    PeptideIdentification& operator=(PeptideIdentification&&) = default; // TODO: add noexcept (gcc 4.8 bug)
     /// Equality operator
     bool operator==(const PeptideIdentification& rhs) const;
     /// Inequality operator

--- a/src/openms/include/OpenMS/METADATA/ProteinHit.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinHit.h
@@ -110,7 +110,7 @@ public:
     ProteinHit(const ProteinHit & source) = default;
 
     /// Move constructor
-    ProteinHit(ProteinHit&&) = default;
+    ProteinHit(ProteinHit&&) noexcept = default;
 
     /// Destructor
     virtual ~ProteinHit();
@@ -120,7 +120,7 @@ public:
     ProteinHit & operator=(const ProteinHit & source) = default;
 
     /// Move assignment operator
-    ProteinHit& operator=(ProteinHit&&) & = default;
+    ProteinHit& operator=(ProteinHit&&) noexcept = default;
 
     /// Assignment for MetaInfo
     ProteinHit & operator=(const MetaInfoInterface & source);

--- a/src/openms/include/OpenMS/METADATA/ProteinHit.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinHit.h
@@ -120,7 +120,7 @@ public:
     ProteinHit & operator=(const ProteinHit & source) = default;
 
     /// Move assignment operator
-    ProteinHit& operator=(ProteinHit&&) noexcept = default;
+    ProteinHit& operator=(ProteinHit&&) = default; // TODO: add noexcept (gcc 4.8 bug)
 
     /// Assignment for MetaInfo
     ProteinHit & operator=(const MetaInfoInterface & source);

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -158,7 +158,7 @@ public:
     /// Assignment operator
     ProteinIdentification& operator=(const ProteinIdentification& source) = default;
     /// Move assignment operator
-    ProteinIdentification& operator=(ProteinIdentification&&) & = default;
+    ProteinIdentification& operator=(ProteinIdentification&&) = default;
 
     /// Equality operator
     bool operator==(const ProteinIdentification& rhs) const;

--- a/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
+++ b/src/openms/include/OpenMS/METADATA/ProteinIdentification.h
@@ -174,6 +174,8 @@ public:
     std::vector<ProteinHit> & getHits();
     /// Appends a protein hit
     void insertHit(const ProteinHit & input);
+    /// Appends a protein hit
+    void insertHit(ProteinHit && input);
 
     /**
         @brief Sets the protein hits

--- a/src/openms/source/DATASTRUCTURES/DataValue.cpp
+++ b/src/openms/source/DATASTRUCTURES/DataValue.cpp
@@ -172,7 +172,7 @@ namespace OpenMS
   }
 
   //--------------------------------------------------------------------
-  //                       copy constructor
+  //                   copy and move constructors
   //--------------------------------------------------------------------
   DataValue::DataValue(const DataValue& p) :
     value_type_(p.value_type_),
@@ -198,7 +198,19 @@ namespace OpenMS
     }
   }
 
-  void DataValue::clear_()
+  DataValue::DataValue(DataValue&& rhs) noexcept :
+    value_type_(rhs.value_type_),
+    unit_type_(rhs.unit_type_),
+    unit_(rhs.unit_),
+    data_(rhs.data_)
+  {
+    // clean up rhs 
+    rhs.value_type_ = EMPTY_VALUE;
+    rhs.unit_type_ = OTHER;
+    rhs.unit_ = -1;
+  }
+
+  void DataValue::clear_() noexcept
   {
     if (value_type_ == STRING_LIST)
     {
@@ -223,7 +235,7 @@ namespace OpenMS
   }
 
   //--------------------------------------------------------------------
-  //                      assignment operator
+  //                    copy and move assignment operators
   //--------------------------------------------------------------------
   DataValue& DataValue::operator=(const DataValue& p)
   {
@@ -262,6 +274,33 @@ namespace OpenMS
     value_type_ = p.value_type_;
     unit_type_ = p.unit_type_;
     unit_ = p.unit_;
+
+    return *this;
+  }
+
+  /// Move assignment operator
+  DataValue& DataValue::operator=(DataValue&& rhs) noexcept
+  {
+    std::cout << "DataValue Move assignemnt operator " << std::endl;
+    // Check for self-assignment
+    if (this == &rhs)
+    {
+      return *this;
+    }
+
+    // clean up *this
+    clear_();
+
+    // assign values to *this
+    data_ = rhs.data_;
+    value_type_ = rhs.value_type_;
+    unit_type_ = rhs.unit_type_;
+    unit_ = rhs.unit_;
+
+    // clean up rhs 
+    rhs.value_type_ = EMPTY_VALUE;
+    rhs.unit_type_ = OTHER;
+    rhs.unit_ = -1;
 
     return *this;
   }

--- a/src/openms/source/DATASTRUCTURES/DataValue.cpp
+++ b/src/openms/source/DATASTRUCTURES/DataValue.cpp
@@ -199,12 +199,13 @@ namespace OpenMS
   }
 
   DataValue::DataValue(DataValue&& rhs) noexcept :
-    value_type_(rhs.value_type_),
-    unit_type_(rhs.unit_type_),
-    unit_(rhs.unit_),
-    data_(rhs.data_)
+    value_type_(std::move(rhs.value_type_)),
+    unit_type_(std::move(rhs.unit_type_)),
+    unit_(std::move(rhs.unit_)),
+    data_(std::move(rhs.data_))
   {
-    // clean up rhs 
+    // clean up rhs, take ownership of data_
+    // NOTE: value_type_ == EMPTY_VALUE implies data_ is empty and can be reset
     rhs.value_type_ = EMPTY_VALUE;
     rhs.unit_type_ = OTHER;
     rhs.unit_ = -1;

--- a/src/openms/source/DATASTRUCTURES/DataValue.cpp
+++ b/src/openms/source/DATASTRUCTURES/DataValue.cpp
@@ -281,7 +281,6 @@ namespace OpenMS
   /// Move assignment operator
   DataValue& DataValue::operator=(DataValue&& rhs) noexcept
   {
-    std::cout << "DataValue Move assignemnt operator " << std::endl;
     // Check for self-assignment
     if (this == &rhs)
     {

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -563,17 +563,17 @@ namespace OpenMS
         prot_hit_.setCoverage(coverage);
       }
 
-      //sequence
+      // sequence
       String tmp;
       optionalAttributeAsString_(tmp, attributes, "sequence");
-      prot_hit_.setSequence(tmp);
+      prot_hit_.setSequence(std::move(tmp));
 
       last_meta_ = &prot_hit_;
 
-      //insert id and accession to map
+      // insert id and accession to map
       proteinid_to_accession_[attributeAsString_(attributes, "id")] = accession;
     }
-    //PEPTIDES
+    // PEPTIDES
     else if (tag == "PeptideIdentification")
     {
       // check whether a prot id has been given, add "empty" one to list else
@@ -736,7 +736,7 @@ namespace OpenMS
 
       last_meta_ = &pep_hit_;
     }
-    //USERPARAM
+    // USERPARAM
     else if (tag == "UserParam")
     {
       if (last_meta_ == nullptr)
@@ -863,7 +863,7 @@ namespace OpenMS
     }
     else if (tag == "ProteinHit")
     {
-      prot_id_.insertHit(prot_hit_);
+      prot_id_.insertHit(std::move(prot_hit_));
       last_meta_ = &prot_id_;
     }
     //PEPTIDES
@@ -881,7 +881,7 @@ namespace OpenMS
         pep_hit_.addAnalysisResults(current_analysis_result_);
       }
       current_analysis_result_ = PeptideHit::PepXMLAnalysisResult();
-      pep_id_.insertHit(pep_hit_);
+      pep_id_.insertHit(std::move(pep_hit_));
       last_meta_ = &pep_id_;
     }
   }

--- a/src/openms/source/METADATA/CVTermListInterface.cpp
+++ b/src/openms/source/METADATA/CVTermListInterface.cpp
@@ -57,11 +57,12 @@ namespace OpenMS
     }
   }
 
-  // http://thbecker.net/articles/rvalue_references/section_05.html
+  /// Move constructor
   CVTermListInterface::CVTermListInterface(CVTermListInterface&& rhs) :
     MetaInfoInterface(std::move(rhs)), // NOTE: rhs itself is an lvalue
     cvt_ptr_(rhs.cvt_ptr_)
   {
+    // see http://thbecker.net/articles/rvalue_references/section_05.html
     // take ownership
     rhs.cvt_ptr_ = nullptr;
   }

--- a/src/openms/source/METADATA/CVTermListInterface.cpp
+++ b/src/openms/source/METADATA/CVTermListInterface.cpp
@@ -60,7 +60,7 @@ namespace OpenMS
   /// Move constructor
   CVTermListInterface::CVTermListInterface(CVTermListInterface&& rhs) :
     MetaInfoInterface(std::move(rhs)), // NOTE: rhs itself is an lvalue
-    cvt_ptr_(rhs.cvt_ptr_)
+    cvt_ptr_(std::move(rhs.cvt_ptr_))
   {
     // see http://thbecker.net/articles/rvalue_references/section_05.html
     // take ownership

--- a/src/openms/source/METADATA/MetaInfoInterface.cpp
+++ b/src/openms/source/METADATA/MetaInfoInterface.cpp
@@ -44,6 +44,7 @@ namespace OpenMS
   {
   }
 
+  /// Copy constructor
   MetaInfoInterface::MetaInfoInterface(const MetaInfoInterface & rhs) :
     meta_(nullptr)
   {
@@ -53,7 +54,8 @@ namespace OpenMS
     }
   }
 
-  MetaInfoInterface::MetaInfoInterface(MetaInfoInterface&& rhs) :
+  /// Move constructor
+  MetaInfoInterface::MetaInfoInterface(MetaInfoInterface&& rhs) noexcept :
     meta_(rhs.meta_)
   {
     // take ownership
@@ -89,7 +91,7 @@ namespace OpenMS
     return *this;
   }
 
-  MetaInfoInterface& MetaInfoInterface::operator=(MetaInfoInterface&& rhs)
+  MetaInfoInterface& MetaInfoInterface::operator=(MetaInfoInterface&& rhs) noexcept
   {
     if (this == &rhs)
     {

--- a/src/openms/source/METADATA/MetaInfoInterface.cpp
+++ b/src/openms/source/METADATA/MetaInfoInterface.cpp
@@ -56,7 +56,7 @@ namespace OpenMS
 
   /// Move constructor
   MetaInfoInterface::MetaInfoInterface(MetaInfoInterface&& rhs) noexcept :
-    meta_(rhs.meta_)
+    meta_(std::move(rhs.meta_))
   {
     // take ownership
     rhs.meta_ = nullptr;

--- a/src/openms/source/METADATA/PeptideHit.cpp
+++ b/src/openms/source/METADATA/PeptideHit.cpp
@@ -81,17 +81,18 @@ namespace OpenMS
     }
   }
 
-  // http://thbecker.net/articles/rvalue_references/section_05.html
-  PeptideHit::PeptideHit(PeptideHit&& source) :
+  /// Move constructor
+  PeptideHit::PeptideHit(PeptideHit&& source) noexcept :
     MetaInfoInterface(std::move(source)), // NOTE: rhs itself is an lvalue
-    sequence_(source.sequence_),
-    score_(source.score_),
-    analysis_results_(source.analysis_results_),
-    rank_(source.rank_),
-    charge_(source.charge_),
-    peptide_evidences_(source.peptide_evidences_),
-    fragment_annotations_(source.fragment_annotations_)
+    sequence_(std::move(source.sequence_)),
+    score_(std::move(source.score_)),
+    analysis_results_(std::move(source.analysis_results_)),
+    rank_(std::move(source.rank_)),
+    charge_(std::move(source.charge_)),
+    peptide_evidences_(std::move(source.peptide_evidences_)),
+    fragment_annotations_(std::move(source.fragment_annotations_))
   {
+    // see http://thbecker.net/articles/rvalue_references/section_05.html
     source.analysis_results_ = nullptr;
   }
 
@@ -125,7 +126,7 @@ namespace OpenMS
     return *this;
   }
 
-  PeptideHit& PeptideHit::operator=(PeptideHit&& source)
+  PeptideHit& PeptideHit::operator=(PeptideHit&& source) noexcept
   {
     if (&source == this)
     {

--- a/src/openms/source/METADATA/PeptideIdentification.cpp
+++ b/src/openms/source/METADATA/PeptideIdentification.cpp
@@ -52,7 +52,7 @@ namespace OpenMS
   {
   }
 
-  PeptideIdentification::~PeptideIdentification()
+  PeptideIdentification::~PeptideIdentification() noexcept
   {
   }
 

--- a/src/openms/source/METADATA/PeptideIdentification.cpp
+++ b/src/openms/source/METADATA/PeptideIdentification.cpp
@@ -122,6 +122,11 @@ namespace OpenMS
     hits_.push_back(hit);
   }
 
+  void PeptideIdentification::insertHit(PeptideHit&& hit)
+  {
+    hits_.push_back(std::forward<PeptideHit>(hit));
+  }
+
   void PeptideIdentification::setHits(const std::vector<PeptideHit>& hits)
   {
     hits_ = hits;

--- a/src/openms/source/METADATA/ProteinIdentification.cpp
+++ b/src/openms/source/METADATA/ProteinIdentification.cpp
@@ -220,6 +220,11 @@ namespace OpenMS
     protein_hits_.push_back(protein_hit);
   }
 
+  void ProteinIdentification::insertHit(ProteinHit&& protein_hit)
+  {
+    protein_hits_.push_back(std::forward<ProteinHit>(protein_hit));
+  }
+
   void ProteinIdentification::setPrimaryMSRunPath(const StringList& s)
   {
     if (!s.empty())

--- a/src/tests/class_tests/openms/source/DataValue_test.cpp
+++ b/src/tests/class_tests/openms/source/DataValue_test.cpp
@@ -36,8 +36,9 @@
 #include <OpenMS/test_config.h>
 
 ///////////////////////////
-
 #include <OpenMS/DATASTRUCTURES/DataValue.h>
+///////////////////////////
+
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <OpenMS/DATASTRUCTURES/ListUtilsIO.h>
 
@@ -258,6 +259,70 @@ START_SECTION((DataValue(const DataValue&)))
 }
 END_SECTION
 
+// move ctor
+START_SECTION((DataValue(DataValue&&) noexcept))
+{
+  // Ensure that DataValue has a no-except move constructor (otherwise
+  // std::vector is inefficient and will copy instead of move).
+  TEST_EQUAL(noexcept(DataValue(std::declval<DataValue&&>())), true)
+
+  DataValue empty;
+  DataValue p1((double) 1.23);
+  DataValue p3((float) 1.23);
+  DataValue p4((Int) -3);
+  DataValue p5((UInt) 123);
+  DataValue p6("test char");
+  DataValue p7(std::string("test string"));
+  DataValue p8(ListUtils::create<String>("test string,string2,last string"));
+  DataValue p9;
+  DataValue p10(ListUtils::create<Int>("1,2,3,4,5"));
+  DataValue p11(ListUtils::create<double>("1.2,2.3,3.4"));
+  DataValue copy_of_p1(std::move(p1));
+  DataValue copy_of_p3(std::move(p3));
+  DataValue copy_of_p4(std::move(p4));
+  DataValue copy_of_p5(std::move(p5));
+  DataValue copy_of_p6(std::move(p6));
+  DataValue copy_of_p7(std::move(p7));
+  DataValue copy_of_p8(std::move(p8));
+  DataValue copy_of_p9(std::move(p9));
+  DataValue copy_of_p10(std::move(p10));
+  DataValue copy_of_p11(std::move(p11));
+  TEST_REAL_SIMILAR( (double) copy_of_p1, 1.23)
+  TEST_REAL_SIMILAR( (float) copy_of_p3, 1.23)
+  TEST_EQUAL( (Int) copy_of_p4, -3)
+  TEST_EQUAL( (UInt) copy_of_p5, 123)
+  TEST_EQUAL( (std::string) copy_of_p6, "test char")
+  TEST_EQUAL( (std::string) copy_of_p7, "test string")
+  TEST_EQUAL( copy_of_p8 == ListUtils::create<String>("test string,string2,last string"), true)
+  TEST_EQUAL( (copy_of_p9.isEmpty()), true)
+  TEST_EQUAL( copy_of_p10 == ListUtils::create<Int>("1,2,3,4,5"), true)
+  TEST_EQUAL( copy_of_p11 == ListUtils::create<double>("1.2,2.3,3.4"), true)
+
+  TEST_EQUAL(p1 == empty, true)
+  TEST_EQUAL(p3 == empty, true)
+  TEST_EQUAL(p4 == empty, true)
+  TEST_EQUAL(p5 == empty, true)
+  TEST_EQUAL(p6 == empty, true)
+  TEST_EQUAL(p7 == empty, true)
+  TEST_EQUAL(p8 == empty, true)
+  TEST_EQUAL(p9 == empty, true)
+  TEST_EQUAL(p10 == empty, true)
+  TEST_EQUAL(p11 == empty, true)
+
+  DataValue val;
+  {
+    DataValue p1((double) 1.23);
+    p1.setUnit(8);
+    val = DataValue(p1);
+  }
+  DataValue val2(std::move(val));
+
+  TEST_EQUAL(val == empty, true)
+  TEST_REAL_SIMILAR( (double) val2, 1.23)
+  TEST_EQUAL( val2.getUnit(), 8)
+}
+END_SECTION
+
 // assignment operator
 START_SECTION((DataValue& operator=(const DataValue&)))
 {
@@ -306,6 +371,70 @@ START_SECTION((DataValue& operator=(const DataValue&)))
   TEST_REAL_SIMILAR( (double) val2, 1.23)
   TEST_EQUAL( val2.getUnit(), 9)
 
+}
+END_SECTION
+
+// move assignment operator
+START_SECTION(( DataValue& operator=(DataValue&&) noexcept ))
+{
+  // Ensure that DataValue has a no-except move assignment operator.
+  TEST_EQUAL(noexcept(declval<DataValue&>() = declval<DataValue &&>()), true)
+
+  DataValue empty;
+  DataValue p1((double) 1.23);
+  DataValue p3((float) 1.23);
+  DataValue p4((Int) -3);
+  DataValue p5((UInt) 123);
+  DataValue p6("test char");
+  DataValue p7(std::string("test string"));
+  DataValue p8(ListUtils::create<String>("test string,string2,last string"));
+  DataValue p9;
+  DataValue p10(ListUtils::create<Int>("1,2,3,4,5"));
+  DataValue p11(ListUtils::create<double>("1.2,2.3,3.4"));
+  DataValue copy_of_p;
+  copy_of_p = std::move(p1);
+  TEST_REAL_SIMILAR( (double) copy_of_p, 1.23)
+  copy_of_p = std::move(p3);
+  TEST_REAL_SIMILAR( (float) copy_of_p, 1.23)
+  copy_of_p = std::move(p4);
+  TEST_EQUAL( (Int) copy_of_p, -3)
+  copy_of_p = std::move(p5);
+  TEST_EQUAL( (UInt) copy_of_p, 123)
+  copy_of_p = std::move(p6);
+  TEST_EQUAL( (std::string) copy_of_p, "test char")
+  copy_of_p = std::move(p7);
+  TEST_EQUAL( (std::string) copy_of_p, "test string")
+  copy_of_p = std::move(p8);
+  TEST_EQUAL( copy_of_p == ListUtils::create<String>("test string,string2,last string"), true)
+  copy_of_p = std::move(p9);
+  TEST_EQUAL( (copy_of_p.isEmpty()), true)
+  copy_of_p = std::move(p10);
+  TEST_EQUAL(copy_of_p == ListUtils::create<Int>("1,2,3,4,5"), true)
+  copy_of_p = std::move(p11);
+  TEST_EQUAL(copy_of_p == ListUtils::create<double>("1.2,2.3,3.4"), true)
+
+  TEST_EQUAL(p1 == empty, true)
+  TEST_EQUAL(p3 == empty, true)
+  TEST_EQUAL(p4 == empty, true)
+  TEST_EQUAL(p5 == empty, true)
+  TEST_EQUAL(p6 == empty, true)
+  TEST_EQUAL(p7 == empty, true)
+  TEST_EQUAL(p8 == empty, true)
+  TEST_EQUAL(p9 == empty, true)
+  TEST_EQUAL(p10 == empty, true)
+  TEST_EQUAL(p11 == empty, true)
+
+  DataValue val;
+  {
+    DataValue p1((double) 1.23);
+    p1.setUnit(8);
+    val = p1;
+  }
+  DataValue val2 = std::move(val);
+
+  TEST_EQUAL(val == empty, true)
+  TEST_REAL_SIMILAR( (double) val2, 1.23)
+  TEST_EQUAL( val2.getUnit(), 8)
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
+++ b/src/tests/class_tests/openms/source/PeptideIdentification_test.cpp
@@ -78,7 +78,9 @@ START_SECTION((virtual ~PeptideIdentification()))
   delete ptr;
 END_SECTION
 
+// Copy Constructor
 START_SECTION((PeptideIdentification(const PeptideIdentification& source)))
+{
   PeptideIdentification hits;
   hits.setSignificanceThreshold(peptide_significance_threshold);
   hits.setHits(peptide_hits);
@@ -96,6 +98,42 @@ START_SECTION((PeptideIdentification(const PeptideIdentification& source)))
   TEST_EQUAL(hits.getIdentifier(),"id")
   TEST_EQUAL(hits.getScoreType(),"score_type")
   TEST_EQUAL(hits.isHigherScoreBetter(),false)
+}
+END_SECTION
+
+// Move Constructor
+START_SECTION((PeptideIdentification(PeptideIdentification&& source) noexcept))
+{
+  // Ensure that PeptideIdentification has a no-except move constructor (otherwise
+  // std::vector is inefficient and will copy instead of move).
+  TEST_EQUAL(noexcept(PeptideIdentification(std::declval<PeptideIdentification&&>())), true)
+
+  PeptideIdentification hits;
+  hits.setSignificanceThreshold(peptide_significance_threshold);
+  hits.setHits(peptide_hits);
+  hits.setMetaValue("label",17);
+  hits.setIdentifier("id");
+  hits.setScoreType("score_type");
+  hits.setHigherScoreBetter(false);
+
+  PeptideIdentification example(hits);
+
+  PeptideIdentification hits2(std::move(example));
+
+  TEST_EQUAL(hits.getSignificanceThreshold(), hits2.getSignificanceThreshold())
+  TEST_EQUAL(hits.getHits().size() == 1, true)
+  TEST_EQUAL(*(hits.getHits().begin()) == peptide_hit, true)
+  TEST_EQUAL((UInt)hits.getMetaValue("label"),17)
+  TEST_EQUAL(hits.getIdentifier(),"id")
+  TEST_EQUAL(hits.getScoreType(),"score_type")
+  TEST_EQUAL(hits.isHigherScoreBetter(),false)
+
+  // the move source should be empty
+  TEST_EQUAL(example.getHits().empty(), true)
+  TEST_EQUAL(example.isMetaEmpty(), true)
+  TEST_EQUAL(example.getIdentifier().empty(), true)
+  TEST_EQUAL(example.getScoreType().empty(), true)
+}
 END_SECTION
 
 START_SECTION((PeptideIdentification& operator=(const PeptideIdentification& source)))


### PR DESCRIPTION
- add noexcept keyword to move constructor (this is crucial for std::vector to work properly and actually move data instead of copying it)
- add move semantics to `DataValue`
- add tests for DataValue_test, MetaInfoInterface_test. and PeptideIdentification_test.cpp which explicitly test the move semantics
- use move semantics in `IdXMLFile` as proof of concept

Using the test file from https://github.com/OpenMS/OpenMS/pull/3750#issuecomment-423726499 I get some nice memory savings:

```
$ /usr/bin/time ../release_2.4/./bin/FileInfo -in E3035_HCV_LAB1.idXML 
Memory usage (loading idXML): 10520 MB (working set delta)
FileInfo took 02:15 m (wall), 02:15 m (CPU), 3.20 s (system), 02:11 m (user).

$ /usr/bin/time ../pr_3744/bin/FileInfo -in E3035_HCV_LAB1.idXML
Memory usage (loading idXML): 5327 MB (working set delta)

$ /usr/bin/time ./bin/FileInfo -in E3035_HCV_LAB1.idXML
Memory usage (loading idXML): 3168 MB (working set delta)
FileInfo took 01:55 m (wall), 01:55 m (CPU), 1.76 s (system), 01:53 m (user).
```

It looks like memory is reduced by a factor of 3 and execution speed is slightly faster (around 15%).
