### PR TITLE
Fix ElementDB and Elements.xml

### DIFF
--- a/share/OpenMS/CHEMISTRY/Elements.xml
+++ b/share/OpenMS/CHEMISTRY/Elements.xml
@@ -20,6 +20,8 @@
         </NODE>
       </NODE>
     </NODE>    
+    <!--
+    === disable these elements for now (Deuterium is available via 'H(2)' anyways) since they cause mem-leaks in ElementsDB (design choice for speed) ===
     <NODE name="Deuterium">
       <ITEM name="Name" value="Deuterium" type="string" />
       <ITEM name="Symbol" value="D" type="string" />
@@ -41,7 +43,8 @@
           <ITEM name="AtomicMass" value="3.01604927" type="float" />
         </NODE>
       </NODE>
-    </NODE>    
+    </NODE>
+    -->
     <NODE name="Helium">
       <ITEM name="Name" value="Helium" type="string"/>
       <ITEM name="Symbol" value="He" type="string"/>

--- a/share/OpenMS/CHEMISTRY/Elements.xml
+++ b/share/OpenMS/CHEMISTRY/Elements.xml
@@ -1202,7 +1202,7 @@
         </NODE>
         <NODE name="208">
           <ITEM name="RelativeAbundance" value="52.4" type="float" />
-          <ITEM name="AtomicMass" value="206.9758969" type="float" />
+          <ITEM name="AtomicMass" value="207.9766538" type="float" />
         </NODE>
       </NODE>
     </NODE>

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -69,19 +69,17 @@ namespace OpenMS
   class OPENMS_DLLAPI ElementDB
   {
 public:
-
+    
     /** @name Accessors
     */
     //@{
     /// returns a pointer to the singleton instance of the element db
-    inline static const ElementDB * getInstance()
+    /// Upon first call, the Elements.xml file is parsed
+    /// This is thread safe upon first and subsequent calls.
+    inline static const ElementDB* getInstance()
     {
-      static ElementDB * db_ = nullptr;
-      if (db_ == nullptr)
-      {
-        db_ = new ElementDB;
-      }
-      return db_;
+      static ElementDB db_; // this is thread safe!
+      return &db_;
     }
 
     /// returns a hashmap that contains names mapped to pointers to the elements

--- a/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ElementDB.h
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors: Andreas Bertsch, Timo Sachsenberg $
+// $Authors: Andreas Bertsch, Timo Sachsenberg, Chris Bielow $
 // --------------------------------------------------------------------------
 //
 
@@ -135,6 +135,10 @@ protected:
      */
     void readFromFile_(const String & file_name);
 
+
+    /// store element after parsing it
+    void storeElement_(const UInt an, const String& name, const String& symbol, const Map<UInt, double>& Z_to_abundancy, const Map<UInt, double>& Z_to_mass);
+
     /*_ resets all containers
      */
     void clear_();
@@ -146,14 +150,12 @@ protected:
     Map<UInt, const Element *> atomic_numbers_;
 
 private:
-
     ElementDB();
+    ~ElementDB();
+    ElementDB(const ElementDB& db) = delete;
+    ElementDB(const ElementDB&& db) = delete;
+    ElementDB& operator=(const ElementDB& db) = delete;
 
-    ElementDB(const ElementDB & db);
-
-    ElementDB & operator=(const ElementDB & db);
-
-    virtual ~ElementDB();
   };
 
 } // namespace OpenMS

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -200,7 +200,7 @@ namespace OpenMS
       }
       if (symbols_.has(iso_symbol))
       {
-        std::cerr << "Error: ElementDB encountered duplicated names for \n" << *symbols_[iso_symbol] << "\n" << *iso_e << "\nKeeping only the first one!\n";
+        std::cerr << "Error: ElementDB encountered duplicated symbol for \n" << *symbols_[iso_symbol] << "\n" << *iso_e << "\nKeeping only the first one!\n";
         delete e;
         return;
       }

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -161,7 +161,7 @@ namespace OpenMS
     }
     if (atomic_numbers_.has(an))
     {
-      std::cerr << "Error: ElementDB encountered duplicated atomic_numbers_ for \n" << *atomic_numbers_[an] << "\n" << *e << "\nKeeping only the first one!\n";
+      std::cerr << "Error: ElementDB encountered duplicated atomic number for \n" << *atomic_numbers_[an] << "\n" << *e << "\nKeeping only the first one!\n";
       delete e;
       return; // next element
     }

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -110,19 +110,11 @@ namespace OpenMS
   double ElementDB::calculateAvgWeight_(const Map<UInt, double>& Z_to_abundance, const Map<UInt, double>& Z_to_mass)
   {
     double avg = 0;
-    // extract Zs
-    vector<UInt> keys;
+    // calculate weighted average
     for (Map<UInt, double>::const_iterator it = Z_to_abundance.begin(); it != Z_to_abundance.end(); ++it)
     {
-      keys.push_back(it->first);
+      avg += Z_to_mass[it->first] * Z_to_abundance[it->first];
     }
-
-    // calculate weighted average
-    for (vector<UInt>::iterator it = keys.begin(); it != keys.end(); ++it)
-    {
-      avg += Z_to_mass[*it] * Z_to_abundance[*it];
-    }
-
     return avg;
   }
 
