### PR TITLE
performance improvements for FeatureFinderMultiplex

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
@@ -106,6 +106,10 @@ public:
     MultiplexFiltering(const MSExperiment& exp_centroided, const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min,
                        int isotopes_per_peptide_max, double intensity_cutoff, double rt_band, double mz_tolerance, bool mz_tolerance_unit,
                        double peptide_similarity, double averagine_similarity, double averagine_similarity_scaling, String averagine_type="peptide");
+    /**
+     * @brief returns the intensity-filtered, centroided spectral data
+     */
+    MSExperiment getCentroidedExperiment();
 
 protected:
     /**

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
@@ -109,7 +109,7 @@ public:
     /**
      * @brief returns the intensity-filtered, centroided spectral data
      */
-    MSExperiment getCentroidedExperiment();
+    const MSExperiment& getCentroidedExperiment();
 
 protected:
     /**

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
@@ -109,7 +109,7 @@ public:
     /**
      * @brief returns the intensity-filtered, centroided spectral data
      */
-    const MSExperiment& getCentroidedExperiment();
+    MSExperiment& getCentroidedExperiment();
 
 protected:
     /**

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.h
@@ -91,7 +91,7 @@ public:
     /**
      * @brief constructor
      *
-     * @param exp_picked    experimental data in centroid mode
+     * @param exp_centroided    experimental data in centroid mode
      * @param patterns    patterns of isotopic peaks to be searched for
      * @param isotopes_per_peptide_min    minimum number of isotopic peaks in peptides
      * @param isotopes_per_peptide_max    maximum number of isotopic peaks in peptides
@@ -103,13 +103,13 @@ public:
      * @param averagine_similarity    similarity score for peptide isotope pattern and averagine model
      * @param averagine_similarity_scaling    scaling factor x for the averagine similarity parameter p when detecting peptide singlets. With p' = p + x(1-p). 
      */
