### PR TITLE
[FIX, GUI] fixed parsing charges from automatic spectrum labeling

### DIFF
--- a/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
+++ b/src/openms_gui/source/VISUAL/SpectraIdentificationViewWidget.cpp
@@ -292,6 +292,7 @@ namespace OpenMS
       }
 
       fragment_window_->resizeColumnsToContents();
+      fragment_window_->resizeRowsToContents();
       fragment_window_->show();
       fragment_window_->setFocus(Qt::ActiveWindowFocusReason);
       QApplication::setActiveWindow(fragment_window_);

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -1162,10 +1162,17 @@ namespace OpenMS
       }
 
       String label = ann.annotation;
+      label.trim();
 
 #ifdef DEBUG_IDENTIFICATION_VIEW
       cout << "Adding annotation item based on fragment annotations: " << label << endl;
 #endif
+
+      QStringList lines = label.toQString().split(QRegExp("[\r\n]"), QString::SkipEmptyParts);
+      if (lines.size() > 1)
+      {
+        label = String(lines[0]);
+      }
 
       // write out positive and negative charges with the correct sign at the end of the annotation string
       switch (ann.charge)
@@ -1204,6 +1211,11 @@ namespace OpenMS
 
       DPosition<2> position(current_spectrum[peak_idx].getMZ(),
         current_spectrum[peak_idx].getIntensity());
+
+      if (lines.size() > 1)
+      {
+        label.append("\n").append(String(lines[1]));
+      }
 
       Annotation1DItem* item = new Annotation1DPeakItem(
         position,


### PR DESCRIPTION
fixes #3970 

There is still one weird behaviour that I can't explain. The line breaks don't work in the PeakAnnotation tables for me, the names containing a line break are not centered in the column and in one line:
![peakannotationstable](https://user-images.githubusercontent.com/15832022/52855201-017a8800-3121-11e9-95a0-fd9702ee35be.png)

It looks correct in the labels on the peaks:
![peakannotationslabels](https://user-images.githubusercontent.com/15832022/52855181-f9bae380-3120-11e9-8af0-7593952d400e.png)

I inserted "\n" for the line breaks, am I missing something here?