### PR TITLE
Feature/metabo decharger ppm

### DIFF
--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -122,7 +122,11 @@ namespace OpenMS
     defaults_.setValue("retention_max_diff", 1.0, "Maximum allowed RT difference between any two features if their relation shall be determined");
     defaults_.setValue("retention_max_diff_local", 1.0, "Maximum allowed RT difference between between two co-features, after adduct shifts have been accounted for (if you do not have any adduct shifts, this value should be equal to 'retention_max_diff', otherwise it should be smaller!)");
 
-    defaults_.setValue("mass_max_diff", 0.05, "Maximum allowed mass difference [in Th] for a single feature.");
+    defaults_.setValue("mass_max_diff", 0.05, "Maximum allowed mass tolerance per feature. Defines a symmetric tolerance window around the feature. When looking at possible feature pairs, the allowed feature-wise errors are combined for consideration of possible adduct shifts. For ppm tolerances, each window is based on the respective observed feature mz (instead of putative experimental mzs causing the observed one)!");
+    defaults_.setMinFloat("mass_max_diff", 0.0);
+    defaults_.setValue("unit", "Da", "Unit of the 'max_difference' parameter");
+    defaults_.setValidStrings("unit", ListUtils::create<String>("Da,ppm"));
+
     // Na+:0.1 , (2)H4H-4:0.1:-2:heavy
     defaults_.setValue("potential_adducts", ListUtils::create<String>("H:+:0.4,Na:+:0.25,NH4:+:0.25,K:+:0.1,H-2O-1:0:0.05"), "Adducts used to explain mass differences in format: 'Elements:Charge(+/-/0):Probability[:RTShift[:Label]]', i.e. the number of '+' or '-' indicate the charge ('0' if neutral adduct), e.g. 'Ca:++:0.5' indicates +2. Probabilites have to be in (0,1]. The optional RTShift param indicates the expected RT shift caused by this adduct, e.g. '(2)H4H-4:0:1:-3' indicates a 4 deuterium label, which causes early elution by 3 seconds. As fifth parameter you can add a label for every feature with this adduct. This also determines the map number in the consensus file. Adduct element losses are written in the form 'H-2'. All provided adducts need to have the same charge sign or be neutral! Mixing of adducts with different charge directions is only allowed as neutral complexes. For example, 'H-1Na:0:0.05' can be used to model Sodium gains (with balancing deprotonation) in negative mode.");
     defaults_.setValue("max_neutrals", 1, "Maximal number of neutral adducts(q=0) allowed. Add them in the 'potential_adducts' section!");
@@ -509,9 +513,33 @@ namespace OpenMS
 
             ++possibleEdges; // internal count, not vital
 
-            // find possible adduct combinations
+            // Find possible adduct combinations.
+            // Masses and tolerances are multiplied with their charges to nullify charge influence on mass shift.
+            // Allows to remove compound mass M from both sides of compomer equation -> queried shift only due to different adducts.
+            // Tolerance must increase when looking at M instead of m/z, as error margins increase as well by multiplication.
             CoordinateType naive_mass_diff = mz2 * abs(q2) - m1;
-            double abs_mass_diff = mz_diff_max * abs(q1) + mz_diff_max * abs(q2); // tolerance must increase when looking at M instead of m/z, as error margins increase as well
+
+            double abs_mass_diff;
+            if (param_.getValue("unit") == "Da")
+            {
+              abs_mass_diff = mz_diff_max * abs(q1) + mz_diff_max * abs(q2);
+            }
+            else
+            {
+              // For the ppm case, we multiply the respective experimental feature mz by its allowed ppm error before multiplication by charge.
+              // We look at the tolerance window with a simplified way: Just use the feature mz, and assume a symmetrc window around it.
+              // Instead of answering the more complex/asymetrical question: "which experimental mz can for given tolerance cause observed mz".
+              // (In the complex case we might have to consider different queries for different tolerance windows.)
+              // The expected error of this simplicfication is negligible:
+              // Assuming Y > X (X > Y is analog), given causative experimental mz Y and observed mz X with
+              // X = Y*(1 - d)
+              // for allowed tolerance d, the expected Error E between experimental mz and maximal mz in the tolerance window based on experimental mz is:
+              // E = (mz_exp - (mz_obs + max tolerance))/mz_exp = (Y - X*(1 + d))/Y = 1 - X*(1 + d)/Y = 1 - Y*(1 - d)*(1 + d)/Y = 1 - 1 - d*d = - d*d
+              // As d should be ppm sized, the error is something around 10 to the power of minus 12.
+              abs_mass_diff = mz1 * mz_diff_max * 1e-6 * abs(q1)   +   mz2 * mz_diff_max * 1e-6 * abs(q2);
+            }
+
+
             //abs charge "3" to abs charge "1" -> simply invert charge delta for negative case?
             hits = me.query(q2 - q1, naive_mass_diff, abs_mass_diff, thresh_logp, md_s, md_e);
             OPENMS_PRECONDITION(hits >= 0, "MetaboliteFeatureDeconvolution querying #hits got negative result!");

