### PR TITLE
added pthread find to cmake

### DIFF
--- a/src/openms/cmake_findExternalLibs.cmake
+++ b/src/openms/cmake_findExternalLibs.cmake
@@ -167,5 +167,10 @@ add_definitions(${Qt5Network_DEFINITIONS})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Qt5Core_EXECUTABLE_COMPILE_FLAGS} ${Qt5Network_EXECUTABLE_COMPILE_FLAGS}")
 
+#------------------------------------------------------------------------------
+# PTHREAD
+#------------------------------------------------------------------------------
+# at least FFSuperHirn requires linking against pthread
+find_package (Threads REQUIRED)
 
 #------------------------------------------------------------------------------

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -77,9 +77,9 @@ endif()
 add_custom_target(UTILS)
 add_dependencies(UTILS ${UTILS_executables})
 
-# FFSuperHirn requires linking against SuperHirn
+# FFSuperHirn requires linking against SuperHirn and pthread (needs find_package (Threads REQUIRED))
 include_directories(SYSTEM ${SuperHirn_INCLUDE_DIRECTORIES})
-target_link_libraries(FeatureFinderSuperHirn SuperHirn)
+target_link_libraries(FeatureFinderSuperHirn SuperHirn ${CMAKE_THREAD_LIBS_INIT})
 
 ## export the list of UTILS tools into CACHE
 set(UTILS_TOOLS ${UTILS_executables}


### PR DESCRIPTION
my local builds were not completely linking anymore - FFSuperHirn failed, which was due to missing pthreads, which is now required.