@@ -312,6 +304,7 @@ namespace OpenMS
 
   void ElementDB::clear_()
   {
+    // names_ has the union of all Element*, deleting this is sufficient to avoid mem leaks
     Map<String, const Element*>::Iterator it = names_.begin();
     for (; it != names_.end(); ++it)
     {

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -29,7 +29,7 @@
 //
 // --------------------------------------------------------------------------
 // $Maintainer: Timo Sachsenberg $
-// $Authors: Andreas Bertsch, Timo Sachsenberg $
+// $Authors: Andreas Bertsch, Timo Sachsenberg, Chris Bielow $
 // --------------------------------------------------------------------------
 //
 #include <OpenMS/CHEMISTRY/ElementDB.h>
@@ -133,6 +133,82 @@ namespace OpenMS
     return smallest_weight;
   }
 
+  void ElementDB::storeElement_(const UInt an, const String& name, const String& symbol, const Map<UInt, double>& Z_to_abundancy, const Map<UInt, double>& Z_to_mass)
+  {
+    // Parsing of previous element is finished. Now store data in Element object
+    IsotopeDistribution isotopes = parseIsotopeDistribution_(Z_to_abundancy, Z_to_mass);
+    double avg_weight = calculateAvgWeight_(Z_to_abundancy, Z_to_mass);
+    double mono_weight = calculateMonoWeight_(Z_to_mass);
+
+    /*
+    // print information about elements
+    cout << "Name: " << name << " AtomicNumber: " << an << " Symbol: " << symbol << " AvgWeight: " << avg_weight
+         << " MonoWeight: " << mono_weight << " NIsotopes: " << isotopes.size() << endl;
+
+    */
+    Element* e = new Element(name, symbol, an, avg_weight, mono_weight, isotopes);
+    if (names_.has(name))
+    {
+      std::cerr << "Error: ElementDB encountered duplicated names for \n" << *names_[name] << "\n" << *e << "\nKeeping only the first one!\n";
+      delete e;
+      return; // next element
+    }
+    if (symbols_.has(symbol))
+    {
+      std::cerr << "Error: ElementDB encountered duplicated symbol for \n" << *symbols_[symbol] << "\n" << *e << "\nKeeping only the first one!\n";
+      delete e;
+      return; // next element
+    }
+    if (atomic_numbers_.has(an))
+    {
+      std::cerr << "Error: ElementDB encountered duplicated atomic_numbers_ for \n" << *atomic_numbers_[an] << "\n" << *e << "\nKeeping only the first one!\n";
+      delete e;
+      return; // next element
+    }
+    // only add if all Maps accept it
+    names_[name] = e;
+    symbols_[symbol] = e;
+    atomic_numbers_[an] = e;
+
+
+    // add all the individual isotopes as separate elements
+    for (const auto& isotope : isotopes)
+    {
+      double atomic_mass = isotope.getMZ();
+      UInt mass_number = round(atomic_mass);
+      String iso_name = "(" + String(mass_number) + ")" + name;
+      String iso_symbol = "(" + String(mass_number) + ")" + symbol;
+
+      // set avg and mono to same value for isotopes (old hack...)
+      double iso_avg_weight = Z_to_mass[mass_number];
+      double iso_mono_weight = iso_avg_weight;
+      IsotopeDistribution iso_isotopes;
+      IsotopeDistribution::ContainerType iso_container;
+      iso_container.push_back(Peak1D(atomic_mass, 1.0));
+      iso_isotopes.set(iso_container);
+
+      /*
+      // print name, symbol and atomic mass of the current isotope
+      cout << "Isotope Name: " << iso_name << " Symbol: " << iso_symbol << " AtomicMass: " << iso_mono_weight << endl;
+      */
+      Element* iso_e = new Element(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
+      if (names_.has(iso_name))
+      {
+        std::cerr << "Error: ElementDB encountered duplicated names for \n" << *names_[iso_name] << "\n" << *iso_e << "\nKeeping only the first one!\n";
+        delete e;
+        return;
+      }
+      if (symbols_.has(iso_symbol))
+      {
+        std::cerr << "Error: ElementDB encountered duplicated names for \n" << *symbols_[iso_symbol] << "\n" << *iso_e << "\nKeeping only the first one!\n";
+        delete e;
+        return;
+      }
+      names_[iso_name] = iso_e;
+      symbols_[iso_symbol] = iso_e;
+    }
+  }
+
   void ElementDB::readFromFile_(const String& file_name)
   {
     String file = File::find(file_name);
@@ -144,7 +220,9 @@ namespace OpenMS
 
     UInt an(0);
     String name, symbol;
-
+    Map<UInt, double> Z_to_abundancy;
+    Map<UInt, double> Z_to_mass;
+    
     // determine prefix
     vector<String> split;
     param.begin().getName().split(':', split);
@@ -155,72 +233,30 @@ namespace OpenMS
     }
     //cout << "first element prefix=" << prefix << endl;
 
-    Map<UInt, double> Z_to_abundancy;
-    Map<UInt, double> Z_to_mass;
 
     for (Param::ParamIterator it = param.begin(); it != param.end(); ++it)
     {
+      it.getName().split(':', split);
+      
       // new element started?
       if (!it.getName().hasPrefix(prefix))
       {
         // update prefix
-        it.getName().split(':', split);
         prefix = "";
         for (Size i = 0; i < split.size() - 1; ++i)
         {
           prefix += split[i] + ":";
         }
         // cout << "new element prefix=" << prefix << endl;
-
-        // Parsing of previous element is finished. Now store data in Element object
-        IsotopeDistribution isotopes = parseIsotopeDistribution_(Z_to_abundancy, Z_to_mass);
-        double avg_weight = calculateAvgWeight_(Z_to_abundancy, Z_to_mass);
-        double mono_weight = calculateMonoWeight_(Z_to_mass);
-
-        /*
-        // print information about elements
-        cout << "Name: " << name << " AtomicNumber: " << an << " Symbol: " << symbol << " AvgWeight: " << avg_weight
-             << " MonoWeight: " << mono_weight << " NIsotopes: " << isotopes.size() << endl;
-
-        */
-        Element* e = new Element(name, symbol, an, avg_weight, mono_weight, isotopes);
-        names_[name] = e;
-        symbols_[symbol] = e;
-        atomic_numbers_[an] = e;
-
-        // add all the individual isotopes as separate elements
-        for (const auto& isotope : isotopes)
-        {
-          double atomic_mass = isotope.getMZ();
-          UInt mass_number = round(atomic_mass);
-          String iso_name = "(" + String(mass_number) + ")" + name;
-          String iso_symbol = "(" + String(mass_number) + ")" + symbol;
-
-          // set avg and mono to same value for isotopes (old hack...)
-          double iso_avg_weight = Z_to_mass[mass_number];
-          double iso_mono_weight = iso_avg_weight;
-          IsotopeDistribution iso_isotopes;
-          IsotopeDistribution::ContainerType iso_container;
-          iso_container.push_back(Peak1D(atomic_mass, 1.0));
-          iso_isotopes.set(iso_container);
-
-          /*
-          // print name, symbol and atomic mass of the current isotope
-          cout << "Isotope Name: " << iso_name << " Symbol: " << iso_symbol << " AtomicMass: " << iso_mono_weight << endl;
-          */
-
-          Element* iso_e = new Element(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
-          names_[iso_name] = iso_e;
-          names_[iso_symbol] = iso_e;
-        }
+        
+        storeElement_(an, name, symbol, Z_to_abundancy, Z_to_mass);
 
         Z_to_abundancy.clear();
         Z_to_mass.clear();
-      }
+      } // new element started
 
       // top level: read the contents of the element section
-      it.getName().split(':', split);
-      String key = split[2];
+      const String& key = split[2];
       String value = it->value;
       value.trim();
 
@@ -271,12 +307,8 @@ namespace OpenMS
     }
 
     // build last element
-    double avg_weight(0), mono_weight(0);
-    IsotopeDistribution isotopes = parseIsotopeDistribution_(Z_to_abundancy,Z_to_mass);
-    Element* e = new Element(name, symbol, an, avg_weight, mono_weight, isotopes);
-    names_[name] = e;
-    symbols_[symbol] = e;
-    atomic_numbers_[an] = e;
+    storeElement_(an, name, symbol, Z_to_abundancy, Z_to_mass);
+
   }
 
   IsotopeDistribution ElementDB::parseIsotopeDistribution_(const Map<UInt, double>& Z_to_abundance, const Map<UInt, double>& Z_to_mass)

--- a/src/openms/source/CHEMISTRY/ElementDB.cpp
+++ b/src/openms/source/CHEMISTRY/ElementDB.cpp
@@ -194,7 +194,7 @@ namespace OpenMS
       Element* iso_e = new Element(iso_name, iso_symbol, an, iso_avg_weight, iso_mono_weight, iso_isotopes);
       if (names_.has(iso_name))
       {
-        std::cerr << "Error: ElementDB encountered duplicated names for \n" << *names_[iso_name] << "\n" << *iso_e << "\nKeeping only the first one!\n";
+        std::cerr << "Error: ElementDB encountered duplicated name for \n" << *names_[iso_name] << "\n" << *iso_e << "\nKeeping only the first one!\n";
         delete e;
         return;
       }


### PR DESCRIPTION
ASAN reported mem leaks for ElementDB. This fixes it, and some other issues:

[FIX] ElementDB: memory leak (lost pointer, [1], e.g. when atomic number already exists (e.g. Hydrogen vs. Deuterium have both '1') and double free (duplicate pointer to same Element [2])

[FIX] fix mass of Pb208 in Elements.xml (also fixes a mem-leak)

[FIX] ElementDB: fix properties of last element 'Samarium' in File (not constructed correctly)

And to avoid future issues:
[FEATURE] ElementDB now reports inconsistencies in Elements.xml (or future versions of it) to avoid mem-leaks

[FIX] make construction of ElementDB thread-safe (using Myers Singleton -- instead of a pointer)


[1] https://github.com/OpenMS/OpenMS/blob/ac4c8767657504e98572baf453c41dcf1d7fff15/src/openms/source/CHEMISTRY/ElementDB.cpp#L197
[2] https://github.com/OpenMS/OpenMS/blob/ac4c8767657504e98572baf453c41dcf1d7fff15/src/openms/source/CHEMISTRY/ElementDB.cpp#L222