--- a/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_ppm_output.featureXML
+++ b/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_ppm_output.featureXML
@@ -15,6 +15,7 @@
 			<UserParam type="stringList" name="adducts" value="[[M+2H]2+]"/>
 			<UserParam type="float" name="dc_charge_adduct_mass" value="2.0156500638"/>
 			<UserParam type="int" name="is_backbone" value="1"/>
+			<UserParam type="string" name="Group" value="15329081911327902813"/>
 		</feature>
 		<feature id="f_1110">
 			<position dim="0">1000</position>
@@ -30,6 +31,7 @@
 			<UserParam type="stringList" name="adducts" value="[[M+H]+]"/>
 			<UserParam type="float" name="dc_charge_adduct_mass" value="1.0078250319"/>
 			<UserParam type="int" name="is_backbone" value="1"/>
+			<UserParam type="string" name="Group" value="15329081911327902813"/>
 		</feature>
 		<feature id="f_2111">
 			<position dim="0">2000</position>
@@ -45,6 +47,7 @@
 			<UserParam type="stringList" name="adducts" value="[[M+2H]2+]"/>
 			<UserParam type="float" name="dc_charge_adduct_mass" value="2.0156500638"/>
 			<UserParam type="int" name="is_backbone" value="1"/>
+			<UserParam type="string" name="Group" value="11881453989308070806"/>
 		</feature>
 		<feature id="f_2110">
 			<position dim="0">2000</position>
@@ -60,6 +63,7 @@
 			<UserParam type="stringList" name="adducts" value="[[M+H]+]"/>
 			<UserParam type="float" name="dc_charge_adduct_mass" value="1.0078250319"/>
 			<UserParam type="int" name="is_backbone" value="1"/>
+			<UserParam type="string" name="Group" value="11881453989308070806"/>
 		</feature>
 		<feature id="f_3111">
 			<position dim="0">3000</position>
@@ -70,10 +74,10 @@
 			<overallquality>1</overallquality>
 			<charge>2</charge>
 			<UserParam type="string" name="label" value="M+2H. Down Error larger 50 ppm"/>
-			<UserParam type="int" name="charge" value="2"/>
 			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
 			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="string" name="Group" value="17348772872452528723"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</feature>
 		<feature id="f_3110">
 			<position dim="0">3000</position>
@@ -84,10 +88,10 @@
 			<overallquality>1</overallquality>
 			<charge>1</charge>
 			<UserParam type="string" name="label" value="M+H. Up Error larger 50 ppm"/>
-			<UserParam type="int" name="charge" value="1"/>
 			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
 			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
-			<UserParam type="int" name="is_single_feature" value="1"/>
+			<UserParam type="string" name="Group" value="17068332045451970805"/>
+			<UserParam type="int" name="is_ungrouped_with_charge" value="1"/>
 		</feature>
 	</featureList>
 </featureMap>

