### PR TITLE
[FEATURE] custom CXX flags via CMake

### DIFF
--- a/cmake/compiler_flags.cmake
+++ b/cmake/compiler_flags.cmake
@@ -35,6 +35,14 @@
 #------------------------------------------------------------------------------
 # This cmake file handles all the project specific compiler flags
 
+# allow additional custom compile flags on the cmake command line by using -DMY_CXX_FLAGS="-g -D_GLIBCXX_ASSERTIONS ..."
+# useful for e.g. Release with debug symbols on gcc/clang
+if (MY_CXX_FLAGS)
+  message(STATUS "Adding custom compile flags: '${MY_CXX_FLAGS}'!")
+  add_compile_options(${MY_CXX_FLAGS})
+endif()
+
+
 if (CMAKE_COMPILER_IS_GNUCXX)
 
   add_compile_options(-Wall -Wextra 

--- a/doc/doxygen/install/common-cmake-parameters.doxygen
+++ b/doc/doxygen/install/common-cmake-parameters.doxygen
@@ -67,6 +67,10 @@ The most important CMake variables are:
     <td>Defines the C++ compiler to use.</td>
   </tr>
   <tr>
+    <td valign="top">\c MY_CXX_FLAGS</td>
+    <td>Additional custom C++ compile options you would like to add (must fit your chosen compiler). This might be useful, for example, for adding debug symbols to a Release build, or for performance analysis (e.g. for '-fno-omit-frame-pointer')</td>
+  </tr>
+  <tr>
     <td valign="top">\c CMAKE_C_COMPILER</td>
     <td>Defines the C compiler to use. This should match the C++ compiler.
     Mixing compilers (e.g., <i>clang++</i> for C++ and <i>gcc</i> for C) can


### PR DESCRIPTION
this PR allows to augment CXX compile flags via
`cmake -DMY_CXX_FLAGS="..." ...`

Useful for a lot of scenarios without resorting to hacks or changing a CMakeLists.txt.
