### PR TITLE
Storing Unicode in OpenMS::String

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/StringUtils.h
@@ -124,7 +124,7 @@ namespace OpenMS
     {
       String res;
       size_t count = 0;
-      while (count < length && *(s + count) != 0)
+      while (count < length)
       {
         res += *(s + count);
         ++count;

--- a/src/pyOpenMS/addons/ADD_TO_FIRST.pyx
+++ b/src/pyOpenMS/addons/ADD_TO_FIRST.pyx
@@ -24,12 +24,15 @@ cdef inline shared_ptr[_String] convString(argument_var):
         res = (<String>argument_var).inst
         return res
     elif isinstance(argument_var, bytes):
-        # Simple, convert directly to char*
-        res = shared_ptr[_String](new _String(<char*>argument_var))
+        # Simple, convert directly to char* - however there may be zero bytes
+        # in the array when using certain encodings, we therefore need to make
+        # sure we capture the full length.
+        res = shared_ptr[_String](new _String(<char*>argument_var, len(argument_var)))
         return res
     elif isinstance(argument_var, str) or isinstance(argument_var, unicode):
-        # First encode with UTF8 (note that toString below decodes with UTF8),
-        # then convert the result to char*
+        # First encode with UTF8 (note that output encoding as well as
+        # String.toString both decode with UTF8), then convert the result to
+        # char*
         py_byte_string = argument_var.encode('UTF-8')
         c_string_argument_var = py_byte_string
         res = shared_ptr[_String](new _String(<char*>c_string_argument_var))

--- a/src/pyOpenMS/addons/String.pyx
+++ b/src/pyOpenMS/addons/String.pyx
@@ -13,6 +13,9 @@
              raise Exception('can not handle type of %s' % (args,)) 
 
     def toString(self):
+        """Cython signature: str toString()
+        -- Note: this returns a unicode string and assumes the input is UTF8 encoded.
+        """
         # Decodes the C string to unicode
         cdef char* c_string = _cast_const_away(self.inst.get().c_str())
         cdef Py_ssize_t length = self.inst.get().length()
@@ -34,4 +37,20 @@
 
     def __repr__(self):
         return self.c_str()
+
+    def c_str(self):
+        """Cython signature: const_char * c_str()"""
+        # See https://cython.readthedocs.io/en/latest/src/tutorial/strings.html
+        #    py_string = <bytes> c_string
+        # This creates a Python byte string object that holds a copy of the
+        # original C string. It can be safely passed around in Python code, and
+        # will be garbage collected when the last reference to it goes out of
+        # scope. It is important to remember that null bytes in the string act
+        # as terminator character, as generally known from C. The above will
+        # therefore only work correctly for C strings that do not contain null
+        # bytes.
+        cdef const_char  * _r = _cast_const_away(self.inst.get().c_str())
+        cdef Py_ssize_t length = self.inst.get().length()
+        py_result = _r[:length] # This will work correctly also if the char array contains null bytes
+        return py_result
 

--- a/src/pyOpenMS/pxds/String.pxd
+++ b/src/pyOpenMS/pxds/String.pxd
@@ -19,7 +19,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/String.h>" namespace "OpenMS":
         String(char *) nogil except + # wrap-ignore
         String(char *, size_t l) nogil except + # wrap-ignore
         String(str) nogil except + # wrap-ignore
-        const_char * c_str() nogil except +
+        const_char * c_str() nogil except + # wrap-ignore
 
         # Creates a Python 2/3 unicode string (use this instead of c_str() if you
         # plan to use any non-ASCII code).

--- a/src/pyOpenMS/pxds/String.pxd
+++ b/src/pyOpenMS/pxds/String.pxd
@@ -17,6 +17,7 @@ cdef extern from "<OpenMS/DATASTRUCTURES/String.h>" namespace "OpenMS":
         String() nogil except +
         String(String) nogil except +  # wrap-ignore
         String(char *) nogil except + # wrap-ignore
+        String(char *, size_t l) nogil except + # wrap-ignore
         String(str) nogil except + # wrap-ignore
         const_char * c_str() nogil except +
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5176,3 +5176,38 @@ def testString():
     pystr2 = pyopenms.String(u"bläh")
     assert(pystr1 == pystr2)
 
+    # Handling of different Unicode Strings:
+    # - unicode is natively stored in OpenMS::String
+    # - encoded bytesequences for utf8, utf16 and iso8859 can be stored as
+    #   char arrays in OpenMS::String (and be accessed using c_str())
+    # - encoded bytesequences for anything other than utf8 cannot use
+    #   "toString()" as this function expects utf8
+    ustr = u"bläh"
+    pystr = pyopenms.String(ustr)
+    assert (pystr.toString() == u"bläh")
+    pystr = pyopenms.String(ustr.encode("utf8"))
+    assert (pystr.toString() == u"bläh")
+
+    pystr = pyopenms.String(ustr.encode("iso8859_15"))
+    assert (pystr.c_str().decode("iso8859_15") == u"bläh")
+    pystr = pyopenms.String(ustr.encode("utf16"))
+    assert (pystr.c_str().decode("utf16") == u"bläh")
+
+    # toString will throw as its not UTF8
+    pystr = pyopenms.String(ustr.encode("iso8859_15"))
+    didThrow = False
+    try:
+        pystr.toString()
+    except UnicodeDecodeError:
+        didThrow = True
+    assert didThrow
+
+    # toString will throw as its not UTF8
+    pystr = pyopenms.String(ustr.encode("utf16"))
+    didThrow = False
+    try:
+        pystr.toString()
+    except UnicodeDecodeError:
+        didThrow = True
+    assert didThrow
+

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -439,8 +439,8 @@ def testEmpiricalFormula():
     s = ef.toString()
     assert s == b"C2H5"
     m = ef.getElementalComposition()
-    assert m["C"] == 2
-    assert m["H"] == 5
+    assert m[b"C"] == 2
+    assert m[b"H"] == 5
     assert ef.getNumberOfAtoms() == 7
 
 @report
@@ -3590,9 +3590,9 @@ def testMxxxFile():
 
     myStr = pyopenms.String()
     fh.storeBuffer(myStr, mse)
-    assert len(str(myStr)) == 5269
+    assert len(myStr.toString()) == 5269
     mse2 = pyopenms.MSExperiment()
-    fh.loadBuffer(str(myStr), mse2)
+    fh.loadBuffer(bytes(myStr), mse2)
     assert mse2 == mse
     assert mse2.size() == 1
 
@@ -3692,7 +3692,7 @@ def testNumpressCoder():
     inp =  [1.0, 2.0, 3.0]
     np.encodeNP(inp, tmp, True, nc)
 
-    res = str(tmp)
+    res = tmp.toString()
     assert len(res) != 0, len(res)
     assert res != "", res
     np.decodeNP(res, out, True, nc)
@@ -3723,7 +3723,7 @@ def testNumpressConfig():
     np.numpressErrorTolerance = 4.2
     np.estimate_fixed_point = True
     np.linear_fp_mass_acc = 4.2
-    np.setCompression("linear")
+    np.setCompression(b"linear")
 
 @report
 def testBase64():
@@ -3734,7 +3734,7 @@ def testBase64():
     out = pyopenms.String()
     inp =  [1.0, 2.0, 3.0]
     b.encode(inp, b.ByteOrder.BYTEORDER_LITTLEENDIAN, out, False)
-    res = str(out)
+    res = out.toString()
     assert len(res) != 0
     assert res != ""
 

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -62,41 +62,41 @@ START_TEST(String, "$Id$")
 String* s_ptr = nullptr;
 String* s_nullPointer = nullptr;
 START_SECTION((String()))
-	s_ptr = new String;
+  s_ptr = new String;
   TEST_NOT_EQUAL(s_ptr, s_nullPointer)
 END_SECTION
 
 START_SECTION(([EXTRA] ~String()))
-	delete s_ptr;
+  delete s_ptr;
 END_SECTION
 
 START_SECTION((String(const QString &s)))
-	QString qs("bla");
-	String s(qs);
-	TEST_EQUAL(s=="bla",true)
+  QString qs("bla");
+  String s(qs);
+  TEST_EQUAL(s=="bla",true)
 END_SECTION
 
 START_SECTION((QString toQString() const))
-	QString qs("bla");
-	String s("bla");
-	TEST_EQUAL(s.toQString()==qs,true)
+  QString qs("bla");
+  String s("bla");
+  TEST_EQUAL(s.toQString()==qs,true)
 END_SECTION
 
 START_SECTION((String(const char* s, SizeType length)))
-	String s("abcdedfg",5);
-	TEST_EQUAL(s,"abcde")
+  String s("abcdedfg",5);
+  TEST_EQUAL(s,"abcde")
 
-	String s2("abcdedfg",0);
-	TEST_EQUAL(s2,"")
+  String s2("abcdedfg",0);
+  TEST_EQUAL(s2,"")
 
-	String s3("abcdedfg",8);
-	TEST_EQUAL(s3,"abcdedfg")
+  String s3("abcdedfg",8);
+  TEST_EQUAL(s3,"abcdedfg")
 
   // This function does *not* check for null bytes as these may be part of a
   // valid string! If you provide a length that is inaccurate, you are to blame
   // (we do not test this since we would cause undefined behavior).
-	// String s4("abcdedfg", 15);
-	// TEST_NOT_EQUAL(s4,"abcdedfg")
+  // String s4("abcdedfg", 15);
+  // TEST_NOT_EQUAL(s4,"abcdedfg")
 
   // Unicode test
   char test_utf8[] =  "T\xc3\xbc\x62ingen";
@@ -121,220 +121,220 @@ START_SECTION((String(const char* s, SizeType length)))
 END_SECTION
 
 START_SECTION((String(const DataValue& d)))
-	TEST_EQUAL(String(DataValue(1.4)),"1.4")
-	TEST_EQUAL(String(DataValue("bla")),"bla")
-	TEST_EQUAL(String(DataValue(4711)),"4711")
+  TEST_EQUAL(String(DataValue(1.4)),"1.4")
+  TEST_EQUAL(String(DataValue("bla")),"bla")
+  TEST_EQUAL(String(DataValue(4711)),"4711")
 END_SECTION
 
 START_SECTION((String(const std::string& s)))
-	String s(string("blablabla"));
-	TEST_EQUAL(s,"blablabla")
+  String s(string("blablabla"));
+  TEST_EQUAL(s,"blablabla")
 END_SECTION
 
 START_SECTION((String(const char* s)))
-	String s("blablabla");
-	TEST_EQUAL(s,"blablabla")
+  String s("blablabla");
+  TEST_EQUAL(s,"blablabla")
 END_SECTION
 
 START_SECTION((String(size_t len, char c)))
-	String s(17,'b');
-	TEST_EQUAL(s,"bbbbbbbbbbbbbbbbb")
+  String s(17,'b');
+  TEST_EQUAL(s,"bbbbbbbbbbbbbbbbb")
 END_SECTION
 
 START_SECTION((String(const char c)))
-	String s('v');
-	TEST_EQUAL(s,"v")
+  String s('v');
+  TEST_EQUAL(s,"v")
 END_SECTION
 
 START_SECTION((String(int i)))
-	String s(int (-17));
-	TEST_EQUAL(s,"-17")
+  String s(int (-17));
+  TEST_EQUAL(s,"-17")
 END_SECTION
 
 START_SECTION((String(unsigned int i)))
-	String s((unsigned int) (17));
-	TEST_EQUAL(s,"17")
+  String s((unsigned int) (17));
+  TEST_EQUAL(s,"17")
 END_SECTION
 
 START_SECTION((String(long int i)))
-	String s((long int)(-17));
-	TEST_EQUAL(s,"-17")
+  String s((long int)(-17));
+  TEST_EQUAL(s,"-17")
 END_SECTION
 
 START_SECTION((String(long unsigned int i)))
-	String s((long unsigned int)(17));
-	TEST_EQUAL(s,"17")
+  String s((long unsigned int)(17));
+  TEST_EQUAL(s,"17")
 END_SECTION
 
 START_SECTION((String(short int i)))
-	String s((short int)(-17));
-	TEST_EQUAL(s,"-17")
+  String s((short int)(-17));
+  TEST_EQUAL(s,"-17")
 END_SECTION
 
 START_SECTION((String(short unsigned int i)))
-	String s((short unsigned int)(17));
-	TEST_EQUAL(s,"17")
+  String s((short unsigned int)(17));
+  TEST_EQUAL(s,"17")
 END_SECTION
 
 START_SECTION((String(float f)))
-	String s(float(17.0123));
-	TEST_EQUAL(s,"17.0123")
+  String s(float(17.0123));
+  TEST_EQUAL(s,"17.0123")
 END_SECTION
 
 START_SECTION((String(double d)))
-	String s(double(17.012345));
-	TEST_EQUAL(s,"17.012345")
+  String s(double(17.012345));
+  TEST_EQUAL(s,"17.012345")
 END_SECTION
 
 START_SECTION((String(long double ld)))
-	String s(17.012345L); // suffix L indicates long double
-	TEST_EQUAL(s,"17.012345")
+  String s(17.012345L); // suffix L indicates long double
+  TEST_EQUAL(s,"17.012345")
 END_SECTION
 
 START_SECTION((String(long long unsigned int i)))
-	String s((long long unsigned int)(12345678));
-	TEST_EQUAL(s,"12345678")
+  String s((long long unsigned int)(12345678));
+  TEST_EQUAL(s,"12345678")
 END_SECTION
 
 START_SECTION((String(long long signed int i)))
-	String s((long long signed int)(-12345678));
-	TEST_EQUAL(s,"-12345678")
+  String s((long long signed int)(-12345678));
+  TEST_EQUAL(s,"-12345678")
 END_SECTION
 
 
 START_SECTION((static String numberLength(double d, UInt n)))
-	TEST_EQUAL(String::numberLength(12345678.9123,11),"12345678.91")
-	TEST_EQUAL(String::numberLength(-12345678.9123,11),"-12345678.9")
-	TEST_EQUAL(String::numberLength(12345678.9123,10),"12345678.9")
-	TEST_EQUAL(String::numberLength(-12345678.9123,10),"-1234.5e04")
-	TEST_EQUAL(String::numberLength(12345678.9123,9),"1234.5e04")
-	TEST_EQUAL(String::numberLength(-12345678.9123,9),"-123.4e05")
+  TEST_EQUAL(String::numberLength(12345678.9123,11),"12345678.91")
+  TEST_EQUAL(String::numberLength(-12345678.9123,11),"-12345678.9")
+  TEST_EQUAL(String::numberLength(12345678.9123,10),"12345678.9")
+  TEST_EQUAL(String::numberLength(-12345678.9123,10),"-1234.5e04")
+  TEST_EQUAL(String::numberLength(12345678.9123,9),"1234.5e04")
+  TEST_EQUAL(String::numberLength(-12345678.9123,9),"-123.4e05")
 END_SECTION
 
 
 START_SECTION((static String number(double d, UInt n)))
-	TEST_EQUAL(String::number(123.1234,0),"123")
-	TEST_EQUAL(String::number(123.1234,1),"123.1")
-	TEST_EQUAL(String::number(123.1234,2),"123.12")
-	TEST_EQUAL(String::number(123.1234,3),"123.123")
-	TEST_EQUAL(String::number(123.1234,4),"123.1234")
-	TEST_EQUAL(String::number(123.1234,5),"123.12340")
-	TEST_EQUAL(String::number(0.0,5),"0.00000")
+  TEST_EQUAL(String::number(123.1234,0),"123")
+  TEST_EQUAL(String::number(123.1234,1),"123.1")
+  TEST_EQUAL(String::number(123.1234,2),"123.12")
+  TEST_EQUAL(String::number(123.1234,3),"123.123")
+  TEST_EQUAL(String::number(123.1234,4),"123.1234")
+  TEST_EQUAL(String::number(123.1234,5),"123.12340")
+  TEST_EQUAL(String::number(0.0,5),"0.00000")
 END_SECTION
 
 
 START_SECTION((template<class InputIterator> String(InputIterator first, InputIterator last)))
-	String s("ABCDEFGHIJKLMNOP");
-	String::Iterator i = s.begin();
-	String::Iterator j = s.end();
-	String s2(i,j);
-	TEST_EQUAL(s,s2)
-	++i;++i;
-	--j;--j;
-	s2 = String(i,j);
-	TEST_EQUAL(s2,"CDEFGHIJKLMN")
+  String s("ABCDEFGHIJKLMNOP");
+  String::Iterator i = s.begin();
+  String::Iterator j = s.end();
+  String s2(i,j);
+  TEST_EQUAL(s,s2)
+  ++i;++i;
+  --j;--j;
+  s2 = String(i,j);
+  TEST_EQUAL(s2,"CDEFGHIJKLMN")
 
-	//test cases where the begin is equal to the end
-	i = s.begin();
-	j = s.begin();
-	s2 = String(i,j);
-	TEST_EQUAL(s2,"")
-	TEST_EQUAL(s2.size(),0U)
+  //test cases where the begin is equal to the end
+  i = s.begin();
+  j = s.begin();
+  s2 = String(i,j);
+  TEST_EQUAL(s2,"")
+  TEST_EQUAL(s2.size(),0U)
 
-	i = s.end();
-	j = s.end();
-	s2 = String(i,j);
-	TEST_EQUAL(s2,"")
-	TEST_EQUAL(s2.size(),0U)
+  i = s.end();
+  j = s.end();
+  s2 = String(i,j);
+  TEST_EQUAL(s2,"")
+  TEST_EQUAL(s2.size(),0U)
 END_SECTION
 
 String s("ACDEFGHIKLMNPQRSTVWY");
 START_SECTION((bool hasPrefix(const String& string) const))
-	TEST_EQUAL(s.hasPrefix(""), true);
-	TEST_EQUAL(s.hasPrefix("ACDEF"), true);
-	TEST_EQUAL(s.hasPrefix("ACDEFGHIKLMNPQRSTVWY"), true);
-	TEST_EQUAL(s.hasPrefix("ABCDEF"), false);
-	TEST_EQUAL(s.hasPrefix("ACDEFGHIKLMNPQRSTVWYACDEF"), false);
+  TEST_EQUAL(s.hasPrefix(""), true);
+  TEST_EQUAL(s.hasPrefix("ACDEF"), true);
+  TEST_EQUAL(s.hasPrefix("ACDEFGHIKLMNPQRSTVWY"), true);
+  TEST_EQUAL(s.hasPrefix("ABCDEF"), false);
+  TEST_EQUAL(s.hasPrefix("ACDEFGHIKLMNPQRSTVWYACDEF"), false);
 END_SECTION
 
 START_SECTION((bool hasSuffix(const String& string) const))
-	TEST_EQUAL(s.hasSuffix(""), true);
-	TEST_EQUAL(s.hasSuffix("TVWY"), true);
-	TEST_EQUAL(s.hasSuffix("ACDEFGHIKLMNPQRSTVWY"), true);
-	TEST_EQUAL(s.hasSuffix("WXYZ"), false);
-	TEST_EQUAL(s.hasSuffix("ACDEFACDEFGHIKLMNPQRSTVWY"), false);
+  TEST_EQUAL(s.hasSuffix(""), true);
+  TEST_EQUAL(s.hasSuffix("TVWY"), true);
+  TEST_EQUAL(s.hasSuffix("ACDEFGHIKLMNPQRSTVWY"), true);
+  TEST_EQUAL(s.hasSuffix("WXYZ"), false);
+  TEST_EQUAL(s.hasSuffix("ACDEFACDEFGHIKLMNPQRSTVWY"), false);
 END_SECTION
 
 START_SECTION((bool hasSubstring(const String& string) const))
-	TEST_EQUAL(s.hasSubstring(""), true);
-	TEST_EQUAL(s.hasSubstring("GHIKLM"), true);
-	TEST_EQUAL(s.hasSubstring("ACDEFGHIKLMNPQRSTVWY"), true);
-	TEST_EQUAL(s.hasSubstring("MLKIGH"), false);
-	TEST_EQUAL(s.hasSubstring("ACDEFGHIKLMNPQRSTVWYACDEF"), false);
+  TEST_EQUAL(s.hasSubstring(""), true);
+  TEST_EQUAL(s.hasSubstring("GHIKLM"), true);
+  TEST_EQUAL(s.hasSubstring("ACDEFGHIKLMNPQRSTVWY"), true);
+  TEST_EQUAL(s.hasSubstring("MLKIGH"), false);
+  TEST_EQUAL(s.hasSubstring("ACDEFGHIKLMNPQRSTVWYACDEF"), false);
 END_SECTION
 
 START_SECTION((bool has(Byte byte) const))
-	TEST_EQUAL(s.has('A'), true);
-	TEST_EQUAL(s.has('O'), false);
+  TEST_EQUAL(s.has('A'), true);
+  TEST_EQUAL(s.has('O'), false);
 END_SECTION
 
 START_SECTION((String prefix(Int length) const))
-	TEST_EQUAL(s.prefix((Int)4), "ACDE");
-	TEST_EQUAL(s.prefix((Int)0), "");
-	TEST_EXCEPTION(Exception::IndexOverflow, s.prefix(s.size()+1));
-	TEST_EXCEPTION(Exception::IndexUnderflow, s.prefix(-1));
+  TEST_EQUAL(s.prefix((Int)4), "ACDE");
+  TEST_EQUAL(s.prefix((Int)0), "");
+  TEST_EXCEPTION(Exception::IndexOverflow, s.prefix(s.size()+1));
+  TEST_EXCEPTION(Exception::IndexUnderflow, s.prefix(-1));
 END_SECTION
 
 START_SECTION((String suffix(Int length) const))
-	TEST_EQUAL(s.suffix((Int)4), "TVWY");
-	TEST_EQUAL(s.suffix((Int)0), "");
-	TEST_EXCEPTION(Exception::IndexOverflow, s.suffix(s.size()+1));
-	TEST_EXCEPTION(Exception::IndexUnderflow, s.suffix(-1));
+  TEST_EQUAL(s.suffix((Int)4), "TVWY");
+  TEST_EQUAL(s.suffix((Int)0), "");
+  TEST_EXCEPTION(Exception::IndexOverflow, s.suffix(s.size()+1));
+  TEST_EXCEPTION(Exception::IndexUnderflow, s.suffix(-1));
 END_SECTION
 
 START_SECTION((String prefix(SizeType length) const))
-	TEST_EQUAL(s.prefix((String::SizeType)4), "ACDE");
-	TEST_EQUAL(s.prefix((String::SizeType)0), "");
-	TEST_EXCEPTION(Exception::IndexOverflow, s.prefix(s.size()+1));
+  TEST_EQUAL(s.prefix((String::SizeType)4), "ACDE");
+  TEST_EQUAL(s.prefix((String::SizeType)0), "");
+  TEST_EXCEPTION(Exception::IndexOverflow, s.prefix(s.size()+1));
 END_SECTION
 
 START_SECTION((String suffix(SizeType length) const))
-	TEST_EQUAL(s.suffix((String::SizeType)4), "TVWY");
-	TEST_EQUAL(s.suffix((String::SizeType)0), "");
-	TEST_EXCEPTION(Exception::IndexOverflow, s.suffix(s.size()+1));
+  TEST_EQUAL(s.suffix((String::SizeType)4), "TVWY");
+  TEST_EQUAL(s.suffix((String::SizeType)0), "");
+  TEST_EXCEPTION(Exception::IndexOverflow, s.suffix(s.size()+1));
 END_SECTION
 
 START_SECTION((String prefix(char delim) const))
-	TEST_EQUAL(s.prefix('F'), "ACDE");
-	TEST_EQUAL(s.prefix('A'), "");
-	TEST_EXCEPTION(Exception::ElementNotFound, s.prefix('Z'));
+  TEST_EQUAL(s.prefix('F'), "ACDE");
+  TEST_EQUAL(s.prefix('A'), "");
+  TEST_EXCEPTION(Exception::ElementNotFound, s.prefix('Z'));
 END_SECTION
 
 START_SECTION((String suffix(char delim) const))
-	TEST_EQUAL(s.suffix('S'), "TVWY");
-	TEST_EQUAL(s.suffix('Y'), "");
-	TEST_EXCEPTION(Exception::ElementNotFound, s.suffix('Z'));
+  TEST_EQUAL(s.suffix('S'), "TVWY");
+  TEST_EQUAL(s.suffix('Y'), "");
+  TEST_EXCEPTION(Exception::ElementNotFound, s.suffix('Z'));
 END_SECTION
 
 START_SECTION((String substr(size_t pos=0, size_t n=npos) const))
-	String s("abcdef");
-	//std::string functionality
-	TEST_EQUAL(s.substr(0,4),"abcd");
-	TEST_EQUAL(s.substr(1,1),"b")
-	TEST_EQUAL(s.substr(1,3),"bcd")
-	TEST_EQUAL(s.substr(0,4),"abcd")
-	TEST_EQUAL(s.substr(0,6),"abcdef")
-	TEST_EQUAL(s.substr(5,1),"f")
-	TEST_EQUAL(s.substr(6,1),"")
-	TEST_EQUAL(s.substr(0,7),"abcdef")
+  String s("abcdef");
+  //std::string functionality
+  TEST_EQUAL(s.substr(0,4),"abcd");
+  TEST_EQUAL(s.substr(1,1),"b")
+  TEST_EQUAL(s.substr(1,3),"bcd")
+  TEST_EQUAL(s.substr(0,4),"abcd")
+  TEST_EQUAL(s.substr(0,6),"abcdef")
+  TEST_EQUAL(s.substr(5,1),"f")
+  TEST_EQUAL(s.substr(6,1),"")
+  TEST_EQUAL(s.substr(0,7),"abcdef")
 
-	TEST_EQUAL(s.substr(0,String::npos), "abcdef")
+  TEST_EQUAL(s.substr(0,String::npos), "abcdef")
 
-	// check with defaults
-	TEST_EQUAL(s.substr(0),"abcdef");
-	TEST_EQUAL(s.substr(1),"bcdef")
-	TEST_EQUAL(s.substr(5),"f")
-	TEST_EQUAL(s.substr(6),"")
+  // check with defaults
+  TEST_EQUAL(s.substr(0),"abcdef");
+  TEST_EQUAL(s.substr(1),"bcdef")
+  TEST_EQUAL(s.substr(5),"f")
+  TEST_EQUAL(s.substr(6),"")
 END_SECTION
 
 START_SECTION((String chop(Size n) const))
@@ -352,31 +352,31 @@ START_SECTION((String chop(Size n) const))
 END_SECTION
 
 START_SECTION((String& reverse()))
-	s.reverse();
-	TEST_EQUAL(s, "YWVTSRQPNMLKIHGFEDCA");
-	s = "";
-	s.reverse();
-	TEST_EQUAL(s, "");
+  s.reverse();
+  TEST_EQUAL(s, "YWVTSRQPNMLKIHGFEDCA");
+  s = "";
+  s.reverse();
+  TEST_EQUAL(s, "");
 END_SECTION
 
 START_SECTION((String& trim()))
-	String s("\n\r\t test \n\r\t");
-	s.trim();
-	TEST_EQUAL(s,"test");
-	s.trim();
-	TEST_EQUAL(s,"test");
-	s = "";
-	s.trim();
-	TEST_EQUAL(s,"");
-	s = " t";
-	s.trim();
-	TEST_EQUAL(s,"t");
-	s = "t ";
-	s.trim();
-	TEST_EQUAL(s,"t");
-	s = "\t\r\n ";
-	s.trim();
-	TEST_EQUAL(s,"");
+  String s("\n\r\t test \n\r\t");
+  s.trim();
+  TEST_EQUAL(s,"test");
+  s.trim();
+  TEST_EQUAL(s,"test");
+  s = "";
+  s.trim();
+  TEST_EQUAL(s,"");
+  s = " t";
+  s.trim();
+  TEST_EQUAL(s,"t");
+  s = "t ";
+  s.trim();
+  TEST_EQUAL(s,"t");
+  s = "\t\r\n ";
+  s.trim();
+  TEST_EQUAL(s,"");
 END_SECTION
 
 START_SECTION((String& quote(char q = '"', QuotingMethod method = ESCAPE)))
@@ -416,51 +416,51 @@ START_SECTION((String& unquote(char q = '"', QuotingMethod method = ESCAPE)))
 END_SECTION
 
 START_SECTION((String& simplify()))
-	String s("\n\r\t te\tst \n\r\t");
-	s.simplify();
-	TEST_EQUAL(s," te st ");
-	s.simplify();
-	TEST_EQUAL(s," te st ");
-	s = "";
-	s.simplify();
-	TEST_EQUAL(s,"");
-	s = " t";
-	s.simplify();
-	TEST_EQUAL(s," t");
-	s = "t ";
-	s.simplify();
-	TEST_EQUAL(s,"t ");
-	s = "\t\r\n ";
-	s.simplify();
-	TEST_EQUAL(s," ");
+  String s("\n\r\t te\tst \n\r\t");
+  s.simplify();
+  TEST_EQUAL(s," te st ");
+  s.simplify();
+  TEST_EQUAL(s," te st ");
+  s = "";
+  s.simplify();
+  TEST_EQUAL(s,"");
+  s = " t";
+  s.simplify();
+  TEST_EQUAL(s," t");
+  s = "t ";
+  s.simplify();
+  TEST_EQUAL(s,"t ");
+  s = "\t\r\n ";
+  s.simplify();
+  TEST_EQUAL(s," ");
 END_SECTION
 
 START_SECTION((String& fillLeft(char c, UInt size)))
-	String s("TEST");
-	s.fillLeft('x',4);
-	TEST_EQUAL(s,"TEST")
-	s.fillLeft('y',5);
-	TEST_EQUAL(s,"yTEST")
-	s.fillLeft('z',7);
-	TEST_EQUAL(s,"zzyTEST")
+  String s("TEST");
+  s.fillLeft('x',4);
+  TEST_EQUAL(s,"TEST")
+  s.fillLeft('y',5);
+  TEST_EQUAL(s,"yTEST")
+  s.fillLeft('z',7);
+  TEST_EQUAL(s,"zzyTEST")
 END_SECTION
 
 START_SECTION((String& fillRight(char c, UInt size)))
-	String s("TEST");
-	s.fillRight('x',4);
-	TEST_EQUAL(s,"TEST")
-	s.fillRight('y',5);
-	TEST_EQUAL(s,"TESTy")
-	s.fillRight('z',7);
-	TEST_EQUAL(s,"TESTyzz")
+  String s("TEST");
+  s.fillRight('x',4);
+  TEST_EQUAL(s,"TEST")
+  s.fillRight('y',5);
+  TEST_EQUAL(s,"TESTy")
+  s.fillRight('z',7);
+  TEST_EQUAL(s,"TESTyzz")
 END_SECTION
 
 START_SECTION((Int toInt() const))
-	String s;
-	s = "123";
-	TEST_EQUAL(s.toInt(),123);
-	s = "-123";
-	TEST_EQUAL(s.toInt(),-123);
+  String s;
+  s = "123";
+  TEST_EQUAL(s.toInt(),123);
+  s = "-123";
+  TEST_EQUAL(s.toInt(),-123);
   s = "  -123";
   TEST_EQUAL(s.toInt(),-123);
   s = "-123  ";
@@ -479,17 +479,17 @@ START_SECTION((Int toInt() const))
 END_SECTION
 
 START_SECTION((float toFloat() const))
-	String s;
-	s = "123.456";
-	TEST_REAL_SIMILAR(s.toFloat(),123.456);
-	s = "-123.456";
-	TEST_REAL_SIMILAR(s.toFloat(),-123.456);
-	s = "123.9";
-	TEST_REAL_SIMILAR(s.toFloat(),123.9);
-	s = "73629.9";
-	TEST_EQUAL(String(s.toFloat()),"73629.9");
-	s = "47218.8";
-	TEST_EQUAL(String(s.toFloat()),"47218.8");
+  String s;
+  s = "123.456";
+  TEST_REAL_SIMILAR(s.toFloat(),123.456);
+  s = "-123.456";
+  TEST_REAL_SIMILAR(s.toFloat(),-123.456);
+  s = "123.9";
+  TEST_REAL_SIMILAR(s.toFloat(),123.9);
+  s = "73629.9";
+  TEST_EQUAL(String(s.toFloat()),"73629.9");
+  s = "47218.8";
+  TEST_EQUAL(String(s.toFloat()),"47218.8");
   s = String("nan");
   TEST_EQUAL(boost::math::isnan(s.toFloat()),true);
   s = "NaN";
@@ -499,17 +499,17 @@ START_SECTION((float toFloat() const))
 END_SECTION
 
 START_SECTION((double toDouble() const))
-	String s;
-	s = "123.456";
-	TEST_REAL_SIMILAR(s.toDouble(),123.456);
-	s = "-123.4567890123";
-	TEST_REAL_SIMILAR(s.toDouble(),-123.4567890123);
-	s = "123.99999";
-	TEST_REAL_SIMILAR(s.toDouble(),123.99999);
-	s = "73629.980123";
-	TEST_EQUAL(String(s.toDouble()),"73629.980123");
-	s = "47218.890000001";
-	TEST_EQUAL(String(s.toDouble()),"47218.890000001");
+  String s;
+  s = "123.456";
+  TEST_REAL_SIMILAR(s.toDouble(),123.456);
+  s = "-123.4567890123";
+  TEST_REAL_SIMILAR(s.toDouble(),-123.4567890123);
+  s = "123.99999";
+  TEST_REAL_SIMILAR(s.toDouble(),123.99999);
+  s = "73629.980123";
+  TEST_EQUAL(String(s.toDouble()),"73629.980123");
+  s = "47218.890000001";
+  TEST_EQUAL(String(s.toDouble()),"47218.890000001");
   s = "nan";
   TEST_EQUAL(boost::math::isnan(s.toDouble()),true);
   s = "NaN";
@@ -519,98 +519,98 @@ START_SECTION((double toDouble() const))
 END_SECTION
 
 START_SECTION((static String random(UInt length)))
-	String s;
-	String s2 = s.random(10);
-	TEST_EQUAL(s2.size(),10);
+  String s;
+  String s2 = s.random(10);
+  TEST_EQUAL(s2.size(),10);
 END_SECTION
 
 START_SECTION((bool split(const char splitter, std::vector<String>& substrings, bool quote_protect=false) const))
-	String s(";1;2;3;4;5;");
-	vector<String> split;
-	bool result = s.split(';',split);
-	TEST_EQUAL(result,true);
-	TEST_EQUAL(split.size(),7);
-	TEST_EQUAL(split[0],String(""));
-	TEST_EQUAL(split[1],String("1"));
-	TEST_EQUAL(split[2],String("2"));
-	TEST_EQUAL(split[3],String("3"));
-	TEST_EQUAL(split[4],String("4"));
-	TEST_EQUAL(split[5],String("5"));
-	TEST_EQUAL(split[6],String(""));
+  String s(";1;2;3;4;5;");
+  vector<String> split;
+  bool result = s.split(';',split);
+  TEST_EQUAL(result,true);
+  TEST_EQUAL(split.size(),7);
+  TEST_EQUAL(split[0],String(""));
+  TEST_EQUAL(split[1],String("1"));
+  TEST_EQUAL(split[2],String("2"));
+  TEST_EQUAL(split[3],String("3"));
+  TEST_EQUAL(split[4],String("4"));
+  TEST_EQUAL(split[5],String("5"));
+  TEST_EQUAL(split[6],String(""));
 
 
-	s = "1;2;3;4;5";
-	result = s.split(';', split);
-	TEST_EQUAL(result,true);
-	TEST_EQUAL(split.size(),5);
-	TEST_EQUAL(split[0],String("1"));
-	TEST_EQUAL(split[1],String("2"));
-	TEST_EQUAL(split[2],String("3"));
-	TEST_EQUAL(split[3],String("4"));
-	TEST_EQUAL(split[4],String("5"));
+  s = "1;2;3;4;5";
+  result = s.split(';', split);
+  TEST_EQUAL(result,true);
+  TEST_EQUAL(split.size(),5);
+  TEST_EQUAL(split[0],String("1"));
+  TEST_EQUAL(split[1],String("2"));
+  TEST_EQUAL(split[2],String("3"));
+  TEST_EQUAL(split[3],String("4"));
+  TEST_EQUAL(split[4],String("5"));
 
   s = "";
   result = s.split(',', split);
   TEST_EQUAL(result, false);
   TEST_EQUAL(split.size(), 0);
 
-	s = ";";
-	result = s.split(';', split);
-	TEST_EQUAL(result,true);
-	TEST_EQUAL(split.size(),2);
-	TEST_EQUAL(split[0],"");
-	TEST_EQUAL(split[1],"");
+  s = ";";
+  result = s.split(';', split);
+  TEST_EQUAL(result,true);
+  TEST_EQUAL(split.size(),2);
+  TEST_EQUAL(split[0],"");
+  TEST_EQUAL(split[1],"");
 
-	result = s.split(',', split);
-	TEST_EQUAL(result,false);
-	TEST_EQUAL(split.size(),1);
+  result = s.split(',', split);
+  TEST_EQUAL(result,false);
+  TEST_EQUAL(split.size(),1);
 
-	s = "nodelim";
-	result = s.split(';', split);
-	TEST_EQUAL(result,false);
-	TEST_EQUAL(split.size(),1);
+  s = "nodelim";
+  result = s.split(';', split);
+  TEST_EQUAL(result,false);
+  TEST_EQUAL(split.size(),1);
 
-	// testing quoting behaviour
-	s=" \"hello\", world, 23.3";
-	result = s.split(',', split, true);
-	TEST_EQUAL(result,true);
-	TEST_EQUAL(split.size(),3);
-	TEST_EQUAL(split[0],"hello");
-	TEST_EQUAL(split[1],"world");
-	TEST_EQUAL(split[2],"23.3");
+  // testing quoting behaviour
+  s=" \"hello\", world, 23.3";
+  result = s.split(',', split, true);
+  TEST_EQUAL(result,true);
+  TEST_EQUAL(split.size(),3);
+  TEST_EQUAL(split[0],"hello");
+  TEST_EQUAL(split[1],"world");
+  TEST_EQUAL(split[2],"23.3");
 
-	s=" \"hello\", \" donot,splitthis \", \"23.4 \" ";
-	result = s.split(',', split, true);
-	TEST_EQUAL(result,true);
-	TEST_EQUAL(split.size(),3);
-	TEST_EQUAL(split[0],"hello");
-	TEST_EQUAL(split[1]," donot,splitthis ");
-	TEST_EQUAL(split[2],"23.4 ");
+  s=" \"hello\", \" donot,splitthis \", \"23.4 \" ";
+  result = s.split(',', split, true);
+  TEST_EQUAL(result,true);
+  TEST_EQUAL(split.size(),3);
+  TEST_EQUAL(split[0],"hello");
+  TEST_EQUAL(split[1]," donot,splitthis ");
+  TEST_EQUAL(split[2],"23.4 ");
 
-	s=" \"hello\", \" donot,splitthis \", \"23.5 \" ";
-	result = s.split(',', split, true);
-	TEST_EQUAL(result,true);
-	TEST_EQUAL(split.size(),3);
-	TEST_EQUAL(split[0],"hello");
-	TEST_EQUAL(split[1]," donot,splitthis ");
-	TEST_EQUAL(split[2],"23.5 ");
+  s=" \"hello\", \" donot,splitthis \", \"23.5 \" ";
+  result = s.split(',', split, true);
+  TEST_EQUAL(result,true);
+  TEST_EQUAL(split.size(),3);
+  TEST_EQUAL(split[0],"hello");
+  TEST_EQUAL(split[1]," donot,splitthis ");
+  TEST_EQUAL(split[2],"23.5 ");
 
-	s=" \"hello\", \" donot,splitthis \", \"23.6 \" ";
-	result = s.split(',', split, true);
-	TEST_EQUAL(result,true);
-	TEST_EQUAL(split.size(),3);
-	TEST_EQUAL(split[0],"hello");
-	TEST_EQUAL(split[1]," donot,splitthis ");
-	TEST_EQUAL(split[2],"23.6 ");
+  s=" \"hello\", \" donot,splitthis \", \"23.6 \" ";
+  result = s.split(',', split, true);
+  TEST_EQUAL(result,true);
+  TEST_EQUAL(split.size(),3);
+  TEST_EQUAL(split[0],"hello");
+  TEST_EQUAL(split[1]," donot,splitthis ");
+  TEST_EQUAL(split[2],"23.6 ");
 
-	s = " \"nodelim \"";
-	result = s.split(';', split, true);
-	TEST_EQUAL(result,false);
-	TEST_EQUAL(split.size(),1);
+  s = " \"nodelim \"";
+  result = s.split(';', split, true);
+  TEST_EQUAL(result,false);
+  TEST_EQUAL(split.size(),1);
 
-	// testing invalid quoting...
-	s = " \"first\", \"seconds\"<thisshouldnotbehere>, third";
-	TEST_EXCEPTION(Exception::ConversionError, s.split(',', split, true));
+  // testing invalid quoting...
+  s = " \"first\", \"seconds\"<thisshouldnotbehere>, third";
+  TEST_EXCEPTION(Exception::ConversionError, s.split(',', split, true));
 END_SECTION
 
 START_SECTION((bool split(const String& splitter, std::vector<String>& substrings) const))
@@ -649,7 +649,7 @@ TEST_EQUAL(result, false);
 TEST_EQUAL(substrings.size(), 0);
 END_SECTION
 
-START_SECTION((bool split_quoted(const String& splitter,	std::vector<String>& substrings, char q = '"', QuotingMethod method = ESCAPE) const))
+START_SECTION((bool split_quoted(const String& splitter,  std::vector<String>& substrings, char q = '"', QuotingMethod method = ESCAPE) const))
 String s = "abcdebcfghbc";
 vector<String> substrings;
 bool result = s.split_quoted("bc", substrings);
@@ -684,7 +684,7 @@ TEST_EQUAL(substrings[2], "\"\"");
 
 s = "\"a,\"b\"";
 TEST_EXCEPTION(Exception::ConversionError, s.split_quoted(",", substrings, '"',
-																													String::ESCAPE));
+                                                          String::ESCAPE));
 s = "\"ab\"___\"cd\"\"ef\"";
 result = s.split_quoted("___", substrings, '"', String::DOUBLE);
 TEST_EQUAL(result, true);
