### PR TITLE
[FIX] CometAdapter terminal modification 

### DIFF
--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -473,8 +473,10 @@ protected:
     {
       for (vector<ResidueModification>::const_iterator it = fixed_modifications.begin(); it != fixed_modifications.end(); ++it)
       {
-        String AA = it->getOrigin();
-        if ((AA!="N-term") && (AA!="C-term"))
+        // check whether amino acid or terminal modification
+        String AA = it->getOrigin(); // X (constructor) or amino acid (e.g. K)
+        String term_specificity = it->getTermSpecificityName(); // N-term, C-term, none
+        if ((AA != "X") && (term_specificity == "none"))
         {
           const Residue* r = ResidueDB::getInstance()->getResidue(AA);
           String name = r->getName();
@@ -482,7 +484,7 @@ protected:
         }
         else
         {
-          os << "add_" << AA.erase(1,1) << "_peptide = " << it->getDiffMonoMass() << endl;
+          os << "add_" << term_specificity.erase(1,1) << "_peptide = " << it->getDiffMonoMass() << endl;
         }
       }
     }


### PR DESCRIPTION
It seems that the terminal modification was not detected properly which lead to the error

> Warning - invalid parameter found: add_X_unspecified/unknown.  Parameter will be ignored 

and in the end, lead to a failure of CometAdapter.

Example:
```
Value of string option 'fixed_modifications': TMT6plex (K)
Value of string option 'fixed_modifications': TMT6plex (N-term)
```
diff param_before.txt param_after.txt
```
< add_X_unspecified/unknown = 229.163
---
> add_Nterm_peptide = 229.163
```

probably related to #3861 

Further I am not sure if we should write more explicite to set the "clear_mz_range" parameter when using isobaric tags (with the corresponding ranges)- please see: http://comet-ms.sourceforge.net/notes/20171005_isotopiclabeling.php
