### PR TITLE
[FIX][ADD] pyOpenMS whl mac

### DIFF
--- a/src/pyOpenMS/fix_pyopenms_dependencies_on_mac.sh
+++ b/src/pyOpenMS/fix_pyopenms_dependencies_on_mac.sh
@@ -6,9 +6,8 @@
 #    $ otool -L pyopenms.so
 #
 # here we look at all of them and fix them using install_name_tool as seen below
-#
 
-for TOFIX in $(find . -name pyopenms*.so); do
+for TOFIX in $(find . -name "pyopenms*.so"); do
     echo
     echo "fix $TOFIX now:"
     echo
@@ -80,4 +79,9 @@ for TOFIX in $(find . -name QtNetwork); do
     otool -L $TOFIX | while read -r line ; do
         echo "    $line"
         done
+
+      
+      
+      
+      
 done;

--- a/src/pyOpenMS/fix_pyopenms_dependencies_on_mac.sh
+++ b/src/pyOpenMS/fix_pyopenms_dependencies_on_mac.sh
@@ -79,9 +79,4 @@ for TOFIX in $(find . -name QtNetwork); do
     otool -L $TOFIX | while read -r line ; do
         echo "    $line"
         done
-
-      
-      
-      
-      
 done;

--- a/src/pyOpenMS/mac_fix_automation_mojave.sh
+++ b/src/pyOpenMS/mac_fix_automation_mojave.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# find "dist" directory
+DIST=$(find . -name "dist")
+cd $DIST
+
+#  whl inside
+NAME=*.whl
+
+# backup .original
+cp $NAME $(basename $NAME .whl).original
+
+unzip $NAME  
+# move to pyopenms folder and relink the libaries
+cd pyopenms
+
+# move QtCore and QtNetwork from framework to pyopenms directory
+# and remove the framework dirs
+QTN=$(find . -name QtNetwork)
+mv $QTN .
+rm -rf ./QtNetwork.framework
+
+QTC=$(find . -name QtCore)
+mv $QTC .
+rm -rf ./QtCore.framework
+
+# call fix script (in pyopenms directory)
+# relative path 
+sh ../../fix_pyopenms_dependencies_on_mac.sh
+
+cd ../ # back to .dist
+
+# zip back to wheel 
+zip -r $NAME pyopenms/ pyopenms*dist-info/  
+
+echo "DONE" 
+
+
+


### PR DESCRIPTION
[FIX] fix find command in `fix_pyopenms_dependencies_on_mac.sh`
[ADD] mac_fix_automation_mojave.sh

mac_fix_automation_mojave.sh
Can be run in the PyOpenMS folder after compiling. 
1) backup the current whl -> .original.
2) unzip  `.whl` in the `dist` folder
3) move QtNetwork/QtCore from framework to main folder and delete frameworks.
3) fix the paths via `fix_pyopenms_dependencies_on_mac.sh`
4) zip the whl again 

The unzipped version and the .original will be retained - if someone wants to check the paths or need the original again 
e.g. `otools -L libOpenMS.dylib``

Was tested on MacOS 10.14.1 (python2.7, 3.7)