@@ -694,212 +694,212 @@ TEST_EQUAL(substrings[1], "\"cd\"\"ef\"");
 END_SECTION
 
 START_SECTION((template<class StringIterator> void concatenate(StringIterator first, StringIterator last, const String& glue = "")))
-	vector<String> split;
-	String("1;2;3;4;5").split(';',split);
-	String s;
-	s.concatenate(split.begin(),split.end(),"g");
-	TEST_EQUAL(s,"1g2g3g4g5");
+  vector<String> split;
+  String("1;2;3;4;5").split(';',split);
+  String s;
+  s.concatenate(split.begin(),split.end(),"g");
+  TEST_EQUAL(s,"1g2g3g4g5");
 
-	String("1;2;3;4;5").split(';',split);
-	s.concatenate(split.begin(),split.end());
-	TEST_EQUAL(s,"12345");
+  String("1;2;3;4;5").split(';',split);
+  s.concatenate(split.begin(),split.end());
+  TEST_EQUAL(s,"12345");
 
-	String("").split(';',split);
-	s.concatenate(split.begin(),split.end());
-	TEST_EQUAL(s,"");
+  String("").split(';',split);
+  s.concatenate(split.begin(),split.end());
+  TEST_EQUAL(s,"");
 
-	s.concatenate(split.begin(),split.end(),"_");
-	TEST_EQUAL(s,"");
+  s.concatenate(split.begin(),split.end(),"_");
+  TEST_EQUAL(s,"");
 END_SECTION
 
 START_SECTION((String& toUpper()))
