### PR TITLE
better wording for FileInfo

### DIFF
--- a/src/tests/topp/FileInfo_1_output.txt
+++ b/src/tests/topp/FileInfo_1_output.txt
@@ -1,12 +1,12 @@
 
 -- General information --
 
-File name: /nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/FileInfo_1_input.dta
+File name: C:/dev/openmsqt5/src/tests/topp/FileInfo_1_input.dta
 File type: dta
 
 MS levels: 2
+Total number of peaks: 57
 Number of spectra: 1
-Number of peaks: 57
 
 Number of spectra per MS level:
   level 2: 1

--- a/src/tests/topp/FileInfo_2_output.txt
+++ b/src/tests/topp/FileInfo_2_output.txt
@@ -1,12 +1,12 @@
 
 -- General information --
 
-File name: /nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/FileInfo_2_input.dta2d
+File name: C:/dev/openmsqt5/src/tests/topp/FileInfo_2_input.dta2d
 File type: dta2d
 
 MS levels: 1
+Total number of peaks: 8
 Number of spectra: 8
-Number of peaks: 8
 
 Number of spectra per MS level:
   level 1: 8

--- a/src/tests/topp/FileInfo_4_output.txt
+++ b/src/tests/topp/FileInfo_4_output.txt
@@ -1,12 +1,12 @@
 
 -- General information --
 
-File name: /nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/FileInfo_4_input.mzXML
+File name: C:/dev/openmsqt5/src/tests/topp/FileInfo_4_input.mzXML
 File type: mzXML
 
 MS levels: 1, 2
+Total number of peaks: 6864
 Number of spectra: 20
-Number of peaks: 6864
 
 Number of spectra per MS level:
   level 1: 14

--- a/src/tests/topp/FileInfo_5_output.txt
+++ b/src/tests/topp/FileInfo_5_output.txt
@@ -1,12 +1,12 @@
 
 -- General information --
 
-File name: /nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/FileInfo_5_input.mzDat
+File name: C:/dev/openmsqt5/src/tests/topp/FileInfo_5_input.mzDat
 File type: mzData
 
 MS levels: 1, 2
+Total number of peaks: 3149
 Number of spectra: 10
-Number of peaks: 3149
 
 Number of spectra per MS level:
   level 1: 4

--- a/src/tests/topp/FileInfo_6_output.txt
+++ b/src/tests/topp/FileInfo_6_output.txt
@@ -1,12 +1,12 @@
 
 -- General information --
 
-File name: /nfs/wsi/abi/old-data/sachsenb/OpenMS_IDE/src/tests/topp/FileInfo_6_input.mzData
+File name: C:/dev/openmsqt5/src/tests/topp/FileInfo_6_input.mzData
 File type: mzData
 
 MS levels: 1
+Total number of peaks: 9
 Number of spectra: 2
-Number of peaks: 9
 
 Number of spectra per MS level:
   level 1: 2

--- a/src/tests/topp/FileInfo_9_output.txt
+++ b/src/tests/topp/FileInfo_9_output.txt
@@ -5,8 +5,8 @@ File name: C:/dev/openmsqt5/src/tests/topp/FileInfo_9_input.mzML
 File type: mzML
 
 MS levels: 1, 2
+Total number of peaks: 40
 Number of spectra: 4
-Number of peaks: 40
 
 Number of spectra per MS level:
   level 1: 3

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -785,12 +785,12 @@ protected:
       os << "\n";
 
       // basic info
-      os << "Number of spectra: " << exp.size() << "\n";
-      os << "Number of peaks: " << exp.getSize() << "\n"
+      os << "Total number of peaks: " << exp.getSize() << "\n"; // count ALL peaks (also chromatographic)
+      os << "Number of spectra: " << exp.size() << "\n"
          << "\n";
       os_tsv << "number of spectra"
              << "\t" << exp.size() << "\n"
-             << "number of peaks"
+             << "total number of peaks"
              << "\t" << exp.getSize() << "\n";
 
       // output


### PR DESCRIPTION
FileInfo now reports the *total* (spec + chrom) number of peaks first.
Before, one might get the impression that the number of peaks is prely from spectra (which it is not).