### PR TITLE
[FIX] LuciphorAdapter 

### DIFF
--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -577,7 +577,7 @@ namespace OpenMS
           {
             f << "\t\t\t<search_score" << " name=\"" << it->getScoreType() << "\" value=\"" << h.getScore() << "\"" << "/>\n";
           }
-          if (it->getScoreType() == "Posterior Error Probability")
+          if (it->getScoreType() == "Posterior Error Probability" || it->getScoreType() == "pep")
           {
             f << "\t\t\t<search_score" << " name=\"" << it->getScoreType() << "\" value=\"" << h.getScore() << "\"" << "/>\n";
             double probability = 1.0 - h.getScore();

--- a/src/pyOpenMS/pxds/PepXMLFile.pxd
+++ b/src/pyOpenMS/pxds/PepXMLFile.pxd
@@ -45,7 +45,8 @@ cdef extern from "<OpenMS/FORMAT/PepXMLFile.h>" namespace "OpenMS":
                   libcpp_vector[PeptideIdentification] & peptide_ids,
                   String mz_file,
                   String mz_name,
-                  bool peptideprophet_analyzed
+                  bool peptideprophet_analyzed,
+                  double rt_tolerance
                   ) nogil except +
 
         void keepNativeSpectrumName(bool keep) nogil except +

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -453,7 +453,7 @@ protected:
   String getSelectionMethod_(const PeptideIdentification& pep_id, String search_engine)
   {
     String selection_method = "";
-    if (pep_id.getScoreType() == "Posterior Error Probability" || search_engine == "Percolator")
+    if (pep_id.getScoreType() == "Posterior Error Probability" || pep_id.getScoreType() == "pep" || search_engine == "Percolator")
     {
       selection_method = score_selection_method_[0];
     }
@@ -558,7 +558,7 @@ protected:
       return ret;
     }
     
-    writeConfigurationFile_(conf_file, config_map);    
+    writeConfigurationFile_(conf_file, config_map);
 
     // memory for JVM
     QString java_memory = "-Xmx" + QString::number(getIntOption_("java_memory")) + "m";
@@ -601,7 +601,7 @@ protected:
       
     map<int, LuciphorPSM> l_psms;    
     ProteinIdentification::SearchParameters search_params;
-    
+
     String error = parseLuciphorOutput_(out, l_psms, lookup);
     if (error != "")
     {


### PR DESCRIPTION
Adjust LuciphorAdapter/PepXMLFile to work with "pep" score type.

Workflow for multiple search engines -> FileMerger -> PSMFeatureExtractor -> PeptideIndexer -> PercolatorAdapter -> IDFilter -> LuciPhorAdapter. 

Add previously added parameter "rt_tolerance" to PepXMLFile.pxd
