### PR TITLE
[FIX] ASan error

### DIFF
--- a/src/tests/class_tests/openms/source/String_test.cpp
+++ b/src/tests/class_tests/openms/source/String_test.cpp
@@ -103,7 +103,7 @@ START_SECTION((String(const char* s, SizeType length)))
   // print(b"\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00".decode("utf16"))
   // print(b"T\xfc\x62ingen".decode("iso8859"))
   char test_utf8[] =  "T\xc3\xbc\x62ingen";
-  char test_utf16[] = "\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00";
+  char test_utf16[] {'\xff','\xfe','T','\x00','\xfc','\x00','b','\x00','i','\x00','n','\x00','g','\x00','e','\x00','n','\x00'};
   char test_iso8859[] = "T\xfc\x62ingen";
 
   String s_utf8(test_utf8, 9);
@@ -290,7 +290,7 @@ START_SECTION((template<class InputIterator> String(InputIterator first, InputIt
   // print(b"\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00".decode("utf16"))
   // print(b"T\xfc\x62ingen".decode("iso8859"))
   char test_utf8[] =  "T\xc3\xbc\x62ingen";
-  char test_utf16[] = "\xff\xfeT\x00\xfc\x00b\x00i\x00n\x00g\x00e\x00n\x00";
+  char test_utf16[] {'\xff','\xfe','T','\x00','\xfc','\x00','b','\x00','i','\x00','n','\x00','g','\x00','e','\x00','n','\x00'};
   char test_iso8859[] = "T\xfc\x62ingen";
 
   std::string std_s_utf8(test_utf8, 9);


### PR DESCRIPTION
From cppreference:
Hexadecimal escape sequences have no length limit and terminate at the first character that is not a valid hexadecimal digit. If the value represented by a single hexadecimal escape sequence does not fit the range of values represented by the character type used in this string literal (char, char16_t, char32_t, or wchar_t), the result is unspecified.