### PR TITLE
[FIX] LuciphorAdapter - ConsensusID 

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/PepXMLFile.h
@@ -107,7 +107,7 @@ public:
     */
     void store(const String& filename, std::vector<ProteinIdentification>& protein_ids, 
                std::vector<PeptideIdentification>& peptide_ids, const String& mz_file = "",
-               const String& mz_name = "", bool peptideprophet_analyzed = false);
+               const String& mz_name = "", bool peptideprophet_analyzed = false, double rt_tolerance = 0.01);
 
     /**
         @brief Whether we should keep the native spectrum name of the pepXML

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -68,7 +68,7 @@ namespace OpenMS
   {
   }
 
-  void PepXMLFile::store(const String& filename, std::vector<ProteinIdentification>& protein_ids, std::vector<PeptideIdentification>& peptide_ids, const String& mz_file, const String& mz_name, bool peptideprophet_analyzed)
+  void PepXMLFile::store(const String& filename, std::vector<ProteinIdentification>& protein_ids, std::vector<PeptideIdentification>& peptide_ids, const String& mz_file, const String& mz_name, bool peptideprophet_analyzed, double rt_tolerance)
   {
     ofstream f(filename.c_str());
     if (!f)
@@ -104,6 +104,7 @@ namespace OpenMS
     String raw_data;
     String base_name;
     SpectrumMetaDataLookup lookup;
+    lookup.rt_tolerance = rt_tolerance;
 
     // The mz-File (if given)
     if (!mz_file.empty())
@@ -293,7 +294,7 @@ namespace OpenMS
           }
           else
           {
-          scan_index = lookup.findByRT(it->getRT());
+            scan_index = lookup.findByRT(it->getRT());
           }
 
           SpectrumMetaDataLookup::SpectrumMetaData meta;

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -183,6 +183,7 @@ protected:
     setValidStrings_("run_mode", ListUtils::create<String>("0,1"));
 
     registerDoubleOption_("rt_tolerance", "<num>", 0.01, "Set the retention time tolerance (for the mapping of identifications to spectra in case multiple search engines were used)", false);
+    setMinFloat_("rt_tolerance", 0.0);
     
     registerInputFile_("java_executable", "<file>", "java", "The Java executable. Usually Java is on the system PATH. If Java is not found, use this parameter to specify the full path to Java", false, false, ListUtils::create<String>("skipexists"));
 


### PR DESCRIPTION
Workflow using multiple search engines lead to small differences in the retention time (identification vs. spectra). Error in LuciphorAdapter.

Using the ConsensusID - PepXMLFile will use the RT for mapping - here the default rt in SpectrumLookup is 0.01.

To be able to use a higher rt_tolerance:
- the parameter was introduced to LuciphorAdapter
- the variable was added to PepXMLFile::store (with the same default as used in SpectrumLookup) 

e.g.
rt_tolerance: 0.05
spectrum_rt: 1724.67
lower_diff: 0.02492
upper_diff: 0.1117