-	String s;
-	s = "test45%#.,";
-	s.toUpper();
-	TEST_EQUAL(s,"TEST45%#.,");
-	s = "";
-	s.toUpper();
-	TEST_EQUAL(s,"");
+  String s;
+  s = "test45%#.,";
+  s.toUpper();
+  TEST_EQUAL(s,"TEST45%#.,");
+  s = "";
+  s.toUpper();
+  TEST_EQUAL(s,"");
 END_SECTION
 
 START_SECTION((String& toLower()))
-	String s;
-	s = "TEST45%#.,";
-	s.toLower();
-	TEST_EQUAL(s,"test45%#.,");
-	s = "";
-	s.toLower();
-	TEST_EQUAL(s,"");
+  String s;
+  s = "TEST45%#.,";
+  s.toLower();
+  TEST_EQUAL(s,"test45%#.,");
+  s = "";
+  s.toLower();
+  TEST_EQUAL(s,"");
 END_SECTION
 
 START_SECTION((String& firstToUpper()))
-	String s;
-	s = "test45%#.,";
-	s.firstToUpper();
-	TEST_EQUAL(s,"Test45%#.,");
-	s = " ";
-	s.firstToUpper();
-	TEST_EQUAL(s," ");
-	s = "";
-	s.firstToUpper();
-	TEST_EQUAL(s,"");
+  String s;
+  s = "test45%#.,";
+  s.firstToUpper();
+  TEST_EQUAL(s,"Test45%#.,");
+  s = " ";
+  s.firstToUpper();
+  TEST_EQUAL(s," ");
+  s = "";
+  s.firstToUpper();
+  TEST_EQUAL(s,"");
 END_SECTION
 
 START_SECTION((String& substitute(char from, char to)))
