### PR TITLE
[FIX] compile issue on MacOS (release)

### DIFF
--- a/src/pyOpenMS/pxds/PeptideAndProteinQuant.pxd
+++ b/src/pyOpenMS/pxds/PeptideAndProteinQuant.pxd
@@ -8,7 +8,6 @@ from Param cimport *
 from DefaultParamHandler cimport *
 from ProgressLogger cimport *
 from ProteinIdentification cimport *
-
 # ctypedef libcpp_map<UInt64, double> SampleAbundances;
 
 cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h>" namespace "OpenMS":
@@ -62,7 +61,7 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h>" names
     cdef cppclass PeptideAndProteinQuant_PeptideData "OpenMS::PeptideAndProteinQuant::PeptideData":
 
       # libcpp_map[Int, SampleAbundances] abundances
-      libcpp_map[unsigned long, double] total_abundances
+      # libcpp_map[unsigned long, double] total_abundances
 
       # protein accessions for this peptide
       libcpp_set[String] accessions
@@ -78,8 +77,9 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h>" names
     cdef cppclass PeptideAndProteinQuant_ProteinData "OpenMS::PeptideAndProteinQuant::ProteinData":
 
       # libcpp_map[String, SampleAbundances] abundances
-
-      libcpp_map[unsigned long, double] total_abundances
+ 
+      # compile issue 
+      # libcpp_map[unsigned long, double] total_abundances
 
       # total number of identifications (of peptides mapping to this protein)
       Size id_count

--- a/src/pyOpenMS/setup.py
+++ b/src/pyOpenMS/setup.py
@@ -5,6 +5,9 @@ from __future__ import print_function
 import sys
 iswin = sys.platform == "win32"
 
+# osx ?
+isosx = sys.platform == "darwin"
+
 import sys
 single_threaded = False
 no_optimization = False
@@ -159,7 +162,13 @@ if IS_DEBUG:
 # Note: we use -std=gnu++11 in Linux by default, also reduce some warnings
 if not iswin:
     extra_link_args.append("-std=c++11")
+    if isosx: # MacOS c++11
+        extra_link_args.append("-stdlib=libc++") # MacOS libstdc++ does not include c++11 lib support.
+        extra_link_args.append("-mmacosx-version-min=10.7") # due to libc++
     extra_compile_args.append("-std=c++11")
+    if isosx: # MacOS c++11
+        extra_compile_args.append("-stdlib=libc++")
+        extra_compile_args.append("-mmacosx-version-min=10.7")
     extra_compile_args.append("-Wno-redeclared-class-member")
     extra_compile_args.append("-Wno-unused-local-typedefs")
     extra_compile_args.append("-Wno-deprecated-register")


### PR DESCRIPTION
MacOS 10.14.1

Fix compile and linking issue with C++11 functions e.g. 'return shared_ptr( std::move(r), p );'.

For further explanations please see PR #3867