### PR TITLE
[FIX] bugfix

### DIFF
--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -1081,7 +1081,7 @@ namespace OpenMS
           res_mod = mod_db->getBestModificationByDiffMonoMass(mass, tolerance, residue->getOneLetterCode(), ResidueModification::N_TERM);
           if (res_mod)
           {
-            aas.c_term_mod_ = res_mod;
+            aas.n_term_mod_ = res_mod;
             return mod_end;
           }
         }

--- a/src/tests/class_tests/openms/source/AASequence_test.cpp
+++ b/src/tests/class_tests/openms/source/AASequence_test.cpp
@@ -116,6 +116,12 @@ START_SECTION(AASequence fromString(const String& s, bool permissive = true))
   TEST_EQUAL(seq7.isModified(), true);
   TEST_EQUAL(seq7.getCTerminalModificationName(), "Amidated");
 
+  AASequence seqq8 = AASequence::fromString("PEPTIDEM(UniMod:10)");
+  TEST_EQUAL(seqq8.hasNTerminalModification(), false);
+  TEST_EQUAL(seqq8.hasCTerminalModification(), true);
+  TEST_EQUAL(seqq8.isModified(), true);
+  TEST_STRING_EQUAL(seqq8.getCTerminalModification()->getFullId(), "Met->Hse (C-term M)");
+
   // test square bracket modifications
   AASequence seq8 = AASequence::fromString("PEPTIDEK[136]");
   TEST_EQUAL(seq8.hasNTerminalModification(), false);
@@ -194,6 +200,11 @@ START_SECTION(AASequence fromString(const String& s, bool permissive = true))
 
   TEST_EXCEPTION(Exception::ParseError,
                  AASequence::fromString("PEP T*I#D+E", false));
+
+  // invalid test case: N/C terminal mods need to be at the termini
+  TEST_EXCEPTION(Exception::InvalidValue, AASequence::fromString("PEPTIDEM(UniMod:10)K"));
+  TEST_EXCEPTION(Exception::InvalidValue, AASequence::fromString("PQ(UniMod:28)EPTIDEK"));
+  TEST_EXCEPTION(Exception::InvalidValue, AASequence::fromString("PC(UniMod:26)EPTIDEK"));
 
   // prefer residue mod. over C-term mod.:
   AASequence seq19 = AASequence::fromString("PEPM(Oxidation)");
@@ -1154,14 +1165,22 @@ START_SECTION([EXTRA] Peptide equivalence)
   TEST_EQUAL(AASequence::fromString("PEPS(UniMod:21)TIDEK"), AASequence::fromString("PEPS[167]TIDEK"))
   TEST_EQUAL(AASequence::fromString("PEPS(UniMod:21)TIDEK"), AASequence::fromString("PEPS[+80]TIDEK"))
 
+  // Test N-terminal modification
   TEST_EQUAL(AASequence::fromString("C[143]PEPTIDEK"), AASequence::fromString("(UniMod:26)CPEPTIDEK"))
   TEST_EQUAL(AASequence::fromString("C[+40]PEPTIDEK"), AASequence::fromString("(UniMod:26)CPEPTIDEK"))
   TEST_EQUAL(AASequence::fromString("Q[111]PEPTIDEK"), AASequence::fromString("(UniMod:28)QPEPTIDEK"))
   TEST_EQUAL(AASequence::fromString("Q[-17]PEPTIDEK"), AASequence::fromString("(UniMod:28)QPEPTIDEK"))
+  TEST_EQUAL(AASequence::fromString("Q[-17.0265]PEPTIDEK"), AASequence::fromString("(UniMod:28)QPEPTIDEK"))
+  TEST_EQUAL(AASequence::fromString("C[+39.994915]PEPTIDEK"), AASequence::fromString("(UniMod:26)CPEPTIDEK"))
 
-  // Note: this will not really work if there is another mod that also matches within the precision of the mass
-  TEST_NOT_EQUAL(AASequence::fromString("Q[-17.0265]PEPTIDEK"), AASequence::fromString("(UniMod:28)QPEPTIDEK"))
-  TEST_NOT_EQUAL(AASequence::fromString("C[+39.994915]PEPTIDEK"), AASequence::fromString("(UniMod:26)CPEPTIDEK"))
+  // Test C-terminal modification
+  TEST_EQUAL(AASequence::fromString("PEPTIDEM[-29.992806]"), AASequence::fromString("PEPTIDEM(UniMod:610)"));
+  TEST_EQUAL(AASequence::fromString("PEPTIDEM[-30]"), AASequence::fromString("PEPTIDEM(UniMod:610)"));
+  TEST_EQUAL(AASequence::fromString("PEPTIDEM[101]"), AASequence::fromString("PEPTIDEM(UniMod:610)"));
+
+  //
+  // TEST_EQUAL(AASequence::fromString("[143]CPEPTIDEK"), AASequence::fromString("(UniMod:26)CPEPTIDEK"))
+  // TEST_EQUAL(AASequence::fromString("n[143]CPEPTIDEK"), AASequence::fromString("(UniMod:26)CPEPTIDEK"))
 
   // Test loss
   TEST_EQUAL(AASequence::fromString("PEPTIDEM(UniMod:10)"), AASequence::fromString("PEPTIDEM(Met->Hse)"))


### PR DESCRIPTION
fix https://github.com/OpenMS/OpenMS/pull/3957 - now also floating point numbers work, e.g. AASequence::fromString("Q[-17.0265]PEPTIDEK")