-	String s = "abcdefg";
+  String s = "abcdefg";
 
-	s.substitute('a','x');
-	TEST_EQUAL(s,"xbcdefg")
+  s.substitute('a','x');
+  TEST_EQUAL(s,"xbcdefg")
 
-	s.substitute('g','y');
-	TEST_EQUAL(s,"xbcdefy")
+  s.substitute('g','y');
+  TEST_EQUAL(s,"xbcdefy")
 
-	s.substitute('c','-');
-	TEST_EQUAL(s,"xb-defy")
+  s.substitute('c','-');
+  TEST_EQUAL(s,"xb-defy")
 
-	s = ".....";
-	s.substitute('.',',');
-	TEST_EQUAL(s,",,,,,")
+  s = ".....";
+  s.substitute('.',',');
+  TEST_EQUAL(s,",,,,,")
 
-	s = ".....";
-	s.substitute(',','.');
-	TEST_EQUAL(s,".....")
+  s = ".....";
+  s.substitute(',','.');
+  TEST_EQUAL(s,".....")
 END_SECTION
 
 START_SECTION((String& substitute(const String& from, const String& to)))
-	//single occurence
-	String s = "abcdefg";
+  //single occurence
+  String s = "abcdefg";
 
-	s.substitute("a","x");
-	TEST_EQUAL(s,"xbcdefg")
+  s.substitute("a","x");
+  TEST_EQUAL(s,"xbcdefg")
 
