### PR TITLE
[FIX] ModificationDefinitionsSet

### DIFF
--- a/src/pyOpenMS/pxds/ModificationDefinitionsSet.pxd
+++ b/src/pyOpenMS/pxds/ModificationDefinitionsSet.pxd
@@ -30,7 +30,8 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationDefinitionsSet.h>" namespace "Op
     libcpp_set[ModificationDefinition] getFixedModifications() nogil except +
     libcpp_set[ModificationDefinition] getVariableModifications() nogil except +
     void getModificationNames(StringList &fixed_modifications, StringList &variable_modifications) nogil except +
-    libcpp_set[String] getFixedModificationNames() nogil except +    libcpp_set[String] getVariableModificationNames() nogil except +
+    libcpp_set[String] getFixedModificationNames() nogil except +
+    libcpp_set[String] getVariableModificationNames() nogil except +
     libcpp_set[String] getModificationNames() nogil except +
     bool isCompatible(AASequence &peptide) nogil except +
     void inferFromPeptides(libcpp_vector[ PeptideIdentification ] &peptides) nogil except +


### PR DESCRIPTION
Cherry-picked fixes from Timo for ModificationDefinitionsSet.pxd for release 2.4.0 branch

Is required to build pyopenms (2.4.0) successfully. 