### PR TITLE
[TEST] sort proteins

### DIFF
--- a/src/tests/class_tests/openms/source/IdentificationDataConverter_test.cpp
+++ b/src/tests/class_tests/openms/source/IdentificationDataConverter_test.cpp
@@ -45,13 +45,21 @@
 
 ///////////////////////////
 
+using namespace OpenMS;
+using namespace std;
+
+struct ComparePIdSize 
+{
+      bool operator()(const ProteinIdentification lhs, const ProteinIdentification rhs) const
+      {
+        return lhs.getHits().size() < rhs.getHits().size();
+      }
+};
+
 START_TEST(IdentificationDataConverter, "$Id$")
 
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
-
-using namespace OpenMS;
-using namespace std;
 
 START_SECTION((void importIDs(IdentificationData&, const vector<ProteinIdentification>&, const vector<PeptideIdentification>&)))
 {
@@ -86,16 +94,23 @@ START_SECTION((void importIDs(IdentificationData&, const vector<ProteinIdentific
                true);
   }
 
+  std::sort(proteins_in.begin(), proteins_in.end(), ComparePIdSize());
+  std::sort(proteins_out.begin(), proteins_out.end(), ComparePIdSize());
   TEST_EQUAL(proteins_in.size(), proteins_out.size());
+  TEST_EQUAL(proteins_in[0].getHits().size(), 1) // is sorted
+  TEST_EQUAL(proteins_in[1].getHits().size(), 2) // is sorted
+
   // the exporter adds target/decoy information (default: target):
-  for (auto& hit : proteins_in[0].getHits()) {
-    hit.setMetaValue("target_decoy", "target");
-  }
-  for (auto& hit : proteins_in[1].getHits()) {
-    hit.setMetaValue("target_decoy", "target");
-  }
-  TEST_EQUAL(proteins_in[0].getHits() == proteins_out[0].getHits(), true);
-  TEST_EQUAL(proteins_in[1].getHits() == proteins_out[1].getHits(), true);
+  for (auto& hit : proteins_in[0].getHits()) hit.setMetaValue("target_decoy", "target");
+  for (auto& hit : proteins_in[1].getHits()) hit.setMetaValue("target_decoy", "target");
+
+  // TEST_EQUAL(proteins_in[0].getIdentifier(), proteins_out[0].getIdentifier() ) // identifiers are not equal
+  // TEST_EQUAL(proteins_in[1].getIdentifier(), proteins_out[1].getIdentifier() ) // identifiers are not equal
+
+  TEST_EQUAL(proteins_in[0].getHits().size(), proteins_out[0].getHits().size() )
+  TEST_EQUAL(proteins_in[1].getHits().size(), proteins_out[1].getHits().size() )
+  TEST_EQUAL(proteins_in[0].getHits() == proteins_out[0].getHits(), true)
+  TEST_EQUAL(proteins_in[1].getHits() == proteins_out[1].getHits(), true)
 
   // String filename = OPENMS_GET_TEST_DATA_PATH("IdentificationDataConverter_out.idXML");
   // IdXMLFile().store(filename, proteins_out, peptides_out);


### PR DESCRIPTION
probably fixes nightly failing test: http://cdash.openms.de/testDetails.php?test=54975401&build=301147


```
 +  line 71:  TEST_EQUAL(peptides_in.size(),peptides_out.size()): got '3', expected '3'
 +  line 81:  TEST_EQUAL(hits_in.size(),hits_out.size()): got '5', expected '5'
 +  line 86:  TEST_EQUAL(find(hits_in.begin(), hits_in.end(), hit) != hits_in.end(),true): got '1', expected '1'
 +  line 86:  TEST_EQUAL(find(hits_in.begin(), hits_in.end(), hit) != hits_in.end(),true): got '1', expected '1'
 +  line 86:  TEST_EQUAL(find(hits_in.begin(), hits_in.end(), hit) != hits_in.end(),true): got '1', expected '1'
 +  line 86:  TEST_EQUAL(find(hits_in.begin(), hits_in.end(), hit) != hits_in.end(),true): got '1', expected '1'
 +  line 86:  TEST_EQUAL(find(hits_in.begin(), hits_in.end(), hit) != hits_in.end(),true): got '1', expected '1'
 +  line 89:  TEST_EQUAL(proteins_in.size(),proteins_out.size()): got '2', expected '2'
 -  line 97:  TEST_EQUAL(proteins_in[0].getHits() == proteins_out[0].getHits(),true): got '0', expected '1'
 -  line 98:  TEST_EQUAL(proteins_in[1].getHits() == proteins_out[1].getHits(),true): got '0', expected '1'
: failed
```