-	s.substitute("bcd","y");
-	TEST_EQUAL(s,"xyefg")
+  s.substitute("bcd","y");
+  TEST_EQUAL(s,"xyefg")
 
-	s.substitute("fg","");
-	TEST_EQUAL(s,"xye")
+  s.substitute("fg","");
+  TEST_EQUAL(s,"xye")
 
-	s.substitute("e","z!");
-	TEST_EQUAL(s,"xyz!")
+  s.substitute("e","z!");
+  TEST_EQUAL(s,"xyz!")
 
-	s.substitute("u","blblblblbl");
-	TEST_EQUAL(s,"xyz!")
+  s.substitute("u","blblblblbl");
+  TEST_EQUAL(s,"xyz!")
 
-	s.substitute("","blblblblbl");
-	TEST_EQUAL(s,"xyz!")
+  s.substitute("","blblblblbl");
+  TEST_EQUAL(s,"xyz!")
 
-	//mutiple occurences
-	s = "abcdefgabcdefgabcdefgab";
-	s.substitute("ab","x");
-	TEST_EQUAL(s,"xcdefgxcdefgxcdefgx")
+  //mutiple occurences
+  s = "abcdefgabcdefgabcdefgab";
+  s.substitute("ab","x");
+  TEST_EQUAL(s,"xcdefgxcdefgxcdefgx")
 
