### PR TITLE
improve peptide intensities in FeatureFinderMultiplex

### DIFF
--- a/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.h
@@ -43,6 +43,7 @@
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexDeltaMasses.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexIsotopicPeakPattern.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteredMSExperiment.h>
+#include <OpenMS/FILTERING/DATAREDUCTION/SplinePackage.h>
 #include <OpenMS/COMPARISON/CLUSTERING/GridBasedCluster.h>
 
 #include <vector>
@@ -71,6 +72,8 @@ protected:
   // experimental data
   MSExperiment exp_profile_;
   MSExperiment exp_centroid_;
+  
+  bool centroided_;
   
   ProgressLogger prog_log_;
   
@@ -101,6 +104,17 @@ protected:
    * @return list of m/z shifts
    */
   std::vector<MultiplexIsotopicPeakPattern> generatePeakPatterns_(int charge_min, int charge_max, int peaks_per_peptide_max, const std::vector<MultiplexDeltaMasses>& mass_pattern_list);
+  
+  /**
+   * @brief determine ratios through linear regression and correct peptide intensities
+   *
+   * In most labelled mass spectrometry experiments, the fold change i.e. ratio and not the individual peptide intensities
+   * are of primary interest. For that reason, we determine the ratios from interpolated chromatogram data points directly,
+   * and then correct the current ones.
+   * 
+   * @param intensity_peptide    peptide intensities to be corrected
+   */
+  void correctPeptideIntensities_(const MultiplexIsotopicPeakPattern& pattern, std::map<size_t, SplinePackage>& spline_chromatograms, const std::vector<double>& rt_peptide, std::vector<double>& intensity_peptide);
   
   /**
    * @brief calculate peptide intensities

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
@@ -39,13 +39,19 @@
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteredMSExperiment.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.h>
-#include <OpenMS/COMPARISON/CLUSTERING/GridBasedCluster.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/MultiplexClustering.h>
 #include <OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.h>
+#include <OpenMS/COMPARISON/CLUSTERING/GridBasedCluster.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h>
+#include <OpenMS/FILTERING/DATAREDUCTION/SplinePackage.h>
+#include <OpenMS/FILTERING/DATAREDUCTION/SplineInterpolatedPeaks.h>
 
 #include <OpenMS/MATH/STATISTICS/StatisticFunctions.h>
 #include <OpenMS/MATH/STATISTICS/LinearRegressionWithoutIntercept.h>
 #include <OpenMS/CONCEPT/Constants.h>
+#include <OpenMS/KERNEL/MSChromatogram.h>
+#include <OpenMS/KERNEL/ChromatogramPeak.h>
+#include <OpenMS/KERNEL/SpectrumHelper.h>
 #include <OpenMS/KERNEL/ConsensusMap.h>
 #include <OpenMS/KERNEL/FeatureMap.h>
 
@@ -137,6 +143,8 @@ namespace OpenMS
     {
       swap(isotopes_per_peptide_min_, isotopes_per_peptide_max_);
     }
+    
+    centroided_ = false;
   }
   
   /**
@@ -233,18 +241,113 @@ namespace OpenMS
     return list;
   }
   
+  void FeatureFinderMultiplexAlgorithm::correctPeptideIntensities_(const MultiplexIsotopicPeakPattern& pattern, std::map<size_t, SplinePackage>& spline_chromatograms, const std::vector<double>& rt_peptide, std::vector<double>& intensity_peptide)
+  {
+    // determine ratios through linear regression
+    // (In most labelled mass spectrometry experiments, the fold change i.e. ratio and not the individual peptide intensities
+    // are of primary interest. For that reason, we determine the ratios from interpolated chromatogram data points directly,
+    // and then correct the current ones.)
+    
+    std::vector<double> ratios;    // light/light, medium/light, heavy/light etc.
+    ratios.push_back(1.0);
+    // loop over peptides
+    for (size_t peptide = 1; peptide < pattern.getMassShiftCount(); ++peptide)
+    {
+      std::vector<double> intensities1;
+      std::vector<double> intensities2;
+      
+      // loop over isotopes
+      for (size_t isotope = 0; isotope < isotopes_per_peptide_max_; ++isotope)
+      {
+        
+        // find splines for the mass traces of the lightest and other peptide
+        size_t idx_1 = isotope;
+        size_t idx_2 = peptide * isotopes_per_peptide_max_ + isotope;
+        if ((spline_chromatograms.find(idx_1) == spline_chromatograms.end()) || (spline_chromatograms.find(idx_2) == spline_chromatograms.end()))
+        {
+           continue;
+        }
+
+        std::map<size_t, SplinePackage>::iterator it1 = spline_chromatograms.find(idx_1);
+        std::map<size_t, SplinePackage>::iterator it2 = spline_chromatograms.find(idx_2);
+
+        double rt_min = std::min(it1->second.getPosMin(), it2->second.getPosMin());
+        double rt_max = std::max(it1->second.getPosMax(), it2->second.getPosMax());        
+        double rt_step_width = 0.7 * std::min(it1->second.getPosStepWidth(), it2->second.getPosStepWidth());
+
+        for (double rt = rt_min; rt < rt_max; rt += rt_step_width)
+        {
+          double intensity1 = it1->second.eval(rt);
+          double intensity2 = it2->second.eval(rt + rt_peptide[peptide] - rt_peptide[0]);    // Take RT shifts between peptide into account to find corresponding intensities.
+          
+          // Use only if we land within both chromatograms i.e. non-zero intensities.
+          if ((intensity1 > 0) && (intensity2 > 0))
+          {
+            intensities1.push_back(intensity1);
+            intensities2.push_back(intensity2);
+          }
+        }
+        
+      }
+
+      // We require at least five data points for a reliable linear interpolation.
+      if (intensities1.size() > 5)
+      {
+        OpenMS::Math::LinearRegressionWithoutIntercept linreg;
+        linreg.addData(intensities1, intensities2);
+        
+        ratios.push_back(linreg.getSlope());        
+      }
+      else
+      {
+        ratios.push_back(-1.0);
+      }
+     
+    }
+    
+    // correction for doublets
+    if ((pattern.getMassShiftCount() == 2) && (ratios[1] > 0))
+    {
+      double intensity0 = (intensity_peptide[0] + ratios[1] * intensity_peptide[1]) / (1 + ratios[1] * ratios[1]);
+      double intensity1 = ratios[1] * intensity0;
+      
+      intensity_peptide[0] = intensity0;
+      intensity_peptide[1] = intensity1;
+    }
+    // correction for triplets or higher multiplets
+    else if ((pattern.getMassShiftCount() > 2) && (ratios[1] > 0))
+    {
+      for (size_t peptide = 1; peptide < pattern.getMassShiftCount(); ++peptide)
+      {
+        intensity_peptide[peptide] = ratios[peptide] * intensity_peptide[0];
+      }
+    }
+
+  }
+  
   std::vector<double> FeatureFinderMultiplexAlgorithm::determinePeptideIntensitiesCentroided_(const MultiplexIsotopicPeakPattern& pattern, const std::multimap<size_t, MultiplexSatelliteCentroided >& satellites)
   {
     // determine peptide intensities and RT shift between the peptides
     // i.e. first determine the RT centre of mass for each peptide
     std::vector<double> rt_peptide;
     std::vector<double> intensity_peptide;
+    
+    std::map<size_t, SplinePackage> spline_chromatograms;
+    
+    PeakIntegrator pi;
+    Param param = pi.getDefaults();
+    param.setValue("integration_type","trapezoid");    // intensity_sum, simpson, trapezoid (Note that 'simpson' may lead to neagtive area-under-the-curve.)
+    pi.setParameters(param);   
+    
     // loop over peptides
     for (size_t peptide = 0; peptide < pattern.getMassShiftCount(); ++peptide)
     {
       // coordinates of the peptide feature
       // RT is the intensity-average of all satellites peaks of all (!) mass traces
       double rt(0);
+      double rt_min(0);
+      double rt_max(0);
+      double intensity_sum_simple(0);    // for intensity-averaged rt
       double intensity_sum(0);
       
       // loop over isotopes i.e. mass traces of the peptide
@@ -255,6 +358,7 @@ namespace OpenMS
         std::pair<std::multimap<size_t, MultiplexSatelliteCentroided >::const_iterator, std::multimap<size_t, MultiplexSatelliteCentroided >::const_iterator> satellites_isotope;
         satellites_isotope = satellites.equal_range(idx);
         
+        MSChromatogram chromatogram;
         // loop over satellites for this isotope i.e. mass trace
         for (std::multimap<size_t, MultiplexSatelliteCentroided >::const_iterator satellite_it = satellites_isotope.first; satellite_it != satellites_isotope.second; ++satellite_it)
         {
@@ -268,15 +372,74 @@ namespace OpenMS
           MSSpectrum::ConstIterator it_mz = it_rt->begin();
           std::advance(it_mz, mz_idx);
           
-          rt += it_rt->getRT() * it_mz->getIntensity();
-          intensity_sum += it_mz->getIntensity();
+          double rt_temp = it_rt->getRT();
+          double intensity_temp = it_mz->getIntensity();
+
+          if ((peptide + isotope == 0) || (rt_temp < rt_min))
+          {
+            rt_min = rt_temp;
+          }
+          
+          if ((peptide + isotope == 0) || (rt_temp > rt_max))
+          {
+            rt_max = rt_temp;
+          }
+          
+          rt += rt_temp * intensity_temp;
+          intensity_sum_simple += intensity_temp;
+          
+          chromatogram.push_back(ChromatogramPeak(rt_temp, intensity_temp));
         }
+        
+        chromatogram.sortByPosition();
+        
+        // construct spline interpolations for later use
+        // Reliable spline interpolation only for 5 or more data points in chromatogram.
+        if (chromatogram.size() > 5)
+        {
+          std::vector<double> rt;
+          std::vector<double> intensity;
+          for (const auto &it : chromatogram)
+          {
+            rt.push_back(it.getRT());
+            intensity.push_back(it.getIntensity());
+          }
+          spline_chromatograms.insert(std::make_pair(idx, SplinePackage(rt, intensity)));
+        }
+
+        if (chromatogram.size() > 2)
+        {
+          double rt_start = chromatogram.begin()->getPos();
+          double rt_end = chromatogram.back().getPos();
+
+          PeakIntegrator::PeakArea pa = pi.integratePeak(chromatogram, rt_start, rt_end);          
+          intensity_sum += pa.area;
+        }
+
       }
       
-      rt /= intensity_sum;
+      rt /= intensity_sum_simple;
       rt_peptide.push_back(rt);
+      if (intensity_sum == 0 || (rt_max - rt_min < static_cast<double>(param_.getValue("algorithm:rt_min"))))
+      {
+        intensity_sum = -1.0;
+      }
       intensity_peptide.push_back(intensity_sum);
     }
+    
+    // If any of the peptide intensities could not be determined (i.e. -1) then there is no need for further corrections.
+    if (std::find(intensity_peptide.begin(), intensity_peptide.end(), -1.0) != intensity_peptide.end())
+    {
+      return intensity_peptide;
+    }
+    
+    // If the pattern searched for peptide singlets, then there are no further corrections possible.
+    if (pattern.getMassShiftCount() < 2)
+    {
+      return intensity_peptide;
+    }
+
+    correctPeptideIntensities_(pattern, spline_chromatograms, rt_peptide, intensity_peptide);
     
     return intensity_peptide;
   }
@@ -287,12 +450,23 @@ namespace OpenMS
     // i.e. first determine the RT centre of mass for each peptide
     std::vector<double> rt_peptide;
     std::vector<double> intensity_peptide;
+    
+    std::map<size_t, SplinePackage> spline_chromatograms;
+    
+    PeakIntegrator pi;
+    Param param = pi.getDefaults();
+    param.setValue("integration_type","trapezoid");    // intensity_sum, simpson, trapezoid (Note that 'simpson' may lead to neagtive area-under-the-curve.)
+    pi.setParameters(param);
+    
     // loop over peptides
     for (size_t peptide = 0; peptide < pattern.getMassShiftCount(); ++peptide)
     {
       // coordinates of the peptide feature
       // RT is the intensity-average of all satellites peaks of all (!) mass traces
       double rt(0);
+      double rt_min(0);
+      double rt_max(0);
+      double intensity_sum_simple(0);    // for intensity-averaged rt
       double intensity_sum(0);
       
       // loop over isotopes i.e. mass traces of the peptide
@@ -303,19 +477,79 @@ namespace OpenMS
         std::pair<std::multimap<size_t, MultiplexSatelliteProfile >::const_iterator, std::multimap<size_t, MultiplexSatelliteProfile >::const_iterator> satellites_isotope;
         satellites_isotope = satellites.equal_range(idx);
         
+        MSChromatogram chromatogram;
         // loop over satellites for this isotope i.e. mass trace
         for (std::multimap<size_t, MultiplexSatelliteProfile >::const_iterator satellite_it = satellites_isotope.first; satellite_it != satellites_isotope.second; ++satellite_it)
         {
-          rt += (satellite_it->second).getRT() * (satellite_it->second).getIntensity();
-          intensity_sum += (satellite_it->second).getIntensity();
+          double rt_temp = (satellite_it->second).getRT();
+          double intensity_temp = (satellite_it->second).getIntensity();
+          
+          if ((peptide + isotope == 0) || (rt_temp < rt_min))
+          {
+            rt_min = rt_temp;
+          }
+          
+          if ((peptide + isotope == 0) || (rt_temp > rt_max))
+          {
+            rt_max = rt_temp;
+          }
+          
+          rt += rt_temp * intensity_temp;
+          intensity_sum_simple += intensity_temp;
+
+          chromatogram.push_back(ChromatogramPeak(rt_temp, intensity_temp));
+        }
+        
+        makePeakPositionUnique(chromatogram, IntensityAveragingMethod::MEDIAN);
+        
+        // construct spline interpolations for later use
+        // Reliable spline interpolation only for 5 or more data points in chromatogram.
+        if (chromatogram.size() > 5)
+        {
+          std::vector<double> rt;
+          std::vector<double> intensity;
+          for (const auto &it : chromatogram)
+          {
+            rt.push_back(it.getRT());
+            intensity.push_back(it.getIntensity());
+          }
+          spline_chromatograms.insert(std::make_pair(idx, SplinePackage(rt, intensity)));
+        }
+        
+        if (chromatogram.size() > 2)
+        {
+          // Positions are already sorted in makePeakPositionUnique(), i.e. sortByPosition() not necessary.
+          double rt_start = chromatogram.begin()->getPos();
+          double rt_end = chromatogram.back().getPos();
+
+          PeakIntegrator::PeakArea pa = pi.integratePeak(chromatogram, rt_start, rt_end);          
+          intensity_sum += pa.area;
         }
       }
       
-      rt /= intensity_sum;
+      rt /= intensity_sum_simple;
       rt_peptide.push_back(rt);
+      if (intensity_sum == 0 || (rt_max - rt_min < static_cast<double>(param_.getValue("algorithm:rt_min"))))
+      {
+        intensity_sum = -1.0;
+      }
       intensity_peptide.push_back(intensity_sum);
     }
     
+    // If any of the peptide intensities could not be determined (i.e. -1) then there is no need for further corrections.
+    if (std::find(intensity_peptide.begin(), intensity_peptide.end(), -1.0) != intensity_peptide.end())
+    {
+      return intensity_peptide;
+    }
+    
+    // If the pattern searched for peptide singlets, then there are no further corrections possible.
+    if (pattern.getMassShiftCount() < 2)
+    {
+      return intensity_peptide;
+    }
+    
+    correctPeptideIntensities_(pattern, spline_chromatograms, rt_peptide, intensity_peptide);
+
     return intensity_peptide;
   }
 
@@ -495,11 +729,10 @@ namespace OpenMS
   }
 
   void FeatureFinderMultiplexAlgorithm::generateMapsProfile_(const std::vector<MultiplexIsotopicPeakPattern>& patterns, const std::vector<MultiplexFilteredMSExperiment>& filter_results, const std::vector<std::map<int, GridBasedCluster> >& cluster_results)
-  {
+  {    
     // progress logger
     unsigned progress = 0;
     startProgress(0, patterns.size(), "constructing maps");
-    
     
     // loop over peak patterns
     for (unsigned pattern = 0; pattern < patterns.size(); ++pattern)
@@ -529,8 +762,8 @@ namespace OpenMS
         // determine peptide intensities
         std::vector<double> peptide_intensities = determinePeptideIntensitiesProfile_(patterns[pattern], satellites);
         
-        // If no reliable peptide intensity can be determined, we do not report the peptide multiplet.
-        if (peptide_intensities[0] == -1)
+        // If no reliable peptide intensity can be determined for one of the peptides, we do not report the peptide multiplet.
+        if (std::find(peptide_intensities.begin(), peptide_intensities.end(), -1.0) != peptide_intensities.end())
         {
           continue;
         }
@@ -692,22 +925,21 @@ namespace OpenMS
     // determine type of spectral data (profile or centroided)
     SpectrumSettings::SpectrumType spectrum_type = exp[0].getType(true);
 
-    bool centroided;
     if (param_.getValue("algorithm:spectrum_type") == "automatic")
     {
-      centroided = (spectrum_type == SpectrumSettings::CENTROID);
+      centroided_ = (spectrum_type == SpectrumSettings::CENTROID);
     }
     else if (param_.getValue("algorithm:spectrum_type") == "centroid")
     {
-      centroided = true;
+      centroided_ = true;
     }
     else  // "profile"
     {
-      centroided = false;
+      centroided_ = false;
     }
     
     // store experiment in member varaibles
-    if (centroided)
+    if (centroided_)
     {
       exp.swap(exp_centroid_);
       // exp_profile_ will never be used.
@@ -724,7 +956,7 @@ namespace OpenMS
     std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > boundaries_exp_s; // peak boundaries for spectra
     std::vector<std::vector<PeakPickerHiRes::PeakBoundary> > boundaries_exp_c; // peak boundaries for chromatograms
     
-    if (!centroided)
+    if (!centroided_)
     {
       PeakPickerHiRes picker;
       Param param = picker.getParameters();
@@ -750,7 +982,7 @@ namespace OpenMS
     std::vector<MultiplexDeltaMasses> masses = generator.getDeltaMassesList();
     std::vector<MultiplexIsotopicPeakPattern> patterns = generatePeakPatterns_(charge_min_, charge_max_, isotopes_per_peptide_max_, masses);
     
-    if (centroided)
+    if (centroided_)
     {
       // centroided data
       

--- a/src/tests/class_tests/openms/source/FeatureFinderMultiplexAlgorithm_test.cpp
+++ b/src/tests/class_tests/openms/source/FeatureFinderMultiplexAlgorithm_test.cpp
@@ -96,9 +96,9 @@ START_SECTION((virtual void run()))
   double L = result[0].getFeatures().begin()->getIntensity();
   double H = (++(result[0].getFeatures().begin()))->getIntensity();
 
-  // Check that the HEAVY:LIGHT ratio is close to the expected 4:1 ratio
+  // Check that the HEAVY:LIGHT ratio is close to the expected 3:1 ratio
   TOLERANCE_ABSOLUTE(0.2);
-  TEST_REAL_SIMILAR(H/L, 4.0);
+  TEST_REAL_SIMILAR(H/L, 3.0);
 }
 END_SECTION
 

--- a/src/tests/topp/FeatureFinderMultiplex_1_output.consensusXML
+++ b/src/tests/topp/FeatureFinderMultiplex_1_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="file:////home/lars/Code/git/OpenMS/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<mapList count="2">
 		<map id="0" name="FeatureFinderMultiplex_1_input.mzML" label="Dimethyl0" size="2">
 			<UserParam type="int" name="channel_id" value="0"/>
@@ -11,17 +11,17 @@
 	</mapList>
 	<consensusElementList>
 		<consensusElement id="e_4835329514588776807" quality="1" charge="2">
-			<centroid rt="1481.91170682959" mz="472.282340766101" it="2.23206e+10"/>
+			<centroid rt="1481.91170682959" mz="472.282340766101" it="1.30209e+08"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1481.91170682959" mz="472.282340766101" it="2.23206e+10" charge="2"/>
-				<element map="1" id="0" rt="1481.3672326728" mz="476.304773819883" it="8.57687e+10" charge="2"/>
+				<element map="0" id="0" rt="1481.91170682959" mz="472.282340766101" it="1.30209e+08" charge="2"/>
+				<element map="1" id="0" rt="1481.3672326728" mz="476.304773819883" it="4.02087e+08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_17749660155506638460" quality="1" charge="2">
-			<centroid rt="1484.48374199201" mz="470.303156673582" it="8.98024e+09"/>
+			<centroid rt="1484.48374199201" mz="470.303156673582" it="6.35075e+07"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1484.48374199201" mz="470.303156673582" it="8.98024e+09" charge="2"/>
-				<element map="1" id="0" rt="1484.18179263412" mz="474.32536238458" it="3.58967e+10" charge="2"/>
+				<element map="0" id="0" rt="1484.48374199201" mz="470.303156673582" it="6.35075e+07" charge="2"/>
+				<element map="1" id="0" rt="1484.18179263412" mz="474.32536238458" it="2.49226e+08" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureFinderMultiplex_1_output.featureXML
+++ b/src/tests/topp/FeatureFinderMultiplex_1_output.featureXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.9" id="fm_7804704400743266335" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.9" id="fm_7804704400743266335" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="4">
 		<feature id="f_15004869347769368353">
 			<position dim="0">1481.3672326728</position>
 			<position dim="1">476.304773819883</position>
-			<intensity>8.57687e+10</intensity>
+			<intensity>4.02087e+08</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -49,7 +49,7 @@
 		<feature id="f_3332699010107892018">
 			<position dim="0">1481.91170682959</position>
 			<position dim="1">472.282340766101</position>
-			<intensity>2.23206e+10</intensity>
+			<intensity>1.30209e+08</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -94,7 +94,7 @@
 		<feature id="f_13440783915218733453">
 			<position dim="0">1484.18179263412</position>
 			<position dim="1">474.32536238458</position>
-			<intensity>3.58967e+10</intensity>
+			<intensity>2.49226e+08</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -127,7 +127,7 @@
 		<feature id="f_15916652588957785155">
 			<position dim="0">1484.48374199201</position>
 			<position dim="1">470.303156673582</position>
-			<intensity>8.98024e+09</intensity>
+			<intensity>6.35075e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>

--- a/src/tests/topp/FeatureFinderMultiplex_2_output.consensusXML
+++ b/src/tests/topp/FeatureFinderMultiplex_2_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="file:////home/lars/Code/git/OpenMS/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<mapList count="2">
 		<map id="0" name="FeatureFinderMultiplex_2_input.mzML" label="no_label" size="4">
 			<UserParam type="int" name="channel_id" value="0"/>
@@ -11,31 +11,31 @@
 	</mapList>
 	<consensusElementList>
 		<consensusElement id="e_4835329514588776807" quality="1" charge="3">
-			<centroid rt="1789.60347039074" mz="830.443470891003" it="910613"/>
+			<centroid rt="1789.60347039074" mz="830.443470891003" it="415415"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1789.60347039074" mz="830.443470891003" it="910613" charge="3"/>
-				<element map="1" id="0" rt="1789.3613688151" mz="833.779044601332" it="16963.7" charge="3"/>
+				<element map="0" id="0" rt="1789.60347039074" mz="830.443470891003" it="415415" charge="3"/>
+				<element map="1" id="0" rt="1789.3613688151" mz="833.779044601332" it="5079.58" charge="3"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_17749660155506638460" quality="1" charge="2">
-			<centroid rt="1791.32677052553" mz="827.402216566653" it="4.78162e+08"/>
+			<centroid rt="1791.32677052553" mz="827.402216566653" it="1.38232e+07"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1791.32677052553" mz="827.402216566653" it="4.78162e+08" charge="2"/>
-				<element map="1" id="0" rt="1790.86966034192" mz="831.409991007333" it="1.52821e+09" charge="2"/>
+				<element map="0" id="0" rt="1791.32677052553" mz="827.402216566653" it="1.38232e+07" charge="2"/>
+				<element map="1" id="0" rt="1790.86966034192" mz="831.409991007333" it="5.2176e+07" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_7804704400743266335" quality="1" charge="2">
-			<centroid rt="1791.33681047428" mz="815.907842856666" it="1.36557e+09"/>
+			<centroid rt="1791.33681047428" mz="815.907842856666" it="2.19586e+07"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1791.33681047428" mz="815.907842856666" it="1.36557e+09" charge="2"/>
-				<element map="1" id="0" rt="1791.13948759749" mz="819.915254361738" it="5.15083e+09" charge="2"/>
+				<element map="0" id="0" rt="1791.33681047428" mz="815.907842856666" it="2.19586e+07" charge="2"/>
+				<element map="1" id="0" rt="1791.13948759749" mz="819.915254361738" it="7.60324e+07" charge="2"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_15004869347769368353" quality="1" charge="1">
-			<centroid rt="1792.82850374491" mz="841.47800470622" it="4.30201e+08"/>
+			<centroid rt="1792.82850374491" mz="841.47800470622" it="5.39181e+06"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1792.82850374491" mz="841.47800470622" it="4.30201e+08" charge="1"/>
-				<element map="1" id="0" rt="1792.49960480228" mz="849.492650831647" it="1.75768e+09" charge="1"/>
+				<element map="0" id="0" rt="1792.82850374491" mz="841.47800470622" it="5.39181e+06" charge="1"/>
+				<element map="1" id="0" rt="1792.49960480228" mz="849.492650831647" it="2.33012e+07" charge="1"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureFinderMultiplex_2_output.featureXML
+++ b/src/tests/topp/FeatureFinderMultiplex_2_output.featureXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.9" id="fm_3332699010107892018" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.9" id="fm_3332699010107892018" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="8">
 		<feature id="f_13440783915218733453">
 			<position dim="0">1789.3613688151</position>
 			<position dim="1">833.779044601332</position>
-			<intensity>16963.7</intensity>
+			<intensity>5079.58</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -37,7 +37,7 @@
 		<feature id="f_15916652588957785155">
 			<position dim="0">1789.60347039074</position>
 			<position dim="1">830.443470891003</position>
-			<intensity>910613</intensity>
+			<intensity>415415</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -76,7 +76,7 @@
 		<feature id="f_15157403601844400700">
 			<position dim="0">1790.86966034192</position>
 			<position dim="1">831.409991007333</position>
-			<intensity>1.52821e+09</intensity>
+			<intensity>5.2176e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -115,7 +115,7 @@
 		<feature id="f_6408859317243173796">
 			<position dim="0">1791.13948759749</position>
 			<position dim="1">819.915254361738</position>
-			<intensity>5.15083e+09</intensity>
+			<intensity>7.60324e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -160,7 +160,7 @@
 		<feature id="f_474525871221756682">
 			<position dim="0">1791.32677052553</position>
 			<position dim="1">827.402216566653</position>
-			<intensity>4.78162e+08</intensity>
+			<intensity>1.38232e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -205,7 +205,7 @@
 		<feature id="f_12999979801269632061">
 			<position dim="0">1791.33681047428</position>
 			<position dim="1">815.907842856666</position>
-			<intensity>1.36557e+09</intensity>
+			<intensity>2.19586e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -238,7 +238,7 @@
 		<feature id="f_17413765565443951891">
 			<position dim="0">1792.49960480228</position>
 			<position dim="1">849.492650831647</position>
-			<intensity>1.75768e+09</intensity>
+			<intensity>2.33012e+07</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -265,7 +265,7 @@
 		<feature id="f_2927519776102075938">
 			<position dim="0">1792.82850374491</position>
 			<position dim="1">841.47800470622</position>
-			<intensity>4.30201e+08</intensity>
+			<intensity>5.39181e+06</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>

--- a/src/tests/topp/FeatureFinderMultiplex_3_output.consensusXML
+++ b/src/tests/topp/FeatureFinderMultiplex_3_output.consensusXML
@@ -1,40 +1,34 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="file:////home/lars/Code/git/OpenMS/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<mapList count="1">
-		<map id="0" name="FeatureFinderMultiplex_3_input.mzML" label="no_label" size="5">
+		<map id="0" name="FeatureFinderMultiplex_3_input.mzML" label="no_label" size="4">
 			<UserParam type="int" name="channel_id" value="0"/>
 		</map>
 	</mapList>
 	<consensusElementList>
 		<consensusElement id="e_4835329514588776807" quality="1" charge="5">
-			<centroid rt="2787.98119123808" mz="681.9754635558" it="225739"/>
+			<centroid rt="2787.98119123808" mz="681.9754635558" it="42202.2"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="2787.98119123808" mz="681.9754635558" it="225739" charge="5"/>
+				<element map="0" id="0" rt="2787.98119123808" mz="681.9754635558" it="42202.2" charge="5"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_17749660155506638460" quality="1" charge="5">
-			<centroid rt="2788.78752574367" mz="678.282299651604" it="856538"/>
+			<centroid rt="2788.78752574367" mz="678.282299651604" it="87152.6"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="2788.78752574367" mz="678.282299651604" it="856538" charge="5"/>
+				<element map="0" id="0" rt="2788.78752574367" mz="678.282299651604" it="87152.6" charge="5"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_7804704400743266335" quality="1" charge="5">
-			<centroid rt="2789.17577728497" mz="683.773677729168" it="272880"/>
+			<centroid rt="2789.17577728497" mz="683.773677729168" it="50567.3"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="2789.17577728497" mz="683.773677729168" it="272880" charge="5"/>
+				<element map="0" id="0" rt="2789.17577728497" mz="683.773677729168" it="50567.3" charge="5"/>
 			</groupedElementList>
 		</consensusElement>
 		<consensusElement id="e_15004869347769368353" quality="1" charge="5">
-			<centroid rt="2789.26364173082" mz="678.182183763685" it="830118"/>
+			<centroid rt="2789.26364173082" mz="678.182183763685" it="121871"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="2789.26364173082" mz="678.182183763685" it="830118" charge="5"/>
-			</groupedElementList>
-		</consensusElement>
-		<consensusElement id="e_3332699010107892018" quality="1" charge="5">
-			<centroid rt="2789.54165090464" mz="683.873513001521" it="178983"/>
-			<groupedElementList>
-				<element map="0" id="0" rt="2789.54165090464" mz="683.873513001521" it="178983" charge="5"/>
+				<element map="0" id="0" rt="2789.26364173082" mz="678.182183763685" it="121871" charge="5"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureFinderMultiplex_3_output.featureXML
+++ b/src/tests/topp/FeatureFinderMultiplex_3_output.featureXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.9" id="fm_13440783915218733453" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-	<featureList count="5">
-		<feature id="f_15916652588957785155">
+<featureMap version="1.9" id="fm_3332699010107892018" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<featureList count="4">
+		<feature id="f_13440783915218733453">
 			<position dim="0">2787.98119123808</position>
 			<position dim="1">681.9754635558</position>
-			<intensity>225739</intensity>
+			<intensity>42202.2</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -64,10 +64,10 @@
 				<pt x="2785.7790625" y="683.606468382666" />
 			</convexhull>
 		</feature>
-		<feature id="f_15157403601844400700">
+		<feature id="f_15916652588957785155">
 			<position dim="0">2788.78752574367</position>
 			<position dim="1">678.282299651604</position>
-			<intensity>856538</intensity>
+			<intensity>87152.6</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -103,10 +103,10 @@
 				<pt x="2785.7890625" y="679.104070926497" />
 			</convexhull>
 		</feature>
-		<feature id="f_6408859317243173796">
+		<feature id="f_15157403601844400700">
 			<position dim="0">2789.17577728497</position>
 			<position dim="1">683.773677729168</position>
-			<intensity>272880</intensity>
+			<intensity>50567.3</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -160,10 +160,10 @@
 				<pt x="2788.96875976562" y="685.19585262296" />
 			</convexhull>
 		</feature>
-		<feature id="f_474525871221756682">
+		<feature id="f_6408859317243173796">
 			<position dim="0">2789.26364173082</position>
 			<position dim="1">678.182183763685</position>
-			<intensity>830118</intensity>
+			<intensity>121871</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -203,51 +203,6 @@
 				<pt x="2785.7990625" y="679.160966452973" />
 				<pt x="2785.7990625" y="679.211334601635" />
 				<pt x="2785.7790625" y="679.211334601635" />
-			</convexhull>
-		</feature>
-		<feature id="f_12999979801269632061">
-			<position dim="0">2789.54165090464</position>
-			<position dim="1">683.873513001521</position>
-			<intensity>178983</intensity>
-			<quality dim="0">0</quality>
-			<quality dim="1">0</quality>
-			<overallquality>1</overallquality>
-			<charge>5</charge>
-			<convexhull nr="0">
-				<pt x="2785.7890625" y="683.861600378776" />
-				<pt x="2792.16870117188" y="683.861600378776" />
-				<pt x="2792.16870117188" y="683.887620878805" />
-				<pt x="2785.7890625" y="683.887620878805" />
-			</convexhull>
-			<convexhull nr="1">
-				<pt x="2785.7890625" y="684.061668774896" />
-				<pt x="2792.16870117188" y="684.061668774896" />
-				<pt x="2792.16870117188" y="684.087689274925" />
-				<pt x="2785.7890625" y="684.087689274925" />
-			</convexhull>
-			<convexhull nr="2">
-				<pt x="2785.7890625" y="684.262025631664" />
-				<pt x="2792.16870117188" y="684.262025631664" />
-				<pt x="2792.16870117188" y="684.288046131693" />
-				<pt x="2785.7890625" y="684.288046131693" />
-			</convexhull>
-			<convexhull nr="3">
-				<pt x="2785.7890625" y="684.461083045769" />
-				<pt x="2792.16870117188" y="684.461083045769" />
-				<pt x="2792.16870117188" y="684.487922669453" />
-				<pt x="2785.7890625" y="684.487922669453" />
-			</convexhull>
-			<convexhull nr="4">
-				<pt x="2785.7890625" y="684.661078733347" />
-				<pt x="2792.16870117188" y="684.661078733347" />
-				<pt x="2792.16870117188" y="684.687397533431" />
-				<pt x="2785.7890625" y="684.687397533431" />
-			</convexhull>
-			<convexhull nr="5">
-				<pt x="2792.15870117187" y="685.054656537947" />
-				<pt x="2792.17870117188" y="685.054656537947" />
-				<pt x="2792.17870117188" y="685.100677037976" />
-				<pt x="2792.15870117187" y="685.100677037976" />
 			</convexhull>
 		</feature>
 	</featureList>

--- a/src/tests/topp/FeatureFinderMultiplex_4_output.consensusXML
+++ b/src/tests/topp/FeatureFinderMultiplex_4_output.consensusXML
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="file:////home/lars/Code/git/OpenMS/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<consensusXML version="1.7" id="cm_1482803050776511530" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<mapList count="1">
 		<map id="0" name="FeatureFinderMultiplex_4_input.mzML" label="no_label" size="5">
 			<UserParam type="int" name="channel_id" value="0"/>
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_4835329514588776807" quality="1" charge="6">
-			<centroid rt="1852.38703065058" mz="620.421165174974" it="356251"/>
+		<consensusElement id="e_7218651875895060194" quality="1" charge="6">
+			<centroid rt="1852.38703065058" mz="620.421165174974" it="13588.4"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1852.38703065058" mz="620.421165174974" it="356251" charge="6"/>
+				<element map="0" id="0" rt="1852.38703065058" mz="620.421165174974" it="13588.4" charge="6"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_17749660155506638460" quality="1" charge="6">
-			<centroid rt="1854.7415167568" mz="614.931864941648" it="338499"/>
+		<consensusElement id="e_7352813712113920064" quality="1" charge="6">
+			<centroid rt="1854.7415167568" mz="614.931864941648" it="15841.7"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1854.7415167568" mz="614.931864941648" it="338499" charge="6"/>
+				<element map="0" id="0" rt="1854.7415167568" mz="614.931864941648" it="15841.7" charge="6"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_7804704400743266335" quality="1" charge="6">
-			<centroid rt="1855.15530488198" mz="616.768446577096" it="6.51352e+06"/>
+		<consensusElement id="e_2504454798279357377" quality="1" charge="6">
+			<centroid rt="1855.15530488198" mz="616.768446577096" it="105434"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1855.15530488198" mz="616.768446577096" it="6.51352e+06" charge="6"/>
+				<element map="0" id="0" rt="1855.15530488198" mz="616.768446577096" it="105434" charge="6"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_15004869347769368353" quality="1" charge="6">
-			<centroid rt="1855.2380935984" mz="620.928213169278" it="37488.2"/>
+		<consensusElement id="e_12843305313432816027" quality="1" charge="6">
+			<centroid rt="1855.2380935984" mz="620.928213169278" it="15871.4"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1855.2380935984" mz="620.928213169278" it="37488.2" charge="6"/>
+				<element map="0" id="0" rt="1855.2380935984" mz="620.928213169278" it="15871.4" charge="6"/>
 			</groupedElementList>
 		</consensusElement>
-		<consensusElement id="e_3332699010107892018" quality="1" charge="6">
-			<centroid rt="1855.79010542035" mz="610.765349095388" it="3.27884e+07"/>
+		<consensusElement id="e_3760414620175943343" quality="1" charge="6">
+			<centroid rt="1855.79010542035" mz="610.765349095388" it="533858"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="1855.79010542035" mz="610.765349095388" it="3.27884e+07" charge="6"/>
+				<element map="0" id="0" rt="1855.79010542035" mz="610.765349095388" it="533858" charge="6"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureFinderMultiplex_4_output.featureXML
+++ b/src/tests/topp/FeatureFinderMultiplex_4_output.featureXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.9" id="fm_13440783915218733453" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.9" id="fm_4390996181604114545" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="5">
-		<feature id="f_15916652588957785155">
+		<feature id="f_8473416907190344936">
 			<position dim="0">1852.38703065058</position>
 			<position dim="1">620.421165174974</position>
-			<intensity>356251</intensity>
+			<intensity>13588.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -46,10 +46,10 @@
 				<pt x="1850.97889160156" y="621.609993168067" />
 			</convexhull>
 		</feature>
-		<feature id="f_15157403601844400700">
+		<feature id="f_1938193418556571614">
 			<position dim="0">1854.7415167568</position>
 			<position dim="1">614.931864941648</position>
-			<intensity>338499</intensity>
+			<intensity>15841.7</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -97,10 +97,10 @@
 				<pt x="1857.07788085938" y="616.453587765442" />
 			</convexhull>
 		</feature>
-		<feature id="f_6408859317243173796">
+		<feature id="f_17506851289809440038">
 			<position dim="0">1855.15530488198</position>
 			<position dim="1">616.768446577096</position>
-			<intensity>6.51352e+06</intensity>
+			<intensity>105434</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -142,10 +142,10 @@
 				<pt x="1850.97889160156" y="617.629724192589" />
 			</convexhull>
 		</feature>
-		<feature id="f_474525871221756682">
+		<feature id="f_13958689921625841361">
 			<position dim="0">1855.2380935984</position>
 			<position dim="1">620.928213169278</position>
-			<intensity>37488.2</intensity>
+			<intensity>15871.4</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -187,10 +187,10 @@
 				<pt x="1857.06788085938" y="622.100457275613" />
 			</convexhull>
 		</feature>
-		<feature id="f_12999979801269632061">
+		<feature id="f_16331726621473442797">
 			<position dim="0">1855.79010542035</position>
 			<position dim="1">610.765349095388</position>
-			<intensity>3.27884e+07</intensity>
+			<intensity>533858</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>

--- a/src/tests/topp/FeatureFinderMultiplex_5_output.consensusXML
+++ b/src/tests/topp/FeatureFinderMultiplex_5_output.consensusXML
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <?xml-stylesheet type="text/xsl" href="file:////home/lars/Code/git/OpenMS/share/OpenMS/XSL/ConsensusXML.xsl"?>
-<consensusXML version="1.7" id="cm_5233264595117471314" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<consensusXML version="1.7" id="cm_7680309197002681991" experiment_type="labeled_MS1" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/ConsensusXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<mapList count="2">
 		<map id="0" name="FeatureFinderMultiplex_5_input.mzML" label="Dimethyl0" size="1">
 			<UserParam type="int" name="channel_id" value="0"/>
@@ -10,11 +10,11 @@
 		</map>
 	</mapList>
 	<consensusElementList>
-		<consensusElement id="e_4835329514588776807" quality="1" charge="3">
-			<centroid rt="2173.49630029615" mz="388.916474205617" it="8.56465e+10"/>
+		<consensusElement id="e_10332075743892896286" quality="1" charge="3">
+			<centroid rt="2173.49630029615" mz="388.916474205617" it="1.79453e+09"/>
 			<groupedElementList>
-				<element map="0" id="0" rt="2173.49630029615" mz="388.916474205617" it="8.56465e+10" charge="3"/>
-				<element map="1" id="0" rt="2170.51847326083" mz="392.937235597873" it="8.55078e+10" charge="3"/>
+				<element map="0" id="0" rt="2173.49630029615" mz="388.916474205617" it="1.79453e+09" charge="3"/>
+				<element map="1" id="0" rt="2170.51847326083" mz="392.937235597873" it="1.60433e+09" charge="3"/>
 			</groupedElementList>
 		</consensusElement>
 	</consensusElementList>

--- a/src/tests/topp/FeatureFinderMultiplex_5_output.featureXML
+++ b/src/tests/topp/FeatureFinderMultiplex_5_output.featureXML
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<featureMap version="1.9" id="fm_17749660155506638460" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<featureMap version="1.9" id="fm_4968704754139293208" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<featureList count="2">
-		<feature id="f_7804704400743266335">
+		<feature id="f_15706079330621831236">
 			<position dim="0">2170.51847326083</position>
 			<position dim="1">392.937235597873</position>
-			<intensity>8.55078e+10</intensity>
+			<intensity>1.60433e+09</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>
@@ -34,10 +34,10 @@
 				<pt x="2165.79125976562" y="393.948112800144" />
 			</convexhull>
 		</feature>
-		<feature id="f_15004869347769368353">
+		<feature id="f_6383563675056436299">
 			<position dim="0">2173.49630029615</position>
 			<position dim="1">388.916474205617</position>
-			<intensity>8.56465e+10</intensity>
+			<intensity>1.79453e+09</intensity>
 			<quality dim="0">0</quality>
 			<quality dim="1">0</quality>
 			<overallquality>1</overallquality>


### PR DESCRIPTION
Previously, `FeatureFinderMultiplex` determined the reported peptide intensities by merely summing the spectral intensities of all filtered data points. The following three changes were made to improve on these results.

(1) The simple intensity sum is replaced by [trapezoid area](https://github.com/OpenMS/OpenMS/pull/3888/files#diff-a4a0a740e6b1905e206e7f5a0ea51757R415) under the curve of all mass traces

(2) Peptide ratios i.e. fold changes are calculated directly from the filter results using [linear regression](https://github.com/OpenMS/OpenMS/pull/3888/files#diff-a4a0a740e6b1905e206e7f5a0ea51757R299).

(3) The [RT shift](https://github.com/OpenMS/OpenMS/pull/3888/files#diff-a4a0a740e6b1905e206e7f5a0ea51757R281) is taken into account when calculating (2). Possible due to the novel `rt_band` approach introduced in #3353.

Each of these three changes improves the QC params of fixed-ratio test datasets, i.e. the standard deviation of peptide intensity fold changes `sd(fc)` decreases.