-    MultiplexFiltering(const MSExperiment& exp_picked, const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min,
+    MultiplexFiltering(const MSExperiment& exp_centroided, const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min,
                        int isotopes_per_peptide_max, double intensity_cutoff, double rt_band, double mz_tolerance, bool mz_tolerance_unit,
                        double peptide_similarity, double averagine_similarity, double averagine_similarity_scaling, String averagine_type="peptide");
 
 protected:
     /**
-     * @brief construct an MS experiment from exp_picked_ containing
+     * @brief construct an MS experiment from exp_centroided_ containing
      * peaks which have not been previously blacklisted in blacklist_
      * 
      * In addition, construct an index mapping of 'white' peak positions
@@ -197,7 +197,7 @@ protected:
     /**
      * @brief centroided experimental data
      */
-    MSExperiment exp_picked_;
+    MSExperiment exp_centroided_;
 
     /**
      * @brief auxiliary structs for blacklisting
@@ -207,14 +207,14 @@ protected:
     /**
      * @brief "white" centroided experimental data
      *
-     * subset of all peaks of <exp_picked_> which are not blacklisted in <blacklist_>
+     * subset of all peaks of <exp_centroided_> which are not blacklisted in <blacklist_>
      */
-    MSExperiment exp_picked_white_;
+    MSExperiment exp_centroided_white_;
     
     /**
-     * @brief mapping of peak indices from a 'white' experiment <exp_picked_white_> to its original experiment <exp_picked_>
+     * @brief mapping of peak indices from a 'white' experiment <exp_centroided_white_> to its original experiment <exp_centroided_>
      */
-    White2Original exp_picked_mapping_;
+    White2Original exp_centroided_mapping_;
 
     /**
      * @brief list of peak patterns

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.h
@@ -70,7 +70,7 @@ public:
     /**
      * @brief constructor
      *
-     * @param exp_picked    experimental data in centroid mode
+     * @param exp_centroided    experimental data in centroid mode
      * @param patterns    patterns of isotopic peaks to be searched for
      * @param isotopes_per_peptide_min    minimum number of isotopic peaks in peptides
      * @param isotopes_per_peptide_max    maximum number of isotopic peaks in peptides
@@ -83,7 +83,7 @@ public:
      * @param averagine_similarity_scaling    scaling factor x for the averagine similarity parameter p when detecting peptide singlets. With p' = p + x(1-p).
      * @param averagine_type    The averagine model to use, current options are RNA DNA or peptide.
      */
-    MultiplexFilteringCentroided(const MSExperiment& exp_picked, const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min, int isotopes_per_peptide_max, double intensity_cutoff, double rt_band, double mz_tolerance, bool mz_tolerance_unit, double peptide_similarity, double averagine_similarity, double averagine_similarity_scaling, String averagine_type="peptide");
+    MultiplexFilteringCentroided(const MSExperiment& exp_centroided, const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min, int isotopes_per_peptide_max, double intensity_cutoff, double rt_band, double mz_tolerance, bool mz_tolerance_unit, double peptide_similarity, double averagine_similarity, double averagine_similarity_scaling, String averagine_type="peptide");
 
     /**
      * @brief filter for patterns

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.h
@@ -107,7 +107,7 @@ public:
     /**
      * @brief returns the intensity-filtered peak boundaries
      */
-    std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > getPeakBoundaries();
+    std::vector<std::vector<PeakPickerHiRes::PeakBoundary> >& getPeakBoundaries();
 
 private:
     /**

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.h
@@ -104,6 +104,11 @@ public:
      */
     std::vector<MultiplexFilteredMSExperiment> filter();
 
+    /**
+     * @brief returns the intensity-filtered peak boundaries
+     */
+    std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > getPeakBoundaries();
+
 private:
     /**
      * @brief averagine filter for profile mode

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.h
@@ -72,8 +72,8 @@ public:
      * @brief constructor
      *
      * @param exp_profile    experimental data in profile mode
-     * @param exp_picked    experimental data in centroid mode
-     * @param boundaries    peak boundaries for exp_picked
+     * @param exp_centroided    experimental data in centroid mode
+     * @param boundaries    peak boundaries for exp_centroided
      * @param patterns    patterns of isotopic peaks to be searched for
      * @param isotopes_per_peptide_min    minimum number of isotopic peaks in peptides
      * @param isotopes_per_peptide_max    maximum number of isotopic peaks in peptides
@@ -89,7 +89,7 @@ public:
      * @throw Exception::IllegalArgument if profile and centroided data do not contain same number of spectra
      * @throw Exception::IllegalArgument if centroided data and the corresponding list of peak boundaries do not contain same number of spectra
      */
-    MultiplexFilteringProfile(MSExperiment& exp_profile, const MSExperiment& exp_picked, const std::vector<std::vector<PeakPickerHiRes::PeakBoundary> >& boundaries,
+    MultiplexFilteringProfile(MSExperiment& exp_profile, const MSExperiment& exp_centroided, const std::vector<std::vector<PeakPickerHiRes::PeakBoundary> >& boundaries,
                               const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min, int isotopes_per_peptide_max, double intensity_cutoff, double rt_band,
                               double mz_tolerance, bool mz_tolerance_unit, double peptide_similarity, double averagine_similarity, double averagine_similarity_scaling, String averagine_type="peptide");
 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
@@ -742,7 +742,7 @@ namespace OpenMS
     }
 
     /**
-     * filter for peak patterns
+     * generate peak patterns for subsequent filtering step
      */
     MultiplexDeltaMassesGenerator generator = MultiplexDeltaMassesGenerator(param_.getValue("algorithm:labels"), param_.getValue("algorithm:missed_cleavages"), label_mass_shift_);
     if (param_.getValue("algorithm:knock_out") == "true")
@@ -755,57 +755,53 @@ namespace OpenMS
     std::vector<MultiplexDeltaMasses> masses = generator.getDeltaMassesList();
     std::vector<MultiplexIsotopicPeakPattern> patterns = generatePeakPatterns_(charge_min_, charge_max_, isotopes_per_peptide_max_, masses);
     
-    std::vector<MultiplexFilteredMSExperiment> filter_results;
     if (centroided)
     {
       // centroided data
+      
+      /**
+       * filter for peak patterns
+       */
       MultiplexFilteringCentroided filtering(exp_centroid_, patterns, isotopes_per_peptide_min_, isotopes_per_peptide_max_, param_.getValue("algorithm:intensity_cutoff"), param_.getValue("algorithm:rt_band"), param_.getValue("algorithm:mz_tolerance"), (param_.getValue("algorithm:mz_unit") == "ppm"), param_.getValue("algorithm:peptide_similarity"), param_.getValue("algorithm:averagine_similarity"), param_.getValue("algorithm:averagine_similarity_scaling"), param_.getValue("algorithm:averagine_type"));
       filtering.setLogType(getLogType());
-      filter_results = filtering.filter();
-      filtering.getCentroidedExperiment().swap(exp_centroid_);
-    }
-    else
-    {
-      // profile data
-      MultiplexFilteringProfile filtering(exp_profile_, exp_centroid_, boundaries_exp_s, patterns, isotopes_per_peptide_min_, isotopes_per_peptide_max_, param_.getValue("algorithm:intensity_cutoff"), param_.getValue("algorithm:rt_band"), param_.getValue("algorithm:mz_tolerance"), (param_.getValue("algorithm:mz_unit") == "ppm"), param_.getValue("algorithm:peptide_similarity"), param_.getValue("algorithm:averagine_similarity"), param_.getValue("algorithm:averagine_similarity_scaling"), param_.getValue("algorithm:averagine_type"));
-      filtering.setLogType(getLogType());
-      filter_results = filtering.filter();
-      filtering.getCentroidedExperiment().swap(exp_centroid_);
-      filtering.getPeakBoundaries().swap(boundaries_exp_s);
-    }
-
-    /**
-     * cluster filter results
-     */
-    std::vector<std::map<int, GridBasedCluster> > cluster_results;
-    if (centroided)
-    {
-      // centroided data
+      std::vector<MultiplexFilteredMSExperiment> filter_results = filtering.filter();
+      
+      /**
+       * cluster filter results
+       */
       MultiplexClustering clustering(exp_centroid_, param_.getValue("algorithm:mz_tolerance"), (param_.getValue("algorithm:mz_unit") == "ppm"), param_.getValue("algorithm:rt_typical"), static_cast<double>(param_.getValue("algorithm:rt_min")));
       clustering.setLogType(getLogType());
-      cluster_results = clustering.cluster(filter_results);
-    }
-    else
-    {
-      // profile data
-      MultiplexClustering clustering(exp_profile_, exp_centroid_, boundaries_exp_s, param_.getValue("algorithm:rt_typical"), static_cast<double>(param_.getValue("algorithm:rt_min")));
-      //clustering.setLogType(getLogType());
-      //cluster_results = clustering.cluster(filter_results);
-    }
+      std::vector<std::map<int, GridBasedCluster> > cluster_results = clustering.cluster(filter_results);
 
-    /**
-     * construct feature and consensus maps i.e. the final results
-     */
-    /*if (centroided)
-    {
-      //consensus_map.setPrimaryMSRunPath(exp_centroid_.getPrimaryMSRunPath());
-      //feature_map.setPrimaryMSRunPath(exp_centroid_.getPrimaryMSRunPath());
+      /**
+       * construct feature and consensus maps i.e. the final results
+       */
+      filtering.getCentroidedExperiment().swap(exp_centroid_);
       generateMapsCentroided_(patterns, filter_results, cluster_results);
     }
     else
     {
-      //consensus_map.setPrimaryMSRunPath(exp_profile_.getPrimaryMSRunPath());
-      //feature_map.setPrimaryMSRunPath(exp_profile_.getPrimaryMSRunPath());
+      // profile data
+      
+      /**
+       * filter for peak patterns
+       */
+      MultiplexFilteringProfile filtering(exp_profile_, exp_centroid_, boundaries_exp_s, patterns, isotopes_per_peptide_min_, isotopes_per_peptide_max_, param_.getValue("algorithm:intensity_cutoff"), param_.getValue("algorithm:rt_band"), param_.getValue("algorithm:mz_tolerance"), (param_.getValue("algorithm:mz_unit") == "ppm"), param_.getValue("algorithm:peptide_similarity"), param_.getValue("algorithm:averagine_similarity"), param_.getValue("algorithm:averagine_similarity_scaling"), param_.getValue("algorithm:averagine_type"));
+      filtering.setLogType(getLogType());
+      std::vector<MultiplexFilteredMSExperiment> filter_results = filtering.filter();
+      
+      /**
+       * cluster filter results
+       */
+      MultiplexClustering clustering(exp_profile_, exp_centroid_, boundaries_exp_s, param_.getValue("algorithm:rt_typical"), static_cast<double>(param_.getValue("algorithm:rt_min")));
+      clustering.setLogType(getLogType());
+      std::vector<std::map<int, GridBasedCluster> > cluster_results = clustering.cluster(filter_results);
+      
+      /**
+       * construct feature and consensus maps i.e. the final results
+       */
+      filtering.getCentroidedExperiment().swap(exp_centroid_);
+      filtering.getPeakBoundaries().swap(boundaries_exp_s);
       generateMapsProfile_(patterns, filter_results, cluster_results);
     }
 