-	s.substitute("x","");
-	TEST_EQUAL(s,"cdefgcdefgcdefg")
+  s.substitute("x","");
+  TEST_EQUAL(s,"cdefgcdefgcdefg")
 END_SECTION
 
 START_SECTION((String& remove(char what)))
-	String s = "abcabc";
+  String s = "abcabc";
 
-	s.remove('a');
-	TEST_EQUAL(s, "bcbc");
+  s.remove('a');
+  TEST_EQUAL(s, "bcbc");
 
-	s.remove('c');
-	TEST_EQUAL(s, "bb");
+  s.remove('c');
+  TEST_EQUAL(s, "bb");
 
-	s.remove('b');
-	TEST_EQUAL(s, "");
+  s.remove('b');
+  TEST_EQUAL(s, "");
 END_SECTION
 
 START_SECTION((String& ensureLastChar(char end)))
-	String s = "/";
-	s.ensureLastChar('/');
-	TEST_EQUAL(s, "/")
+  String s = "/";
+  s.ensureLastChar('/');
+  TEST_EQUAL(s, "/")
 
-	s.ensureLastChar('\\');
-	TEST_EQUAL(s, "/\\")
+  s.ensureLastChar('\\');
+  TEST_EQUAL(s, "/\\")
 
-	s.ensureLastChar('\\');
-	TEST_EQUAL(s, "/\\")
+  s.ensureLastChar('\\');
+  TEST_EQUAL(s, "/\\")
 
-	s.ensureLastChar('/');
-	TEST_EQUAL(s, "/\\/")
+  s.ensureLastChar('/');
+  TEST_EQUAL(s, "/\\/")
 END_SECTION
 
 START_SECTION((String& removeWhitespaces()))
-	String s;
+  String s;
 
-	s.removeWhitespaces();
-	TEST_EQUAL(s,"");
+  s.removeWhitespaces();
+  TEST_EQUAL(s,"");
   
   s = " \t \n ";
   s.removeWhitespaces();
   TEST_EQUAL(s, "");
 
-	s = "test";
-	s.removeWhitespaces();
-	TEST_EQUAL(s,"test");
+  s = "test";
+  s.removeWhitespaces();
+  TEST_EQUAL(s,"test");
 
-	s = "\n\r\t test \n\r\t";
-	s.removeWhitespaces();
-	TEST_EQUAL(s,"test");
+  s = "\n\r\t test \n\r\t";
+  s.removeWhitespaces();
+  TEST_EQUAL(s,"test");
 
-	s = "\n\r\t t\ne \ts\rt \n\r\t";
-	s.removeWhitespaces();
-	TEST_EQUAL(s,"test");
+  s = "\n\r\t t\ne \ts\rt \n\r\t";
+  s.removeWhitespaces();
+  TEST_EQUAL(s,"test");
 END_SECTION
 
 const String fixed("test");
 
 START_SECTION((String operator+ (int i) const))
