### PR TITLE
[STYLE] LPWrapper: avoid pointers, use const, use STL containers

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/LPWrapper.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/LPWrapper.h
@@ -148,11 +148,11 @@ public:
 
     // problem creation/manipulation
     /// adds a row to the LP matrix, returns index
-    Int addRow(std::vector<Int> row_indices, std::vector<double> row_values, const String& name);
+    Int addRow(const std::vector<Int>& row_indices, const std::vector<double>& row_values, const String& name);
     /// adds an empty column to the LP matrix, returns index
     Int addColumn();
     /// adds a column to the LP matrix, returns index
-    Int addColumn(std::vector<Int> column_indices, std::vector<double> column_values, const String& name);
+    Int addColumn(const std::vector<Int>& column_indices, const std::vector<double>& column_values, const String& name);
 
     /**
       @brief Adds a row with boundaries to the LP matrix, returns index
@@ -166,7 +166,8 @@ public:
       @param upper_bound
       @param type Type of the row 1 - unbounded, 2 - only lower bound, 3 - only upper bound, 4 - double-bounded variable, 5 - fixed variable
     */
-    Int addRow(std::vector<Int>& row_indices, std::vector<double>& row_values, const String& name, double lower_bound, double upper_bound, Type type);
+    Int addRow(const std::vector<Int>& row_indices, const std::vector<double>& row_values,
+               const String& name, double lower_bound, double upper_bound, Type type);
 
     /**
       @brief Adds a column with boundaries to the LP matrix, returns index
@@ -178,7 +179,7 @@ public:
       @param upper_bound
       @param type 1 - unbounded, 2 - only lower bound, 3 - only upper bound, 4 - double-bounded variable, 5 - fixed variable
     */
-    Int addColumn(std::vector<Int>& column_indices, std::vector<double>& column_values, const String& name, double lower_bound, double upper_bound, Type type);
+    Int addColumn(const std::vector<Int>& column_indices, const std::vector<double>& column_values, const String& name, double lower_bound, double upper_bound, Type type);
 
     /// delete index-th row
     void deleteRow(Int index);
@@ -267,7 +268,7 @@ public:
       @param filename Filename where to store the LP problem.
       @param format LP, MPS or GLPK.
      */
-    void readProblem(String filename, String format);
+    void readProblem(const String& filename, const String& format);
 
     /**
       @brief Write LP formulation to a file.

--- a/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
+++ b/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
@@ -528,11 +528,14 @@ namespace OpenMS
 
 #if COINOR_SOLVER == 1
     else if (solver_ == SOLVER_COINOR)
+    {
       return model_->getRowName(index);
-
+    }
 #endif
     else
+    {
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Invalid Solver chosen", String(solver_));
+    }
   }
 
   Int LPWrapper::getRowIndex(const String& name)
@@ -544,8 +547,9 @@ namespace OpenMS
     }
 #if COINOR_SOLVER == 1
     else if (solver_ == SOLVER_COINOR)
+    {
       return model_->row(name.c_str());
-
+    }
 #endif
     else
       throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Invalid Solver chosen", String(solver_));
@@ -581,7 +585,9 @@ namespace OpenMS
   {
     if (solver_ == LPWrapper::SOLVER_GLPK)
     {
+      // delete old model and create a new model in its place (using same ptr)
       glp_erase_prob(lp_problem_);
+      
       if (format == "LP")
       {
         glp_read_lp(lp_problem_, nullptr, filename.c_str());
@@ -600,6 +606,8 @@ namespace OpenMS
 #if COINOR_SOLVER == 1
     else if (solver_ == LPWrapper::SOLVER_COINOR && format == "MPS")
     {
+      // delete old model and create a new model in its place (using same ptr)
+      delete model_;
       model_ = new CoinModel(filename.c_str());
     }
 #endif
@@ -636,7 +644,9 @@ namespace OpenMS
         model_->writeMps(filename.c_str());
       }
       else
+      {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Invalid LP format, allowed is MPS");
+      }
     }
 #endif
   }

--- a/src/tests/class_tests/openms/source/LPWrapper_test.cpp
+++ b/src/tests/class_tests/openms/source/LPWrapper_test.cpp
@@ -80,7 +80,7 @@ END_SECTION
 
 
 
-START_SECTION((Int addRow(std::vector< Int > row_indices, std::vector< double > row_values, const String &name)))
+START_SECTION((Int addRow(fewer args)))
 {
   lp.addColumn();
   lp.addRow(indices,values,String("row1"));
@@ -99,7 +99,7 @@ START_SECTION((Int addColumn(std::vector< Int > column_indices, std::vector< dou
 }
 END_SECTION
 
-START_SECTION((Int addRow(std::vector< Int > &row_indices, std::vector< double > &row_values, const String &name, double lower_bound, double upper_bound, Type type)))
+START_SECTION((Int addRow(all args)))
 {
   lp.addRow(indices,values,String("row3"),0.2,1.2,LPWrapper::DOUBLE_BOUNDED);
   TEST_EQUAL(lp.getNumberOfRows(),3);


### PR DESCRIPTION
A few improvements to the class. I'm using it in some code of mine and it was very annoying to have to pass non-`const` variables to functions/methods that actually did not need to change the passed data.

This cleanup does not change the behaviour of the class.

**Advantages**
- the user is not required to passo non-`const` variables
- it better informs the user, because `const`-correctness assures that passed data won't be changed
- in some cases, copying of data is avoided (or delayed, when the right conditions are `true`, i.e. `if (solver_ == SOLVER_GLPK)`)
- avoid usage of `new`, no need of `delete`-ing memory
- it should be easier to spot out-of-range bugs (which I suspect might be present: glpk's routines assume 1-indexed arrays while we commonly assume 0-indexed arrays/vectors. It's easy to mistake some `<= n` / `< n` comparison or similar)