@@ -884,7 +880,7 @@ namespace OpenMS
 
     // finalize feature map
     feature_map_.sortByPosition();
-    feature_map_.applyMemberFunction(&UniqueIdInterface::setUniqueId);*/
+    feature_map_.applyMemberFunction(&UniqueIdInterface::setUniqueId);
   }
   
   FeatureMap& FeatureFinderMultiplexAlgorithm::getFeatureMap()

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
@@ -762,6 +762,7 @@ namespace OpenMS
       MultiplexFilteringCentroided filtering(exp_centroid_, patterns, isotopes_per_peptide_min_, isotopes_per_peptide_max_, param_.getValue("algorithm:intensity_cutoff"), param_.getValue("algorithm:rt_band"), param_.getValue("algorithm:mz_tolerance"), (param_.getValue("algorithm:mz_unit") == "ppm"), param_.getValue("algorithm:peptide_similarity"), param_.getValue("algorithm:averagine_similarity"), param_.getValue("algorithm:averagine_similarity_scaling"), param_.getValue("algorithm:averagine_type"));
       filtering.setLogType(getLogType());
       filter_results = filtering.filter();
+      filtering.getCentroidedExperiment().swap(exp_centroid_);
     }
     else
     {
@@ -769,6 +770,7 @@ namespace OpenMS
       MultiplexFilteringProfile filtering(exp_profile_, exp_centroid_, boundaries_exp_s, patterns, isotopes_per_peptide_min_, isotopes_per_peptide_max_, param_.getValue("algorithm:intensity_cutoff"), param_.getValue("algorithm:rt_band"), param_.getValue("algorithm:mz_tolerance"), (param_.getValue("algorithm:mz_unit") == "ppm"), param_.getValue("algorithm:peptide_similarity"), param_.getValue("algorithm:averagine_similarity"), param_.getValue("algorithm:averagine_similarity_scaling"), param_.getValue("algorithm:averagine_type"));
       filtering.setLogType(getLogType());
       filter_results = filtering.filter();
+      filtering.getCentroidedExperiment().swap(exp_centroid_);
     }
 
     /**

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
@@ -771,6 +771,7 @@ namespace OpenMS
       filtering.setLogType(getLogType());
       filter_results = filtering.filter();
       filtering.getCentroidedExperiment().swap(exp_centroid_);
+      filtering.getPeakBoundaries().swap(boundaries_exp_s);
     }
 
     /**
@@ -788,14 +789,14 @@ namespace OpenMS
     {
       // profile data
       MultiplexClustering clustering(exp_profile_, exp_centroid_, boundaries_exp_s, param_.getValue("algorithm:rt_typical"), static_cast<double>(param_.getValue("algorithm:rt_min")));
-      clustering.setLogType(getLogType());
-      cluster_results = clustering.cluster(filter_results);
+      //clustering.setLogType(getLogType());
+      //cluster_results = clustering.cluster(filter_results);
     }
 
     /**
      * construct feature and consensus maps i.e. the final results
      */
-    if (centroided)
+    /*if (centroided)
     {
       //consensus_map.setPrimaryMSRunPath(exp_centroid_.getPrimaryMSRunPath());
       //feature_map.setPrimaryMSRunPath(exp_centroid_.getPrimaryMSRunPath());
@@ -883,7 +884,7 @@ namespace OpenMS
 
     // finalize feature map
     feature_map_.sortByPosition();
-    feature_map_.applyMemberFunction(&UniqueIdInterface::setUniqueId);
+    feature_map_.applyMemberFunction(&UniqueIdInterface::setUniqueId);*/
   }
   
   FeatureMap& FeatureFinderMultiplexAlgorithm::getFeatureMap()

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexClustering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexClustering.cpp
@@ -92,10 +92,10 @@ namespace OpenMS
     // determine RT scaling
     std::vector<double> mz;
     MSExperiment::ConstIterator it_rt;
