### PR TITLE
[ADD] .ms as file format (SIRIUS)

### DIFF
--- a/cmake/knime/mime.types
+++ b/cmake/knime/mime.types
@@ -37,3 +37,4 @@ application/x-mztab mzTab
 application/x-paramxml paramXML
 application/x-percolatortab tab
 application/x-pqp pqp
+application/x-ms ms

--- a/cmake/knime/mimetypes.xml
+++ b/cmake/knime/mimetypes.xml
@@ -37,4 +37,5 @@
  <mimetype name="PARAMXML" binary="false" description="paramXML (subset of the general %OpenMS ini parameter files)" ext="paramXML"/>
  <mimetype name="PERCOLATORTAB" binary="false" description="Percolator tab seperated in/output" ext="tab"/>
  <mimetype name="PQP" binary="true" description="The PQP files are SQLite databases consisting of several tables representing the data contained in TraML files." ext="pqp"/>
+ <mimetype name="MS" binary="false" description="SIRIUS file format" ext="ms"/  >
 </mimetypes>

--- a/src/openms/include/OpenMS/FORMAT/FileTypes.h
+++ b/src/openms/include/OpenMS/FORMAT/FileTypes.h
@@ -102,6 +102,7 @@ namespace OpenMS
       MRM,                ///< SpectraST MRM List
       SQMASS,             ///< SqLite format for mass and chromatograms
       PQP,                ///< OpenSWATH Peptide Query Parameter (PQP) SQLite DB
+      MS,                 ///< SIRIUS file format (.ms)
       OSW,                ///< OpenSWATH OpenSWATH report (OSW) SQLite DB
       PSMS,               ///< Percolator tab-delimited output (PSM level)
       PIN,                ///< Percolator tab-delimited input (PSM level)

--- a/src/openms/source/FORMAT/FileTypes.cpp
+++ b/src/openms/source/FORMAT/FileTypes.cpp
@@ -132,6 +132,7 @@ namespace OpenMS
     targetMap[FileTypes::MRM] = "mrm";
     targetMap[FileTypes::SQMASS] = "sqMass";
     targetMap[FileTypes::PQP] = "pqp";
+    targetMap[FileTypes::MS] = "ms";
     targetMap[FileTypes::OSW] = "osw";
     targetMap[FileTypes::PSMS] = "psms";
     targetMap[FileTypes::PIN] = "pin";

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -139,6 +139,8 @@ protected:
     setValidFormats_("out_fingerid", ListUtils::create<String>("mzTab"));
 
     registerOutputFile_("out_ms","<file>", "", "Internal SIRIUS .ms format after OpenMS preprocessing", false);
+    setValidFormats_("out_ms", ListUtils::create<String>("ms"));
+
     registerStringOption_("out_workspace_directory", "<directory>", "", "Output directory for SIRIUS workspace", false);
 
     registerFlag_("converter_mode", "Use this flag in combination with the out_ms file to only convert the input mzML and featureXML to an .ms file. Without further SIRIUS processing.", true);


### PR DESCRIPTION
Will add "ms" as SIRIUS file format.

SIRIUS uses the ms file as input format. 

The SiriusAdapter is able to preprocess and convert spectra and identification/adduct data into the ms format.

This PR fixes a bug in the OpenMS KNIME, since the output could not be generated due the missing file format. 