-	TEST_EQUAL(fixed + (int)(4), "test4")
+  TEST_EQUAL(fixed + (int)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (unsigned int i) const))
-	TEST_EQUAL(fixed + (unsigned int)(4), "test4")
+  TEST_EQUAL(fixed + (unsigned int)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (short int i) const))
-	TEST_EQUAL(fixed + (short int)(4), "test4")
+  TEST_EQUAL(fixed + (short int)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (short unsigned int i) const))
-	TEST_EQUAL(fixed + (short unsigned int)(4), "test4")
+  TEST_EQUAL(fixed + (short unsigned int)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (long int i) const))
-	TEST_EQUAL(fixed + (long int)(4), "test4")
+  TEST_EQUAL(fixed + (long int)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (long unsigned int i) const))
-	TEST_EQUAL(fixed + (long unsigned int)(4), "test4")
+  TEST_EQUAL(fixed + (long unsigned int)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (long long unsigned int i) const))
-	TEST_EQUAL(fixed + (long long unsigned int)(4), "test4")
+  TEST_EQUAL(fixed + (long long unsigned int)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (float f) const))
-	TEST_EQUAL(fixed + (float)(4), "test4")
+  TEST_EQUAL(fixed + (float)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (double d) const))
-	TEST_EQUAL(fixed + (double)(4), "test4")
+  TEST_EQUAL(fixed + (double)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+(long double ld) const ))
-	TEST_EQUAL(fixed + (long double)(4), "test4")
+  TEST_EQUAL(fixed + (long double)(4), "test4")
 END_SECTION
 
 START_SECTION((String operator+ (char c) const))
-	TEST_EQUAL(fixed + '4', "test4")
+  TEST_EQUAL(fixed + '4', "test4")
 END_SECTION
 
 START_SECTION((String operator+ (const char* s) const))
-	TEST_EQUAL(fixed + "bla4", "testbla4")
+  TEST_EQUAL(fixed + "bla4", "testbla4")
 END_SECTION
 
 START_SECTION((String operator+ (const String& s) const))
-	TEST_EQUAL(fixed + String("bla4"), "testbla4")
+  TEST_EQUAL(fixed + String("bla4"), "testbla4")
 END_SECTION
 
 START_SECTION((String operator+ (const std::string& s) const))
@@ -908,139 +908,139 @@ END_SECTION
 
 
 START_SECTION((String& operator+= (int i)))
-	String s = "test";
-	s += (int)(7);
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += (int)(7);
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (unsigned int i)))
-	String s = "test";
-	s += (unsigned int)(7);
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += (unsigned int)(7);
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (short int i)))
-	String s = "test";
-	s += (short int)(7);
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += (short int)(7);
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (short unsigned int i)))
-	String s = "test";
-	s += (short unsigned int)(7);
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += (short unsigned int)(7);
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (long int i)))
-	String s = "test";
-	s += (long int)(7);
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += (long int)(7);
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (long unsigned int i)))
-	String s = "test";
-	s += (long unsigned int)(7);
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += (long unsigned int)(7);
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (long long unsigned int i)))
-	String s = "test";
-	s += (long long unsigned int)(7);
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += (long long unsigned int)(7);
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (float f)))
-	String s = "test";
-	s += (float)(7.4);
-	TEST_EQUAL(s, "test7.4")
+  String s = "test";
+  s += (float)(7.4);
+  TEST_EQUAL(s, "test7.4")
 END_SECTION
 
 START_SECTION((String& operator+= (double d)))
-	String s = "test";
-	s += (double)(7.4);
-	TEST_EQUAL(s, "test7.4")
+  String s = "test";
+  s += (double)(7.4);
+  TEST_EQUAL(s, "test7.4")
 END_SECTION
 
 START_SECTION((String& operator+= (long double d)))
 {
-	/*
-	NOTE (by Clemens): Windows platforms do not really support long double.  See
-	<CONCEPT/Types.h>.  I am leaving this code here because it will help to
-	clarify how to set writtenDigits on new platforms.
-	*/
+  /*
+  NOTE (by Clemens): Windows platforms do not really support long double.  See
+  <CONCEPT/Types.h>.  I am leaving this code here because it will help to
+  clarify how to set writtenDigits on new platforms.
+  */
 #if 0
 #define ECHO_AND_DO(bla) STATUS(""#bla); bla
 #define ECHO_AND_VALUE(bla) STATUS(""#bla << ": " << bla);
   typedef long double longdouble;
 
-	ECHO_AND_VALUE(sizeof(double));
-	ECHO_AND_VALUE(std::numeric_limits<double>::digits);
-	ECHO_AND_VALUE(std::numeric_limits<double>::digits10);
-	ECHO_AND_VALUE(writtenDigits<double>(0.0));
+  ECHO_AND_VALUE(sizeof(double));
+  ECHO_AND_VALUE(std::numeric_limits<double>::digits);
+  ECHO_AND_VALUE(std::numeric_limits<double>::digits10);
+  ECHO_AND_VALUE(writtenDigits<double>(0.0));
 
-	ECHO_AND_DO(std::cout.precision(std::numeric_limits<double>::digits10));
-	ECHO_AND_VALUE(typeAsString(7.4) << ": " << 7.4);
-	ECHO_AND_VALUE(typeAsString(7.4L) << ": " << 7.4L);
+  ECHO_AND_DO(std::cout.precision(std::numeric_limits<double>::digits10));
+  ECHO_AND_VALUE(typeAsString(7.4) << ": " << 7.4);
+  ECHO_AND_VALUE(typeAsString(7.4L) << ": " << 7.4L);
 
-	ECHO_AND_DO(std::cout.precision( writtenDigits<>(double()) ));
-	ECHO_AND_VALUE(typeAsString(7.4) << ": " << 7.4);
-	ECHO_AND_VALUE(typeAsString(7.4L) << ": " << 7.4L);
+  ECHO_AND_DO(std::cout.precision( writtenDigits<>(double()) ));
+  ECHO_AND_VALUE(typeAsString(7.4) << ": " << 7.4);
+  ECHO_AND_VALUE(typeAsString(7.4L) << ": " << 7.4L);
 
-	ECHO_AND_VALUE(sizeof(long double));
-	ECHO_AND_VALUE(std::numeric_limits<long double>::digits);
-	ECHO_AND_VALUE(std::numeric_limits<long double>::digits10);
-	ECHO_AND_VALUE( writtenDigits<>( longdouble() ) );
+  ECHO_AND_VALUE(sizeof(long double));
+  ECHO_AND_VALUE(std::numeric_limits<long double>::digits);
+  ECHO_AND_VALUE(std::numeric_limits<long double>::digits10);
+  ECHO_AND_VALUE( writtenDigits<>( longdouble() ) );
 
-	ECHO_AND_DO(std::cout.precision(std::numeric_limits<long double>::digits10));
-	STATUS(typeAsString(7.4) << ": " << 7.4);
-	STATUS(typeAsString(7.4L) << ": " << 7.4L);
+  ECHO_AND_DO(std::cout.precision(std::numeric_limits<long double>::digits10));
+  STATUS(typeAsString(7.4) << ": " << 7.4);
+  STATUS(typeAsString(7.4L) << ": " << 7.4L);
 
-	ECHO_AND_DO(std::cout.precision(writtenDigits<>( longdouble() )));
-	STATUS(typeAsString(7.4) << ": " << 7.4);
-	STATUS(typeAsString(7.4L) << ": " << 7.4L);
+  ECHO_AND_DO(std::cout.precision(writtenDigits<>( longdouble() )));
+  STATUS(typeAsString(7.4) << ": " << 7.4);
+  STATUS(typeAsString(7.4L) << ": " << 7.4L);
 
-	const UInt save_prec  = std::cout.precision();
-	for ( UInt prec = 10; prec <= 30; ++prec)
-	{
-		std::cout.precision(prec);
-		STATUS("prec: " << prec << "   7.4: " << 7.4 << "   7.4L: " << 7.4L);
-	}
-	std::cout.precision(save_prec);
+  const UInt save_prec  = std::cout.precision();
+  for ( UInt prec = 10; prec <= 30; ++prec)
+  {
+    std::cout.precision(prec);
+    STATUS("prec: " << prec << "   7.4: " << 7.4 << "   7.4L: " << 7.4L);
+  }
+  std::cout.precision(save_prec);
 
 #undef ECHO_AND_DO
 #undef ECHO_AND_VALUE
 #endif /* End of funny stuff by Clemens */
 
-	String s = "test";
-	// long double x = 7.4; // implictly double (not long double!)  =>  7.40000000000000036
-	long double x = 7.4L; // explictly long double  =>  7.4
-	s += x;
-	TEST_EQUAL(s, "test7.4");
+  String s = "test";
+  // long double x = 7.4; // implictly double (not long double!)  =>  7.40000000000000036
+  long double x = 7.4L; // explictly long double  =>  7.4
+  s += x;
+  TEST_EQUAL(s, "test7.4");
 }
 END_SECTION
 
 START_SECTION((String& operator+= (char c)))