-    for (it_rt = exp_picked.begin(); it_rt < exp_picked.end(); ++it_rt)
+    for (it_rt = exp_picked.begin(); it_rt != exp_picked.end(); ++it_rt)
     {
       MSSpectrum::ConstIterator it_mz;
-      for (it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
+      for (it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
       {
         mz.push_back(it_mz->getMZ());
       }
@@ -151,10 +151,10 @@ namespace OpenMS
     // determine RT scaling
     std::vector<double> mz;
     MSExperiment::ConstIterator it_rt;
-    for (it_rt = exp.begin(); it_rt < exp.end(); ++it_rt)
+    for (it_rt = exp.begin(); it_rt != exp.end(); ++it_rt)
     {
       MSSpectrum::ConstIterator it_mz;
-      for (it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
+      for (it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
       {
         mz.push_back(it_mz->getMZ());
       }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -51,19 +51,41 @@ using namespace boost::math;
 namespace OpenMS
 {
 
-  MultiplexFiltering::MultiplexFiltering(const MSExperiment& exp_picked, const std::vector<MultiplexIsotopicPeakPattern>& patterns,
+  MultiplexFiltering::MultiplexFiltering(const MSExperiment& exp_centroided, const std::vector<MultiplexIsotopicPeakPattern>& patterns,
                                          int isotopes_per_peptide_min, int isotopes_per_peptide_max, double intensity_cutoff, double rt_band,
                                          double mz_tolerance, bool mz_tolerance_unit, double peptide_similarity, double averagine_similarity,
                                          double averagine_similarity_scaling, String averagine_type) :
-  exp_picked_(exp_picked), patterns_(patterns), isotopes_per_peptide_min_(isotopes_per_peptide_min), isotopes_per_peptide_max_(isotopes_per_peptide_max),
+  patterns_(patterns), isotopes_per_peptide_min_(isotopes_per_peptide_min), isotopes_per_peptide_max_(isotopes_per_peptide_max),
   intensity_cutoff_(intensity_cutoff), rt_band_(rt_band), mz_tolerance_(mz_tolerance), mz_tolerance_unit_in_ppm_(mz_tolerance_unit),
   peptide_similarity_(peptide_similarity), averagine_similarity_(averagine_similarity),
   averagine_similarity_scaling_(averagine_similarity_scaling), averagine_type_(averagine_type)
   {
-    // initialise blacklist <blacklist_>
-    blacklist_.reserve(exp_picked_.getNrSpectra());
+    // initialise experiment exp_centroided_
+    // Any peaks below the intensity cutoff cannot be relevant and are therefore removed.
     // loop over spectra
-    for (MSExperiment::ConstIterator it_rt = exp_picked_.begin(); it_rt < exp_picked_.end(); ++it_rt)
+    for (MSExperiment::ConstIterator it_rt = exp_centroided.begin(); it_rt < exp_centroided.end(); ++it_rt)
+    {
+      MSSpectrum spectrum;
+      spectrum.setRT(it_rt->getRT());
+      // loop over m/z
+      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
+      {
+        if (it_mz->getIntensity() > intensity_cutoff_)
+        {
+          Peak1D peak;
+          peak.setMZ(it_mz->getMZ());
+          peak.setIntensity(it_mz->getIntensity());
+          spectrum.push_back(peak);
+        }
+      }
+      exp_centroided_.addSpectrum(spectrum);
+    }
+    exp_centroided_.updateRanges();
+    
+    // initialise blacklist <blacklist_>
+    blacklist_.reserve(exp_centroided_.getNrSpectra());
+    // loop over spectra
+    for (MSExperiment::ConstIterator it_rt = exp_centroided_.begin(); it_rt < exp_centroided_.end(); ++it_rt)
     {
       std::vector<int> blacklist_spectrum;
       blacklist_spectrum.reserve(it_rt->size());
@@ -76,13 +98,13 @@ namespace OpenMS
     }
     
     // blacklist low-intensity peaks
-    for (MSExperiment::ConstIterator it_rt = exp_picked_.begin(); it_rt < exp_picked_.end(); ++it_rt)
+    for (MSExperiment::ConstIterator it_rt = exp_centroided_.begin(); it_rt < exp_centroided_.end(); ++it_rt)
     {
       for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
       {
         if (it_mz->getIntensity() < intensity_cutoff_)
         {
-          blacklist_[it_rt - exp_picked_.begin()][it_mz - it_rt->begin()] = 666;
+          blacklist_[it_rt - exp_centroided_.begin()][it_mz - it_rt->begin()] = 666;
         }
       }
     }
@@ -92,11 +114,11 @@ namespace OpenMS
   void MultiplexFiltering::updateWhiteMSExperiment_()
   {
     // reset both the white MS experiment and the corresponding mapping to the complete i.e. original MS experiment
-    exp_picked_white_.clear(true);
-    exp_picked_mapping_.clear();
+    exp_centroided_white_.clear(true);
+    exp_centroided_mapping_.clear();
     
     // loop over spectra
-    for (MSExperiment::ConstIterator it_rt = exp_picked_.begin(); it_rt < exp_picked_.end(); ++it_rt)
+    for (MSExperiment::ConstIterator it_rt = exp_centroided_.begin(); it_rt < exp_centroided_.end(); ++it_rt)
     {
       MSSpectrum spectrum_picked_white;
       spectrum_picked_white.setRT(it_rt->getRT());
@@ -106,7 +128,7 @@ namespace OpenMS
       // loop over m/z
       for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
       {
-        if (blacklist_[it_rt - exp_picked_.begin()][it_mz - it_rt->begin()] == -1)
+        if (blacklist_[it_rt - exp_centroided_.begin()][it_mz - it_rt->begin()] == -1)
         {
           Peak1D peak;
           peak.setMZ(it_mz->getMZ());
@@ -117,10 +139,10 @@ namespace OpenMS
           ++count;
         }
       }
-      exp_picked_white_.addSpectrum(spectrum_picked_white);
-      exp_picked_mapping_.push_back(mapping_spectrum);
+      exp_centroided_white_.addSpectrum(spectrum_picked_white);
+      exp_centroided_mapping_.push_back(mapping_spectrum);
     }
-    exp_picked_white_.updateRanges();
+    exp_centroided_white_.updateRanges();
   }
   
   bool MultiplexFiltering::checkForSignificantPeak_(double mz, double mz_tolerance, MSExperiment::ConstIterator& it_rt, double intensity_first_peak) const
@@ -201,10 +223,10 @@ namespace OpenMS
             // Note that as primary peaks, satellite peaks are also restricted by the blacklist.
             // The peak can either be pure white i.e. untouched, or have been seen earlier as part of the same mass trace.
             size_t rt_idx = it_rt - it_rt_begin;
-            size_t mz_idx = exp_picked_mapping_.at(it_rt - it_rt_begin).at(i);
+            size_t mz_idx = exp_centroided_mapping_.at(it_rt - it_rt_begin).at(i);
             if ((blacklist_[rt_idx][mz_idx] == -1) || (blacklist_[rt_idx][mz_idx] == static_cast<int>(idx_mz_shift)))
             {
-              peak.addSatellite(it_rt - it_rt_begin, exp_picked_mapping_.at(it_rt - it_rt_begin).at(i), idx_mz_shift);
+              peak.addSatellite(it_rt - it_rt_begin, exp_centroided_mapping_.at(it_rt - it_rt_begin).at(i), idx_mz_shift);
               found = true;
             }
           }
@@ -354,15 +376,15 @@ namespace OpenMS
       double mz = peak.getMZ() + patterns_[pattern_idx].getMZShiftAt(it.first);
       
       // Extend the RT boundary by rt_band_ earlier
-      MSExperiment::ConstIterator it_rt_begin = exp_picked_.begin() + (it.second).first;
-      it_rt_begin = exp_picked_.RTBegin(it_rt_begin->getRT() - 2 * rt_band_);
+      MSExperiment::ConstIterator it_rt_begin = exp_centroided_.begin() + (it.second).first;
+      it_rt_begin = exp_centroided_.RTBegin(it_rt_begin->getRT() - 2 * rt_band_);
       
       // Extend the RT boundary by rt_band_ later
-      MSExperiment::ConstIterator it_rt_end = exp_picked_.begin() + (it.second).second;
-      it_rt_end = exp_picked_.RTBegin(it_rt_end->getRT() + 2 * rt_band_);
+      MSExperiment::ConstIterator it_rt_end = exp_centroided_.begin() + (it.second).second;
+      it_rt_end = exp_centroided_.RTBegin(it_rt_end->getRT() + 2 * rt_band_);
       
       // prepare for loop
-      if (it_rt_end != exp_picked_.end())
+      if (it_rt_end != exp_centroided_.end())
       {
         ++it_rt_end;
       }
@@ -375,7 +397,7 @@ namespace OpenMS
         if (idx_mz != -1)
         {
           // blacklist entries: -1 = white, any isotope pattern index (it.first) = black
-          blacklist_[it_rt - exp_picked_.begin()][idx_mz] = it.first;
+          blacklist_[it_rt - exp_centroided_.begin()][idx_mz] = it.first;
         }
       }
       
@@ -431,7 +453,7 @@ namespace OpenMS
           size_t mz_idx = (satellite_it->second).getMZidx();
           
           // find peak itself
-          MSExperiment::ConstIterator it_rt = exp_picked_.begin();
+          MSExperiment::ConstIterator it_rt = exp_centroided_.begin();
           std::advance(it_rt, rt_idx);
           MSSpectrum::ConstIterator it_mz = it_rt->begin();
           std::advance(it_mz, mz_idx);
@@ -514,8 +536,8 @@ namespace OpenMS
                 size_t mz_idx_2 = (satellite_it_2->second).getMZidx();
                 
                 // find peak itself
-                MSExperiment::ConstIterator it_rt_1 = exp_picked_.begin();
-                MSExperiment::ConstIterator it_rt_2 = exp_picked_.begin();
+                MSExperiment::ConstIterator it_rt_1 = exp_centroided_.begin();
+                MSExperiment::ConstIterator it_rt_2 = exp_centroided_.begin();
                 std::advance(it_rt_1, rt_idx_1);
                 std::advance(it_rt_2, rt_idx_2);
                 MSSpectrum::ConstIterator it_mz_1 = it_rt_1->begin();

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -110,24 +110,21 @@ namespace OpenMS
     exp_centroided_mapping_.clear();
     
     // loop over spectra
-    for (MSExperiment::ConstIterator it_rt = exp_centroided_.begin(); it_rt < exp_centroided_.end(); ++it_rt)
+    for (const auto &it_rt : exp_centroided_)
     {
       MSSpectrum spectrum_picked_white;
-      spectrum_picked_white.setRT(it_rt->getRT());
+      spectrum_picked_white.setRT(it_rt.getRT());
       
       std::map<int, int> mapping_spectrum;
       int count = 0;
       // loop over m/z
-      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
+      for (const auto &it_mz : it_rt)
       {
-        if (blacklist_[it_rt - exp_centroided_.begin()][it_mz - it_rt->begin()] == -1)
+        if (blacklist_[&it_rt - &exp_centroided_[0]][&it_mz - &it_rt[0]] == -1)
         {
-          Peak1D peak;
-          peak.setMZ(it_mz->getMZ());
-          peak.setIntensity(it_mz->getIntensity());
-          spectrum_picked_white.push_back(peak);
+          spectrum_picked_white.push_back(it_mz);
           
-          mapping_spectrum[count] = it_mz - it_rt->begin();
+          mapping_spectrum[count] = &it_mz - &it_rt[0];
           ++count;
         }
       }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -112,7 +112,7 @@ namespace OpenMS
     
   }
   
-  MSExperiment MultiplexFiltering::getCentroidedExperiment()
+  const MSExperiment& MultiplexFiltering::getCentroidedExperiment()
   {
     return(exp_centroided_);
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -64,20 +64,16 @@ namespace OpenMS
     // Any peaks below the intensity cutoff cannot be relevant. They are therefore removed resulting in reduced memory footprint and runtime.
     exp_centroided_.reserve(exp_centroided.getNrSpectra());
     // loop over spectra
-    //for (MSExperiment::ConstIterator it_rt = exp_centroided.begin(); it_rt < exp_centroided.end(); ++it_rt)
     for (const auto &it_rt : exp_centroided)
     {
       MSSpectrum spectrum;
       spectrum.setRT(it_rt.getRT());
       // loop over m/z
-      for (const auto it_mz : it_rt)
+      for (const auto &it_mz : it_rt)
       {
         if (it_mz.getIntensity() > intensity_cutoff_)
         {
-          Peak1D peak;
-          peak.setMZ(it_mz.getMZ());
-          peak.setIntensity(it_mz.getIntensity());
-          spectrum.push_back(peak);
+          spectrum.push_back(it_mz);
         }
       }
       exp_centroided_.addSpectrum(std::move(spectrum));

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -62,6 +62,7 @@ namespace OpenMS
   {
     // initialise experiment exp_centroided_
     // Any peaks below the intensity cutoff cannot be relevant. They are therefore removed resulting in reduced memory footprint and runtime.
+    exp_centroided_.reserve(exp_centroided.getNrSpectra());
     // loop over spectra
     for (MSExperiment::ConstIterator it_rt = exp_centroided.begin(); it_rt < exp_centroided.end(); ++it_rt)
     {
@@ -78,7 +79,7 @@ namespace OpenMS
           spectrum.push_back(peak);
         }
       }
-      exp_centroided_.addSpectrum(spectrum);
+      exp_centroided_.addSpectrum(std::move(spectrum));
     }
     exp_centroided_.updateRanges();
     exp_centroided_.sortSpectra();

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -61,7 +61,7 @@ namespace OpenMS
   averagine_similarity_scaling_(averagine_similarity_scaling), averagine_type_(averagine_type)
   {
     // initialise experiment exp_centroided_
-    // Any peaks below the intensity cutoff cannot be relevant and are therefore removed.
+    // Any peaks below the intensity cutoff cannot be relevant. They are therefore removed resulting in reduced memory footprint and runtime.
     // loop over spectra
     for (MSExperiment::ConstIterator it_rt = exp_centroided.begin(); it_rt < exp_centroided.end(); ++it_rt)
     {
@@ -81,6 +81,7 @@ namespace OpenMS
       exp_centroided_.addSpectrum(spectrum);
     }
     exp_centroided_.updateRanges();
+    exp_centroided_.sortSpectra();
     
     // initialise blacklist <blacklist_>
     blacklist_.reserve(exp_centroided_.getNrSpectra());
@@ -109,6 +110,11 @@ namespace OpenMS
       }
     }
     
+  }
+  
+  MSExperiment MultiplexFiltering::getCentroidedExperiment()
+  {
+    return(exp_centroided_);
   }
 
   void MultiplexFiltering::updateWhiteMSExperiment_()

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -68,7 +68,7 @@ namespace OpenMS
       MSSpectrum spectrum;
       spectrum.setRT(it_rt->getRT());
       // loop over m/z
-      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
+      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
       {
         if (it_mz->getIntensity() > intensity_cutoff_)
         {
@@ -91,7 +91,7 @@ namespace OpenMS
       std::vector<int> blacklist_spectrum;
       blacklist_spectrum.reserve(it_rt->size());
       // loop over m/z
-      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
+      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
       {
         blacklist_spectrum.push_back(-1);
       }
@@ -101,7 +101,7 @@ namespace OpenMS
     // blacklist low-intensity peaks
     for (MSExperiment::ConstIterator it_rt = exp_centroided_.begin(); it_rt < exp_centroided_.end(); ++it_rt)
     {
-      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
+      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
       {
         if (it_mz->getIntensity() < intensity_cutoff_)
         {
@@ -112,7 +112,7 @@ namespace OpenMS
     
   }
   
-  const MSExperiment& MultiplexFiltering::getCentroidedExperiment()
+  MSExperiment& MultiplexFiltering::getCentroidedExperiment()
   {
     return(exp_centroided_);
   }
@@ -132,7 +132,7 @@ namespace OpenMS
       std::map<int, int> mapping_spectrum;
       int count = 0;
       // loop over m/z
-      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
+      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
       {
         if (blacklist_[it_rt - exp_centroided_.begin()][it_mz - it_rt->begin()] == -1)
         {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -64,18 +64,19 @@ namespace OpenMS
     // Any peaks below the intensity cutoff cannot be relevant. They are therefore removed resulting in reduced memory footprint and runtime.
     exp_centroided_.reserve(exp_centroided.getNrSpectra());
     // loop over spectra
-    for (MSExperiment::ConstIterator it_rt = exp_centroided.begin(); it_rt < exp_centroided.end(); ++it_rt)
+    //for (MSExperiment::ConstIterator it_rt = exp_centroided.begin(); it_rt < exp_centroided.end(); ++it_rt)
+    for (const auto &it_rt : exp_centroided)
     {
       MSSpectrum spectrum;
-      spectrum.setRT(it_rt->getRT());
+      spectrum.setRT(it_rt.getRT());
       // loop over m/z
-      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
+      for (const auto it_mz : it_rt)
       {
-        if (it_mz->getIntensity() > intensity_cutoff_)
+        if (it_mz.getIntensity() > intensity_cutoff_)
         {
           Peak1D peak;
-          peak.setMZ(it_mz->getMZ());
-          peak.setIntensity(it_mz->getIntensity());
+          peak.setMZ(it_mz.getMZ());
+          peak.setIntensity(it_mz.getIntensity());
           spectrum.push_back(peak);
         }
       }
@@ -87,28 +88,16 @@ namespace OpenMS
     // initialise blacklist <blacklist_>
     blacklist_.reserve(exp_centroided_.getNrSpectra());
     // loop over spectra
-    for (MSExperiment::ConstIterator it_rt = exp_centroided_.begin(); it_rt < exp_centroided_.end(); ++it_rt)
+    for (const auto &it_rt : exp_centroided_)
     {
       std::vector<int> blacklist_spectrum;
-      blacklist_spectrum.reserve(it_rt->size());
+      blacklist_spectrum.reserve(it_rt.size());
       // loop over m/z
-      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
+      for (const auto &it_mz : it_rt)
       {
         blacklist_spectrum.push_back(-1);
       }
       blacklist_.push_back(blacklist_spectrum);
-    }
-    
-    // blacklist low-intensity peaks
-    for (MSExperiment::ConstIterator it_rt = exp_centroided_.begin(); it_rt < exp_centroided_.end(); ++it_rt)
-    {
-      for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
-      {
-        if (it_mz->getIntensity() < intensity_cutoff_)
-        {
-          blacklist_[it_rt - exp_centroided_.begin()][it_mz - it_rt->begin()] = 666;
-        }
-      }
     }
     
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFiltering.cpp
@@ -100,7 +100,7 @@ namespace OpenMS
   
   MSExperiment& MultiplexFiltering::getCentroidedExperiment()
   {
-    return(exp_centroided_);
+    return exp_centroided_;
   }
 
   void MultiplexFiltering::updateWhiteMSExperiment_()

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
@@ -95,7 +95,7 @@ namespace OpenMS
         MSExperiment::ConstIterator it_rt_band_end = exp_centroided_white_.RTEnd(rt + rt_band_/2);
         
         // loop over m/z
-        for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
+        for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
         {
           double mz = it_mz->getMZ();
           MultiplexFilteredPeak peak(mz, rt, exp_centroided_mapping_[it_rt - exp_centroided_white_.begin()][it_mz - it_rt->begin()], it_rt - exp_centroided_white_.begin());

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
@@ -47,8 +47,8 @@ using namespace boost::math;
 namespace OpenMS
 {
 
-  MultiplexFilteringCentroided::MultiplexFilteringCentroided(const MSExperiment& exp_picked, const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min, int isotopes_per_peptide_max, double intensity_cutoff, double rt_band, double mz_tolerance, bool mz_tolerance_unit, double peptide_similarity, double averagine_similarity, double averagine_similarity_scaling, String averagine_type) :
-    MultiplexFiltering(exp_picked, patterns, isotopes_per_peptide_min, isotopes_per_peptide_max, intensity_cutoff, rt_band, mz_tolerance, mz_tolerance_unit, peptide_similarity, averagine_similarity, averagine_similarity_scaling, averagine_type)
+  MultiplexFilteringCentroided::MultiplexFilteringCentroided(const MSExperiment& exp_centroided, const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min, int isotopes_per_peptide_max, double intensity_cutoff, double rt_band, double mz_tolerance, bool mz_tolerance_unit, double peptide_similarity, double averagine_similarity, double averagine_similarity_scaling, String averagine_type) :
+    MultiplexFiltering(exp_centroided, patterns, isotopes_per_peptide_min, isotopes_per_peptide_max, intensity_cutoff, rt_band, mz_tolerance, mz_tolerance_unit, peptide_similarity, averagine_similarity, averagine_similarity_scaling, averagine_type)
   {
   }
 
@@ -56,7 +56,7 @@ namespace OpenMS
   {
     // progress logger
     unsigned progress = 0;
-    startProgress(0, patterns_.size() * exp_picked_.size(), "filtering LC-MS data");
+    startProgress(0, patterns_.size() * exp_centroided_.size(), "filtering LC-MS data");
     
     // list of filter results for each peak pattern
     vector<MultiplexFilteredMSExperiment> filter_results;
@@ -80,7 +80,7 @@ namespace OpenMS
   
       // filter (white) experiment
       // loop over spectra
-      for (MSExperiment::ConstIterator it_rt = exp_picked_white_.begin(); it_rt < exp_picked_white_.end(); ++it_rt)
+      for (MSExperiment::ConstIterator it_rt = exp_centroided_white_.begin(); it_rt < exp_centroided_white_.end(); ++it_rt)
       {
         // skip empty spectra
         if (it_rt->empty())
@@ -91,16 +91,16 @@ namespace OpenMS
         setProgress(++progress);
 
         double rt = it_rt->getRT();
-        MSExperiment::ConstIterator it_rt_band_begin = exp_picked_white_.RTBegin(rt - rt_band_/2);
-        MSExperiment::ConstIterator it_rt_band_end = exp_picked_white_.RTEnd(rt + rt_band_/2);
+        MSExperiment::ConstIterator it_rt_band_begin = exp_centroided_white_.RTBegin(rt - rt_band_/2);
+        MSExperiment::ConstIterator it_rt_band_end = exp_centroided_white_.RTEnd(rt + rt_band_/2);
         
         // loop over m/z
         for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz < it_rt->end(); ++it_mz)
         {
           double mz = it_mz->getMZ();
-          MultiplexFilteredPeak peak(mz, rt, exp_picked_mapping_[it_rt - exp_picked_white_.begin()][it_mz - it_rt->begin()], it_rt - exp_picked_white_.begin());
+          MultiplexFilteredPeak peak(mz, rt, exp_centroided_mapping_[it_rt - exp_centroided_white_.begin()][it_mz - it_rt->begin()], it_rt - exp_centroided_white_.begin());
           
-          if (!(filterPeakPositions_(it_mz, exp_picked_white_.begin(), it_rt_band_begin, it_rt_band_end, pattern, peak)))
+          if (!(filterPeakPositions_(it_mz, exp_centroided_white_.begin(), it_rt_band_begin, it_rt_band_end, pattern, peak)))
           {
             continue;
           }
@@ -128,7 +128,7 @@ namespace OpenMS
       // write filtered peaks to debug output
       std::stringstream debug_out;
       debug_out << "filter_result_" << pattern_idx << ".consensusXML";
-      result.writeDebugOutput(exp_picked_, debug_out.str());
+      result.writeDebugOutput(exp_centroided_, debug_out.str());
 #endif
       
       // add results of this pattern to list

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
@@ -80,25 +80,27 @@ namespace OpenMS
   
       // filter (white) experiment
       // loop over spectra
-      for (MSExperiment::ConstIterator it_rt = exp_centroided_white_.begin(); it_rt < exp_centroided_white_.end(); ++it_rt)
+      for (const auto &it_rt : exp_centroided_white_)
       {
         // skip empty spectra
-        if (it_rt->empty())
+        if (it_rt.empty())
         {
           continue;
         }
 
         setProgress(++progress);
 
-        double rt = it_rt->getRT();
+        double rt = it_rt.getRT();
+        size_t idx_rt = &it_rt - &exp_centroided_white_[0];
+        
         MSExperiment::ConstIterator it_rt_band_begin = exp_centroided_white_.RTBegin(rt - rt_band_/2);
         MSExperiment::ConstIterator it_rt_band_end = exp_centroided_white_.RTEnd(rt + rt_band_/2);
         
         // loop over m/z
-        for (MSSpectrum::ConstIterator it_mz = it_rt->begin(); it_mz != it_rt->end(); ++it_mz)
+        for (MSSpectrum::ConstIterator it_mz = it_rt.begin(); it_mz != it_rt.end(); ++it_mz)
         {
           double mz = it_mz->getMZ();
-          MultiplexFilteredPeak peak(mz, rt, exp_centroided_mapping_[it_rt - exp_centroided_white_.begin()][it_mz - it_rt->begin()], it_rt - exp_centroided_white_.begin());
+          MultiplexFilteredPeak peak(mz, rt, exp_centroided_mapping_[idx_rt][it_mz - it_rt.begin()], idx_rt);
           
           if (!(filterPeakPositions_(it_mz, exp_centroided_white_.begin(), it_rt_band_begin, it_rt_band_end, pattern, peak)))
           {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -60,7 +60,7 @@ namespace OpenMS
     MSExperiment::ConstIterator it_rt;
     std::vector<std::vector<PeakPickerHiRes::PeakBoundary> >::const_iterator it_rt_boundaries;
     for (it_rt = exp_centroided.begin(), it_rt_boundaries = boundaries.begin();
-         it_rt < exp_centroided.end(), it_rt_boundaries < boundaries.end();
+         it_rt != exp_centroided.end() && it_rt_boundaries != boundaries.end();
          ++it_rt, ++it_rt_boundaries)
     {
       // new boundaries of a single spectrum

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -85,23 +85,8 @@ namespace OpenMS
         }
       }
       
-#ifdef DEBUG
-      size_t number_boundaries = boundaries_temp.size();
-      size_t number_peaks_original = (*it_rt).size();
-      size_t number_removed = number_peaks_original - number_boundaries;
-      double percent_removed = 100 * (double) number_removed / (double) number_peaks_original;
-      LOG_INFO << "In spectrum RT = " << it_rt->getRT() << ", " << number_removed << " peaks (" << percent_removed << "%) were removed.\n";
-#endif
-
       boundaries_.push_back(boundaries_temp);
     }
-
-#ifdef DEBUG
-    // Check consistency of peaks and peak boundaries
-    LOG_INFO << "\nChecking consistency of peaks and peak bounadries.\n";
-#endif
-
-    
     
     if (exp_profile.size() != exp_centroided.size())
     {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -70,7 +70,7 @@ namespace OpenMS
       MSSpectrum::ConstIterator it_mz;
       std::vector<PeakPickerHiRes::PeakBoundary>::const_iterator it_mz_boundaries;
       for (it_mz = it_rt->begin(), it_mz_boundaries = it_rt_boundaries->begin();
-           it_mz < it_rt->end(), it_mz_boundaries < it_rt_boundaries->end();
+           it_mz != it_rt->end(), it_mz_boundaries != it_rt_boundaries->end();
            ++it_mz, ++it_mz_boundaries)
       {
         if (it_mz->getIntensity() > intensity_cutoff_)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -49,7 +49,7 @@ namespace OpenMS
 {
 
   MultiplexFilteringProfile::MultiplexFilteringProfile(MSExperiment& exp_profile, const MSExperiment& exp_centroided, const std::vector<std::vector<PeakPickerHiRes::PeakBoundary> >& boundaries, const std::vector<MultiplexIsotopicPeakPattern>& patterns, int isotopes_per_peptide_min, int isotopes_per_peptide_max, double intensity_cutoff, double rt_band, double mz_tolerance, bool mz_tolerance_unit, double peptide_similarity, double averagine_similarity, double averagine_similarity_scaling, String averagine_type) :
-    MultiplexFiltering(exp_centroided, patterns, isotopes_per_peptide_min, isotopes_per_peptide_max, intensity_cutoff, rt_band, mz_tolerance, mz_tolerance_unit, peptide_similarity, averagine_similarity, averagine_similarity_scaling, averagine_type), boundaries_(boundaries)
+    MultiplexFiltering(exp_centroided, patterns, isotopes_per_peptide_min, isotopes_per_peptide_max, intensity_cutoff, rt_band, mz_tolerance, mz_tolerance_unit, peptide_similarity, averagine_similarity, averagine_similarity_scaling, averagine_type)
   {
     // initialise peak boundaries
     // In the MultiplexFiltering() constructor we initialise the centroided experiment exp_centroided_.

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -55,7 +55,7 @@ namespace OpenMS
     // In the MultiplexFiltering() constructor we initialise the centroided experiment exp_centroided_.
     // (We run a simple intensity filter. Peaks below the intensity cutoff can be discarded right from the start.)
     // Now we still need to discard boundaries of low intensity peaks, in order to preserve the one-to-one mapping between peaks and boundaries.
-    
+    boundaries_.reserve(boundaries.size());
     // loop over spectra and boundaries
     MSExperiment::ConstIterator it_rt;
     std::vector<std::vector<PeakPickerHiRes::PeakBoundary> >::const_iterator it_rt_boundaries;
@@ -70,7 +70,7 @@ namespace OpenMS
       MSSpectrum::ConstIterator it_mz;
       std::vector<PeakPickerHiRes::PeakBoundary>::const_iterator it_mz_boundaries;
       for (it_mz = it_rt->begin(), it_mz_boundaries = it_rt_boundaries->begin();
-           it_mz != it_rt->end(), it_mz_boundaries != it_rt_boundaries->end();
+           it_mz != it_rt->end() && it_mz_boundaries != it_rt_boundaries->end();
            ++it_mz, ++it_mz_boundaries)
       {
         if (it_mz->getIntensity() > intensity_cutoff_)

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -40,7 +40,7 @@
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.h>
 #include <OpenMS/MATH/STATISTICS/StatisticFunctions.h>
 
-#define DEBUG
+//#define DEBUG
 
 using namespace std;
 using namespace boost::math;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -133,7 +133,7 @@ namespace OpenMS
     // clock for monitoring run time performance
     unsigned int start = clock();
 #endif
-
+    
     // construct navigators for all spline spectra
     std::vector<SplineSpectrum::Navigator> navigators;
     for (std::vector<SplineSpectrum>::iterator it = exp_spline_profile_.begin(); it < exp_spline_profile_.end(); ++it)
@@ -278,6 +278,11 @@ namespace OpenMS
     endProgress();
 
     return filter_results;
+  }
+  
+  std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > MultiplexFilteringProfile::getPeakBoundaries()
+  {
+    return boundaries_;
   }
 
   bool MultiplexFilteringProfile::filterAveragineModel_(const MultiplexIsotopicPeakPattern& pattern, const MultiplexFilteredPeak& peak, const std::multimap<size_t, MultiplexSatelliteProfile >& satellites_profile) const

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -280,7 +280,7 @@ namespace OpenMS
     return filter_results;
   }
   
-  std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > MultiplexFilteringProfile::getPeakBoundaries()
+  std::vector<std::vector<PeakPickerHiRes::PeakBoundary> >& MultiplexFilteringProfile::getPeakBoundaries()
   {
     return boundaries_;
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -76,14 +76,31 @@ namespace OpenMS
         if (it_mz->getIntensity() > intensity_cutoff_)
         {
           boundaries_temp.push_back(*it_mz_boundaries);
+
+          // Check consistency of peaks and their peak boundaries, i.e. check that the peak lies in the boundary interval.
+          if (((*it_mz_boundaries).mz_min > it_mz->getMZ()) || (it_mz->getMZ() > (*it_mz_boundaries).mz_max))
+          {
+            throw Exception::InvalidRange(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
+          }
         }
       }
       
+#ifdef DEBUG
+      size_t number_boundaries = boundaries_temp.size();
+      size_t number_peaks_original = (*it_rt).size();
+      size_t number_removed = number_peaks_original - number_boundaries;
+      double percent_removed = 100 * (double) number_removed / (double) number_peaks_original;
+      LOG_INFO << "In spectrum RT = " << it_rt->getRT() << ", " << number_removed << " peaks (" << percent_removed << "%) were removed.\n";
+#endif
+
       boundaries_.push_back(boundaries_temp);
     }
 
-    
-    
+#ifdef DEBUG
+    // Check consistency of peaks and peak boundaries
+    LOG_INFO << "\nChecking consistency of peaks and peak bounadries.\n";
+#endif
+
     
     
     if (exp_profile.size() != exp_centroided.size())


### PR DESCRIPTION
PR #3644 fixed a bug by simply removing a [pre-filtering step](https://github.com/OpenMS/OpenMS/compare/develop...lars20070:fix/FFM_performance?expand=1#diff-d07005aa96a93e57990ba6d481c8425eR66). (The peak map is pre-filtered using an intensity cutoff. This step reduces memory footprint and runtime.)

This PR re-introduces the pre-filtering step and fixes the old bug by passing the filtered peaks and peak boundaries to the subsequent `featureXML` and `consensusXML` map construction.

Results remain the same, see unchanged `TOPP` tests.