### PR TITLE
correct negative intensities in FeatureFinderMultiplex in centroid mode

### DIFF
--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderMultiplexAlgorithm.cpp
@@ -595,7 +595,7 @@ namespace OpenMS
         std::vector<double> peptide_intensities = determinePeptideIntensitiesCentroided_(patterns[pattern], satellites);
         
         // If no reliable peptide intensity can be determined, we do not report the peptide multiplet.
-        if (peptide_intensities[0] == -1)
+        if (std::find(peptide_intensities.begin(), peptide_intensities.end(), -1.0) != peptide_intensities.end())
         {
           continue;
         }


### PR DESCRIPTION
Peptides which elude for less than `rt_min` get the peptide intensity `-1` and will not be reported.

Previously only the first peptide intensity in a multiplet was checked for `-1`. This PR fixes the bug and all peptides are checked.