-	String s = "test";
-	s += 'x';
-	TEST_EQUAL(s, "testx")
+  String s = "test";
+  s += 'x';
+  TEST_EQUAL(s, "testx")
 END_SECTION
 
 START_SECTION((String& operator+= (const char* s)))
-	String s = "test";
-	s += 7;
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += 7;
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (const String& s)))
-	String s = "test";
-	s += String("7");
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += String("7");
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 START_SECTION((String& operator+= (const std::string& s)))
-	String s = "test";
-	s += std::string("7");
-	TEST_EQUAL(s, "test7")
+  String s = "test";
+  s += std::string("7");
+  TEST_EQUAL(s, "test7")
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -92,8 +92,32 @@ START_SECTION((String(const char* s, SizeType length)))
 	String s3("abcdedfg",8);
 	TEST_EQUAL(s3,"abcdedfg")
 
-	String s4("abcdedfg",15);
-	TEST_EQUAL(s4,"abcdedfg")
+  // This function does *not* check for null bytes as these may be part of a
+  // valid string! If you provide a length that is inaccurate, you are to blame
+  // (we do not test this since we would cause undefined behavior).
+	// String s4("abcdedfg", 15);
+	// TEST_NOT_EQUAL(s4,"abcdedfg")
+
+  // Unicode test
+  char test_utf8[] =  "T\xc3\xbc\x62ingen";
+  char test_utf16[] = "\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00";
+  char test_iso8859[] = "T\xfc\x62ingen";
+
+  String s_utf8(test_utf8, 9);
+  String s_utf16(test_utf16, 18);
+  String s_iso8859(test_iso8859, 8);
+
+  TEST_EQUAL(s_utf16.size(), 18);
+  TEST_EQUAL(s_utf8.size(), 9);
+  TEST_EQUAL(s_iso8859.size(), 8);
+
+  TEST_EQUAL(s_iso8859[0], 'T')
+  TEST_EQUAL(s_iso8859[1], '\xfc') // single byte for u
+  TEST_EQUAL(s_iso8859[2], 'b')
+  TEST_EQUAL(s_utf8[0], 'T')
+  TEST_EQUAL(s_utf8[1], '\xc3')
+  TEST_EQUAL(s_utf8[2], '\xbc') // two bytes for u
+  TEST_EQUAL(s_utf8[3], 'b')
 END_SECTION
 
 START_SECTION((String(const DataValue& d)))

--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -99,6 +99,9 @@ START_SECTION((String(const char* s, SizeType length)))
   // TEST_NOT_EQUAL(s4,"abcdedfg")
 
   // Unicode test
+  // print(b"T\xc3\xbc\x62ingen".decode("utf8"))
+  // print(b"\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00".decode("utf16"))
+  // print(b"T\xfc\x62ingen".decode("iso8859"))
   char test_utf8[] =  "T\xc3\xbc\x62ingen";
   char test_utf16[] = "\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00";
   char test_iso8859[] = "T\xfc\x62ingen";
@@ -118,6 +121,12 @@ START_SECTION((String(const char* s, SizeType length)))
   TEST_EQUAL(s_utf8[1], '\xc3')
   TEST_EQUAL(s_utf8[2], '\xbc') // two bytes for u
   TEST_EQUAL(s_utf8[3], 'b')
+
+  // Its very easy to produce nonsense with unicode (e.g. chop string in half
+  // in the middle of a character)
+  String nonsense(test_utf8, 2);
+  TEST_EQUAL(nonsense.size(), 2);
+  TEST_EQUAL(nonsense[1], '\xc3')
 END_SECTION
 
 START_SECTION((String(const DataValue& d)))
@@ -129,6 +138,34 @@ END_SECTION
 START_SECTION((String(const std::string& s)))
   String s(string("blablabla"));
   TEST_EQUAL(s,"blablabla")
+
+  // Unicode test
+  // print(b"T\xc3\xbc\x62ingen".decode("utf8"))
+  // print(b"\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00".decode("utf16"))
+  // print(b"T\xfc\x62ingen".decode("iso8859"))
+  char test_utf8[] =  "T\xc3\xbc\x62ingen";
+  char test_utf16[] = "\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00";
+  char test_iso8859[] = "T\xfc\x62ingen";
+
+  std::string std_s_utf8(test_utf8, 9);
+  std::string std_s_utf16(test_utf16, 18);
+  std::string std_s_iso8859(test_iso8859, 8);
+
+  String s_utf8(std_s_utf8);
+  String s_utf16(std_s_utf16);
+  String s_iso8859(std_s_iso8859);
+
+  TEST_EQUAL(s_utf16.size(), 18);
+  TEST_EQUAL(s_utf8.size(), 9);
+  TEST_EQUAL(s_iso8859.size(), 8);
+
+  TEST_EQUAL(s_iso8859[0], 'T')
+  TEST_EQUAL(s_iso8859[1], '\xfc') // single byte for u
+  TEST_EQUAL(s_iso8859[2], 'b')
+  TEST_EQUAL(s_utf8[0], 'T')
+  TEST_EQUAL(s_utf8[1], '\xc3')
+  TEST_EQUAL(s_utf8[2], '\xbc') // two bytes for u
+  TEST_EQUAL(s_utf8[3], 'b')
 END_SECTION
 
 START_SECTION((String(const char* s)))
@@ -246,6 +283,42 @@ START_SECTION((template<class InputIterator> String(InputIterator first, InputIt
   s2 = String(i,j);
   TEST_EQUAL(s2,"")
   TEST_EQUAL(s2.size(),0U)
+
+
+  // Unicode test
+  // print(b"T\xc3\xbc\x62ingen".decode("utf8"))
+  // print(b"\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00".decode("utf16"))
+  // print(b"T\xfc\x62ingen".decode("iso8859"))
+  char test_utf8[] =  "T\xc3\xbc\x62ingen";
+  char test_utf16[] = "\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00";
+  char test_iso8859[] = "T\xfc\x62ingen";
+
+  std::string std_s_utf8(test_utf8, 9);
+  std::string std_s_utf16(test_utf16, 18);
+  std::string std_s_iso8859(test_iso8859, 8);
+
+  String s_utf8(std_s_utf8.begin(), std_s_utf8.end());
+  String s_utf16(std_s_utf16.begin(), std_s_utf16.end());
+  String s_iso8859(std_s_iso8859.begin(), std_s_iso8859.end());
+
+  TEST_EQUAL(s_utf16.size(), 18);
+  TEST_EQUAL(s_utf8.size(), 9);
+  TEST_EQUAL(s_iso8859.size(), 8);
+
+  TEST_EQUAL(s_iso8859[0], 'T')
+  TEST_EQUAL(s_iso8859[1], '\xfc') // single byte for u
+  TEST_EQUAL(s_iso8859[2], 'b')
+  TEST_EQUAL(s_utf8[0], 'T')
+  TEST_EQUAL(s_utf8[1], '\xc3')
+  TEST_EQUAL(s_utf8[2], '\xbc') // two bytes for u
+  TEST_EQUAL(s_utf8[3], 'b')
+
+  // Its very easy to produce nonsense with unicode (e.g. chop string in half
+  // in the middle of a character)
+  String nonsense(std_s_utf8.begin(), std_s_utf8.begin() + 2);
+  TEST_EQUAL(nonsense.size(), 2);
+  TEST_EQUAL(nonsense[1], '\xc3')
+
 END_SECTION
 
 String s("ACDEFGHIKLMNPQRSTVWY");


### PR DESCRIPTION

- Allow generation of unicode strings from a `char*` which was not possible before as the conversion would abort at zero bytes, thus truncating data
- Adds tests for the new behavior
- Add pyOpenMS wrappers that utilize the new behavior

This basically makes the two constructors

```
String(const char* s, size_type count)
std::string(const char* s, size_type count)
```

behave the same way as before the `std::string` would not stop at zero bytes while the `OpenMS::String` would. Quite a bit of surprising behaviour there! See

https://en.cppreference.com/w/cpp/string/basic_string/basic_string

"Constructs the string with the first count characters of character string pointed to by s. s can contain null characters. The length of the string is count. The behavior is undefined if [s, s + count) is not a valid range."

Allows the following:

```
  // Unicode test
  char test_utf8[] =  "T\xc3\xbc\x62ingen";
  char test_utf16[] = "\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00";
  char test_iso8859[] = "T\xfc\x62ingen";

  String s_utf8(test_utf8, 9);
  String s_utf16(test_utf16, 18);
  String s_iso8859(test_iso8859, 8);

  TEST_EQUAL(s_utf16.size(), 18);
  TEST_EQUAL(s_utf8.size(), 9);
  TEST_EQUAL(s_iso8859.size(), 8);
```