### PR TITLE
[FEATURE] OpenSwathWorkflow: better checking of swath_window_file

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h
@@ -60,41 +60,46 @@ namespace OpenMS
   public:
 
     /**
-     * @brief Annotate a Swath map using a Swath window file specifying the individual windows
-     *
-     * @note It is assumed that the files in the swath_maps vector are in the
-     * same order as the windows in the provided file (usually from lowest to
-     * highest).
-     *
-     * @param filename The filename of the tab delimited file
-     * @param swath_maps The list of SWATH maps (assumed to be in the same order as in the file)
-     * @param doSort Sort the windows after reading in ascending order
-     * @throw Exception::IllegalArgument if the maps in the file and the provided input maps to not match
-     *
-     */
-    static void annotateSwathMapsFromFile(const std::string & filename,
-                                          std::vector< OpenSwath::SwathMap >& swath_maps,
-                                          bool doSort);
+       @brief Annotate a Swath map using a Swath window file specifying the individual windows
+     
+       @note It is assumed that the files in the swath_maps vector are in the
+       same order as the windows in the provided file (usually from lowest to
+       highest).
+
+       @param filename The filename of the tab delimited file
+       @param swath_maps The list of SWATH maps (assumed to be in the same order as in the file)
+       @param do_sort Sort the windows after reading in ascending order
+       @param force Force overriding the window boundaries, even if the new boundaries are wider than the data boundaries
+       @throw Exception::IllegalArgument if the number of maps in the file and the provided input maps to not match
+              , or if the new boundaries are outside of the data boundaries (unless force==true)
+    */
+    static void annotateSwathMapsFromFile(const std::string& filename,
+                                          std::vector<OpenSwath::SwathMap>& swath_maps,
+                                          bool do_sort,
+                                          bool force);
 
     /**
-     * @brief Reading a tab delimited file specifying the SWATH windows
-     *
-     * The file must of be tab delimited and of the following format:
-     *    window_lower window_upper
-     *    400 425
-     *    425 450
-     *    ...
-     *
-     * Note that the first line is a header and will be skipped.
-     *
-     * @param filename The filename of the tab delimited file
-     * @param swath_prec_lower_ The output vector for the window start
-     * @param swath_prec_upper_ The output vector for the window end
+      @brief Reading a tab delimited file specifying the SWATH windows
+     
+      The file must of be tab delimited and of the following format:
+         window_lower window_upper
+         400 425
+         425 450
+         ...
+     
+      Note that the first line is a header and will be skipped.
+     
+      @param filename The filename of the tab delimited file
+      @param swath_prec_lower_ The output vector for the window start
+      @param swath_prec_upper_ The output vector for the window end
+
+      @throw Exception::InvalidValue if window's start >= end
+
      *
      */
-    static void readSwathWindows(const std::string & filename,
-                                 std::vector<double> & swath_prec_lower_,
-                                 std::vector<double> & swath_prec_upper_ );
+    static void readSwathWindows(const std::string& filename,
+                                 std::vector<double>& swath_prec_lower,
+                                 std::vector<double>& swath_prec_upper);
   };
 }
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h
@@ -70,8 +70,8 @@ namespace OpenMS
        @param swath_maps The list of SWATH maps (assumed to be in the same order as in the file)
        @param do_sort Sort the windows after reading in ascending order
        @param force Force overriding the window boundaries, even if the new boundaries are wider than the data boundaries
