### PR TITLE
[FIX] Made new OpenMP CMake code backwards compatible

### DIFF
--- a/src/openms/CMakeLists.txt
+++ b/src/openms/CMakeLists.txt
@@ -107,7 +107,7 @@ if(APPLE)
                            ${CoreServices_LIBRARY})
 endif()
 
-if (OpenMP_CXX_FOUND)
+if (OPENMP_FOUND)
   list(APPEND OPENMS_DEP_LIBRARIES OpenMP::OpenMP_CXX)
 endif()
 


### PR DESCRIPTION
 OpenMP_CXX_FOUND only exists in newer CMakes