### PR TITLE
Feature/rework decharger output

### DIFF
--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -958,6 +958,15 @@ namespace OpenMS
         continue;
       }
 
+      // store element adducts
+      for (ConsensusFeature::HandleSetType::const_iterator it_h = hst.begin(); it_h != hst.end(); ++it_h)
+      {
+        if (fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].metaValueExists("dc_charge_adducts"))
+        {
+          it->setMetaValue(String(it_h->getUniqueId()), fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].getMetaValue("dc_charge_adducts"));
+        }
+      }
+
       // store number of distinct charges
       std::set<Int> charges;
       for (ConsensusFeature::HandleSetType::const_iterator it_h = hst.begin(); it_h != hst.end(); ++it_h)
@@ -1041,6 +1050,11 @@ namespace OpenMS
 
       cons_map.push_back(cf);
       cons_map.back().computeDechargeConsensus(fm_out);//previously used fm_out_untouched. does fm_out also work?
+      //If computing decharge mz is 0 (meaning monoisotopic singleton), we instead use the feature mz
+      if (cons_map.back().getMZ() == 0)
+      {
+        cons_map.back().setMZ(f_single.getMZ());
+      }
       ++singletons_count;
     }
     if (verbose_level_ > 2)

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -865,8 +865,14 @@ namespace OpenMS
         cons_map_p.push_back(cf);
 
         //remove info not wanted in decharged consensus
-        cf.removeMetaValue("Local");
-        cf.removeMetaValue("CP");
+        std::vector<String> keys;
+        cf.getKeys(keys);
+        for (std::vector<String>::const_iterator it = keys.begin(); it != keys.end(); ++it)
+        {
+          cf.removeMetaValue(*it);
+        }
+        //cf.removeMetaValue("Local");
+        //cf.removeMetaValue("CP");
 
 
         //
@@ -984,7 +990,14 @@ namespace OpenMS
         continue;
 
       FeatureMapType::FeatureType f_single = fm_out_untouched[i];
-      f_single.setMetaValue("is_single_feature", 1);
+      if (f_single.getCharge() == 0)
+      {
+        f_single.setMetaValue("is_ungrouped_monoisotopic", 1);
+      }
+      else
+      {
+        f_single.setMetaValue("is_ungrouped_with_charge", 1);
+      }
 
       if (is_neg)
       {
@@ -1016,6 +1029,16 @@ namespace OpenMS
       cf.setQuality(0.0);
       cf.setUniqueId();
       cf.insert(0, f_single);
+      //remove info not wanted in decharged consensus
+      std::vector<String> keys;
+      cf.getKeys(keys);
+      for (std::vector<String>::const_iterator it = keys.begin(); it != keys.end(); ++it)
+      {
+        if (*it == "is_ungrouped_monoisotopic" || *it == "is_ungrouped_with_charge")
+          continue;
+
+        cf.removeMetaValue(*it);
+      }
 
       cons_map.push_back(cf);
       cons_map.back().computeDechargeConsensus(fm_out);//previously used fm_out_untouched. does fm_out also work?

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -846,34 +846,29 @@ namespace OpenMS
         cf.setUniqueId();
         cf.insert((UInt64) fm_out[f0_idx].getMetaValue("map_idx"), fm_out[f0_idx]);
         cf.insert((UInt64) fm_out[f1_idx].getMetaValue("map_idx"), fm_out[f1_idx]);
-        cf.setMetaValue("Local", String(old_q0) + ":" + String(old_q1));
-        cf.setMetaValue("CP", String(fm_out[f0_idx].getCharge()) + "(" + String(fm_out[f0_idx].getMetaValue("dc_charge_adducts")) + "):"
-                        + String(fm_out[f1_idx].getCharge()) + "(" + String(fm_out[f1_idx].getMetaValue("dc_charge_adducts")) + ") "
-                        + String("Delta M: ") + feature_relation[i].getMassDiff()
-                        + String(" Score: ") + feature_relation[i].getEdgeScore());
-        //cf.computeDechargeConsensus(fm_out);
 
-        //remove info not wanted in pair info nor in decharged consensus
-        cf.removeMetaValue("label");
-        cf.removeMetaValue("dc_charge_adducts");
-        cf.removeMetaValue("adducts");
-        cf.removeMetaValue("dc_charge_adduct_mass");
-        cf.removeMetaValue("is_backbone");
-        cf.removeMetaValue("old_charge");
-        cf.removeMetaValue("map_idx");
-        // print pairs only
-        cons_map_p.push_back(cf);
-
-        //remove info not wanted in decharged consensus
+        //remove info not wanted in pair
         std::vector<String> keys;
         cf.getKeys(keys);
         for (std::vector<String>::const_iterator it = keys.begin(); it != keys.end(); ++it)
         {
           cf.removeMetaValue(*it);
         }
-        //cf.removeMetaValue("Local");
-        //cf.removeMetaValue("CP");
+        cf.setMetaValue("Old_charges", String(old_q0) + ":" + String(old_q1));
+        cf.setMetaValue("CP", String(fm_out[f0_idx].getCharge()) + "(" + String(fm_out[f0_idx].getMetaValue("dc_charge_adducts")) + "):"
+                        + String(fm_out[f1_idx].getCharge()) + "(" + String(fm_out[f1_idx].getMetaValue("dc_charge_adducts")) + ") "
+                        + String("Delta M: ") + feature_relation[i].getMassDiff()
+                        + String(" Score: ") + feature_relation[i].getEdgeScore());
+        //cf.computeDechargeConsensus(fm_out);
 
+        cons_map_p.push_back(cf);
+
+        //remove info not wanted in decharged consensus
+        cf.getKeys(keys);
+        for (std::vector<String>::const_iterator it = keys.begin(); it != keys.end(); ++it)
+        {
+          cf.removeMetaValue(*it);
+        }
 
         //
         // create cliques for decharge consensus features

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -959,6 +959,8 @@ namespace OpenMS
         if (fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].metaValueExists("dc_charge_adducts"))
         {
           it->setMetaValue(String(it_h->getUniqueId()), fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].getMetaValue("dc_charge_adducts"));
+          // also add consensusID of group to feature_relation
+          fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].setMetaValue("Group", it->getUniqueId());
         }
       }
 

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -959,9 +959,9 @@ namespace OpenMS
         if (fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].metaValueExists("dc_charge_adducts"))
         {
           it->setMetaValue(String(it_h->getUniqueId()), fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].getMetaValue("dc_charge_adducts"));
-          // also add consensusID of group to feature_relation
-          fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].setMetaValue("Group", it->getUniqueId());
         }
+        // also add consensusID of group to all feature_relation
+        fm_out[fm_out.uniqueIdToIndex(it_h->getUniqueId())].setMetaValue("Group", String(it->getUniqueId()));
       }
 
       // store number of distinct charges
@@ -1022,11 +1022,6 @@ namespace OpenMS
         f_single.setMetaValue("dc_charge_adducts", (default_ef  * abs(f_single.getCharge())).toString());
         f_single.setMetaValue("dc_charge_adduct_mass", (default_adduct.getSingleMass() * abs(f_single.getCharge())));
       }
-      //What happens with charge 0 features? We can do normal annotation and at end set mz to feature mz?
-      //something like
-      //const double orig_mz = f_single.getMZ();
-      //and set consensusmz at end to that?
-
 
       fm_out[i] = f_single; // overwrite whatever DC has done to this feature!
 
@@ -1044,6 +1039,9 @@ namespace OpenMS
 
         cf.removeMetaValue(*it);
       }
+      // Nedd to set userParam Group output feature map features for singletons here
+      fm_out[i].setMetaValue("Group", String(cf.getUniqueId()));
+
 
       cons_map.push_back(cf);
       cons_map.back().computeDechargeConsensus(fm_out);//previously used fm_out_untouched. does fm_out also work?

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -1004,7 +1004,6 @@ namespace OpenMS
         //if negative mode, we report only negative charges. abs() for chains of negative mode dechargers.
         f_single.setCharge(- abs(f_single.getCharge()));
       }
-      f_single.setMetaValue("charge", f_single.getCharge());
 
       //if negative mode, replace former positive charges with their negative sign version?
       //If singleton, set dc_charge_adduct to default, and charge negative in neg mode?,

--- a/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_easy_output.consensusXML
+++ b/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_easy_output.consensusXML
@@ -14,6 +14,8 @@
 				<element map="0" id="121" rt="0" mz="912.31" it="22004" charge="1"/>
 				<element map="0" id="122" rt="0" mz="456.655" it="22004" charge="2"/>
 			</groupedElementList>
+			<UserParam type="string" name="121" value="H1"/>
+			<UserParam type="string" name="122" value="H2"/>
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
@@ -27,6 +29,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="912" value="H1"/>
+			<UserParam type="string" name="913" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_3749176663227866731" quality="0">
 			<centroid rt="37.576417014774" mz="486.29043742025" it="22500"/>
@@ -37,6 +41,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="401" value="H3"/>
+			<UserParam type="string" name="402" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17648507968597771516" quality="0">
 			<centroid rt="43.5558673692008" mz="274.17826245215" it="255204"/>
@@ -47,6 +53,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2155" value="H1"/>
+			<UserParam type="string" name="2157" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3393824606581918541" quality="0">
 			<centroid rt="51.9591918848894" mz="524.2143499362" it="67172"/>
@@ -57,6 +65,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="892" value="H1"/>
+			<UserParam type="string" name="893" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_1233230981423630429" quality="0">
 			<centroid rt="60.0536442760688" mz="546.31043742025" it="96088"/>
@@ -67,6 +77,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1341" value="H3"/>
+			<UserParam type="string" name="1342" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16419438213446853038" quality="0">
 			<centroid rt="69.5559420695666" mz="910.440437420251" it="191544"/>
@@ -77,6 +89,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2053" value="H3"/>
+			<UserParam type="string" name="2054" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2934336688081369014" quality="0">
 			<centroid rt="86.4334137212732" mz="621.3443499362" it="235962"/>
@@ -88,6 +102,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1628" value="H1"/>
+			<UserParam type="string" name="1629" value="H3"/>
+			<UserParam type="string" name="1630" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11914004532768579511" quality="0">
 			<centroid rt="89.9967845460248" mz="345.216306194175" it="114886"/>
@@ -100,6 +117,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="1205" value="H1"/>
+			<UserParam type="string" name="1207" value="H3"/>
+			<UserParam type="string" name="2309" value="H1"/>
+			<UserParam type="string" name="2310" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5441031069051211757" quality="0">
 			<centroid rt="92.3073785457429" mz="146.0843499362" it="203359"/>
@@ -111,6 +132,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1016" value="H3"/>
+			<UserParam type="string" name="1345" value="H1"/>
+			<UserParam type="string" name="1346" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11708330324181821974" quality="0">
 			<centroid rt="107.038203016022" mz="373.231306194175" it="147525"/>
@@ -123,6 +147,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="1139" value="H1"/>
+			<UserParam type="string" name="2258" value="H1"/>
+			<UserParam type="string" name="2259" value="H3"/>
+			<UserParam type="string" name="2260" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2205439982488162092" quality="0">
 			<centroid rt="108.22645076955" mz="375.22043742025" it="119670"/>
@@ -133,6 +161,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1191" value="H2"/>
+			<UserParam type="string" name="2046" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_16854092442615782435" quality="0">
 			<centroid rt="115.279572566664" mz="387.2502916135" it="248512"/>
@@ -147,6 +177,12 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="6"/>
+			<UserParam type="string" name="266" value="H3"/>
+			<UserParam type="string" name="267" value="H2"/>
+			<UserParam type="string" name="603" value="H1"/>
+			<UserParam type="string" name="1090" value="H1"/>
+			<UserParam type="string" name="2298" value="H1"/>
+			<UserParam type="string" name="2299" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3689261140477220175" quality="0">
 			<centroid rt="116.455547565225" mz="389.210437420249" it="22500"/>
@@ -157,6 +193,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="386" value="H3"/>
+			<UserParam type="string" name="387" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4867232715518835913" quality="0">
 			<centroid rt="117.136305109981" mz="1117.55826245215" it="70416"/>
@@ -167,6 +205,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="517" value="H1"/>
+			<UserParam type="string" name="518" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5830204045439265130" quality="0">
 			<centroid rt="120.547029300518" mz="396.1643499362" it="35844"/>
@@ -177,6 +217,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="946" value="H1"/>
+			<UserParam type="string" name="947" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_18260815667738914815" quality="0">
 			<centroid rt="123.392362399176" mz="401.24391494258" it="639039"/>
@@ -190,6 +232,11 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="5"/>
+			<UserParam type="string" name="12" value="H1"/>
+			<UserParam type="string" name="1009" value="H1"/>
+			<UserParam type="string" name="1010" value="H3"/>
+			<UserParam type="string" name="1011" value="H2"/>
+			<UserParam type="string" name="2056" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4820763536411289908" quality="0">
 			<centroid rt="125.738333862553" mz="405.2143499362" it="92016"/>
@@ -201,6 +248,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="26" value="H1"/>
+			<UserParam type="string" name="27" value="H3"/>
+			<UserParam type="string" name="28" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5821247793124038316" quality="0">
 			<centroid rt="126.158201320579" mz="403.211741592233" it="113692"/>
@@ -212,6 +262,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="520" value="H2"/>
+			<UserParam type="string" name="1343" value="H3"/>
+			<UserParam type="string" name="1344" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2109097196062066881" quality="0">
 			<centroid rt="129.636860829114" mz="412.14043742025" it="11844"/>
@@ -222,6 +275,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1370" value="H3"/>
+			<UserParam type="string" name="1371" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12009660396631036810" quality="0">
 			<centroid rt="131.355564395529" mz="415.2643499362" it="286704"/>
@@ -233,6 +288,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1510" value="H1"/>
+			<UserParam type="string" name="1512" value="H3"/>
+			<UserParam type="string" name="1513" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17689450036681742932" quality="0">
 			<centroid rt="132.482143002632" mz="417.2243499362" it="533043"/>
@@ -244,6 +302,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="985" value="H1"/>
+			<UserParam type="string" name="986" value="H3"/>
+			<UserParam type="string" name="987" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12262480791455599226" quality="0">
 			<centroid rt="133.046726410572" mz="418.22826245215" it="44008"/>
@@ -254,6 +315,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="150" value="H1"/>
+			<UserParam type="string" name="151" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1689548244641891662" quality="0">
 			<centroid rt="139.796208784914" mz="430.26826245215" it="108796"/>
@@ -264,6 +327,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1743" value="H1"/>
+			<UserParam type="string" name="1744" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6385792639293407798" quality="0">
 			<centroid rt="140.293808712931" mz="431.240437420249" it="86142"/>
@@ -274,6 +339,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2170" value="H3"/>
+			<UserParam type="string" name="2171" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16708561783842155992" quality="0">
 			<centroid rt="141.401697994551" mz="433.2043499362" it="6309"/>
@@ -285,6 +352,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1819" value="H1"/>
+			<UserParam type="string" name="1820" value="H3"/>
+			<UserParam type="string" name="1821" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5127159779622715996" quality="0">
 			<centroid rt="141.968411119672" mz="431.22826245215" it="70416"/>
@@ -295,6 +365,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="515" value="H1"/>
+			<UserParam type="string" name="516" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14929859954397689983" quality="0">
 			<centroid rt="146.889223701133" mz="443.27043742025" it="236908"/>
@@ -305,6 +377,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1006" value="H3"/>
+			<UserParam type="string" name="1007" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3234152552746739377" quality="0">
 			<centroid rt="147.434790938763" mz="444.230437420249" it="41478"/>
@@ -315,6 +389,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1930" value="H3"/>
+			<UserParam type="string" name="1931" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11615228266221962187" quality="0">
 			<centroid rt="148.053385714951" mz="417.2143499362" it="377565"/>
@@ -330,6 +406,13 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="7"/>
+			<UserParam type="string" name="357" value="H1"/>
+			<UserParam type="string" name="358" value="H2"/>
+			<UserParam type="string" name="1433" value="H1"/>
+			<UserParam type="string" name="1434" value="H3"/>
+			<UserParam type="string" name="1435" value="H2"/>
+			<UserParam type="string" name="1934" value="H3"/>
+			<UserParam type="string" name="1935" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12511772691995177188" quality="0">
 			<centroid rt="149.341797304889" mz="819.4843499362" it="140184"/>
@@ -341,6 +424,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="259" value="H1"/>
+			<UserParam type="string" name="260" value="H3"/>
+			<UserParam type="string" name="261" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4040114418401744339" quality="0">
 			<centroid rt="156.081831522207" mz="460.2543499362" it="67500"/>
@@ -352,6 +438,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="409" value="H1"/>
+			<UserParam type="string" name="411" value="H3"/>
+			<UserParam type="string" name="412" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13544601804648356514" quality="0">
 			<centroid rt="156.684941609751" mz="1336.4743499362" it="80649"/>
@@ -363,6 +452,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="952" value="H1"/>
+			<UserParam type="string" name="953" value="H3"/>
+			<UserParam type="string" name="954" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18182188859721298676" quality="0">
 			<centroid rt="157.206285933849" mz="462.2143499362" it="62217"/>
@@ -374,6 +466,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1952" value="H1"/>
+			<UserParam type="string" name="1953" value="H3"/>
+			<UserParam type="string" name="1954" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15756650387420709477" quality="0">
 			<centroid rt="162.521820195769" mz="472.280437420249" it="2804"/>
@@ -384,6 +479,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1814" value="H3"/>
+			<UserParam type="string" name="1815" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7389918414133251354" quality="0">
 			<centroid rt="163.560795755311" mz="474.1543499362" it="99018"/>
@@ -395,6 +492,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="157" value="H1"/>
+			<UserParam type="string" name="158" value="H3"/>
+			<UserParam type="string" name="159" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4681727475063025172" quality="0">
 			<centroid rt="164.633337143973" mz="476.2543499362" it="377244"/>
@@ -406,6 +506,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1642" value="H1"/>
+			<UserParam type="string" name="1643" value="H3"/>
+			<UserParam type="string" name="1644" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14474073871351839234" quality="0">
 			<centroid rt="180.126100832585" mz="474.2343499362" it="98250"/>
@@ -417,6 +520,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="582" value="H1"/>
+			<UserParam type="string" name="583" value="H3"/>
+			<UserParam type="string" name="1339" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3653142717956854595" quality="0">
 			<centroid rt="180.97803055564" mz="504.26826245215" it="44008"/>
@@ -427,6 +533,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="141" value="H1"/>
+			<UserParam type="string" name="142" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7682285360754967626" quality="0">
 			<centroid rt="184.816766567657" mz="515.314349936201" it="251496"/>
@@ -437,6 +545,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1648" value="H1"/>
+			<UserParam type="string" name="1650" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_9615495567243385811" quality="0">
 			<centroid rt="185.779463795605" mz="517.27043742025" it="44008"/>
@@ -447,6 +557,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="132" value="H3"/>
+			<UserParam type="string" name="133" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6953433582095987829" quality="0">
 			<centroid rt="186.677076963054" mz="905.3343499362" it="57663"/>
@@ -458,6 +570,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="654" value="H1"/>
+			<UserParam type="string" name="655" value="H3"/>
+			<UserParam type="string" name="656" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5850344344638243780" quality="0">
 			<centroid rt="187.757082643087" mz="488.2743499362" it="11844"/>
@@ -468,6 +583,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1366" value="H1"/>
+			<UserParam type="string" name="1367" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_8698552683287131943" quality="0">
 			<centroid rt="192.861816999347" mz="967.40826245215" it="155144"/>
@@ -478,6 +595,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="736" value="H1"/>
+			<UserParam type="string" name="737" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16389192520305277702" quality="0">
 			<centroid rt="197.473961523261" mz="989.496306194175" it="516033"/>
@@ -490,6 +609,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="457" value="H1"/>
+			<UserParam type="string" name="2143" value="H1"/>
+			<UserParam type="string" name="2145" value="H3"/>
+			<UserParam type="string" name="2146" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2394605098954710365" quality="0">
 			<centroid rt="204.135553407049" mz="550.28826245215" it="119628"/>
@@ -500,6 +623,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="819" value="H1"/>
+			<UserParam type="string" name="820" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13696138177401351671" quality="0">
 			<centroid rt="205.174173687425" mz="556.3543499362" it="99018"/>
@@ -511,6 +636,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="72" value="H1"/>
+			<UserParam type="string" name="73" value="H3"/>
+			<UserParam type="string" name="74" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7201249942028865195" quality="0">
 			<centroid rt="216.362131353303" mz="1060.5843499362" it="269163"/>
@@ -522,6 +650,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="821" value="H1"/>
+			<UserParam type="string" name="822" value="H3"/>
+			<UserParam type="string" name="823" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5480919462940853731" quality="0">
 			<centroid rt="217.030124787991" mz="544.2943499362" it="50625"/>
@@ -533,6 +664,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="413" value="H1"/>
+			<UserParam type="string" name="414" value="H3"/>
+			<UserParam type="string" name="415" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12946874817643234292" quality="0">
 			<centroid rt="224.153922818876" mz="558.14043742025" it="62304"/>
@@ -543,6 +677,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="211" value="H3"/>
+			<UserParam type="string" name="212" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6454617566979140295" quality="0">
 			<centroid rt="225.702337433592" mz="1607.52826245215" it="27652"/>
@@ -553,6 +689,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1972" value="H1"/>
+			<UserParam type="string" name="1973" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5264711331793316269" quality="0">
 			<centroid rt="226.205270140334" mz="600.3443499362" it="43660"/>
@@ -563,6 +701,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1234" value="H1"/>
+			<UserParam type="string" name="1235" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_11249530710477422551" quality="0">
 			<centroid rt="230.915461886258" mz="610.25826245215" it="179442"/>
@@ -573,6 +713,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="806" value="H1"/>
+			<UserParam type="string" name="808" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2379849755935675623" quality="0">
 			<centroid rt="234.12248368149" mz="617.3243499362" it="6309"/>
@@ -584,6 +726,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1835" value="H1"/>
+			<UserParam type="string" name="1836" value="H3"/>
+			<UserParam type="string" name="1837" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4009288077735937497" quality="0">
 			<centroid rt="235.273078387883" mz="1128.62826245215" it="43660"/>
@@ -594,6 +739,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1210" value="H1"/>
+			<UserParam type="string" name="1211" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6670246060302002180" quality="0">
 			<centroid rt="242.129372777318" mz="630.329712430884" it="159068"/>
@@ -608,6 +755,12 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="6"/>
+			<UserParam type="string" name="136" value="H1"/>
+			<UserParam type="string" name="138" value="H2"/>
+			<UserParam type="string" name="1215" value="H3"/>
+			<UserParam type="string" name="1216" value="H2"/>
+			<UserParam type="string" name="2303" value="H3"/>
+			<UserParam type="string" name="2304" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12628330791510435167" quality="0">
 			<centroid rt="242.434041447677" mz="635.3443499362" it="26649"/>
@@ -619,6 +772,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1409" value="H1"/>
+			<UserParam type="string" name="1410" value="H3"/>
+			<UserParam type="string" name="1411" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13861633209641739541" quality="0">
 			<centroid rt="243.047649834896" mz="632.29826245215" it="108796"/>
@@ -629,6 +785,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1709" value="H1"/>
+			<UserParam type="string" name="1710" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5824608157929324458" quality="0">
 			<centroid rt="243.551925941487" mz="633.32043742025" it="101292"/>
@@ -639,6 +797,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1557" value="H3"/>
+			<UserParam type="string" name="1558" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5540086033413939129" quality="0">
 			<centroid rt="245.574177025115" mz="642.33826245215" it="95568"/>
@@ -649,6 +809,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1483" value="H1"/>
+			<UserParam type="string" name="1484" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5810271152339173650" quality="0">
 			<centroid rt="251.03708044183" mz="1197.5043499362" it="33750"/>
@@ -659,6 +821,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="364" value="H1"/>
+			<UserParam type="string" name="366" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_2521601465549612039" quality="0">
 			<centroid rt="251.152444360668" mz="274.14826245215" it="123568"/>
@@ -669,6 +833,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="706" value="H1"/>
+			<UserParam type="string" name="707" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14705663600352314330" quality="0">
 			<centroid rt="253.73738109319" mz="1208.46826245215" it="139372"/>
@@ -679,6 +845,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1449" value="H1"/>
+			<UserParam type="string" name="1450" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9775987800108098995" quality="0">
 			<centroid rt="255.061994859603" mz="663.38043742025" it="139372"/>
@@ -689,6 +857,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1427" value="H3"/>
+			<UserParam type="string" name="1428" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13220962751586050085" quality="0">
 			<centroid rt="259.949928987652" mz="674.34826245215" it="25628"/>
@@ -699,6 +869,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="636" value="H1"/>
+			<UserParam type="string" name="637" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6902916940610965704" quality="0">
 			<centroid rt="260.659533422546" mz="633.28826245215" it="67172"/>
@@ -709,6 +881,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="875" value="H1"/>
+			<UserParam type="string" name="876" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12887217358916438804" quality="0">
 			<centroid rt="263.394279097891" mz="1248.6243499362" it="494937"/>
@@ -720,6 +894,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1890" value="H1"/>
+			<UserParam type="string" name="1891" value="H3"/>
+			<UserParam type="string" name="1892" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7516972427153251485" quality="0">
 			<centroid rt="265.981199223512" mz="288.1343499362" it="151137"/>
@@ -731,6 +908,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="878" value="H1"/>
+			<UserParam type="string" name="879" value="H3"/>
+			<UserParam type="string" name="880" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11193672689319028190" quality="0">
 			<centroid rt="268.205341980109" mz="649.23826245215" it="95568"/>
@@ -741,6 +921,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1539" value="H1"/>
+			<UserParam type="string" name="1540" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1530584577298592600" quality="0">
 			<centroid rt="268.2998173518" mz="693.364349936201" it="179442"/>
@@ -751,6 +933,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="762" value="H1"/>
+			<UserParam type="string" name="764" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_3331403230535688913" quality="0">
 			<centroid rt="270.315300538503" mz="1946.8643499362" it="100758"/>
@@ -761,6 +945,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="870" value="H1"/>
+			<UserParam type="string" name="872" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_3339536125496735273" quality="0">
 			<centroid rt="271.304634207364" mz="1156.35826245215" it="22500"/>
@@ -771,6 +957,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="443" value="H1"/>
+			<UserParam type="string" name="444" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6751127875391210335" quality="0">
 			<centroid rt="273.919586907429" mz="1225.46826245215" it="96088"/>
@@ -781,6 +969,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1277" value="H1"/>
+			<UserParam type="string" name="1278" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17123655756602803352" quality="0">
 			<centroid rt="280.455427254639" mz="302.15826245215" it="68819"/>
@@ -791,6 +981,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1920" value="H2"/>
+			<UserParam type="string" name="1980" value="H1"/>
 		</consensusElement>
 		<consensusElement id="e_16751980007608063774" quality="0">
 			<centroid rt="282.563474291661" mz="304.156958280167" it="119798"/>
@@ -802,6 +994,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="145" value="H1"/>
+			<UserParam type="string" name="1746" value="H1"/>
+			<UserParam type="string" name="1747" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_9464548758349838292" quality="0">
 			<centroid rt="283.855446096505" mz="729.41826245215" it="22500"/>
@@ -812,6 +1007,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="382" value="H1"/>
+			<UserParam type="string" name="383" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18306029319870456046" quality="0">
 			<centroid rt="290.772450329762" mz="1364.65826245215" it="145280"/>
@@ -822,6 +1019,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2092" value="H1"/>
+			<UserParam type="string" name="2093" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14051950164019764845" quality="0">
 			<centroid rt="292.770669135855" mz="750.420437420251" it="101292"/>
@@ -832,6 +1031,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1584" value="H3"/>
+			<UserParam type="string" name="1585" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14637089016487238086" quality="0">
 			<centroid rt="295.696031233206" mz="317.1443499362" it="132024"/>
@@ -843,6 +1044,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="146" value="H1"/>
+			<UserParam type="string" name="148" value="H3"/>
+			<UserParam type="string" name="149" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9531617589606093433" quality="0">
 			<centroid rt="296.645015966645" mz="318.1593499362" it="163052"/>
@@ -855,6 +1059,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="522" value="H3"/>
+			<UserParam type="string" name="523" value="H2"/>
+			<UserParam type="string" name="2199" value="H1"/>
+			<UserParam type="string" name="2200" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3865198601058924625" quality="0">
 			<centroid rt="298.989385440151" mz="765.36826245215" it="199396"/>
@@ -865,6 +1073,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1088" value="H1"/>
+			<UserParam type="string" name="1089" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6755797289213850422" quality="0">
 			<centroid rt="308.974951473473" mz="2296.97043742025" it="119628"/>
@@ -875,6 +1085,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="787" value="H3"/>
+			<UserParam type="string" name="788" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13861942564234988757" quality="0">
 			<centroid rt="309.873825766981" mz="786.36826245215" it="62304"/>
@@ -885,6 +1097,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="262" value="H1"/>
+			<UserParam type="string" name="263" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15910657558162614540" quality="0">
 			<centroid rt="310.485667795316" mz="332.1643499362" it="99018"/>
@@ -896,6 +1110,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="84" value="H1"/>
+			<UserParam type="string" name="85" value="H3"/>
+			<UserParam type="string" name="86" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10166224148868448297" quality="0">
 			<centroid rt="312.426660319322" mz="334.12043742025" it="163194"/>
@@ -906,6 +1123,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1739" value="H3"/>
+			<UserParam type="string" name="1740" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15580919964397491649" quality="0">
 			<centroid rt="312.601549139224" mz="798.3343499362" it="235188"/>
@@ -917,6 +1136,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="532" value="H1"/>
+			<UserParam type="string" name="534" value="H3"/>
+			<UserParam type="string" name="535" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5359066125511492168" quality="0">
 			<centroid rt="313.652278733039" mz="795.343624946833" it="60495"/>
@@ -928,6 +1150,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="16" value="H1"/>
+			<UserParam type="string" name="17" value="H2"/>
+			<UserParam type="string" name="542" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_303888516526326815" quality="0">
 			<centroid rt="315.074804775288" mz="804.41043742025" it="57428"/>
@@ -938,6 +1163,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2181" value="H3"/>
+			<UserParam type="string" name="2182" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15068949529243170918" quality="0">
 			<centroid rt="318.791684407701" mz="762.38043742025" it="62304"/>
@@ -948,6 +1175,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="244" value="H3"/>
+			<UserParam type="string" name="245" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14857937123530962969" quality="0">
 			<centroid rt="320.152588501081" mz="342.18826245215" it="27652"/>
@@ -958,6 +1187,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1936" value="H1"/>
+			<UserParam type="string" name="1937" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5428465079364001328" quality="0">
 			<centroid rt="322.069927464204" mz="344.19878492982" it="217927"/>
@@ -971,6 +1202,11 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="5"/>
+			<UserParam type="string" name="173" value="H2"/>
+			<UserParam type="string" name="573" value="H1"/>
+			<UserParam type="string" name="574" value="H3"/>
+			<UserParam type="string" name="798" value="H2"/>
+			<UserParam type="string" name="1791" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_12659797177087098225" quality="0">
 			<centroid rt="322.226863102843" mz="770.29043742025" it="119628"/>
@@ -981,6 +1217,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="749" value="H3"/>
+			<UserParam type="string" name="750" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10259040993376617673" quality="0">
 			<centroid rt="323.03149810166" mz="345.15043742025" it="49396"/>
@@ -991,6 +1229,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2214" value="H3"/>
+			<UserParam type="string" name="2215" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6838850249128907110" quality="0">
 			<centroid rt="323.75717898744" mz="768.2943499362" it="67500"/>
@@ -1002,6 +1242,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="473" value="H1"/>
+			<UserParam type="string" name="475" value="H3"/>
+			<UserParam type="string" name="476" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10953835905226332437" quality="0">
 			<centroid rt="325.00300202571" mz="823.350437420251" it="71916"/>
@@ -1012,6 +1255,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1876" value="H3"/>
+			<UserParam type="string" name="1877" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5226631383535234277" quality="0">
 			<centroid rt="325.887981746754" mz="348.14826245215" it="25628"/>
@@ -1022,6 +1267,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="665" value="H1"/>
+			<UserParam type="string" name="666" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13661975717892968103" quality="0">
 			<centroid rt="327.763592182559" mz="830.41826245215" it="86142"/>
@@ -1032,6 +1279,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2184" value="H1"/>
+			<UserParam type="string" name="2186" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17448885682388952853" quality="0">
 			<centroid rt="328.988080244403" mz="786.37043742025" it="44008"/>
@@ -1042,6 +1291,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="82" value="H3"/>
+			<UserParam type="string" name="83" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2136612772032166066" quality="0">
 			<centroid rt="329.65892358228" mz="318.1343499362" it="187479"/>
@@ -1053,6 +1304,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="369" value="H1"/>
+			<UserParam type="string" name="370" value="H2"/>
+			<UserParam type="string" name="1919" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_13892141741539497133" quality="0">
 			<centroid rt="331.144169936175" mz="1545.6843499362" it="143832"/>
@@ -1064,6 +1318,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1856" value="H1"/>
+			<UserParam type="string" name="1858" value="H3"/>
+			<UserParam type="string" name="1859" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13614824326406154070" quality="0">
 			<centroid rt="331.869592943709" mz="787.3943499362" it="108796"/>
@@ -1074,6 +1331,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1770" value="H1"/>
+			<UserParam type="string" name="1771" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_10876598055094447352" quality="0">
 			<centroid rt="332.588602633847" mz="842.4543499362" it="82956"/>
@@ -1085,6 +1344,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1944" value="H1"/>
+			<UserParam type="string" name="1946" value="H3"/>
+			<UserParam type="string" name="1947" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_516214271458253095" quality="0">
 			<centroid rt="333.552979270649" mz="356.2143499362" it="111141"/>
@@ -1096,6 +1358,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2272" value="H1"/>
+			<UserParam type="string" name="2273" value="H3"/>
+			<UserParam type="string" name="2274" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18265836702438688038" quality="0">
 			<centroid rt="334.334782857783" mz="1479.59826245215" it="62304"/>
@@ -1106,6 +1371,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="226" value="H1"/>
+			<UserParam type="string" name="227" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11640339124559834410" quality="0">
 			<centroid rt="334.985707285732" mz="854.43826245215" it="139372"/>
@@ -1116,6 +1383,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1420" value="H1"/>
+			<UserParam type="string" name="1421" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6510424408054565566" quality="0">
 			<centroid rt="336.277049015305" mz="359.18791494258" it="145293"/>
@@ -1129,6 +1398,11 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="5"/>
+			<UserParam type="string" name="405" value="H1"/>
+			<UserParam type="string" name="407" value="H3"/>
+			<UserParam type="string" name="408" value="H2"/>
+			<UserParam type="string" name="827" value="H2"/>
+			<UserParam type="string" name="2059" value="H1"/>
 		</consensusElement>
 		<consensusElement id="e_10407266148476639596" quality="0">
 			<centroid rt="337.212463035182" mz="360.1943499362" it="279979"/>
@@ -1140,6 +1414,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="983" value="H1"/>
+			<UserParam type="string" name="984" value="H2"/>
+			<UserParam type="string" name="2187" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_16192080319400614886" quality="0">
 			<centroid rt="338.159416827139" mz="862.40826245215" it="119628"/>
@@ -1150,6 +1427,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="768" value="H1"/>
+			<UserParam type="string" name="769" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11920269770908102056" quality="0">
 			<centroid rt="339.145364481239" mz="362.1743499362" it="153185"/>
@@ -1164,6 +1443,12 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="6"/>
+			<UserParam type="string" name="351" value="H1"/>
+			<UserParam type="string" name="352" value="H3"/>
+			<UserParam type="string" name="353" value="H2"/>
+			<UserParam type="string" name="486" value="H1"/>
+			<UserParam type="string" name="1126" value="H2"/>
+			<UserParam type="string" name="1183" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_2594893345340989928" quality="0">
 			<centroid rt="339.9983728714" mz="812.310437420251" it="145280"/>
@@ -1174,6 +1459,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2090" value="H3"/>
+			<UserParam type="string" name="2091" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12109319218587594170" quality="0">
 			<centroid rt="341.293336416844" mz="1576.59043742025" it="145280"/>
@@ -1184,6 +1471,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2085" value="H3"/>
+			<UserParam type="string" name="2086" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13327553597570019161" quality="0">
 			<centroid rt="343.579687344137" mz="2539.2043499362" it="224780"/>
@@ -1194,6 +1483,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="174" value="H1"/>
+			<UserParam type="string" name="175" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_11064254708540892455" quality="0">
 			<centroid rt="345.722270896043" mz="772.22043742025" it="104872"/>
@@ -1204,6 +1495,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1604" value="H3"/>
+			<UserParam type="string" name="1605" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_762250977569711826" quality="0">
 			<centroid rt="346.210597088184" mz="827.45826245215" it="144132"/>
@@ -1214,6 +1507,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1322" value="H1"/>
+			<UserParam type="string" name="1324" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4562922765641115243" quality="0">
 			<centroid rt="348.317663524418" mz="1609.70043742025" it="119628"/>
@@ -1224,6 +1519,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="860" value="H3"/>
+			<UserParam type="string" name="861" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11777694543767517161" quality="0">
 			<centroid rt="348.441994100436" mz="372.2443499362" it="98235"/>
@@ -1235,6 +1532,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1223" value="H1"/>
+			<UserParam type="string" name="1224" value="H3"/>
+			<UserParam type="string" name="1225" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8962534923201445474" quality="0">
 			<centroid rt="349.269903437296" mz="373.19043742025" it="117594"/>
@@ -1245,6 +1545,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="540" value="H3"/>
+			<UserParam type="string" name="541" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17021685179428908193" quality="0">
 			<centroid rt="349.384703327061" mz="891.3443499362" it="44008"/>
@@ -1255,6 +1557,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="34" value="H1"/>
+			<UserParam type="string" name="35" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_14381614262961404196" quality="0">
 			<centroid rt="350.188639897466" mz="374.2143499362" it="327456"/>
@@ -1266,6 +1570,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1116" value="H1"/>
+			<UserParam type="string" name="1117" value="H3"/>
+			<UserParam type="string" name="1118" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4490040756851272168" quality="0">
 			<centroid rt="351.106156142258" mz="375.1943499362" it="50625"/>
@@ -1277,6 +1584,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="461" value="H1"/>
+			<UserParam type="string" name="462" value="H3"/>
+			<UserParam type="string" name="463" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11157801636400394411" quality="0">
 			<centroid rt="351.464456054243" mz="1632.70043742025" it="74228"/>
@@ -1287,6 +1597,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="598" value="H3"/>
+			<UserParam type="string" name="599" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4313342658551957614" quality="0">
 			<centroid rt="352.113326105051" mz="376.1743499362" it="494937"/>
@@ -1298,6 +1610,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1887" value="H1"/>
+			<UserParam type="string" name="1888" value="H3"/>
+			<UserParam type="string" name="1889" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8620983441184055778" quality="0">
 			<centroid rt="353.034180047619" mz="377.150437420249" it="67172"/>
@@ -1308,6 +1623,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="882" value="H3"/>
+			<UserParam type="string" name="883" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13894638201390852440" quality="0">
 			<centroid rt="353.920953149291" mz="374.1893499362" it="92124"/>
@@ -1320,6 +1637,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="810" value="H2"/>
+			<UserParam type="string" name="1984" value="H1"/>
+			<UserParam type="string" name="1985" value="H3"/>
+			<UserParam type="string" name="1986" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4991596156778081846" quality="0">
 			<centroid rt="355.677116608034" mz="380.18826245215" it="139372"/>
@@ -1330,6 +1651,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1423" value="H1"/>
+			<UserParam type="string" name="1424" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16327037495896691215" quality="0">
 			<centroid rt="355.707596182333" mz="838.2743499362" it="158436"/>
@@ -1341,6 +1664,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="526" value="H1"/>
+			<UserParam type="string" name="527" value="H3"/>
+			<UserParam type="string" name="528" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1680969305911844181" quality="0">
 			<centroid rt="356.105754005315" mz="902.38826245215" it="49396"/>
@@ -1351,6 +1677,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2245" value="H1"/>
+			<UserParam type="string" name="2246" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13820505630266040532" quality="0">
 			<centroid rt="358.376169027252" mz="346.1443499362" it="283520"/>
@@ -1363,6 +1691,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="765" value="H1"/>
+			<UserParam type="string" name="766" value="H3"/>
+			<UserParam type="string" name="767" value="H2"/>
+			<UserParam type="string" name="2202" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14574564359867106852" quality="0">
 			<centroid rt="359.351941818037" mz="917.47043742025" it="49396"/>
@@ -1373,6 +1705,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2268" value="H3"/>
+			<UserParam type="string" name="2269" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17935012925381716076" quality="0">
 			<centroid rt="361.209586361166" mz="386.2443499362" it="41738"/>
@@ -1384,6 +1718,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1397" value="H1"/>
+			<UserParam type="string" name="1398" value="H2"/>
+			<UserParam type="string" name="1847" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_6231832979177215395" quality="0">
 			<centroid rt="361.292125059378" mz="922.4243499362" it="50625"/>
@@ -1395,6 +1732,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="392" value="H1"/>
+			<UserParam type="string" name="393" value="H3"/>
+			<UserParam type="string" name="394" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17150099368523549144" quality="0">
 			<centroid rt="362.02238645412" mz="387.20826245215" it="62304"/>
@@ -1405,6 +1745,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="205" value="H1"/>
+			<UserParam type="string" name="206" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5595376604118922889" quality="0">
 			<centroid rt="363.014527696936" mz="388.2243499362" it="137510"/>
@@ -1416,6 +1758,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1736" value="H1"/>
+			<UserParam type="string" name="1737" value="H2"/>
+			<UserParam type="string" name="2172" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_16458741447446419218" quality="0">
 			<centroid rt="365.628777139587" mz="391.14826245215" it="67172"/>
@@ -1426,6 +1771,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="886" value="H1"/>
+			<UserParam type="string" name="887" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4576798593346933596" quality="0">
 			<centroid rt="368.070363483036" mz="940.43826245215" it="74228"/>
@@ -1436,6 +1783,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="590" value="H1"/>
+			<UserParam type="string" name="591" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15751785847848334819" quality="0">
 			<centroid rt="368.541509942002" mz="390.1643499362" it="533043"/>
@@ -1447,6 +1796,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="992" value="H1"/>
+			<UserParam type="string" name="993" value="H3"/>
+			<UserParam type="string" name="994" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16741851888721107236" quality="0">
 			<centroid rt="370.688814416531" mz="947.4143499362" it="62217"/>
@@ -1458,6 +1810,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1963" value="H1"/>
+			<UserParam type="string" name="1964" value="H3"/>
+			<UserParam type="string" name="1965" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18102205372429128833" quality="0">
 			<centroid rt="371.690281502248" mz="3888.76043742025" it="33750"/>
@@ -1468,6 +1823,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="417" value="H3"/>
+			<UserParam type="string" name="418" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3126757167111155444" quality="0">
 			<centroid rt="372.39758816797" mz="360.170328065188" it="482932"/>
@@ -1484,6 +1841,14 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="8"/>
+			<UserParam type="string" name="495" value="H1"/>
+			<UserParam type="string" name="496" value="H2"/>
+			<UserParam type="string" name="777" value="H1"/>
+			<UserParam type="string" name="778" value="H3"/>
+			<UserParam type="string" name="779" value="H2"/>
+			<UserParam type="string" name="2164" value="H1"/>
+			<UserParam type="string" name="2165" value="H3"/>
+			<UserParam type="string" name="2166" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3484558724104043683" quality="0">
 			<centroid rt="375.105049088024" mz="959.5543499362" it="140184"/>
@@ -1495,6 +1860,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="286" value="H1"/>
+			<UserParam type="string" name="287" value="H3"/>
+			<UserParam type="string" name="288" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7333023931319111871" quality="0">
 			<centroid rt="377.207022313358" mz="404.17826245215" it="43660"/>
@@ -1505,6 +1873,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1203" value="H1"/>
+			<UserParam type="string" name="1204" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9174892464712619146" quality="0">
 			<centroid rt="379.301960734719" mz="402.20826245215" it="84485"/>
@@ -1515,6 +1885,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="724" value="H1"/>
+			<UserParam type="string" name="1970" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15153436977104711717" quality="0">
 			<centroid rt="380.191826340629" mz="403.1843499362" it="288264"/>
@@ -1526,6 +1898,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1306" value="H1"/>
+			<UserParam type="string" name="1308" value="H3"/>
+			<UserParam type="string" name="1309" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5762738895808714267" quality="0">
 			<centroid rt="380.47661021266" mz="912.5143499362" it="269163"/>
@@ -1537,6 +1912,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="824" value="H1"/>
+			<UserParam type="string" name="825" value="H3"/>
+			<UserParam type="string" name="826" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8524147271801856022" quality="0">
 			<centroid rt="380.836278582335" mz="408.2018499362" it="228547"/>
@@ -1549,6 +1927,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="1311" value="H1"/>
+			<UserParam type="string" name="1312" value="H3"/>
+			<UserParam type="string" name="1313" value="H2"/>
+			<UserParam type="string" name="2210" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18140603549907533607" quality="0">
 			<centroid rt="382.910153365272" mz="406.15791494258" it="375891"/>
@@ -1562,6 +1944,11 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="5"/>
+			<UserParam type="string" name="192" value="H1"/>
+			<UserParam type="string" name="193" value="H2"/>
+			<UserParam type="string" name="1437" value="H1"/>
+			<UserParam type="string" name="1438" value="H3"/>
+			<UserParam type="string" name="1439" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15008427511225474588" quality="0">
 			<centroid rt="385.5060303307" mz="987.50043742025" it="22500"/>
@@ -1572,6 +1959,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="348" value="H3"/>
+			<UserParam type="string" name="349" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15483183002182184079" quality="0">
 			<centroid rt="385.506229173659" mz="2766.22826245215" it="185352"/>
@@ -1582,6 +1971,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="686" value="H1"/>
+			<UserParam type="string" name="688" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11005949482763208404" quality="0">
 			<centroid rt="386.050467997037" mz="374.1943499362" it="50625"/>
@@ -1593,6 +1984,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="453" value="H1"/>
+			<UserParam type="string" name="454" value="H3"/>
+			<UserParam type="string" name="455" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2986176908586394324" quality="0">
 			<centroid rt="386.941110992093" mz="415.26826245215" it="11844"/>
@@ -1603,6 +1997,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1395" value="H1"/>
+			<UserParam type="string" name="1396" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4935649125788090567" quality="0">
 			<centroid rt="387.345149581637" mz="1731.91826245215" it="74094"/>
@@ -1613,6 +2009,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2231" value="H1"/>
+			<UserParam type="string" name="2233" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17247587268268495010" quality="0">
 			<centroid rt="388.539487254434" mz="926.4743499362" it="176391"/>
@@ -1624,6 +2022,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="547" value="H1"/>
+			<UserParam type="string" name="548" value="H3"/>
+			<UserParam type="string" name="549" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9447481036681906783" quality="0">
 			<centroid rt="388.753632032001" mz="996.43043742025" it="49396"/>
@@ -1634,6 +2035,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2261" value="H3"/>
+			<UserParam type="string" name="2262" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6531735591087340934" quality="0">
 			<centroid rt="389.154017474867" mz="997.42826245215" it="104872"/>
@@ -1644,6 +2047,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1608" value="H1"/>
+			<UserParam type="string" name="1609" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4834201762527682492" quality="0">
 			<centroid rt="389.552829223372" mz="418.205074925567" it="86214"/>
@@ -1655,6 +2060,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="571" value="H3"/>
+			<UserParam type="string" name="572" value="H2"/>
+			<UserParam type="string" name="1852" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11174587021400785296" quality="0">
 			<centroid rt="393.016356860967" mz="422.2243499362" it="111141"/>
@@ -1666,6 +2074,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2247" value="H1"/>
+			<UserParam type="string" name="2248" value="H3"/>
+			<UserParam type="string" name="2249" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3665346557358958339" quality="0">
 			<centroid rt="395.169653697765" mz="1759.6343499362" it="215028"/>
@@ -1677,6 +2088,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1515" value="H1"/>
+			<UserParam type="string" name="1516" value="H3"/>
+			<UserParam type="string" name="1517" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9182647610268163580" quality="0">
 			<centroid rt="396.982324311962" mz="422.191741592234" it="30003"/>
@@ -1688,6 +2102,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1769" value="H2"/>
+			<UserParam type="string" name="1804" value="H3"/>
+			<UserParam type="string" name="1805" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17065165586124823299" quality="0">
 			<centroid rt="401.777987818437" mz="967.54043742025" it="119628"/>
@@ -1698,6 +2115,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="832" value="H3"/>
+			<UserParam type="string" name="833" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5512254034064962131" quality="0">
 			<centroid rt="402.490557951076" mz="433.216958280167" it="178195"/>
@@ -1709,6 +2128,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1414" value="H2"/>
+			<UserParam type="string" name="1531" value="H1"/>
+			<UserParam type="string" name="1533" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15382244702731556800" quality="0">
 			<centroid rt="403.236754149023" mz="392.136958280167" it="112153"/>
@@ -1720,6 +2142,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="229" value="H1"/>
+			<UserParam type="string" name="230" value="H2"/>
+			<UserParam type="string" name="1022" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15324372495313328414" quality="0">
 			<centroid rt="404.16652390996" mz="435.21043742025" it="107730"/>
@@ -1730,6 +2155,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1158" value="H3"/>
+			<UserParam type="string" name="1652" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17522844710416281548" quality="0">
 			<centroid rt="404.675422005284" mz="431.19278492982" it="121518"/>
@@ -1743,6 +2170,11 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="5"/>
+			<UserParam type="string" name="102" value="H1"/>
+			<UserParam type="string" name="103" value="H3"/>
+			<UserParam type="string" name="104" value="H2"/>
+			<UserParam type="string" name="315" value="H3"/>
+			<UserParam type="string" name="316" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10479840143396665791" quality="0">
 			<centroid rt="408.493529242122" mz="1051.53826245215" it="101292"/>
@@ -1753,6 +2185,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1570" value="H1"/>
+			<UserParam type="string" name="1571" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16650707177245122271" quality="0">
 			<centroid rt="409.201980349397" mz="1053.56043742025" it="96088"/>
@@ -1763,6 +2197,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1325" value="H3"/>
+			<UserParam type="string" name="1326" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1064765506461733296" quality="0">
 			<centroid rt="409.257112641535" mz="441.2443499362" it="47944"/>
@@ -1773,6 +2209,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1845" value="H1"/>
+			<UserParam type="string" name="1846" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_14160447212373628614" quality="0">
 			<centroid rt="411.789264249587" mz="444.25826245215" it="74094"/>
@@ -1783,6 +2221,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2253" value="H1"/>
+			<UserParam type="string" name="2255" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11727982836775051617" quality="0">
 			<centroid rt="412.433405952312" mz="1062.50826245215" it="22500"/>
@@ -1793,6 +2233,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="375" value="H1"/>
+			<UserParam type="string" name="376" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4974058833414362447" quality="0">
 			<centroid rt="412.611625293508" mz="402.206306194175" it="183872"/>
@@ -1805,6 +2247,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="75" value="H3"/>
+			<UserParam type="string" name="1253" value="H1"/>
+			<UserParam type="string" name="1669" value="H1"/>
+			<UserParam type="string" name="2047" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14963360323727092680" quality="0">
 			<centroid rt="413.474382949564" mz="446.23826245215" it="49396"/>
@@ -1815,6 +2261,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2239" value="H1"/>
+			<UserParam type="string" name="2240" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12456301316875125227" quality="0">
 			<centroid rt="412.715575537533" mz="445.26826245215" it="121124"/>
@@ -1825,6 +2273,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2027" value="H1"/>
+			<UserParam type="string" name="2028" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14537950122392186284" quality="0">
 			<centroid rt="413.548945757938" mz="403.1643499362" it="151137"/>
@@ -1836,6 +2286,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="897" value="H1"/>
+			<UserParam type="string" name="898" value="H3"/>
+			<UserParam type="string" name="899" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6290192726424767374" quality="0">
 			<centroid rt="415.744138365653" mz="1869.7543499362" it="50625"/>
@@ -1847,6 +2300,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="338" value="H1"/>
+			<UserParam type="string" name="339" value="H3"/>
+			<UserParam type="string" name="340" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14394637352603421838" quality="0">
 			<centroid rt="417.320962673175" mz="1008.43826245215" it="86142"/>
@@ -1857,6 +2313,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2203" value="H1"/>
+			<UserParam type="string" name="2205" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17132439150973634788" quality="0">
 			<centroid rt="417.548487082551" mz="446.18043742025" it="62304"/>
@@ -1867,6 +2325,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="292" value="H3"/>
+			<UserParam type="string" name="293" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2145086746732522357" quality="0">
 			<centroid rt="418.468456151149" mz="1873.9443499362" it="44008"/>
@@ -1877,6 +2337,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="94" value="H1"/>
+			<UserParam type="string" name="95" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_12387416987438877775" quality="0">
 			<centroid rt="418.627530470907" mz="1072.47043742025" it="35844"/>
@@ -1887,6 +2349,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="940" value="H3"/>
+			<UserParam type="string" name="941" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6997614443443287613" quality="0">
 			<centroid rt="418.798631185897" mz="1012.57043742025" it="78396"/>
@@ -1897,6 +2361,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="550" value="H3"/>
+			<UserParam type="string" name="551" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6400837867620738983" quality="0">
 			<centroid rt="421.14339323679" mz="1087.6118499362" it="385458"/>
@@ -1909,6 +2375,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="720" value="H1"/>
+			<UserParam type="string" name="721" value="H3"/>
+			<UserParam type="string" name="722" value="H2"/>
+			<UserParam type="string" name="1142" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_321274170279366372" quality="0">
 			<centroid rt="422.105839440694" mz="1082.41043742025" it="185352"/>
@@ -1919,6 +2389,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="701" value="H3"/>
+			<UserParam type="string" name="702" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11568677127311698258" quality="0">
 			<centroid rt="422.747456253814" mz="457.296958280167" it="96904"/>
@@ -1930,6 +2402,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="123" value="H1"/>
+			<UserParam type="string" name="125" value="H2"/>
+			<UserParam type="string" name="695" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6643632688924426635" quality="0">
 			<centroid rt="423.909385007484" mz="1901.0043499362" it="100758"/>
@@ -1940,6 +2415,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="919" value="H1"/>
+			<UserParam type="string" name="921" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_16474422853683527225" quality="0">
 			<centroid rt="424.406593791033" mz="459.27043742025" it="22500"/>
@@ -1950,6 +2427,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="464" value="H3"/>
+			<UserParam type="string" name="465" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3929419912479647119" quality="0">
 			<centroid rt="426.242838977186" mz="417.2420168374" it="101754"/>
@@ -1963,6 +2442,11 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="44" value="H1"/>
+			<UserParam type="string" name="46" value="H2"/>
+			<UserParam type="string" name="1171" value="Na2"/>
+			<UserParam type="string" name="1402" value="H1Na2"/>
+			<UserParam type="string" name="1403" value="Na2"/>
 		</consensusElement>
 		<consensusElement id="e_2779271665215668688" quality="0">
 			<centroid rt="429.281925495302" mz="465.2143499362" it="122688"/>
@@ -1974,6 +2458,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="22" value="H1"/>
+			<UserParam type="string" name="24" value="H3"/>
+			<UserParam type="string" name="25" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9735070476369927329" quality="0">
 			<centroid rt="429.291316040235" mz="420.16043742025" it="62304"/>
@@ -1984,6 +2471,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="283" value="H3"/>
+			<UserParam type="string" name="284" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17030667672638136943" quality="0">
 			<centroid rt="429.716758723453" mz="1034.3643499362" it="377244"/>
@@ -1995,6 +2484,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1670" value="H1"/>
+			<UserParam type="string" name="1671" value="H3"/>
+			<UserParam type="string" name="1672" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3927525400249623109" quality="0">
 			<centroid rt="432.252255079792" mz="1119.60826245215" it="67172"/>
@@ -2005,6 +2497,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="917" value="H1"/>
+			<UserParam type="string" name="918" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5787993065284627483" quality="0">
 			<centroid rt="432.930450838302" mz="1113.52043742025" it="96088"/>
@@ -2015,6 +2509,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1275" value="H3"/>
+			<UserParam type="string" name="1276" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3453333120821794829" quality="0">
 			<centroid rt="433.99958422608" mz="1053.46826245215" it="74228"/>
@@ -2025,6 +2521,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="608" value="H1"/>
+			<UserParam type="string" name="609" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16015422033481812468" quality="0">
 			<centroid rt="434.261156070066" mz="471.275799914933" it="42125"/>
@@ -2036,6 +2534,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1399" value="H3"/>
+			<UserParam type="string" name="1400" value="H2"/>
+			<UserParam type="string" name="2019" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_18224553694319862929" quality="0">
 			<centroid rt="436.661049514224" mz="474.21826245215" it="62304"/>
@@ -2046,6 +2547,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="297" value="H1"/>
+			<UserParam type="string" name="298" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12599647476361939529" quality="0">
 			<centroid rt="437.636697873744" mz="1969.88826245215" it="219972"/>
@@ -2056,6 +2559,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1894" value="H1"/>
+			<UserParam type="string" name="1895" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4742408110451377537" quality="0">
 			<centroid rt="438.836624514491" mz="1138.49826245215" it="145280"/>
@@ -2066,6 +2571,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2104" value="H1"/>
+			<UserParam type="string" name="2105" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8482581021593860320" quality="0">
 			<centroid rt="439.185163758902" mz="477.210437420251" it="62304"/>
@@ -2076,6 +2583,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="213" value="H3"/>
+			<UserParam type="string" name="214" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6196143334683817528" quality="0">
 			<centroid rt="439.910561803916" mz="478.2143499362" it="215082"/>
@@ -2087,6 +2596,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1192" value="H1"/>
+			<UserParam type="string" name="1193" value="H3"/>
+			<UserParam type="string" name="1194" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16840130520628058789" quality="0">
 			<centroid rt="440.077561961192" mz="473.25326245215" it="93404"/>
@@ -2099,6 +2611,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="48" value="H1"/>
+			<UserParam type="string" name="49" value="H2"/>
+			<UserParam type="string" name="2229" value="H1"/>
+			<UserParam type="string" name="2230" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14256772951414695730" quality="0">
 			<centroid rt="443.872585198183" mz="1153.6243499362" it="62217"/>
@@ -2110,6 +2626,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1939" value="H1"/>
+			<UserParam type="string" name="1940" value="H3"/>
+			<UserParam type="string" name="1941" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14184938802529654304" quality="0">
 			<centroid rt="446.461240133884" mz="486.28826245215" it="219972"/>
@@ -2120,6 +2639,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1899" value="H1"/>
+			<UserParam type="string" name="1900" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14950406413925881405" quality="0">
 			<centroid rt="449.675253800177" mz="490.21826245215" it="167664"/>
@@ -2130,6 +2651,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1683" value="H1"/>
+			<UserParam type="string" name="1684" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_440249715354388942" quality="0">
 			<centroid rt="449.906067695284" mz="485.25826245215" it="74228"/>
@@ -2140,6 +2663,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="584" value="H1"/>
+			<UserParam type="string" name="585" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7107341125117951502" quality="0">
 			<centroid rt="452.08039685591" mz="493.22826245215" it="44008"/>
@@ -2150,6 +2675,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="165" value="H1"/>
+			<UserParam type="string" name="166" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13955671359794871833" quality="0">
 			<centroid rt="453.873810870349" mz="490.21826245215" it="43660"/>
@@ -2160,6 +2687,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1220" value="H1"/>
+			<UserParam type="string" name="1221" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9594807628692769567" quality="0">
 			<centroid rt="459.156098872658" mz="1182.6043499362" it="448641"/>
@@ -2171,6 +2700,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1066" value="H1"/>
+			<UserParam type="string" name="1067" value="H3"/>
+			<UserParam type="string" name="1068" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16423879009339834294" quality="0">
 			<centroid rt="459.242553685175" mz="502.2743499362" it="216198"/>
@@ -2182,6 +2714,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1262" value="H1"/>
+			<UserParam type="string" name="1263" value="H3"/>
+			<UserParam type="string" name="1264" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12848761633962267536" quality="0">
 			<centroid rt="463.194879627505" mz="507.28826245215" it="44008"/>
@@ -2192,6 +2727,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="38" value="H1"/>
+			<UserParam type="string" name="39" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3419113160980455378" quality="0">
 			<centroid rt="466.607544314619" mz="1221.5443499362" it="235962"/>
@@ -2203,6 +2740,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1622" value="H1"/>
+			<UserParam type="string" name="1623" value="H3"/>
+			<UserParam type="string" name="1624" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6026302776217774078" quality="0">
 			<centroid rt="468.00357469753" mz="1148.4743499362" it="269163"/>
@@ -2214,6 +2754,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="794" value="H1"/>
+			<UserParam type="string" name="795" value="H3"/>
+			<UserParam type="string" name="796" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8103122350921705158" quality="0">
 			<centroid rt="468.739147190321" mz="503.23043742025" it="49396"/>
@@ -2224,6 +2767,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2256" value="H3"/>
+			<UserParam type="string" name="2257" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12513894661274122058" quality="0">
 			<centroid rt="470.259493632901" mz="516.2243499362" it="121124"/>
@@ -2234,6 +2779,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1990" value="H1"/>
+			<UserParam type="string" name="1991" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_1559867016406224744" quality="0">
 			<centroid rt="472.928825207835" mz="1162.50826245215" it="35844"/>
@@ -2244,6 +2791,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="932" value="H1"/>
+			<UserParam type="string" name="933" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9643466504444831152" quality="0">
 			<centroid rt="473.858212787062" mz="515.28826245215" it="167664"/>
@@ -2254,6 +2803,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1664" value="H1"/>
+			<UserParam type="string" name="1665" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6083422039371001447" quality="0">
 			<centroid rt="474.215684296081" mz="6985.04043742024" it="199396"/>
@@ -2264,6 +2815,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1083" value="H3"/>
+			<UserParam type="string" name="1084" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7559504081944627532" quality="0">
 			<centroid rt="474.465943225076" mz="3594.59826245215" it="22500"/>
@@ -2274,6 +2827,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="481" value="H1"/>
+			<UserParam type="string" name="482" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7984813253886622187" quality="0">
 			<centroid rt="474.644456058436" mz="516.260437420249" it="40896"/>
@@ -2284,6 +2839,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="10" value="H3"/>
+			<UserParam type="string" name="11" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5877645964089705485" quality="0">
 			<centroid rt="474.67295379681" mz="2173.90043742025" it="96088"/>
@@ -2294,6 +2851,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1320" value="H3"/>
+			<UserParam type="string" name="1321" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17223954051248654534" quality="0">
 			<centroid rt="476.169429461266" mz="473.24826245215" it="96088"/>
@@ -2304,6 +2863,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1268" value="H1"/>
+			<UserParam type="string" name="1269" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5879952623087992595" quality="0">
 			<centroid rt="477.885614861626" mz="475.22826245215" it="44008"/>
@@ -2314,6 +2875,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="126" value="H1"/>
+			<UserParam type="string" name="127" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10970609347931289623" quality="0">
 			<centroid rt="478.742361475109" mz="476.20826245215" it="22500"/>
@@ -2324,6 +2887,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="424" value="H1"/>
+			<UserParam type="string" name="425" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1759108753185650422" quality="0">
 			<centroid rt="480.576380871484" mz="518.20826245215" it="25628"/>
@@ -2334,6 +2899,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="641" value="H1"/>
+			<UserParam type="string" name="642" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4563374591199834960" quality="0">
 			<centroid rt="482.213688100936" mz="1269.72826245215" it="119628"/>
@@ -2344,6 +2911,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="813" value="H1"/>
+			<UserParam type="string" name="814" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10419782216722942275" quality="0">
 			<centroid rt="485.08639879621" mz="3297.49826245215" it="145280"/>
@@ -2354,6 +2923,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2109" value="H1"/>
+			<UserParam type="string" name="2110" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2067996624673004148" quality="0">
 			<centroid rt="485.750323355009" mz="536.22826245215" it="2804"/>
@@ -2364,6 +2935,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1781" value="H1"/>
+			<UserParam type="string" name="1782" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10440112721691596498" quality="0">
 			<centroid rt="488.19188840711" mz="487.27826245215" it="251496"/>
@@ -2374,6 +2947,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1654" value="H1"/>
+			<UserParam type="string" name="1656" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4699590009228525430" quality="0">
 			<centroid rt="490.237329943809" mz="1294.66043742025" it="22500"/>
@@ -2384,6 +2959,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="333" value="H3"/>
+			<UserParam type="string" name="334" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6386168500953320963" quality="0">
 			<centroid rt="490.900144795836" mz="2250.02826245215" it="155144"/>
@@ -2394,6 +2971,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="715" value="H1"/>
+			<UserParam type="string" name="716" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14112555514612631219" quality="0">
 			<centroid rt="491.366316604278" mz="1128.45826245215" it="199396"/>
@@ -2404,6 +2983,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1092" value="H1"/>
+			<UserParam type="string" name="1093" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2778273558408840020" quality="0">
 			<centroid rt="491.515170822718" mz="1298.75826245215" it="139372"/>
@@ -2414,6 +2995,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1444" value="H1"/>
+			<UserParam type="string" name="1445" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18330719757468760466" quality="0">
 			<centroid rt="492.322469403355" mz="533.2243499362" it="327456"/>
@@ -2425,6 +3008,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1145" value="H1"/>
+			<UserParam type="string" name="1146" value="H3"/>
+			<UserParam type="string" name="1147" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6479298634829126017" quality="0">
 			<centroid rt="492.541497379868" mz="1219.55043742025" it="144132"/>
@@ -2435,6 +3021,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1318" value="H3"/>
+			<UserParam type="string" name="1319" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11417980576139428928" quality="0">
 			<centroid rt="493.534086498512" mz="1222.62043742025" it="11844"/>
@@ -2445,6 +3033,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1356" value="H3"/>
+			<UserParam type="string" name="1357" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2199003180324098312" quality="0">
 			<centroid rt="496.398043374239" mz="1304.62826245215" it="199396"/>
@@ -2455,6 +3045,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1079" value="H1"/>
+			<UserParam type="string" name="1080" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14842915157782576560" quality="0">
 			<centroid rt="496.435330406396" mz="550.233806194175" it="287720"/>
@@ -2467,6 +3059,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="595" value="H1"/>
+			<UserParam type="string" name="857" value="H1"/>
+			<UserParam type="string" name="858" value="H3"/>
+			<UserParam type="string" name="859" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12500149530915164647" quality="0">
 			<centroid rt="496.976289098826" mz="1315.57826245215" it="108796"/>
@@ -2477,6 +3073,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1748" value="H1"/>
+			<UserParam type="string" name="1749" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15273813460907076003" quality="0">
 			<centroid rt="500.793005112742" mz="502.2543499362" it="26649"/>
@@ -2488,6 +3086,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1373" value="H1"/>
+			<UserParam type="string" name="1374" value="H3"/>
+			<UserParam type="string" name="1375" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10986590742964000857" quality="0">
 			<centroid rt="504.701701487898" mz="1321.65826245215" it="38442"/>
@@ -2498,6 +3099,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="659" value="H1"/>
+			<UserParam type="string" name="661" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18312229299972622810" quality="0">
 			<centroid rt="505.524735822936" mz="562.2843499362" it="533043"/>
@@ -2509,6 +3112,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="998" value="H1"/>
+			<UserParam type="string" name="999" value="H3"/>
+			<UserParam type="string" name="1000" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9458924816156755133" quality="0">
 			<centroid rt="507.652454940746" mz="1349.75826245215" it="191544"/>
@@ -2519,6 +3125,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2063" value="H1"/>
+			<UserParam type="string" name="2064" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18020237115167740791" quality="0">
 			<centroid rt="508.591052366275" mz="560.27826245215" it="95592"/>
@@ -2529,6 +3137,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1164" value="H1"/>
+			<UserParam type="string" name="1165" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7102647048954581247" quality="0">
 			<centroid rt="509.936205909873" mz="568.220437420249" it="33750"/>
@@ -2539,6 +3149,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="451" value="H3"/>
+			<UserParam type="string" name="452" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13118177852738659852" quality="0">
 			<centroid rt="512.223831249453" mz="2153.8743499362" it="244791"/>
@@ -2550,6 +3162,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1723" value="H1"/>
+			<UserParam type="string" name="1724" value="H3"/>
+			<UserParam type="string" name="1725" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1998787784036228696" quality="0">
 			<centroid rt="512.745089164004" mz="1270.64826245215" it="96088"/>
@@ -2560,6 +3175,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1271" value="H1"/>
+			<UserParam type="string" name="1272" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6107477181472595481" quality="0">
 			<centroid rt="516.488064288409" mz="521.26826245215" it="74228"/>
@@ -2570,6 +3187,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="586" value="H1"/>
+			<UserParam type="string" name="587" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9485741616047753819" quality="0">
 			<centroid rt="519.635936034928" mz="581.2902916135" it="155948"/>
@@ -2581,6 +3200,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="775" value="H1"/>
+			<UserParam type="string" name="776" value="H2"/>
+			<UserParam type="string" name="2108" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2877072156372138182" quality="0">
 			<centroid rt="520.661309534647" mz="1381.6243499362" it="598188"/>
@@ -2592,6 +3214,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1073" value="H1"/>
+			<UserParam type="string" name="1075" value="H3"/>
+			<UserParam type="string" name="1076" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13063169846370933099" quality="0">
 			<centroid rt="521.107827539338" mz="583.32826245215" it="157308"/>
@@ -2602,6 +3227,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1619" value="H1"/>
+			<UserParam type="string" name="1621" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15642734789465095752" quality="0">
 			<centroid rt="524.04489413468" mz="587.3152916135" it="284941"/>
@@ -2616,6 +3243,12 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="6"/>
+			<UserParam type="string" name="725" value="H2"/>
+			<UserParam type="string" name="973" value="H1"/>
+			<UserParam type="string" name="974" value="H2"/>
+			<UserParam type="string" name="1049" value="H1"/>
+			<UserParam type="string" name="1050" value="H2"/>
+			<UserParam type="string" name="1201" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6048961673850771048" quality="0">
 			<centroid rt="524.539544889403" mz="1315.6543499362" it="148188"/>
@@ -2627,6 +3260,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2290" value="H1"/>
+			<UserParam type="string" name="2292" value="H3"/>
+			<UserParam type="string" name="2293" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3729202750351211727" quality="0">
 			<centroid rt="529.156533656297" mz="594.32826245215" it="155144"/>
@@ -2637,6 +3273,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="738" value="H1"/>
+			<UserParam type="string" name="739" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4016857092791769002" quality="0">
 			<centroid rt="529.425576786965" mz="2599.48043742025" it="143388"/>
@@ -2647,6 +3285,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1175" value="H3"/>
+			<UserParam type="string" name="1176" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7203075450583926429" quality="0">
 			<centroid rt="530.858843845103" mz="590.22826245215" it="104872"/>
@@ -2657,6 +3297,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1598" value="H1"/>
+			<UserParam type="string" name="1599" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8527437538422482433" quality="0">
 			<centroid rt="532.615453970451" mz="2349.84043742025" it="62304"/>
@@ -2667,6 +3309,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="301" value="H3"/>
+			<UserParam type="string" name="302" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16907642466873554244" quality="0">
 			<centroid rt="533.50496918389" mz="542.280437420251" it="145280"/>
@@ -2677,6 +3321,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2101" value="H3"/>
+			<UserParam type="string" name="2102" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7452631076573786844" quality="0">
 			<centroid rt="534.240137925052" mz="601.2843499362" it="27652"/>
@@ -2687,6 +3333,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1924" value="H1"/>
+			<UserParam type="string" name="1925" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_3819245790297166298" quality="0">
 			<centroid rt="535.111278082455" mz="544.2802916135" it="148323"/>
@@ -2698,6 +3346,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1745" value="H2"/>
+			<UserParam type="string" name="2025" value="H1"/>
+			<UserParam type="string" name="2026" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13906450391496812008" quality="0">
 			<centroid rt="538.176726934241" mz="2275.0443499362" it="80649"/>
@@ -2709,6 +3360,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="965" value="H1"/>
+			<UserParam type="string" name="966" value="H3"/>
+			<UserParam type="string" name="967" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5951227995441851688" quality="0">
 			<centroid rt="538.244032199409" mz="600.300437420251" it="27652"/>
@@ -2719,6 +3373,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1978" value="H3"/>
+			<UserParam type="string" name="1979" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11305709453097654554" quality="0">
 			<centroid rt="539.703694089945" mz="602.3043499362" it="58344"/>
@@ -2731,6 +3387,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="377" value="H3"/>
+			<UserParam type="string" name="378" value="H2"/>
+			<UserParam type="string" name="970" value="H1"/>
+			<UserParam type="string" name="971" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9274988716083026227" quality="0">
 			<centroid rt="540.776491671877" mz="551.20826245215" it="128476"/>
@@ -2741,6 +3401,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2119" value="H1"/>
+			<UserParam type="string" name="2120" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9116394531052818823" quality="0">
 			<centroid rt="542.178145495499" mz="612.26826245215" it="62304"/>
@@ -2751,6 +3413,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="197" value="H1"/>
+			<UserParam type="string" name="198" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17136602070904251669" quality="0">
 			<centroid rt="543.178853386162" mz="1283.64043742025" it="123568"/>
@@ -2761,6 +3425,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="703" value="H3"/>
+			<UserParam type="string" name="704" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14122932603772364057" quality="0">
 			<centroid rt="543.476717192282" mz="491.1943499362" it="6309"/>
@@ -2772,6 +3438,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1839" value="H1"/>
+			<UserParam type="string" name="1840" value="H3"/>
+			<UserParam type="string" name="1841" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4402327125264367820" quality="0">
 			<centroid rt="543.997875657667" mz="2687.62826245215" it="35844"/>
@@ -2782,6 +3451,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="925" value="H1"/>
+			<UserParam type="string" name="926" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2643175790747466271" quality="0">
 			<centroid rt="545.501670428976" mz="610.2543499362" it="50625"/>
@@ -2793,6 +3464,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="421" value="H1"/>
+			<UserParam type="string" name="422" value="H3"/>
+			<UserParam type="string" name="423" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5962336574991718563" quality="0">
 			<centroid rt="546.154614413589" mz="2700.3443499362" it="235962"/>
@@ -2804,6 +3478,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1595" value="H1"/>
+			<UserParam type="string" name="1596" value="H3"/>
+			<UserParam type="string" name="1597" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3144901311098465244" quality="0">
 			<centroid rt="546.469283343279" mz="618.29043742025" it="355362"/>
@@ -2814,6 +3491,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1004" value="H3"/>
+			<UserParam type="string" name="1005" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16290167828225403216" quality="0">
 			<centroid rt="546.476073855718" mz="2674.15826245215" it="104872"/>
@@ -2824,6 +3503,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1616" value="H1"/>
+			<UserParam type="string" name="1617" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5190864071242158864" quality="0">
 			<centroid rt="549.71392357039" mz="4327.22826245215" it="95568"/>
@@ -2834,6 +3515,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1547" value="H1"/>
+			<UserParam type="string" name="1548" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16460324240984466504" quality="0">
 			<centroid rt="550.547962186816" mz="1479.6243499362" it="62217"/>
@@ -2845,6 +3528,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1981" value="H1"/>
+			<UserParam type="string" name="1982" value="H3"/>
+			<UserParam type="string" name="1983" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12909798799036020002" quality="0">
 			<centroid rt="550.74425509575" mz="624.240437420251" it="104872"/>
@@ -2855,6 +3541,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1632" value="H3"/>
+			<UserParam type="string" name="1633" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6090268312439906181" quality="0">
 			<centroid rt="551.454748641369" mz="625.2843499362" it="199396"/>
@@ -2865,6 +3553,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1086" value="H1"/>
+			<UserParam type="string" name="1087" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_9274950507605421903" quality="0">
 			<centroid rt="551.769517183136" mz="565.26826245215" it="96088"/>
@@ -2875,6 +3565,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1315" value="H1"/>
+			<UserParam type="string" name="1316" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12221013924058114087" quality="0">
 			<centroid rt="552.503610159257" mz="2597.15826245215" it="43660"/>
@@ -2885,6 +3577,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1228" value="H1"/>
+			<UserParam type="string" name="1229" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4736206810500769545" quality="0">
 			<centroid rt="558.417227994026" mz="628.29826245215" it="139372"/>
@@ -2895,6 +3589,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1442" value="H1"/>
+			<UserParam type="string" name="1443" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16328008726864507464" quality="0">
 			<centroid rt="558.597038173099" mz="635.2993499362" it="140832"/>
@@ -2907,6 +3603,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="511" value="H1"/>
+			<UserParam type="string" name="512" value="H2"/>
+			<UserParam type="string" name="529" value="H3"/>
+			<UserParam type="string" name="530" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7333622529661258601" quality="0">
 			<centroid rt="558.982696061427" mz="5617.37043742025" it="219972"/>
@@ -2917,6 +3617,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1901" value="H3"/>
+			<UserParam type="string" name="1902" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3429444044022484679" quality="0">
 			<centroid rt="558.998750285263" mz="622.27043742025" it="123568"/>
@@ -2927,6 +3629,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="684" value="H3"/>
+			<UserParam type="string" name="685" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3359547879629251495" quality="0">
 			<centroid rt="559.840804702131" mz="630.3443499362" it="215028"/>
@@ -2938,6 +3642,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1525" value="H1"/>
+			<UserParam type="string" name="1526" value="H3"/>
+			<UserParam type="string" name="1527" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18144057177236202302" quality="0">
 			<centroid rt="560.551758244834" mz="631.32826245215" it="199396"/>
@@ -2948,6 +3655,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1077" value="H1"/>
+			<UserParam type="string" name="1078" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9513857176956224707" quality="0">
 			<centroid rt="562.147676396702" mz="1432.60826245215" it="11844"/>
@@ -2958,6 +3667,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1363" value="H1"/>
+			<UserParam type="string" name="1364" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17252333304086938544" quality="0">
 			<centroid rt="563.799073670036" mz="1427.51826245215" it="95568"/>
@@ -2968,6 +3679,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1545" value="H1"/>
+			<UserParam type="string" name="1546" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1054943957081762723" quality="0">
 			<centroid rt="565.146059542116" mz="1528.86043742025" it="101292"/>
@@ -2978,6 +3691,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1559" value="H3"/>
+			<UserParam type="string" name="1560" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_516040760734733647" quality="0">
 			<centroid rt="565.61499035995" mz="645.36043742025" it="199396"/>
@@ -2988,6 +3703,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1071" value="H3"/>
+			<UserParam type="string" name="1072" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8796508501445044680" quality="0">
 			<centroid rt="566.126038605257" mz="1542.7343499362" it="6309"/>
@@ -2999,6 +3716,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1832" value="H1"/>
+			<UserParam type="string" name="1833" value="H3"/>
+			<UserParam type="string" name="1834" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3141621002396984455" quality="0">
 			<centroid rt="569.105724703995" mz="650.35043742025" it="49396"/>
@@ -3009,6 +3729,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2227" value="H3"/>
+			<UserParam type="string" name="2228" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12780129024736863381" quality="0">
 			<centroid rt="569.812788482005" mz="644.3043499362" it="99018"/>
@@ -3020,6 +3742,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="31" value="H1"/>
+			<UserParam type="string" name="32" value="H3"/>
+			<UserParam type="string" name="33" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10823116916162478535" quality="0">
 			<centroid rt="570.300690753964" mz="1524.8243499362" it="111141"/>
@@ -3031,6 +3756,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2311" value="H1"/>
+			<UserParam type="string" name="2312" value="H3"/>
+			<UserParam type="string" name="2313" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12403209488123538411" quality="0">
 			<centroid rt="573.061067484804" mz="1467.6443499362" it="140184"/>
@@ -3042,6 +3770,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="270" value="H1"/>
+			<UserParam type="string" name="271" value="H3"/>
+			<UserParam type="string" name="272" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4634788559324351281" quality="0">
 			<centroid rt="573.274406379932" mz="656.37826245215" it="22500"/>
@@ -3052,6 +3783,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="311" value="H1"/>
+			<UserParam type="string" name="312" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_524643825173921287" quality="0">
 			<centroid rt="574.023468889237" mz="650.2643499362" it="505755"/>
@@ -3063,6 +3796,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="170" value="H1"/>
+			<UserParam type="string" name="171" value="H3"/>
+			<UserParam type="string" name="172" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4435438499400492594" quality="0">
 			<centroid rt="575.192632201536" mz="1474.74826245215" it="22500"/>
@@ -3073,6 +3809,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="395" value="H1"/>
+			<UserParam type="string" name="396" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5280556581517672547" quality="0">
 			<centroid rt="575.483963992694" mz="535.1943499362" it="57663"/>
@@ -3084,6 +3822,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="619" value="H1"/>
+			<UserParam type="string" name="620" value="H3"/>
+			<UserParam type="string" name="621" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6860847167659921154" quality="0">
 			<centroid rt="576.071952232825" mz="2605.21826245215" it="22500"/>
@@ -3094,6 +3835,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="471" value="H1"/>
+			<UserParam type="string" name="472" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18116626514246875092" quality="0">
 			<centroid rt="576.800710230278" mz="661.36826245215" it="2804"/>
@@ -3104,6 +3847,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1826" value="H1"/>
+			<UserParam type="string" name="1827" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11168556540206211906" quality="0">
 			<centroid rt="577.490051852608" mz="662.33043742025" it="47944"/>
@@ -3114,6 +3859,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1850" value="H3"/>
+			<UserParam type="string" name="1851" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18334247160669242179" quality="0">
 			<centroid rt="578.113892307029" mz="663.37043742025" it="44008"/>
@@ -3124,6 +3871,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="80" value="H3"/>
+			<UserParam type="string" name="81" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4078884094220574297" quality="0">
 			<centroid rt="578.73209285384" mz="664.31826245215" it="35844"/>
@@ -3134,6 +3883,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="934" value="H1"/>
+			<UserParam type="string" name="935" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15419868016373941840" quality="0">
 			<centroid rt="579.491908248365" mz="665.3143499362" it="269163"/>
@@ -3145,6 +3896,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="799" value="H1"/>
+			<UserParam type="string" name="800" value="H3"/>
+			<UserParam type="string" name="801" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1443720508436610245" quality="0">
 			<centroid rt="580.304153495562" mz="659.3543499362" it="448641"/>
@@ -3156,6 +3910,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1031" value="H1"/>
+			<UserParam type="string" name="1032" value="H3"/>
+			<UserParam type="string" name="1033" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14510037157409592973" quality="0">
 			<centroid rt="580.865687750448" mz="667.4143499362" it="269163"/>
@@ -3167,6 +3924,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="846" value="H1"/>
+			<UserParam type="string" name="847" value="H3"/>
+			<UserParam type="string" name="848" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6691798372119354117" quality="0">
 			<centroid rt="582.17788250093" mz="669.28826245215" it="74228"/>
@@ -3177,6 +3937,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="579" value="H1"/>
+			<UserParam type="string" name="580" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6763389827165421278" quality="0">
 			<centroid rt="585.596949361926" mz="674.35826245215" it="96088"/>
@@ -3187,6 +3949,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1247" value="H1"/>
+			<UserParam type="string" name="1248" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9860600984622535233" quality="0">
 			<centroid rt="585.675096291683" mz="1497.6743499362" it="227907"/>
@@ -3198,6 +3962,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1573" value="H1"/>
+			<UserParam type="string" name="1574" value="H3"/>
+			<UserParam type="string" name="1575" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12404435338572738804" quality="0">
 			<centroid rt="591.464656485536" mz="1527.81826245215" it="35844"/>
@@ -3208,6 +3975,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="968" value="H1"/>
+			<UserParam type="string" name="969" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6567492989738467385" quality="0">
 			<centroid rt="592.500463482177" mz="618.25826245215" it="167664"/>
@@ -3218,6 +3987,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1646" value="H1"/>
+			<UserParam type="string" name="1647" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14057747088844657614" quality="0">
 			<centroid rt="593.279796271285" mz="1511.7143499362" it="111141"/>
@@ -3229,6 +4000,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2265" value="H1"/>
+			<UserParam type="string" name="2266" value="H3"/>
+			<UserParam type="string" name="2267" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16802030658014152699" quality="0">
 			<centroid rt="598.56798673595" mz="693.28826245215" it="123568"/>
@@ -3239,6 +4013,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="674" value="H1"/>
+			<UserParam type="string" name="675" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2009145850889836706" quality="0">
 			<centroid rt="600.055144329887" mz="628.260437420251" it="27652"/>
@@ -3249,6 +4025,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1966" value="H3"/>
+			<UserParam type="string" name="1967" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15199979853978279154" quality="0">
 			<centroid rt="600.597164438987" mz="696.32043742025" it="95568"/>
@@ -3259,6 +4037,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1499" value="H3"/>
+			<UserParam type="string" name="1500" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5197986081683712416" quality="0">
 			<centroid rt="603.033701851693" mz="632.30326245215" it="201942"/>
@@ -3271,6 +4051,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="384" value="H1"/>
+			<UserParam type="string" name="385" value="H2"/>
+			<UserParam type="string" name="816" value="H1"/>
+			<UserParam type="string" name="818" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6011560369388042562" quality="0">
 			<centroid rt="605.264155150908" mz="635.30043742025" it="179442"/>
@@ -3281,6 +4065,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="829" value="H3"/>
+			<UserParam type="string" name="830" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8408308123582013544" quality="0">
 			<centroid rt="607.580284571797" mz="631.27826245215" it="199396"/>
@@ -3291,6 +4077,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1038" value="H1"/>
+			<UserParam type="string" name="1039" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17317412191553977585" quality="0">
 			<centroid rt="608.638749129694" mz="708.3143499362" it="326880"/>
@@ -3302,6 +4090,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2095" value="H1"/>
+			<UserParam type="string" name="2096" value="H3"/>
+			<UserParam type="string" name="2097" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16372634790253565131" quality="0">
 			<centroid rt="609.305796878643" mz="709.31826245215" it="44008"/>
@@ -3312,6 +4103,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="139" value="H1"/>
+			<UserParam type="string" name="140" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_114554574745714434" quality="0">
 			<centroid rt="610.087645688976" mz="695.28826245215" it="95592"/>
@@ -3322,6 +4115,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1196" value="H1"/>
+			<UserParam type="string" name="1197" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6942482656073269684" quality="0">
 			<centroid rt="611.07957108826" mz="704.32826245215" it="22500"/>
@@ -3332,6 +4127,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="317" value="H1"/>
+			<UserParam type="string" name="318" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4252623630674506397" quality="0">
 			<centroid rt="615.281018801076" mz="718.3443499362" it="57663"/>
@@ -3343,6 +4140,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="651" value="H1"/>
+			<UserParam type="string" name="652" value="H3"/>
+			<UserParam type="string" name="653" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6210473933281799881" quality="0">
 			<centroid rt="615.95809002154" mz="1574.77826245215" it="25628"/>
@@ -3353,6 +4153,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="630" value="H1"/>
+			<UserParam type="string" name="631" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11222509349114437539" quality="0">
 			<centroid rt="616.008983323622" mz="719.373624946833" it="61693"/>
@@ -3364,6 +4166,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1034" value="H2"/>
+			<UserParam type="string" name="1380" value="H1"/>
+			<UserParam type="string" name="1381" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15428401767894219366" quality="0">
 			<centroid rt="617.82887257195" mz="1603.49826245215" it="199396"/>
@@ -3374,6 +4179,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1099" value="H1"/>
+			<UserParam type="string" name="1100" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17523955775953923566" quality="0">
 			<centroid rt="620.57454795056" mz="726.3043499362" it="107874"/>
@@ -3385,6 +4192,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1878" value="H1"/>
+			<UserParam type="string" name="1879" value="H3"/>
+			<UserParam type="string" name="1880" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7576493044140612050" quality="0">
 			<centroid rt="621.951809739274" mz="728.3893499362" it="24866"/>
@@ -3397,6 +4207,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="610" value="H2"/>
+			<UserParam type="string" name="1828" value="H1"/>
+			<UserParam type="string" name="1829" value="H3"/>
+			<UserParam type="string" name="1830" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14410510635280617068" quality="0">
 			<centroid rt="622.515528561417" mz="721.320437420251" it="145280"/>
@@ -3407,6 +4221,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2099" value="H3"/>
+			<UserParam type="string" name="2100" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11586450234016228318" quality="0">
 			<centroid rt="623.199522234173" mz="730.41826245215" it="44008"/>
@@ -3417,6 +4233,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="62" value="H1"/>
+			<UserParam type="string" name="63" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15125980272336070922" quality="0">
 			<centroid rt="624.556375188271" mz="732.371741592234" it="154795"/>
@@ -3428,6 +4246,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="977" value="H2"/>
+			<UserParam type="string" name="1543" value="H3"/>
+			<UserParam type="string" name="1544" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4551845017192447523" quality="0">
 			<centroid rt="626.172360457941" mz="656.2243499362" it="62304"/>
@@ -3438,6 +4259,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="222" value="H1"/>
+			<UserParam type="string" name="223" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_13770412002122718165" quality="0">
 			<centroid rt="627.788668353281" mz="737.36043742025" it="143352"/>
@@ -3448,6 +4271,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1502" value="H3"/>
+			<UserParam type="string" name="1503" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17941323642429683017" quality="0">
 			<centroid rt="629.782431029875" mz="1767.83826245215" it="78396"/>
@@ -3458,6 +4283,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="568" value="H1"/>
+			<UserParam type="string" name="569" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2709633254729553329" quality="0">
 			<centroid rt="630.133750513018" mz="669.2343499362" it="2804"/>
@@ -3468,6 +4295,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1809" value="H1"/>
+			<UserParam type="string" name="1810" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_2150182319637011612" quality="0">
 			<centroid rt="630.183552891614" mz="1633.60043742025" it="62304"/>
@@ -3478,6 +4307,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="239" value="H3"/>
+			<UserParam type="string" name="240" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4861519461251182967" quality="0">
 			<centroid rt="632.025561047061" mz="664.30826245215" it="4206"/>
@@ -3488,6 +4319,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1806" value="H1"/>
+			<UserParam type="string" name="1808" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12962517912631299232" quality="0">
 			<centroid rt="632.481098676086" mz="1653.83043742025" it="40896"/>
@@ -3498,6 +4331,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="19" value="H3"/>
+			<UserParam type="string" name="20" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6961219444821998841" quality="0">
 			<centroid rt="633.026982520624" mz="673.31826245215" it="49396"/>
@@ -3508,6 +4343,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2301" value="H1"/>
+			<UserParam type="string" name="2302" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14862281851974734994" quality="0">
 			<centroid rt="633.158408476199" mz="1667.78826245215" it="78396"/>
@@ -3518,6 +4355,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="557" value="H1"/>
+			<UserParam type="string" name="558" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4215448138524491229" quality="0">
 			<centroid rt="635.675348524657" mz="733.32826245215" it="95592"/>
@@ -3528,6 +4367,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1187" value="H1"/>
+			<UserParam type="string" name="1188" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_424308983059169924" quality="0">
 			<centroid rt="636.375935312025" mz="742.39043742025" it="2804"/>
@@ -3538,6 +4379,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1783" value="H3"/>
+			<UserParam type="string" name="1784" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17697154292408418165" quality="0">
 			<centroid rt="640.851310542488" mz="757.4202916135" it="66014"/>
@@ -3549,6 +4392,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2076" value="H2"/>
+			<UserParam type="string" name="2282" value="H1"/>
+			<UserParam type="string" name="2283" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11983977174892259861" quality="0">
 			<centroid rt="642.2841487829" mz="1788.91826245215" it="108796"/>
@@ -3559,6 +4405,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1711" value="H1"/>
+			<UserParam type="string" name="1712" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9527863918416234523" quality="0">
 			<centroid rt="642.407724289971" mz="686.37826245215" it="74094"/>
@@ -3569,6 +4417,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2220" value="H1"/>
+			<UserParam type="string" name="2222" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7965824966058872793" quality="0">
 			<centroid rt="643.120698036913" mz="687.35826245215" it="57428"/>
@@ -3579,6 +4429,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2191" value="H1"/>
+			<UserParam type="string" name="2192" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13745545552410179539" quality="0">
 			<centroid rt="643.620096106941" mz="680.2943499362" it="227907"/>
@@ -3590,6 +4442,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1576" value="H1"/>
+			<UserParam type="string" name="1577" value="H3"/>
+			<UserParam type="string" name="1578" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8322828562087463792" quality="0">
 			<centroid rt="645.185421654166" mz="690.29826245215" it="95568"/>
@@ -3600,6 +4455,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1535" value="H1"/>
+			<UserParam type="string" name="1536" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4301765000375830830" quality="0">
 			<centroid rt="648.163347603553" mz="1719.7543499362" it="216198"/>
@@ -3611,6 +4468,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1334" value="H1"/>
+			<UserParam type="string" name="1335" value="H3"/>
+			<UserParam type="string" name="1336" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15450454893249521935" quality="0">
 			<centroid rt="650.50929382729" mz="3217.48826245215" it="35844"/>
@@ -3621,6 +4481,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="955" value="H1"/>
+			<UserParam type="string" name="956" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2934049713569013999" quality="0">
 			<centroid rt="650.630755593451" mz="764.3543499362" it="244791"/>
@@ -3632,6 +4494,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1732" value="H1"/>
+			<UserParam type="string" name="1733" value="H3"/>
+			<UserParam type="string" name="1734" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10682740432397837719" quality="0">
 			<centroid rt="651.111616614819" mz="1833.87826245215" it="121124"/>
@@ -3642,6 +4507,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2023" value="H1"/>
+			<UserParam type="string" name="2024" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8541274303051173305" quality="0">
 			<centroid rt="653.04856862586" mz="701.404349936201" it="47944"/>
@@ -3652,6 +4519,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1854" value="H1"/>
+			<UserParam type="string" name="1855" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_5517567423235574588" quality="0">
 			<centroid rt="653.667404151484" mz="777.38826245215" it="199396"/>
@@ -3662,6 +4531,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1017" value="H1"/>
+			<UserParam type="string" name="1018" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6619954781274908704" quality="0">
 			<centroid rt="655.099944442678" mz="1848.94043742025" it="251496"/>
@@ -3672,6 +4543,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1692" value="H3"/>
+			<UserParam type="string" name="1693" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9746133592519337224" quality="0">
 			<centroid rt="656.700379776221" mz="1749.8943499362" it="278028"/>
@@ -3683,6 +4556,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="689" value="H1"/>
+			<UserParam type="string" name="690" value="H3"/>
+			<UserParam type="string" name="691" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14685016479309565389" quality="0">
 			<centroid rt="656.9108824057" mz="782.3743499362" it="227741"/>
@@ -3694,6 +4570,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="184" value="H1"/>
+			<UserParam type="string" name="185" value="H3"/>
+			<UserParam type="string" name="1404" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_104770329333648869" quality="0">
 			<centroid rt="657.275501381711" mz="707.36826245215" it="35844"/>
@@ -3704,6 +4583,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="936" value="H1"/>
+			<UserParam type="string" name="937" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_648858821650960047" quality="0">
 			<centroid rt="657.962154845873" mz="767.33043742025" it="44008"/>
@@ -3714,6 +4595,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="105" value="H3"/>
+			<UserParam type="string" name="106" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12005284933064456841" quality="0">
 			<centroid rt="658.100934967916" mz="784.3743499362" it="120110"/>
@@ -3725,6 +4608,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1282" value="H1"/>
+			<UserParam type="string" name="1283" value="H2"/>
+			<UserParam type="string" name="1340" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_13706204379823523531" quality="0">
 			<centroid rt="660.078710218986" mz="711.28826245215" it="40896"/>
@@ -3735,6 +4621,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="6" value="H1"/>
+			<UserParam type="string" name="7" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3698924538087970764" quality="0">
 			<centroid rt="660.080859836672" mz="787.36826245215" it="167664"/>
@@ -3745,6 +4633,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1694" value="H1"/>
+			<UserParam type="string" name="1695" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8139445168304938735" quality="0">
 			<centroid rt="661.569064719798" mz="1885.96826245215" it="35844"/>
@@ -3755,6 +4645,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="927" value="H1"/>
+			<UserParam type="string" name="928" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17862986126533835347" quality="0">
 			<centroid rt="662.545929384002" mz="791.40826245215" it="22500"/>
@@ -3765,6 +4657,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="313" value="H1"/>
+			<UserParam type="string" name="314" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2722956880498890145" quality="0">
 			<centroid rt="662.684046511852" mz="5029.52826245215" it="155144"/>
@@ -3775,6 +4669,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="728" value="H1"/>
+			<UserParam type="string" name="729" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17555532099440483980" quality="0">
 			<centroid rt="663.814858144484" mz="2991.31826245215" it="67172"/>
@@ -3785,6 +4681,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="903" value="H1"/>
+			<UserParam type="string" name="904" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_271481900878323344" quality="0">
 			<centroid rt="667.645446411611" mz="799.43826245215" it="108796"/>
@@ -3795,6 +4693,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1707" value="H1"/>
+			<UserParam type="string" name="1708" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4065653029215530090" quality="0">
 			<centroid rt="668.591911109182" mz="715.3643499362" it="377244"/>
@@ -3806,6 +4706,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1639" value="H1"/>
+			<UserParam type="string" name="1640" value="H3"/>
+			<UserParam type="string" name="1641" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10092840486465942217" quality="0">
 			<centroid rt="670.603010784386" mz="726.40826245215" it="67172"/>
@@ -3816,6 +4719,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="868" value="H1"/>
+			<UserParam type="string" name="869" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8837283152632509182" quality="0">
 			<centroid rt="672.033502207182" mz="806.39826245215" it="119628"/>
@@ -3826,6 +4731,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="780" value="H1"/>
+			<UserParam type="string" name="781" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1607223678160079273" quality="0">
 			<centroid rt="677.031718977963" mz="814.440437420251" it="139372"/>
@@ -3836,6 +4743,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1429" value="H3"/>
+			<UserParam type="string" name="1430" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14943444919146946016" quality="0">
 			<centroid rt="677.478324603355" mz="1932.9143499362" it="44008"/>
@@ -3846,6 +4755,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="129" value="H1"/>
+			<UserParam type="string" name="130" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_7758198940295734762" quality="0">
 			<centroid rt="679.334841836953" mz="809.35826245215" it="101292"/>
@@ -3856,6 +4767,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1581" value="H1"/>
+			<UserParam type="string" name="1582" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4389809971396329425" quality="0">
 			<centroid rt="682.273173823299" mz="1720.85043742025" it="108796"/>
@@ -3866,6 +4779,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1751" value="H3"/>
+			<UserParam type="string" name="1752" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7133448079454035304" quality="0">
 			<centroid rt="682.402005268184" mz="1695.6343499362" it="62217"/>
@@ -3877,6 +4792,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1948" value="H1"/>
+			<UserParam type="string" name="1949" value="H3"/>
+			<UserParam type="string" name="1950" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7885875911127215182" quality="0">
 			<centroid rt="684.210610902847" mz="1847.84826245215" it="11844"/>
@@ -3887,6 +4805,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1352" value="H1"/>
+			<UserParam type="string" name="1353" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11849062194899468266" quality="0">
 			<centroid rt="685.081764168311" mz="827.460437420251" it="44008"/>
@@ -3897,6 +4817,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="116" value="H3"/>
+			<UserParam type="string" name="117" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13879341723533171256" quality="0">
 			<centroid rt="688.663511915282" mz="815.39826245215" it="25628"/>
@@ -3907,6 +4829,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="626" value="H1"/>
+			<UserParam type="string" name="627" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17739000492228651929" quality="0">
 			<centroid rt="689.067406367149" mz="3271.5943499362" it="216198"/>
@@ -3918,6 +4842,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1294" value="H1"/>
+			<UserParam type="string" name="1295" value="H3"/>
+			<UserParam type="string" name="1296" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4545048209363013286" quality="0">
 			<centroid rt="690.572545139558" mz="827.3543499362" it="235962"/>
@@ -3929,6 +4856,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1635" value="H1"/>
+			<UserParam type="string" name="1636" value="H3"/>
+			<UserParam type="string" name="1637" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1645963886683715582" quality="0">
 			<centroid rt="691.872896976363" mz="829.38826245215" it="119628"/>
@@ -3939,6 +4869,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="789" value="H1"/>
+			<UserParam type="string" name="790" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_519816672606219176" quality="0">
 			<centroid rt="691.939292133491" mz="1753.70826245215" it="2804"/>
@@ -3949,6 +4881,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1789" value="H1"/>
+			<UserParam type="string" name="1790" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3379047375300374488" quality="0">
 			<centroid rt="692.118143867124" mz="2003.01043742025" it="145536"/>
@@ -3959,6 +4893,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1155" value="H3"/>
+			<UserParam type="string" name="1156" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16354652835639597362" quality="0">
 			<centroid rt="693.058012094395" mz="831.4243499362" it="149562"/>
@@ -3970,6 +4906,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2072" value="H1"/>
+			<UserParam type="string" name="2073" value="H3"/>
+			<UserParam type="string" name="2074" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8597552835155454172" quality="0">
 			<centroid rt="694.523369839601" mz="761.2943499362" it="244791"/>
@@ -3981,6 +4920,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1758" value="H1"/>
+			<UserParam type="string" name="1759" value="H3"/>
+			<UserParam type="string" name="1760" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9667834559726616834" quality="0">
 			<centroid rt="696.134877939121" mz="845.49826245215" it="2804"/>
@@ -3991,6 +4933,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1785" value="H1"/>
+			<UserParam type="string" name="1786" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7458891370033960267" quality="0">
 			<centroid rt="699.827437285958" mz="851.4193499362" it="365802"/>
@@ -4003,6 +4947,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="959" value="H1"/>
+			<UserParam type="string" name="960" value="H2"/>
+			<UserParam type="string" name="1909" value="H3"/>
+			<UserParam type="string" name="1910" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6015182170856650486" quality="0">
 			<centroid rt="699.839852735789" mz="842.39826245215" it="33750"/>
@@ -4013,6 +4961,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="389" value="H1"/>
+			<UserParam type="string" name="391" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5592930065701520129" quality="0">
 			<centroid rt="701.987686004891" mz="2042.00826245215" it="121124"/>
@@ -4023,6 +4973,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2017" value="H1"/>
+			<UserParam type="string" name="2018" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3821868105824509993" quality="0">
 			<centroid rt="702.831746794123" mz="856.40826245215" it="108796"/>
@@ -4033,6 +4985,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1741" value="H1"/>
+			<UserParam type="string" name="1742" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_906032794589086705" quality="0">
 			<centroid rt="703.523614734039" mz="848.3643499362" it="430974"/>
@@ -4044,6 +4998,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2031" value="H1"/>
+			<UserParam type="string" name="2032" value="H3"/>
+			<UserParam type="string" name="2033" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9968002106700402655" quality="0">
 			<centroid rt="705.030461637112" mz="1798.7943499362" it="6309"/>
@@ -4055,6 +5012,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1795" value="H1"/>
+			<UserParam type="string" name="1796" value="H3"/>
+			<UserParam type="string" name="1797" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1375651541133399764" quality="0">
 			<centroid rt="708.486460178575" mz="856.4643499362" it="2804"/>
@@ -4065,6 +5025,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1802" value="H1"/>
+			<UserParam type="string" name="1803" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_5115917665751684615" quality="0">
 			<centroid rt="709.880001782061" mz="1927.87826245215" it="22500"/>
@@ -4075,6 +5037,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="441" value="H1"/>
+			<UserParam type="string" name="442" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16248686406929570732" quality="0">
 			<centroid rt="710.307951799826" mz="1816.80043742025" it="139372"/>
@@ -4085,6 +5049,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1431" value="H3"/>
+			<UserParam type="string" name="1432" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14068230000182934728" quality="0">
 			<centroid rt="710.368243104438" mz="859.45043742025" it="191544"/>
@@ -4095,6 +5061,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2057" value="H3"/>
+			<UserParam type="string" name="2058" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2525899015573589476" quality="0">
 			<centroid rt="712.132971499326" mz="862.3543499362" it="140184"/>
@@ -4106,6 +5074,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="277" value="H1"/>
+			<UserParam type="string" name="278" value="H3"/>
+			<UserParam type="string" name="279" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9081879179265952313" quality="0">
 			<centroid rt="714.238571142839" mz="875.42043742025" it="139372"/>
@@ -4116,6 +5087,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1425" value="H3"/>
+			<UserParam type="string" name="1426" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5432832126185344037" quality="0">
 			<centroid rt="714.586176221167" mz="5204.41826245215" it="96088"/>
@@ -4126,6 +5099,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1299" value="H1"/>
+			<UserParam type="string" name="1300" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12794260829875973986" quality="0">
 			<centroid rt="715.532545218785" mz="3616.85043742024" it="255204"/>
@@ -4136,6 +5111,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2151" value="H3"/>
+			<UserParam type="string" name="2152" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13816964718297068881" quality="0">
 			<centroid rt="715.714840529548" mz="1963.99826245215" it="49396"/>
@@ -4146,6 +5123,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2284" value="H1"/>
+			<UserParam type="string" name="2285" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3152410890476472062" quality="0">
 			<centroid rt="716.704746869298" mz="879.420437420251" it="255204"/>
@@ -4156,6 +5135,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2141" value="H3"/>
+			<UserParam type="string" name="2142" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1163133572766419785" quality="0">
 			<centroid rt="716.792443583427" mz="3113.12043742024" it="22500"/>
@@ -4166,6 +5147,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="445" value="H3"/>
+			<UserParam type="string" name="446" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11110401915623091385" quality="0">
 			<centroid rt="721.544460013899" mz="887.5043499362" it="436608"/>
@@ -4177,6 +5160,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1104" value="H1"/>
+			<UserParam type="string" name="1106" value="H3"/>
+			<UserParam type="string" name="1107" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16827761293177826840" quality="0">
 			<centroid rt="721.759774731991" mz="1971.97826245215" it="299094"/>
@@ -4187,6 +5173,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1035" value="H1"/>
+			<UserParam type="string" name="1037" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1183526457488033633" quality="0">
 			<centroid rt="722.344960209343" mz="721.2943499362" it="327456"/>
@@ -4198,6 +5186,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1113" value="H1"/>
+			<UserParam type="string" name="1114" value="H3"/>
+			<UserParam type="string" name="1115" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15794046469701932844" quality="0">
 			<centroid rt="723.898800419121" mz="872.4143499362" it="172284"/>
@@ -4209,6 +5200,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2159" value="H1"/>
+			<UserParam type="string" name="2161" value="H3"/>
+			<UserParam type="string" name="2162" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11821261031288699280" quality="0">
 			<centroid rt="725.950910802357" mz="2122.0143499362" it="167013"/>
@@ -4220,6 +5214,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="592" value="H1"/>
+			<UserParam type="string" name="593" value="H3"/>
+			<UserParam type="string" name="594" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4433508872969715763" quality="0">
 			<centroid rt="727.283718278917" mz="887.41043742025" it="96088"/>
@@ -4230,6 +5227,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1238" value="H3"/>
+			<UserParam type="string" name="1239" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16338580120290395025" quality="0">
 			<centroid rt="729.848528335503" mz="901.500437420251" it="255204"/>
@@ -4240,6 +5239,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2134" value="H3"/>
+			<UserParam type="string" name="2135" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12646043913154559820" quality="0">
 			<centroid rt="730.023176186682" mz="805.34826245215" it="49396"/>
@@ -4250,6 +5251,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2295" value="H1"/>
+			<UserParam type="string" name="2296" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_66993194361785441" quality="0">
 			<centroid rt="730.217608443593" mz="892.41826245215" it="167664"/>
@@ -4260,6 +5263,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1676" value="H1"/>
+			<UserParam type="string" name="1677" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16080046969627771731" quality="0">
 			<centroid rt="730.443412577903" mz="902.4943499362" it="313587"/>
@@ -4271,6 +5276,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1473" value="H1"/>
+			<UserParam type="string" name="1474" value="H3"/>
+			<UserParam type="string" name="1475" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4181020739228481919" quality="0">
 			<centroid rt="731.971119731305" mz="3730.51826245215" it="43660"/>
@@ -4281,6 +5289,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1218" value="H1"/>
+			<UserParam type="string" name="1219" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6079233733730643866" quality="0">
 			<centroid rt="732.810998036042" mz="906.48826245215" it="38442"/>
@@ -4291,6 +5301,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="632" value="H1"/>
+			<UserParam type="string" name="634" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18023077705730205150" quality="0">
 			<centroid rt="734.240237375147" mz="889.44826245215" it="22500"/>
@@ -4301,6 +5313,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="327" value="H1"/>
+			<UserParam type="string" name="328" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16544898845004130808" quality="0">
 			<centroid rt="737.48323499608" mz="914.5243499362" it="204884"/>
@@ -4313,6 +5327,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="1301" value="H1"/>
+			<UserParam type="string" name="1302" value="H2"/>
+			<UserParam type="string" name="1762" value="H3"/>
+			<UserParam type="string" name="1763" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16446406379708170819" quality="0">
 			<centroid rt="738.606969394594" mz="818.39043742025" it="123568"/>
@@ -4323,6 +5341,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="697" value="H3"/>
+			<UserParam type="string" name="698" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9317398446088771894" quality="0">
 			<centroid rt="739.671674845117" mz="736.25826245215" it="219972"/>
@@ -4333,6 +5353,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1903" value="H1"/>
+			<UserParam type="string" name="1904" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4622680142861777537" quality="0">
 			<centroid rt="742.795457051331" mz="1916.76043742025" it="121124"/>
@@ -4343,6 +5365,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2000" value="H3"/>
+			<UserParam type="string" name="2001" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8778851329554063808" quality="0">
 			<centroid rt="744.526642903187" mz="916.48826245215" it="38442"/>
@@ -4353,6 +5377,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="638" value="H1"/>
+			<UserParam type="string" name="640" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8191574428992650177" quality="0">
 			<centroid rt="745.060558709132" mz="927.364349936201" it="95568"/>
@@ -4363,6 +5389,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1522" value="H1"/>
+			<UserParam type="string" name="1523" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_11959176084661277982" quality="0">
 			<centroid rt="746.824449455385" mz="920.41826245215" it="191544"/>
@@ -4373,6 +5401,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2036" value="H1"/>
+			<UserParam type="string" name="2037" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6094512300343484972" quality="0">
 			<centroid rt="747.75624153206" mz="832.40043742025" it="44008"/>
@@ -4383,6 +5413,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="78" value="H3"/>
+			<UserParam type="string" name="79" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1584747711549665024" quality="0">
 			<centroid rt="750.936574443521" mz="927.39826245215" it="167664"/>
@@ -4393,6 +5425,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1681" value="H1"/>
+			<UserParam type="string" name="1682" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14853129704431484498" quality="0">
 			<centroid rt="752.633202769822" mz="1951.9143499362" it="50625"/>
@@ -4404,6 +5438,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="426" value="H1"/>
+			<UserParam type="string" name="427" value="H3"/>
+			<UserParam type="string" name="428" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5652460348997451083" quality="0">
 			<centroid rt="754.409209971067" mz="943.45826245215" it="22500"/>
@@ -4414,6 +5451,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="341" value="H1"/>
+			<UserParam type="string" name="342" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18220637110677598582" quality="0">
 			<centroid rt="754.531650280288" mz="852.40043742025" it="95568"/>
@@ -4424,6 +5463,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1491" value="H3"/>
+			<UserParam type="string" name="1492" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2402892195625609167" quality="0">
 			<centroid rt="760.347692865074" mz="2102.89826245215" it="95568"/>
@@ -4434,6 +5475,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1485" value="H1"/>
+			<UserParam type="string" name="1486" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18191594939226601938" quality="0">
 			<centroid rt="760.485312028346" mz="6300.92826245215" it="199396"/>
@@ -4444,6 +5487,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1025" value="H1"/>
+			<UserParam type="string" name="1026" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7945515466415104888" quality="0">
 			<centroid rt="760.808193573333" mz="954.56043742025" it="40896"/>
@@ -4454,6 +5499,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1" value="H3"/>
+			<UserParam type="string" name="2" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10293544571728618177" quality="0">
 			<centroid rt="761.966322263581" mz="776.35826245215" it="96088"/>
@@ -4464,6 +5511,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1284" value="H1"/>
+			<UserParam type="string" name="1285" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16764071763488742932" quality="0">
 			<centroid rt="763.158105221517" mz="2129.02043742025" it="47944"/>
@@ -4474,6 +5523,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1861" value="H3"/>
+			<UserParam type="string" name="1862" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5680537715477334044" quality="0">
 			<centroid rt="763.6294491774" mz="959.53826245215" it="66472"/>
@@ -4484,6 +5535,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2079" value="H1"/>
+			<UserParam type="string" name="2080" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_323437829595056064" quality="0">
 			<centroid rt="766.685569342091" mz="1987.8643499362" it="235962"/>
@@ -4495,6 +5548,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1613" value="H1"/>
+			<UserParam type="string" name="1614" value="H3"/>
+			<UserParam type="string" name="1615" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4186283897764190797" quality="0">
 			<centroid rt="769.153628404657" mz="875.44826245215" it="167664"/>
@@ -4505,6 +5561,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1685" value="H1"/>
+			<UserParam type="string" name="1686" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3749922145957405642" quality="0">
 			<centroid rt="770.174229607508" mz="960.48826245215" it="199396"/>
@@ -4515,6 +5573,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1054" value="H1"/>
+			<UserParam type="string" name="1055" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12910973365677308727" quality="0">
 			<centroid rt="773.65789367648" mz="2012.78043742025" it="167664"/>
@@ -4525,6 +5585,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1674" value="H3"/>
+			<UserParam type="string" name="1675" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10500111325539071631" quality="0">
 			<centroid rt="774.765306810174" mz="884.3593499362" it="97662"/>
@@ -4537,6 +5599,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="4"/>
+			<UserParam type="string" name="202" value="H1"/>
+			<UserParam type="string" name="204" value="H2"/>
+			<UserParam type="string" name="1799" value="H3"/>
+			<UserParam type="string" name="1800" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7763012927111852708" quality="0">
 			<centroid rt="774.882958066108" mz="2159.03043742025" it="35844"/>
@@ -4547,6 +5613,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="944" value="H3"/>
+			<UserParam type="string" name="945" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4156637832951945082" quality="0">
 			<centroid rt="778.014065472632" mz="879.40043742025" it="111342"/>
@@ -4557,6 +5625,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="601" value="H3"/>
+			<UserParam type="string" name="602" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3227594787017866758" quality="0">
 			<centroid rt="781.939730995062" mz="970.42826245215" it="27652"/>
@@ -4567,6 +5637,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1927" value="H1"/>
+			<UserParam type="string" name="1928" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7090363646250031233" quality="0">
 			<centroid rt="785.452546463685" mz="976.4643499362" it="57663"/>
@@ -4578,6 +5650,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="646" value="H1"/>
+			<UserParam type="string" name="647" value="H3"/>
+			<UserParam type="string" name="648" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13626619843787949618" quality="0">
 			<centroid rt="786.277061854091" mz="3747.64043742025" it="44008"/>
@@ -4588,6 +5663,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="162" value="H3"/>
+			<UserParam type="string" name="163" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8313427922516313771" quality="0">
 			<centroid rt="787.319897108647" mz="904.43826245215" it="145536"/>
@@ -4598,6 +5675,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1111" value="H1"/>
+			<UserParam type="string" name="1112" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1629817780182747024" quality="0">
 			<centroid rt="790.422327430909" mz="909.43826245215" it="62304"/>
@@ -4608,6 +5687,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="268" value="H1"/>
+			<UserParam type="string" name="269" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9541636205850722181" quality="0">
 			<centroid rt="791.660883802333" mz="911.4243499362" it="99018"/>
@@ -4619,6 +5700,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="59" value="H1"/>
+			<UserParam type="string" name="60" value="H3"/>
+			<UserParam type="string" name="61" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14767114513030273991" quality="0">
 			<centroid rt="791.711275910109" mz="2409.33826245215" it="44008"/>
@@ -4629,6 +5713,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="36" value="H1"/>
+			<UserParam type="string" name="37" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1999264100999954919" quality="0">
 			<centroid rt="793.041751731891" mz="1000.55043742025" it="181686"/>
@@ -4639,6 +5725,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2021" value="H3"/>
+			<UserParam type="string" name="2022" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5177408038033229059" quality="0">
 			<centroid rt="794.037731124602" mz="991.50826245215" it="144132"/>
@@ -4649,6 +5737,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1265" value="H1"/>
+			<UserParam type="string" name="1267" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10836954650138995631" quality="0">
 			<centroid rt="795.860717769663" mz="1005.41043742025" it="22500"/>
@@ -4659,6 +5749,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="479" value="H3"/>
+			<UserParam type="string" name="480" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12240904197748094729" quality="0">
 			<centroid rt="802.926438093271" mz="2286.19826245215" it="144132"/>
@@ -4669,6 +5761,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1244" value="H1"/>
+			<UserParam type="string" name="1246" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6579420843257599780" quality="0">
 			<centroid rt="804.646024901236" mz="932.45043742025" it="145536"/>
@@ -4679,6 +5773,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1148" value="H3"/>
+			<UserParam type="string" name="1149" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14535831244823143316" quality="0">
 			<centroid rt="804.725988508214" mz="2414.06043742025" it="219972"/>
@@ -4689,6 +5785,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1912" value="H3"/>
+			<UserParam type="string" name="1913" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15258991887701584427" quality="0">
 			<centroid rt="811.87581667457" mz="2169.8243499362" it="50625"/>
@@ -4700,6 +5798,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="335" value="H1"/>
+			<UserParam type="string" name="336" value="H3"/>
+			<UserParam type="string" name="337" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15112981171784358919" quality="0">
 			<centroid rt="813.026441010119" mz="1047.53826245215" it="199396"/>
@@ -4710,6 +5811,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1056" value="H1"/>
+			<UserParam type="string" name="1057" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8419248334486184473" quality="0">
 			<centroid rt="813.492459845888" mz="2503.1743499362" it="101292"/>
@@ -4720,6 +5823,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1566" value="H1"/>
+			<UserParam type="string" name="1567" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_2761584690914628629" quality="0">
 			<centroid rt="814.448414138924" mz="217.09043742025" it="43660"/>
@@ -4730,6 +5835,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1236" value="H3"/>
+			<UserParam type="string" name="1237" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15719580208000367851" quality="0">
 			<centroid rt="817.013342960944" mz="1043.42043742025" it="199396"/>
@@ -4740,6 +5847,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1023" value="H3"/>
+			<UserParam type="string" name="1024" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3405228593109388726" quality="0">
 			<centroid rt="818.028834261175" mz="954.47826245215" it="119628"/>
@@ -4750,6 +5859,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="773" value="H1"/>
+			<UserParam type="string" name="774" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2796958425778637828" quality="0">
 			<centroid rt="818.109576997939" mz="1045.5143499362" it="95568"/>
@@ -4760,6 +5871,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1493" value="H1"/>
+			<UserParam type="string" name="1494" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_15839943842778952391" quality="0">
 			<centroid rt="819.345769914138" mz="2369.14826245215" it="199396"/>
@@ -4770,6 +5883,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1045" value="H1"/>
+			<UserParam type="string" name="1046" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17957732343348111342" quality="0">
 			<centroid rt="820.446391071412" mz="958.53826245215" it="41478"/>
@@ -4780,6 +5895,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1955" value="H1"/>
+			<UserParam type="string" name="1957" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1916388497520491578" quality="0">
 			<centroid rt="821.498723876678" mz="2538.12043742025" it="62304"/>
@@ -4790,6 +5907,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="280" value="H3"/>
+			<UserParam type="string" name="281" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5387450930142686082" quality="0">
 			<centroid rt="823.329805119668" mz="4636.03826245215" it="22500"/>
@@ -4800,6 +5919,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="306" value="H1"/>
+			<UserParam type="string" name="307" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9158932438104640838" quality="0">
 			<centroid rt="823.961560211126" mz="953.42826245215" it="95592"/>
@@ -4810,6 +5931,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1168" value="H1"/>
+			<UserParam type="string" name="1169" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5699723754880480479" quality="0">
 			<centroid rt="825.376395360978" mz="1058.58043742025" it="167664"/>
@@ -4820,6 +5943,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1660" value="H3"/>
+			<UserParam type="string" name="1661" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15590123491927496012" quality="0">
 			<centroid rt="828.764544792631" mz="2200.80826245215" it="67172"/>
@@ -4830,6 +5955,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="873" value="H1"/>
+			<UserParam type="string" name="874" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14781833514150156705" quality="0">
 			<centroid rt="829.458374543513" mz="1054.43043742025" it="355362"/>
@@ -4840,6 +5967,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="989" value="H3"/>
+			<UserParam type="string" name="990" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1928055058855024483" quality="0">
 			<centroid rt="830.697809022935" mz="964.4643499362" it="76884"/>
@@ -4851,6 +5980,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="622" value="H1"/>
+			<UserParam type="string" name="624" value="H3"/>
+			<UserParam type="string" name="625" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12956212030721043758" quality="0">
 			<centroid rt="832.930210897847" mz="2267.06826245215" it="41478"/>
@@ -4861,6 +5993,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1960" value="H1"/>
+			<UserParam type="string" name="1962" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9992739656857458711" quality="0">
 			<centroid rt="833.820068344801" mz="2592.37043742025" it="104872"/>
@@ -4871,6 +6005,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1626" value="H3"/>
+			<UserParam type="string" name="1627" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4984093879518071343" quality="0">
 			<centroid rt="835.32751896741" mz="2226.0543499362" it="269163"/>
@@ -4882,6 +6018,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="770" value="H1"/>
+			<UserParam type="string" name="771" value="H3"/>
+			<UserParam type="string" name="772" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3001766304494280148" quality="0">
 			<centroid rt="835.897196791021" mz="1089.5743499362" it="418116"/>
@@ -4893,6 +6032,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1456" value="H1"/>
+			<UserParam type="string" name="1458" value="H3"/>
+			<UserParam type="string" name="1459" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5237160359476727093" quality="0">
 			<centroid rt="846.585953354532" mz="1097.60826245215" it="121124"/>
@@ -4903,6 +6045,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2011" value="H1"/>
+			<UserParam type="string" name="2012" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18309317681846756208" quality="0">
 			<centroid rt="853.058097225416" mz="2641.2343499362" it="326880"/>
@@ -4914,6 +6058,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2115" value="H1"/>
+			<UserParam type="string" name="2116" value="H3"/>
+			<UserParam type="string" name="2117" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3851833606193072940" quality="0">
 			<centroid rt="854.939038631761" mz="1016.5243499362" it="172284"/>
@@ -4925,6 +6072,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2174" value="H1"/>
+			<UserParam type="string" name="2176" value="H3"/>
+			<UserParam type="string" name="2177" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15203126865329768859" quality="0">
 			<centroid rt="860.616154965942" mz="4682.3743499362" it="327456"/>
@@ -4936,6 +6086,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1127" value="H1"/>
+			<UserParam type="string" name="1128" value="H3"/>
+			<UserParam type="string" name="1129" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9364396440904641659" quality="0">
 			<centroid rt="864.035946233642" mz="2389.08043742025" it="62304"/>
@@ -4946,6 +6099,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="264" value="H3"/>
+			<UserParam type="string" name="265" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1846148176570407832" quality="0">
 			<centroid rt="871.938565326642" mz="939.42826245215" it="123568"/>
@@ -4956,6 +6111,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="680" value="H1"/>
+			<UserParam type="string" name="681" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18356824222400832005" quality="0">
 			<centroid rt="874.287991165654" mz="1149.5243499362" it="163194"/>
@@ -4966,6 +6123,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1755" value="H1"/>
+			<UserParam type="string" name="1757" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_4598824217221984028" quality="0">
 			<centroid rt="875.242326764359" mz="1039.4543499362" it="151137"/>
@@ -4977,6 +6136,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="900" value="H1"/>
+			<UserParam type="string" name="901" value="H3"/>
+			<UserParam type="string" name="902" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1242491088143640233" quality="0">
 			<centroid rt="875.718579428759" mz="4099.72043742025" it="22500"/>
@@ -4987,6 +6149,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="431" value="H3"/>
+			<UserParam type="string" name="432" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18159376284158056427" quality="0">
 			<centroid rt="876.397859319633" mz="1041.49043742025" it="155144"/>
@@ -4997,6 +6161,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="717" value="H3"/>
+			<UserParam type="string" name="718" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9418982797118398484" quality="0">
 			<centroid rt="879.266731172827" mz="1171.6743499362" it="191544"/>
@@ -5007,6 +6173,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2060" value="H1"/>
+			<UserParam type="string" name="2061" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_5900083719314339296" quality="0">
 			<centroid rt="881.399970581754" mz="2630.1243499362" it="448641"/>
@@ -5018,6 +6186,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1096" value="H1"/>
+			<UserParam type="string" name="1097" value="H3"/>
+			<UserParam type="string" name="1098" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14523335377893132951" quality="0">
 			<centroid rt="883.376027953127" mz="1065.4743499362" it="140184"/>
@@ -5029,6 +6200,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="253" value="H1"/>
+			<UserParam type="string" name="254" value="H3"/>
+			<UserParam type="string" name="255" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12662736383495395747" quality="0">
 			<centroid rt="884.960631450495" mz="1182.57043742025" it="108796"/>
@@ -5039,6 +6213,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1730" value="H3"/>
+			<UserParam type="string" name="1731" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14139091675187802737" quality="0">
 			<centroid rt="886.292422215383" mz="1070.5143499362" it="215082"/>
@@ -5050,6 +6226,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1180" value="H1"/>
+			<UserParam type="string" name="1181" value="H3"/>
+			<UserParam type="string" name="1182" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5289999120601095961" quality="0">
 			<centroid rt="890.783442636754" mz="2831.41826245215" it="35844"/>
@@ -5060,6 +6239,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="948" value="H1"/>
+			<UserParam type="string" name="949" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12032666433946298905" quality="0">
 			<centroid rt="891.041321447979" mz="2294.0043499362" it="436608"/>
@@ -5071,6 +6252,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1135" value="H1"/>
+			<UserParam type="string" name="1137" value="H3"/>
+			<UserParam type="string" name="1138" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10613377149032503711" quality="0">
 			<centroid rt="891.455085501099" mz="1067.4143499362" it="140184"/>
@@ -5082,6 +6266,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="194" value="H1"/>
+			<UserParam type="string" name="195" value="H3"/>
+			<UserParam type="string" name="196" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13730067782011426475" quality="0">
 			<centroid rt="891.943732943832" mz="1080.5143499362" it="218304"/>
@@ -5092,6 +6279,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1119" value="H1"/>
+			<UserParam type="string" name="1121" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_4930683533963607757" quality="0">
 			<centroid rt="896.272439219822" mz="1204.61826245215" it="95568"/>
@@ -5102,6 +6291,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1541" value="H1"/>
+			<UserParam type="string" name="1542" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2249963279326441275" quality="0">
 			<centroid rt="897.241111919972" mz="1077.53826245215" it="78396"/>
@@ -5112,6 +6303,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="555" value="H1"/>
+			<UserParam type="string" name="556" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9846502931635594977" quality="0">
 			<centroid rt="899.724790288902" mz="2690.32043742025" it="62304"/>
@@ -5122,6 +6315,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="290" value="H3"/>
+			<UserParam type="string" name="291" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11765687643841428631" quality="0">
 			<centroid rt="899.840049443353" mz="2515.2443499362" it="50625"/>
@@ -5133,6 +6328,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="324" value="H1"/>
+			<UserParam type="string" name="325" value="H3"/>
+			<UserParam type="string" name="326" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17548055532691336765" quality="0">
 			<centroid rt="902.394565764427" mz="1216.65826245215" it="139372"/>
@@ -5143,6 +6341,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1467" value="H1"/>
+			<UserParam type="string" name="1468" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7266019630070595179" quality="0">
 			<centroid rt="907.247028647144" mz="2927.5943499362" it="50625"/>
@@ -5154,6 +6354,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="458" value="H1"/>
+			<UserParam type="string" name="459" value="H3"/>
+			<UserParam type="string" name="460" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4827034196203347288" quality="0">
 			<centroid rt="907.597495691234" mz="1213.49043742025" it="22500"/>
@@ -5164,6 +6367,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="438" value="H3"/>
+			<UserParam type="string" name="439" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9724693396246329309" quality="0">
 			<centroid rt="908.667992999182" mz="1202.5484082589" it="81141"/>
@@ -5175,6 +6380,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="596" value="H3"/>
+			<UserParam type="string" name="597" value="H2"/>
+			<UserParam type="string" name="1977" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_294577059354628333" quality="0">
 			<centroid rt="912.586718567994" mz="1236.6643499362" it="26649"/>
@@ -5186,6 +6394,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1385" value="H1"/>
+			<UserParam type="string" name="1386" value="H3"/>
+			<UserParam type="string" name="1387" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8347303947256825192" quality="0">
 			<centroid rt="914.847018294087" mz="1214.5443499362" it="502992"/>
@@ -5197,6 +6408,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1687" value="H1"/>
+			<UserParam type="string" name="1689" value="H3"/>
+			<UserParam type="string" name="1690" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18406571613952770283" quality="0">
 			<centroid rt="915.861229384611" mz="2561.10043742025" it="96088"/>
@@ -5207,6 +6421,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1259" value="H3"/>
+			<UserParam type="string" name="1260" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10415145175686088847" quality="0">
 			<centroid rt="917.260007616522" mz="1245.59043742025" it="191544"/>
@@ -5217,6 +6433,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2069" value="H3"/>
+			<UserParam type="string" name="2070" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3939039147394322648" quality="0">
 			<centroid rt="917.985551580184" mz="1220.61043742025" it="74228"/>
@@ -5227,6 +6445,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="575" value="H3"/>
+			<UserParam type="string" name="576" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2962766539900618075" quality="0">
 			<centroid rt="919.331005531536" mz="1236.5843499362" it="119628"/>
@@ -5237,6 +6457,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="838" value="H1"/>
+			<UserParam type="string" name="839" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_15391754392399315547" quality="0">
 			<centroid rt="920.072100422372" mz="991.42826245215" it="232716"/>
@@ -5247,6 +6469,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="730" value="H1"/>
+			<UserParam type="string" name="732" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8172970359628258515" quality="0">
 			<centroid rt="920.387297979869" mz="1238.67043742025" it="95568"/>
@@ -5257,6 +6481,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1481" value="H3"/>
+			<UserParam type="string" name="1482" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15401098168308364459" quality="0">
 			<centroid rt="921.146692451155" mz="1132.56826245215" it="78396"/>
@@ -5267,6 +6493,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="560" value="H1"/>
+			<UserParam type="string" name="561" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16913515782720084390" quality="0">
 			<centroid rt="921.73130330253" mz="1133.49391494258" it="595792"/>
@@ -5280,6 +6508,11 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="5"/>
+			<UserParam type="string" name="841" value="H1"/>
+			<UserParam type="string" name="843" value="H3"/>
+			<UserParam type="string" name="844" value="H2"/>
+			<UserParam type="string" name="1001" value="H1"/>
+			<UserParam type="string" name="1002" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13529642047807645565" quality="0">
 			<centroid rt="925.973741077023" mz="261.11826245215" it="67172"/>
@@ -5290,6 +6523,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="923" value="H1"/>
+			<UserParam type="string" name="924" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3944137302982412380" quality="0">
 			<centroid rt="926.410199904037" mz="1250.53826245215" it="199396"/>
@@ -5300,6 +6535,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1058" value="H1"/>
+			<UserParam type="string" name="1059" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10694838760065283970" quality="0">
 			<centroid rt="928.082840371593" mz="2415.0643499362" it="448641"/>
@@ -5311,6 +6548,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1028" value="H1"/>
+			<UserParam type="string" name="1029" value="H3"/>
+			<UserParam type="string" name="1030" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15766294287899682793" quality="0">
 			<centroid rt="931.08454742326" mz="1273.5443499362" it="215082"/>
@@ -5322,6 +6562,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1161" value="H1"/>
+			<UserParam type="string" name="1162" value="H3"/>
+			<UserParam type="string" name="1163" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4773141559872697308" quality="0">
 			<centroid rt="931.650293507241" mz="2646.32826245215" it="44008"/>
@@ -5332,6 +6575,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="96" value="H1"/>
+			<UserParam type="string" name="97" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6284946306235188237" quality="0">
 			<centroid rt="931.930268220363" mz="2832.0843499362" it="50625"/>
@@ -5343,6 +6588,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="354" value="H1"/>
+			<UserParam type="string" name="355" value="H3"/>
+			<UserParam type="string" name="356" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11801146446692621214" quality="0">
 			<centroid rt="933.358764714811" mz="1154.5243499362" it="349074"/>
@@ -5354,6 +6602,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="743" value="H1"/>
+			<UserParam type="string" name="744" value="H3"/>
+			<UserParam type="string" name="745" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13981108694288818464" quality="0">
 			<centroid rt="937.749471485706" mz="3073.56826245215" it="191544"/>
@@ -5364,6 +6615,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2067" value="H1"/>
+			<UserParam type="string" name="2068" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4082701688423915875" quality="0">
 			<centroid rt="938.298490456558" mz="1163.55826245215" it="123568"/>
@@ -5374,6 +6627,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="678" value="H1"/>
+			<UserParam type="string" name="679" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18007121877071956208" quality="0">
 			<centroid rt="938.586441264222" mz="1288.6143499362" it="80649"/>
@@ -5385,6 +6640,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="929" value="H1"/>
+			<UserParam type="string" name="930" value="H3"/>
+			<UserParam type="string" name="931" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3868083808101753180" quality="0">
 			<centroid rt="939.940824204166" mz="1166.5443499362" it="186912"/>
@@ -5396,6 +6654,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="249" value="H1"/>
+			<UserParam type="string" name="251" value="H3"/>
+			<UserParam type="string" name="252" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8845211633845135581" quality="0">
 			<centroid rt="941.047999879409" mz="1293.6543499362" it="145536"/>
@@ -5406,6 +6667,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1140" value="H1"/>
+			<UserParam type="string" name="1141" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_7326926441669508028" quality="0">
 			<centroid rt="944.458398172032" mz="1286.64826245215" it="121124"/>
@@ -5416,6 +6679,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2013" value="H1"/>
+			<UserParam type="string" name="2014" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7159865721324032450" quality="0">
 			<centroid rt="944.682136803083" mz="2660.1343499362" it="132024"/>
@@ -5427,6 +6692,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="68" value="H1"/>
+			<UserParam type="string" name="70" value="H3"/>
+			<UserParam type="string" name="71" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13549075598764822742" quality="0">
 			<centroid rt="948.040273394952" mz="1307.8143499362" it="216198"/>
@@ -5438,6 +6706,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1241" value="H1"/>
+			<UserParam type="string" name="1242" value="H3"/>
+			<UserParam type="string" name="1243" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7448958785830709296" quality="0">
 			<centroid rt="948.97296797439" mz="1309.78826245215" it="145536"/>
@@ -5448,6 +6719,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1108" value="H1"/>
+			<UserParam type="string" name="1109" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2361129409772472856" quality="0">
 			<centroid rt="965.811761140652" mz="1200.52826245215" it="67172"/>
@@ -5458,6 +6731,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="906" value="H1"/>
+			<UserParam type="string" name="907" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6116796534507884967" quality="0">
 			<centroid rt="966.226969263731" mz="1330.6543499362" it="108796"/>
@@ -5468,6 +6743,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1713" value="H1"/>
+			<UserParam type="string" name="1714" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_17269231335907461035" quality="0">
 			<centroid rt="967.145077563306" mz="2754.15826245215" it="145280"/>
@@ -5478,6 +6755,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2113" value="H1"/>
+			<UserParam type="string" name="2114" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16124423156931800671" quality="0">
 			<centroid rt="969.827621448195" mz="3004.25826245215" it="181686"/>
@@ -5488,6 +6767,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2002" value="H1"/>
+			<UserParam type="string" name="2004" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10864186841000086070" quality="0">
 			<centroid rt="971.116344472551" mz="1196.49826245215" it="96088"/>
@@ -5498,6 +6779,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1251" value="H1"/>
+			<UserParam type="string" name="1252" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1036371003552427054" quality="0">
 			<centroid rt="972.418835759209" mz="1226.65043742025" it="22500"/>
@@ -5508,6 +6791,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="429" value="H3"/>
+			<UserParam type="string" name="430" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8107405634188901657" quality="0">
 			<centroid rt="973.342288226613" mz="1330.55043742025" it="119628"/>
@@ -5518,6 +6803,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="792" value="H3"/>
+			<UserParam type="string" name="793" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_777246384762696662" quality="0">
 			<centroid rt="976.608203680572" mz="1366.60043742025" it="95592"/>
@@ -5528,6 +6815,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1185" value="H3"/>
+			<UserParam type="string" name="1186" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14927158780887950372" quality="0">
 			<centroid rt="981.535535430959" mz="3241.4443499362" it="99018"/>
@@ -5539,6 +6828,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="167" value="H1"/>
+			<UserParam type="string" name="168" value="H3"/>
+			<UserParam type="string" name="169" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6566991409768822958" quality="0">
 			<centroid rt="984.707027493522" mz="1368.54043742025" it="104872"/>
@@ -5549,6 +6841,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1610" value="H3"/>
+			<UserParam type="string" name="1611" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15815137934115216358" quality="0">
 			<centroid rt="986.144153834214" mz="1371.64826245215" it="44008"/>
@@ -5559,6 +6853,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="112" value="H1"/>
+			<UserParam type="string" name="113" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18153876983311221762" quality="0">
 			<centroid rt="994.210234001269" mz="3139.54043742025" it="199396"/>
@@ -5569,6 +6865,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1069" value="H3"/>
+			<UserParam type="string" name="1070" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16276502732758861967" quality="0">
 			<centroid rt="995.311934950778" mz="1255.56826245215" it="25628"/>
@@ -5579,6 +6877,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="657" value="H1"/>
+			<UserParam type="string" name="658" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4462556854496386233" quality="0">
 			<centroid rt="998.654462225051" mz="1412.66826245215" it="218304"/>
@@ -5589,6 +6889,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1101" value="H1"/>
+			<UserParam type="string" name="1103" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_299472926290285444" quality="0">
 			<centroid rt="1000.29676823087" mz="1250.54826245215" it="67172"/>
@@ -5599,6 +6901,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="884" value="H1"/>
+			<UserParam type="string" name="885" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_938248210966487978" quality="0">
 			<centroid rt="1011.38771699688" mz="1168.56043742025" it="199396"/>
@@ -5609,6 +6913,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1064" value="H3"/>
+			<UserParam type="string" name="1065" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8583154838779800703" quality="0">
 			<centroid rt="1013.69259230077" mz="1172.6443499362" it="67500"/>
@@ -5620,6 +6926,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="329" value="H1"/>
+			<UserParam type="string" name="331" value="H3"/>
+			<UserParam type="string" name="332" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7143433850838032076" quality="0">
 			<centroid rt="1013.85950755032" mz="1290.6343499362" it="349074"/>
@@ -5631,6 +6940,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="740" value="H1"/>
+			<UserParam type="string" name="741" value="H3"/>
+			<UserParam type="string" name="742" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_185451910370605520" quality="0">
 			<centroid rt="1019.70386098553" mz="1457.74043742025" it="62304"/>
@@ -5641,6 +6953,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="241" value="H3"/>
+			<UserParam type="string" name="242" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8786194898324064577" quality="0">
 			<centroid rt="1021.17228581806" mz="1319.65826245215" it="47944"/>
@@ -5651,6 +6965,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1881" value="H1"/>
+			<UserParam type="string" name="1882" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12917662585537764322" quality="0">
 			<centroid rt="1021.40358642008" mz="1445.61826245215" it="33750"/>
@@ -5661,6 +6977,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="447" value="H1"/>
+			<UserParam type="string" name="449" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16776392268118481991" quality="0">
 			<centroid rt="1022.08654573997" mz="1291.58826245215" it="95568"/>
@@ -5671,6 +6989,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1537" value="H1"/>
+			<UserParam type="string" name="1538" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13029802185157419756" quality="0">
 			<centroid rt="1024.26590746061" mz="1325.52826245215" it="299094"/>
@@ -5681,6 +7001,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1051" value="H1"/>
+			<UserParam type="string" name="1053" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17070305877265571362" quality="0">
 			<centroid rt="1024.9501052592" mz="3026.39826245215" it="66012"/>
@@ -5691,6 +7013,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="40" value="H1"/>
+			<UserParam type="string" name="42" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14698303401566419292" quality="0">
 			<centroid rt="1025.76297488889" mz="1298.66826245215" it="95568"/>
@@ -5701,6 +7025,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1489" value="H1"/>
+			<UserParam type="string" name="1490" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11438544294081777508" quality="0">
 			<centroid rt="1031.69297111478" mz="1467.74043742025" it="74228"/>
@@ -5711,6 +7037,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="613" value="H3"/>
+			<UserParam type="string" name="614" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3732705051905514612" quality="0">
 			<centroid rt="1035.39579412197" mz="1210.58043742025" it="139372"/>
@@ -5721,6 +7049,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1446" value="H3"/>
+			<UserParam type="string" name="1447" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11204227896176547783" quality="0">
 			<centroid rt="1035.4475258886" mz="1347.5543499362" it="218304"/>
@@ -5731,6 +7061,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1151" value="H1"/>
+			<UserParam type="string" name="1153" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_10051288122624842162" quality="0">
 			<centroid rt="1038.04204578817" mz="1352.6643499362" it="129213"/>
@@ -5742,6 +7074,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2178" value="H1"/>
+			<UserParam type="string" name="2179" value="H3"/>
+			<UserParam type="string" name="2180" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1878528837631963954" quality="0">
 			<centroid rt="1040.08870167062" mz="3335.55826245215" it="179442"/>
@@ -5752,6 +7087,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="835" value="H1"/>
+			<UserParam type="string" name="837" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_610313385444401565" quality="0">
 			<centroid rt="1046.15824383096" mz="1368.71826245215" it="44008"/>
@@ -5762,6 +7099,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="76" value="H1"/>
+			<UserParam type="string" name="77" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16528145150624414662" quality="0">
 			<centroid rt="1046.37804897227" mz="1307.5243499362" it="430974"/>
@@ -5773,6 +7112,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2049" value="H1"/>
+			<UserParam type="string" name="2050" value="H3"/>
+			<UserParam type="string" name="2051" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_148099044462658531" quality="0">
 			<centroid rt="1051.43112111379" mz="1526.76826245215" it="74228"/>
@@ -5783,6 +7125,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="588" value="H1"/>
+			<UserParam type="string" name="589" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3362466924399686892" quality="0">
 			<centroid rt="1059.2831821083" mz="1378.57043742025" it="22500"/>
@@ -5793,6 +7137,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="483" value="H3"/>
+			<UserParam type="string" name="484" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14692048793154324226" quality="0">
 			<centroid rt="1062.62191551469" mz="3220.57043742025" it="123568"/>
@@ -5803,6 +7149,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="682" value="H3"/>
+			<UserParam type="string" name="683" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2665174969528771266" quality="0">
 			<centroid rt="1063.17682237104" mz="1386.69043742025" it="62304"/>
@@ -5813,6 +7161,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="247" value="H3"/>
+			<UserParam type="string" name="248" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11819842411009442369" quality="0">
 			<centroid rt="1067.91099070104" mz="3471.57826245215" it="108796"/>
@@ -5823,6 +7173,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1721" value="H1"/>
+			<UserParam type="string" name="1722" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6999321261323078376" quality="0">
 			<centroid rt="1069.98452203268" mz="1567.68826245215" it="139372"/>
@@ -5833,6 +7185,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1418" value="H1"/>
+			<UserParam type="string" name="1419" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6988983091627340729" quality="0">
 			<centroid rt="1070.76371214335" mz="1535.76043742025" it="74094"/>
@@ -5843,6 +7197,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2235" value="H3"/>
+			<UserParam type="string" name="2236" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17067233280635010273" quality="0">
 			<centroid rt="1072.06561646295" mz="2996.41043742025" it="40896"/>
@@ -5853,6 +7209,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="4" value="H3"/>
+			<UserParam type="string" name="5" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7250201296697898447" quality="0">
 			<centroid rt="1076.22623241333" mz="1412.65043742025" it="78396"/>
@@ -5863,6 +7221,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="563" value="H3"/>
+			<UserParam type="string" name="564" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7485346196216038253" quality="0">
 			<centroid rt="1076.28007770683" mz="1396.63043742025" it="27652"/>
@@ -5873,6 +7233,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1968" value="H3"/>
+			<UserParam type="string" name="1969" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7033434343632695038" quality="0">
 			<centroid rt="1077.3091746777" mz="1285.6343499362" it="66012"/>
@@ -5883,6 +7245,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="64" value="H1"/>
+			<UserParam type="string" name="66" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_8139538992938845712" quality="0">
 			<centroid rt="1079.02180396899" mz="1570.6743499362" it="235962"/>
@@ -5894,6 +7258,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1601" value="H1"/>
+			<UserParam type="string" name="1602" value="H3"/>
+			<UserParam type="string" name="1603" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4816220207346568434" quality="0">
 			<centroid rt="1081.7690341362" mz="1423.59043742025" it="121124"/>
@@ -5904,6 +7271,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1998" value="H3"/>
+			<UserParam type="string" name="1999" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5403514295358055572" quality="0">
 			<centroid rt="1083.86970417215" mz="3738.7343499362" it="6309"/>
@@ -5915,6 +7284,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1778" value="H1"/>
+			<UserParam type="string" name="1779" value="H3"/>
+			<UserParam type="string" name="1780" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5932209541084602240" quality="0">
 			<centroid rt="1084.39539470939" mz="1565.74826245215" it="74094"/>
@@ -5925,6 +7297,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2217" value="H1"/>
+			<UserParam type="string" name="2219" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18139616601720336803" quality="0">
 			<centroid rt="1091.53581263727" mz="1598.74826245215" it="40896"/>
@@ -5935,6 +7309,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="8" value="H1"/>
+			<UserParam type="string" name="9" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12126564254943423976" quality="0">
 			<centroid rt="1093.89186968432" mz="1586.72043742025" it="100758"/>
@@ -5945,6 +7321,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="915" value="H3"/>
+			<UserParam type="string" name="916" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5269505805940726351" quality="0">
 			<centroid rt="1102.21352271116" mz="1622.84826245215" it="95568"/>
@@ -5955,6 +7333,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1508" value="H1"/>
+			<UserParam type="string" name="1509" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9300090625335653276" quality="0">
 			<centroid rt="1106.70981571755" mz="1323.58826245215" it="2804"/>
@@ -5965,6 +7345,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1787" value="H1"/>
+			<UserParam type="string" name="1788" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4540088603560624231" quality="0">
 			<centroid rt="1108.85529902547" mz="2932.16043742025" it="93456"/>
@@ -5975,6 +7357,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="237" value="H3"/>
+			<UserParam type="string" name="238" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16053043948607638819" quality="0">
 			<centroid rt="1110.51182805556" mz="1431.62826245215" it="70416"/>
@@ -5985,6 +7369,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="524" value="H1"/>
+			<UserParam type="string" name="525" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12029831031450392801" quality="0">
 			<centroid rt="1115.96471357613" mz="3185.39826245215" it="22500"/>
@@ -5995,6 +7381,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="308" value="H1"/>
+			<UserParam type="string" name="309" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10645519393696584869" quality="0">
 			<centroid rt="1125.96795676492" mz="1694.99043742025" it="11844"/>
@@ -6005,6 +7393,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1388" value="H3"/>
+			<UserParam type="string" name="1389" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16962736030867091508" quality="0">
 			<centroid rt="1127.06799239857" mz="1498.5843499362" it="22500"/>
@@ -6015,6 +7405,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="433" value="H1"/>
+			<UserParam type="string" name="434" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_6602418471455196042" quality="0">
 			<centroid rt="1128.17104104293" mz="1535.68826245215" it="139372"/>
@@ -6025,6 +7417,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1453" value="H1"/>
+			<UserParam type="string" name="1454" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14562563451542568056" quality="0">
 			<centroid rt="1135.61204885126" mz="1481.6043499362" it="26649"/>
@@ -6036,6 +7430,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1349" value="H1"/>
+			<UserParam type="string" name="1350" value="H3"/>
+			<UserParam type="string" name="1351" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7466719830446196387" quality="0">
 			<centroid rt="1136.63805973597" mz="1719.80826245215" it="126834"/>
@@ -6046,6 +7443,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="500" value="H1"/>
+			<UserParam type="string" name="502" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1156787066631433995" quality="0">
 			<centroid rt="1141.2364967129" mz="1387.6143499362" it="99018"/>
@@ -6057,6 +7456,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="88" value="H1"/>
+			<UserParam type="string" name="89" value="H3"/>
+			<UserParam type="string" name="90" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4457699797544099770" quality="0">
 			<centroid rt="1154.43751026446" mz="1429.66043742025" it="49396"/>
@@ -6067,6 +7469,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2225" value="H3"/>
+			<UserParam type="string" name="2226" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10533673530789558777" quality="0">
 			<centroid rt="1163.6911249868" mz="3451.47826245215" it="57428"/>
@@ -6077,6 +7481,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2194" value="H1"/>
+			<UserParam type="string" name="2195" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17180065165694989362" quality="0">
 			<centroid rt="1169.65697884836" mz="3026.39826245215" it="139372"/>
@@ -6087,6 +7493,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1471" value="H1"/>
+			<UserParam type="string" name="1472" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_331078914537642712" quality="0">
 			<centroid rt="1174.68179618106" mz="1770.8843499362" it="287316"/>
@@ -6097,6 +7505,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2042" value="H1"/>
+			<UserParam type="string" name="2044" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_8997732016971227334" quality="0">
 			<centroid rt="1176.68284810575" mz="1583.78043742025" it="11844"/>
@@ -6107,6 +7517,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1378" value="H3"/>
+			<UserParam type="string" name="1379" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11202360727296405826" quality="0">
 			<centroid rt="1176.99941245239" mz="1718.7243499362" it="43660"/>
@@ -6117,6 +7529,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1212" value="H1"/>
+			<UserParam type="string" name="1213" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_14324326643182622967" quality="0">
 			<centroid rt="1178.05895103328" mz="1817.89826245215" it="96088"/>
@@ -6127,6 +7541,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1337" value="H1"/>
+			<UserParam type="string" name="1338" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5006079976222180646" quality="0">
 			<centroid rt="1178.55511998783" mz="1819.06826245215" it="128476"/>
@@ -6137,6 +7553,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2121" value="H1"/>
+			<UserParam type="string" name="2122" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6286428456806121647" quality="0">
 			<centroid rt="1194.72435839549" mz="3595.65826245215" it="22500"/>
@@ -6147,6 +7565,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="403" value="H1"/>
+			<UserParam type="string" name="404" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6991262349704516560" quality="0">
 			<centroid rt="1199.54912375083" mz="1669.75043742025" it="167664"/>
@@ -6157,6 +7577,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1678" value="H3"/>
+			<UserParam type="string" name="1679" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8972433239094224713" quality="0">
 			<centroid rt="1202.20132077708" mz="1835.94043742025" it="96088"/>
@@ -6167,6 +7589,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1290" value="H3"/>
+			<UserParam type="string" name="1291" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16621971388739211704" quality="0">
 			<centroid rt="1218.92994777899" mz="3889.70826245215" it="151938"/>
@@ -6177,6 +7601,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1592" value="H1"/>
+			<UserParam type="string" name="1594" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5887771321863689397" quality="0">
 			<centroid rt="1219.347964259" mz="1556.69826245215" it="167664"/>
@@ -6187,6 +7613,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1701" value="H1"/>
+			<UserParam type="string" name="1702" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13241518605126825793" quality="0">
 			<centroid rt="1229.35227617695" mz="1921.9443499362" it="151137"/>
@@ -6198,6 +7626,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="865" value="H1"/>
+			<UserParam type="string" name="866" value="H3"/>
+			<UserParam type="string" name="867" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1218322259342643428" quality="0">
 			<centroid rt="1230.47054434831" mz="1717.8443499362" it="176391"/>
@@ -6209,6 +7640,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="565" value="H1"/>
+			<UserParam type="string" name="566" value="H3"/>
+			<UserParam type="string" name="567" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8026919641073684149" quality="0">
 			<centroid rt="1232.40183110385" mz="1741.9143499362" it="167013"/>
@@ -6220,6 +7654,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="605" value="H1"/>
+			<UserParam type="string" name="606" value="H3"/>
+			<UserParam type="string" name="607" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1184113299694509322" quality="0">
 			<centroid rt="1234.56160295806" mz="1746.87826245215" it="192714"/>
@@ -6230,6 +7667,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2128" value="H1"/>
+			<UserParam type="string" name="2130" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5196751351181609807" quality="0">
 			<centroid rt="1238.188681381" mz="1964.96826245215" it="44008"/>
@@ -6240,6 +7679,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="160" value="H1"/>
+			<UserParam type="string" name="161" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12307230336813812062" quality="0">
 			<centroid rt="1250.85856874969" mz="1762.79826245215" it="209058"/>
@@ -6250,6 +7691,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1463" value="H1"/>
+			<UserParam type="string" name="1465" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17122652153471178478" quality="0">
 			<centroid rt="1252.53441116676" mz="2000.92826245215" it="101292"/>
@@ -6260,6 +7703,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1563" value="H1"/>
+			<UserParam type="string" name="1564" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3721094159470797158" quality="0">
 			<centroid rt="1263.69133303207" mz="2029.01043742025" it="209058"/>
@@ -6270,6 +7715,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1416" value="H3"/>
+			<UserParam type="string" name="1417" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10109232435417822478" quality="0">
 			<centroid rt="1267.13063987212" mz="1653.8143499362" it="533043"/>
@@ -6281,6 +7728,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="995" value="H1"/>
+			<UserParam type="string" name="996" value="H3"/>
+			<UserParam type="string" name="997" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15408433364646702686" quality="0">
 			<centroid rt="1267.62900437062" mz="2039.07043742025" it="4206"/>
@@ -6291,6 +7741,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1776" value="H3"/>
+			<UserParam type="string" name="1777" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14315989389504828861" quality="0">
 			<centroid rt="1276.50449690061" mz="1819.75826245215" it="329958"/>
@@ -6301,6 +7753,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1921" value="H1"/>
+			<UserParam type="string" name="1923" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4854241134085153878" quality="0">
 			<centroid rt="1285.5953348586" mz="1819.76043742025" it="49396"/>
@@ -6311,6 +7765,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2314" value="H3"/>
+			<UserParam type="string" name="2315" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9271141736259369102" quality="0">
 			<centroid rt="1301.23618694139" mz="4346.3143499362" it="176391"/>
@@ -6322,6 +7778,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="544" value="H1"/>
+			<UserParam type="string" name="545" value="H3"/>
+			<UserParam type="string" name="546" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12554845244454538169" quality="0">
 			<centroid rt="1302.87547008411" mz="1901.96826245215" it="191544"/>
@@ -6332,6 +7791,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2038" value="H1"/>
+			<UserParam type="string" name="2039" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17574426434861343224" quality="0">
 			<centroid rt="1303.13122247857" mz="3585.68826245215" it="62304"/>
@@ -6342,6 +7803,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="257" value="H1"/>
+			<UserParam type="string" name="258" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14975485729746204160" quality="0">
 			<centroid rt="1305.05854411506" mz="1906.95043742025" it="199396"/>
@@ -6352,6 +7815,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1040" value="H3"/>
+			<UserParam type="string" name="1041" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17751424057674884149" quality="0">
 			<centroid rt="1306.77905909893" mz="1910.8743499362" it="140184"/>
@@ -6363,6 +7828,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="233" value="H1"/>
+			<UserParam type="string" name="234" value="H3"/>
+			<UserParam type="string" name="235" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5947518681065794385" quality="0">
 			<centroid rt="1307.43953897324" mz="4412.10826245215" it="355362"/>
@@ -6373,6 +7841,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="978" value="H1"/>
+			<UserParam type="string" name="980" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17598414698612584066" quality="0">
 			<centroid rt="1317.2850524801" mz="4193.92043742025" it="145536"/>
@@ -6383,6 +7853,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1124" value="H3"/>
+			<UserParam type="string" name="1125" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13217433794335918537" quality="0">
 			<centroid rt="1322.35876412406" mz="2157.06043742025" it="139372"/>
@@ -6393,6 +7865,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1460" value="H3"/>
+			<UserParam type="string" name="1461" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9154985432682511546" quality="0">
 			<centroid rt="1340.9384248966" mz="1787.7943499362" it="6309"/>
@@ -6404,6 +7878,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1811" value="H1"/>
+			<UserParam type="string" name="1812" value="H3"/>
+			<UserParam type="string" name="1813" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15750685928998517642" quality="0">
 			<centroid rt="1358.91212369175" mz="2010.87826245215" it="95568"/>
@@ -6414,6 +7891,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1497" value="H1"/>
+			<UserParam type="string" name="1498" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3291715652148947634" quality="0">
 			<centroid rt="1367.4479242" mz="2007.87043742025" it="163194"/>
@@ -6424,6 +7903,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1717" value="H3"/>
+			<UserParam type="string" name="1718" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_172399186522237111" quality="0">
 			<centroid rt="1372.82728670106" mz="2290.17043742025" it="67172"/>
@@ -6434,6 +7915,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="890" value="H3"/>
+			<UserParam type="string" name="891" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8778414488314215058" quality="0">
 			<centroid rt="1387.37624544551" mz="2079.0443499362" it="176391"/>
@@ -6445,6 +7928,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="536" value="H1"/>
+			<UserParam type="string" name="537" value="H3"/>
+			<UserParam type="string" name="538" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1046040594492608378" quality="0">
 			<centroid rt="1395.6464467919" mz="4824.25826245215" it="44008"/>
@@ -6455,6 +7941,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="118" value="H1"/>
+			<UserParam type="string" name="119" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15875778115546668748" quality="0">
 			<centroid rt="1404.73141312005" mz="2402.2143499362" it="326880"/>
@@ -6466,6 +7954,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="2082" value="H1"/>
+			<UserParam type="string" name="2083" value="H3"/>
+			<UserParam type="string" name="2084" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12821346041123224628" quality="0">
 			<centroid rt="1417.84300753042" mz="2412.24043742025" it="121124"/>
@@ -6476,6 +7967,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1992" value="H3"/>
+			<UserParam type="string" name="1993" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9333502802522717116" quality="0">
 			<centroid rt="1418.66142100025" mz="1980.86826245215" it="128476"/>
@@ -6486,6 +7979,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2123" value="H1"/>
+			<UserParam type="string" name="2124" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16290676826731493094" quality="0">
 			<centroid rt="1427.00795576019" mz="2411.19043742025" it="11844"/>
@@ -6496,6 +7991,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1392" value="H3"/>
+			<UserParam type="string" name="1393" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1149685461730456803" quality="0">
 			<centroid rt="1428.67116361818" mz="2230.00826245215" it="33750"/>
@@ -6506,6 +8003,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="361" value="H1"/>
+			<UserParam type="string" name="363" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15742233939678999868" quality="0">
 			<centroid rt="1430.71347740582" mz="2235.1843499362" it="26649"/>
@@ -6517,6 +8016,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1405" value="H1"/>
+			<UserParam type="string" name="1406" value="H3"/>
+			<UserParam type="string" name="1407" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14954491698616266362" quality="0">
 			<centroid rt="1446.49720898818" mz="2147.95043742025" it="49396"/>
@@ -6527,6 +8029,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2263" value="H3"/>
+			<UserParam type="string" name="2264" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14581421697385334693" quality="0">
 			<centroid rt="1447.27272538789" mz="2175.08826245215" it="155144"/>
@@ -6537,6 +8041,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="734" value="H1"/>
+			<UserParam type="string" name="735" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6352423677477416598" quality="0">
 			<centroid rt="1452.50442256708" mz="2008.82043742025" it="62304"/>
@@ -6547,6 +8053,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="224" value="H3"/>
+			<UserParam type="string" name="225" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12336859030993137229" quality="0">
 			<centroid rt="1454.50803149583" mz="2243.9743499362" it="215082"/>
@@ -6558,6 +8066,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1177" value="H1"/>
+			<UserParam type="string" name="1178" value="H3"/>
+			<UserParam type="string" name="1179" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8356236929481550174" quality="0">
 			<centroid rt="1464.01690889875" mz="2568.53043742025" it="62304"/>
@@ -6568,6 +8079,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="295" value="H3"/>
+			<UserParam type="string" name="296" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6304914629964338428" quality="0">
 			<centroid rt="1478.14501017936" mz="2330.14826245215" it="25628"/>
@@ -6578,6 +8091,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="663" value="H1"/>
+			<UserParam type="string" name="664" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1495186743674678050" quality="0">
 			<centroid rt="1479.022457729" mz="5799.91826245215" it="43660"/>
@@ -6588,6 +8103,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1208" value="H1"/>
+			<UserParam type="string" name="1209" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16816645573881456813" quality="0">
 			<centroid rt="1482.76572453708" mz="2128.08043742025" it="67172"/>
@@ -6598,6 +8115,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="895" value="H3"/>
+			<UserParam type="string" name="896" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_2613167037075113080" quality="0">
 			<centroid rt="1495.99221028929" mz="2056.9043499362" it="218304"/>
@@ -6608,6 +8127,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1132" value="H1"/>
+			<UserParam type="string" name="1134" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_7090651465611770259" quality="0">
 			<centroid rt="1524.5525609286" mz="2395.1243499362" it="269163"/>
@@ -6619,6 +8140,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="851" value="H1"/>
+			<UserParam type="string" name="852" value="H3"/>
+			<UserParam type="string" name="853" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12006574520086523701" quality="0">
 			<centroid rt="1526.2394377217" mz="568.2243499362" it="190251"/>
@@ -6630,6 +8154,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="506" value="H1"/>
+			<UserParam type="string" name="507" value="H3"/>
+			<UserParam type="string" name="508" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4052643037427892202" quality="0">
 			<centroid rt="1526.77905542084" mz="2178.89043742025" it="22500"/>
@@ -6640,6 +8167,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="436" value="H3"/>
+			<UserParam type="string" name="437" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_12441705442148206093" quality="0">
 			<centroid rt="1531.00452347803" mz="2189.0343499362" it="99018"/>
@@ -6651,6 +8180,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="91" value="H1"/>
+			<UserParam type="string" name="92" value="H3"/>
+			<UserParam type="string" name="93" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11447662113386695970" quality="0">
 			<centroid rt="1556.95288828005" mz="2276.95826245215" it="27652"/>
@@ -6661,6 +8193,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1988" value="H1"/>
+			<UserParam type="string" name="1989" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5509383915639459666" quality="0">
 			<centroid rt="1565.57615505675" mz="2866.41043742025" it="191544"/>
@@ -6671,6 +8205,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2065" value="H3"/>
+			<UserParam type="string" name="2066" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1904563756875743800" quality="0">
 			<centroid rt="1579.21088499389" mz="2247.9843499362" it="66012"/>
@@ -6681,6 +8217,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="54" value="H1"/>
+			<UserParam type="string" name="56" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_12493515834771266033" quality="0">
 			<centroid rt="1579.83679015927" mz="601.354349936201" it="74228"/>
@@ -6691,6 +8229,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="617" value="H1"/>
+			<UserParam type="string" name="618" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_1423821826472748158" quality="0">
 			<centroid rt="1580.84435594028" mz="2912.6143499362" it="253668"/>
@@ -6702,6 +8242,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="488" value="H1"/>
+			<UserParam type="string" name="490" value="H3"/>
+			<UserParam type="string" name="491" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15870662966092337649" quality="0">
 			<centroid rt="1584.07422967494" mz="2343.1943499362" it="269163"/>
@@ -6713,6 +8256,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="746" value="H1"/>
+			<UserParam type="string" name="747" value="H3"/>
+			<UserParam type="string" name="748" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_14213487048528816582" quality="0">
 			<centroid rt="1587.11376080672" mz="2618.26043742025" it="2804"/>
@@ -6723,6 +8269,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1822" value="H3"/>
+			<UserParam type="string" name="1823" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_18285633435195019379" quality="0">
 			<centroid rt="1606.99751456457" mz="2086.93826245215" it="25628"/>
@@ -6733,6 +8281,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="667" value="H1"/>
+			<UserParam type="string" name="668" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7432743070689371084" quality="0">
 			<centroid rt="1615.32058472394" mz="2953.4643499362" it="349074"/>
@@ -6744,6 +8294,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="711" value="H1"/>
+			<UserParam type="string" name="712" value="H3"/>
+			<UserParam type="string" name="713" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15887647853629698988" quality="0">
 			<centroid rt="1615.49997154362" mz="2160.00826245215" it="170136"/>
@@ -6754,6 +8307,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2147" value="H1"/>
+			<UserParam type="string" name="2148" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17638138937727664771" quality="0">
 			<centroid rt="1641.64629603268" mz="1965.69826245215" it="62304"/>
@@ -6764,6 +8319,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="208" value="H1"/>
+			<UserParam type="string" name="209" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10273547885557171936" quality="0">
 			<centroid rt="1661.43480483893" mz="2234.08826245215" it="78396"/>
@@ -6774,6 +8331,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="552" value="H1"/>
+			<UserParam type="string" name="553" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16969847863680344640" quality="0">
 			<centroid rt="1670.37190880431" mz="4925.19826245215" it="57428"/>
@@ -6784,6 +8343,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2189" value="H1"/>
+			<UserParam type="string" name="2190" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5614857707846512519" quality="0">
 			<centroid rt="1680.01769683038" mz="2305.0443499362" it="227907"/>
@@ -6795,6 +8356,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1586" value="H1"/>
+			<UserParam type="string" name="1587" value="H3"/>
+			<UserParam type="string" name="1588" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_6925070158502464530" quality="0">
 			<centroid rt="1684.7685222348" mz="3201.8643499362" it="269163"/>
@@ -6806,6 +8370,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="803" value="H1"/>
+			<UserParam type="string" name="804" value="H3"/>
+			<UserParam type="string" name="805" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4574991467315221490" quality="0">
 			<centroid rt="1701.82988380064" mz="2576.1843499362" it="96088"/>
@@ -6816,6 +8383,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1303" value="H1"/>
+			<UserParam type="string" name="1304" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_3171926701331811374" quality="0">
 			<centroid rt="1734.6484316714" mz="3000.43043742025" it="101292"/>
@@ -6826,6 +8395,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1561" value="H3"/>
+			<UserParam type="string" name="1562" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15500326789970591191" quality="0">
 			<centroid rt="1739.52335229557" mz="560.2743499362" it="139372"/>
@@ -6836,6 +8407,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1476" value="H1"/>
+			<UserParam type="string" name="1477" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_14325916067359767697" quality="0">
 			<centroid rt="1740.86381726845" mz="6104.71826245215" it="144132"/>
@@ -6846,6 +8419,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1331" value="H1"/>
+			<UserParam type="string" name="1333" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9360755643028273834" quality="0">
 			<centroid rt="1766.54218161129" mz="2252.03826245215" it="84556"/>
@@ -6856,6 +8431,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="497" value="H1"/>
+			<UserParam type="string" name="498" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_878511986651826464" quality="0">
 			<centroid rt="1776.50915096795" mz="2836.2743499362" it="41478"/>
@@ -6866,6 +8443,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1974" value="H1"/>
+			<UserParam type="string" name="1976" value="H3"/>
 		</consensusElement>
 		<consensusElement id="e_413914599372591410" quality="0">
 			<centroid rt="1777.08886509685" mz="431.19826245215" it="86142"/>
@@ -6876,6 +8455,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2207" value="H1"/>
+			<UserParam type="string" name="2209" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9706230593307898592" quality="0">
 			<centroid rt="1778.3146742829" mz="3200.55826245215" it="35844"/>
@@ -6886,6 +8467,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="961" value="H1"/>
+			<UserParam type="string" name="962" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3618103136346350031" quality="0">
 			<centroid rt="1796.43678033596" mz="3145.45043742025" it="167664"/>
@@ -6896,6 +8479,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1657" value="H3"/>
+			<UserParam type="string" name="1658" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_5853386163962377979" quality="0">
 			<centroid rt="1846.57585598082" mz="780.38826245215" it="95592"/>
@@ -6906,6 +8491,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1198" value="H1"/>
+			<UserParam type="string" name="1199" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17698010843714859552" quality="0">
 			<centroid rt="1852.02597108287" mz="3042.61043742025" it="27652"/>
@@ -6916,6 +8503,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1942" value="H3"/>
+			<UserParam type="string" name="1943" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_13795773311341649157" quality="0">
 			<centroid rt="1857.05562665493" mz="3093.45826245215" it="43660"/>
@@ -6926,6 +8515,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1226" value="H1"/>
+			<UserParam type="string" name="1227" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_214790508669342523" quality="0">
 			<centroid rt="1887.14295767276" mz="3418.60043742025" it="22500"/>
@@ -6936,6 +8527,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="319" value="H3"/>
+			<UserParam type="string" name="320" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_16952124018244576804" quality="0">
 			<centroid rt="1903.41440768012" mz="3549.6843499362" it="26649"/>
@@ -6947,6 +8540,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1360" value="H1"/>
+			<UserParam type="string" name="1361" value="H3"/>
+			<UserParam type="string" name="1362" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10160199960047977550" quality="0">
 			<centroid rt="1906.42393549034" mz="2779.05826245215" it="93456"/>
@@ -6957,6 +8553,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="199" value="H1"/>
+			<UserParam type="string" name="201" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4095298779814014264" quality="0">
 			<centroid rt="1925.0294929476" mz="3248.48043742024" it="44008"/>
@@ -6967,6 +8565,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="108" value="H3"/>
+			<UserParam type="string" name="109" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10874916574229329364" quality="0">
 			<centroid rt="1940.5629822917" mz="3214.4843499362" it="99018"/>
@@ -6978,6 +8578,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="50" value="H1"/>
+			<UserParam type="string" name="51" value="H3"/>
+			<UserParam type="string" name="52" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_578841297261985521" quality="0">
 			<centroid rt="1979.68088806165" mz="878.37826245215" it="121124"/>
@@ -6988,6 +8591,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2029" value="H1"/>
+			<UserParam type="string" name="2030" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9822438612666863440" quality="0">
 			<centroid rt="2022.0236151086" mz="4359.14043742024" it="199396"/>
@@ -6998,6 +8603,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1061" value="H3"/>
+			<UserParam type="string" name="1062" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_4898859662840460052" quality="0">
 			<centroid rt="2065.22198762001" mz="3663.76826245215" it="35844"/>
@@ -7008,6 +8615,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="957" value="H1"/>
+			<UserParam type="string" name="958" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3141787288646252083" quality="0">
 			<centroid rt="2213.18251549446" mz="3637.71826245215" it="44008"/>
@@ -7018,6 +8627,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="110" value="H1"/>
+			<UserParam type="string" name="111" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9484812960280877519" quality="0">
 			<centroid rt="2479.52098673809" mz="976.36826245215" it="224780"/>
@@ -7028,6 +8639,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="189" value="H1"/>
+			<UserParam type="string" name="190" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_150323667264780492" quality="0">
 			<centroid rt="2600.72573520029" mz="1091.5343499362" it="269163"/>
@@ -7039,6 +8652,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="862" value="H1"/>
+			<UserParam type="string" name="863" value="H3"/>
+			<UserParam type="string" name="864" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_9511057425339495826" quality="0">
 			<centroid rt="2637.06979555726" mz="5216.4843499362" it="216198"/>
@@ -7050,6 +8666,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1255" value="H1"/>
+			<UserParam type="string" name="1256" value="H3"/>
+			<UserParam type="string" name="1257" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10468907994776734394" quality="0">
 			<centroid rt="2998.63696059486" mz="4841.40043742026" it="74094"/>
@@ -7060,6 +8679,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2279" value="H3"/>
+			<UserParam type="string" name="2280" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_7793421361209332225" quality="0">
 			<centroid rt="3038.22815337594" mz="1105.4843499362" it="140184"/>
@@ -7071,6 +8692,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="303" value="H1"/>
+			<UserParam type="string" name="304" value="H3"/>
+			<UserParam type="string" name="305" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_1159069157417596337" quality="0">
 			<centroid rt="3108.42091586594" mz="5165.38043742025" it="96088"/>
@@ -7081,6 +8705,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1288" value="H3"/>
+			<UserParam type="string" name="1289" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_10993450417376199581" quality="0">
 			<centroid rt="3131.80851026947" mz="5235.6343499362" it="107874"/>
@@ -7092,6 +8718,9 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="1864" value="H1"/>
+			<UserParam type="string" name="1865" value="H3"/>
+			<UserParam type="string" name="1866" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_3324387083549946335" quality="0">
 			<centroid rt="3256.6490962944" mz="884.27826245215" it="95568"/>
@@ -7102,6 +8731,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1553" value="H1"/>
+			<UserParam type="string" name="1554" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_17484350322137107479" quality="0">
 			<centroid rt="3726.63025438367" mz="6874.48043742025" it="144132"/>
@@ -7112,6 +8743,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="1280" value="H3"/>
+			<UserParam type="string" name="1281" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_8609000627103583239" quality="0">
 			<centroid rt="4050.413210765" mz="1925.77826245215" it="40896"/>
@@ -7122,6 +8755,8 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="29" value="H1"/>
+			<UserParam type="string" name="30" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_15068101509242272941" quality="0">
 			<centroid rt="7000" mz="3848.66826245215" it="128476"/>
@@ -7132,6686 +8767,4684 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="2"/>
+			<UserParam type="string" name="2131" value="H1"/>
+			<UserParam type="string" name="2132" value="H2"/>
 		</consensusElement>
 		<consensusElement id="e_11483414885195026261" quality="0">
 			<centroid rt="3.64578539422209" mz="402.265447066458" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1885" rt="3.64578539422209" mz="202.14" it="11986" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2528618053164501508" quality="0">
 			<centroid rt="15.3050568634641" mz="430.275447066458" it="17604"/>
 			<groupedElementList>
 				<element map="0" id="519" rt="15.3050568634641" mz="216.145" it="17604" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_412717682724576035" quality="0">
 			<centroid rt="43.5558673692008" mz="274.160894132916" it="127602"/>
 			<groupedElementList>
 				<element map="0" id="2156" rt="43.5558673692008" mz="69.5475" it="127602" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2516641484712619794" quality="0">
 			<centroid rt="65.1092571204024" mz="560.320894132916" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2250" rt="65.1092571204024" mz="141.0875" it="12349" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7203453455793000143" quality="0">
 			<centroid rt="89.9971098291832" mz="345.200894132916" it="32745"/>
 			<groupedElementList>
 				<element map="0" id="1206" rt="89.9971098291832" mz="87.3075" it="32745" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18131249952897058709" quality="0">
 			<centroid rt="92.3073785457429" mz="146.070894132916" it="23972"/>
 			<groupedElementList>
 				<element map="0" id="1886" rt="92.3073785457429" mz="37.525" it="23972" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18113583712846482965" quality="0">
 			<centroid rt="98.5708782843229" mz="359.205447066458" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1085" rt="98.5708782843229" mz="180.61" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1401529175877215833" quality="0">
 			<centroid rt="99.7819761969976" mz="361.205447066458" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="152" rt="99.7819761969976" mz="181.61" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6322442066154616051" quality="0">
 			<centroid rt="104.025028846147" mz="368.122723533229" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1518" rt="104.025028846147" mz="369.13" it="23892" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10718451943880587883" quality="0">
 			<centroid rt="108.22678993014" mz="375.210894132916" it="95772"/>
 			<groupedElementList>
 				<element map="0" id="2045" rt="108.22678993014" mz="94.81" it="95772" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1338866470626644381" quality="0">
 			<centroid rt="115.230669884737" mz="387.200894132916" it="99698"/>
 			<groupedElementList>
 				<element map="0" id="1091" rt="115.230669884737" mz="97.8075" it="99698" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4787164336817333115" quality="0">
 			<centroid rt="116.457765939485" mz="389.200894132916" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1383" rt="116.457765939485" mz="98.3075" it="2961" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11274106427224202407" quality="0">
 			<centroid rt="121.642704735959" mz="398.110894132916" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="753" rt="121.642704735959" mz="100.535" it="59814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16650585310693836439" quality="0">
 			<centroid rt="121.642704735959" mz="398.125447066458" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="754" rt="121.642704735959" mz="200.07" it="59814" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10496268287503925254" quality="0">
 			<centroid rt="123.392363935444" mz="401.240894132916" it="95772"/>
 			<groupedElementList>
 				<element map="0" id="2055" rt="123.392363935444" mz="101.3175" it="95772" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1286836985246043543" quality="0">
 			<centroid rt="130.824212510955" mz="414.125447066458" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="972" rt="130.824212510955" mz="208.07" it="8961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14114636986123373428" quality="0">
 			<centroid rt="131.355564395529" mz="415.250894132916" it="95568"/>
 			<groupedElementList>
 				<element map="0" id="1511" rt="131.355564395529" mz="104.82" it="95568" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8784439554344309249" quality="0">
 			<centroid rt="140.293808712931" mz="431.230894132916" it="43071"/>
 			<groupedElementList>
 				<element map="0" id="2169" rt="140.293808712931" mz="108.815" it="43071" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17349261716258547717" quality="0">
 			<centroid rt="142.765905922957" mz="797.325447066458" it="36320"/>
 			<groupedElementList>
 				<element map="0" id="2103" rt="142.765905922957" mz="399.67" it="36320" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17829375172087066944" quality="0">
 			<centroid rt="145.830255475181" mz="441.140894132916" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="344" rt="145.830255475181" mz="111.2925" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_607941761086497712" quality="0">
 			<centroid rt="145.830255475181" mz="441.155447066458" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="345" rt="145.830255475181" mz="221.585" it="11250" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3673441443818809352" quality="0">
 			<centroid rt="147.434790938763" mz="444.220894132916" it="20739"/>
 			<groupedElementList>
 				<element map="0" id="1929" rt="147.434790938763" mz="112.0625" it="20739" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1552693816883481149" quality="0">
 			<centroid rt="148.053991756106" mz="417.200894132916" it="20739"/>
 			<groupedElementList>
 				<element map="0" id="1933" rt="148.053991756106" mz="105.3075" it="20739" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2594423472232253546" quality="0">
 			<centroid rt="149.611693793228" mz="448.242723533229" it="56195"/>
 			<groupedElementList>
 				<element map="0" id="176" rt="149.611693793228" mz="449.25" it="56195" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1347879706495489433" quality="0">
 			<centroid rt="156.081831522207" mz="460.240894132916" it="22500"/>
 			<groupedElementList>
 				<element map="0" id="410" rt="156.081831522207" mz="116.0675" it="22500" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11790837842331084087" quality="0">
 			<centroid rt="165.159634401558" mz="477.265447066458" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="791" rt="165.159634401558" mz="239.64" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15057888314550208246" quality="0">
 			<centroid rt="165.713186105998" mz="875.402723533229" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1549" rt="165.713186105998" mz="876.41" it="23892" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17372658856201375320" quality="0">
 			<centroid rt="166.597453988129" mz="878.355447066458" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1766" rt="166.597453988129" mz="440.185" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2761656083679178823" quality="0">
 			<centroid rt="184.816766567657" mz="515.300894132916" it="125748"/>
 			<groupedElementList>
 				<element map="0" id="1649" rt="184.816766567657" mz="129.8325" it="125748" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10403223734762675614" quality="0">
 			<centroid rt="197.466949809299" mz="989.530894132916" it="170136"/>
 			<groupedElementList>
 				<element map="0" id="2144" rt="197.466949809299" mz="248.39" it="170136" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11692814056369800161" quality="0">
 			<centroid rt="198.688169268543" mz="539.212723533229" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="243" rt="198.688169268543" mz="540.22" it="15576" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2368255457570785066" quality="0">
 			<centroid rt="199.738754566223" mz="545.315447066458" it="6913"/>
 			<groupedElementList>
 				<element map="0" id="1926" rt="199.738754566223" mz="273.665" it="6913" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1318733519639569490" quality="0">
 			<centroid rt="201.128501788973" mz="544.305447066458" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1047" rt="201.128501788973" mz="273.16" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12690230652445512040" quality="0">
 			<centroid rt="203.710528771649" mz="553.305447066458" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="128" rt="203.710528771649" mz="277.66" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12995642420941638996" quality="0">
 			<centroid rt="207.069410087958" mz="3077.13089413292" it="52436"/>
 			<groupedElementList>
 				<element map="0" id="1606" rt="207.069410087958" mz="770.29" it="52436" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4887557552808587556" quality="0">
 			<centroid rt="207.069410087958" mz="3077.14544706646" it="52436"/>
 			<groupedElementList>
 				<element map="0" id="1607" rt="207.069410087958" mz="1539.58" it="52436" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9877858886518304662" quality="0">
 			<centroid rt="210.063266482104" mz="566.240894132916" it="30281"/>
 			<groupedElementList>
 				<element map="0" id="2016" rt="210.063266482104" mz="142.5675" it="30281" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1376017864806352825" quality="0">
 			<centroid rt="210.37511668322" mz="531.248170599687" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2252" rt="210.37511668322" mz="178.09" it="12349" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2268492650159771688" quality="0">
 			<centroid rt="212.433962882313" mz="571.342723533229" it="19599"/>
 			<groupedElementList>
 				<element map="0" id="543" rt="212.433962882313" mz="572.35" it="19599" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4241226370287198407" quality="0">
 			<centroid rt="217.73653422351" mz="582.250894132916" it="72768"/>
 			<groupedElementList>
 				<element map="0" id="1130" rt="217.73653422351" mz="146.57" it="72768" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7679938748115760041" quality="0">
 			<centroid rt="217.73653422351" mz="582.258170599686" it="72768"/>
 			<groupedElementList>
 				<element map="0" id="1131" rt="217.73653422351" mz="195.093333333333" it="72768" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12363525437628391882" quality="0">
 			<centroid rt="230.915461886258" mz="610.240894132916" it="89721"/>
 			<groupedElementList>
 				<element map="0" id="807" rt="230.915461886258" mz="153.5675" it="89721" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12835342732909417455" quality="0">
 			<centroid rt="232.315708291577" mz="613.375447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2224" rt="232.315708291577" mz="307.695" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8138877078872425754" quality="0">
 			<centroid rt="233.242974414614" mz="615.382723533229" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="809" rt="233.242974414614" mz="616.39" it="29907" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6218981626921514405" quality="0">
 			<centroid rt="236.977481840663" mz="623.280894132916" it="118454"/>
 			<groupedElementList>
 				<element map="0" id="1012" rt="236.977481840663" mz="156.8275" it="118454" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15579726503601015697" quality="0">
 			<centroid rt="236.977481840663" mz="623.295447066458" it="118454"/>
 			<groupedElementList>
 				<element map="0" id="1013" rt="236.977481840663" mz="312.655" it="118454" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1316026820178283013" quality="0">
 			<centroid rt="238.143765637378" mz="617.285447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2243" rt="238.143765637378" mz="309.65" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14955383976544734866" quality="0">
 			<centroid rt="242.129665717156" mz="630.310894132916" it="33006"/>
 			<groupedElementList>
 				<element map="0" id="137" rt="242.129665717156" mz="158.585" it="33006" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9103428330657937898" quality="0">
 			<centroid rt="243.795582527233" mz="638.265447066458" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="759" rt="243.795582527233" mz="320.14" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15091972979705231724" quality="0">
 			<centroid rt="244.250307534586" mz="639.275447066458" it="34843"/>
 			<groupedElementList>
 				<element map="0" id="1466" rt="244.250307534586" mz="320.645" it="34843" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8266234587044497738" quality="0">
 			<centroid rt="244.750101509279" mz="640.270894132916" it="54398"/>
 			<groupedElementList>
 				<element map="0" id="1729" rt="244.750101509279" mz="161.075" it="54398" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8435553508965657441" quality="0">
 			<centroid rt="244.750101509279" mz="640.292723533229" it="54398"/>
 			<groupedElementList>
 				<element map="0" id="1728" rt="244.750101509279" mz="641.3" it="54398" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16828120077346917194" quality="0">
 			<centroid rt="251.03708044183" mz="1197.49089413292" it="16875"/>
 			<groupedElementList>
 				<element map="0" id="365" rt="251.03708044183" mz="300.38" it="16875" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12318487507321968002" quality="0">
 			<centroid rt="253.319285384314" mz="659.385447066458" it="6407"/>
 			<groupedElementList>
 				<element map="0" id="645" rt="253.319285384314" mz="330.7" it="6407" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6120831841611847135" quality="0">
 			<centroid rt="259.065104248033" mz="672.365447066458" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="294" rt="259.065104248033" mz="337.19" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12562707972573079264" quality="0">
 			<centroid rt="259.285841224267" mz="630.215447066458" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1190" rt="259.285841224267" mz="316.115" it="23898" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17854581176132345485" quality="0">
 			<centroid rt="260.793413075832" mz="283.062723533229" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="976" rt="260.793413075832" mz="284.07" it="8961" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3701291582613091230" quality="0">
 			<centroid rt="263.024253508631" mz="2788.27544706646" it="59227"/>
 			<groupedElementList>
 				<element map="0" id="1015" rt="263.024253508631" mz="1395.145" it="59227" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4318804810959211030" quality="0">
 			<centroid rt="268.2998173518" mz="693.350894132916" it="89721"/>
 			<groupedElementList>
 				<element map="0" id="763" rt="268.2998173518" mz="174.345" it="89721" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15635227382822675061" quality="0">
 			<centroid rt="269.375033217922" mz="1273.61089413292" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1863" rt="269.375033217922" mz="319.41" it="11986" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17469508651569246689" quality="0">
 			<centroid rt="270.315300538503" mz="1946.85089413292" it="50379"/>
 			<groupedElementList>
 				<element map="0" id="871" rt="270.315300538503" mz="487.72" it="50379" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1728274663739219" quality="0">
 			<centroid rt="270.8252562406" mz="1279.59089413292" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="419" rt="270.8252562406" mz="320.905" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15510252771853238513" quality="0">
 			<centroid rt="270.8252562406" mz="1279.59817059969" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="420" rt="270.8252562406" mz="427.54" it="11250" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16812397617599652569" quality="0">
 			<centroid rt="272.648583254025" mz="703.355447066458" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1314" rt="272.648583254025" mz="352.685" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10670943912452690927" quality="0">
 			<centroid rt="273.603894645018" mz="705.202723533229" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1844" rt="273.603894645018" mz="706.21" it="11986" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1536608021613680278" quality="0">
 			<centroid rt="277.82652104637" mz="715.400894132916" it="95772"/>
 			<groupedElementList>
 				<element map="0" id="2040" rt="277.82652104637" mz="179.8575" it="95772" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1689002367636513327" quality="0">
 			<centroid rt="277.82652104637" mz="715.415447066458" it="95772"/>
 			<groupedElementList>
 				<element map="0" id="2041" rt="277.82652104637" mz="358.715" it="95772" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7759472992311686892" quality="0">
 			<centroid rt="285.180047368945" mz="727.250894132916" it="109986"/>
 			<groupedElementList>
 				<element map="0" id="1906" rt="285.180047368945" mz="182.82" it="109986" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2590864657441526157" quality="0">
 			<centroid rt="285.180047368945" mz="727.265447066458" it="109986"/>
 			<groupedElementList>
 				<element map="0" id="1907" rt="285.180047368945" mz="364.64" it="109986" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9968778569325447945" quality="0">
 			<centroid rt="292.697446974905" mz="314.160894132916" it="64238"/>
 			<groupedElementList>
 				<element map="0" id="2126" rt="292.697446974905" mz="79.5475" it="64238" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4695486897383053442" quality="0">
 			<centroid rt="292.697446974905" mz="314.175447066458" it="64238"/>
 			<groupedElementList>
 				<element map="0" id="2127" rt="292.697446974905" mz="158.095" it="64238" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5940581222029626302" quality="0">
 			<centroid rt="294.448062695388" mz="754.315447066458" it="6913"/>
 			<groupedElementList>
 				<element map="0" id="1987" rt="294.448062695388" mz="378.165" it="6913" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17203722403382665480" quality="0">
 			<centroid rt="295.696031233206" mz="317.130894132916" it="44008"/>
 			<groupedElementList>
 				<element map="0" id="147" rt="295.696031233206" mz="80.29" it="44008" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11048236097473439430" quality="0">
 			<centroid rt="296.692407699624" mz="318.160894132916" it="52812"/>
 			<groupedElementList>
 				<element map="0" id="521" rt="296.692407699624" mz="80.5475" it="52812" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17618117916983736901" quality="0">
 			<centroid rt="306.390894977925" mz="4370.19272353323" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="811" rt="306.390894977925" mz="4371.2" it="29907" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12069514671641804034" quality="0">
 			<centroid rt="312.426660319322" mz="334.110894132916" it="81597"/>
 			<groupedElementList>
 				<element map="0" id="1738" rt="312.426660319322" mz="84.535" it="81597" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17648708507182967440" quality="0">
 			<centroid rt="312.601549139224" mz="798.320894132916" it="78396"/>
 			<groupedElementList>
 				<element map="0" id="533" rt="312.601549139224" mz="200.5875" it="78396" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4153373163253755714" quality="0">
 			<centroid rt="316.054497988162" mz="801.445447066458" it="6913"/>
 			<groupedElementList>
 				<element map="0" id="1959" rt="316.054497988162" mz="401.73" it="6913" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6444708438424668751" quality="0">
 			<centroid rt="316.06338275306" mz="2318.99544706646" it="10915"/>
 			<groupedElementList>
 				<element map="0" id="1217" rt="316.06338275306" mz="1160.505" it="10915" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10586565448922323269" quality="0">
 			<centroid rt="316.647566660845" mz="808.440894132916" it="112390"/>
 			<groupedElementList>
 				<element map="0" id="186" rt="316.647566660845" mz="203.1175" it="112390" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4236938831623087533" quality="0">
 			<centroid rt="316.647566660845" mz="808.448170599687" it="112390"/>
 			<groupedElementList>
 				<element map="0" id="187" rt="316.647566660845" mz="270.49" it="112390" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4356684009862102649" quality="0">
 			<centroid rt="319.443821291734" mz="758.225447066458" it="21139"/>
 			<groupedElementList>
 				<element map="0" id="503" rt="319.443821291734" mz="380.12" it="21139" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17773845816276105290" quality="0">
 			<centroid rt="319.873990453201" mz="816.455447066458" it="25323"/>
 			<groupedElementList>
 				<element map="0" id="1583" rt="319.873990453201" mz="409.235" it="25323" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1937190994358371760" quality="0">
 			<centroid rt="323.75717898744" mz="768.280894132916" it="22500"/>
 			<groupedElementList>
 				<element map="0" id="474" rt="323.75717898744" mz="193.0775" it="22500" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6573593110286615638" quality="0">
 			<centroid rt="323.986709031468" mz="346.202723533229" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="154" rt="323.986709031468" mz="347.21" it="11002" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13912543221554542927" quality="0">
 			<centroid rt="324.744000064192" mz="776.348170599687" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1753" rt="324.744000064192" mz="259.79" it="27199" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16090040194238353021" quality="0">
 			<centroid rt="324.940536521486" mz="347.162723533229" it="26218"/>
 			<groupedElementList>
 				<element map="0" id="1631" rt="324.940536521486" mz="348.17" it="26218" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9986371770955997111" quality="0">
 			<centroid rt="325.00300202571" mz="823.340894132916" it="35958"/>
 			<groupedElementList>
 				<element map="0" id="1875" rt="325.00300202571" mz="206.8425" it="35958" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8565758539158046988" quality="0">
 			<centroid rt="325.266814694164" mz="818.385447066458" it="38786"/>
 			<groupedElementList>
 				<element map="0" id="726" rt="325.266814694164" mz="410.2" it="38786" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3947704378171248019" quality="0">
 			<centroid rt="327.571747231917" mz="346.172723533229" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1754" rt="327.571747231917" mz="347.18" it="27199" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3109798891521040899" quality="0">
 			<centroid rt="327.763592182559" mz="830.400894132916" it="43071"/>
 			<groupedElementList>
 				<element map="0" id="2185" rt="327.763592182559" mz="208.6075" it="43071" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7067646548137481926" quality="0">
 			<centroid rt="329.65892358228" mz="318.120894132916" it="164979"/>
 			<groupedElementList>
 				<element map="0" id="1918" rt="329.65892358228" mz="80.5375" it="164979" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7875899164895988507" quality="0">
 			<centroid rt="331.144169936175" mz="1545.67089413292" it="47944"/>
 			<groupedElementList>
 				<element map="0" id="1857" rt="331.144169936175" mz="387.425" it="47944" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2345277038435442616" quality="0">
 			<centroid rt="332.224728639685" mz="847.390894132916" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="877" rt="332.224728639685" mz="212.855" it="16793" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14996896624291802433" quality="0">
 			<centroid rt="332.251669386041" mz="788.395447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2300" rt="332.251669386041" mz="395.205" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8733120912851106520" quality="0">
 			<centroid rt="332.588602633847" mz="842.440894132916" it="27652"/>
 			<groupedElementList>
 				<element map="0" id="1945" rt="332.588602633847" mz="211.6175" it="27652" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2501657797259727883" quality="0">
 			<centroid rt="332.619380200539" mz="848.450894132916" it="54398"/>
 			<groupedElementList>
 				<element map="0" id="1719" rt="332.619380200539" mz="213.12" it="54398" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4818574918222442627" quality="0">
 			<centroid rt="332.619380200539" mz="848.465447066458" it="54398"/>
 			<groupedElementList>
 				<element map="0" id="1720" rt="332.619380200539" mz="425.24" it="54398" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16964300794853756765" quality="0">
 			<centroid rt="335.432127280352" mz="358.235447066458" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1394" rt="335.432127280352" mz="180.125" it="2961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11506264953225510078" quality="0">
 			<centroid rt="336.276033537355" mz="359.180894132916" it="22500"/>
 			<groupedElementList>
 				<element map="0" id="406" rt="336.276033537355" mz="90.8025" it="22500" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8590132726007187378" quality="0">
 			<centroid rt="339.179880228972" mz="362.160894132916" it="42278"/>
 			<groupedElementList>
 				<element map="0" id="487" rt="339.179880228972" mz="91.5475" it="42278" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10053897320734154050" quality="0">
 			<centroid rt="346.210597088184" mz="827.440894132916" it="72066"/>
 			<groupedElementList>
 				<element map="0" id="1323" rt="346.210597088184" mz="207.8675" it="72066" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18194680373387369255" quality="0">
 			<centroid rt="348.267426801194" mz="888.345447066458" it="26218"/>
 			<groupedElementList>
 				<element map="0" id="1600" rt="348.267426801194" mz="445.18" it="26218" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9152937959565107418" quality="0">
 			<centroid rt="349.269903437296" mz="373.180894132916" it="58797"/>
 			<groupedElementList>
 				<element map="0" id="539" rt="349.269903437296" mz="94.3025" it="58797" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14916635860478367100" quality="0">
 			<centroid rt="350.188639897466" mz="374.200894132916" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1507" rt="350.188639897466" mz="94.5575" it="23892" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15082965786365187043" quality="0">
 			<centroid rt="350.239174069505" mz="887.405447066458" it="30892"/>
 			<groupedElementList>
 				<element map="0" id="705" rt="350.239174069505" mz="444.71" it="30892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1215803889027365625" quality="0">
 			<centroid rt="356.095938329848" mz="851.405447066458" it="18557"/>
 			<groupedElementList>
 				<element map="0" id="577" rt="356.095938329848" mz="426.71" it="18557" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7106285935196866740" quality="0">
 			<centroid rt="358.30128002517" mz="1595.73544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="289" rt="358.30128002517" mz="798.875" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11910473886899840997" quality="0">
 			<centroid rt="360.962247039537" mz="863.385447066458" it="16618"/>
 			<groupedElementList>
 				<element map="0" id="2078" rt="360.962247039537" mz="432.7" it="16618" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2818589068800115817" quality="0">
 			<centroid rt="365.195475001183" mz="1689.68089413292" it="37114"/>
 			<groupedElementList>
 				<element map="0" id="615" rt="365.195475001183" mz="423.4275" it="37114" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14855913738005832727" quality="0">
 			<centroid rt="365.195475001183" mz="1689.69544706646" it="37114"/>
 			<groupedElementList>
 				<element map="0" id="616" rt="365.195475001183" mz="845.855" it="37114" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17539060510839859266" quality="0">
 			<centroid rt="366.609836693121" mz="392.150894132916" it="77572"/>
 			<groupedElementList>
 				<element map="0" id="708" rt="366.609836693121" mz="99.045" it="77572" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18289672163601538554" quality="0">
 			<centroid rt="366.609836693121" mz="392.158170599688" it="77572"/>
 			<groupedElementList>
 				<element map="0" id="709" rt="366.609836693121" mz="131.726666666667" it="77572" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15830661633525372849" quality="0">
 			<centroid rt="367.360066538271" mz="1628.77089413292" it="31152"/>
 			<groupedElementList>
 				<element map="0" id="274" rt="367.360066538271" mz="408.2" it="31152" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16942571901105106217" quality="0">
 			<centroid rt="367.360066538271" mz="1628.78544706646" it="31152"/>
 			<groupedElementList>
 				<element map="0" id="275" rt="367.360066538271" mz="815.4" it="31152" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13235119118677053780" quality="0">
 			<centroid rt="368.403320264058" mz="394.205447066458" it="34843"/>
 			<groupedElementList>
 				<element map="0" id="1462" rt="368.403320264058" mz="198.11" it="34843" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16319183872288616053" quality="0">
 			<centroid rt="371.690281502248" mz="3888.75089413292" it="16875"/>
 			<groupedElementList>
 				<element map="0" id="416" rt="371.690281502248" mz="973.195" it="16875" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1043676272231437147" quality="0">
 			<centroid rt="372.770822690675" mz="399.205447066458" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1479" rt="372.770822690675" mz="200.61" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5790686993788975788" quality="0">
 			<centroid rt="373.622946012368" mz="955.532723533229" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1761" rt="373.622946012368" mz="956.54" it="27199" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17485556699512888389" quality="0">
 			<centroid rt="374.635115421573" mz="401.232723533229" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1274" rt="374.635115421573" mz="402.24" it="24022" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_459593805520764447" quality="0">
 			<centroid rt="379.462090294425" mz="964.435447066458" it="6913"/>
 			<groupedElementList>
 				<element map="0" id="1951" rt="379.462090294425" mz="483.225" it="6913" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3533992232834017451" quality="0">
 			<centroid rt="380.191826340629" mz="403.170894132916" it="96088"/>
 			<groupedElementList>
 				<element map="0" id="1307" rt="380.191826340629" mz="101.8" it="96088" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17398306538723196813" quality="0">
 			<centroid rt="380.204385178296" mz="966.470894132916" it="48044"/>
 			<groupedElementList>
 				<element map="0" id="1249" rt="380.204385178296" mz="242.625" it="48044" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9172089518603594644" quality="0">
 			<centroid rt="380.204385178296" mz="966.485447066458" it="48044"/>
 			<groupedElementList>
 				<element map="0" id="1250" rt="380.204385178296" mz="484.25" it="48044" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1805492840887466937" quality="0">
 			<centroid rt="382.537608850715" mz="979.420894132916" it="61784"/>
 			<groupedElementList>
 				<element map="0" id="676" rt="382.537608850715" mz="245.8625" it="61784" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14994550109761422676" quality="0">
 			<centroid rt="382.537608850715" mz="979.435447066458" it="61784"/>
 			<groupedElementList>
 				<element map="0" id="677" rt="382.537608850715" mz="490.725" it="61784" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4320538850174207451" quality="0">
 			<centroid rt="384.005018768842" mz="983.435447066458" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1298" rt="384.005018768842" mz="492.725" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4853807232133713674" quality="0">
 			<centroid rt="385.141318490263" mz="986.475447066458" it="34843"/>
 			<groupedElementList>
 				<element map="0" id="1436" rt="385.141318490263" mz="494.245" it="34843" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5190555654545064613" quality="0">
 			<centroid rt="385.506229173659" mz="2766.21089413292" it="92676"/>
 			<groupedElementList>
 				<element map="0" id="687" rt="385.506229173659" mz="692.56" it="92676" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16437435303306390768" quality="0">
 			<centroid rt="387.345149581637" mz="1731.90089413292" it="37047"/>
 			<groupedElementList>
 				<element map="0" id="2232" rt="387.345149581637" mz="433.9825" it="37047" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15147397594793366808" quality="0">
 			<centroid rt="387.979918095336" mz="376.155447066458" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="943" rt="387.979918095336" mz="189.085" it="8961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5303136317788416731" quality="0">
 			<centroid rt="389.089451154534" mz="990.555447066458" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1043" rt="389.089451154534" mz="496.285" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5129424018536779782" quality="0">
 			<centroid rt="391.748674962775" mz="416.222723533229" it="10224"/>
 			<groupedElementList>
 				<element map="0" id="21" rt="391.748674962775" mz="417.23" it="10224" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7613279686438318347" quality="0">
 			<centroid rt="392.070531701505" mz="421.195447066458" it="6913"/>
 			<groupedElementList>
 				<element map="0" id="1932" rt="392.070531701505" mz="211.605" it="6913" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13401281210354452297" quality="0">
 			<centroid rt="394.66217348929" mz="424.178170599687" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="761" rt="394.66217348929" mz="142.4" it="29907" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15653953618697144722" quality="0">
 			<centroid rt="399.127183671659" mz="429.272723533229" it="25323"/>
 			<groupedElementList>
 				<element map="0" id="1591" rt="399.127183671659" mz="430.28" it="25323" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9618122346317393244" quality="0">
 			<centroid rt="399.450552701719" mz="388.195447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2251" rt="399.450552701719" mz="195.105" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8540926337629668602" quality="0">
 			<centroid rt="400.75389563061" mz="431.255447066458" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1768" rt="400.75389563061" mz="216.635" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5739188838063884242" quality="0">
 			<centroid rt="400.913188258978" mz="1875.92817059969" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1726" rt="400.913188258978" mz="626.316666666667" it="27199" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17010014635031362914" quality="0">
 			<centroid rt="402.462359587287" mz="433.200894132916" it="71676"/>
 			<groupedElementList>
 				<element map="0" id="1532" rt="402.462359587287" mz="109.3075" it="71676" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10981025392007257222" quality="0">
 			<centroid rt="404.166886975376" mz="435.220894132916" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1651" rt="404.166886975376" mz="109.8125" it="83832" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2857678320973038436" quality="0">
 			<centroid rt="405.565931769006" mz="390.155447066458" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1849" rt="405.565931769006" mz="196.085" it="11986" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13513552841835540" quality="0">
 			<centroid rt="408.412920973464" mz="440.165447066458" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="135" rt="408.412920973464" mz="221.09" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13255041917814467763" quality="0">
 			<centroid rt="409.840549710781" mz="974.495447066458" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="273" rt="409.840549710781" mz="488.255" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17556849954037969723" quality="0">
 			<centroid rt="411.711483668461" mz="1849.80089413292" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1044" rt="411.711483668461" mz="463.4575" it="49849" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14189704501769887714" quality="0">
 			<centroid rt="411.789264249587" mz="444.240894132916" it="37047"/>
 			<groupedElementList>
 				<element map="0" id="2254" rt="411.789264249587" mz="112.0675" it="37047" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1844284059715235111" quality="0">
 			<centroid rt="412.108985186235" mz="3076.57544706646" it="6913"/>
 			<groupedElementList>
 				<element map="0" id="1971" rt="412.108985186235" mz="1539.295" it="6913" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4729281842247212624" quality="0">
 			<centroid rt="412.611754484814" mz="402.190894132916" it="72066"/>
 			<groupedElementList>
 				<element map="0" id="1254" rt="412.611754484814" mz="101.555" it="72066" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17420371949481877347" quality="0">
 			<centroid rt="417.320962673175" mz="1008.42089413292" it="43071"/>
 			<groupedElementList>
 				<element map="0" id="2204" rt="417.320962673175" mz="253.1125" it="43071" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17050026077910227482" quality="0">
 			<centroid rt="419.084526081777" mz="1081.61544706646" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="797" rt="419.084526081777" mz="541.815" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7794966098291685997" quality="0">
 			<centroid rt="420.184954686754" mz="1084.43544706646" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1705" rt="420.184954686754" mz="543.225" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17481340297920409268" quality="0">
 			<centroid rt="420.644143891776" mz="4288.81544706646" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1735" rt="420.644143891776" mz="2145.415" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13128147187009675716" quality="0">
 			<centroid rt="422.105839440694" mz="1082.40089413292" it="92676"/>
 			<groupedElementList>
 				<element map="0" id="700" rt="422.105839440694" mz="271.6075" it="92676" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6296976449246913943" quality="0">
 			<centroid rt="422.747458429782" mz="457.290894132916" it="33006"/>
 			<groupedElementList>
 				<element map="0" id="124" rt="422.747458429782" mz="115.33" it="33006" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10346429383843306920" quality="0">
 			<centroid rt="423.494510563307" mz="458.245447066458" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="845" rt="423.494510563307" mz="230.13" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1051382210571081704" quality="0">
 			<centroid rt="423.909385007484" mz="1900.99089413292" it="50379"/>
 			<groupedElementList>
 				<element map="0" id="920" rt="423.909385007484" mz="476.255" it="50379" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3510759251176122475" quality="0">
 			<centroid rt="426.552378270281" mz="417.190894132916" it="33006"/>
 			<groupedElementList>
 				<element map="0" id="45" rt="426.552378270281" mz="105.305" it="33006" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17815179323134486434" quality="0">
 			<centroid rt="426.767529444527" mz="1103.58544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="343" rt="426.767529444527" mz="552.8" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12196074589938995029" quality="0">
 			<centroid rt="427.637336388821" mz="463.205447066458" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="889" rt="427.637336388821" mz="232.61" it="16793" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8315842699588339660" quality="0">
 			<centroid rt="429.281925495302" mz="465.200894132916" it="40896"/>
 			<groupedElementList>
 				<element map="0" id="23" rt="429.281925495302" mz="117.3075" it="40896" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1835647559468540467" quality="0">
 			<centroid rt="429.872741859186" mz="1042.47089413292" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="380" rt="429.872741859186" mz="261.625" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6153139728324007872" quality="0">
 			<centroid rt="429.872741859186" mz="1042.48544706646" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="381" rt="429.872741859186" mz="522.25" it="11250" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9453183417474472419" quality="0">
 			<centroid rt="435.845063419546" mz="473.200894132916" it="47784"/>
 			<groupedElementList>
 				<element map="0" id="1504" rt="435.845063419546" mz="119.3075" it="47784" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8461965850982681215" quality="0">
 			<centroid rt="435.845063419546" mz="473.215447066458" it="47784"/>
 			<groupedElementList>
 				<element map="0" id="1505" rt="435.845063419546" mz="237.615" it="47784" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18349261203367843340" quality="0">
 			<centroid rt="435.920865630975" mz="473.295447066458" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="388" rt="435.920865630975" mz="237.655" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5266513847202632919" quality="0">
 			<centroid rt="441.587343455819" mz="1074.52089413292" it="22004"/>
 			<groupedElementList>
 				<element map="0" id="144" rt="441.587343455819" mz="269.6375" it="22004" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4190152766724496934" quality="0">
 			<centroid rt="441.587343455819" mz="1074.54272353323" it="22004"/>
 			<groupedElementList>
 				<element map="0" id="143" rt="441.587343455819" mz="1075.55" it="22004" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17762669840959142482" quality="0">
 			<centroid rt="441.807133420527" mz="1147.60544706646" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1195" rt="441.807133420527" mz="574.81" it="23898" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2593414531002602212" quality="0">
 			<centroid rt="444.37621169427" mz="2014.98089413292" it="24698"/>
 			<groupedElementList>
 				<element map="0" id="2238" rt="444.37621169427" mz="504.7525" it="24698" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6649726284893524114" quality="0">
 			<centroid rt="444.37621169427" mz="2015.00272353323" it="24698"/>
 			<groupedElementList>
 				<element map="0" id="2237" rt="444.37621169427" mz="2016.01" it="24698" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7601317917648255123" quality="0">
 			<centroid rt="445.732235403006" mz="2010.96544706646" it="56195"/>
 			<groupedElementList>
 				<element map="0" id="183" rt="445.732235403006" mz="1006.49" it="56195" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2375936534317368196" quality="0">
 			<centroid rt="448.799213345001" mz="489.235447066458" it="25323"/>
 			<groupedElementList>
 				<element map="0" id="1589" rt="448.799213345001" mz="245.625" it="25323" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10984151226490866759" quality="0">
 			<centroid rt="451.444605237505" mz="487.222723533229" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2277" rt="451.444605237505" mz="488.23" it="12349" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_552935026997537111" quality="0">
 			<centroid rt="453.678014242042" mz="495.225447066458" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="938" rt="453.678014242042" mz="248.62" it="8961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5849609293186393911" quality="0">
 			<centroid rt="454.013672820768" mz="1175.55544706646" it="41916"/>
 			<groupedElementList>
 				<element map="0" id="1659" rt="454.013672820768" mz="588.785" it="41916" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8696492331790582135" quality="0">
 			<centroid rt="454.925984443745" mz="1186.55089413292" it="118454"/>
 			<groupedElementList>
 				<element map="0" id="981" rt="454.925984443745" mz="297.645" it="118454" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13303997041803238149" quality="0">
 			<centroid rt="454.925984443745" mz="1186.56544706646" it="118454"/>
 			<groupedElementList>
 				<element map="0" id="982" rt="454.925984443745" mz="594.29" it="118454" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4069920736830607890" quality="0">
 			<centroid rt="455.270532822252" mz="497.305447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2281" rt="455.270532822252" mz="249.66" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18405160885878480029" quality="0">
 			<centroid rt="455.682113919317" mz="1188.52544706646" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1019" rt="455.682113919317" mz="595.27" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13516433498353822538" quality="0">
 			<centroid rt="455.846361718682" mz="404.155447066458" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1514" rt="455.846361718682" mz="203.085" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8265495347814775031" quality="0">
 			<centroid rt="459.925957195442" mz="4746.36544706646" it="36320"/>
 			<groupedElementList>
 				<element map="0" id="2106" rt="459.925957195442" mz="2374.19" it="36320" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7380656586219470381" quality="0">
 			<centroid rt="460.26672408237" mz="1964.97272353323" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="153" rt="460.26672408237" mz="1965.98" it="11002" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6904042788370631893" quality="0">
 			<centroid rt="461.61628726701" mz="505.252723533229" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="831" rt="461.61628726701" mz="506.26" it="29907" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7764638718295913481" quality="0">
 			<centroid rt="461.84389965881" mz="1190.59544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2286" rt="461.84389965881" mz="596.305" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_197304241618587785" quality="0">
 			<centroid rt="464.039646049616" mz="1205.61272353323" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1358" rt="464.039646049616" mz="1206.62" it="2961" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15622065239948641671" quality="0">
 			<centroid rt="468.421851910356" mz="2246.05544706646" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="888" rt="468.421851910356" mz="1124.035" it="16793" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16462250760722390907" quality="0">
 			<centroid rt="470.484630447737" mz="2177.03544706646" it="42534"/>
 			<groupedElementList>
 				<element map="0" id="2149" rt="470.484630447737" mz="1089.525" it="42534" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1860421429938019231" quality="0">
 			<centroid rt="471.822006016248" mz="518.230894132916" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1354" rt="471.822006016248" mz="130.565" it="2961" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_782313987315662594" quality="0">
 			<centroid rt="474.361071377115" mz="1236.56272353323" it="6407"/>
 			<groupedElementList>
 				<element map="0" id="650" rt="474.361071377115" mz="1237.57" it="6407" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1796533685533848596" quality="0">
 			<centroid rt="477.02741311102" mz="474.205447066458" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="854" rt="477.02741311102" mz="238.11" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_475429397920879355" quality="0">
 			<centroid rt="477.2705822933" mz="525.235447066458" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1081" rt="477.2705822933" mz="263.625" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12734938869540712959" quality="0">
 			<centroid rt="480.010485337805" mz="1262.66544706646" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="758" rt="480.010485337805" mz="632.34" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2628373002991296784" quality="0">
 			<centroid rt="480.36428984906" mz="529.268170599687" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2163" rt="480.36428984906" mz="177.43" it="14357" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15780867159915724644" quality="0">
 			<centroid rt="480.947904376974" mz="1265.59089413292" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="322" rt="480.947904376974" mz="317.405" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11724922739368158890" quality="0">
 			<centroid rt="480.947904376974" mz="1265.61272353323" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="321" rt="480.947904376974" mz="1266.62" it="11250" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18222927512018932963" quality="0">
 			<centroid rt="481.129707915274" mz="530.282723533229" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1916" rt="481.129707915274" mz="531.29" it="54993" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4785792933626533499" quality="0">
 			<centroid rt="482.747695499245" mz="532.258170599688" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1060" rt="482.747695499245" mz="178.426666666667" it="49849" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10916456843578251467" quality="0">
 			<centroid rt="484.208038630291" mz="534.252723533229" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1347" rt="484.208038630291" mz="535.26" it="2961" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14126329949324381954" quality="0">
 			<centroid rt="485.572881379235" mz="530.265447066458" it="6913"/>
 			<groupedElementList>
 				<element map="0" id="1938" rt="485.572881379235" mz="266.14" it="6913" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13954863390026850398" quality="0">
 			<centroid rt="488.19188840711" mz="487.260894132916" it="125748"/>
 			<groupedElementList>
 				<element map="0" id="1655" rt="488.19188840711" mz="122.8225" it="125748" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1269628711334509647" quality="0">
 			<centroid rt="489.795036034869" mz="1211.52089413292" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="751" rt="489.795036034869" mz="303.8875" it="29907" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5654669125489472865" quality="0">
 			<centroid rt="490.983027933189" mz="537.235447066458" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="760" rt="490.983027933189" mz="269.625" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8249370268409684679" quality="0">
 			<centroid rt="491.095052365462" mz="543.298170599688" it="25323"/>
 			<groupedElementList>
 				<element map="0" id="1565" rt="491.095052365462" mz="182.106666666667" it="25323" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12920813165618362140" quality="0">
 			<centroid rt="491.586324284988" mz="3607.39544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="217" rt="491.586324284988" mz="1804.705" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3369330330948274179" quality="0">
 			<centroid rt="491.86292797209" mz="544.282723533229" it="42534"/>
 			<groupedElementList>
 				<element map="0" id="2154" rt="491.86292797209" mz="545.29" it="42534" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6697090643399817142" quality="0">
 			<centroid rt="492.541497379868" mz="1219.54089413292" it="72066"/>
 			<groupedElementList>
 				<element map="0" id="1317" rt="492.541497379868" mz="305.8925" it="72066" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6440626839693319305" quality="0">
 			<centroid rt="493.171705270195" mz="493.222723533229" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1095" rt="493.171705270195" mz="494.23" it="49849" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7382903112161185223" quality="0">
 			<centroid rt="493.453752390908" mz="546.275447066458" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2168" rt="493.453752390908" mz="274.145" it="14357" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7459473479491030335" quality="0">
 			<centroid rt="496.059717046818" mz="3661.60544706646" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1519" rt="496.059717046818" mz="1831.81" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4140434344149649031" quality="0">
 			<centroid rt="499.434585683771" mz="554.245447066458" it="41916"/>
 			<groupedElementList>
 				<element map="0" id="1653" rt="499.434585683771" mz="278.13" it="41916" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2654820587663498701" quality="0">
 			<centroid rt="500.18859872224" mz="555.268170599688" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="164" rt="500.18859872224" mz="186.096666666667" it="11002" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17794208216508358145" quality="0">
 			<centroid rt="501.677828358108" mz="545.262723533229" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="120" rt="501.677828358108" mz="546.27" it="11002" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5560753433462013595" quality="0">
 			<centroid rt="502.446590066705" mz="558.268170599688" it="30281"/>
 			<groupedElementList>
 				<element map="0" id="2005" rt="502.446590066705" mz="187.096666666667" it="30281" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4876940612252582937" quality="0">
 			<centroid rt="503.994412619323" mz="3285.23544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="219" rt="503.994412619323" mz="1643.625" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12290241409187649873" quality="0">
 			<centroid rt="504.701701487898" mz="1321.64089413292" it="19221"/>
 			<groupedElementList>
 				<element map="0" id="660" rt="504.701701487898" mz="331.4175" it="19221" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4043327685887040284" quality="0">
 			<centroid rt="505.358499318407" mz="1248.64272353323" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="310" rt="505.358499318407" mz="1249.65" it="5625" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15692624221939361689" quality="0">
 			<centroid rt="506.335957057058" mz="503.242723533229" it="41916"/>
 			<groupedElementList>
 				<element map="0" id="1668" rt="506.335957057058" mz="504.25" it="41916" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5720832661828307665" quality="0">
 			<centroid rt="507.007621642271" mz="1262.67544706646" it="30892"/>
 			<groupedElementList>
 				<element map="0" id="692" rt="507.007621642271" mz="632.345" it="30892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2216094993768176502" quality="0">
 			<centroid rt="507.032190918726" mz="3615.59544706646" it="36320"/>
 			<groupedElementList>
 				<element map="0" id="2089" rt="507.032190918726" mz="1808.805" it="36320" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12926616920681926353" quality="0">
 			<centroid rt="507.081067944765" mz="558.298170599688" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1764" rt="507.081067944765" mz="187.106666666667" it="27199" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8534383320899244865" quality="0">
 			<centroid rt="507.173899839383" mz="504.180894132916" it="12814"/>
 			<groupedElementList>
 				<element map="0" id="643" rt="507.173899839383" mz="127.0525" it="12814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14649771387921410454" quality="0">
 			<centroid rt="507.173899839383" mz="504.195447066458" it="12814"/>
 			<groupedElementList>
 				<element map="0" id="644" rt="507.173899839383" mz="253.105" it="12814" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5265078445676991161" quality="0">
 			<centroid rt="509.936205909873" mz="568.210894132916" it="16875"/>
 			<groupedElementList>
 				<element map="0" id="450" rt="509.936205909873" mz="143.06" it="16875" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10899586959379104221" quality="0">
 			<centroid rt="514.462266866673" mz="574.345447066458" it="42534"/>
 			<groupedElementList>
 				<element map="0" id="2138" rt="514.462266866673" mz="288.18" it="42534" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11392614474628334188" quality="0">
 			<centroid rt="515.671349978704" mz="520.180894132916" it="31152"/>
 			<groupedElementList>
 				<element map="0" id="220" rt="515.671349978704" mz="131.0525" it="31152" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16131565712718396685" quality="0">
 			<centroid rt="515.671349978704" mz="520.195447066458" it="31152"/>
 			<groupedElementList>
 				<element map="0" id="221" rt="515.671349978704" mz="261.105" it="31152" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16030874278241962089" quality="0">
 			<centroid rt="516.688970216363" mz="577.245447066458" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1825" rt="516.688970216363" mz="289.63" it="701" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7655796081356063523" quality="0">
 			<centroid rt="520.661309534647" mz="1381.61089413292" it="199396"/>
 			<groupedElementList>
 				<element map="0" id="1074" rt="520.661309534647" mz="346.41" it="199396" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4205179857221129069" quality="0">
 			<centroid rt="521.107827539338" mz="583.310894132916" it="78654"/>
 			<groupedElementList>
 				<element map="0" id="1620" rt="521.107827539338" mz="146.835" it="78654" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18122727928561852870" quality="0">
 			<centroid rt="523.30892728166" mz="586.350894132916" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1698" rt="523.30892728166" mz="147.595" it="83832" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4794964755397423882" quality="0">
 			<centroid rt="523.30892728166" mz="586.365447066458" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1699" rt="523.30892728166" mz="294.19" it="83832" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11084123115394103739" quality="0">
 			<centroid rt="523.686096008566" mz="574.275447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2307" rt="523.686096008566" mz="288.145" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3967261961834778051" quality="0">
 			<centroid rt="524.539544889403" mz="1315.64089413292" it="49396"/>
 			<groupedElementList>
 				<element map="0" id="2291" rt="524.539544889403" mz="329.9175" it="49396" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4476045071158104411" quality="0">
 			<centroid rt="528.676952777203" mz="536.245447066458" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1765" rt="528.676952777203" mz="269.13" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15102245111036826406" quality="0">
 			<centroid rt="529.425576786965" mz="2599.47089413292" it="71694"/>
 			<groupedElementList>
 				<element map="0" id="1174" rt="529.425576786965" mz="650.875" it="71694" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15496630811709623317" quality="0">
 			<centroid rt="531.153086369334" mz="1335.53272353323" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2173" rt="531.153086369334" mz="1336.54" it="14357" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2769530748307775165" quality="0">
 			<centroid rt="533.25735849434" mz="3548.37544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="374" rt="533.25735849434" mz="1775.195" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7874681411339427795" quality="0">
 			<centroid rt="533.565215642043" mz="1423.49089413292" it="23972"/>
 			<groupedElementList>
 				<element map="0" id="1873" rt="533.565215642043" mz="356.88" it="23972" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17601892499656775722" quality="0">
 			<centroid rt="533.565215642043" mz="1423.50544706646" it="23972"/>
 			<groupedElementList>
 				<element map="0" id="1874" rt="533.565215642043" mz="712.76" it="23972" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18212882177025028160" quality="0">
 			<centroid rt="533.862507918894" mz="594.275447066458" it="18557"/>
 			<groupedElementList>
 				<element map="0" id="604" rt="533.862507918894" mz="298.145" it="18557" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9243264760445874954" quality="0">
 			<centroid rt="534.14130819591" mz="1172.42817059969" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1706" rt="534.14130819591" mz="391.816666666667" it="27199" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12446237013717538735" quality="0">
 			<centroid rt="534.719645135975" mz="1346.57544706646" it="26218"/>
 			<groupedElementList>
 				<element map="0" id="1618" rt="534.719645135975" mz="674.295" it="26218" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16827430738835029479" quality="0">
 			<centroid rt="536.951628751724" mz="1434.54544706646" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2188" rt="536.951628751724" mz="718.28" it="14357" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7598155479235806497" quality="0">
 			<centroid rt="538.972500233157" mz="601.305447066458" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1159" rt="538.972500233157" mz="301.66" it="23898" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16259445809645670289" quality="0">
 			<centroid rt="539.187084604217" mz="2532.93544706646" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1898" rt="539.187084604217" mz="1267.475" it="54993" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16121364074248016111" quality="0">
 			<centroid rt="542.271889040022" mz="1350.57089413292" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="469" rt="542.271889040022" mz="338.65" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17166207965349575060" quality="0">
 			<centroid rt="542.271889040022" mz="1350.57817059969" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="470" rt="542.271889040022" mz="451.2" it="11250" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12846034626119647409" quality="0">
 			<centroid rt="542.605801656567" mz="606.300894132916" it="69686"/>
 			<groupedElementList>
 				<element map="0" id="1441" rt="542.605801656567" mz="152.5825" it="69686" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7775094007463555874" quality="0">
 			<centroid rt="542.605801656567" mz="606.322723533229" it="69686"/>
 			<groupedElementList>
 				<element map="0" id="1440" rt="542.605801656567" mz="607.33" it="69686" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18012168725762815189" quality="0">
 			<centroid rt="543.631848066194" mz="2436.03272353323" it="34843"/>
 			<groupedElementList>
 				<element map="0" id="1448" rt="543.631848066194" mz="2437.04" it="34843" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10534969551466968733" quality="0">
 			<centroid rt="546.469283343279" mz="618.280894132916" it="177681"/>
 			<groupedElementList>
 				<element map="0" id="1003" rt="546.469283343279" mz="155.5775" it="177681" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17662820484983458363" quality="0">
 			<centroid rt="548.842369490024" mz="1390.60544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="256" rt="548.842369490024" mz="696.31" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1658459391944141765" quality="0">
 			<centroid rt="549.409131529638" mz="562.292723533229" it="10224"/>
 			<groupedElementList>
 				<element map="0" id="15" rt="549.409131529638" mz="563.3" it="10224" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17319040485570651489" quality="0">
 			<centroid rt="551.061876996204" mz="564.245447066458" it="18557"/>
 			<groupedElementList>
 				<element map="0" id="612" rt="551.061876996204" mz="283.13" it="18557" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14298244275542202673" quality="0">
 			<centroid rt="553.587448934444" mz="628.338170599686" it="6407"/>
 			<groupedElementList>
 				<element map="0" id="635" rt="553.587448934444" mz="210.453333333333" it="6407" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5037731456228317350" quality="0">
 			<centroid rt="554.998715323825" mz="630.325447066458" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1327" rt="554.998715323825" mz="316.17" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7991119262528065312" quality="0">
 			<centroid rt="557.819694590826" mz="2715.24272353323" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="67" rt="557.819694590826" mz="2716.25" it="11002" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11553691739129680172" quality="0">
 			<centroid rt="557.891336038165" mz="634.295447066458" it="18557"/>
 			<groupedElementList>
 				<element map="0" id="570" rt="557.891336038165" mz="318.155" it="18557" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6516107640176768026" quality="0">
 			<centroid rt="558.035070784606" mz="573.280894132916" it="42278"/>
 			<groupedElementList>
 				<element map="0" id="493" rt="558.035070784606" mz="144.3275" it="42278" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17572421612855458318" quality="0">
 			<centroid rt="558.035070784606" mz="573.295447066458" it="42278"/>
 			<groupedElementList>
 				<element map="0" id="494" rt="558.035070784606" mz="287.655" it="42278" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6426310261629158355" quality="0">
 			<centroid rt="559.129295072556" mz="629.328170599686" it="25323"/>
 			<groupedElementList>
 				<element map="0" id="1572" rt="559.129295072556" mz="210.783333333333" it="25323" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6405552799757951011" quality="0">
 			<centroid rt="563.101123289709" mz="4094.74089413292" it="30281"/>
 			<groupedElementList>
 				<element map="0" id="2010" rt="563.101123289709" mz="1024.6925" it="30281" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14194683363419547435" quality="0">
 			<centroid rt="563.445271892736" mz="642.345447066458" it="34843"/>
 			<groupedElementList>
 				<element map="0" id="1455" rt="563.445271892736" mz="322.18" it="34843" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16088624218142305297" quality="0">
 			<centroid rt="569.018387781001" mz="636.255447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2306" rt="569.018387781001" mz="319.135" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7436858392575544357" quality="0">
 			<centroid rt="570.512116036205" mz="1459.67089413292" it="47784"/>
 			<groupedElementList>
 				<element map="0" id="1488" rt="570.512116036205" mz="365.925" it="47784" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_267601845855923471" quality="0">
 			<centroid rt="570.512116036205" mz="1459.69272353323" it="47784"/>
 			<groupedElementList>
 				<element map="0" id="1487" rt="570.512116036205" mz="1460.7" it="47784" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9821447694596533774" quality="0">
 			<centroid rt="571.05384418792" mz="632.255447066458" it="6913"/>
 			<groupedElementList>
 				<element map="0" id="1958" rt="571.05384418792" mz="317.135" it="6913" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_897783181882650538" quality="0">
 			<centroid rt="571.206528733137" mz="590.292723533229" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="101" rt="571.206528733137" mz="591.3" it="11002" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13207780051883194579" quality="0">
 			<centroid rt="572.230586969183" mz="1552.74089413292" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="346" rt="572.230586969183" mz="389.1925" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12133199033398854568" quality="0">
 			<centroid rt="572.230586969183" mz="1552.75544706646" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="347" rt="572.230586969183" mz="777.385" it="11250" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7177397922210469043" quality="0">
 			<centroid rt="573.400559323325" mz="1556.69544706646" it="18557"/>
 			<groupedElementList>
 				<element map="0" id="578" rt="573.400559323325" mz="779.355" it="18557" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7941472822136372496" quality="0">
 			<centroid rt="574.80749166962" mz="1462.53089413292" it="50646"/>
 			<groupedElementList>
 				<element map="0" id="1568" rt="574.80749166962" mz="366.64" it="50646" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13170096584793280179" quality="0">
 			<centroid rt="574.80749166962" mz="1462.54544706646" it="50646"/>
 			<groupedElementList>
 				<element map="0" id="1569" rt="574.80749166962" mz="732.28" it="50646" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8869296627884561334" quality="0">
 			<centroid rt="576.107974220362" mz="646.305447066458" it="16618"/>
 			<groupedElementList>
 				<element map="0" id="2077" rt="576.107974220362" mz="324.16" it="16618" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13292724500259134280" quality="0">
 			<centroid rt="581.571035743027" mz="1452.63544706646" it="17604"/>
 			<groupedElementList>
 				<element map="0" id="513" rt="581.571035743027" mz="727.325" it="17604" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_162798521694952973" quality="0">
 			<centroid rt="583.712143001547" mz="664.295447066458" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="922" rt="583.712143001547" mz="333.155" it="16793" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16020576920077531491" quality="0">
 			<centroid rt="586.536268900446" mz="610.198170599688" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2193" rt="586.536268900446" mz="204.406666666667" it="14357" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16376552445502218134" quality="0">
 			<centroid rt="587.920664971855" mz="670.275447066458" it="10224"/>
 			<groupedElementList>
 				<element map="0" id="3525220823171556399" rt="587.920664971855" mz="336.145" it="10224" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3964395554887509154" quality="0">
 			<centroid rt="590.420669604261" mz="1615.77544706646" it="36384"/>
 			<groupedElementList>
 				<element map="0" id="1150" rt="590.420669604261" mz="808.895" it="36384" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16564851957981259942" quality="0">
 			<centroid rt="593.759073733351" mz="1424.67272353323" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="58" rt="593.759073733351" mz="1425.68" it="11002" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3215646569116061538" quality="0">
 			<centroid rt="594.045234452387" mz="1639.77089413292" it="1402"/>
 			<groupedElementList>
 				<element map="0" id="1792" rt="594.045234452387" mz="410.95" it="1402" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10824046930259319688" quality="0">
 			<centroid rt="594.045234452387" mz="1639.78544706646" it="1402"/>
 			<groupedElementList>
 				<element map="0" id="1793" rt="594.045234452387" mz="820.9" it="1402" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8947496807814220218" quality="0">
 			<centroid rt="597.894207479177" mz="692.295447066458" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="228" rt="597.894207479177" mz="347.155" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_570044218834897123" quality="0">
 			<centroid rt="601.935112459485" mz="698.362723533229" it="56195"/>
 			<groupedElementList>
 				<element map="0" id="180" rt="601.935112459485" mz="699.37" it="56195" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15016096000989994984" quality="0">
 			<centroid rt="603.029960146854" mz="632.300894132916" it="89721"/>
 			<groupedElementList>
 				<element map="0" id="817" rt="603.029960146854" mz="159.0825" it="89721" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18092990402151292529" quality="0">
 			<centroid rt="603.370019091379" mz="1555.67089413292" it="50646"/>
 			<groupedElementList>
 				<element map="0" id="1580" rt="603.370019091379" mz="389.925" it="50646" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18149744622533071573" quality="0">
 			<centroid rt="603.370019091379" mz="1555.69272353323" it="50646"/>
 			<groupedElementList>
 				<element map="0" id="1579" rt="603.370019091379" mz="1556.7" it="50646" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8137784942475385042" quality="0">
 			<centroid rt="605.264155150908" mz="635.290894132916" it="89721"/>
 			<groupedElementList>
 				<element map="0" id="828" rt="605.264155150908" mz="159.83" it="89721" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9237422465693850506" quality="0">
 			<centroid rt="606.019823265043" mz="3078.34544706646" it="36320"/>
 			<groupedElementList>
 				<element map="0" id="2098" rt="606.019823265043" mz="1540.18" it="36320" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7475837047917402048" quality="0">
 			<centroid rt="611.689210502884" mz="1666.78544706646" it="38786"/>
 			<groupedElementList>
 				<element map="0" id="710" rt="611.689210502884" mz="834.4" it="38786" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4936036263890097350" quality="0">
 			<centroid rt="615.511671526713" mz="4270.05544706646" it="19599"/>
 			<groupedElementList>
 				<element map="0" id="562" rt="615.511671526713" mz="2136.035" it="19599" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11256113556835832034" quality="0">
 			<centroid rt="616.312145035452" mz="650.285447066458" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="435" rt="616.312145035452" mz="326.15" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3229353291029578171" quality="0">
 			<centroid rt="621.291879987746" mz="727.435447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2275" rt="621.291879987746" mz="364.725" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15182380965380918109" quality="0">
 			<centroid rt="622.016950706519" mz="1629.77544706646" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1824" rt="622.016950706519" mz="815.895" it="701" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7694535028704737925" quality="0">
 			<centroid rt="625.137691123561" mz="662.362723533229" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2196" rt="625.137691123561" mz="663.37" it="14357" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10524888388771884095" quality="0">
 			<centroid rt="627.788668353281" mz="737.350894132916" it="71676"/>
 			<groupedElementList>
 				<element map="0" id="1501" rt="627.788668353281" mz="185.345" it="71676" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8836600704192588263" quality="0">
 			<centroid rt="628.507827693864" mz="738.445447066458" it="59227"/>
 			<groupedElementList>
 				<element map="0" id="1008" rt="628.507827693864" mz="370.23" it="59227" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6025212228845947727" quality="0">
 			<centroid rt="629.613900491577" mz="1742.87089413292" it="47784"/>
 			<groupedElementList>
 				<element map="0" id="1496" rt="629.613900491577" mz="436.725" it="47784" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8548024054024286796" quality="0">
 			<centroid rt="629.613900491577" mz="1742.89272353323" it="47784"/>
 			<groupedElementList>
 				<element map="0" id="1495" rt="629.613900491577" mz="1743.9" it="47784" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7688907895034441513" quality="0">
 			<centroid rt="629.833249285325" mz="661.315447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2289" rt="629.833249285325" mz="331.665" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16492796687809580897" quality="0">
 			<centroid rt="631.010314741182" mz="3227.73272353323" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1818" rt="631.010314741182" mz="3228.74" it="701" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3357783571530299401" quality="0">
 			<centroid rt="631.118489168906" mz="742.445447066458" it="38786"/>
 			<groupedElementList>
 				<element map="0" id="714" rt="631.118489168906" mz="372.23" it="38786" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6093270694886024393" quality="0">
 			<centroid rt="631.650031244593" mz="671.402723533229" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1838" rt="631.650031244593" mz="672.41" it="701" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9879744183229909035" quality="0">
 			<centroid rt="632.025561047061" mz="664.290894132916" it="2103"/>
 			<groupedElementList>
 				<element map="0" id="1807" rt="632.025561047061" mz="167.08" it="2103" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3784797448550614940" quality="0">
 			<centroid rt="632.988541619002" mz="3223.68544706646" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1160" rt="632.988541619002" mz="1612.85" it="23898" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4493938076035655752" quality="0">
 			<centroid rt="633.729451343926" mz="746.385447066458" it="41916"/>
 			<groupedElementList>
 				<element map="0" id="1680" rt="633.729451343926" mz="374.2" it="41916" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2996587865178909111" quality="0">
 			<centroid rt="634.998785128968" mz="740.325447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2276" rt="634.998785128968" mz="371.17" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8284477506213917926" quality="0">
 			<centroid rt="641.456136560109" mz="677.288170599687" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2305" rt="641.456136560109" mz="226.77" it="12349" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1768153592346240713" quality="0">
 			<centroid rt="642.407724289971" mz="686.360894132916" it="37047"/>
 			<groupedElementList>
 				<element map="0" id="2221" rt="642.407724289971" mz="172.5975" it="37047" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8159401784777621539" quality="0">
 			<centroid rt="642.971499065628" mz="1803.72089413292" it="60562"/>
 			<groupedElementList>
 				<element map="0" id="2006" rt="642.971499065628" mz="451.9375" it="60562" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17365351744674775206" quality="0">
 			<centroid rt="642.971499065628" mz="1803.73544706646" it="60562"/>
 			<groupedElementList>
 				<element map="0" id="2007" rt="642.971499065628" mz="902.875" it="60562" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9587046800552415504" quality="0">
 			<centroid rt="644.01068059303" mz="762.305447066458" it="26218"/>
 			<groupedElementList>
 				<element map="0" id="1612" rt="644.01068059303" mz="382.16" it="26218" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17184379983819772876" quality="0">
 			<centroid rt="645.644475980747" mz="1587.81544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2271" rt="645.644475980747" mz="794.915" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12256503688662404517" quality="0">
 			<centroid rt="647.388590507439" mz="759.350894132916" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1662" rt="647.388590507439" mz="190.845" it="83832" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6053478136540398163" quality="0">
 			<centroid rt="647.388590507439" mz="759.365447066458" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1663" rt="647.388590507439" mz="380.69" it="83832" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13942279850637405490" quality="0">
 			<centroid rt="652.00689059541" mz="3056.39544706646" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="964" rt="652.00689059541" mz="1529.205" it="8961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11589094064363465259" quality="0">
 			<centroid rt="652.401119526767" mz="775.395447066458" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1240" rt="652.401119526767" mz="388.705" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17706109446296775909" quality="0">
 			<centroid rt="654.466605648013" mz="703.315447066458" it="10224"/>
 			<groupedElementList>
 				<element map="0" id="14" rt="654.466605648013" mz="352.665" it="10224" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17480755777236332221" quality="0">
 			<centroid rt="655.099944442678" mz="1848.93089413292" it="125748"/>
 			<groupedElementList>
 				<element map="0" id="1691" rt="655.099944442678" mz="463.24" it="125748" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7902011863024965825" quality="0">
 			<centroid rt="655.322460145599" mz="1744.81544706646" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="156" rt="655.322460145599" mz="873.415" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9829076178928296162" quality="0">
 			<centroid rt="655.36624450213" mz="763.372723533229" it="59227"/>
 			<groupedElementList>
 				<element map="0" id="1014" rt="655.36624450213" mz="764.38" it="59227" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12207258410763267184" quality="0">
 			<centroid rt="655.83426132062" mz="3342.46544706646" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1552" rt="655.83426132062" mz="1672.24" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1326992760813576126" quality="0">
 			<centroid rt="658.160543098869" mz="1754.80544706646" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1801" rt="658.160543098869" mz="878.41" it="701" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16326880434738651536" quality="0">
 			<centroid rt="660.13538704275" mz="3106.5281705997" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1817" rt="660.13538704275" mz="1036.51666666667" it="701" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11076488467808905137" quality="0">
 			<centroid rt="666.068013393119" mz="788.375447066458" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="456" rt="666.068013393119" mz="395.195" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15352162147169720575" quality="0">
 			<centroid rt="667.165202149646" mz="165.065447066458" it="36384"/>
 			<groupedElementList>
 				<element map="0" id="1157" rt="667.165202149646" mz="83.54" it="36384" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6420257134563894795" quality="0">
 			<centroid rt="667.933288615698" mz="1776.85544706646" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1831" rt="667.933288615698" mz="889.435" it="701" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4018296777766069252" quality="0">
 			<centroid rt="670.844630669009" mz="804.425447066458" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1401" rt="670.844630669009" mz="403.22" it="2961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16979292956458979937" quality="0">
 			<centroid rt="671.911309452336" mz="1790.88544706646" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1872" rt="671.911309452336" mz="896.45" it="11986" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4101292515860687198" quality="0">
 			<centroid rt="674.469485038357" mz="810.425447066458" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1917" rt="674.469485038357" mz="406.22" it="54993" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_720675463936253111" quality="0">
 			<centroid rt="674.931883050558" mz="802.375447066458" it="36320"/>
 			<groupedElementList>
 				<element map="0" id="2094" rt="674.931883050558" mz="402.195" it="36320" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11210609045946442234" quality="0">
 			<centroid rt="675.718805091941" mz="812.395447066458" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1292" rt="675.718805091941" mz="407.205" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5468948019258719737" quality="0">
 			<centroid rt="679.839023050886" mz="1818.85272353323" it="6407"/>
 			<groupedElementList>
 				<element map="0" id="662" rt="679.839023050886" mz="1819.86" it="6407" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4309348781916082851" quality="0">
 			<centroid rt="682.98844182746" mz="719.282723533229" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2212" rt="682.98844182746" mz="720.29" it="12349" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8217512596488295588" quality="0">
 			<centroid rt="684.464205198013" mz="826.505447066458" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1027" rt="684.464205198013" mz="414.26" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4864991491656656773" quality="0">
 			<centroid rt="685.681510157505" mz="748.315447066458" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1896" rt="685.681510157505" mz="375.165" it="54993" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8566660037201566358" quality="0">
 			<centroid rt="685.749834589663" mz="748.355447066458" it="10915"/>
 			<groupedElementList>
 				<element map="0" id="1222" rt="685.749834589663" mz="375.185" it="10915" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10557584010124332352" quality="0">
 			<centroid rt="685.898082317763" mz="3434.70544706646" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="905" rt="685.898082317763" mz="1718.36" it="16793" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8008607333840924172" quality="0">
 			<centroid rt="685.982054332222" mz="3434.61544706646" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="950" rt="685.982054332222" mz="1718.315" it="8961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8865390600616721946" quality="0">
 			<centroid rt="688.145241384135" mz="823.342723533229" it="21139"/>
 			<groupedElementList>
 				<element map="0" id="485" rt="688.145241384135" mz="824.35" it="21139" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4764619624703990753" quality="0">
 			<centroid rt="689.762950451029" mz="754.375447066458" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="910" rt="689.762950451029" mz="378.195" it="16793" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9837619831794077347" quality="0">
 			<centroid rt="689.804768935385" mz="737.305447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2297" rt="689.804768935385" mz="369.66" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3087622252920034941" quality="0">
 			<centroid rt="694.300925417955" mz="842.508170599686" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="87" rt="694.300925417955" mz="281.843333333333" it="11002" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11875452141702786705" quality="0">
 			<centroid rt="696.745484521755" mz="846.355447066458" it="19599"/>
 			<groupedElementList>
 				<element map="0" id="559" rt="696.745484521755" mz="424.185" it="19599" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11754600924144557207" quality="0">
 			<centroid rt="699.800915750109" mz="851.390894132916" it="164979"/>
 			<groupedElementList>
 				<element map="0" id="1908" rt="699.800915750109" mz="213.855" it="164979" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7429278957607722323" quality="0">
 			<centroid rt="699.839852735789" mz="842.380894132916" it="16875"/>
 			<groupedElementList>
 				<element map="0" id="390" rt="699.839852735789" mz="211.6025" it="16875" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5250143588109198580" quality="0">
 			<centroid rt="700.030522927898" mz="1905.93089413292" it="31152"/>
 			<groupedElementList>
 				<element map="0" id="299" rt="700.030522927898" mz="477.49" it="31152" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5101522921872789118" quality="0">
 			<centroid rt="700.030522927898" mz="1905.94544706646" it="31152"/>
 			<groupedElementList>
 				<element map="0" id="300" rt="700.030522927898" mz="953.98" it="31152" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9141974745740633616" quality="0">
 			<centroid rt="700.401543381373" mz="852.385447066458" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1167" rt="700.401543381373" mz="427.2" it="23898" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17262954464456198330" quality="0">
 			<centroid rt="701.937910296761" mz="772.350894132916" it="72768"/>
 			<groupedElementList>
 				<element map="0" id="1123" rt="701.937910296761" mz="194.095" it="72768" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2600033206649280855" quality="0">
 			<centroid rt="701.937910296761" mz="772.372723533229" it="72768"/>
 			<groupedElementList>
 				<element map="0" id="1122" rt="701.937910296761" mz="773.38" it="72768" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11938812023127106385" quality="0">
 			<centroid rt="705.255282165148" mz="860.382723533229" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="191" rt="705.255282165148" mz="861.39" it="15576" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11439153194968577844" quality="0">
 			<centroid rt="705.540455212689" mz="2055.98089413292" it="21830"/>
 			<groupedElementList>
 				<element map="0" id="1230" rt="705.540455212689" mz="515.0025" it="21830" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6854631840081998983" quality="0">
 			<centroid rt="705.540455212689" mz="2055.99544706646" it="21830"/>
 			<groupedElementList>
 				<element map="0" id="1231" rt="705.540455212689" mz="1029.005" it="21830" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3329464348008611881" quality="0">
 			<centroid rt="709.788684758014" mz="3734.75544706646" it="38786"/>
 			<groupedElementList>
 				<element map="0" id="723" rt="709.788684758014" mz="1868.385" it="38786" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16510628061413857361" quality="0">
 			<centroid rt="715.532545218785" mz="3616.84089413292" it="127602"/>
 			<groupedElementList>
 				<element map="0" id="2150" rt="715.532545218785" mz="905.2175" it="127602" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11590129042843092785" quality="0">
 			<centroid rt="715.716757395669" mz="3480.54544706646" it="25323"/>
 			<groupedElementList>
 				<element map="0" id="1556" rt="715.716757395669" mz="1741.28" it="25323" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11807754452132854215" quality="0">
 			<centroid rt="716.704746869298" mz="879.410894132916" it="127602"/>
 			<groupedElementList>
 				<element map="0" id="2140" rt="716.704746869298" mz="220.86" it="127602" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8909361898036007235" quality="0">
 			<centroid rt="721.544460013899" mz="887.490894132916" it="145536"/>
 			<groupedElementList>
 				<element map="0" id="1105" rt="721.544460013899" mz="222.88" it="145536" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12888443117346741102" quality="0">
 			<centroid rt="721.759774731991" mz="1971.96089413292" it="149547"/>
 			<groupedElementList>
 				<element map="0" id="1036" rt="721.759774731991" mz="493.9975" it="149547" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6583626776279552374" quality="0">
 			<centroid rt="723.898800419121" mz="872.400894132916" it="57428"/>
 			<groupedElementList>
 				<element map="0" id="2160" rt="723.898800419121" mz="219.1075" it="57428" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3690658799804563582" quality="0">
 			<centroid rt="728.022478674242" mz="898.310894132916" it="60562"/>
 			<groupedElementList>
 				<element map="0" id="1996" rt="728.022478674242" mz="225.585" it="60562" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11556162873906182809" quality="0">
 			<centroid rt="728.022478674242" mz="898.325447066458" it="60562"/>
 			<groupedElementList>
 				<element map="0" id="1997" rt="728.022478674242" mz="450.17" it="60562" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3499612233825101951" quality="0">
 			<centroid rt="729.848528335503" mz="901.490894132916" it="127602"/>
 			<groupedElementList>
 				<element map="0" id="2133" rt="729.848528335503" mz="226.38" it="127602" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14316297324333585614" quality="0">
 			<centroid rt="732.4880845503" mz="2012.09544706646" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1480" rt="732.4880845503" mz="1007.055" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11466861114844782323" quality="0">
 			<centroid rt="732.810998036042" mz="906.470894132916" it="19221"/>
 			<groupedElementList>
 				<element map="0" id="633" rt="732.810998036042" mz="227.625" it="19221" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11255591927007635695" quality="0">
 			<centroid rt="733.797885836793" mz="898.462723533229" it="18557"/>
 			<groupedElementList>
 				<element map="0" id="611" rt="733.797885836793" mz="899.47" it="18557" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14679411504912639770" quality="0">
 			<centroid rt="734.452216360775" mz="821.382723533229" it="36384"/>
 			<groupedElementList>
 				<element map="0" id="1110" rt="734.452216360775" mz="822.39" it="36384" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_571263141455682740" quality="0">
 			<centroid rt="735.277032909183" mz="730.295447066458" it="10915"/>
 			<groupedElementList>
 				<element map="0" id="1202" rt="735.277032909183" mz="366.155" it="10915" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18197691148193239509" quality="0">
 			<centroid rt="740.920234475618" mz="920.425447066458" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1382" rt="740.920234475618" mz="461.22" it="2961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7087559629775477008" quality="0">
 			<centroid rt="741.522616863449" mz="911.418170599686" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1261" rt="741.522616863449" mz="304.813333333333" it="24022" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7172749077504922066" quality="0">
 			<centroid rt="743.268632906444" mz="1932.91544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2287" rt="743.268632906444" mz="967.465" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4237108075305098109" quality="0">
 			<centroid rt="744.526642903187" mz="916.470894132916" it="19221"/>
 			<groupedElementList>
 				<element map="0" id="639" rt="744.526642903187" mz="230.125" it="19221" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4886721407249260880" quality="0">
 			<centroid rt="749.821966706717" mz="925.458170599686" it="19599"/>
 			<groupedElementList>
 				<element map="0" id="554" rt="749.821966706717" mz="309.493333333333" it="19599" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4509126281348446583" quality="0">
 			<centroid rt="753.251638751866" mz="850.445447066458" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="951" rt="753.251638751866" mz="426.23" it="8961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13387753535090479604" quality="0">
 			<centroid rt="755.072298298156" mz="2097.97544706646" it="42534"/>
 			<groupedElementList>
 				<element map="0" id="2139" rt="755.072298298156" mz="1049.995" it="42534" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4581917377042574534" quality="0">
 			<centroid rt="755.747699660183" mz="854.435447066458" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1893" rt="755.747699660183" mz="428.225" it="54993" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10455704265668420410" quality="0">
 			<centroid rt="757.304529843833" mz="948.445447066458" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="207" rt="757.304529843833" mz="475.23" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6172821862468651061" quality="0">
 			<centroid rt="762.293263989782" mz="2002.00272353323" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2167" rt="762.293263989782" mz="2003.01" it="14357" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4140069438038053723" quality="0">
 			<centroid rt="762.476455862195" mz="957.475447066458" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1355" rt="762.476455862195" mz="479.745" it="2961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1428825640474552550" quality="0">
 			<centroid rt="763.455867465399" mz="866.452723533229" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="114" rt="763.455867465399" mz="867.46" it="11002" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_61518813294515263" quality="0">
 			<centroid rt="764.251641332359" mz="960.465447066458" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1021" rt="764.251641332359" mz="481.24" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11749170336175040384" quality="0">
 			<centroid rt="774.009115844017" mz="793.255447066458" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="218" rt="774.009115844017" mz="397.635" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10925430061092791132" quality="0">
 			<centroid rt="774.202593051437" mz="967.492723533229" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1868" rt="774.202593051437" mz="968.5" it="11986" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1113279357661672761" quality="0">
 			<centroid rt="774.760881733123" mz="884.380894132916" it="2103"/>
 			<groupedElementList>
 				<element map="0" id="1798" rt="774.760881733123" mz="222.1025" it="2103" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1870582854220171083" quality="0">
 			<centroid rt="774.769731887225" mz="884.310894132916" it="46728"/>
 			<groupedElementList>
 				<element map="0" id="203" rt="774.769731887225" mz="222.085" it="46728" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12161644562500383165" quality="0">
 			<centroid rt="776.219802494311" mz="981.590894132916" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1703" rt="776.219802494311" mz="246.405" it="83832" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9291180656081197389" quality="0">
 			<centroid rt="776.219802494311" mz="981.605447066458" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1704" rt="776.219802494311" mz="491.81" it="83832" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6621462278707896220" quality="0">
 			<centroid rt="776.798547525087" mz="961.465447066458" it="10915"/>
 			<groupedElementList>
 				<element map="0" id="1214" rt="776.798547525087" mz="481.74" it="10915" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13722842780965967270" quality="0">
 			<centroid rt="777.545575901141" mz="2333.14089413292" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="856" rt="777.545575901141" mz="584.2925" it="59814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14752973248762831047" quality="0">
 			<centroid rt="777.545575901141" mz="2333.16272353323" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="855" rt="777.545575901141" mz="2334.17" it="59814" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12646936808944010297" quality="0">
 			<centroid rt="777.63791610817" mz="973.435447066458" it="19599"/>
 			<groupedElementList>
 				<element map="0" id="531" rt="777.63791610817" mz="487.725" it="19599" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3035968140654410916" quality="0">
 			<centroid rt="778.014065472632" mz="879.390894132916" it="55671"/>
 			<groupedElementList>
 				<element map="0" id="600" rt="778.014065472632" mz="220.855" it="55671" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2534795394374275578" quality="0">
 			<centroid rt="779.615747126367" mz="987.555447066458" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="894" rt="779.615747126367" mz="494.785" it="16793" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12277858546893287669" quality="0">
 			<centroid rt="781.71388435766" mz="895.405447066458" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="840" rt="781.71388435766" mz="448.71" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16254827746334912830" quality="0">
 			<centroid rt="782.96211985245" mz="897.378170599686" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="399" rt="782.96211985245" mz="300.133333333333" it="5625" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15778066805412038452" quality="0">
 			<centroid rt="785.454346484789" mz="901.445447066458" it="56195"/>
 			<groupedElementList>
 				<element map="0" id="179" rt="785.454346484789" mz="451.73" it="56195" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2796907653127438599" quality="0">
 			<centroid rt="786.199162173081" mz="988.370894132916" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1666" rt="786.199162173081" mz="248.1" it="83832" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17690522151336382691" quality="0">
 			<centroid rt="786.199162173081" mz="988.385447066458" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1667" rt="786.199162173081" mz="495.2" it="83832" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2277887101541743210" quality="0">
 			<centroid rt="786.787992124436" mz="893.405447066458" it="30892"/>
 			<groupedElementList>
 				<element map="0" id="693" rt="786.787992124436" mz="447.71" it="30892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5699726986842512975" quality="0">
 			<centroid rt="791.189721336309" mz="900.422723533229" it="42534"/>
 			<groupedElementList>
 				<element map="0" id="2136" rt="791.189721336309" mz="901.43" it="42534" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8073364190052451635" quality="0">
 			<centroid rt="793.041751731891" mz="1000.54089413292" it="90843"/>
 			<groupedElementList>
 				<element map="0" id="2020" rt="793.041751731891" mz="251.1425" it="90843" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13831441354209038061" quality="0">
 			<centroid rt="794.037731124602" mz="991.490894132916" it="72066"/>
 			<groupedElementList>
 				<element map="0" id="1266" rt="794.037731124602" mz="248.88" it="72066" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12763809731924455905" quality="0">
 			<centroid rt="796.780699285681" mz="2431.09544706646" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="812" rt="796.780699285681" mz="1216.555" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4193271034769686005" quality="0">
 			<centroid rt="796.799323111487" mz="985.475447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2294" rt="796.799323111487" mz="493.745" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5964868078031023859" quality="0">
 			<centroid rt="797.002068393953" mz="1018.54544706646" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1772" rt="797.002068393953" mz="510.28" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9958914473595287684" quality="0">
 			<centroid rt="801.422023651974" mz="1004.47272353323" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2158" rt="801.422023651974" mz="1005.48" it="14357" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15615571292739319949" quality="0">
 			<centroid rt="802.037870875476" mz="1016.52817059969" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="43" rt="802.037870875476" mz="339.85" it="11002" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7467975480354151429" quality="0">
 			<centroid rt="802.541782893146" mz="1017.46544706646" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1305" rt="802.541782893146" mz="509.74" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3608535254220689465" quality="0">
 			<centroid rt="802.926438093271" mz="2286.18089413292" it="72066"/>
 			<groupedElementList>
 				<element map="0" id="1245" rt="802.926438093271" mz="572.5525" it="72066" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8389600887944813845" quality="0">
 			<centroid rt="806.668447512555" mz="1973.82272353323" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2308" rt="806.668447512555" mz="1974.83" it="12349" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11804723473796500098" quality="0">
 			<centroid rt="808.383193851465" mz="2290.79089413292" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="359" rt="808.383193851465" mz="573.705" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5679930433028830081" quality="0">
 			<centroid rt="808.383193851465" mz="2290.80544706646" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="360" rt="808.383193851465" mz="1146.41" it="11250" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11827384453370388407" quality="0">
 			<centroid rt="811.519061480396" mz="1033.54089413292" it="72640"/>
 			<groupedElementList>
 				<element map="0" id="2111" rt="811.519061480396" mz="259.3925" it="72640" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11406230969764213388" quality="0">
 			<centroid rt="811.519061480396" mz="1033.55544706646" it="72640"/>
 			<groupedElementList>
 				<element map="0" id="2112" rt="811.519061480396" mz="517.785" it="72640" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8184364280735151771" quality="0">
 			<centroid rt="812.255159357822" mz="4334.87272353323" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1867" rt="812.255159357822" mz="4335.88" it="11986" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18280251371219560427" quality="0">
 			<centroid rt="820.089241747639" mz="1060.49089413292" it="30281"/>
 			<groupedElementList>
 				<element map="0" id="2008" rt="820.089241747639" mz="266.13" it="30281" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17140297874929866805" quality="0">
 			<centroid rt="820.446391071412" mz="958.520894132916" it="20739"/>
 			<groupedElementList>
 				<element map="0" id="1956" rt="820.446391071412" mz="240.6375" it="20739" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2070316154912952113" quality="0">
 			<centroid rt="822.661529300434" mz="2543.28544706646" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1530" rt="822.661529300434" mz="1272.65" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6992869171762718515" quality="0">
 			<centroid rt="823.621678157102" mz="1055.43544706646" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1715" rt="823.621678157102" mz="528.725" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18016006947463860624" quality="0">
 			<centroid rt="825.373483876848" mz="868.385447066458" it="10915"/>
 			<groupedElementList>
 				<element map="0" id="1200" rt="825.373483876848" mz="435.2" it="10915" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11793687339539370623" quality="0">
 			<centroid rt="829.458374543513" mz="1054.42089413292" it="177681"/>
 			<groupedElementList>
 				<element map="0" id="988" rt="829.458374543513" mz="264.6125" it="177681" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8316176416314330034" quality="0">
 			<centroid rt="830.048956912025" mz="2396.14544706646" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1297" rt="830.048956912025" mz="1199.08" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_735130921137560071" quality="0">
 			<centroid rt="830.697809022935" mz="964.450894132916" it="25628"/>
 			<groupedElementList>
 				<element map="0" id="623" rt="830.697809022935" mz="242.12" it="25628" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4787383482455322637" quality="0">
 			<centroid rt="832.930210897847" mz="2267.05089413292" it="20739"/>
 			<groupedElementList>
 				<element map="0" id="1961" rt="832.930210897847" mz="567.77" it="20739" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17655867949361831008" quality="0">
 			<centroid rt="835.897196791021" mz="1089.56089413292" it="139372"/>
 			<groupedElementList>
 				<element map="0" id="1457" rt="835.897196791021" mz="273.3975" it="139372" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15756601391748647062" quality="0">
 			<centroid rt="836.638749188025" mz="985.408170599688" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1328" rt="836.638749188025" mz="329.476666666667" it="24022" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4611648505861555397" quality="0">
 			<centroid rt="837.650916445626" mz="2427.08544706646" it="21139"/>
 			<groupedElementList>
 				<element map="0" id="499" rt="837.650916445626" mz="1214.55" it="21139" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10987051719639094925" quality="0">
 			<centroid rt="841.980505698159" mz="893.425447066458" it="21139"/>
 			<groupedElementList>
 				<element map="0" id="504" rt="841.980505698159" mz="447.72" it="21139" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7840665296678508535" quality="0">
 			<centroid rt="842.678209814992" mz="984.385447066458" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="210" rt="842.678209814992" mz="493.2" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4479995351980485537" quality="0">
 			<centroid rt="847.178670050225" mz="901.365447066458" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="975" rt="847.178670050225" mz="451.69" it="8961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8613509480953054307" quality="0">
 			<centroid rt="850.829269197896" mz="1009.46272353323" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1911" rt="850.829269197896" mz="1010.47" it="54993" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6289648954914068300" quality="0">
 			<centroid rt="851.928175384314" mz="1119.53272353323" it="41916"/>
 			<groupedElementList>
 				<element map="0" id="1673" rt="851.928175384314" mz="1120.54" it="41916" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5931250823345747394" quality="0">
 			<centroid rt="854.939038631761" mz="1016.51089413292" it="57428"/>
 			<groupedElementList>
 				<element map="0" id="2175" rt="854.939038631761" mz="255.135" it="57428" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3737221911068131654" quality="0">
 			<centroid rt="856.455840608133" mz="2323.79544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="232" rt="856.455840608133" mz="1162.905" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9598631305141155295" quality="0">
 			<centroid rt="859.071017368113" mz="919.475447066458" it="30892"/>
 			<groupedElementList>
 				<element map="0" id="694" rt="859.071017368113" mz="460.745" it="30892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3199221937292318147" quality="0">
 			<centroid rt="860.79520701639" mz="1026.45544706646" it="26218"/>
 			<groupedElementList>
 				<element map="0" id="1625" rt="860.79520701639" mz="514.235" it="26218" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14925052321433342016" quality="0">
 			<centroid rt="862.555934011146" mz="2513.22544706646" it="36320"/>
 			<groupedElementList>
 				<element map="0" id="2107" rt="862.555934011146" mz="1257.62" it="36320" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14960436128489023736" quality="0">
 			<centroid rt="864.910911131137" mz="917.445447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2270" rt="864.910911131137" mz="459.73" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12678589149572049823" quality="0">
 			<centroid rt="867.692611899769" mz="2386.19272353323" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2213" rt="867.692611899769" mz="2387.2" it="12349" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5434216499796066363" quality="0">
 			<centroid rt="867.951724278182" mz="1137.52817059969" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="782" rt="867.951724278182" mz="380.183333333333" it="29907" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9896041544323275580" quality="0">
 			<centroid rt="871.234836072433" mz="938.398170599688" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1166" rt="871.234836072433" mz="313.806666666667" it="23898" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12124899977588683157" quality="0">
 			<centroid rt="872.126805470272" mz="1145.56544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="397" rt="872.126805470272" mz="573.79" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2822109265705715313" quality="0">
 			<centroid rt="872.401445921406" mz="2351.17544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="379" rt="872.401445921406" mz="1176.595" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15585912397691783047" quality="0">
 			<centroid rt="874.287991165654" mz="1149.51089413292" it="81597"/>
 			<groupedElementList>
 				<element map="0" id="1756" rt="874.287991165654" mz="288.385" it="81597" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6750909427836087963" quality="0">
 			<centroid rt="880.306848189968" mz="1173.51544706646" it="41916"/>
 			<groupedElementList>
 				<element map="0" id="1700" rt="880.306848189968" mz="587.765" it="41916" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3455747772463136032" quality="0">
 			<centroid rt="882.850691789953" mz="1178.56272353323" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1063" rt="882.850691789953" mz="1179.57" it="49849" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3860421605056340965" quality="0">
 			<centroid rt="890.454134602559" mz="968.388170599686" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="215" rt="890.454134602559" mz="323.803333333333" it="15576" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14069327061196513184" quality="0">
 			<centroid rt="891.041321447979" mz="2293.99089413292" it="145536"/>
 			<groupedElementList>
 				<element map="0" id="1136" rt="891.041321447979" mz="574.505" it="145536" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10092261147796088846" quality="0">
 			<centroid rt="891.943732943832" mz="1080.50089413292" it="109152"/>
 			<groupedElementList>
 				<element map="0" id="1120" rt="891.943732943832" mz="271.1325" it="109152" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1345929857451362072" quality="0">
 			<centroid rt="897.757621142574" mz="2883.70544706646" it="17604"/>
 			<groupedElementList>
 				<element map="0" id="510" rt="897.757621142574" mz="1442.86" it="17604" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17811945781423872532" quality="0">
 			<centroid rt="900.973331451292" mz="973.380894132916" it="69686"/>
 			<groupedElementList>
 				<element map="0" id="1451" rt="900.973331451292" mz="244.3525" it="69686" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10600284442903184411" quality="0">
 			<centroid rt="900.973331451292" mz="973.395447066458" it="69686"/>
 			<groupedElementList>
 				<element map="0" id="1452" rt="900.973331451292" mz="487.705" it="69686" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8283075795861318011" quality="0">
 			<centroid rt="905.496533447901" mz="1222.67544706646" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1170" rt="905.496533447901" mz="612.345" it="23898" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6036633674049288761" quality="0">
 			<centroid rt="910.535029944593" mz="988.432723533229" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="231" rt="910.535029944593" mz="989.44" it="15576" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14903314431267073228" quality="0">
 			<centroid rt="914.847018294087" mz="1214.53089413292" it="167664"/>
 			<groupedElementList>
 				<element map="0" id="1688" rt="914.847018294087" mz="304.64" it="167664" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_374027537295347714" quality="0">
 			<centroid rt="915.886464743706" mz="1216.49544706646" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1915" rt="915.886464743706" mz="609.255" it="54993" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15512154333406293600" quality="0">
 			<centroid rt="916.501805265596" mz="2784.31544706646" it="32119"/>
 			<groupedElementList>
 				<element map="0" id="2125" rt="916.501805265596" mz="1393.165" it="32119" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14794815986681948807" quality="0">
 			<centroid rt="917.309527220231" mz="1125.64272353323" it="42534"/>
 			<groupedElementList>
 				<element map="0" id="2137" rt="917.309527220231" mz="1126.65" it="42534" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17142346056787539917" quality="0">
 			<centroid rt="920.072100422372" mz="991.410894132916" it="116358"/>
 			<groupedElementList>
 				<element map="0" id="731" rt="920.072100422372" mz="248.86" it="116358" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13915024089790587884" quality="0">
 			<centroid rt="921.621149743902" mz="1120.54544706646" it="38786"/>
 			<groupedElementList>
 				<element map="0" id="727" rt="921.621149743902" mz="561.28" it="38786" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9087341864519324552" quality="0">
 			<centroid rt="921.711864163711" mz="1133.47089413292" it="119628"/>
 			<groupedElementList>
 				<element map="0" id="842" rt="921.711864163711" mz="284.375" it="119628" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11807454575290022955" quality="0">
 			<centroid rt="922.611535928275" mz="1229.61544706646" it="16618"/>
 			<groupedElementList>
 				<element map="0" id="2075" rt="922.611535928275" mz="615.815" it="16618" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_124525069669966754" quality="0">
 			<centroid rt="928.392932667118" mz="1132.53544706646" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1520" rt="928.392932667118" mz="567.275" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11509617927430774370" quality="0">
 			<centroid rt="928.73086724632" mz="1241.63544706646" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1258" rt="928.73086724632" mz="621.825" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14024262548237562104" quality="0">
 			<centroid rt="929.785806791866" mz="4685.64544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="440" rt="929.785806791866" mz="2343.83" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6872403626028436065" quality="0">
 			<centroid rt="932.406196243342" mz="7792.7081705997" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="815" rt="932.406196243342" mz="2598.57666666667" it="29907" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17780324352910343601" quality="0">
 			<centroid rt="934.545751516713" mz="1130.42089413292" it="12814"/>
 			<groupedElementList>
 				<element map="0" id="628" rt="934.545751516713" mz="283.6125" it="12814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7415832784406195256" quality="0">
 			<centroid rt="934.545751516713" mz="1130.43544706646" it="12814"/>
 			<groupedElementList>
 				<element map="0" id="629" rt="934.545751516713" mz="566.225" it="12814" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1934091833892098206" quality="0">
 			<centroid rt="936.017635820023" mz="1269.67544706646" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1860" rt="936.017635820023" mz="635.845" it="11986" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18138015938539317847" quality="0">
 			<centroid rt="939.940824204166" mz="1166.53089413292" it="62304"/>
 			<groupedElementList>
 				<element map="0" id="250" rt="939.940824204166" mz="292.64" it="62304" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12473178138943898523" quality="0">
 			<centroid rt="940.367568944692" mz="2682.17089413292" it="28714"/>
 			<groupedElementList>
 				<element map="0" id="2197" rt="940.367568944692" mz="671.55" it="28714" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6739192327742314444" quality="0">
 			<centroid rt="940.367568944692" mz="2682.18544706646" it="28714"/>
 			<groupedElementList>
 				<element map="0" id="2198" rt="940.367568944692" mz="1342.1" it="28714" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6429714075402663990" quality="0">
 			<centroid rt="941.962586011762" mz="3007.4981705997" it="17604"/>
 			<groupedElementList>
 				<element map="0" id="509" rt="941.962586011762" mz="1003.50666666667" it="17604" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8560591139817537638" quality="0">
 			<centroid rt="944.682136803083" mz="2660.12089413292" it="44008"/>
 			<groupedElementList>
 				<element map="0" id="69" rt="944.682136803083" mz="666.0375" it="44008" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14963553634260018923" quality="0">
 			<centroid rt="945.954026756527" mz="1289.50272353323" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1905" rt="945.954026756527" mz="1290.51" it="54993" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8733644945191526470" quality="0">
 			<centroid rt="946.954800173864" mz="1291.63544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="246" rt="946.954800173864" mz="646.825" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6637770612805768385" quality="0">
 			<centroid rt="948.103138313794" mz="2715.36817059969" it="18557"/>
 			<groupedElementList>
 				<element map="0" id="581" rt="948.103138313794" mz="906.13" it="18557" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12032065936684472591" quality="0">
 			<centroid rt="951.973978519065" mz="1188.61089413292" it="6407"/>
 			<groupedElementList>
 				<element map="0" id="669" rt="951.973978519065" mz="298.16" it="6407" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15004593200444852518" quality="0">
 			<centroid rt="953.276829650597" mz="1177.49089413292" it="60562"/>
 			<groupedElementList>
 				<element map="0" id="1994" rt="953.276829650597" mz="295.38" it="60562" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18427362018147659790" quality="0">
 			<centroid rt="953.276829650597" mz="1177.50544706646" it="60562"/>
 			<groupedElementList>
 				<element map="0" id="1995" rt="953.276829650597" mz="589.76" it="60562" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5575976212058602033" quality="0">
 			<centroid rt="954.953876081944" mz="1293.64544706646" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1750" rt="954.953876081944" mz="647.83" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16421901560902706258" quality="0">
 			<centroid rt="955.464187340948" mz="1181.54272353323" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1478" rt="955.464187340948" mz="1182.55" it="23892" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2574287915259085081" quality="0">
 			<centroid rt="955.763215270049" mz="1195.61544706646" it="30892"/>
 			<groupedElementList>
 				<element map="0" id="699" rt="955.763215270049" mz="598.815" it="30892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5167916511671063528" quality="0">
 			<centroid rt="956.902954131063" mz="1311.63544706646" it="10224"/>
 			<groupedElementList>
 				<element map="0" id="18" rt="956.902954131063" mz="656.825" it="10224" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1713748860343201639" quality="0">
 			<centroid rt="957.383394782097" mz="1198.65544706646" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1042" rt="957.383394782097" mz="600.335" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6229303422485420462" quality="0">
 			<centroid rt="963.847147902386" mz="1210.64544706646" it="30892"/>
 			<groupedElementList>
 				<element map="0" id="696" rt="963.847147902386" mz="606.33" it="30892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13132423787078113913" quality="0">
 			<centroid rt="965.508813049539" mz="1090.50089413292" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1696" rt="965.508813049539" mz="273.6325" it="83832" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6429088751278265888" quality="0">
 			<centroid rt="965.508813049539" mz="1090.51544706646" it="83832"/>
 			<groupedElementList>
 				<element map="0" id="1697" rt="965.508813049539" mz="546.265" it="83832" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2154538086248554709" quality="0">
 			<centroid rt="967.061300226287" mz="1216.60544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2241" rt="967.061300226287" mz="609.31" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14580165132108754334" quality="0">
 			<centroid rt="969.827621448195" mz="3004.24089413292" it="90843"/>
 			<groupedElementList>
 				<element map="0" id="2003" rt="969.827621448195" mz="752.0675" it="90843" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_297696814317415880" quality="0">
 			<centroid rt="972.214382174514" mz="3241.89544706646" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1310" rt="972.214382174514" mz="1621.955" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16338431689860844581" quality="0">
 			<centroid rt="974.324968076975" mz="1332.60544706646" it="47886"/>
 			<groupedElementList>
 				<element map="0" id="2035" rt="974.324968076975" mz="667.31" it="47886" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4053263408069839562" quality="0">
 			<centroid rt="979.849237058853" mz="2829.29544706646" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1273" rt="979.849237058853" mz="1415.655" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9312858060744412024" quality="0">
 			<centroid rt="980.374536936398" mz="1227.60272353323" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2216" rt="980.374536936398" mz="1228.61" it="12349" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18254375322677259128" quality="0">
 			<centroid rt="983.827904935893" mz="1366.59544706646" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="849" rt="983.827904935893" mz="684.305" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9590757163009334010" quality="0">
 			<centroid rt="985.322711936023" mz="1384.68817059969" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1390" rt="985.322711936023" mz="462.57" it="2961" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9341617048337286210" quality="0">
 			<centroid rt="985.391511590157" mz="3009.18089413292" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="368" rt="985.391511590157" mz="753.3025" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6680407737132509854" quality="0">
 			<centroid rt="985.391511590157" mz="3009.20272353323" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="367" rt="985.391511590157" mz="3010.21" it="11250" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18390875480459542566" quality="0">
 			<centroid rt="991.353954909825" mz="2879.39817059969" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1094" rt="991.353954909825" mz="960.806666666667" it="49849" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5909728612680109873" quality="0">
 			<centroid rt="993.26816395269" mz="2909.31272353323" it="42534"/>
 			<groupedElementList>
 				<element map="0" id="2153" rt="993.26816395269" mz="2910.32" it="42534" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7299959053955635048" quality="0">
 			<centroid rt="996.75982341439" mz="1393.65817059969" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1391" rt="996.75982341439" mz="465.56" it="2961" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9988690999967655481" quality="0">
 			<centroid rt="998.654462225051" mz="1412.65089413292" it="109152"/>
 			<groupedElementList>
 				<element map="0" id="1102" rt="998.654462225051" mz="354.17" it="109152" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17681088807987785543" quality="0">
 			<centroid rt="1013.69259230077" mz="1172.63089413292" it="22500"/>
 			<groupedElementList>
 				<element map="0" id="330" rt="1013.69259230077" mz="294.165" it="22500" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8736462081558417127" quality="0">
 			<centroid rt="1014.9447306332" mz="1307.62544706646" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1897" rt="1014.9447306332" mz="654.82" it="54993" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3628370299146074760" quality="0">
 			<centroid rt="1021.40358642008" mz="1445.60089413292" it="16875"/>
 			<groupedElementList>
 				<element map="0" id="448" rt="1021.40358642008" mz="362.4075" it="16875" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6202164461190471806" quality="0">
 			<centroid rt="1024.26590746061" mz="1325.51089413292" it="149547"/>
 			<groupedElementList>
 				<element map="0" id="1052" rt="1024.26590746061" mz="332.385" it="149547" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17314177683436079450" quality="0">
 			<centroid rt="1024.9501052592" mz="3026.38089413292" it="33006"/>
 			<groupedElementList>
 				<element map="0" id="41" rt="1024.9501052592" mz="757.6025" it="33006" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13830401256603338057" quality="0">
 			<centroid rt="1033.58556520278" mz="1328.65544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="323" rt="1033.58556520278" mz="665.335" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3515113107196651606" quality="0">
 			<centroid rt="1033.89590735038" mz="3089.39544706646" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="115" rt="1033.89590735038" mz="1545.705" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3193006364349599852" quality="0">
 			<centroid rt="1035.4475258886" mz="1347.54089413292" it="109152"/>
 			<groupedElementList>
 				<element map="0" id="1152" rt="1035.4475258886" mz="337.8925" it="109152" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5113750691882813385" quality="0">
 			<centroid rt="1040.08870167062" mz="3335.54089413292" it="89721"/>
 			<groupedElementList>
 				<element map="0" id="836" rt="1040.08870167062" mz="834.8925" it="89721" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3459314247331157014" quality="0">
 			<centroid rt="1045.14452703006" mz="1512.92544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2211" rt="1045.14452703006" mz="757.47" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12308378267540763764" quality="0">
 			<centroid rt="1048.69804840974" mz="1520.74544706646" it="34843"/>
 			<groupedElementList>
 				<element map="0" id="1422" rt="1048.69804840974" mz="761.38" it="34843" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4239798526223481724" quality="0">
 			<centroid rt="1050.3672603196" mz="1491.73272353323" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1286" rt="1050.3672603196" mz="1492.74" it="24022" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9249852639764060046" quality="0">
 			<centroid rt="1053.25425807996" mz="1382.71272353323" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="57" rt="1053.25425807996" mz="1383.72" it="11002" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15915099455827407243" quality="0">
 			<centroid rt="1059.62465352777" mz="2966.34272353323" it="10224"/>
 			<groupedElementList>
 				<element map="0" id="3" rt="1059.62465352777" mz="2967.35" it="10224" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15071017670063587347" quality="0">
 			<centroid rt="1060.3217659327" mz="1396.61544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="282" rt="1060.3217659327" mz="699.315" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7774393106207247701" quality="0">
 			<centroid rt="1061.7664820423" mz="1399.73817059969" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1287" rt="1061.7664820423" mz="467.586666666667" it="24022" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3539836698445754663" quality="0">
 			<centroid rt="1065.18636924436" mz="1390.64544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="400" rt="1065.18636924436" mz="696.33" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15751478418665955032" quality="0">
 			<centroid rt="1065.53545858636" mz="2826.29544706646" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1869" rt="1065.53545858636" mz="1414.155" it="11986" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1656214217210395826" quality="0">
 			<centroid rt="1070.76371214335" mz="1535.75089413292" it="37047"/>
 			<groupedElementList>
 				<element map="0" id="2234" rt="1070.76371214335" mz="384.945" it="37047" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16410770623101951084" quality="0">
 			<centroid rt="1071.23942023179" mz="3235.54544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="276" rt="1071.23942023179" mz="1618.78" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8222097176906417623" quality="0">
 			<centroid rt="1073.25766340812" mz="1422.70544706646" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1082" rt="1073.25766340812" mz="712.36" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8035469014252269612" quality="0">
 			<centroid rt="1077.3091746777" mz="1285.62089413292" it="33006"/>
 			<groupedElementList>
 				<element map="0" id="65" rt="1077.3091746777" mz="322.4125" it="33006" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7360089423757594063" quality="0">
 			<centroid rt="1084.39539470939" mz="1565.73089413292" it="37047"/>
 			<groupedElementList>
 				<element map="0" id="2218" rt="1084.39539470939" mz="392.44" it="37047" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4491005714350612750" quality="0">
 			<centroid rt="1089.42774882741" mz="3578.80544706646" it="38786"/>
 			<groupedElementList>
 				<element map="0" id="719" rt="1089.42774882741" mz="1790.41" it="38786" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17727256151514936574" quality="0">
 			<centroid rt="1093.89186968432" mz="1586.71089413292" it="50379"/>
 			<groupedElementList>
 				<element map="0" id="914" rt="1093.89186968432" mz="397.685" it="50379" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_891958856332281939" quality="0">
 			<centroid rt="1094.42140411913" mz="1432.69089413292" it="47784"/>
 			<groupedElementList>
 				<element map="0" id="1528" rt="1094.42140411913" mz="359.18" it="47784" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18299538658746816028" quality="0">
 			<centroid rt="1094.42140411913" mz="1432.70544706646" it="47784"/>
 			<groupedElementList>
 				<element map="0" id="1529" rt="1094.42140411913" mz="717.36" it="47784" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_309318047348074364" quality="0">
 			<centroid rt="1094.8004255892" mz="3269.56544706646" it="30281"/>
 			<groupedElementList>
 				<element map="0" id="2015" rt="1094.8004255892" mz="1635.79" it="30281" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6067405064559535831" quality="0">
 			<centroid rt="1096.60651299735" mz="1420.64089413292" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="756" rt="1096.60651299735" mz="356.1675" it="59814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9725830237038746970" quality="0">
 			<centroid rt="1096.60651299735" mz="1420.65544706646" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="757" rt="1096.60651299735" mz="711.335" it="59814" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1810043759073172767" quality="0">
 			<centroid rt="1107.84105939626" mz="1617.82544706646" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="100" rt="1107.84105939626" mz="809.92" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4209000191412708874" quality="0">
 			<centroid rt="1108.85529902547" mz="2932.15089413292" it="46728"/>
 			<groupedElementList>
 				<element map="0" id="236" rt="1108.85529902547" mz="734.045" it="46728" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14412446604174243675" quality="0">
 			<centroid rt="1109.375033952" mz="1638.82544706646" it="16618"/>
 			<groupedElementList>
 				<element map="0" id="2071" rt="1109.375033952" mz="820.42" it="16618" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4296279300828029145" quality="0">
 			<centroid rt="1109.79366297839" mz="3389.33089413292" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="786" rt="1109.79366297839" mz="848.34" it="59814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_853575161041888942" quality="0">
 			<centroid rt="1109.79366297839" mz="3389.35272353323" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="785" rt="1109.79366297839" mz="3390.36" it="59814" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16929059504295312813" quality="0">
 			<centroid rt="1114.26879141799" mz="1489.65544706646" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1816" rt="1114.26879141799" mz="745.835" it="701" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6307706233177755229" quality="0">
 			<centroid rt="1124.41745459072" mz="2995.39544706646" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="131" rt="1124.41745459072" mz="1498.705" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13437070332645325885" quality="0">
 			<centroid rt="1124.68840706743" mz="1673.87272353323" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1534" rt="1124.68840706743" mz="1674.88" it="23892" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3111747257834121663" quality="0">
 			<centroid rt="1125.07284962984" mz="1692.89544706646" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1020" rt="1125.07284962984" mz="847.455" it="49849" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13724622163519226730" quality="0">
 			<centroid rt="1136.63805973597" mz="1719.79089413292" it="63417"/>
 			<groupedElementList>
 				<element map="0" id="501" rt="1136.63805973597" mz="430.955" it="63417" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5363734854678121207" quality="0">
 			<centroid rt="1136.9704973751" mz="1346.54544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="350" rt="1136.9704973751" mz="674.28" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6014063811476066500" quality="0">
 			<centroid rt="1141.87471319973" mz="1405.60544706646" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="155" rt="1141.87471319973" mz="703.81" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8229081382639936402" quality="0">
 			<centroid rt="1144.52777050403" mz="1534.76544706646" it="38786"/>
 			<groupedElementList>
 				<element map="0" id="733" rt="1144.52777050403" mz="768.39" it="38786" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3076726171191626208" quality="0">
 			<centroid rt="1148.57484235742" mz="1578.78272353323" it="49849"/>
 			<groupedElementList>
 				<element map="0" id="1048" rt="1148.57484235742" mz="1579.79" it="49849" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6754764540415440966" quality="0">
 			<centroid rt="1155.72247025896" mz="1262.59272353323" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1372" rt="1155.72247025896" mz="1263.6" it="2961" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17275890892186575677" quality="0">
 			<centroid rt="1165.34659368709" mz="3486.68089413292" it="33586"/>
 			<groupedElementList>
 				<element map="0" id="909" rt="1165.34659368709" mz="872.6775" it="33586" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3534783779494434230" quality="0">
 			<centroid rt="1165.34659368709" mz="3486.70272353323" it="33586"/>
 			<groupedElementList>
 				<element map="0" id="908" rt="1165.34659368709" mz="3487.71" it="33586" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1607661491742528876" quality="0">
 			<centroid rt="1172.86334889661" mz="1785.98272353323" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1348" rt="1172.86334889661" mz="1786.99" it="2961" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6042585952787300858" quality="0">
 			<centroid rt="1174.68179618106" mz="1770.87089413292" it="143658"/>
 			<groupedElementList>
 				<element map="0" id="2043" rt="1174.68179618106" mz="443.725" it="143658" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14793709856661714140" quality="0">
 			<centroid rt="1176.48968054063" mz="1454.67544706646" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="47" rt="1176.48968054063" mz="728.345" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10652224619586560857" quality="0">
 			<centroid rt="1177.69075470774" mz="1622.69272353323" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="942" rt="1177.69075470774" mz="1623.7" it="8961" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1714743014888225975" quality="0">
 			<centroid rt="1180.53006704286" mz="1628.83817059969" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1767" rt="1180.53006704286" mz="543.953333333333" it="27199" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13149711436293033670" quality="0">
 			<centroid rt="1189.54890035561" mz="1805.85544706646" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1384" rt="1189.54890035561" mz="903.935" it="2961" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17480494061886756340" quality="0">
 			<centroid rt="1194.48202638517" mz="1658.85544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2242" rt="1194.48202638517" mz="830.435" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8597485644000106325" quality="0">
 			<centroid rt="1202.73138727807" mz="1676.77544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2223" rt="1202.73138727807" mz="839.395" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4038993171980588072" quality="0">
 			<centroid rt="1203.39601017334" mz="1361.67272353323" it="6407"/>
 			<groupedElementList>
 				<element map="0" id="649" rt="1203.39601017334" mz="1362.68" it="6407" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17509894168221548632" quality="0">
 			<centroid rt="1208.43253705363" mz="3867.72089413292" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="939" rt="1208.43253705363" mz="967.9375" it="8961" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17104374150788358311" quality="0">
 			<centroid rt="1212.38489535927" mz="1697.76089413292" it="59227"/>
 			<groupedElementList>
 				<element map="0" id="991" rt="1212.38489535927" mz="425.4475" it="59227" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5189109166198525980" quality="0">
 			<centroid rt="1216.95757105709" mz="1850.81544706646" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1506" rt="1216.95757105709" mz="926.415" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9997247196465192781" quality="0">
 			<centroid rt="1217.96847415027" mz="1387.65272353323" it="10224"/>
 			<groupedElementList>
 				<element map="0" id="13" rt="1217.96847415027" mz="1388.66" it="10224" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17273600200567741075" quality="0">
 			<centroid rt="1218.92994777899" mz="3889.69089413292" it="75969"/>
 			<groupedElementList>
 				<element map="0" id="1593" rt="1218.92994777899" mz="973.43" it="75969" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10573170795778553723" quality="0">
 			<centroid rt="1220.326868207" mz="1899.88089413292" it="21830"/>
 			<groupedElementList>
 				<element map="0" id="1232" rt="1220.326868207" mz="475.9775" it="21830" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17436877252947301725" quality="0">
 			<centroid rt="1220.326868207" mz="1899.89544706646" it="21830"/>
 			<groupedElementList>
 				<element map="0" id="1233" rt="1220.326868207" mz="950.955" it="21830" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14314550740910817996" quality="0">
 			<centroid rt="1223.91685600861" mz="1664.71544706646" it="26218"/>
 			<groupedElementList>
 				<element map="0" id="1634" rt="1223.91685600861" mz="833.365" it="26218" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18220005507143319686" quality="0">
 			<centroid rt="1234.56160295806" mz="1746.86089413292" it="96357"/>
 			<groupedElementList>
 				<element map="0" id="2129" rt="1234.56160295806" mz="437.7225" it="96357" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4331783204053385055" quality="0">
 			<centroid rt="1250.85856874969" mz="1762.78089413292" it="104529"/>
 			<groupedElementList>
 				<element map="0" id="1464" rt="1250.85856874969" mz="441.7025" it="104529" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4456728677152772023" quality="0">
 			<centroid rt="1252.28705455016" mz="1806.81272353323" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1853" rt="1252.28705455016" mz="1807.82" it="11986" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18102557624454694401" quality="0">
 			<centroid rt="1252.78176783346" mz="1585.62544706646" it="17604"/>
 			<groupedElementList>
 				<element map="0" id="514" rt="1252.78176783346" mz="793.82" it="17604" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6830464585923049831" quality="0">
 			<centroid rt="1262.05936535019" mz="1623.68089413292" it="69686"/>
 			<groupedElementList>
 				<element map="0" id="1469" rt="1262.05936535019" mz="406.9275" it="69686" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5696712460866795386" quality="0">
 			<centroid rt="1262.05936535019" mz="1623.69544706646" it="69686"/>
 			<groupedElementList>
 				<element map="0" id="1470" rt="1262.05936535019" mz="812.855" it="69686" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15512818529828717098" quality="0">
 			<centroid rt="1263.69133303207" mz="2029.00089413292" it="104529"/>
 			<groupedElementList>
 				<element map="0" id="1415" rt="1263.69133303207" mz="508.2575" it="104529" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10628316575826211992" quality="0">
 			<centroid rt="1264.26172855364" mz="1792.85544706646" it="25323"/>
 			<groupedElementList>
 				<element map="0" id="1590" rt="1264.26172855364" mz="897.435" it="25323" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10133287901893044970" quality="0">
 			<centroid rt="1264.49650922162" mz="1965.92544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="285" rt="1264.49650922162" mz="983.97" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10733659836614551022" quality="0">
 			<centroid rt="1267.62900437062" mz="2039.06089413292" it="2103"/>
 			<groupedElementList>
 				<element map="0" id="1775" rt="1267.62900437062" mz="510.7725" it="2103" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4212528915845946997" quality="0">
 			<centroid rt="1268.77295558988" mz="2041.90089413292" it="23972"/>
 			<groupedElementList>
 				<element map="0" id="1883" rt="1268.77295558988" mz="511.4825" it="23972" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_6198749480899727614" quality="0">
 			<centroid rt="1268.77295558988" mz="2041.91544706646" it="23972"/>
 			<groupedElementList>
 				<element map="0" id="1884" rt="1268.77295558988" mz="1021.965" it="23972" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8706560295251011845" quality="0">
 			<centroid rt="1275.90367860043" mz="2016.03544706646" it="47886"/>
 			<groupedElementList>
 				<element map="0" id="2048" rt="1275.90367860043" mz="1009.025" it="47886" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14190591994408115858" quality="0">
 			<centroid rt="1276.50449690061" mz="1819.74089413292" it="164979"/>
 			<groupedElementList>
 				<element map="0" id="1922" rt="1276.50449690061" mz="455.9425" it="164979" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15913334705697827130" quality="0">
 			<centroid rt="1282.82282501101" mz="4926.75272353323" it="30281"/>
 			<groupedElementList>
 				<element map="0" id="2009" rt="1282.82282501101" mz="4927.76" it="30281" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4358736103156308121" quality="0">
 			<centroid rt="1294.26953336358" mz="1689.82544706646" it="41916"/>
 			<groupedElementList>
 				<element map="0" id="1645" rt="1294.26953336358" mz="845.92" it="41916" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18087753299762278746" quality="0">
 			<centroid rt="1301.71472946572" mz="4380.98089413292" it="54993"/>
 			<groupedElementList>
 				<element map="0" id="1914" rt="1301.71472946572" mz="1096.2525" it="54993" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8844141177182949826" quality="0">
 			<centroid rt="1307.43953897324" mz="4412.09089413292" it="177681"/>
 			<groupedElementList>
 				<element map="0" id="979" rt="1307.43953897324" mz="1104.03" it="177681" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_2630345414182815229" quality="0">
 			<centroid rt="1308.80557659631" mz="2099.00089413292" it="112390"/>
 			<groupedElementList>
 				<element map="0" id="181" rt="1308.80557659631" mz="525.7575" it="112390" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5683299880187061077" quality="0">
 			<centroid rt="1308.80557659631" mz="2099.01544706646" it="112390"/>
 			<groupedElementList>
 				<element map="0" id="182" rt="1308.80557659631" mz="1050.515" it="112390" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17411567109020322770" quality="0">
 			<centroid rt="1314.30914717239" mz="2112.96089413292" it="72768"/>
 			<groupedElementList>
 				<element map="0" id="1143" rt="1314.30914717239" mz="529.2475" it="72768" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1395673638007870920" quality="0">
 			<centroid rt="1314.30914717239" mz="2112.97544706646" it="72768"/>
 			<groupedElementList>
 				<element map="0" id="1144" rt="1314.30914717239" mz="1057.495" it="72768" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15962709127297412934" quality="0">
 			<centroid rt="1340.40481555401" mz="8693.24544706646" it="21139"/>
 			<groupedElementList>
 				<element map="0" id="492" rt="1340.40481555401" mz="4347.63" it="21139" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10602907435410589596" quality="0">
 			<centroid rt="1353.4662432529" mz="1998.04544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2288" rt="1353.4662432529" mz="1000.03" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12023921847819545994" quality="0">
 			<centroid rt="1367.4479242" mz="2007.86089413292" it="81597"/>
 			<groupedElementList>
 				<element map="0" id="1716" rt="1367.4479242" mz="502.9725" it="81597" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5953171321821697193" quality="0">
 			<centroid rt="1384.91958523098" mz="2120.99089413292" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="372" rt="1384.91958523098" mz="531.255" it="11250" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1049940942989175053" quality="0">
 			<centroid rt="1384.91958523098" mz="2121.00544706646" it="11250"/>
 			<groupedElementList>
 				<element map="0" id="373" rt="1384.91958523098" mz="1061.51" it="11250" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16963977041615521015" quality="0">
 			<centroid rt="1385.15630653359" mz="375.145447066458" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2316" rt="1385.15630653359" mz="188.58" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5763081754320040823" quality="0">
 			<centroid rt="1388.6784719179" mz="2358.17544706646" it="25323"/>
 			<groupedElementList>
 				<element map="0" id="1555" rt="1388.6784719179" mz="1180.095" it="25323" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5521637556047356167" quality="0">
 			<centroid rt="1398.15131572389" mz="1934.92544706646" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1270" rt="1398.15131572389" mz="968.47" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11435717699705089346" quality="0">
 			<centroid rt="1402.62576509431" mz="3966.70817059968" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="834" rt="1402.62576509431" mz="1323.24333333333" it="29907" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3368539890997500281" quality="0">
 			<centroid rt="1402.74482181635" mz="1921.82544706646" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="755" rt="1402.74482181635" mz="961.92" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13677143355937389549" quality="0">
 			<centroid rt="1409.14798257932" mz="2414.53544706646" it="11986"/>
 			<groupedElementList>
 				<element map="0" id="1848" rt="1409.14798257932" mz="1208.275" it="11986" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3417572007376557076" quality="0">
 			<centroid rt="1420.63943144095" mz="2446.51544706646" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="134" rt="1420.63943144095" mz="1224.265" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14020652711951625426" quality="0">
 			<centroid rt="1428.67116361818" mz="2229.99089413292" it="16875"/>
 			<groupedElementList>
 				<element map="0" id="362" rt="1428.67116361818" mz="558.505" it="16875" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3295358041857509289" quality="0">
 			<centroid rt="1429.32871538886" mz="1566.70272353323" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1524" rt="1429.32871538886" mz="1567.71" it="23892" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15414211982455940461" quality="0">
 			<centroid rt="1433.92988121284" mz="2218.04089413292" it="48044"/>
 			<groupedElementList>
 				<element map="0" id="1330" rt="1433.92988121284" mz="555.5175" it="48044" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17044623790177121407" quality="0">
 			<centroid rt="1433.92988121284" mz="2218.06272353323" it="48044"/>
 			<groupedElementList>
 				<element map="0" id="1329" rt="1433.92988121284" mz="2219.07" it="48044" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9286121541876280430" quality="0">
 			<centroid rt="1434.55990436631" mz="5081.1581705997" it="8961"/>
 			<groupedElementList>
 				<element map="0" id="963" rt="1434.55990436631" mz="1694.72666666667" it="8961" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14616935448177817987" quality="0">
 			<centroid rt="1440.78641790583" mz="1790.83544706646" it="24022"/>
 			<groupedElementList>
 				<element map="0" id="1293" rt="1440.78641790583" mz="896.425" it="24022" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_18192724310750904638" quality="0">
 			<centroid rt="1483.49771022408" mz="2624.42544706646" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="911" rt="1483.49771022408" mz="1313.22" it="16793" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16806430720955556924" quality="0">
 			<centroid rt="1487.07946574585" mz="2578.32089413292" it="47886"/>
 			<groupedElementList>
 				<element map="0" id="2062" rt="1487.07946574585" mz="645.5875" it="47886" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15360991392025983875" quality="0">
 			<centroid rt="1495.99221028929" mz="2056.89089413292" it="109152"/>
 			<groupedElementList>
 				<element map="0" id="1133" rt="1495.99221028929" mz="515.23" it="109152" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17830593150196652308" quality="0">
 			<centroid rt="1496.91801930065" mz="2109.91089413292" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1727" rt="1496.91801930065" mz="528.485" it="27199" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13292285565269156532" quality="0">
 			<centroid rt="1507.27344633711" mz="2664.28089413292" it="5922"/>
 			<groupedElementList>
 				<element map="0" id="1368" rt="1507.27344633711" mz="667.0775" it="5922" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7693840529337348465" quality="0">
 			<centroid rt="1507.27344633711" mz="2664.28817059969" it="5922"/>
 			<groupedElementList>
 				<element map="0" id="1369" rt="1507.27344633711" mz="889.103333333333" it="5922" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11842398665707248330" quality="0">
 			<centroid rt="1512.22755158988" mz="2446.20544706646" it="36384"/>
 			<groupedElementList>
 				<element map="0" id="1154" rt="1512.22755158988" mz="1224.11" it="36384" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7435113447151628480" quality="0">
 			<centroid rt="1512.73770169961" mz="2392.01544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="478" rt="1512.73770169961" mz="1197.015" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8223335619648664949" quality="0">
 			<centroid rt="1519.64329223626" mz="2354.90089413292" it="47796"/>
 			<groupedElementList>
 				<element map="0" id="1172" rt="1519.64329223626" mz="589.7325" it="47796" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16952840902878950530" quality="0">
 			<centroid rt="1519.64329223626" mz="2354.91544706646" it="47796"/>
 			<groupedElementList>
 				<element map="0" id="1173" rt="1519.64329223626" mz="1178.465" it="47796" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5760343191864795999" quality="0">
 			<centroid rt="1526.68128511468" mz="2232.04089413292" it="72640"/>
 			<groupedElementList>
 				<element map="0" id="2087" rt="1526.68128511468" mz="559.0175" it="72640" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_614567019958073085" quality="0">
 			<centroid rt="1526.68128511468" mz="2232.05544706646" it="72640"/>
 			<groupedElementList>
 				<element map="0" id="2088" rt="1526.68128511468" mz="1117.035" it="72640" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8196693066820754724" quality="0">
 			<centroid rt="1554.36236937017" mz="2052.89817059969" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="752" rt="1554.36236937017" mz="685.306666666667" it="29907" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8618883870002875833" quality="0">
 			<centroid rt="1559.78315693222" mz="2544.24544706646" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="850" rt="1559.78315693222" mz="1273.13" it="29907" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13231770754261349691" quality="0">
 			<centroid rt="1576.47344663455" mz="2100.94272353323" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2201" rt="1576.47344663455" mz="2101.95" it="14357" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10009616024249618274" quality="0">
 			<centroid rt="1579.21088499389" mz="2247.97089413292" it="33006"/>
 			<groupedElementList>
 				<element map="0" id="55" rt="1579.21088499389" mz="563" it="33006" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_744354814704278941" quality="0">
 			<centroid rt="1580.84435594028" mz="2912.60089413292" it="84556"/>
 			<groupedElementList>
 				<element map="0" id="489" rt="1580.84435594028" mz="729.1575" it="84556" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_819124947569987741" quality="0">
 			<centroid rt="1581.30660487265" mz="2084.99544706646" it="47886"/>
 			<groupedElementList>
 				<element map="0" id="2052" rt="1581.30660487265" mz="1043.505" it="47886" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13863071652331696744" quality="0">
 			<centroid rt="1589.15526918721" mz="2564.13089413292" it="5922"/>
 			<groupedElementList>
 				<element map="0" id="1376" rt="1589.15526918721" mz="642.04" it="5922" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17694369526112401230" quality="0">
 			<centroid rt="1589.15526918721" mz="2564.14544706646" it="5922"/>
 			<groupedElementList>
 				<element map="0" id="1377" rt="1589.15526918721" mz="1283.08" it="5922" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10655898103940162201" quality="0">
 			<centroid rt="1604.22702040559" mz="4566.13544706646" it="12349"/>
 			<groupedElementList>
 				<element map="0" id="2244" rt="1604.22702040559" mz="2284.075" it="12349" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4402716419664513817" quality="0">
 			<centroid rt="1613.24780535695" mz="2415.03544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="477" rt="1613.24780535695" mz="1208.525" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_494755642314242994" quality="0">
 			<centroid rt="1637.09895888874" mz="2179.89089413292" it="12814"/>
 			<groupedElementList>
 				<element map="0" id="671" rt="1637.09895888874" mz="545.98" it="12814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10032216305673772895" quality="0">
 			<centroid rt="1637.09895888874" mz="2179.91272353323" it="12814"/>
 			<groupedElementList>
 				<element map="0" id="670" rt="1637.09895888874" mz="2180.92" it="12814" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15825378592894353784" quality="0">
 			<centroid rt="1646.6268527432" mz="3115.82272353323" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1189" rt="1646.6268527432" mz="3116.83" it="23898" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5242291979391720491" quality="0">
 			<centroid rt="1651.49626669644" mz="2828.51544706646" it="16793"/>
 			<groupedElementList>
 				<element map="0" id="881" rt="1651.49626669644" mz="1415.265" it="16793" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13398793854970525814" quality="0">
 			<centroid rt="1666.77465139465" mz="2711.31544706646" it="23892"/>
 			<groupedElementList>
 				<element map="0" id="1521" rt="1666.77465139465" mz="1356.665" it="23892" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8917128996527175570" quality="0">
 			<centroid rt="1669.05572602813" mz="2555.17089413292" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1365" rt="1669.05572602813" mz="639.8" it="2961" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1939691502263863969" quality="0">
 			<centroid rt="1688.73970720211" mz="2803.39272353323" it="47886"/>
 			<groupedElementList>
 				<element map="0" id="2034" rt="1688.73970720211" mz="2804.4" it="47886" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1855014030614400969" quality="0">
 			<centroid rt="1690.15890226942" mz="2358.07544706646" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2206" rt="1690.15890226942" mz="1180.045" it="14357" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11794153378379873722" quality="0">
 			<centroid rt="1705.23906193614" mz="3266.75544706646" it="21139"/>
 			<groupedElementList>
 				<element map="0" id="505" rt="1705.23906193614" mz="1634.385" it="21139" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11994720539823609423" quality="0">
 			<centroid rt="1709.44301171363" mz="2403.25544706646" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="398" rt="1709.44301171363" mz="1202.635" it="5625" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1433656310788761276" quality="0">
 			<centroid rt="1731.87540341839" mz="2456.14817059969" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="107" rt="1731.87540341839" mz="819.723333333333" it="11002" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9030663325051632791" quality="0">
 			<centroid rt="1740.86381726845" mz="6104.70089413292" it="72066"/>
 			<groupedElementList>
 				<element map="0" id="1332" rt="1740.86381726845" mz="1527.1825" it="72066" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_7221240334039127522" quality="0">
 			<centroid rt="1741.5357517164" mz="3020.27544706646" it="701"/>
 			<groupedElementList>
 				<element map="0" id="1794" rt="1741.5357517164" mz="1511.145" it="701" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3187787977997334635" quality="0">
 			<centroid rt="1776.50915096795" mz="2836.26089413292" it="20739"/>
 			<groupedElementList>
 				<element map="0" id="1975" rt="1776.50915096795" mz="710.0725" it="20739" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_884835851137558028" quality="0">
 			<centroid rt="1777.08886509685" mz="431.180894132916" it="43071"/>
 			<groupedElementList>
 				<element map="0" id="2208" rt="1777.08886509685" mz="108.8025" it="43071" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_12100414040409261647" quality="0">
 			<centroid rt="1795.15862785934" mz="6170.94089413292" it="22004"/>
 			<groupedElementList>
 				<element map="0" id="99" rt="1795.15862785934" mz="1543.7425" it="22004" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_1388791982618034610" quality="0">
 			<centroid rt="1795.15862785934" mz="6170.96272353323" it="22004"/>
 			<groupedElementList>
 				<element map="0" id="98" rt="1795.15862785934" mz="6171.97" it="22004" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5666966500666806671" quality="0">
 			<centroid rt="1796.76391320626" mz="3256.42544706646" it="14357"/>
 			<groupedElementList>
 				<element map="0" id="2183" rt="1796.76391320626" mz="1629.22" it="14357" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17276467570563406521" quality="0">
 			<centroid rt="1816.37734218797" mz="5667.58089413292" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="783" rt="1816.37734218797" mz="1417.9025" it="59814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_5293115233477443436" quality="0">
 			<centroid rt="1816.37734218797" mz="5667.59544706646" it="59814"/>
 			<groupedElementList>
 				<element map="0" id="784" rt="1816.37734218797" mz="2834.805" it="59814" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16589117625317410860" quality="0">
 			<centroid rt="1906.42393549034" mz="2779.04089413292" it="46728"/>
 			<groupedElementList>
 				<element map="0" id="200" rt="1906.42393549034" mz="695.7675" it="46728" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11723216462731371057" quality="0">
 			<centroid rt="1944.4585776574" mz="3344.75272353323" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1408" rt="1944.4585776574" mz="3345.76" it="2961" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3073596133236986496" quality="0">
 			<centroid rt="2082.11632114064" mz="3626.59544706646" it="23898"/>
 			<groupedElementList>
 				<element map="0" id="1184" rt="2082.11632114064" mz="1814.305" it="23898" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17338190767468918167" quality="0">
 			<centroid rt="2096.78176921289" mz="3581.6681705997" it="2961"/>
 			<groupedElementList>
 				<element map="0" id="1359" rt="2096.78176921289" mz="1194.89666666667" it="2961" charge="3"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="3"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H3"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="3.021829400313"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_4632934399976314156" quality="0">
 			<centroid rt="2447.13089511541" mz="980.410894132916" it="5922"/>
 			<groupedElementList>
 				<element map="0" id="1412" rt="2447.13089511541" mz="246.11" it="5922" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_17348967989636128271" quality="0">
 			<centroid rt="2447.13089511541" mz="980.425447066458" it="5922"/>
 			<groupedElementList>
 				<element map="0" id="1413" rt="2447.13089511541" mz="491.22" it="5922" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14358798804368453433" quality="0">
 			<centroid rt="2520.0865114501" mz="4506.94544706646" it="56195"/>
 			<groupedElementList>
 				<element map="0" id="188" rt="2520.0865114501" mz="2254.48" it="56195" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14029582528910281313" quality="0">
 			<centroid rt="2580.42330828542" mz="5881.87272353323" it="29907"/>
 			<groupedElementList>
 				<element map="0" id="802" rt="2580.42330828542" mz="5882.88" it="29907" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_16818540346386426022" quality="0">
 			<centroid rt="2588.52025391945" mz="4238.69272353323" it="5625"/>
 			<groupedElementList>
 				<element map="0" id="371" rt="2588.52025391945" mz="4239.7" it="5625" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_13160704639196076478" quality="0">
 			<centroid rt="2625.32038186004" mz="4845.43544706646" it="11002"/>
 			<groupedElementList>
 				<element map="0" id="53" rt="2625.32038186004" mz="2423.725" it="11002" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10995937961722274052" quality="0">
 			<centroid rt="2998.63696059486" mz="4841.39089413292" it="37047"/>
 			<groupedElementList>
 				<element map="0" id="2278" rt="2998.63696059486" mz="1211.355" it="37047" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_11596252661058005647" quality="0">
 			<centroid rt="3185.67338408758" mz="18869.5627235332" it="41916"/>
 			<groupedElementList>
 				<element map="0" id="1638" rt="3185.67338408758" mz="18870.57" it="41916" charge="1"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3660630664131106987" quality="0">
 			<centroid rt="3422.86296594827" mz="1288.51089413292" it="12814"/>
 			<groupedElementList>
 				<element map="0" id="672" rt="3422.86296594827" mz="323.135" it="12814" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_8105847836702258353" quality="0">
 			<centroid rt="3422.86296594827" mz="1288.52544706646" it="12814"/>
 			<groupedElementList>
 				<element map="0" id="673" rt="3422.86296594827" mz="645.27" it="12814" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_833928112226144305" quality="0">
 			<centroid rt="3726.63025438367" mz="6874.47089413292" it="72066"/>
 			<groupedElementList>
 				<element map="0" id="1279" rt="3726.63025438367" mz="1719.625" it="72066" charge="4"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="4"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H4"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="4.029105867084"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_9271304144720704117" quality="0">
 			<centroid rt="3742.91154477293" mz="1992.93544706646" it="27199"/>
 			<groupedElementList>
 				<element map="0" id="1773" rt="3742.91154477293" mz="997.475" it="27199" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_10311433926975669622" quality="0">
 			<centroid rt="4143.23161943818" mz="5479.11544706646" it="15576"/>
 			<groupedElementList>
 				<element map="0" id="216" rt="4143.23161943818" mz="2740.565" it="15576" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_3612476004253346273" quality="0">
 			<centroid rt="5003.44106756443" mz="3606.87544706646" it="36320"/>
 			<groupedElementList>
 				<element map="0" id="2118" rt="5003.44106756443" mz="1804.445" it="36320" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_15919661368307713756" quality="0">
 			<centroid rt="5350.7820087241" mz="2948.48544706646" it="16618"/>
 			<groupedElementList>
 				<element map="0" id="2081" rt="5350.7820087241" mz="1475.25" it="16618" charge="2"/>
 			</groupedElementList>
-			<UserParam type="int" name="charge" value="2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
 	</consensusElementList>
 </consensusXML>

--- a/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_neg_output.consensusXML
+++ b/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_neg_output.consensusXML
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="file:////home/fa/OpenMS/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_16772366217575462398" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<consensusXML version="1.7" id="cm_5305331602851715574" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<mapList count="1">
 		<map id="0" name="" label="decharged features" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_9850914649229975897" quality="0">
+		<consensusElement id="e_5544180789932800495" quality="0">
 			<centroid rt="102" mz="300.000670404656" it="900"/>
 			<groupedElementList>
 				<element map="0" id="100" rt="102" mz="298.992724" it="100" charge="-1"/>
@@ -22,145 +22,120 @@
 			<UserParam type="intList" name="distinct_charges" value="[-3, -2, -1]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="102" value="H-3O-1"/>
+			<UserParam type="string" name="103" value="H-2Na1"/>
+			<UserParam type="string" name="104" value="Cl1"/>
+			<UserParam type="string" name="105" value="H-2K1"/>
+			<UserParam type="string" name="106" value="Br1"/>
+			<UserParam type="string" name="108" value="C1H1O2"/>
+			<UserParam type="string" name="101" value="H-2"/>
+			<UserParam type="string" name="100" value="H-1"/>
+			<UserParam type="string" name="107" value="H-3"/>
 		</consensusElement>
-		<consensusElement id="e_6880193271103366492" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_2820855813419109252" quality="0">
+			<centroid rt="100" mz="101.007276" it="100"/>
 			<groupedElementList>
 				<element map="0" id="9" rt="100" mz="101.007276" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+3H"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_3204005357819090916" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_15821371501051276986" quality="0">
+			<centroid rt="100" mz="108.33459" it="100"/>
 			<groupedElementList>
 				<element map="0" id="10" rt="100" mz="108.33459" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+2H+Na"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_10426138329936021616" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_16247858443050999688" quality="0">
+			<centroid rt="100" mz="115.661904" it="100"/>
 			<groupedElementList>
 				<element map="0" id="11" rt="100" mz="115.661904" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+H+2Na; Fiehn contained wrong 1 after decimal point!"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_2383276411667268957" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_17589328263146396490" quality="0">
+			<centroid rt="100" mz="122.989218" it="100"/>
 			<groupedElementList>
 				<element map="0" id="12" rt="100" mz="122.989218" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+3Na"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_1724540965148085580" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_1668569847566219630" quality="0">
+			<centroid rt="100" mz="151.007276" it="100"/>
 			<groupedElementList>
 				<element map="0" id="4" rt="100" mz="151.007276" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+2H"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_12089703765419726127" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_2923859055626839012" quality="0">
+			<centroid rt="100" mz="159.52055" it="100"/>
 			<groupedElementList>
 				<element map="0" id="5" rt="100" mz="159.52055" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+H+NH4"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_14478002218863592706" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_7079299220379506483" quality="0">
+			<centroid rt="100" mz="161.998247" it="100"/>
 			<groupedElementList>
 				<element map="0" id="6" rt="100" mz="161.998247" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+H+Na"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_14585985052890294934" quality="0">
 			<centroid rt="100" mz="341.984986933542" it="100"/>
 			<groupedElementList>
 				<element map="0" id="7" rt="100" mz="169.985217" it="100" charge="-2"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+H+K"/>
-			<UserParam type="int" name="charge" value="-2"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H-2"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="-2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_2751474909210888071" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_15228323068357874672" quality="0">
+			<centroid rt="100" mz="172.989218" it="100"/>
 			<groupedElementList>
 				<element map="0" id="8" rt="100" mz="172.989218" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+2Na"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_15077792389597376379" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_7904331021332342013" quality="0">
+			<centroid rt="100" mz="301.007276" it="100"/>
 			<groupedElementList>
 				<element map="0" id="15" rt="100" mz="301.007276" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+H; all adducts/masses according to Fiehn MS-Adduct-Calculator"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_13609274597567497170" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_16824643771122819542" quality="0">
+			<centroid rt="100" mz="318.033823" it="100"/>
 			<groupedElementList>
 				<element map="0" id="1" rt="100" mz="318.033823" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+NH4"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_13285034069144910286" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_10427798130343062978" quality="0">
+			<centroid rt="100" mz="322.989218" it="100"/>
 			<groupedElementList>
 				<element map="0" id="2" rt="100" mz="322.989218" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+Na"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
 		<consensusElement id="e_277288293309248432" quality="0">
 			<centroid rt="100" mz="339.970434466771" it="100"/>
 			<groupedElementList>
 				<element map="0" id="3" rt="100" mz="338.963158" it="100" charge="-1"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+K"/>
-			<UserParam type="int" name="charge" value="-1"/>
-			<UserParam type="string" name="dc_charge_adducts" value="H-1"/>
-			<UserParam type="float" name="dc_charge_adduct_mass" value="-1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_9230425309037047512" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_8060924860367445558" quality="0">
+			<centroid rt="100" mz="342.033823" it="100"/>
 			<groupedElementList>
 				<element map="0" id="13" rt="100" mz="342.033823" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+ACN+H (C2H3N)"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_8433547158073717133" quality="0">
-			<centroid rt="100" mz="0" it="100"/>
+		<consensusElement id="e_1889377723564787800" quality="0">
+			<centroid rt="100" mz="344.97116" it="100"/>
 			<groupedElementList>
 				<element map="0" id="14" rt="100" mz="344.97116" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+2Na-H"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
 	</consensusElementList>
 </consensusXML>

--- a/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_pos_output.consensusXML
+++ b/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_pos_output.consensusXML
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="file:////home/fa/OpenMS/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_13032301277884797235" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<consensusXML version="1.7" id="cm_4535059993814874937" experiment_type="label-free" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<mapList count="1">
 		<map id="0" name="" label="decharged features" size="24">
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_17209116430947459327" quality="0">
+		<consensusElement id="e_15012824780294977354" quality="0">
 			<centroid rt="100" mz="299.9989730357" it="1500"/>
 			<groupedElementList>
 				<element map="0" id="1" rt="100" mz="318.033823" it="100" charge="1"/>
@@ -28,8 +28,23 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2, 3]"/>
 			<UserParam type="int" name="distinct_charges_size" value="3"/>
 			<UserParam type="int" name="pure_proton_features" value="3"/>
+			<UserParam type="string" name="12" value="Na3"/>
+			<UserParam type="string" name="10" value="H2Na1"/>
+			<UserParam type="string" name="11" value="H1Na2"/>
+			<UserParam type="string" name="6" value="H1Na1"/>
+			<UserParam type="string" name="7" value="H1K1"/>
+			<UserParam type="string" name="1" value="H4N1"/>
+			<UserParam type="string" name="2" value="Na1"/>
+			<UserParam type="string" name="4" value="H2"/>
+			<UserParam type="string" name="5" value="H5N1"/>
+			<UserParam type="string" name="8" value="Na2"/>
+			<UserParam type="string" name="9" value="H3"/>
+			<UserParam type="string" name="3" value="K1"/>
+			<UserParam type="string" name="13" value="C2H4N1"/>
+			<UserParam type="string" name="14" value="H-1Na2"/>
+			<UserParam type="string" name="15" value="H1"/>
 		</consensusElement>
-		<consensusElement id="e_4497306292672144602" quality="0">
+		<consensusElement id="e_9719341755803132182" quality="0">
 			<centroid rt="102" mz="295.9877466281" it="200"/>
 			<groupedElementList>
 				<element map="0" id="101" rt="102" mz="148.992724" it="100" charge="2"/>
@@ -38,8 +53,10 @@
 			<UserParam type="intList" name="distinct_charges" value="[1, 2]"/>
 			<UserParam type="int" name="distinct_charges_size" value="2"/>
 			<UserParam type="int" name="pure_proton_features" value="1"/>
+			<UserParam type="string" name="104" value="K1"/>
+			<UserParam type="string" name="101" value="H2"/>
 		</consensusElement>
-		<consensusElement id="e_2163174111164391872" quality="0">
+		<consensusElement id="e_6622229003048850247" quality="0">
 			<centroid rt="102" mz="297.984761259775" it="400"/>
 			<groupedElementList>
 				<element map="0" id="100" rt="102" mz="298.992724" it="100" charge="1"/>
@@ -50,33 +67,31 @@
 			<UserParam type="intList" name="distinct_charges" value="[1]"/>
 			<UserParam type="int" name="distinct_charges_size" value="1"/>
 			<UserParam type="int" name="pure_proton_features" value="1"/>
+			<UserParam type="string" name="102" value="H-1O-1"/>
+			<UserParam type="string" name="103" value="Na1"/>
+			<UserParam type="string" name="105" value="K1"/>
+			<UserParam type="string" name="100" value="H1"/>
 		</consensusElement>
-		<consensusElement id="e_550333940545105376" quality="0">
-			<centroid rt="102" mz="0" it="100"/>
+		<consensusElement id="e_3689926504636764757" quality="0">
+			<centroid rt="102" mz="98.992724" it="100"/>
 			<groupedElementList>
 				<element map="0" id="107" rt="102" mz="98.992724" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M-3H"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_15596712492036028027" quality="0">
-			<centroid rt="102" mz="0" it="100"/>
+		<consensusElement id="e_4535459246731618248" quality="0">
+			<centroid rt="102" mz="344.998201" it="100"/>
 			<groupedElementList>
 				<element map="0" id="108" rt="102" mz="344.998201" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+FA-H (CH2O2)"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
-		<consensusElement id="e_15090182187976258121" quality="0">
-			<centroid rt="102" mz="0" it="100"/>
+		<consensusElement id="e_7556918200442838868" quality="0">
+			<centroid rt="102" mz="378.918885" it="100"/>
 			<groupedElementList>
 				<element map="0" id="106" rt="102" mz="378.918885" it="100"/>
 			</groupedElementList>
-			<UserParam type="string" name="label" value="M+Br"/>
-			<UserParam type="int" name="charge" value="0"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="int" name="is_ungrouped_monoisotopic" value="1"/>
 		</consensusElement>
 	</consensusElementList>
 </consensusXML>


### PR DESCRIPTION
Improved output. Fixed removal of new userParams from FFM not wanted in Decharger output. Changed decharged mz of ungrouped monoisotopic features in Decharger consensusXML to the value of the input feature (in addition to flag marking such ungrouped monoisotopic), in accordance with user wishes.