### PR TITLE
new makePeakPositionUnique() method for SpectrumHelper

### DIFF
--- a/src/tests/class_tests/openms/source/SpectrumHelper_test.cpp
+++ b/src/tests/class_tests/openms/source/SpectrumHelper_test.cpp
@@ -238,45 +238,133 @@ START_SECTION(void subtractMinimumIntensity(PeakContainerT& p))
 {
   MSSpectrum s;
   MSChromatogram c;
-
+  
   for (Int i = -5; i < 5; ++i) // Intensities: [-5 4]
   {
     s.push_back(Peak1D(0, i));
     c.push_back(ChromatogramPeak(0, i));
   }
-
+  
   subtractMinimumIntensity(s);
   TEST_REAL_SIMILAR(s[0].getIntensity(), 0)
   TEST_REAL_SIMILAR(s[1].getIntensity(), 1)
   TEST_REAL_SIMILAR(s[9].getIntensity(), 9)
-
+  
   subtractMinimumIntensity(c);
   TEST_REAL_SIMILAR(c[0].getIntensity(), 0)
   TEST_REAL_SIMILAR(c[1].getIntensity(), 1)
   TEST_REAL_SIMILAR(c[9].getIntensity(), 9)
-
+  
   MSChromatogram c_empty;
   subtractMinimumIntensity(c_empty);
   TEST_EQUAL(c_empty.size(), 0)
-
+  
   s.clear(true);
   c.clear(true);
-
+  
   for (Int i = 5; i < 15; ++i) // Intensities: [5 14]
   {
     s.push_back(Peak1D(0, i));
     c.push_back(ChromatogramPeak(0, i));
   }
-
+  
   subtractMinimumIntensity(s);
   TEST_REAL_SIMILAR(s[0].getIntensity(), 0)
   TEST_REAL_SIMILAR(s[1].getIntensity(), 1)
   TEST_REAL_SIMILAR(s[9].getIntensity(), 9)
-
+  
   subtractMinimumIntensity(c);
   TEST_REAL_SIMILAR(c[0].getIntensity(), 0)
   TEST_REAL_SIMILAR(c[1].getIntensity(), 1)
   TEST_REAL_SIMILAR(c[9].getIntensity(), 9)
+}
+END_SECTION
+
+START_SECTION(void makePeakPositionUnique(PeakContainerT& p, const int m) )
+{
+  MSSpectrum s;
+  MSChromatogram c;
+  
+  MSSpectrum s_template;
+  MSChromatogram c_template;
+  
+  s_template.push_back(Peak1D(1, 1));
+  s_template.push_back(Peak1D(2, 4));
+  s_template.push_back(Peak1D(2, 8));
+  s_template.push_back(Peak1D(3, 9));
+  s_template.push_back(Peak1D(4, 7));
+  s_template.push_back(Peak1D(2, 10));
+  
+  c_template.push_back(ChromatogramPeak(1, 1));
+  c_template.push_back(ChromatogramPeak(2, 4));
+  c_template.push_back(ChromatogramPeak(2, 8));
+  c_template.push_back(ChromatogramPeak(3, 9));
+  c_template.push_back(ChromatogramPeak(4, 7));
+  c_template.push_back(ChromatogramPeak(2, 10));
+
+  s = s_template;
+  makePeakPositionUnique(s, 1);
+  TEST_REAL_SIMILAR(s[0].getIntensity(), 1)
+  TEST_REAL_SIMILAR(s[1].getIntensity(), 8)
+  TEST_REAL_SIMILAR(s[2].getIntensity(), 9)
+  TEST_REAL_SIMILAR(s[3].getIntensity(), 7)
+  
+  c = c_template;
+  makePeakPositionUnique(c, 1);
+  TEST_REAL_SIMILAR(c[0].getIntensity(), 1)
+  TEST_REAL_SIMILAR(c[1].getIntensity(), 8)
+  TEST_REAL_SIMILAR(c[2].getIntensity(), 9)
+  TEST_REAL_SIMILAR(c[3].getIntensity(), 7)
+  
+  s = s_template;
+  makePeakPositionUnique(s, 2);
+  TEST_REAL_SIMILAR(s[0].getIntensity(), 1)
+  TEST_REAL_SIMILAR(s[1].getIntensity(), (4+8+10)/3.0)
+  TEST_REAL_SIMILAR(s[2].getIntensity(), 9)
+  TEST_REAL_SIMILAR(s[3].getIntensity(), 7)
+  
+  c = c_template;
+  makePeakPositionUnique(c, 2);
+  TEST_REAL_SIMILAR(c[0].getIntensity(), 1)
+  TEST_REAL_SIMILAR(c[1].getIntensity(), (4+8+10)/3.0)
+  TEST_REAL_SIMILAR(c[2].getIntensity(), 9)
+  TEST_REAL_SIMILAR(c[3].getIntensity(), 7)
+  
+  s = s_template;
+  makePeakPositionUnique(s, 3);
+  TEST_REAL_SIMILAR(s[0].getIntensity(), 1)
+  TEST_REAL_SIMILAR(s[1].getIntensity(), 4)
+  TEST_REAL_SIMILAR(s[2].getIntensity(), 9)
+  TEST_REAL_SIMILAR(s[3].getIntensity(), 7)
+  
+  c = c_template;
+  makePeakPositionUnique(c, 3);
+  TEST_REAL_SIMILAR(c[0].getIntensity(), 1)
+  TEST_REAL_SIMILAR(c[1].getIntensity(), 4)
+  TEST_REAL_SIMILAR(c[2].getIntensity(), 9)
+  TEST_REAL_SIMILAR(c[3].getIntensity(), 7)
+  
+  s = s_template;
+  makePeakPositionUnique(s, 4);
+  TEST_REAL_SIMILAR(s[0].getIntensity(), 1)
+  TEST_REAL_SIMILAR(s[1].getIntensity(), 10)
+  TEST_REAL_SIMILAR(s[2].getIntensity(), 9)
+  TEST_REAL_SIMILAR(s[3].getIntensity(), 7)
+  
+  c = c_template;
+  makePeakPositionUnique(c, 4);
+  TEST_REAL_SIMILAR(c[0].getIntensity(), 1)
+  TEST_REAL_SIMILAR(c[1].getIntensity(), 10)
+  TEST_REAL_SIMILAR(c[2].getIntensity(), 9)
+  TEST_REAL_SIMILAR(c[3].getIntensity(), 7)
+  
+  MSSpectrum s_empty;
+  makePeakPositionUnique(s_empty);
+  TEST_EQUAL(s_empty.size(), 0)
+  
+  MSChromatogram c_empty;
+  makePeakPositionUnique(c_empty);
+  TEST_EQUAL(c_empty.size(), 0)
 }
 END_SECTION
 


### PR DESCRIPTION
Spectra and chromatograms might contain some peaks with identical position i.e. m/z or RT.

The new `makePeakPositionUnique()` method combines peaks with identical position to a single one. Its intensity is the median, mean, min or max of the individual peaks. The resulting new spectrum/chromatogram contains only unique positions.