--- a/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_ppm_output.featureXML
+++ b/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_ppm_output.featureXML
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.9" id="fm_6995089216872835842" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/share/OpenMS/SCHEMAS/FeatureXML_1_9.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<featureList count="6">
+		<feature id="f_1111">
+			<position dim="0">1000</position>
+			<position dim="1">501.007276</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>2</charge>
+			<UserParam type="string" name="label" value="M+2H, perfect"/>
+			<UserParam type="int" name="map_idx" value="0"/>
+			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
+			<UserParam type="stringList" name="adducts" value="[[M+2H]2+]"/>
+			<UserParam type="float" name="dc_charge_adduct_mass" value="2.0156500638"/>
+			<UserParam type="int" name="is_backbone" value="1"/>
+		</feature>
+		<feature id="f_1110">
+			<position dim="0">1000</position>
+			<position dim="1">1001.007276</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>1</charge>
+			<UserParam type="string" name="label" value="M+H, perfect"/>
+			<UserParam type="int" name="map_idx" value="0"/>
+			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
+			<UserParam type="stringList" name="adducts" value="[[M+H]+]"/>
+			<UserParam type="float" name="dc_charge_adduct_mass" value="1.0078250319"/>
+			<UserParam type="int" name="is_backbone" value="1"/>
+		</feature>
+		<feature id="f_2111">
+			<position dim="0">2000</position>
+			<position dim="1">500.982226</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>2</charge>
+			<UserParam type="string" name="label" value="M+2H. Down Error lower 50 ppm"/>
+			<UserParam type="int" name="map_idx" value="0"/>
+			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
+			<UserParam type="stringList" name="adducts" value="[[M+2H]2+]"/>
+			<UserParam type="float" name="dc_charge_adduct_mass" value="2.0156500638"/>
+			<UserParam type="int" name="is_backbone" value="1"/>
+		</feature>
+		<feature id="f_2110">
+			<position dim="0">2000</position>
+			<position dim="1">1001.057276</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>1</charge>
+			<UserParam type="string" name="label" value="M+H. Up Error lower 50 ppm"/>
+			<UserParam type="int" name="map_idx" value="0"/>
+			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
+			<UserParam type="stringList" name="adducts" value="[[M+H]+]"/>
+			<UserParam type="float" name="dc_charge_adduct_mass" value="1.0078250319"/>
+			<UserParam type="int" name="is_backbone" value="1"/>
+		</feature>
+		<feature id="f_3111">
+			<position dim="0">3000</position>
+			<position dim="1">500.98</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>2</charge>
+			<UserParam type="string" name="label" value="M+2H. Down Error larger 50 ppm"/>
+			<UserParam type="int" name="charge" value="2"/>
+			<UserParam type="string" name="dc_charge_adducts" value="H2"/>
+			<UserParam type="float" name="dc_charge_adduct_mass" value="2.014552933542"/>
+			<UserParam type="int" name="is_single_feature" value="1"/>
+		</feature>
+		<feature id="f_3110">
+			<position dim="0">3000</position>
+			<position dim="1">1001.06</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>1</charge>
+			<UserParam type="string" name="label" value="M+H. Up Error larger 50 ppm"/>
+			<UserParam type="int" name="charge" value="1"/>
+			<UserParam type="string" name="dc_charge_adducts" value="H1"/>
+			<UserParam type="float" name="dc_charge_adduct_mass" value="1.007276466771"/>
+			<UserParam type="int" name="is_single_feature" value="1"/>
+		</feature>
+	</featureList>
+</featureMap>