-       @throw Exception::IllegalArgument if the number of maps in the file and the provided input maps to not match
-              , or if the new boundaries are outside of the data boundaries (unless force==true)
+       
+       @throw Exception::IllegalArgument if the number of maps in the file and the provided input maps to not match, or if the new boundaries are outside of the data boundaries (unless force==true)
     */
     static void annotateSwathMapsFromFile(const std::string& filename,
                                           std::vector<OpenSwath::SwathMap>& swath_maps,
@@ -90,8 +90,8 @@ namespace OpenMS
       Note that the first line is a header and will be skipped.
      
       @param filename The filename of the tab delimited file
-      @param swath_prec_lower_ The output vector for the window start
-      @param swath_prec_upper_ The output vector for the window end
+      @param swath_prec_lower The output vector for the window start
+      @param swath_prec_upper The output vector for the window end
 
       @throw Exception::InvalidValue if window's start >= end
 

--- a/src/openms/include/OpenMS/APPLICATIONS/OpenSwathBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/OpenSwathBase.h
@@ -97,12 +97,6 @@
 namespace OpenMS
 {
 
-static bool SortPairDoubleByFirst(const std::pair<double,double> & left, const std::pair<double,double> & right)
-{
-  return left.first < right.first;
-}
-
-
 class TOPPOpenSwathBase :
   public TOPPBase
 {
@@ -181,8 +175,8 @@ protected:
    *
    */
   bool loadSwathFiles(const StringList& file_list,
-                      boost::shared_ptr<ExperimentalSettings > & exp_meta,
-                      std::vector< OpenSwath::SwathMap > & swath_maps,
+                      boost::shared_ptr<ExperimentalSettings >& exp_meta,
+                      std::vector< OpenSwath::SwathMap >& swath_maps,
                       const bool split_file,
                       const String& tmp,
                       const String& readoptions,
@@ -198,7 +192,7 @@ protected:
     // (ii) Allow the user to specify the SWATH windows
     if (!swath_windows_file.empty())
     {
-      SwathWindowLoader::annotateSwathMapsFromFile(swath_windows_file, swath_maps, sort_swath_maps);
+      SwathWindowLoader::annotateSwathMapsFromFile(swath_windows_file, swath_maps, sort_swath_maps, force);
     }
 
     for (Size i = 0; i < swath_maps.size(); i++)
@@ -211,7 +205,7 @@ protected:
     }
 
     // (iii) Sanity check: there should be no overlap between the windows:
-    std::vector<std::pair<double, double> > sw_windows;
+    std::vector<std::pair<double, double>> sw_windows;
     for (Size i = 0; i < swath_maps.size(); i++)
     {
       if (!swath_maps[i].ms1)
@@ -219,7 +213,8 @@ protected:
         sw_windows.push_back(std::make_pair(swath_maps[i].lower, swath_maps[i].upper));
       }
     }
-    std::sort(sw_windows.begin(), sw_windows.end(), SortPairDoubleByFirst);
+    // sort by lower bound (first entry in pair)
+    std::sort(sw_windows.begin(), sw_windows.end());
 
     for (Size i = 1; i < sw_windows.size(); i++)
     {
@@ -241,10 +236,10 @@ protected:
 
       if (lower_map_end - upper_map_start > 0.01)
       {
-        LOG_WARN << "Extraction will overlap between " << lower_map_end << " and " << upper_map_start << std::endl;
-        LOG_WARN << "This will lead to multiple extraction of the transitions in the overlapping region" <<
-                    "which will lead to duplicated output. It is very unlikely that you want this." << std::endl;
-        LOG_WARN << "Please fix this by providing an appropriate extraction file with -swath_windows_file" << std::endl;
+        LOG_WARN << "Extraction will overlap between " << lower_map_end << " and " << upper_map_start << "!\n"
+                 << "This will lead to multiple extraction of the transitions in the overlapping region "
+                 << "which will lead to duplicated output. It is very unlikely that you want this." << "\n"
+                 << "Please fix this by providing an appropriate extraction file with -swath_windows_file" << std::endl;
         if (!force)
         {
           LOG_ERROR << "Extraction windows overlap. Will abort (override with -force)" << std::endl;

--- a/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/SwathMap.h
+++ b/src/openswathalgo/include/OpenMS/OPENSWATHALGO/DATAACCESS/SwathMap.h
@@ -57,6 +57,13 @@ namespace OpenSwath
       ms1(false)
     {}
 
+    SwathMap(double mz_start, double mz_end, double mz_center, bool is_ms1)
+      : lower(mz_start),
+        upper(mz_end),
+        center(mz_center),
+        ms1(is_ms1)
+    {}
+
   };
 
 } //end Namespace OpenSwath

--- a/src/pyOpenMS/pxds/SwathWindowLoader.pxd
+++ b/src/pyOpenMS/pxds/SwathWindowLoader.pxd
@@ -6,12 +6,12 @@ cdef extern from "<OpenMS/ANALYSIS/OPENSWATH/SwathWindowLoader.h>" namespace "Op
     cdef cppclass SwathWindowLoader:
 
         SwathWindowLoader() nogil except +
-        SwathWindowLoader(SwathWindowLoader) nogil except + 
+        SwathWindowLoader(SwathWindowLoader) nogil except +
 
         void annotateSwathMapsFromFile(libcpp_string filename,
-                                       libcpp_vector[ SwathMap ] & swath_maps, bool doSort) nogil except +
+                                       libcpp_vector[ SwathMap ]& swath_maps, bool do_sort, bool force) nogil except +
 
-        void readSwathWindows(libcpp_string filename, 
-                              libcpp_vector[double] & swath_prec_lower_,
-                              libcpp_vector[double] & swath_prec_upper_ ) nogil except +
+        void readSwathWindows(libcpp_string filename,
+                              libcpp_vector[double]& swath_prec_lower,
+                              libcpp_vector[double]& swath_prec_upper) nogil except +
 

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -482,7 +482,7 @@ protected:
     setValidFormats_("out_chrom", ListUtils::create<String>("mzML,sqMass"));
 
     // misc options
-    registerDoubleOption_("min_upper_edge_dist", "<double>", 0.0, "Minimal distance to the edge to still consider a precursor, in Thomson", false, true);
+    registerDoubleOption_("min_upper_edge_dist", "<double>", 0.0, "Minimal distance to the upper edge of a Swath window to still consider a precursor, in Thomson", false, true);
     registerFlag_("sonar", "data is scanning SWATH data");
 
     // RT, mz and IM windows
@@ -742,7 +742,6 @@ protected:
       std::vector<double> swath_prec_upper;
       SwathWindowLoader::readSwathWindows(swath_windows_file, swath_prec_lower, swath_prec_upper);
 
-      LOG_INFO << "Read Swath maps file with " << swath_prec_lower.size() << " windows." << std::endl;
       for (Size i = 0; i < swath_prec_lower.size(); i++)
       {
         LOG_DEBUG << "Read lower swath window " << swath_prec_lower[i] << " and upper window " << swath_prec_upper[i] << std::endl;


### PR DESCRIPTION
[FEATURE] OpenSwathWorkflow: better checking of swath_window_file ranges before overwriting the data ranges 
 - only narrowing of isolation window ranges is allowed (unless -force flag is specified)
 - new window range constraint: lower < upper
