### PR TITLE
release/2.4.0 fixed OpenPepXL parallelization errors

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
@@ -57,12 +57,12 @@ namespace OpenMS
        * @param cross_link_residue1 A list of residues, to which the first side of the linker can react
        * @param cross_link_residue2 A list of residues, to which the second side of the linker can react
        * @param spectrum_precursors A vector of all MS2 precursor masses of the searched spectra. Used to filter out candidates.
-       * @param precursor_correction_positions A vector of the position of the used precursor correction 
+       * @param precursor_correction_positions A vector of the position of the used precursor correction
        * @param precursor_mass_tolerance The precursor mass tolerance
        * @param precursor_mass_tolerance_unit_ppm The unit of the precursor mass tolerance ("Da" or "ppm")
        * @return A vector of XLPrecursors containing all possible candidate cross-links
        */
-      static std::vector<OPXLDataStructs::XLPrecursor> enumerateCrossLinksAndMasses(const std::vector<OPXLDataStructs::AASeqWithMass>&  peptides, double cross_link_mass_light, const DoubleList& cross_link_mass_mono_link, const StringList& cross_link_residue1, const StringList& cross_link_residue2, std::vector< double >& spectrum_precursors, std::vector< int >& precursor_correction_positions, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm);
+      static std::vector<OPXLDataStructs::XLPrecursor> enumerateCrossLinksAndMasses(const std::vector<OPXLDataStructs::AASeqWithMass>&  peptides, double cross_link_mass_light, const DoubleList& cross_link_mass_mono_link, const StringList& cross_link_residue1, const StringList& cross_link_residue2, const std::vector< double >& spectrum_precursors, std::vector< int >& precursor_correction_positions, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm);
 
       /**
        * @brief A helper function, that turns a StringList with modification names into a vector of ResidueModifications
@@ -109,15 +109,15 @@ namespace OpenMS
        * @return A vector of ProteinProteinCrossLink candidates containing all necessary information to generate theoretical spectra
        */
       static std::vector <OPXLDataStructs::ProteinProteinCrossLink> buildCandidates(const std::vector< OPXLDataStructs::XLPrecursor > & candidates,
-                                                                                    std::vector< int > & precursor_corrections,
-                                                                                    std::vector< int >& precursor_correction_positions,
+                                                                                    const std::vector< int > & precursor_corrections,
+                                                                                    const std::vector< int > & precursor_correction_positions,
                                                                                     const std::vector<OPXLDataStructs::AASeqWithMass> & peptide_masses,
                                                                                     const StringList & cross_link_residue1,
                                                                                     const StringList & cross_link_residue2,
                                                                                     double cross_link_mass,
                                                                                     const DoubleList & cross_link_mass_mono_link,
-                                                                                    std::vector< double >& spectrum_precursor_vector,
-                                                                                    std::vector< double >& allowed_error_vector,
+                                                                                    const std::vector< double >& spectrum_precursor_vector,
+                                                                                    const std::vector< double >& allowed_error_vector,
                                                                                     String cross_link_name);
 
       /**
@@ -156,7 +156,7 @@ namespace OpenMS
 
       // check whether the candidate pair is within the given tolerance to at least one precursor mass in the spectra data
       // helper function for enumerateCrossLinksAndMasses
-      static bool filter_and_add_candidate(std::vector<OPXLDataStructs::XLPrecursor>& mass_to_candidates, std::vector< double >& spectrum_precursors, std::vector< int >& precursor_correction_positions, bool precursor_mass_tolerance_unit_ppm, double precursor_mass_tolerance, OPXLDataStructs::XLPrecursor precursor);
+      static bool filter_and_add_candidate(std::vector<OPXLDataStructs::XLPrecursor>& mass_to_candidates, const std::vector< double >& spectrum_precursors, std::vector< int >& precursor_correction_positions, bool precursor_mass_tolerance_unit_ppm, double precursor_mass_tolerance, OPXLDataStructs::XLPrecursor precursor);
 
   };
 }

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -38,7 +38,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 
 // turn on additional debug output
-#define DEBUG_OPXLHELPER
+//#define DEBUG_OPXLHELPER
 
 
 using namespace std;

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -37,13 +37,16 @@
 #include <OpenMS/CHEMISTRY/ModificationsDB.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 
+// turn on additional debug output
+#define DEBUG_OPXLHELPER
+
 
 using namespace std;
 
 namespace OpenMS
 {
   // Enumerate all pairs of peptides from the searched database and calculate their masses (inlcuding mono-links and loop-links)
-  vector<OPXLDataStructs::XLPrecursor> OPXLHelper::enumerateCrossLinksAndMasses(const vector<OPXLDataStructs::AASeqWithMass>&  peptides, double cross_link_mass, const DoubleList& cross_link_mass_mono_link, const StringList& cross_link_residue1, const StringList& cross_link_residue2, vector< double >& spectrum_precursors, vector< int >& precursor_correction_positions, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm)
+  vector<OPXLDataStructs::XLPrecursor> OPXLHelper::enumerateCrossLinksAndMasses(const vector<OPXLDataStructs::AASeqWithMass>&  peptides, double cross_link_mass, const DoubleList& cross_link_mass_mono_link, const StringList& cross_link_residue1, const StringList& cross_link_residue2, const vector< double >& spectrum_precursors, vector< int >& precursor_correction_positions, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm)
   {
     // initialize empty vector for the results
     vector<OPXLDataStructs::XLPrecursor> mass_to_candidates;
@@ -51,11 +54,6 @@ namespace OpenMS
     double min_precursor = spectrum_precursors[0];
     double max_precursor = spectrum_precursors[spectrum_precursors.size()-1];
 
-// Multithreading options: schedule: static, dynamic, guided
-// use OpenMP to run this for-loop on multiple CPU cores
-#ifdef _OPENMP
-#pragma omp parallel for schedule(static)
-#endif
     for (SignedSize p1 = 0; p1 < static_cast<SignedSize>(peptides.size()); ++p1)
     {
       // get the amino acid sequence of this peptide as a character string
@@ -170,10 +168,10 @@ namespace OpenMS
     return mass_to_candidates;
   }
 
-  bool OPXLHelper::filter_and_add_candidate(vector<OPXLDataStructs::XLPrecursor>& mass_to_candidates, vector< double >& spectrum_precursors, vector< int >& precursor_correction_positions, bool precursor_mass_tolerance_unit_ppm, double precursor_mass_tolerance, OPXLDataStructs::XLPrecursor precursor)
+  bool OPXLHelper::filter_and_add_candidate(vector<OPXLDataStructs::XLPrecursor>& mass_to_candidates, const vector< double >& spectrum_precursors, vector< int >& precursor_correction_positions, bool precursor_mass_tolerance_unit_ppm, double precursor_mass_tolerance, OPXLDataStructs::XLPrecursor precursor)
   {
-    vector< double >::iterator low_it;
-    vector< double >::iterator up_it;
+    vector< double >::const_iterator low_it;
+    vector< double >::const_iterator up_it;
 
     // compute absolute tolerance from relative, if necessary
     double allowed_error = 0;
@@ -195,16 +193,9 @@ namespace OpenMS
     if (low_it != up_it) // if they are not equal, there are matching precursors in the data
     {
       // found_matching_precursors = true;
-
-// don't access this vector from two processing threads at the same time
-#ifdef _OPENMP
-#pragma omp critical
-#endif
-      {
-        mass_to_candidates.push_back(precursor);
-        // take the position of the highest matching precursor mass in the vector (prioritize smallest correction)
-        precursor_correction_positions.push_back(std::distance(spectrum_precursors.begin(), std::prev(up_it, 1)));
-      }
+      mass_to_candidates.push_back(precursor);
+      // take the position of the highest matching precursor mass in the vector (prioritize smallest correction)
+      precursor_correction_positions.push_back(std::distance(spectrum_precursors.begin(), std::prev(up_it, 1)));
       return true;
     }
     else
@@ -342,7 +333,17 @@ namespace OpenMS
     return peptide_masses;
   }
 
-  vector <OPXLDataStructs::ProteinProteinCrossLink> OPXLHelper::buildCandidates(const std::vector< OPXLDataStructs::XLPrecursor > & candidates, std::vector< int > & precursor_corrections, std::vector< int >& precursor_correction_positions, const std::vector<OPXLDataStructs::AASeqWithMass> & peptide_masses, const StringList & cross_link_residue1, const StringList & cross_link_residue2, double cross_link_mass, const DoubleList & cross_link_mass_mono_link, std::vector< double >& spectrum_precursor_vector, std::vector< double >& allowed_error_vector, String cross_link_name)
+  vector <OPXLDataStructs::ProteinProteinCrossLink> OPXLHelper::buildCandidates(const std::vector< OPXLDataStructs::XLPrecursor > & candidates,
+                                                                                const std::vector< int > & precursor_corrections,
+                                                                                const std::vector< int >& precursor_correction_positions,
+                                                                                const std::vector<OPXLDataStructs::AASeqWithMass> & peptide_masses,
+                                                                                const StringList & cross_link_residue1,
+                                                                                const StringList & cross_link_residue2,
+                                                                                double cross_link_mass,
+                                                                                const DoubleList & cross_link_mass_mono_link,
+                                                                                const std::vector< double >& spectrum_precursor_vector,
+                                                                                const std::vector< double >& allowed_error_vector,
+                                                                                String cross_link_name)
   {
     bool n_term_linker = false;
     bool c_term_linker = false;
@@ -673,9 +674,18 @@ namespace OpenMS
       {
         vector< String > mods;
         const String residue = seq_alpha[alpha_pos].getOneLetterCode();
+
+#ifdef DEBUG_OPXLHELPER
+#pragma omp critical (LOG_DEBUG_access)
         LOG_DEBUG << "Searching mono-link for " << residue << " | " << alpha_pos << endl;
+#endif
         ModificationsDB::getInstance()->searchModificationsByDiffMonoMass(mods, top_csms_spectrum[i].cross_link.cross_linker_mass, 0.001, residue, ResidueModification::ANYWHERE);
+
+#ifdef DEBUG_OPXLHELPER
+#pragma omp critical (LOG_DEBUG_access)
         LOG_DEBUG << "number of modifications fitting the diff mass: " << mods.size() << endl;
+#endif
+
         bool mod_set = false;
         if (mods.size() > 0) // If several mods have the same diff mass, try to resolve ambiguity by cross-linker name (e.g. DSS and BS3 are different reagents, but have the same result after the reaction)
         {
@@ -683,7 +693,10 @@ namespace OpenMS
           {
             if (mods[s].hasSubstring(top_csms_spectrum[i].cross_link.cross_linker_name))
             {
+#ifdef DEBUG_OPXLHELPER
+#pragma omp critical (LOG_DEBUG_access)
               LOG_DEBUG << "applied modification: " << mods[s] << endl;
+#endif
               seq_alpha.setModification(alpha_pos, mods[s]);
               mod_set = true;
               break;
@@ -692,7 +705,10 @@ namespace OpenMS
         }
         else if (mods.size() == 0 && (alpha_pos == 0 || alpha_pos == static_cast<int>(seq_alpha.size())-1))
         {
+#ifdef DEBUG_OPXLHELPER
+#pragma omp critical (LOG_DEBUG_access)
           LOG_DEBUG << "No residue specific mono-link found, searching for terminal mods..." << endl;
+#endif
           ModificationsDB::getInstance()->searchModificationsByDiffMonoMass(mods, top_csms_spectrum[i].cross_link.cross_linker_mass, 0.001, "", alpha_term_spec);
           if (mods.size() > 0)
           {
@@ -706,12 +722,18 @@ namespace OpenMS
             }
             if (alpha_term_spec == ResidueModification::N_TERM)
             {
+#ifdef DEBUG_OPXLHELPER
+#pragma omp critical (LOG_DEBUG_access)
               LOG_DEBUG << "Setting N-term mono-link: " << mods[mod_index] << endl;
+#endif
               seq_alpha.setNTerminalModification(mods[mod_index]);
             }
             else
             {
+#ifdef DEBUG_OPXLHELPER
+#pragma omp critical (LOG_DEBUG_access)
               LOG_DEBUG << "Setting C-term mono-link: " << mods[mod_index] << endl;
+#endif
               seq_alpha.setCTerminalModification(mods[mod_index]);
             }
             mod_set = true;
@@ -832,7 +854,11 @@ namespace OpenMS
       ph_alpha.setMetaValue("selected", "false");
 
       ph_alpha.setPeakAnnotations(top_csms_spectrum[i].frag_annotations);
+
+#ifdef DEBUG_OPXLHELPER
+#pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "Annotations of size " << ph_alpha.getPeakAnnotations().size() << endl;
+#endif
 
       if (top_csms_spectrum[i].cross_link.getType() == OPXLDataStructs::CROSS)
       {
@@ -899,6 +925,8 @@ namespace OpenMS
       peptide_id.setHits(phs);
       peptide_id.setScoreType("OpenXQuest:combined score");
 
+// this critical section is called this way, because access to all_top_csms also happens in OpenPepXL and OpenPepXLLF
+// access to peptide_ids is also critical, but it is only accessed here during parallel processing
 #ifdef _OPENMP
 #pragma omp critical (all_top_csms_access)
 #endif

--- a/src/utils/OpenPepXL.cpp
+++ b/src/utils/OpenPepXL.cpp
@@ -71,6 +71,9 @@ using namespace OpenMS;
 #define NUMBER_OF_THREADS (1)
 #endif
 
+// turn on additional debug output
+#define DEBUG_OPENPEPXL
+
 //-------------------------------------------------------------
 //Doxygen docu
 //-------------------------------------------------------------
@@ -291,8 +294,10 @@ protected:
       DataArrays::IntegerDataArray dummy_charges;
       OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentFastCharge(matched_fragments_without_shift, fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, spectrum_light, spectrum_heavy, dummy_charges, dummy_charges, dummy_array, 0.3);
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << " heavy_light comparison, matching peaks without shift: " << matched_fragments_without_shift.size() << endl;
+#endif
 
       // transform by m/z difference between unlabeled and labeled cross-link to make heavy and light comparable.
       PeakSpectrum xlink_peaks;
@@ -359,8 +364,10 @@ protected:
         }
         spectrum_heavy_to_light.getIntegerDataArrays().push_back(spectrum_heavy_to_light_charges);
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
         LOG_DEBUG << "Spectrum heavy to light: " << spectrum_heavy_to_light.size() << endl;
+#endif
 
         // align peaks from light spectrum with shifted peaks from heavy spectrum
         // matching fragments are potentially carrying the cross-linker
@@ -372,8 +379,10 @@ protected:
           dummy_array.clear();
           OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentFastCharge(matched_fragments_with_shift, fragment_mass_tolerance_xlinks, fragment_mass_tolerance_unit_ppm, spectrum_light, spectrum_heavy_to_light, dummy_charges, dummy_charges, dummy_array, 0.3);
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
           LOG_DEBUG << "matched with shift: " << matched_fragments_with_shift.size() << endl;
+#endif
 
           // fill xlink_peaks spectrum with matched peaks from the light spectrum and add the currently considered charge
           for (Size i = 0; i < matched_fragments_with_shift.size(); ++i)
@@ -394,8 +403,10 @@ protected:
         }
       }
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "done shifting peaks, total xlink peaks: " << xlink_peaks.size() << endl;
+#endif
 
       // generate linear peaks spectrum, include charges determined through deisotoping in preprocessing
       PeakSpectrum linear_peaks;
@@ -423,12 +434,10 @@ protected:
           linear_peaks.getIntegerDataArrays()[1].push_back(spectrum_light_iso_peaks[matched_fragments_without_shift[i].first]);
         }
       }
-#pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "done creating linear ion spectrum, total linear peaks: " << linear_peaks.size() << endl;
 
 #ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Peaks to match: " << linear_peaks.size() << endl;
+        LOG_DEBUG << "done creating linear ion spectrum, total linear peaks: " << linear_peaks.size() << endl;
 #endif
 
       // TODO make this a tool parameter ? Leave it out completely? Comparing Light/Heavy spectra should already be good enough filtering
@@ -448,8 +457,10 @@ protected:
       xlink_peaks.sortByPosition();
       all_peaks.sortByPosition();
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "paired up, linear peaks: " << linear_peaks.size() << " | xlink peaks: " << xlink_peaks.size() << " | all peaks: " << all_peaks.size() << endl;
+#endif
 
 #ifdef _OPENMP
 #pragma omp critical (preprocessed_pair_spectra_access)
@@ -501,7 +512,9 @@ protected:
     {
       fragment_mass_tolerance_xlinks = fragment_mass_tolerance;
     }
+#ifdef DEBUG_OPENPEPXL
     LOG_DEBUG << "XLinks Tolerance: " << fragment_mass_tolerance_xlinks << endl;
+#endif
 
     bool fragment_mass_tolerance_unit_ppm = (getStringOption_("fragment:mass_tolerance_unit") == "ppm");
 
@@ -529,7 +542,9 @@ protected:
 
     if (fixed_unique.size() != fixedModNames.size())
     {
+#ifdef DEBUG_OPENPEPXL
       LOG_DEBUG << "duplicate fixed modification provided." << endl;
+#endif
       return ILLEGAL_PARAMETERS;
     }
 
@@ -537,7 +552,9 @@ protected:
     set<String> var_unique(varModNames.begin(), varModNames.end());
     if (var_unique.size() != varModNames.size())
     {
+#ifdef DEBUG_OPENPEPXL
       LOG_DEBUG << "duplicate variable modification provided." << endl;
+#endif
       return ILLEGAL_PARAMETERS;
     }
     vector<ResidueModification> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames);
@@ -729,12 +746,16 @@ protected:
     specGenParams.setValue("add_k_linked_ions", "true");
     specGen.setParameters(specGenParams);
 
+#ifdef DEBUG_OPENPEPXL
     LOG_DEBUG << "Peptide candidates: " << peptide_masses.size() << endl;
+#endif
     search_params = protein_ids[0].getSearchParameters();
     search_params.setMetaValue("MS:1001029", peptide_masses.size()); // number of sequences searched = MS:1001029
     protein_ids[0].setSearchParameters(search_params);
 
+#ifdef DEBUG_OPENPEPXL
     LOG_DEBUG << "Number of paired precursor masses: " << spectrum_precursors.size() << endl;
+#endif
 
     sort(peptide_masses.begin(), peptide_masses.end(), OPXLDataStructs::AASeqWithMassComparator());
 
@@ -756,7 +777,9 @@ protected:
     // maximal possible peptide mass given the largest precursor
     double max_peptide_mass = max_precursor_mass - cross_link_mass_light + max_peptide_allowed_error;
 
+#ifdef DEBUG_OPENPEPXL
     LOG_DEBUG << "Filtering peptides with precursors" << endl;
+#endif
 
     // search for the first mass greater than the maximim, use everything before that peptide
     vector<OPXLDataStructs::AASeqWithMass>::iterator last = upper_bound(peptide_masses.begin(), peptide_masses.end(), max_peptide_mass, OPXLDataStructs::AASeqWithMassComparator());
@@ -778,8 +801,10 @@ protected:
       Size scan_index = spectrum_pairs[pair_index].first;
       Size scan_index_heavy = spectrum_pairs[pair_index].second;
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "Scan indices: " << scan_index << "\t" << scan_index_heavy << endl;
+#endif
       const PeakSpectrum& spectrum_light = spectra[scan_index];
       const double precursor_charge = spectrum_light.getPrecursors()[0].getCharge();
       const double precursor_mz = spectrum_light.getPrecursors()[0].getMZ();
@@ -855,9 +880,11 @@ protected:
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = cross_link_candidates[i];
         double candidate_mz = (cross_link_candidate.alpha.getMonoWeight() + cross_link_candidate.beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
         LOG_DEBUG << "Pair: " << cross_link_candidate.alpha.toString() << "-" << cross_link_candidate.beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index_heavy
               << " with m/z: " << precursor_mz << "\t" << "and candidate m/z: " << candidate_mz << "\tK Positions: " << cross_link_candidate.cross_link_position.first << "\t" << cross_link_candidate.cross_link_position.second << endl;
+#endif
 
         OPXLDataStructs::CrossLinkSpectrumMatch csm;
         csm.cross_link = cross_link_candidate;
@@ -951,12 +978,14 @@ protected:
         Size matched_beta_count = matched_spec_linear_beta.size() + matched_spec_xlinks_beta.size();
         Size theor_beta_count = theoretical_spec_linear_beta.size() + theoretical_spec_xlinks_beta.size();
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
         {
           LOG_DEBUG << "matched peaks: " << matched_alpha_count + matched_beta_count << endl;
           LOG_DEBUG << "theoretical peaks: " << theor_alpha_count + theor_beta_count << endl;
           LOG_DEBUG << "exp peaks: " << all_peaks.size() << endl;
         }
+#endif
 
         if (matched_alpha_count + matched_beta_count > 0)
         {
@@ -1094,10 +1123,10 @@ protected:
           {
             weight += cross_link_candidate.cross_linker_mass;
           }
-          double precursor_mass = (precursor_mz * static_cast<double>(precursor_charge)) - (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)
+          double corrected_precursor_mass = (precursor_mz * static_cast<double>(precursor_charge)) - (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)
                             - (static_cast<double>(cross_link_candidate.precursor_correction) * Constants::C13C12_MASSDIFF_U);
-          double error = precursor_mass - weight;
-          double rel_error = (error / precursor_mass) / 1e-6;
+          double error = corrected_precursor_mass - weight;
+          double rel_error = (error / corrected_precursor_mass) / 1e-6;
 
           double new_match_odds_weight = 0.2;
           double new_rel_error_weight = -0.03;
@@ -1309,8 +1338,10 @@ protected:
           }
 
           // write fragment annotations
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
           LOG_DEBUG << "Start writing annotations" << endl;
+#endif
 
           vector<PeptideHit::PeakAnnotation> frag_annotations;
           OPXLHelper::buildFragmentAnnotations(frag_annotations, matched_spec_linear_alpha, theoretical_spec_linear_alpha, linear_peaks);
@@ -1318,8 +1349,10 @@ protected:
           OPXLHelper::buildFragmentAnnotations(frag_annotations, matched_spec_xlinks_alpha, theoretical_spec_xlinks_alpha, xlink_peaks);
           OPXLHelper::buildFragmentAnnotations(frag_annotations, matched_spec_xlinks_beta, theoretical_spec_xlinks_beta, xlink_peaks);
 
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
           LOG_DEBUG << "End writing fragment annotations, size: " << frag_annotations.size() << endl;
+#endif
 
           // make annotations unique
           sort(frag_annotations.begin(), frag_annotations.end());
@@ -1362,13 +1395,17 @@ protected:
       {
         OPXLHelper::buildPeptideIDs(peptide_ids, top_csms_spectrum, all_top_csms, all_top_csms_current_index, spectra, scan_index, scan_index_heavy);
       }
+#ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "Next Spectrum #############################################" << endl;
+#endif
     } // end of parallel for-loop
     // end of matching / scoring
     progresslogger.endProgress();
 
+#ifdef DEBUG_OPENPEPXL
     LOG_DEBUG << "# Peptide IDs: " << peptide_ids.size() << " | # all_top_csms: " << all_top_csms.size() << endl;
+#endif
 
     // Add protein identifications
     PeptideIndexing pep_indexing;

--- a/src/utils/OpenPepXL.cpp
+++ b/src/utils/OpenPepXL.cpp
@@ -290,6 +290,8 @@ protected:
       DataArrays::FloatDataArray dummy_array;
       DataArrays::IntegerDataArray dummy_charges;
       OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentFastCharge(matched_fragments_without_shift, fragment_mass_tolerance, fragment_mass_tolerance_unit_ppm, spectrum_light, spectrum_heavy, dummy_charges, dummy_charges, dummy_array, 0.3);
+
+#pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << " heavy_light comparison, matching peaks without shift: " << matched_fragments_without_shift.size() << endl;
 
       // transform by m/z difference between unlabeled and labeled cross-link to make heavy and light comparable.
@@ -357,6 +359,7 @@ protected:
         }
         spectrum_heavy_to_light.getIntegerDataArrays().push_back(spectrum_heavy_to_light_charges);
 
+#pragma omp critical (LOG_DEBUG_access)
         LOG_DEBUG << "Spectrum heavy to light: " << spectrum_heavy_to_light.size() << endl;
 
         // align peaks from light spectrum with shifted peaks from heavy spectrum
@@ -369,6 +372,7 @@ protected:
           dummy_array.clear();
           OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentFastCharge(matched_fragments_with_shift, fragment_mass_tolerance_xlinks, fragment_mass_tolerance_unit_ppm, spectrum_light, spectrum_heavy_to_light, dummy_charges, dummy_charges, dummy_array, 0.3);
 
+#pragma omp critical (LOG_DEBUG_access)
           LOG_DEBUG << "matched with shift: " << matched_fragments_with_shift.size() << endl;
 
           // fill xlink_peaks spectrum with matched peaks from the light spectrum and add the currently considered charge
@@ -390,6 +394,7 @@ protected:
         }
       }
 
+#pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "done shifting peaks, total xlink peaks: " << xlink_peaks.size() << endl;
 
       // generate linear peaks spectrum, include charges determined through deisotoping in preprocessing
@@ -418,9 +423,11 @@ protected:
           linear_peaks.getIntegerDataArrays()[1].push_back(spectrum_light_iso_peaks[matched_fragments_without_shift[i].first]);
         }
       }
+#pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "done creating linear ion spectrum, total linear peaks: " << linear_peaks.size() << endl;
 
 #ifdef DEBUG_OPENPEPXL
+#pragma omp critical (LOG_DEBUG_access)
         LOG_DEBUG << "Peaks to match: " << linear_peaks.size() << endl;
 #endif
 
@@ -441,6 +448,7 @@ protected:
       xlink_peaks.sortByPosition();
       all_peaks.sortByPosition();
 
+#pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "paired up, linear peaks: " << linear_peaks.size() << " | xlink peaks: " << xlink_peaks.size() << " | all peaks: " << all_peaks.size() << endl;
 
 #ifdef _OPENMP
@@ -453,8 +461,11 @@ protected:
       }
 
 #ifdef DEBUG_OPENPEPXL
-        LOG_DEBUG << "spctrum_linear_peaks: " << preprocessed_pair_spectra.spectra_linear_peaks[pair_index].size() << endl;
-        LOG_DEBUG << "spectrum_xlink_peaks: " << preprocessed_pair_spectra.spectra_xlink_peaks[pair_index].size() << endl;
+#pragma omp critical (LOG_DEBUG_access)
+        {
+          LOG_DEBUG << "spectrum_linear_peaks: " << preprocessed_pair_spectra.spectra_linear_peaks[pair_index].size() << endl;
+          LOG_DEBUG << "spectrum_xlink_peaks: " << preprocessed_pair_spectra.spectra_xlink_peaks[pair_index].size() << endl;
+        }
 #endif
 
     }
@@ -766,6 +777,8 @@ protected:
     {
       Size scan_index = spectrum_pairs[pair_index].first;
       Size scan_index_heavy = spectrum_pairs[pair_index].second;
+
+#pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "Scan indices: " << scan_index << "\t" << scan_index_heavy << endl;
       const PeakSpectrum& spectrum_light = spectra[scan_index];
       const double precursor_charge = spectrum_light.getPrecursors()[0].getCharge();
@@ -773,7 +786,7 @@ protected:
       const double precursor_mass = precursor_mz * static_cast<double>(precursor_charge) - static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U;
 
 #ifdef _OPENMP
-#pragma omp critical
+#pragma omp critical (cout_access)
 #endif
       {
         spectrum_counter++;
@@ -828,7 +841,7 @@ protected:
       vector <OPXLDataStructs::ProteinProteinCrossLink> cross_link_candidates = OPXLHelper::buildCandidates(candidates, precursor_corrections, precursor_correction_positions, filtered_peptide_masses, cross_link_residue1, cross_link_residue2, cross_link_mass_light, cross_link_mass_mono_link, spectrum_precursor_vector, allowed_error_vector, cross_link_name);
 
 #ifdef _OPENMP
-#pragma omp critical
+#pragma omp critical (cout_access)
 #endif
       cout << "Pair number: " << spectrum_counter << " |\tNumber of peaks in light spectrum: " << spectrum_light.size() << " |\tNumber of candidates: " << candidates.size() << endl;
 
@@ -842,6 +855,7 @@ protected:
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = cross_link_candidates[i];
         double candidate_mz = (cross_link_candidate.alpha.getMonoWeight() + cross_link_candidate.beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
 
+#pragma omp critical (LOG_DEBUG_access)
         LOG_DEBUG << "Pair: " << cross_link_candidate.alpha.toString() << "-" << cross_link_candidate.beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index_heavy
               << " with m/z: " << precursor_mz << "\t" << "and candidate m/z: " << candidate_mz << "\tK Positions: " << cross_link_candidate.cross_link_position.first << "\t" << cross_link_candidate.cross_link_position.second << endl;
 
@@ -931,16 +945,18 @@ protected:
           OPXLSpectrumProcessingAlgorithms::getSpectrumAlignmentFastCharge(matched_spec_xlinks_beta, fragment_mass_tolerance_xlinks, fragment_mass_tolerance_unit_ppm, theoretical_spec_xlinks_beta, xlink_peaks, theo_charges_beta, exp_charges, ppm_error_array_xlinks_beta);
         }
 
-
         // Pre-Score calculations
         Size matched_alpha_count = matched_spec_linear_alpha.size() + matched_spec_xlinks_alpha.size();
         Size theor_alpha_count = theoretical_spec_linear_alpha.size() + theoretical_spec_xlinks_alpha.size();
         Size matched_beta_count = matched_spec_linear_beta.size() + matched_spec_xlinks_beta.size();
         Size theor_beta_count = theoretical_spec_linear_beta.size() + theoretical_spec_xlinks_beta.size();
 
-        LOG_DEBUG << "matched peaks: " << matched_alpha_count + matched_beta_count << endl;
-        LOG_DEBUG << "theoretical peaks: " << theor_alpha_count + theor_beta_count << endl;
-        LOG_DEBUG << "exp peaks: " << all_peaks.size() << endl;
+#pragma omp critical (LOG_DEBUG_access)
+        {
+          LOG_DEBUG << "matched peaks: " << matched_alpha_count + matched_beta_count << endl;
+          LOG_DEBUG << "theoretical peaks: " << theor_alpha_count + theor_beta_count << endl;
+          LOG_DEBUG << "exp peaks: " << all_peaks.size() << endl;
+        }
 
         if (matched_alpha_count + matched_beta_count > 0)
         {
@@ -1293,13 +1309,16 @@ protected:
           }
 
           // write fragment annotations
+#pragma omp critical (LOG_DEBUG_access)
           LOG_DEBUG << "Start writing annotations" << endl;
-          vector<PeptideHit::PeakAnnotation> frag_annotations;
 
+          vector<PeptideHit::PeakAnnotation> frag_annotations;
           OPXLHelper::buildFragmentAnnotations(frag_annotations, matched_spec_linear_alpha, theoretical_spec_linear_alpha, linear_peaks);
           OPXLHelper::buildFragmentAnnotations(frag_annotations, matched_spec_linear_beta, theoretical_spec_linear_beta, linear_peaks);
           OPXLHelper::buildFragmentAnnotations(frag_annotations, matched_spec_xlinks_alpha, theoretical_spec_xlinks_alpha, xlink_peaks);
           OPXLHelper::buildFragmentAnnotations(frag_annotations, matched_spec_xlinks_beta, theoretical_spec_xlinks_beta, xlink_peaks);
+
+#pragma omp critical (LOG_DEBUG_access)
           LOG_DEBUG << "End writing fragment annotations, size: " << frag_annotations.size() << endl;
 
           // make annotations unique
@@ -1343,9 +1362,9 @@ protected:
       {
         OPXLHelper::buildPeptideIDs(peptide_ids, top_csms_spectrum, all_top_csms, all_top_csms_current_index, spectra, scan_index, scan_index_heavy);
       }
-
+#pragma omp critical (LOG_DEBUG_access)
       LOG_DEBUG << "Next Spectrum #############################################" << endl;
-    }
+    } // end of parallel for-loop
     // end of matching / scoring
     progresslogger.endProgress();
 

--- a/src/utils/OpenPepXL.cpp
+++ b/src/utils/OpenPepXL.cpp
@@ -72,7 +72,7 @@ using namespace OpenMS;
 #endif
 
 // turn on additional debug output
-#define DEBUG_OPENPEPXL
+//#define DEBUG_OPENPEPXL
 
 //-------------------------------------------------------------
 //Doxygen docu

--- a/src/utils/OpenPepXL.cpp
+++ b/src/utils/OpenPepXL.cpp
@@ -878,12 +878,14 @@ protected:
       for (Size i = 0; i != cross_link_candidates.size(); ++i)
       {
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = cross_link_candidates[i];
-        double candidate_mz = (cross_link_candidate.alpha.getMonoWeight() + cross_link_candidate.beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
 
 #ifdef DEBUG_OPENPEPXL
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Pair: " << cross_link_candidate.alpha.toString() << "-" << cross_link_candidate.beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index_heavy
+        {
+          double candidate_mz = (cross_link_candidate.alpha.getMonoWeight() + cross_link_candidate.beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
+          LOG_DEBUG << "Pair: " << cross_link_candidate.alpha.toString() << "-" << cross_link_candidate.beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index_heavy
               << " with m/z: " << precursor_mz << "\t" << "and candidate m/z: " << candidate_mz << "\tK Positions: " << cross_link_candidate.cross_link_position.first << "\t" << cross_link_candidate.cross_link_position.second << endl;
+        }
 #endif
 
         OPXLDataStructs::CrossLinkSpectrumMatch csm;

--- a/src/utils/OpenPepXLLF.cpp
+++ b/src/utils/OpenPepXLLF.cpp
@@ -706,12 +706,14 @@ protected:
       for (Size i = 0; i < last_candidate_index ; ++i)
       {
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = prescore_csms_spectrum[i].cross_link;
-        double candidate_mz = (cross_link_candidate.alpha.getMonoWeight() + cross_link_candidate.beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
 
 #ifdef DEBUG_OPENPEPXLLF
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Pair: " << cross_link_candidate.alpha.toString() << "-" << cross_link_candidate.beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index
+        {
+          double candidate_mz = (cross_link_candidate.alpha.getMonoWeight() + cross_link_candidate.beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
+          LOG_DEBUG << "Pair: " << cross_link_candidate.alpha.toString() << "-" << cross_link_candidate.beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index
             << " with m/z: " << precursor_mz << "\t" << "and candidate m/z: " << candidate_mz << "\tK Positions: " << cross_link_candidate.cross_link_position.first << "\t" << cross_link_candidate.cross_link_position.second << endl;
+        }
 #endif
 
         OPXLDataStructs::CrossLinkSpectrumMatch csm;

--- a/src/utils/OpenPepXLLF.cpp
+++ b/src/utils/OpenPepXLLF.cpp
@@ -72,7 +72,7 @@ using namespace OpenMS;
 #endif
 
 // turn on additional debug output
-#define DEBUG_OPENPEPXLLF
+//#define DEBUG_OPENPEPXLLF
 
 //-------------------------------------------------------------
 //Doxygen docu


### PR DESCRIPTION
race conditions caused crashes, when LOG_DEBUG was written in from different threads.
Now all LOG_DEBUG writing operations are in critical sections and only compiled and run if they are activated using the `#define DEBUG_...`and `#ifdef DEBUG_...`conditions.