### PR TITLE
FuzzDiff Performance improvements

### DIFF
--- a/src/openms/include/OpenMS/SYSTEM/StopWatch.h
+++ b/src/openms/include/OpenMS/SYSTEM/StopWatch.h
@@ -93,6 +93,10 @@ public:
     /** Start the stop watch.
             The stop watch is started. If the stop watch is already running, <b>false</b>
             is returned.
+
+            If the watch holds data from previous measurements, these will be reset before starting up,
+            i.e. it is not possible to resume by start(), stop(), start().
+
             @return bool <b>false</b> if the stop watch was already running, <b>true</b> otherwise
     */
     bool start();

--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -821,18 +821,20 @@ namespace OpenMS
     }
     else
     {
+      // go back to initial position and try to read as double
       input_line.seekGToSavedPosition();
 #ifdef OPENMS_HAS_STREAM_EXTRACTION_BUG
       // is a number? (explicit bool op for C11)
       if (tryExtractDouble(input_line, number))
 #else
-      if ((is_number = (bool(input_line.line_ >> number))))
+      if ((is_number = (bool(input_line.line_ >> number)))) // the >>operator is awfully slow (especially on VS); huge potential for speed improvement
 #endif
       {
         is_number = true;
       }
       else
       {
+        // go back to initial position and read as letter (since its neither space nor number)
         input_line.seekGToSavedPosition();
         input_line.line_ >> letter; // read letter
       }

--- a/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
+++ b/src/openms/source/CONCEPT/FuzzyStringComparator.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/CONCEPT/FuzzyStringComparator.h>
+#include <OpenMS/FORMAT/TextFile.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <QDir>
 #include <fstream>
@@ -295,6 +296,9 @@ namespace OpenMS
 
   bool FuzzyStringComparator::compareLines_(std::string const& line_str_1, std::string const& line_str_2)
   {
+    // in most cases, results will be identical. If not, do the expensive fuzzy compare
+    if (line_str_1 == line_str_2) return true;
+    
     for (StringList::const_iterator slit = whitelist_.begin();
          slit != whitelist_.end(); ++slit)
     {
@@ -582,11 +586,13 @@ namespace OpenMS
 
   void FuzzyStringComparator::readNextLine_(std::istream& input_stream, std::string& line_string, int& line_number) const
   {
-    for (line_string.clear(); static_cast<void>(++line_number), std::getline(input_stream, line_string); )
+    // use TextFile::getLine for reading, since it will remove \r automatically on all platforms without much overhead
+    // This allows to compare otherwise equal lines between files quickly (see compareLines_(...))
+    for (line_string.clear(); static_cast<void>(++line_number), TextFile::getLine(input_stream, line_string); )
     {
       if (line_string.empty())
       {
-        continue; // shortcut
+        continue; // read next line
       }
       std::string::const_iterator iter = line_string.begin(); // loop initialization
       for (; iter != line_string.end() && isspace((unsigned char)*iter); ++iter)
@@ -595,7 +601,7 @@ namespace OpenMS
       // skip over whitespace
       if (iter != line_string.end())
       {
-        break; // line is not empty or whitespace only
+        return; // line is not empty or whitespace only
       }
     }
   }

--- a/src/openms/source/SYSTEM/StopWatch.cpp
+++ b/src/openms/source/SYSTEM/StopWatch.cpp
@@ -117,6 +117,10 @@ namespace OpenMS
   void StopWatch::clear()
   {
     is_running_ = false;
+    start_secs_ = 0;
+    start_usecs_ = 0;
+    start_user_time_ = 0;
+    start_system_time_ = 0;
     current_secs_ = 0L;
     current_usecs_ = 0L;
     current_user_time_ = 0L;

--- a/src/tests/class_tests/openms/source/StopWatch_test.cpp
+++ b/src/tests/class_tests/openms/source/StopWatch_test.cpp
@@ -39,15 +39,19 @@
 
 #include <OpenMS/SYSTEM/StopWatch.h>
 
-#include <ctime>
+#include <chrono>
 /////////////////////////////////////////////////////////////
 
 using namespace OpenMS;
 
-void wait (int seconds)
+void wait(double seconds)
 {
-    clock_t endwait = clock () + seconds * CLOCKS_PER_SEC;
-    while (clock () < endwait) {}
+  auto start = std::chrono::system_clock::now();
+  while (true)
+  {
+   double s = std::chrono::duration<double>(std::chrono::system_clock::now() - start).count();
+   if (s > seconds) break;
+  };
 }
 
 START_TEST(StopWatch, "$Id$")
@@ -55,31 +59,41 @@ START_TEST(StopWatch, "$Id$")
 /////////////////////////////////////////////////////////////
 
 START_SECTION((StopWatch& operator = (const StopWatch& stop_watch)))
-  StopWatch s1;
-  s1.start();
-  wait(1);
-  s1.stop();
-
-  StopWatch s2;
-  TEST_EQUAL(s1!=s2, true)
-  s2 = s1;
-  TEST_EQUAL(s1==s2, true)
-
+  NOT_TESTABLE; // tested below
 END_SECTION
 
 START_SECTION((StopWatch()))
-  NOT_TESTABLE; // tested above
+  NOT_TESTABLE; // tested below
 END_SECTION
 
 START_SECTION((StopWatch(const StopWatch& stop_watch)))
-  StopWatch s1;
+  StopWatch s1, s2;
   s1.start();
-  wait(1);
+  wait(0.01);
+  TEST_EQUAL(s1 != s2, true) // before stop
+  s1.stop();
+  TEST_EQUAL(s1 != s2, true)
+  s2 = s1;
+  TEST_EQUAL(s1 == s2, true)
+
+  StopWatch s3(s1);
+  TEST_EQUAL(s1==s3, true)
+  
+  StopWatch s4;
+  s1.reset();
+  TEST_EQUAL(s1 == s4, true)
+
+  s1.start();
+  s2.start();
+  wait(0.01);
   s1.stop();
 
-  StopWatch s2(s1);
-  TEST_EQUAL(s1==s2, true)
-  
+  wait(0.01);
+  s2.stop();
+
+  TEST_EQUAL(s1 != s2, true)
+  TEST_EQUAL(s1 <= s2, true)
+  TEST_EQUAL(s2 >= s1, true)
 END_SECTION
 
 START_SECTION((bool isRunning() const))
@@ -87,40 +101,11 @@ START_SECTION((bool isRunning() const))
 
   w.start();
   TEST_EQUAL(w.isRunning(), true);
-
   w.stop();
-
 END_SECTION
 
 START_SECTION((bool operator != (const StopWatch& stop_watch) const))
-  StopWatch s, s2;
-  StopWatch s3(s2);
-  TEST_EQUAL(s2==s3, true);
-
-
-  s.start();
-  s2.start();
-  wait(3);
-  s.stop();
-
-  wait(3);
-  s2.stop();
-
-  TEST_EQUAL(s!=s2, true)
-
-  TEST_EQUAL(s<=s2, true)
-
-  TEST_EQUAL(s2>=s, true)
-
-  TEST_EQUAL(s2!=s3, true)
-  s3 = s2;
-  TEST_EQUAL(s2==s3, true)
-
-  s2.start();
-  wait(1);
-  TEST_EQUAL(s2==s3, false)
-  s2.stop();
-
+  NOT_TESTABLE; // tested above
 END_SECTION
 
 START_SECTION((bool operator < (const StopWatch& stop_watch) const))
@@ -148,41 +133,39 @@ START_SECTION((bool start()))
 END_SECTION
 
 START_SECTION((bool stop()))
+  const double t_wait = 0.2;
   StopWatch s;
   s.start();
-  wait(3);
+  wait(t_wait);
   s.stop();
 
-  TEST_EQUAL(s.getClockTime() > 2, true)
-  TEST_EQUAL(s.getClockTime() < 4, true)
+  TEST_EQUAL(s.getClockTime() > 0.1, true)
+  TEST_EQUAL(s.getClockTime() < 0.3, true)
   
   double t1 = s.getCPUTime();
   double t2 = s.getClockTime();
   double t3 = s.getSystemTime();
   double t4 = s.getUserTime();
   // wait some more
-  wait(3);
+  wait(0.1);
   // ... and see if time is still the old one
   TEST_EQUAL(s.getCPUTime(), t1)
   TEST_EQUAL(s.getClockTime(), t2)
   TEST_EQUAL(s.getSystemTime(), t3)
   TEST_EQUAL(s.getUserTime(), t4)
+  TEST_EQUAL(s.getCPUTime(), t1)
 
+  TEST_EQUAL(s.getCPUTime() > t_wait / 2, true) // waiting costs CPU time in our implementation... just not sure how much...
+  TEST_EQUAL(s.getClockTime() > t_wait * 0.95, true) // and must consume wall time
+  TEST_EQUAL(s.getClockTime() < t_wait * 3, true) // be a bit more loose if e.g. a VM is busy
+  TEST_EQUAL(s.getUserTime() > t_wait / 2, true) //  and some user time
+  TEST_EQUAL(s.getUserTime() < t_wait * 2, true)
+  TEST_EQUAL(s.getSystemTime() < t_wait, true) // and usually quite few system time
+                                               //(not guaranteed on VMs, therefore do a trivial check)
 END_SECTION
 
 START_SECTION((double getCPUTime() const ))
-  StopWatch s;
-  s.start();
-  wait(3);
-  s.stop();
-
-  TEST_EQUAL(s.getCPUTime() > 0.1, true) // waiting costs CPU time... just not sure how much...
-  TEST_EQUAL(s.getClockTime() > 2, true) // and must consume wall time
-  TEST_EQUAL(s.getClockTime() < 10, true) // be a bit more loose if e.g. a VM is busy
-  TEST_EQUAL(s.getUserTime() > 0.1, true) //  and some user time
-  TEST_EQUAL(s.getUserTime() < 4, true)
-  TEST_EQUAL(s.getSystemTime() < 3, true) // and usually quite few system time
-  //(not guaranteed on VMs, therefore do a trivial check)
+  NOT_TESTABLE; // done above
 END_SECTION
 
 START_SECTION((double getClockTime() const ))

--- a/src/utils/FuzzyDiff.cpp
+++ b/src/utils/FuzzyDiff.cpp
@@ -141,8 +141,7 @@ protected:
           String(raw_matched_whitelist[i]) + " does not have the format String1:String2");
       }
 
-      std::pair<std::string, std::string> tmp_tuple(tmp[0], tmp[1]);
-      parsed_matched_whitelist.push_back(tmp_tuple);
+      parsed_matched_whitelist.emplace_back(tmp[0], tmp[1]);
     }
 
     fsc.setAcceptableRelative(acceptable_ratio);


### PR DESCRIPTION
## FuzzyDiff speed
comparing "large" files (6MB) using FuzzyDiff takes about 9 seconds on VS2015 Release(!), whereas its rather fast (0.3 sec) on GCC.
This PR speeds up FuzzyDiff by avoiding the  `stringstream>>double operator` which is awfully slow on VS.
Test time on Windows is now also 0.3 secs for this special case.
In general the combined time of TOPP+UTIL tests (1117 tests), many of which use FuzzyDiff, went from 55 sec to 36 sec (10 jobs parallel) on VS. GCC builds also profit, but not as much (102 sec --> 82 sec).

## reduces time for the stopwatch test 
12 sec to 0.5 sec by reducing waiting time