### PR TITLE
[FIX] pyOpenMS fix for Win/OSX

### DIFF
--- a/src/pyOpenMS/pxds/PeptideAndProteinQuant.pxd
+++ b/src/pyOpenMS/pxds/PeptideAndProteinQuant.pxd
@@ -62,7 +62,7 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h>" names
     cdef cppclass PeptideAndProteinQuant_PeptideData "OpenMS::PeptideAndProteinQuant::PeptideData":
 
       # libcpp_map[Int, SampleAbundances] abundances
-      libcpp_map[unsigned long, double] total_abundances
+      # libcpp_map[unsigned long, double] total_abundances
 
       # protein accessions for this peptide
       libcpp_set[String] accessions
@@ -78,8 +78,7 @@ cdef extern from "<OpenMS/ANALYSIS/QUANTITATION/PeptideAndProteinQuant.h>" names
     cdef cppclass PeptideAndProteinQuant_ProteinData "OpenMS::PeptideAndProteinQuant::ProteinData":
 
       # libcpp_map[String, SampleAbundances] abundances
-
-      libcpp_map[unsigned long, double] total_abundances
+      # libcpp_map[unsigned long, double] total_abundances
 
       # total number of identifications (of peptides mapping to this protein)
       Size id_count


### PR DESCRIPTION
- unsigned long is apparently not the same as uint64_t on all platforms
  and we need to implement a different solution that is also portable