### PR TITLE
[FIX, GUI] moved a warning message box to the end of the function

### DIFF
--- a/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DCanvas.cpp
@@ -65,7 +65,7 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 
 #define PEN_SIZE_MAX_LIMIT 100    // maximum size of a rectangle representing a point for raw peak data
-#define PEN_SIZE_MIN_LIMIT 1      // minimum. This should not be changed without adapting the way dots are plotted 
+#define PEN_SIZE_MIN_LIMIT 1      // minimum. This should not be changed without adapting the way dots are plotted
                                   // (might lead to inconsistencies when switching between drawing modes of
                                   //  paintMaximumIntensities() vs. paintAllIntensities() )
 
@@ -372,11 +372,11 @@ namespace OpenMS
           {
             const ExperimentType::SpectrumType& spec = peak_map[rt_indices[n_ms1_scans*quantiles[i]]];
             n_s.push_back(std::distance(spec.MZBegin(mz_min), spec.MZEnd(mz_max)) + 1); // +1 to since distance is 0 if only one m/z is shown
-          } 
+          }
           std::sort(n_s.begin(), n_s.end());
           n_peaks_in_scan = n_s[1]; // median
         }
-      
+
         double ratio_data2pixel_rt = n_ms1_scans / (double)rt_pixel_count;
         double ratio_data2pixel_mz = n_peaks_in_scan / (double)mz_pixel_count;
 
@@ -403,7 +403,7 @@ namespace OpenMS
 
           // compute ideal pen width (from data);
           // since points are rectangular, we take the value of the most "crowded" dimension
-          // i.e. so that adjacent points do not overlap      
+          // i.e. so that adjacent points do not overlap
           double pen_width = std::min(1/ratio_data2pixel_rt, 1/ratio_data2pixel_mz);
           // ... and make sure its within our boundaries
           pen_width = std::max(pen_width, pen_size_min_);
@@ -523,7 +523,7 @@ namespace OpenMS
       double scale_factor = canvas_coverage_min_ / ratio_data2pixel;
       // however, within bounds (no need to check the pen_size_min_, because we can only exceed here, not underestimate)
       scale_factor = std::min(pen_size_max_, scale_factor);
-      // The difference between the original pen_width vs. this scale 
+      // The difference between the original pen_width vs. this scale
       // gives the number of peaks to merge in the crowded dimension
       merge_factor = scale_factor / pen_width;
       // set pen width to the new scale
@@ -1314,12 +1314,6 @@ namespace OpenMS
       }
     }
 
-    // warn if negative intensities are contained
-    if (getMinIntensity(current_layer_) < 0.0)
-    {
-      QMessageBox::warning(this, "Warning", "This dataset contains negative intensities. Use it at your own risk!");
-    }
-
     // overall values update
     recalculateRanges_(0, 1, 2);
     if (layers_.size() == 1)
@@ -1335,6 +1329,12 @@ namespace OpenMS
 
     emit layerActivated(this);
 
+    // warn if negative intensities are contained
+    if (getMinIntensity(current_layer_) < 0.0)
+    {
+      QMessageBox::warning(this, "Warning", "This dataset contains negative intensities. Use it at your own risk!");
+    }
+    
     return true;
   }
 
@@ -1512,7 +1512,7 @@ namespace OpenMS
     // invert 'value' (since the VERTICAL(!) scrollbar's range is negative -- see SpectrumWidget::updateVScrollbar())
     // this is independent on isMzToXAxis()!
     value *= -1;
-    
+
     AreaType new_area = visible_area_;
     if (!isMzToXAxis())
     {
@@ -2318,7 +2318,7 @@ namespace OpenMS
         // risk of iterating through *all* the scans.
 
         const AreaType & area = getVisibleArea();
-        double mz_min_vis = area.minPosition()[0]; 
+        double mz_min_vis = area.minPosition()[0];
         double mz_max_vis = area.maxPosition()[0];
 
         double rt5s_min = getCurrentLayer().getPeakData()->getSpectra()[ indices[indices.size()-1] ].getRT();
@@ -2329,7 +2329,7 @@ namespace OpenMS
         if (!item_added)
         {
           // ok, now lets search the whole visible area (may be large!)
-          double rt_min_vis = area.minPosition()[1]; 
+          double rt_min_vis = area.minPosition()[1];
           double rt_max_vis = area.maxPosition()[1];
           item_added = collectFragmentScansInArea(rt_min_vis, rt_max_vis, mz_min_vis, mz_max_vis, a, msn_scans, msn_meta);
         }
@@ -2902,7 +2902,7 @@ namespace OpenMS
       String status_changed;
       // +Home (MacOSX small keyboard: Fn+ArrowLeft) => increase point size
       if ((e->key() == Qt::Key_Home) && (pen_size_max_ < PEN_SIZE_MAX_LIMIT))
-      { 
+      {
         ++pen_size_max_;
         status_changed = "Max. dot size increased to '" + String(pen_size_max_) + "'";
       }


### PR DESCRIPTION
the message box paused the execution of the rest of the function prematurely

fixes #213 

I think this is a multi-threading issue:
The function Spectrum2DCanvas::finishAdding_() is supposed to update ranges and initialize the color gradient before anything is drawn on the Canvas. The function was paused at the position where the warning about negative intensities in a feature map was evoked and another thread started drawing the features already, leading to a segfault when accessing the color gradient.
The negative intensities themselves don't seem to cause any issue, it was the warning about them at the wrong place.

I moved the warning to the end of the function, so that the update of ranges and color gradients is finished before the warning pops-up.

As a side note:
I could not figure out where and when the drawing on the canvas is evoked. Somehow we should make sure that only happens after the necessary data is initialized. There might be other ways the initialization might be delayed.