### PR TITLE
fix: LPWrapper destructor frees ctor's allocated memory

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/LPWrapper.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/LPWrapper.h
@@ -312,11 +312,11 @@ public:
 
 protected:
 #if COINOR_SOLVER == 1
-    CoinModel * model_;
+    CoinModel * model_ = nullptr;
     std::vector<double> solution_;
 #endif
 
-    glp_prob * lp_problem_;
+    glp_prob * lp_problem_ = nullptr;
 
     SOLVER solver_;
 

--- a/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
+++ b/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
@@ -79,6 +79,10 @@ namespace OpenMS
 
   LPWrapper::~LPWrapper()
   {
+#if COINOR_SOLVER == 1
+    delete model_;
+#endif
+    glp_delete_prob(lp_problem_);
   }
 
   Int LPWrapper::addRow(std::vector<Int> row_indices, std::vector<double> row_values, const String& name) // return index


### PR DESCRIPTION
While testing my code with Valgrind I noticed a large amount of memory not freed. The code (_MRMFeatureSelector_) uses _LPWrapper_. I looked into it and it seems that the reason might lie within the destructor.

Hopefully the proposed changes solve the issue. I did not have a chance to do extensive testing on my machine today, therefore I am relying on the CI system you have put in place.