### PR TITLE
[FEATURE] OpenPepXL: more efficient memory usage

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
@@ -71,8 +71,8 @@ namespace OpenMS
        */
       struct ProteinProteinCrossLink
       {
-        const AASequence *alpha; // longer peptide
-        const AASequence *beta; // shorter peptide (empty for mono-link), tie bracker: mass then lexicographical
+        const AASequence *alpha = nullptr; // longer peptide
+        const AASequence *beta = nullptr; // shorter peptide (empty for mono-link), tie bracker: mass then lexicographical
         std::pair<SignedSize, SignedSize> cross_link_position; // index in alpha, beta or between alpha, alpha in loop-links
         double cross_linker_mass = 0;
         String cross_linker_name;
@@ -82,7 +82,7 @@ namespace OpenMS
 
         ProteinProteinCrossLinkType getType() const
         {
-          if ( beta && !beta->empty() ) return CROSS;
+          if (beta && !beta->empty()) return CROSS;
 
           if (cross_link_position.second == -1) return MONO;
 

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h
@@ -71,8 +71,8 @@ namespace OpenMS
        */
       struct ProteinProteinCrossLink
       {
-        AASequence alpha; // longer peptide
-        AASequence beta; // shorter peptide (empty for mono-link), tie bracker: mass then lexicographical
+        const AASequence *alpha; // longer peptide
+        const AASequence *beta; // shorter peptide (empty for mono-link), tie bracker: mass then lexicographical
         std::pair<SignedSize, SignedSize> cross_link_position; // index in alpha, beta or between alpha, alpha in loop-links
         double cross_linker_mass = 0;
         String cross_linker_name;
@@ -82,7 +82,7 @@ namespace OpenMS
 
         ProteinProteinCrossLinkType getType() const
         {
-          if (!beta.empty()) return CROSS;
+          if ( beta && !beta->empty() ) return CROSS;
 
           if (cross_link_position.second == -1) return MONO;
 

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
@@ -224,7 +224,7 @@ namespace OpenMS
        * @param cross_link_residue2 A list of one-letter-code residues, that the second side of the cross-linker can attach to
        * @param cross_link_name The name of the cross-linker, e.g. "DSS" or "BS3"
        */
-      static std::vector <OPXLDataStructs::ProteinProteinCrossLink> collectPrecursorCandidates(IntList precursor_correction_steps, double precursor_mass, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm, std::vector<OPXLDataStructs::AASeqWithMass> filtered_peptide_masses, double cross_link_mass, DoubleList cross_link_mass_mono_link, StringList cross_link_residue1, StringList cross_link_residue2, String cross_link_name);
+      static std::vector <OPXLDataStructs::ProteinProteinCrossLink> collectPrecursorCandidates(const IntList& precursor_correction_steps, double precursor_mass, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm, const std::vector<OPXLDataStructs::AASeqWithMass>& filtered_peptide_masses, double cross_link_mass, DoubleList cross_link_mass_mono_link, StringList cross_link_residue1, StringList cross_link_residue2, String cross_link_name);
 
       /**
        * @brief Computes the mass error of a precursor mass to a hit

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -47,7 +47,7 @@ using namespace std;
 namespace OpenMS
 {
   // Enumerate all pairs of peptides from the searched database and calculate their masses (inlcuding mono-links and loop-links)
-  vector<OPXLDataStructs::XLPrecursor> OPXLHelper::enumerateCrossLinksAndMasses(const vector<OPXLDataStructs::AASeqWithMass>&  peptides, double cross_link_mass, const DoubleList& cross_link_mass_mono_link, const StringList& cross_link_residue1, const StringList& cross_link_residue2, const vector< double >& spectrum_precursors, vector< int >& precursor_correction_positions, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm)
+  vector<OPXLDataStructs::XLPrecursor> OPXLHelper::enumerateCrossLinksAndMasses(const vector<OPXLDataStructs::AASeqWithMass>& peptides, double cross_link_mass, const DoubleList& cross_link_mass_mono_link, const StringList& cross_link_residue1, const StringList& cross_link_residue2, const vector< double >& spectrum_precursors, vector< int >& precursor_correction_positions, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm)
   {
     // initialize empty vector for the results
     vector<OPXLDataStructs::XLPrecursor> mass_to_candidates;
@@ -377,24 +377,25 @@ namespace OpenMS
       OPXLDataStructs::XLPrecursor candidate = candidates[i];
       vector <SignedSize> link_pos_first;
       vector <SignedSize> link_pos_second;
-      AASequence peptide_first = peptide_masses[candidate.alpha_index].peptide_seq;
+      const AASequence* peptide_first = &(peptide_masses[candidate.alpha_index].peptide_seq);
       OPXLDataStructs::PeptidePosition peptide_pos_first = peptide_masses[candidate.alpha_index].position;
-      AASequence peptide_second;
+      const AASequence* peptide_second = nullptr;
       OPXLDataStructs::PeptidePosition peptide_pos_second = OPXLDataStructs::INTERNAL;
       if (candidate.beta_index < peptide_masses.size())
       {
-        peptide_second = peptide_masses[candidate.beta_index].peptide_seq;
+        peptide_second = &(peptide_masses[candidate.beta_index].peptide_seq);
         peptide_pos_second = peptide_masses[candidate.beta_index].position;
       }
-      String seq_first = peptide_first.toUnmodifiedString();
-      String seq_second =  peptide_second.toUnmodifiedString();
+      String seq_first = peptide_first->toUnmodifiedString();
+      String seq_second;
+      if (peptide_second) { seq_second = peptide_second->toUnmodifiedString(); }
 
       // mono-links and loop-links with different masses can be generated for the same precursor mass, but only one of them can be valid each time.
       // Find out which is the case. But it should not happen often enough to slow down the tool significantly.
       bool is_loop = false;
       for (Size f = 0; f < allowed_error_vector.size(); ++f)
       {
-        if (abs(spectrum_precursor_vector[f] - (peptide_first.getMonoWeight() + cross_link_mass)) <= allowed_error_vector[f])
+        if (abs(spectrum_precursor_vector[f] - (peptide_first->getMonoWeight() + cross_link_mass)) <= allowed_error_vector[f])
         {
           is_loop = true;
         }
@@ -443,7 +444,7 @@ namespace OpenMS
       {
         alpha_first = false;
       }
-      else if (seq_second.size() == seq_first.size() && peptide_second.getMonoWeight() > peptide_first.getMonoWeight())
+      else if ( (seq_second.size() == seq_first.size()) && peptide_second && (peptide_second->getMonoWeight() > peptide_first->getMonoWeight()) )
       {
         alpha_first = false;
       }
@@ -492,7 +493,7 @@ namespace OpenMS
             {
               // only use the correct mono-links (at this point we know it is a mono-link, but not which one)
               bool is_correct_monolink = false;
-              if (abs(spectrum_precursor_vector[precursor_correction_positions[i]] - (peptide_first.getMonoWeight() + cross_link_mass_mono_link[k])) <= allowed_error_vector[precursor_correction_positions[i]])
+              if (abs(spectrum_precursor_vector[precursor_correction_positions[i]] - (peptide_first->getMonoWeight() + cross_link_mass_mono_link[k])) <= allowed_error_vector[precursor_correction_positions[i]])
               {
                 is_correct_monolink = true;
               }
@@ -516,10 +517,10 @@ namespace OpenMS
         {
           compatible = true;
         }
-        if (c_term_linker && (peptide_pos_second == OPXLDataStructs::C_TERM))
+        if (c_term_linker && (peptide_pos_second == OPXLDataStructs::C_TERM) && peptide_second)
         {
           second_spec = ResidueModification::C_TERM;
-          mod_pos = peptide_second.size()-1;
+          mod_pos = peptide_second->size() - 1;
           compatible = true;
         }
         if (compatible)
@@ -568,7 +569,7 @@ namespace OpenMS
         if (c_term_linker && (peptide_pos_first == OPXLDataStructs::C_TERM))
         {
           first_spec = ResidueModification::C_TERM;
-          mod_pos = peptide_first.size()-1;
+          mod_pos = peptide_first->size() - 1;
           compatible = true;
         }
         if (compatible)
@@ -608,7 +609,7 @@ namespace OpenMS
               {
                 // only use the correct mono-links (at this point we know it is a mono-link, but not which one)
                 bool is_correct_monolink = false;
-                if (abs(spectrum_precursor_vector[precursor_correction_positions[i]] - (peptide_first.getMonoWeight() + cross_link_mass_mono_link[k])) <= allowed_error_vector[precursor_correction_positions[i]])
+                if (abs(spectrum_precursor_vector[precursor_correction_positions[i]] - (peptide_first->getMonoWeight() + cross_link_mass_mono_link[k])) <= allowed_error_vector[precursor_correction_positions[i]])
                 {
                   is_correct_monolink = true;
                 }
@@ -671,7 +672,7 @@ namespace OpenMS
 
       PeptideHit ph_alpha, ph_beta;
       // Set monolink as a modification or add MetaValue for cross-link identity and mass
-      AASequence seq_alpha = top_csms_spectrum[i].cross_link.alpha;
+      AASequence seq_alpha = *top_csms_spectrum[i].cross_link.alpha;
       ResidueModification::TermSpecificity alpha_term_spec = top_csms_spectrum[i].cross_link.term_spec_alpha;
       if (top_csms_spectrum[i].cross_link.getType() == OPXLDataStructs::MONO)
       {
@@ -871,12 +872,12 @@ namespace OpenMS
 
       if (top_csms_spectrum[i].cross_link.getType() == OPXLDataStructs::CROSS)
       {
-        ph_beta.setSequence(top_csms_spectrum[i].cross_link.beta);
+        ph_beta.setSequence(*top_csms_spectrum[i].cross_link.beta);
         ph_beta.setCharge(precursor_charge);
         ph_beta.setScore(top_csms_spectrum[i].score);
         ph_beta.setRank(DataValue(i+1));
-        ph_alpha.setMetaValue("beta_sequence", top_csms_spectrum[i].cross_link.beta.toString());
-        ph_beta.setMetaValue("beta_sequence", top_csms_spectrum[i].cross_link.beta.toString());
+        ph_alpha.setMetaValue("beta_sequence", (*top_csms_spectrum[i].cross_link.beta).toString());
+        ph_beta.setMetaValue("beta_sequence", (*top_csms_spectrum[i].cross_link.beta).toString());
         ph_beta.setMetaValue("xl_chain", "MS:1002510"); // receiver
         ph_beta.setMetaValue("xl_pos", DataValue(alpha_pos));
         ph_beta.setMetaValue("xl_pos2", DataValue(beta_pos));
@@ -1098,7 +1099,7 @@ namespace OpenMS
     return new_peptide_ids;
   }
 
-  std::vector <OPXLDataStructs::ProteinProteinCrossLink> OPXLHelper::collectPrecursorCandidates(IntList precursor_correction_steps, double precursor_mass, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm, vector<OPXLDataStructs::AASeqWithMass> filtered_peptide_masses, double cross_link_mass, DoubleList cross_link_mass_mono_link, StringList cross_link_residue1, StringList cross_link_residue2, String cross_link_name)
+  std::vector <OPXLDataStructs::ProteinProteinCrossLink> OPXLHelper::collectPrecursorCandidates(const IntList& precursor_correction_steps, double precursor_mass, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm, const vector<OPXLDataStructs::AASeqWithMass>& filtered_peptide_masses, double cross_link_mass, DoubleList cross_link_mass_mono_link, StringList cross_link_residue1, StringList cross_link_residue2, String cross_link_name)
   {
     // determine candidates
     std::vector< OPXLDataStructs::XLPrecursor > candidates;
@@ -1141,10 +1142,10 @@ namespace OpenMS
   double OPXLHelper::computePrecursorError(OPXLDataStructs::CrossLinkSpectrumMatch csm, double precursor_mz, int precursor_charge)
   {
     // Error calculation
-    double weight = csm.cross_link.alpha.getMonoWeight();
+    double weight = csm.cross_link.alpha->getMonoWeight();
     if (csm.cross_link.getType() == OPXLDataStructs::CROSS)
     {
-      weight += csm.cross_link.beta.getMonoWeight() + csm.cross_link.cross_linker_mass;
+      weight += csm.cross_link.beta->getMonoWeight() + csm.cross_link.cross_linker_mass;
     }
     else
     {

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -380,7 +380,7 @@ namespace OpenMS
 #ifdef _OPENMP
 #pragma omp parallel for schedule(guided)
 #endif
-    for (Size i = 0; i < candidates.size(); ++i)
+    for (SignedSize i = 0; i < static_cast<SignedSize>(candidates.size()); ++i)
     {
       OPXLDataStructs::XLPrecursor candidate = candidates[i];
       vector <SignedSize> link_pos_first;

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -429,9 +429,9 @@ using namespace OpenMS;
     progresslogger.startProgress(0, 1, "Matching to theoretical spectra and scoring...");
     Size spectrum_counter = 0;
 
-#ifdef _OPENMP
-#pragma omp parallel for schedule(guided)
-#endif
+// #ifdef _OPENMP
+// #pragma omp parallel for schedule(guided)
+// #endif
     for (SignedSize pair_index = 0; pair_index < static_cast<SignedSize>(spectrum_pairs.size()); ++pair_index)
     {
       Size scan_index = spectrum_pairs[pair_index].first;
@@ -476,6 +476,10 @@ using namespace OpenMS;
       vector< OPXLDataStructs::CrossLinkSpectrumMatch > all_csms_spectrum;
 
       vector< OPXLDataStructs::CrossLinkSpectrumMatch > mainscore_csms_spectrum;
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(guided)
+#endif
       for (Size i = 0; i != cross_link_candidates.size(); ++i)
       {
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = cross_link_candidates[i];
@@ -596,6 +600,7 @@ using namespace OpenMS;
         csm.match_odds_beta = match_odds_beta;
         csm.precursor_error_ppm = rel_error;
 
+#pragma omp critical (mainscore_csms_spectrum_access)
         mainscore_csms_spectrum.push_back(csm);
       }
       // progresslogger.endProgress();

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -492,10 +492,15 @@ using namespace OpenMS;
         {
           link_pos_B = cross_link_candidate.cross_link_position.second;
         }
-        specGen_mainscore.getLinearIonSpectrum(theoretical_spec_linear_alpha, cross_link_candidate.alpha, cross_link_candidate.cross_link_position.first, 2, link_pos_B);
+        AASequence alpha;
+        AASequence beta;
+        if (cross_link_candidate.alpha) { alpha = *cross_link_candidate.alpha; }
+        if (cross_link_candidate.beta) { beta = *cross_link_candidate.beta; }
+
+        specGen_mainscore.getLinearIonSpectrum(theoretical_spec_linear_alpha, alpha, cross_link_candidate.cross_link_position.first, 2, link_pos_B);
         if (type_is_cross_link)
         {
-          specGen_mainscore.getLinearIonSpectrum(theoretical_spec_linear_beta, cross_link_candidate.beta, cross_link_candidate.cross_link_position.second, 2);
+          specGen_mainscore.getLinearIonSpectrum(theoretical_spec_linear_beta, beta, cross_link_candidate.cross_link_position.second, 2);
         }
 
         // Something like this can happen, e.g. with a loop link connecting the first and last residue of a peptide
@@ -534,7 +539,7 @@ using namespace OpenMS;
         else
         {
           // Function for mono-links or loop-links
-          specGen_mainscore.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, cross_link_candidate.alpha, cross_link_candidate.cross_link_position.first, precursor_mass, 2, precursor_charge, link_pos_B);
+          specGen_mainscore.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, alpha, cross_link_candidate.cross_link_position.first, precursor_mass, 2, precursor_charge, link_pos_B);
         }
         if (theoretical_spec_xlinks_alpha.size() < 1)
         {
@@ -602,12 +607,16 @@ using namespace OpenMS;
       for (Size i = 0; i < last_candidate_index ; ++i)
       {
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = mainscore_csms_spectrum[i].cross_link;
+        AASequence alpha;
+        AASequence beta;
+        if (cross_link_candidate.alpha) { alpha = *cross_link_candidate.alpha; }
+        if (cross_link_candidate.beta) { beta = *cross_link_candidate.beta; }
 
 #ifdef DEBUG_OPENPEPXLALGO
-        double candidate_mz = (cross_link_candidate.alpha.getMonoWeight() + cross_link_candidate.beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
+        double candidate_mz = (alpha.getMonoWeight() + beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
 #pragma omp critical (LOG_DEBUG_access)
         {
-          LOG_DEBUG << "Pair: " << cross_link_candidate.alpha.toString() << "-" << cross_link_candidate.beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index_heavy
+          LOG_DEBUG << "Pair: " << alpha.toString() << "-" << beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index_heavy
               << " with m/z: " << precursor_mz << "\t" << "and candidate m/z: " << candidate_mz << "\tK Positions: " << cross_link_candidate.cross_link_position.first << "\t" << cross_link_candidate.cross_link_position.second << endl;
         }
 #endif
@@ -628,17 +637,17 @@ using namespace OpenMS;
           link_pos_B = cross_link_candidate.cross_link_position.second;
         }
 
-        specGen.getLinearIonSpectrum(theoretical_spec_linear_alpha, cross_link_candidate.alpha, cross_link_candidate.cross_link_position.first, true, 2, link_pos_B);
+        specGen.getLinearIonSpectrum(theoretical_spec_linear_alpha, alpha, cross_link_candidate.cross_link_position.first, true, 2, link_pos_B);
         if (type_is_cross_link)
         {
-          specGen.getLinearIonSpectrum(theoretical_spec_linear_beta, cross_link_candidate.beta, cross_link_candidate.cross_link_position.second, false, 2);
+          specGen.getLinearIonSpectrum(theoretical_spec_linear_beta, beta, cross_link_candidate.cross_link_position.second, false, 2);
           specGen.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, cross_link_candidate, true, 1, precursor_charge);
           specGen.getXLinkIonSpectrum(theoretical_spec_xlinks_beta, cross_link_candidate, false, 1, precursor_charge);
         }
         else
         {
           // Function for mono-links or loop-links
-          specGen.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, cross_link_candidate.alpha, cross_link_candidate.cross_link_position.first, precursor_mass, true, 2, precursor_charge, link_pos_B);
+          specGen.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, alpha, cross_link_candidate.cross_link_position.first, precursor_mass, true, 2, precursor_charge, link_pos_B);
         }
 
         vector< pair< Size, Size > > matched_spec_linear_alpha;
@@ -759,8 +768,8 @@ using namespace OpenMS;
           }
 
           // compute wTIC
-          double wTIC = XQuestScores::weightedTICScore(cross_link_candidate.alpha.size(), cross_link_candidate.beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
-          double wTICold = XQuestScores::weightedTICScoreXQuest(cross_link_candidate.alpha.size(), cross_link_candidate.beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
+          double wTIC = XQuestScores::weightedTICScore(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
+          double wTICold = XQuestScores::weightedTICScoreXQuest(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
 
           // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2
           Size n_xlink_charges = (precursor_charge - 1) - 2;

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -480,7 +480,7 @@ using namespace OpenMS;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(guided)
 #endif
-      for (Size i = 0; i != cross_link_candidates.size(); ++i)
+      for (SignedSize i = 0; i < static_cast<SignedSize>(cross_link_candidates.size()); ++i)
       {
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = cross_link_candidates[i];
 

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
@@ -392,9 +392,9 @@ using namespace OpenMS;
     LOG_DEBUG << "Spectra left after preprocessing and filtering: " << spectra.size() << " of " << unprocessed_spectra.size() << endl;
 #endif
 
-#ifdef _OPENMP
-#pragma omp parallel for schedule(guided)
-#endif
+// #ifdef _OPENMP
+// #pragma omp parallel for schedule(guided)
+// #endif
     for (SignedSize scan_index = 0; scan_index < static_cast<SignedSize>(spectra.size()); ++scan_index)
     {
       const PeakSpectrum& spectrum = spectra[scan_index];
@@ -424,6 +424,10 @@ using namespace OpenMS;
       vector< OPXLDataStructs::CrossLinkSpectrumMatch > all_csms_spectrum;
 
       vector< OPXLDataStructs::CrossLinkSpectrumMatch > mainscore_csms_spectrum;
+
+#ifdef _OPENMP
+#pragma omp parallel for schedule(guided)
+#endif
       for (Size i = 0; i < cross_link_candidates.size(); ++i)
       {
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = cross_link_candidates[i];
@@ -535,7 +539,9 @@ using namespace OpenMS;
         csm.match_odds_beta = match_odds_beta;
         csm.precursor_error_ppm = rel_error;
 
+#pragma omp critical (mainscore_csms_spectrum_access)
         mainscore_csms_spectrum.push_back(csm);
+
       }
       std::sort(mainscore_csms_spectrum.rbegin(), mainscore_csms_spectrum.rend(), OPXLDataStructs::CLSMScoreComparator());
 

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
@@ -404,7 +404,7 @@ using namespace OpenMS;
       const double precursor_mass = (precursor_mz * static_cast<double>(precursor_charge)) - (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U);
 
       vector< OPXLDataStructs::CrossLinkSpectrumMatch > top_csms_spectrum;
-      vector <OPXLDataStructs::ProteinProteinCrossLink> cross_link_candidates = OPXLHelper::collectPrecursorCandidates(precursor_correction_steps_, precursor_mass, precursor_mass_tolerance_, precursor_mass_tolerance_unit_ppm_, filtered_peptide_masses, cross_link_mass_, cross_link_mass_mono_link_, cross_link_residue1_, cross_link_residue2_, cross_link_name_);
+      vector< OPXLDataStructs::ProteinProteinCrossLink > cross_link_candidates = OPXLHelper::collectPrecursorCandidates(precursor_correction_steps_, precursor_mass, precursor_mass_tolerance_, precursor_mass_tolerance_unit_ppm_, filtered_peptide_masses, cross_link_mass_, cross_link_mass_mono_link_, cross_link_residue1_, cross_link_residue2_, cross_link_name_);
 
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
@@ -440,10 +440,15 @@ using namespace OpenMS;
         {
           link_pos_B = cross_link_candidate.cross_link_position.second;
         }
-        specGen_mainscore.getLinearIonSpectrum(theoretical_spec_linear_alpha, cross_link_candidate.alpha, cross_link_candidate.cross_link_position.first, 2, link_pos_B);
+        AASequence alpha;
+        AASequence beta;
+        if (cross_link_candidate.alpha) { alpha = *cross_link_candidate.alpha; }
+        if (cross_link_candidate.beta) { beta = *cross_link_candidate.beta; }
+
+        specGen_mainscore.getLinearIonSpectrum(theoretical_spec_linear_alpha, alpha, cross_link_candidate.cross_link_position.first, 2, link_pos_B);
         if (type_is_cross_link)
         {
-          specGen_mainscore.getLinearIonSpectrum(theoretical_spec_linear_beta, cross_link_candidate.beta, cross_link_candidate.cross_link_position.second, 2);
+          specGen_mainscore.getLinearIonSpectrum(theoretical_spec_linear_beta, beta, cross_link_candidate.cross_link_position.second, 2);
         }
 
         // Something like this can happen, e.g. with a loop link connecting the first and last residue of a peptide
@@ -480,7 +485,7 @@ using namespace OpenMS;
         else
         {
           // Function for mono-links or loop-links
-          specGen_mainscore.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, cross_link_candidate.alpha, cross_link_candidate.cross_link_position.first, precursor_mass, 2, precursor_charge, link_pos_B);
+          specGen_mainscore.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, alpha, cross_link_candidate.cross_link_position.first, precursor_mass, 2, precursor_charge, link_pos_B);
         }
         if (theoretical_spec_xlinks_alpha.size() < 1)
         {
@@ -540,12 +545,16 @@ using namespace OpenMS;
       for (Size i = 0; i < last_candidate_index ; ++i)
       {
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = mainscore_csms_spectrum[i].cross_link;
+        AASequence alpha;
+        AASequence beta;
+        if (cross_link_candidate.alpha) { alpha = *cross_link_candidate.alpha; }
+        if (cross_link_candidate.beta) { beta = *cross_link_candidate.beta; }
 
 #ifdef DEBUG_OPENPEPXLLFALGO
-        double candidate_mz = (cross_link_candidate.alpha.getMonoWeight() + cross_link_candidate.beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
+        double candidate_mz = (alpha.getMonoWeight() + beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass + (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
 #pragma omp critical (LOG_DEBUG_access)
         {
-          LOG_DEBUG << "Pair: " << cross_link_candidate.alpha.toString() << "-" << cross_link_candidate.beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index
+          LOG_DEBUG << "Pair: " << alpha.toString() << "-" << beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index
             << " with m/z: " << precursor_mz << "\t" << "and candidate m/z: " << candidate_mz << "\tK Positions: " << cross_link_candidate.cross_link_position.first << "\t" << cross_link_candidate.cross_link_position.second << endl;
         }
 #endif
@@ -563,17 +572,17 @@ using namespace OpenMS;
         {
           link_pos_B = cross_link_candidate.cross_link_position.second;
         }
-        specGen_full.getLinearIonSpectrum(theoretical_spec_linear_alpha, cross_link_candidate.alpha, cross_link_candidate.cross_link_position.first, true, 2, link_pos_B);
+        specGen_full.getLinearIonSpectrum(theoretical_spec_linear_alpha, alpha, cross_link_candidate.cross_link_position.first, true, 2, link_pos_B);
         if (type_is_cross_link)
         {
-          specGen_full.getLinearIonSpectrum(theoretical_spec_linear_beta, cross_link_candidate.beta, cross_link_candidate.cross_link_position.second, false, 2);
+          specGen_full.getLinearIonSpectrum(theoretical_spec_linear_beta, beta, cross_link_candidate.cross_link_position.second, false, 2);
           specGen_full.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, cross_link_candidate, true, 1, precursor_charge);
           specGen_full.getXLinkIonSpectrum(theoretical_spec_xlinks_beta, cross_link_candidate, false, 1, precursor_charge);
         }
         else
         {
           // Function for mono-links or loop-links
-          specGen_full.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, cross_link_candidate.alpha, cross_link_candidate.cross_link_position.first, precursor_mass, true, 2, precursor_charge, link_pos_B);
+          specGen_full.getXLinkIonSpectrum(theoretical_spec_xlinks_alpha, alpha, cross_link_candidate.cross_link_position.first, precursor_mass, true, 2, precursor_charge, link_pos_B);
         }
 
         // Something like this can happen, e.g. with a loop link connecting the first and last residue of a peptide
@@ -673,8 +682,8 @@ using namespace OpenMS;
 #endif
 
         // compute weighted TIC
-        double wTIC = XQuestScores::weightedTICScore(cross_link_candidate.alpha.size(), cross_link_candidate.beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
-        double wTICold = XQuestScores::weightedTICScoreXQuest(cross_link_candidate.alpha.size(), cross_link_candidate.beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
+        double wTIC = XQuestScores::weightedTICScore(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
+        double wTICold = XQuestScores::weightedTICScoreXQuest(alpha.size(), beta.size(), intsum_alpha, intsum_beta, total_current, type_is_cross_link);
 
         // maximal xlink ion charge = (Precursor charge - 1), minimal xlink ion charge: 2
         Size n_xlink_charges = (precursor_charge - 1) - 2;

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
@@ -428,7 +428,7 @@ using namespace OpenMS;
 #ifdef _OPENMP
 #pragma omp parallel for schedule(guided)
 #endif
-      for (Size i = 0; i < cross_link_candidates.size(); ++i)
+      for (SignedSize i = 0; i < static_cast<SignedSize>(cross_link_candidates.size()); ++i)
       {
         OPXLDataStructs::ProteinProteinCrossLink cross_link_candidate = cross_link_candidates[i];
 

--- a/src/openms/source/CHEMISTRY/SimpleTSGXLMS.cpp
+++ b/src/openms/source/CHEMISTRY/SimpleTSGXLMS.cpp
@@ -544,19 +544,27 @@ namespace OpenMS
     std::vector< LossIndex > backward_losses;
     LossIndex losses_peptide2;
 
+    if (!crosslink.alpha)
+    {
+      return;
+    }
+    AASequence alpha = *crosslink.alpha;
+    AASequence beta;
+    if (crosslink.beta) { beta = *crosslink.beta; }
+
     if (add_losses_)
     {
       if (frag_alpha)
       {
-        losses_peptide2 = getBackwardLosses_(crosslink.beta)[0];
-        forward_losses = getForwardLosses_(crosslink.alpha);
-        backward_losses = getBackwardLosses_(crosslink.alpha);
+        losses_peptide2 = getBackwardLosses_(beta)[0];
+        forward_losses = getForwardLosses_(alpha);
+        backward_losses = getBackwardLosses_(alpha);
       }
       else
       {
-        losses_peptide2 = getBackwardLosses_(crosslink.alpha)[0];
-        forward_losses = getForwardLosses_(crosslink.beta);
-        backward_losses = getBackwardLosses_(crosslink.beta);
+        losses_peptide2 = getBackwardLosses_(alpha)[0];
+        forward_losses = getForwardLosses_(beta);
+        backward_losses = getBackwardLosses_(beta);
       }
     }
 
@@ -588,21 +596,21 @@ namespace OpenMS
       }
       if (add_k_linked_ions_)
       {
-        double precursor_mass = crosslink.alpha.getMonoWeight() + crosslink.cross_linker_mass;
-        if (!crosslink.beta.empty())
+        double precursor_mass = alpha.getMonoWeight() + crosslink.cross_linker_mass;
+        if (!beta.empty())
         {
-          precursor_mass += crosslink.beta.getMonoWeight();
+          precursor_mass += beta.getMonoWeight();
         }
         AASequence peptide;
         Size link_pos;
         if (frag_alpha)
         {
-          peptide = crosslink.alpha;
+          peptide = alpha;
           link_pos = crosslink.cross_link_position.first;
         }
         else
         {
-          peptide = crosslink.beta;
+          peptide = beta;
           link_pos = crosslink.cross_link_position.second;
         }
         addKLinkedIonPeaks_(spectrum, peptide, link_pos, precursor_mass, z);
@@ -611,10 +619,10 @@ namespace OpenMS
 
     if (add_precursor_peaks_)
     {
-      double precursor_mass = crosslink.alpha.getMonoWeight() + crosslink.cross_linker_mass;
-      if (!crosslink.beta.empty())
+      double precursor_mass = alpha.getMonoWeight() + crosslink.cross_linker_mass;
+      if (!beta.empty())
       {
-        precursor_mass += crosslink.beta.getMonoWeight();
+        precursor_mass += beta.getMonoWeight();
       }
       addPrecursorPeaks_(spectrum, precursor_mass, maxcharge);
     }
@@ -625,17 +633,21 @@ namespace OpenMS
 
   void SimpleTSGXLMS::addXLinkIonPeaks_(std::vector< SimplePeak >& spectrum, OPXLDataStructs::ProteinProteinCrossLink& crosslink, bool frag_alpha, Residue::ResidueType res_type, std::vector< LossIndex >& forward_losses, std::vector< LossIndex >& backward_losses, LossIndex& losses_peptide2, int charge) const
   {
-    if (crosslink.alpha.empty())
+    if (!crosslink.alpha || crosslink.alpha->empty())
     {
       cout << "Warning: Attempt at creating XLink Ions Spectrum from empty string!" << endl;
       return;
     }
 
-    double precursor_mass = crosslink.alpha.getMonoWeight() + crosslink.cross_linker_mass;
+    AASequence alpha = *crosslink.alpha;
+    AASequence beta;
+    if (crosslink.beta) { beta = *crosslink.beta; }
 
-    if (!crosslink.beta.empty())
+    double precursor_mass = alpha.getMonoWeight() + crosslink.cross_linker_mass;
+
+    if (!beta.empty())
     {
-      precursor_mass += crosslink.beta.getMonoWeight();
+      precursor_mass += beta.getMonoWeight();
     }
 
     AASequence peptide;
@@ -643,14 +655,14 @@ namespace OpenMS
     Size link_pos;
     if (frag_alpha)
     {
-      peptide = crosslink.alpha;
-      peptide2 = crosslink.beta;
+      peptide = alpha;
+      peptide2 = beta;
       link_pos = crosslink.cross_link_position.first;
     }
     else
     {
-      peptide = crosslink.beta;
-      peptide2 = crosslink.alpha;
+      peptide = beta;
+      peptide2 = alpha;
       link_pos = crosslink.cross_link_position.second;
     }
 

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGeneratorXLMS.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGeneratorXLMS.cpp
@@ -875,19 +875,27 @@ namespace OpenMS
     std::vector< LossIndex > backward_losses;
     LossIndex losses_peptide2;
 
+    if (!crosslink.alpha)
+    {
+      return;
+    }
+    AASequence alpha = *crosslink.alpha;
+    AASequence beta;
+    if (crosslink.beta) { beta = *crosslink.beta; }
+
     if (add_losses_)
     {
       if (frag_alpha)
       {
-        losses_peptide2 = getBackwardLosses_(crosslink.beta)[0];
-        forward_losses = getForwardLosses_(crosslink.alpha);
-        backward_losses = getBackwardLosses_(crosslink.alpha);
+        losses_peptide2 = getBackwardLosses_(beta)[0];
+        forward_losses = getForwardLosses_(alpha);
+        backward_losses = getBackwardLosses_(alpha);
       }
       else
       {
-        losses_peptide2 = getBackwardLosses_(crosslink.alpha)[0];
-        forward_losses = getForwardLosses_(crosslink.beta);
-        backward_losses = getBackwardLosses_(crosslink.beta);
+        losses_peptide2 = getBackwardLosses_(alpha)[0];
+        forward_losses = getForwardLosses_(beta);
+        backward_losses = getBackwardLosses_(beta);
       }
     }
 
@@ -919,21 +927,21 @@ namespace OpenMS
       }
       if (add_k_linked_ions_)
       {
-        double precursor_mass = crosslink.alpha.getMonoWeight() + crosslink.cross_linker_mass;
-        if (!crosslink.beta.empty())
+        double precursor_mass = alpha.getMonoWeight() + crosslink.cross_linker_mass;
+        if (!beta.empty())
         {
-          precursor_mass += crosslink.beta.getMonoWeight();
+          precursor_mass += beta.getMonoWeight();
         }
         AASequence peptide;
         Size link_pos;
         if (frag_alpha)
         {
-          peptide = crosslink.alpha;
+          peptide = alpha;
           link_pos = crosslink.cross_link_position.first;
         }
         else
         {
-          peptide = crosslink.beta;
+          peptide = beta;
           link_pos = crosslink.cross_link_position.second;
         }
         addKLinkedIonPeaks_(spectrum, charges, ion_names, peptide, link_pos, precursor_mass, frag_alpha, z);
@@ -942,10 +950,10 @@ namespace OpenMS
 
     if (add_precursor_peaks_)
     {
-      double precursor_mass = crosslink.alpha.getMonoWeight() + crosslink.cross_linker_mass;
-      if (!crosslink.beta.empty())
+      double precursor_mass = alpha.getMonoWeight() + crosslink.cross_linker_mass;
+      if (!beta.empty())
       {
-        precursor_mass += crosslink.beta.getMonoWeight();
+        precursor_mass += beta.getMonoWeight();
       }
       addPrecursorPeaks_(spectrum, charges, ion_names, precursor_mass, maxcharge);
     }
@@ -979,17 +987,21 @@ namespace OpenMS
 
   void TheoreticalSpectrumGeneratorXLMS::addXLinkIonPeaks_(PeakSpectrum & spectrum, DataArrays::IntegerDataArray & charges, DataArrays::StringDataArray & ion_names, OPXLDataStructs::ProteinProteinCrossLink & crosslink, bool frag_alpha, Residue::ResidueType res_type, std::vector< LossIndex > & forward_losses, std::vector< LossIndex > & backward_losses, LossIndex & losses_peptide2, int charge) const
   {
-    if (crosslink.alpha.empty())
+    if (!crosslink.alpha || crosslink.alpha->empty())
     {
       cout << "Warning: Attempt at creating XLink Ions Spectrum from empty string!" << endl;
       return;
     }
 
-    double precursor_mass = crosslink.alpha.getMonoWeight() + crosslink.cross_linker_mass;
+    AASequence alpha = *crosslink.alpha;
+    AASequence beta;
+    if (crosslink.beta)  { beta = *crosslink.beta; }
 
-    if (!crosslink.beta.empty())
+    double precursor_mass = alpha.getMonoWeight() + crosslink.cross_linker_mass;
+
+    if (!beta.empty())
     {
-      precursor_mass += crosslink.beta.getMonoWeight();
+      precursor_mass += beta.getMonoWeight();
     }
 
     String ion_type;
@@ -999,15 +1011,15 @@ namespace OpenMS
     if (frag_alpha)
     {
       ion_type = "alpha|xi";
-      peptide = crosslink.alpha;
-      peptide2 = crosslink.beta;
+      peptide = alpha;
+      peptide2 = beta;
       link_pos = crosslink.cross_link_position.first;
     }
     else
     {
       ion_type = "beta|xi";
-      peptide = crosslink.beta;
-      peptide2 = crosslink.alpha;
+      peptide = beta;
+      peptide2 = alpha;
       link_pos = crosslink.cross_link_position.second;
     }
 

--- a/src/pyOpenMS/pxds/ProteinProteinCrossLink.pxd
+++ b/src/pyOpenMS/pxds/ProteinProteinCrossLink.pxd
@@ -13,8 +13,8 @@ cdef extern from "<OpenMS/ANALYSIS/XLMS/OPXLDataStructs.h>" namespace "OpenMS::O
         ProteinProteinCrossLink() nogil except +
 
 
-        AASequence alpha
-        AASequence beta
+        const AASequence *alpha
+        const AASequence *beta
         libcpp_pair[ ptrdiff_t, ptrdiff_t] cross_link_position
         double cross_linker_mass
         String cross_linker_name

--- a/src/tests/class_tests/openms/source/OPXLDataStructs_test.cpp
+++ b/src/tests/class_tests/openms/source/OPXLDataStructs_test.cpp
@@ -46,8 +46,10 @@ using namespace OpenMS;
 START_TEST(OPXLDataStructs, "$Id$")
 
   OPXLDataStructs::ProteinProteinCrossLink cross_link;
-  cross_link.alpha = AASequence::fromString("PEPTIDE");
-  cross_link.beta = AASequence::fromString("EDEPITPEPE");
+  AASequence alpha = AASequence::fromString("PEPTIDE");
+  AASequence beta = AASequence::fromString("EDEPITPEPE");
+  cross_link.alpha = &alpha;
+  cross_link.beta = &beta;
   cross_link.cross_link_position = std::make_pair<SignedSize, SignedSize>(3, 5);
   cross_link.cross_linker_mass = 150.0;
   cross_link.cross_linker_name = "NOTDSS";
@@ -58,7 +60,7 @@ START_SECTION(ProteinProteinCrossLink())
 
   TEST_EQUAL(cross_link.getType(), OPXLDataStructs::CROSS)
 
-  cross_link.beta = AASequence::fromString("");
+  cross_link.beta = nullptr;
   TEST_EQUAL(cross_link.getType(), OPXLDataStructs::LOOP)
 
   cross_link.cross_link_position = std::make_pair<SignedSize, SignedSize>(3, -1);

--- a/src/tests/class_tests/openms/source/OPXLHelper_test.cpp
+++ b/src/tests/class_tests/openms/source/OPXLHelper_test.cpp
@@ -203,7 +203,7 @@ START_SECTION(static std::vector <OPXLDataStructs::ProteinProteinCrossLink> buil
   TEST_EQUAL(spectrum_candidates[50].cross_linker_name, "MyLinker")
   for (Size i = 0; i < spectrum_candidates.size(); i += 200)
   {
-    TEST_REAL_SIMILAR(spectrum_candidates[i].alpha.getMonoWeight() + spectrum_candidates[i].beta.getMonoWeight() + spectrum_candidates[i].cross_linker_mass, precursor_mass)
+    TEST_REAL_SIMILAR(spectrum_candidates[i].alpha->getMonoWeight() + spectrum_candidates[i].beta->getMonoWeight() + spectrum_candidates[i].cross_linker_mass, precursor_mass)
   }
 
 END_SECTION
@@ -284,7 +284,7 @@ START_SECTION(static std::vector <OPXLDataStructs::ProteinProteinCrossLink> OPXL
   TEST_EQUAL(spectrum_candidates[50].cross_linker_name, "MyLinker")
   for (Size i = 0; i < spectrum_candidates.size(); i += 100)
   {
-    TEST_REAL_SIMILAR(spectrum_candidates[i].alpha.getMonoWeight() + spectrum_candidates[i].beta.getMonoWeight() + spectrum_candidates[i].cross_linker_mass, precursor_mass - 1 * Constants::C13C12_MASSDIFF_U)
+    TEST_REAL_SIMILAR(spectrum_candidates[i].alpha->getMonoWeight() + spectrum_candidates[i].beta->getMonoWeight() + spectrum_candidates[i].cross_linker_mass, precursor_mass - 1 * Constants::C13C12_MASSDIFF_U)
   }
 
 END_SECTION
@@ -292,8 +292,10 @@ END_SECTION
 START_SECTION(static double OPXLHelper::computePrecursorError(OPXLDataStructs::CrossLinkSpectrumMatch csm, double precursor_mz, int precursor_charge))
 
   OPXLDataStructs::ProteinProteinCrossLink ppcl;
-  ppcl.alpha = AASequence::fromString("TESTPEPTIDE");
-  ppcl.beta = AASequence::fromString("TESTTESTESTE");
+  AASequence alpha = AASequence::fromString("TESTPEPTIDE");
+  AASequence beta = AASequence::fromString("TESTTESTESTE");
+  ppcl.alpha = &alpha;
+  ppcl.beta = &beta;
   ppcl.cross_linker_mass = 150.0;
 
   OPXLDataStructs::CrossLinkSpectrumMatch csm;
@@ -301,7 +303,7 @@ START_SECTION(static double OPXLHelper::computePrecursorError(OPXLDataStructs::C
   csm.precursor_correction = 0;
 
   double precursor_charge = 3;
-  double precursor_mz = (ppcl.alpha.getMonoWeight() + ppcl.beta.getMonoWeight() + ppcl.cross_linker_mass + precursor_charge * Constants::PROTON_MASS_U) / precursor_charge;
+  double precursor_mz = (ppcl.alpha->getMonoWeight() + ppcl.beta->getMonoWeight() + ppcl.cross_linker_mass + precursor_charge * Constants::PROTON_MASS_U) / precursor_charge;
 
   double rel_error = OPXLHelper::computePrecursorError(csm, precursor_mz, precursor_charge);
   TEST_REAL_SIMILAR(rel_error, 0)

--- a/src/tests/class_tests/openms/source/SimpleTSGXLMS_test.cpp
+++ b/src/tests/class_tests/openms/source/SimpleTSGXLMS_test.cpp
@@ -412,8 +412,9 @@ START_SECTION(virtual void getXLinkIonSpectrum(PeakSpectrum & spectrum, OPXLData
   ptr->setParameters(param);
 
   OPXLDataStructs::ProteinProteinCrossLink test_link;
-  test_link.alpha = peptide;
-  test_link.beta = AASequence::fromString("TESTPEP");
+  test_link.alpha = &peptide;
+  AASequence beta = AASequence::fromString("TESTPEP");
+  test_link.beta = &beta;
   test_link.cross_link_position = std::make_pair<SignedSize, SignedSize> (3, 4);
   test_link.cross_linker_mass = 150.0;
 
@@ -502,8 +503,9 @@ START_SECTION(virtual void getXLinkIonSpectrum(PeakSpectrum & spectrum, OPXLData
   AASequence testseq = AASequence::fromString("HA");
 
   OPXLDataStructs::ProteinProteinCrossLink test_link_short;
-  test_link_short.alpha = testseq;
-  test_link_short.beta = AASequence::fromString("TESTPEP");
+  test_link_short.alpha = &testseq;
+  // AASequence beta = AASequence::fromString("TESTPEP");
+  test_link_short.beta = &beta;
   test_link_short.cross_link_position = std::make_pair<SignedSize, SignedSize> (1, 4);
   test_link_short.cross_linker_mass = 150.0;
 

--- a/src/tests/class_tests/openms/source/TheoreticalSpectrumGeneratorXLMS_test.cpp
+++ b/src/tests/class_tests/openms/source/TheoreticalSpectrumGeneratorXLMS_test.cpp
@@ -554,8 +554,9 @@ START_SECTION(virtual void getXLinkIonSpectrum(PeakSpectrum & spectrum, OPXLData
   ptr->setParameters(param);
 
   OPXLDataStructs::ProteinProteinCrossLink test_link;
-  test_link.alpha = peptide;
-  test_link.beta = AASequence::fromString("TESTPEP");
+  test_link.alpha = &peptide;
+  AASequence beta = AASequence::fromString("TESTPEP");
+  test_link.beta = &beta;
   test_link.cross_link_position = std::make_pair<SignedSize, SignedSize> (3, 4);
   test_link.cross_linker_mass = 150.0;
 
@@ -736,8 +737,8 @@ START_SECTION(virtual void getXLinkIonSpectrum(PeakSpectrum & spectrum, OPXLData
   AASequence testseq = AASequence::fromString("HA");
 
   OPXLDataStructs::ProteinProteinCrossLink test_link_short;
-  test_link_short.alpha = testseq;
-  test_link_short.beta = AASequence::fromString("TESTPEP");
+  test_link_short.alpha = &testseq;
+  test_link_short.beta = &beta;
   test_link_short.cross_link_position = std::make_pair<SignedSize, SignedSize> (1, 4);
   test_link_short.cross_linker_mass = 150.0;
 


### PR DESCRIPTION
- Improved memory efficiency by using pointers: Enumeration of candidates of peptide pairs now points to the list of single peptides instead of copying the AASequences for each pair.

- Reduced memory usage by reworking the parallelization: previously the parallelized loop was looping over the spectra. The lists of candidates and results for each spectrum had to be enumerated and computed for each spectrum in parallel and this increased the memory usage proportional to the number of used threads. Now several parallelized loops loop over the candidate enumeration and result computation for one spectrum. This makes the parallelization slightly less efficient, but it removes the increase in memory usage for multiple threads.

I tested it on a data set with a 256 protein database, where some spectra have more than 10 million peptide pair candidates within a 6 ppm precursor tolerance window. I previously needed somewhere between 75GB and 100GB memory to run it on 50 threads on a cluster (2GB for each thread does not sound much, until you have dozens of them :) ). Now this data set needs around 5GB.