### PR TITLE
Fixed infinite loop during overlap resolution in FeatureFinderMetaboIdent

### DIFF
--- a/src/utils/FeatureFinderMetaboIdent.cpp
+++ b/src/utils/FeatureFinderMetaboIdent.cpp
@@ -614,20 +614,22 @@ protected:
   void resolveOverlappingFeatures_(FeatureGroup& group,
                                    const FeatureBoundsMap& feature_bounds)
   {
-    LOG_DEBUG << "Overlapping features:";
-    for (FeatureGroup::const_iterator it = group.begin(); it != group.end();
-         ++it)
+    if (debug_level_ > 0)
     {
-      if (it != group.begin()) LOG_DEBUG << ",";
-      LOG_DEBUG << " " << (*it)->getMetaValue("PeptideRef") << " (RT "
-                << float((*it)->getRT()) << ")";
+      String msg = "Overlapping features: ";
+      for (FeatureGroup::const_iterator it = group.begin(); it != group.end();
+           ++it)
+      {
+        if (it != group.begin()) msg += ", ";
+        msg += String((*it)->getMetaValue("PeptideRef")) + " (RT " + String(float((*it)->getRT())) + ")";
+      }
+      LOG_DEBUG << msg << endl;
     }
-    LOG_DEBUG << endl;
 
-    double best_rt_delta = numeric_limits<double>::infinity();
     Feature* best_feature = 0;
     while (!group.empty())
     {
+      double best_rt_delta = numeric_limits<double>::infinity();
       // best feature is the one with min. RT deviation to target:
       for (FeatureGroup::const_iterator it = group.begin(); it != group.end();
            ++it)


### PR DESCRIPTION
The fix was to move the `best_rt_delta` variable definition into the loop, so that it gets reinitialised as required.

The other bits only improve some debug output.