### PR TITLE
[ADD] Param: processors (SiriusAdapter)

### DIFF
--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -167,7 +167,7 @@ protected:
     registerIntOption_("compound_timeout", "<num>", 10, "Time out in seconds per compound. To disable the timeout set the value to 0", false);
     registerIntOption_("tree_timeout", "<num>", 0, "Time out in seconds per fragmentation tree computation.", false);
     registerIntOption_("top_n_hits", "<num>", 10, "The number of top hits for each compound written to the CSI:FingerID output", false);
-
+    registerIntOption_("processors", "<num>", -1, "Number of cpu cores to use. If set to -1 Sirius uses all available cores.", false);
     registerFlag_("auto_charge", "Use this option if the charge of your compounds is unknown and you do not want to assume [M+H]+ as default. With the auto charge option SIRIUS will not care about charges and allow arbitrary adducts for the precursor peak.", false);
     registerFlag_("ion_tree", "Print molecular formulas and node labels with the ion formula instead of the neutral formula", false);
     registerFlag_("no_recalibration", "If this option is set, SIRIUS will not recalibrate the spectrum during the analysis.", false);
@@ -220,6 +220,7 @@ protected:
     const Size candidates = getIntOption_("candidates");
     const QString compound_timeout = QString::number(getIntOption_("compound_timeout"));
     const QString tree_timeout = QString::number(getIntOption_("tree_timeout"));
+    const QString processors = QString::number(getIntOption_("processors"));
 
     bool auto_charge = getFlag_("auto_charge");
     bool no_recalibration = getFlag_("no_recalibration");
@@ -333,6 +334,10 @@ protected:
                    << "--output" << out_dir.toQString(); //internal output folder for temporary SIRIUS output file storage
 
     // add flags
+    if (processors != QString::number(-1))
+    {
+      process_params << "--processors" << processors;
+    } 
     if (no_recalibration)
     {
       process_params << "--no-recalibration";

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -51,9 +51,6 @@
 
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <fstream>
-#ifdef _OPENMP
-  #include <omp.h>
-#endif
 
 using namespace OpenMS;
 using namespace std;
@@ -228,18 +225,8 @@ protected:
     bool ion_tree = getFlag_("ion_tree");
     bool most_intense_ms2 = getFlag_("most_intense_ms2");
    
-    
-    // if OpenMP is not available threads will not be set and SIRIUS will use all available cpus as per default
-    #ifdef _OPENMP
-      int threads = getIntOption_("threads");
-      int num_procs = omp_get_num_procs();
+    int threads = getIntOption_("threads");
       
-      // check if number of threads are available
-      if (threads > num_procs)
-      {
-        threads = num_procs;
-      }
-    #endif
     //-------------------------------------------------------------
     // Determination of the Executable
     //-------------------------------------------------------------
@@ -343,13 +330,10 @@ protected:
                    << "--ppm-max" << ppm_max
                    << "--compound-timeout" << compound_timeout
                    << "--tree-timeout" << tree_timeout
+                   << "--processors" << QString::number(threads) 
                    << "--quiet"
                    << "--output" << out_dir.toQString(); //internal output folder for temporary SIRIUS output file storage
 
-    // check OpenMP
-    #ifdef _OPENMP
-       process_params << "--processors" << QString::number(threads); 
-    #endif
     // add flags 
     if (no_recalibration)
     {


### PR DESCRIPTION
Added recently to SIRIUS.
May come in handy when processing locally.

edit:
Use OpenMP check number of processors.
If OpenMP is not available - SIRIUS default -> all possible CPUs
If OpenMS is available parameter "threads" used for the number of processors.
If threads was set too high -> reset to maximal numbers of processors.

@jpfeuffer  Is it OK, to abuse the threads parameter that way? 