### PR TITLE
[TEST] Fix/bugfix subisotope

### DIFF
--- a/src/openms/thirdparty/IsoSpec/IsoSpec/marginalTrek++.cpp
+++ b/src/openms/thirdparty/IsoSpec/IsoSpec/marginalTrek++.cpp
@@ -358,8 +358,11 @@ allocator(isotopeNo, tabSize)
     Conf currentConf = allocator.makeCopy(mode_conf);
     if(logProb(currentConf) >= lCutOff)
     {
-        configurations.push_back(allocator.makeCopy(currentConf));
-        visited.insert(currentConf);
+        // create a copy and store a ptr to the *same* copy in both structures
+        // (save some space and time)
+        auto tmp = allocator.makeCopy(currentConf);
+        configurations.push_back(tmp);
+        visited.insert(tmp);
     }
 
     unsigned int idx = 0;
@@ -377,8 +380,12 @@ allocator(isotopeNo, tabSize)
 
                     if (visited.count(currentConf) == 0 && logProb(currentConf) >= lCutOff)
                     {
-                        visited.insert(currentConf);
-                        configurations.push_back(allocator.makeCopy(currentConf));
+                        // create a copy and store a ptr to the *same* copy in
+                        // both structures (save some space and time)
+                        auto tmp = allocator.makeCopy(currentConf);
+                        visited.insert(tmp);
+                        configurations.push_back(tmp);
+                        // std::cout << " V: "; for (auto it : visited) std::cout << it << " "; std::cout << std::endl;
                     }
 
                     currentConf[ii]--;

--- a/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
@@ -130,12 +130,6 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
     gen.setThreshold(1e-20);
     TEST_EQUAL(gen.run(EmpiricalFormula("C100")).size(), 21)
 
-    // These tests dont work on clang++, providing slightly different results
-    // than gcc and MSVS:
-    //
-    // line 130:  TEST_EQUAL(gen.run(EmpiricalFormula("C100")).size(),34): got 35, expected 34
-    // line 133:  TEST_EQUAL(gen.run(EmpiricalFormula("C100")).size(),46): got 48, expected 46
-#if 0
     gen.setThreshold(1e-40);
     TEST_EQUAL(gen.run(EmpiricalFormula("C100")).size(), 34)
 
@@ -153,7 +147,6 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
 
     gen.setThreshold(1e-1000);
     TEST_EQUAL(gen.run(EmpiricalFormula("C100")).size(), 101)
-#endif
   }
 }
 END_SECTION


### PR DESCRIPTION
- currently a ptr to the *current* configuration was stored in "visited"
  which meant the *same* ptr was stored N times instead of storing the
  different configurations. This meant that visited.count(currentConf)
  would not work reliably.
- this PR is to test whether this fixes the issues with the calculations of C100