### PR TITLE
[FIX] replace hostname in mascot query

### DIFF
--- a/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+++ b/src/openms/source/FORMAT/MascotRemoteQuery.cpp
@@ -742,7 +742,11 @@ namespace OpenMS
       endRun_();
       return;
     }
-    url.remove(host_name_.toQString());
+    
+    // makes sure that only the first occurrence in the String is replaced,
+    // in case of an equal server_name_
+    url.replace(url.indexOf(host_name_.toQString()),
+                          host_name_.toQString().size(), QString(""));
 
     // ensure path starts with /
     if (url[0] != '/') url.prepend('/');


### PR DESCRIPTION
Was replacing all occurrences of the hostname. Wrong in case of equal servername.
This is on top of my head. Changes untested.
fixes #3611 if successful