--- a/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_test_ppm.featureXML
+++ b/src/tests/class_tests/openms/data/MetaboliteFeatureDeconvolution_test_ppm.featureXML
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<featureMap version="1.7" id="fm_6995089216872835842" xsi:noNamespaceSchemaLocation="http://open-ms.sourceforge.net/schemas/FeatureXML_1_7.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<featureList count="6">
+		<feature id="f_1110">
+			<position dim="0">1000</position>
+			<position dim="1">1001.007276</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>1</charge>
+			<userParam type="string" name="label" value="M+H, perfect"/>
+		</feature>
+		<feature id="f_1111">
+			<position dim="0">1000</position>
+			<position dim="1">501.007276</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>2</charge>
+			<userParam type="string" name="label" value="M+2H, perfect"/>
+		</feature>
+		<feature id="f_2110">
+			<position dim="0">2000</position>
+			<position dim="1">1001.057276</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>1</charge>
+			<userParam type="string" name="label" value="M+H. Up Error lower 50 ppm"/>
+		</feature>
+		<feature id="f_2111">
+			<position dim="0">2000</position>
+			<position dim="1">500.982226</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>2</charge>
+			<userParam type="string" name="label" value="M+2H. Down Error lower 50 ppm"/>
+		</feature>
+		<feature id="f_3110">
+			<position dim="0">3000</position>
+			<position dim="1">1001.06</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>1</charge>
+			<userParam type="string" name="label" value="M+H. Up Error larger 50 ppm"/>
+		</feature>
+		<feature id="f_3111">
+			<position dim="0">3000</position>
+			<position dim="1">500.98</position>
+			<intensity>100</intensity>
+			<quality dim="0">1</quality>
+			<quality dim="1">1</quality>
+			<overallquality>1</overallquality>
+			<charge>2</charge>
+			<userParam type="string" name="label" value="M+2H. Down Error larger 50 ppm"/>
+		</feature>
+	</featureList>
+</featureMap>

--- a/src/tests/class_tests/openms/source/MetaboliteFeatureDeconvolution_test.cpp
+++ b/src/tests/class_tests/openms/source/MetaboliteFeatureDeconvolution_test.cpp
@@ -297,6 +297,36 @@ START_SECTION(void compute(const FeatureMapType &fm_in, FeatureMapType &fm_out, 
   TEST_FILE_SIMILAR(out_file_n, OPENMS_GET_TEST_DATA_PATH("MetaboliteFeatureDeconvolution_neg_output.consensusXML"));
 
 
+  //small pos test file with specific ions and ppm error
+  Param p_pos_ppm;
+  p_pos_ppm.setValue("potential_adducts", ListUtils::create<String>("H:+:0.6,Na:+:0.4"), "Ad_p");
+  p_pos_ppm.setValue("charge_min", 1, "minimal possible charge");
+  p_pos_ppm.setValue("charge_max", 3, "maximal possible charge");
+  p_pos_ppm.setValue("charge_span_max", 3);
+  p_pos_ppm.setValue("max_neutrals", 1);
+  p_pos_ppm.setValue("q_try", "feature");
+  p_pos_ppm.setValue("mass_max_diff", 50.0);
+  p_pos_ppm.setValue("unit", "ppm");
+  p_pos_ppm.setValue("retention_max_diff", 1.0);
+  p_pos_ppm.setValue("retention_max_diff_local", 1.0);
+  p_pos_ppm.setValue("intensity_filter", "false");
+  p_pos_ppm.setValue("use_minority_bound", "false");
+
+  fd.setParameters(p_pos_ppm);
+
+  FeatureMap fm_ppm_in, fm_ppm_out;
+  ConsensusMap cm_ppm, cm_ppm2;
+  FeatureXMLFile fl_ppm;
+  fl_ppm.load(OPENMS_GET_TEST_DATA_PATH("MetaboliteFeatureDeconvolution_test_ppm.featureXML"), fm_ppm_in);
+  fd.compute(fm_ppm_in, fm_ppm_out, cm_ppm, cm_ppm2);
+
+  String out_file_ppm;
+  NEW_TMP_FILE(out_file_ppm)
+  FeatureXMLFile f_ppm;
+  f_ppm.store(out_file_ppm,fm_ppm_out);
+
+  WHITELIST("xml-stylesheet,consensusXML version=,consensusElement id=,<UserParam type=");
+  TEST_FILE_SIMILAR(out_file_ppm, OPENMS_GET_TEST_DATA_PATH("MetaboliteFeatureDeconvolution_ppm_output.featureXML"));
 
 END_SECTION
 


### PR DESCRIPTION
Added support for ppm-based mass errors.

Assumes simplification that such error window is symmetric around the observed mz (e.g., +- exp_mz*5*10^-6). (Instead of computing error windows based on putative causative true mzs leading to observed exp_mz).

Analogously to the previous absolute Thomson tolerance case, observed mass shifts then have to match to entries in the mass shift table, +- the sum of the ppm tolerances of both affected observed mzs.