### PR TITLE
[REFACTOR] Replace boost::regex with std::regex in some parsers

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h
+++ b/src/openms/include/OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h
@@ -39,8 +39,6 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/CsvFile.h>
 #include <map>
-#include <fstream>
-#include <boost/regex.hpp>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/ChromeleonFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ChromeleonFile.h
@@ -37,8 +37,6 @@
 #include <OpenMS/config.h> // OPENMS_DLLAPI
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
-#include <fstream>
-#include <regex>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/ChromeleonFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ChromeleonFile.h
@@ -37,8 +37,8 @@
 #include <OpenMS/config.h> // OPENMS_DLLAPI
 #include <OpenMS/DATASTRUCTURES/String.h>
 #include <OpenMS/KERNEL/MSExperiment.h>
-#include <boost/regex.hpp>
 #include <fstream>
+#include <regex>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
+++ b/src/openms/include/OpenMS/FORMAT/MRMFeatureQCFile.h
@@ -36,7 +36,6 @@
 
 #include <OpenMS/FORMAT/CsvFile.h>
 #include <OpenMS/CONCEPT/ProgressLogger.h>
-#include <OpenMS/DATASTRUCTURES/StringListUtils.h>
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h>
 
 namespace OpenMS

--- a/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
+++ b/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/AbsoluteQuantitationMethodFile.h>
+#include <regex>
 
 namespace OpenMS
 {
@@ -117,8 +118,8 @@ namespace OpenMS
     {
       const String& header = h.first;
       const Size& i = h.second;
-      boost::smatch m;
-      if (boost::regex_search(header, m, boost::regex("transformation_model_param_(.+)")))
+      std::smatch m;
+      if (std::regex_match(header, m, std::regex("transformation_model_param_(.+)")))
       {
         setCastValue_(String(m[1]), tl[i], tm_params);
       }

--- a/src/openms/source/FORMAT/ChromeleonFile.cpp
+++ b/src/openms/source/FORMAT/ChromeleonFile.cpp
@@ -33,6 +33,8 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/FORMAT/ChromeleonFile.h>
+#include <fstream>
+#include <regex>
 
 namespace OpenMS
 {

--- a/src/openms/source/FORMAT/ChromeleonFile.cpp
+++ b/src/openms/source/FORMAT/ChromeleonFile.cpp
@@ -43,66 +43,66 @@ namespace OpenMS
     {
       throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
     }
-    const Size BUFSIZE = 65536;
+    const Size BUFSIZE = 8192;
     char line[BUFSIZE];
     experiment.clear(true);
     MSChromatogram chromatogram;
-    boost::cmatch m;
-    boost::regex re_channel("^Channel\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_injection("^Injection\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_processing_method("^Processing Method\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_instrument_method("^Instrument Method\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_injection_date("^Injection Date\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_injection_time("^Injection Time\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_detector("^Detector\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_signal_quantity("^Signal Quantity\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_signal_unit("^Signal Unit\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_signal_info("^Signal Info\t(.+)", boost::regex::no_mod_s);
-    boost::regex re_raw_data("^Raw Data:", boost::regex::no_mod_s);
+    std::cmatch m;
+    std::regex re_channel("^Channel\t([^\r]+)");
+    std::regex re_injection("^Injection\t([^\r]+)");
+    std::regex re_processing_method("^Processing Method\t([^\r]+)");
+    std::regex re_instrument_method("^Instrument Method\t([^\r]+)");
+    std::regex re_injection_date("^Injection Date\t([^\r]+)");
+    std::regex re_injection_time("^Injection Time\t([^\r]+)");
+    std::regex re_detector("^Detector\t([^\r]+)");
+    std::regex re_signal_quantity("^Signal Quantity\t([^\r]+)");
+    std::regex re_signal_unit("^Signal Unit\t([^\r]+)");
+    std::regex re_signal_info("^Signal Info\t([^\r]+)");
+    std::regex re_raw_data("^Raw Data:");
     while (!ifs.eof())
     {
       ifs.getline(line, BUFSIZE);
-      if (boost::regex_search(line, m, re_injection))
+      if (std::regex_search(line, m, re_injection))
       {
         experiment.setMetaValue("mzml_id", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_channel))
+      else if (std::regex_search(line, m, re_channel))
       {
         experiment.setMetaValue("acq_method_name", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_processing_method))
+      else if (std::regex_search(line, m, re_processing_method))
       {
         experiment.getExperimentalSettings().getInstrument().getSoftware().setName(String(m[1]));
       }
-      else if (boost::regex_search(line, m, re_instrument_method))
+      else if (std::regex_search(line, m, re_instrument_method))
       {
         experiment.getExperimentalSettings().getInstrument().setName(String(m[1]));
       }
-      else if (boost::regex_search(line, m, re_injection_date))
+      else if (std::regex_search(line, m, re_injection_date))
       {
         experiment.setMetaValue("injection_date", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_injection_time))
+      else if (std::regex_search(line, m, re_injection_time))
       {
         experiment.setMetaValue("injection_time", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_detector))
+      else if (std::regex_search(line, m, re_detector))
       {
         experiment.setMetaValue("detector", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_signal_quantity))
+      else if (std::regex_search(line, m, re_signal_quantity))
       {
         experiment.setMetaValue("signal_quantity", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_signal_unit))
+      else if (std::regex_search(line, m, re_signal_unit))
       {
         experiment.setMetaValue("signal_unit", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_signal_info))
+      else if (std::regex_search(line, m, re_signal_info))
       {
         experiment.setMetaValue("signal_info", std::string(m[1]));
       }
-      else if (boost::regex_search(line, m, re_raw_data))
+      else if (std::regex_search(line, m, re_raw_data))
       {
         ifs.getline(line, BUFSIZE); // remove the subsequent line, right before the raw data
         break;

--- a/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
+++ b/src/openms/source/FORMAT/MRMFeatureQCFile.cpp
@@ -37,7 +37,7 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMFeatureQC.h>
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/DATASTRUCTURES/StringListUtils.h>
-#include <boost/regex.hpp>
+#include <regex>
 
 namespace OpenMS
 {
@@ -93,8 +93,9 @@ namespace OpenMS
     {
       const String& header = h.first;
       const Size& i = h.second;
-      boost::smatch m;
-      if (boost::regex_search(header, m, boost::regex("metaValue_(.+)_(l|u)"))) // capture the metavalue name and the boundary and save them to m[1] and m[2]
+      std::smatch m;
+      // capture the metavalue name and the boundary and save them to m[1] and m[2]
+      if (std::regex_match(header, m, std::regex("metaValue_(.+)_(l|u)")))
       {
         setPairValue_(String(m[1]), line[i], String(m[2]), c.meta_value_qc);
       }
@@ -138,8 +139,9 @@ namespace OpenMS
     {
       const String& header = h.first;
       const Size& i = h.second;
-      boost::smatch m;
-      if (boost::regex_search(header, m, boost::regex("metaValue_(.+)_(l|u)"))) // capture the metavalue name and the boundary and save them to m[1] and m[2]
+      std::smatch m;
+      // capture the metavalue name and the boundary and save them to m[1] and m[2]
+      if (std::regex_match(header, m, std::regex("metaValue_(.+)_(l|u)")))
       {
         setPairValue_(String(m[1]), line[i], String(m[2]), cg.meta_value_qc);
       }

--- a/src/openms/source/FORMAT/MSPGenericFile.cpp
+++ b/src/openms/source/FORMAT/MSPGenericFile.cpp
@@ -112,13 +112,13 @@ namespace OpenMS
         } while ( std::regex_search(line, m, re_point) );
       }
       // Synon
-      else if (std::regex_search(line, m, re_synon))
+      else if (std::regex_match(line, m, re_synon))
       {
         // LOG_DEBUG << "Synon: " << m[1] << "\n";
         synonyms_.push_back(String(m[1]));
       }
       // Name
-      else if (std::regex_search(line, m, re_name))
+      else if (std::regex_match(line, m, re_name))
       {
         addSpectrumToLibrary(spectrum, library);
         // LOG_DEBUG << "\n\nName: " << m[1] << "\n";
@@ -135,7 +135,7 @@ namespace OpenMS
         spectrum.setMetaValue(String("NIST#"), String(m[2]));
       }
       // Other metadata
-      else if (std::regex_search(line, m, re_metadatum))
+      else if (std::regex_match(line, m, re_metadatum))
       {
         // LOG_DEBUG << m[1] << m[2] << "\n";
         spectrum.setMetaValue(String(m[1]), String(m[2]));

--- a/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
+++ b/src/tests/class_tests/openms/source/ChromeleonFile_test.cpp
@@ -48,9 +48,8 @@ START_TEST(ChromeleonFile, "$Id$")
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
-ChromeleonFile* ptr = 0;
-ChromeleonFile* null_ptr = 0;
-const String input_filepath = OPENMS_GET_TEST_DATA_PATH("20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2.txt");
+ChromeleonFile* ptr = nullptr;
+ChromeleonFile* null_ptr = nullptr;
 
 START_SECTION(ChromeleonFile())
 {
@@ -65,12 +64,12 @@ START_SECTION(~ChromeleonFile())
 }
 END_SECTION
 
-ptr = new ChromeleonFile();
-
 START_SECTION(void load(const String& filename, MSExperiment& experiment) const)
 {
+  ChromeleonFile chromeleonFile;
   MSExperiment experiment;
-  ptr->load(input_filepath, experiment);
+  const String input_filepath = OPENMS_GET_TEST_DATA_PATH("20171013_HMP_C61_ISO_P1_GA1_UV_VIS_2.txt");
+  chromeleonFile.load(input_filepath, experiment);
   TEST_EQUAL(experiment.getMetaValue("acq_method_name"), "UV_VIS_2")
   TEST_EQUAL(experiment.getMetaValue("mzml_id"), "20171013_C61_ISO_P1_GA1")
   TEST_EQUAL(experiment.getExperimentalSettings().getInstrument().getName(), "HM_metode_ZorBax_0,02%_Acetic_acid_ver6")
@@ -121,8 +120,6 @@ START_SECTION(void load(const String& filename, MSExperiment& experiment) const)
   TEST_REAL_SIMILAR(c1[3300].getIntensity(), c2[3300].getIntensity())
 }
 END_SECTION
-
-delete ptr;
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR replaces `boost::regex` usage with `std::regex`.
Also `std::regex_search` with `std::regex_match`, where possible.

The affected classes are:
AbsoluteQuantitationMethodFile
ChromeleonFile
MRMFeatureQCFile
MSPGenericFile