### PR TITLE
Make ResidueDB and ModificationsDB thread-safe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 project("OpenMS_host")
 
+# required for cmake < 3.13 if ccache is used
+set(CMAKE_AUTOMOC_COMPILER_PREDEFINES OFF)
+
 #------------------------------------------------------------------------------
 # General CMake definitions & helper
 #------------------------------------------------------------------------------
@@ -43,8 +46,6 @@ SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 # Set C++ version
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-set(CMAKE_AUTOMOC_COMPILER_PREDEFINES OFF)
 
 #------------------------------------------------------------------------------
 ## CMake sanity check: sometimes CMAKE_SIZEOF_VOID_P just vanishes when

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_AUTOMOC_COMPILER_PREDEFINES OFF)
+
 #------------------------------------------------------------------------------
 ## CMake sanity check: sometimes CMAKE_SIZEOF_VOID_P just vanishes when
 ## updating CMake.

--- a/doc/code_examples/Tutorial_ResidueModification.cpp
+++ b/doc/code_examples/Tutorial_ResidueModification.cpp
@@ -50,11 +50,11 @@ int main()
   // find a modification in ModificationsDB
   // and output some of its properties
   // getInstance() returns a pointer to a ModsDB instance
-  ResidueModification mod = ModificationsDB::getInstance()->getModification("Carbamidomethyl (C)");
-  cout << mod.getOrigin() << " "
-       << mod.getFullId() << " "
-       << mod.getDiffMonoMass() << " "
-       << mod.getMonoMass() << endl;
+  const ResidueModification* mod = ModificationsDB::getInstance()->getModification("Carbamidomethyl (C)");
+  cout << mod->getOrigin() << " "
+       << mod->getFullId() << " "
+       << mod->getDiffMonoMass() << " "
+       << mod->getMonoMass() << endl;
   
   // set the modification on a residue of a peptide
   // and output some of its properties (the formula and mass have changed)
@@ -62,9 +62,9 @@ int main()
   // to relate the name of the mod to its attributes
   aas.setModification(2, "Carbamidomethyl (C)");
   cout << aas[2].getName() << " "
-   	<< aas[2].getFormula().toString() << " "
-   	<< aas[2].getModificationName() << " "
-   	<< aas[2].getMonoWeight() << endl;
+       << aas[2].getFormula().toString() << " "
+       << aas[2].getModificationName() << " "
+       << aas[2].getMonoWeight() << endl;
 
   return 0;
 } //end of main

--- a/src/openms/include/OpenMS/CHEMISTRY/CrossLinksDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/CrossLinksDB.h
@@ -46,11 +46,7 @@ namespace OpenMS
     /// Returns a pointer to the modifications DB (singleton)
     inline static CrossLinksDB* getInstance()
     {
-      static CrossLinksDB* db_ = nullptr;
-      if (db_ == nullptr)
-      {
-        db_ = new CrossLinksDB;
-      }
+      static CrossLinksDB* db_ = new CrossLinksDB;
       return db_;
     }
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -76,11 +76,7 @@ public:
     /// Returns a pointer to the modifications DB (singleton)
     inline static ModificationsDB* getInstance(OpenMS::String unimod_file = "CHEMISTRY/unimod.xml", OpenMS::String psimod_file = "CHEMISTRY/PSI-MOD.obo", OpenMS::String xlmod_file = "CHEMISTRY/XLMOD.obo")
     {
-      static ModificationsDB* db_ = nullptr;
-      if (db_ == nullptr)
-      {
-        db_ = new ModificationsDB(unimod_file, psimod_file, xlmod_file);
-      }
+      static ModificationsDB* db_ = new ModificationsDB(unimod_file, psimod_file, xlmod_file);
       return db_;
     }
 
@@ -94,10 +90,8 @@ public:
 
     /**
        @brief Returns the modification with the given index
-
-       @throw Exception::IndexOverflow if the index is too large
     */
-    const ResidueModification& getModification(Size index) const;
+    const ResidueModification* getModification(Size index) const;
 
     /**
        @brief Collects all modifications which have the given name as synonym
@@ -119,10 +113,9 @@ public:
 
        If more than one matching modification is found, the first one is returned with a warning.
 
-       @throw Exception::ElementNotFound if no modification named @p mod_name exists (via searchModifications())
-       @throw Exception::InvalidValue if no matching modification exists
+       Returns nullptr if no modification named @p mod_name exists (via searchModifications()) or if no matching modification exists
     */
-    const ResidueModification& getModification(const String& mod_name, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
+    const ResidueModification* getModification(const String& mod_name, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
 
     /// Returns true if the modification exists
     bool has(String modification) const;

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -99,7 +99,7 @@ public:
 
        If @p residue is set, only modifications with matching residue of origin are considered.
        If @p term_spec is set, only modifications with matching term specificity are considered.
-       The resulting set of modifications may be empty if no modification exists that fulfills the criteria.
+        The resulting set of modifications will be empty if no modification exists that fulfills the criteria.
     */
     void searchModifications(std::set<const ResidueModification*>& mods, const String& mod_name, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -89,7 +89,8 @@ public:
     Size getNumberOfModifications() const;
 
     /**
-       @brief Returns the modification with the given index
+       @brief Returns the modification with the given index.
+       note: out-of-bounds check is only performed in debug mode.
     */
     const ResidueModification* getModification(Size index) const;
 
@@ -99,7 +100,6 @@ public:
        If @p residue is set, only modifications with matching residue of origin are considered.
        If @p term_spec is set, only modifications with matching term specificity are considered.
        The resulting set of modifications may be empty if no modification exists that fulfills the criteria.
-
     */
     void searchModifications(std::set<const ResidueModification*>& mods, const String& mod_name, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
 
@@ -111,7 +111,8 @@ public:
 
        If more than one matching modification is found, the first one is returned with a warning.
 
-       Returns nullptr if no modification named @p mod_name exists (via searchModifications()) or if no matching modification exists
+       @throw Exception::ElementNotFound if no modification named @p mod_name exists (via searchModifications())
+       @throw Exception::InvalidValue if no matching modification exists
     */
     const ResidueModification* getModification(const String& mod_name, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
 
@@ -129,6 +130,8 @@ public:
 
        return numeric_limits<Size>::max() if not exactly one matching modification was found
        or no matching residue or modification were found
+
+       @throw Exception::ElementNotFound if not exactly one matching modification was found. 
     */
     Size findModificationIndex(const String& mod_name) const;
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -111,7 +111,9 @@ public:
 
        If more than one matching modification is found, the first one is returned with a warning.
 
-       @throw Exception::ElementNotFound if no modification named @p mod_name exists (via searchModifications())
+        @note Will never return a null pointer, instead will throw an exceptions.
+       
+        @throw Exception::ElementNotFound if no modification named @p mod_name exists (via searchModifications())
        @throw Exception::InvalidValue if no matching modification exists
     */
     const ResidueModification* getModification(const String& mod_name, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;

--- a/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ModificationsDB.h
@@ -100,8 +100,6 @@ public:
        If @p term_spec is set, only modifications with matching term specificity are considered.
        The resulting set of modifications may be empty if no modification exists that fulfills the criteria.
 
-       @throw Exception::ElementNotFound if no modification named @p mod_name exists
-       @throw Exception::InvalidValue if no residue named @p residue exists
     */
     void searchModifications(std::set<const ResidueModification*>& mods, const String& mod_name, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY) const;
 
@@ -122,15 +120,15 @@ public:
 
     /**
        @brief Add a new modification to ModificationsDB.
-       @throw Exception::InvalidValue if modification already exists (based on its fullID)
+       Will skip adding if modification already exists (based on its fullID)
     */
     void addModification(ResidueModification * new_mod);
 
     /**
        @brief Returns the index of the modification in the mods_ vector; a unique name must be given
 
-       @throw Exception::ElementNotFound if not exactly one matching modification was found
-       @throw Exception::InvalidValue if no matching residue or modification were found
+       return numeric_limits<Size>::max() if not exactly one matching modification was found
+       or no matching residue or modification were found
     */
     Size findModificationIndex(const String& mod_name) const;
 
@@ -142,25 +140,6 @@ public:
     */
     void searchModificationsByDiffMonoMass(std::vector<String>& mods, double mass, double max_error, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY);
 
-    /** @brief Returns the best matching modification for the given mass and residue
-
-        Query the modifications DB to get the best matching modification with
-        the given mass at the given residue (NULL pointer means no result,
-        maybe the maximal error tolerance needs to be increased). Possible
-        input for CAM modification would be a mass of 160 and a residue of
-        "C".
-
-        @note If there are multiple possible matches with equal masses, it
-        will choose the _first_ match which defaults to the first matching
-        UniMod entry.
-
-        @param residue The residue at which the modifications occurs
-        @param mass The monoisotopic mass of the residue including the mass of the modification
-        @param max_error The maximal mass error in the modification search
-
-        @return A pointer to the best matching modification (or NULL if none was found)
-    */
-    const ResidueModification* getBestModificationByMonoMass(double mass, double max_error, const String& residue = "", ResidueModification::TermSpecificity term_spec = ResidueModification::NUMBER_OF_TERM_SPECIFICITY);
 
     /** @brief Returns the best matching modification for the given delta mass and residue
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
@@ -136,9 +136,6 @@ public:
     /// returns all residue sets that are registered which this instance
     const std::set<String>& getResidueSets() const;
 
-    /// sets the residues from given file
-    void setResidues(const String& filename);
-
     /// adds a residue, i.e. a unknown residue, where only the weight is known
     void addResidue(const Residue& residue);
     //@}
@@ -166,6 +163,8 @@ public:
     //@}
 
 protected:
+    /// sets the residues from given file
+    void setResidues_(const String& filename);
 
     /** @name Private Constructors
     */

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
@@ -69,11 +69,7 @@ public:
     //@}
 
     /// this member function serves as a replacement of the constructor
-    inline static ResidueDB* getInstance()
-    {
-      static ResidueDB* db_ = new ResidueDB;
-      return db_;
-    }
+    static ResidueDB* getInstance();
 
     /** @name Constructors and Destructors
     */
@@ -129,12 +125,12 @@ public:
        Ambiguous - all amino acids including all ambiguous ones (X can be every other amino acid)
        AllNatural - naturally occurring residues, including selenocysteine (U)
 
-       @throw Exception::ElementNotFound if the specified residue set is not defined
+       returns an empty set if the specified residue set is not defined
     */
     const std::set<const Residue*> getResidues(const String& residue_set = "All") const;
 
     /// returns all residue sets that are registered which this instance
-    const std::set<String>& getResidueSets() const;
+    const std::set<String> getResidueSets() const;
 
     //@}
 
@@ -194,8 +190,11 @@ protected:
     /// deletes all sub-instances of the stored data like modifications and residues
     void clear_();
 
-    /// clears the residues
+    /// clears the residues and all lookup structures
     void clearResidues_();
+
+    /// clears the residue modifications and all lookup structures
+    void clearResidueModifications_();
 
     /// builds an index of residue names for fast access, synonyms are also considered
     void buildResidueNames_();

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
@@ -71,11 +71,7 @@ public:
     /// this member function serves as a replacement of the constructor
     inline static ResidueDB* getInstance()
     {
-      static ResidueDB* db_ = nullptr;
-      if (db_ == nullptr)
-      {
-        db_ = new ResidueDB;
-      }
+      static ResidueDB* db_ = new ResidueDB;
       return db_;
     }
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ResidueDB.h
@@ -136,8 +136,6 @@ public:
     /// returns all residue sets that are registered which this instance
     const std::set<String>& getResidueSets() const;
 
-    /// adds a residue, i.e. a unknown residue, where only the weight is known
-    void addResidue(const Residue& residue);
     //@}
 
     /** @name Predicates

--- a/src/openms/include/OpenMS/FORMAT/OMSSAXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/OMSSAXMLFile.h
@@ -146,7 +146,7 @@ private:
     bool load_empty_hits_;
 
     /// modifications mapping file from OMSSA mod num to UniMod accession
-    Map<UInt, std::vector<ResidueModification> > mods_map_;
+    Map<UInt, std::vector<const ResidueModification*> > mods_map_;
 
     /// modification mapping reverse, from the modification to the mod_num
     Map<String, UInt> mods_to_num_;

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -216,8 +216,7 @@ namespace OpenMS
     // iterate over modification names and add to vector
     for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
     {
-      String modification(*mod_it);
-      modifications.push_back(ModificationsDB::getInstance()->getModification(modification));
+      modifications.push_back(*ModificationsDB::getInstance()->getModification(*mod_it));
     }
 
     return modifications;

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -912,7 +912,7 @@ namespace OpenMS
       if (m == nullptr)
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, str,
-          "Cannot convert string to peptide modification. No N-terminal modification matches to term specificty and origin.");
+          "Cannot convert string to peptide modification. No N-terminal modification matches to term specificity and origin.");
       }
       aas.n_term_mod_ = m;
       return mod_end;

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -908,44 +908,55 @@ namespace OpenMS
       ++next_aa;
       if (*next_aa == '.') ++next_aa;
 
-      aas.n_term_mod_ = &(mod_db->getModification(mod, String(*next_aa), ResidueModification::N_TERM));
+      const ResidueModification* m = mod_db->getModification(mod, String(*next_aa), ResidueModification::N_TERM);
+      if (m == nullptr)
+      {
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, str,
+          "Cannot convert string to peptide modification. No N-terminal modification matches to term specificty and origin.");
+      }
+      aas.n_term_mod_ = m;
       return mod_end;
     }
 
     const String& res = aas.peptide_.back()->getOneLetterCode();
     if (specificity == ResidueModification::C_TERM) 
     {
-      aas.c_term_mod_ = &(mod_db->getModification(mod, res, ResidueModification::C_TERM));
+      const ResidueModification* m = mod_db->getModification(mod, res, ResidueModification::C_TERM);
+      if (m == nullptr)
+      {
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, str,
+          "Cannot convert string to peptide modification. No C-terminal modification matches to term specificty and origin.");
+      }
+      aas.c_term_mod_ = m;
       return mod_end;
     }
 
-    try
+    const Residue* internal = ResidueDB::getInstance()->getModifiedResidue(aas.peptide_.back(), mod);
+    if (internal != nullptr)
     {
-      aas.peptide_.back() = ResidueDB::getInstance()->getModifiedResidue(aas.peptide_.back(), mod);
+      aas.peptide_.back() = internal;
     }
-    catch (Exception::InvalidValue) // no such mod for this residue
+    else // no internal mod for this residue
     {
       // TODO: get rid of this code path, its deprecated and is only a hack for
       // C-terminal modifications that don't use the dot notation
       if (std::distance(mod_end, str.end()) == 1) // potentially a C-terminal mod without explicitly declaring it using dot notation?
       {
         // old ambiguous notation: Modification might be at last amino acid or at C-terminus
-        try
+        const ResidueModification* term_mod = mod_db->getModification(mod, res, ResidueModification::C_TERM);
+        aas.c_term_mod_ = term_mod;
+        if (term_mod == nullptr)
         {
-          // this might throw ElementNotFound, but so be it:
-          const ResidueModification* term_mod = &(mod_db->getModification(mod, res, ResidueModification::C_TERM));
-          aas.c_term_mod_ = term_mod;
-        }
-        catch (Exception::ElementNotFound& /* e */)
-        { // just do nothing, the mod is presumably a non-terminal one
+          cout << "Residue with name " + res + " was not registered in residue DB, register first!" << endl;
         }
       }
       else
       {
-        throw; // re-throw the InvalidValue
+        // neither internal nor terminal modification matches to our database
+        throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, str,
+          "Cannot convert string to peptide modification. No modification matches in our database.");
       }
     }
-
     return mod_end;
   }
 
@@ -997,7 +1008,7 @@ namespace OpenMS
         mod_db->searchModificationsByDiffMonoMass(term_mods, mass, tolerance, String(*next_aa), ResidueModification::N_TERM);
         if (!term_mods.empty())
         {
-          aas.n_term_mod_ = &(mod_db->getModification(term_mods[0], String(*next_aa), ResidueModification::N_TERM));
+          aas.n_term_mod_ = mod_db->getModification(term_mods[0], String(*next_aa), ResidueModification::N_TERM);
           return mod_end;
         }
         LOG_WARN << "Warning: unknown N-terminal modification '" + mod + "' - adding it to the database" << std::endl;
@@ -1009,7 +1020,7 @@ namespace OpenMS
         mod_db->searchModificationsByDiffMonoMass(term_mods, mod_mass, tolerance, String(*next_aa), ResidueModification::N_TERM);
         if (!term_mods.empty())
         {
-          aas.n_term_mod_ = &(mod_db->getModification(term_mods[0], String(*next_aa), ResidueModification::N_TERM));
+          aas.n_term_mod_ = mod_db->getModification(term_mods[0], String(*next_aa), ResidueModification::N_TERM);
           return mod_end;
         }
         LOG_WARN << "Warning: unknown N-terminal modification '" + mod + "' - adding it to the database" << std::endl;
@@ -1049,7 +1060,7 @@ namespace OpenMS
           mod_db->searchModificationsByDiffMonoMass(term_mods, mass, tolerance, residue->getOneLetterCode(), ResidueModification::N_TERM);
           if (!term_mods.empty())
           {
-            aas.n_term_mod_ = &(mod_db->getModification(term_mods[0], residue->getOneLetterCode(), ResidueModification::N_TERM));
+            aas.n_term_mod_ = mod_db->getModification(term_mods[0], residue->getOneLetterCode(), ResidueModification::N_TERM);
             return mod_end;
           }
         }
@@ -1058,7 +1069,7 @@ namespace OpenMS
           mod_db->searchModificationsByDiffMonoMass(res_mods, mass, tolerance, residue->getOneLetterCode(), ResidueModification::C_TERM);
           if (!res_mods.empty())
           {
-            aas.c_term_mod_ = &(mod_db->getModification(res_mods[0], residue->getOneLetterCode(), ResidueModification::C_TERM));
+            aas.c_term_mod_ = mod_db->getModification(res_mods[0], residue->getOneLetterCode(), ResidueModification::C_TERM);
             return mod_end;
           }
         }
@@ -1108,7 +1119,7 @@ namespace OpenMS
                                                   ResidueModification::C_TERM);
         if (!term_mods.empty())
         {
-          aas.c_term_mod_ = &(mod_db->getModification(term_mods[0], residue->getOneLetterCode(), ResidueModification::C_TERM));
+          aas.c_term_mod_ = mod_db->getModification(term_mods[0], residue->getOneLetterCode(), ResidueModification::C_TERM);
           return mod_end;
         }
         LOG_WARN << "Warning: unknown C-terminal modification '" + mod + "' - adding it to the database" << std::endl;
@@ -1121,7 +1132,7 @@ namespace OpenMS
                                                   ResidueModification::C_TERM);
         if (!term_mods.empty())
         {
-          aas.c_term_mod_ = &(mod_db->getModification(term_mods[0], residue->getOneLetterCode(), ResidueModification::C_TERM));
+          aas.c_term_mod_ = mod_db->getModification(term_mods[0], residue->getOneLetterCode(), ResidueModification::C_TERM);
           return mod_end;
         }
         LOG_WARN << "Warning: unknown C-terminal modification '" + mod + "' - adding it to the database" << std::endl;
@@ -1156,7 +1167,7 @@ namespace OpenMS
       else
       {
         Size mod_idx = mod_db->findModificationIndex(residue_name);
-        aas.n_term_mod_ = &mod_db->getModification(mod_idx);
+        aas.n_term_mod_ = mod_db->getModification(mod_idx);
       }
       return mod_end;
     }
@@ -1180,7 +1191,7 @@ namespace OpenMS
       else
       {
         Size mod_idx = mod_db->findModificationIndex(residue_name);
-        aas.c_term_mod_ = &mod_db->getModification(mod_idx);
+        aas.c_term_mod_ = mod_db->getModification(mod_idx);
       }
       return mod_end;
     }
@@ -1219,7 +1230,7 @@ namespace OpenMS
 
       // now use the new modification
       Size mod_idx = mod_db->findModificationIndex(modification_name);
-      const ResidueModification* res_mod = &mod_db->getModification(mod_idx);
+      const ResidueModification* res_mod = mod_db->getModification(mod_idx);
 
       // Note: this calls setModification_ on a new Residue which changes its
       // weight to the weight of the modification (set above)
@@ -1370,7 +1381,7 @@ namespace OpenMS
       return;
     }
 
-    n_term_mod_ = &ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::N_TERM);
+    n_term_mod_ = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::N_TERM);
   }
 
   void AASequence::setCTerminalModification(const String& modification)
@@ -1380,7 +1391,7 @@ namespace OpenMS
       c_term_mod_ = nullptr;
       return;
     }
-    c_term_mod_ = &ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::C_TERM);
+    c_term_mod_ = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::C_TERM);
   }
 
   const String& AASequence::getNTerminalModificationName() const

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -925,7 +925,7 @@ namespace OpenMS
       if (m == nullptr)
       {
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, str,
-          "Cannot convert string to peptide modification. No C-terminal modification matches to term specificty and origin.");
+          "Cannot convert string to peptide modification. No C-terminal modification matches to term specificity and origin.");
       }
       aas.c_term_mod_ = m;
       return mod_end;

--- a/src/openms/source/CHEMISTRY/ModificationDefinition.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationDefinition.cpp
@@ -113,9 +113,7 @@ namespace OpenMS
 
   void ModificationDefinition::setModification(const String& modification)
   {
-    //cerr << "setModification(" << modification << ")" << endl;
-    mod_ = &ModificationsDB::getInstance()->getModification(modification);
-    //cerr << "setModification: id=" << mod_->getId() << ", full_id=" << mod_->getFullId() << ", UniMod=" << mod_->getUniModAccession() << ", origin=" << mod_->getOrigin() << ", PSI-MOD=" << mod_->getPSIMODAccession() << endl;
+    mod_ = ModificationsDB::getInstance()->getModification(modification);
   }
 
   const ResidueModification& ModificationDefinition::getModification() const

--- a/src/openms/source/CHEMISTRY/ModificationDefinitionsSet.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationDefinitionsSet.cpp
@@ -237,12 +237,10 @@ namespace OpenMS
     // check whether the fixed modifications are fulfilled
     for (set<String>::const_iterator it1 = fixed_names.begin(); it1 != fixed_names.end(); ++it1)
     {
-      String origin = ModificationsDB::getInstance()->getModification(*it1).getOrigin();
+      String origin = ModificationsDB::getInstance()->getModification(*it1)->getOrigin();
       // only single 1lc amino acids are allowed
-      if (origin.size() != 1)
-      {
-        continue;
-      }
+      if (origin.size() != 1) continue;
+     
       for (AASequence::ConstIterator it2 = peptide.begin(); it2 != peptide.end(); ++it2)
       {
         if (origin == it2->getOneLetterCode())
@@ -253,7 +251,7 @@ namespace OpenMS
             return false;
           }
           // check whether the modification is the same
-          if (ModificationsDB::getInstance()->getModification(*it1).getId() != it2->getModificationName())
+          if (ModificationsDB::getInstance()->getModification(*it1)->getId() != it2->getModificationName())
           {
             return false;
           }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -42,6 +42,7 @@
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Macros.h>
 
+#include <limits>
 #include <fstream>
 
 using namespace std;
@@ -118,8 +119,8 @@ namespace OpenMS
 
       if (!modification_names_.has(mod_name))
       {
-        throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
-            mod_name);
+        LOG_WARN << OPENMS_PRETTY_FUNCTION << "Modification not found: " << mod_name << endl;
+        return; 
       }
     }
 
@@ -177,12 +178,14 @@ namespace OpenMS
   {
     if (!modification_names_.has(mod_name))
     {
-      throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, mod_name);
+      LOG_WARN << OPENMS_PRETTY_FUNCTION  << " Modification not found: " << mod_name << endl;
+      return numeric_limits<Size>::max();
     }
 
     if (modification_names_[mod_name].size() > 1)
     {
-      throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "more than one element of name '" + mod_name + "' found!");
+      LOG_WARN << OPENMS_PRETTY_FUNCTION  << " More than one Modification with name: " << mod_name << endl;
+      return numeric_limits<Size>::max();
     }
 
     const ResidueModification* mod = *modification_names_[mod_name].begin();
@@ -194,8 +197,8 @@ namespace OpenMS
       }
     }
 
-    // throw if we did not find the modification
-    throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, mod_name);
+    LOG_WARN << OPENMS_PRETTY_FUNCTION  << " Modification name found but modification not found: " << mod_name << endl;
+    return numeric_limits<Size>::max();
   }
 
 
@@ -232,7 +235,7 @@ namespace OpenMS
         // map to multiple residues), we calculate a monoisotopic mass from the
         // delta mass.
         // First the internal (inside an AA chain) weight of the residue:
-        if (residue_ != nullptr) continue; // @TODO: throw an exception here?
+        if (residue_ != nullptr) continue;
         double internal_weight = residue_->getMonoWeight() -
           residue_->getInternalToFull().getMonoWeight();
         mono_mass = (*it)->getDiffMonoMass() + internal_weight;
@@ -303,7 +306,8 @@ namespace OpenMS
   {
     if (has(new_mod->getFullId()))
     {
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Modification already exists in ModificationsDB.", String(new_mod->getFullId()));
+      LOG_WARN << "Modification already exists in ModificationsDB. Skipping." << new_mod->getFullId() << endl;
+      return;
     }
     modification_names_[new_mod->getFullId()].insert(new_mod);
     modification_names_[new_mod->getId()].insert(new_mod);

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -37,7 +37,6 @@
 
 #include <OpenMS/FORMAT/UnimodXMLFile.h>
 #include <OpenMS/SYSTEM/File.h>
-#include <OpenMS/CHEMISTRY/ResidueDB.h>
 #include <OpenMS/CHEMISTRY/Residue.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/CONCEPT/Macros.h>
@@ -88,7 +87,10 @@ namespace OpenMS
   Size ModificationsDB::getNumberOfModifications() const
   {
     Size s;
-    s = mods_.size();
+    #pragma omp critical (OpenMS_ModificationsDB)
+    {
+      s = mods_.size();
+    }
     return s;
   }
 
@@ -109,31 +111,38 @@ namespace OpenMS
 
     String mod_name = mod_name_;
 
-    if (!modification_names_.has(mod_name))
+    #pragma omp critical(OpenMS_ModificationsDB)
     {
-      // Try to fix things, Skyline for example uses unimod:10 and not UniMod:10 syntax
-      if (mod_name.size() > 6 && mod_name.prefix(6).toLower() == "unimod")
-      {
-        mod_name = "UniMod" + mod_name.substr(6, mod_name.size() - 6);
-      }
-
+      bool found = true;
       if (!modification_names_.has(mod_name))
       {
-        LOG_WARN << OPENMS_PRETTY_FUNCTION << "Modification not found: " << mod_name << endl;
-        return; 
-      }
-    }
+        // Try to fix things, Skyline for example uses unimod:10 and not UniMod:10 syntax
+        if (mod_name.size() > 6 && mod_name.prefix(6).toLower() == "unimod")
+        {
+          mod_name = "UniMod" + mod_name.substr(6, mod_name.size() - 6);
+        }
 
-    const set<const ResidueModification*>& temp = modification_names_[mod_name];
-    for (const auto& it : temp)
-    {
-      if (residuesMatch_(residue, it->getOrigin()) &&
-           (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY ||
-             (term_spec == it->getTermSpecificity())))
-      {
-        mods.insert(it);
+        if (!modification_names_.has(mod_name))
+        {
+          LOG_WARN << OPENMS_PRETTY_FUNCTION << "Modification not found: " << mod_name << endl;
+          found = false; 
+        }
       }
-    }
+
+      if (found)
+      {
+        const set<const ResidueModification*>& temp = modification_names_[mod_name];
+        for (const auto& it : temp)
+        {
+          if (residuesMatch_(residue, it->getOrigin()) &&
+               (term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY ||
+               (term_spec == it->getTermSpecificity())))
+          {
+            mods.insert(it);
+          }
+        }
+      }
+    } 
   }
 
 
@@ -171,89 +180,70 @@ namespace OpenMS
 
   bool ModificationsDB::has(String modification) const
   {
-    return modification_names_.has(modification);
+    bool has_mod;
+    #pragma omp critical(OpenMS_ModificationsDB)
+    {
+      has_mod = modification_names_.has(modification);
+    }
+    return has_mod;
   }
 
   Size ModificationsDB::findModificationIndex(const String & mod_name) const
   {
-    if (!modification_names_.has(mod_name))
+    if (!has(mod_name))
     {
       LOG_WARN << OPENMS_PRETTY_FUNCTION  << " Modification not found: " << mod_name << endl;
       return numeric_limits<Size>::max();
     }
 
-    if (modification_names_[mod_name].size() > 1)
+    bool one_mod(true);
+    #pragma omp critical(OpenMS_ModificationsDB)
     {
-      LOG_WARN << OPENMS_PRETTY_FUNCTION  << " More than one Modification with name: " << mod_name << endl;
-      return numeric_limits<Size>::max();
-    }
-
-    const ResidueModification* mod = *modification_names_[mod_name].begin();
-    for (Size i = 0; i != mods_.size(); ++i)
-    {
-      if (mods_[i] == mod)
+      if (modification_names_[mod_name].size() > 1)
       {
-        return i;
+        LOG_WARN << OPENMS_PRETTY_FUNCTION  << " More than one Modification with name: " << mod_name << endl;
+        one_mod = false;
       }
     }
+    if (!one_mod) return numeric_limits<Size>::max();
 
-    LOG_WARN << OPENMS_PRETTY_FUNCTION  << " Modification name found but modification not found: " << mod_name << endl;
-    return numeric_limits<Size>::max();
+    Size index(numeric_limits<Size>::max());
+    #pragma omp critical(OpenMS_ModificationsDB)
+    {
+      const ResidueModification* mod = *modification_names_[mod_name].begin();
+      for (Size i = 0; i != mods_.size(); ++i)
+      {
+        if (mods_[i] == mod)
+        {
+          index = i;
+          break;
+        }
+      }
+    }
+    if (index == numeric_limits<Size>::max())
+    {
+      LOG_WARN << OPENMS_PRETTY_FUNCTION  << " Modification name found but modification not found: " << mod_name << endl;
+    }
+    return index;
   }
 
 
   void ModificationsDB::searchModificationsByDiffMonoMass(vector<String>& mods, double mass, double max_error, const String& residue, ResidueModification::TermSpecificity term_spec)
   {
     mods.clear();
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin();
-         it != mods_.end(); ++it)
+    #pragma omp critical(OpenMS_ModificationsDB)
     {
-      if ((fabs((*it)->getDiffMonoMass() - mass) <= max_error) &&
-          residuesMatch_(residue, (*it)->getOrigin()) &&
-          ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
-           (term_spec == (*it)->getTermSpecificity())))
+      for (auto const & m : mods_)
       {
-        mods.push_back((*it)->getFullId());
+        if ((fabs(m->getDiffMonoMass() - mass) <= max_error) &&
+            residuesMatch_(residue, m->getOrigin()) &&
+            ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
+             (term_spec == m->getTermSpecificity())))
+        {
+          mods.push_back(m->getFullId());
+        }
       }
     }
-  }
-
-
-  const ResidueModification* ModificationsDB::getBestModificationByMonoMass(double mass, double max_error, const String& residue,
-                                                                            ResidueModification::TermSpecificity term_spec)
-  {
-    double min_error = max_error;
-    const ResidueModification* mod = nullptr;
-    const Residue* residue_ = ResidueDB::getInstance()->getResidue(residue); // is NULL if not found
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin();
-         it != mods_.end(); ++it)
-    {
-      double mono_mass = (*it)->getMonoMass();
-      if ((mono_mass <= 0) && !residue.empty())
-      {
-        // Since not all modifications have a monoisotopic mass stored (they may
-        // map to multiple residues), we calculate a monoisotopic mass from the
-        // delta mass.
-        // First the internal (inside an AA chain) weight of the residue:
-        if (residue_ != nullptr) continue;
-        double internal_weight = residue_->getMonoWeight() -
-          residue_->getInternalToFull().getMonoWeight();
-        mono_mass = (*it)->getDiffMonoMass() + internal_weight;
-      }
-      // using less instead of less-or-equal will pick the first matching
-      // modification of equally heavy modifications (in our case this is the
-      // first matching UniMod entry)
-      double mass_error = fabs(mono_mass - mass);
-      if ((mass_error < min_error) &&
-          residuesMatch_(residue, (*it)->getOrigin()) &&
-          ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
-           (term_spec == (*it)->getTermSpecificity())))
-      {
-        min_error = mass_error;
-        mod = *it;
-      }
-    }
-    return mod;
   }
 
 
@@ -261,20 +251,22 @@ namespace OpenMS
   {
     double min_error = max_error;
     const ResidueModification* mod = nullptr;
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin();
-         it != mods_.end(); ++it)
+    #pragma omp critical(OpenMS_ModificationsDB)
     {
-      // using less instead of less-or-equal will pick the first matching
-      // modification of equally heavy modifications (in our case this is the
-      // first matching UniMod entry)
-      double mass_error = fabs((*it)->getDiffMonoMass() - mass);
-      if ((mass_error < min_error) &&
-          residuesMatch_(residue, (*it)->getOrigin()) &&
-          ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
-           (term_spec == (*it)->getTermSpecificity())))
+      for (auto const & m : mods_)
       {
-        min_error = mass_error;
-        mod = *it;
+        // using less instead of less-or-equal will pick the first matching
+        // modification of equally heavy modifications (in our case this is the
+        // first matching UniMod entry)
+        double mass_error = fabs(m->getDiffMonoMass() - mass);
+        if ((mass_error < min_error) &&
+            residuesMatch_(residue, m->getOrigin()) &&
+            ((term_spec == ResidueModification::NUMBER_OF_TERM_SPECIFICITY) ||
+             (term_spec == m->getTermSpecificity())))
+        {
+          min_error = mass_error;
+          mod = m;
+        }
       }
     }
     return mod;
@@ -285,20 +277,23 @@ namespace OpenMS
     vector<ResidueModification*> new_mods;
     UnimodXMLFile().load(filename, new_mods);
 
-    for (vector<ResidueModification*>::iterator it = new_mods.begin(); it != new_mods.end(); ++it)
+    for (auto & m : new_mods)
     {
       // create full ID based on other information:
-      (*it)->setFullId();
+      m->setFullId();
 
-      // e.g. Oxidation (M)
-      modification_names_[(*it)->getFullId()].insert(*it);
-      // e.g. Oxidation
-      modification_names_[(*it)->getId()].insert(*it);
-      // e.g. Oxidized
-      modification_names_[(*it)->getFullName()].insert(*it);
-      // e.g. UniMod:312
-      modification_names_[(*it)->getUniModAccession()].insert(*it);
-      mods_.push_back(*it);
+      #pragma omp critical(OpenMS_ModificationsDB)
+      {
+        // e.g. Oxidation (M)
+        modification_names_[m->getFullId()].insert(m);
+        // e.g. Oxidation
+        modification_names_[m->getId()].insert(m);
+        // e.g. Oxidized
+        modification_names_[m->getFullName()].insert(m);
+        // e.g. UniMod:312
+        modification_names_[m->getUniModAccession()].insert(m);
+        mods_.push_back(m);
+      }
     }
   }
 
@@ -309,12 +304,15 @@ namespace OpenMS
       LOG_WARN << "Modification already exists in ModificationsDB. Skipping." << new_mod->getFullId() << endl;
       return;
     }
-    modification_names_[new_mod->getFullId()].insert(new_mod);
-    modification_names_[new_mod->getId()].insert(new_mod);
-    modification_names_[new_mod->getFullName()].insert(new_mod);
-    modification_names_[new_mod->getUniModAccession()].insert(new_mod);
 
-    mods_.push_back(new_mod); // we probably want that
+    #pragma omp critical(OpenMS_ModificationsDB)
+    {
+      modification_names_[new_mod->getFullId()].insert(new_mod);
+      modification_names_[new_mod->getId()].insert(new_mod);
+      modification_names_[new_mod->getFullName()].insert(new_mod);
+      modification_names_[new_mod->getUniModAccession()].insert(new_mod);
+      mods_.push_back(new_mod); // we probably want that
+    }
   }
 
   void ModificationsDB::readFromOBOFile(const String& filename)
@@ -574,43 +572,45 @@ namespace OpenMS
     // now use the term and all synonyms to build the database
     for (multimap<String, ResidueModification>::const_iterator it = all_mods.begin(); it != all_mods.end(); ++it)
     {
-
-      // check whether a unimod definition already exists, then simply add synonyms to it
-      if (it->second.getUniModRecordId() > 0)
+      #pragma omp critical(OpenMS_ModificationsDB)
       {
-        //cerr << "Found UniMod PSI-MOD mapping: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
-        set<const ResidueModification*> mods = modification_names_[it->second.getUniModAccession()];
-        for (set<const ResidueModification*>::const_iterator mit = mods.begin(); mit != mods.end(); ++mit)
+        // check whether a unimod definition already exists, then simply add synonyms to it
+        if (it->second.getUniModRecordId() > 0)
         {
-          //cerr << "Adding PSIMOD accession: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
-          modification_names_[it->second.getPSIMODAccession()].insert(*mit);
-        }
-      }
-      else
-      {
-        // the mod has so far not been mapped to a unimod mod
-        // first check whether the mod is specific
-        if ((it->second.getOrigin() != 'X') ||
-            ((it->second.getTermSpecificity() != ResidueModification::ANYWHERE) &&
-             (it->second.getDiffMonoMass() != 0)))
-        {
-          mods_.push_back(new ResidueModification(it->second));
-
-          set<String> synonyms = it->second.getSynonyms();
-          synonyms.insert(it->first);
-          synonyms.insert(it->second.getFullName());
-          //synonyms.insert(it->second.getUniModAccession());
-          synonyms.insert(it->second.getPSIMODAccession());
-          // full ID is auto-generated based on (short) ID, but we want the name instead:
-          mods_.back()->setId(it->second.getFullName());
-          mods_.back()->setFullId();
-          mods_.back()->setId(it->second.getId());
-          synonyms.insert(mods_.back()->getFullId());
-
-          // now check each of the names and link it to the residue modification
-          for (set<String>::const_iterator nit = synonyms.begin(); nit != synonyms.end(); ++nit)
+          //cerr << "Found UniMod PSI-MOD mapping: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
+          set<const ResidueModification*> mods = modification_names_[it->second.getUniModAccession()];
+          for (set<const ResidueModification*>::const_iterator mit = mods.begin(); mit != mods.end(); ++mit)
           {
-            modification_names_[*nit].insert(mods_.back());
+            //cerr << "Adding PSIMOD accession: " << it->second.getPSIMODAccession() << " " << it->second.getUniModAccession() << endl;
+            modification_names_[it->second.getPSIMODAccession()].insert(*mit);
+          }
+        }
+        else
+        {
+          // the mod has so far not been mapped to a unimod mod
+          // first check whether the mod is specific
+          if ((it->second.getOrigin() != 'X') ||
+             ((it->second.getTermSpecificity() != ResidueModification::ANYWHERE) &&
+             (it->second.getDiffMonoMass() != 0)))
+          {
+            mods_.push_back(new ResidueModification(it->second));
+
+            set<String> synonyms = it->second.getSynonyms();
+            synonyms.insert(it->first);
+            synonyms.insert(it->second.getFullName());
+            //synonyms.insert(it->second.getUniModAccession());
+            synonyms.insert(it->second.getPSIMODAccession());
+            // full ID is auto-generated based on (short) ID, but we want the name instead:
+            mods_.back()->setId(it->second.getFullName());
+            mods_.back()->setFullId();
+            mods_.back()->setId(it->second.getId());
+            synonyms.insert(mods_.back()->getFullId());
+
+            // now check each of the names and link it to the residue modification
+            for (set<String>::const_iterator nit = synonyms.begin(); nit != synonyms.end(); ++nit)
+            {
+              modification_names_[*nit].insert(mods_.back());
+            }
           }
         }
       }
@@ -621,13 +621,17 @@ namespace OpenMS
   {
     modifications.clear();
 
-    for (vector<ResidueModification*>::const_iterator it = mods_.begin(); it != mods_.end(); ++it)
+    #pragma omp critical(OpenMS_ModificationsDB)
     {
-      if ((*it)->getUniModRecordId() > 0)
+      for (auto const & m : mods_)
       {
-        modifications.push_back((*it)->getFullId());
+        if (m->getUniModRecordId() > 0)
+        {
+          modifications.push_back(m->getFullId());
+        }
       }
     }
+
     // sort by name (case INsensitive)
     sort(modifications.begin(), modifications.end(), [&](const String& a, const String& b) {
       size_t i(0);

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -145,7 +145,6 @@ namespace OpenMS
     } 
   }
 
-
   const ResidueModification* ModificationsDB::getModification(const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const
   {
     set<const ResidueModification*> mods;
@@ -161,14 +160,14 @@ namespace OpenMS
 
     if (mods.empty())
     {
-      LOG_WARN << "Warning ("<< OPENMS_PRETTY_FUNCTION << ") Retrieving the modification failed. It is not available for the residue '" + String(residue) + "' and term specificity " + String(Int(term_spec)) + ". " <<  mod_name << endl;
-      return nullptr;
+      String message = String("Retrieving the modification failed. It is not available for the residue '") + residue 
+        + "' and term specificity '" + ResidueModification().getTermSpecificityName(term_spec) + "'. ";
+      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, message, mod_name);
     }
     if (mods.size() > 1)
     {
       LOG_WARN << "Warning (ModificationsDB::getModification): more than one modification with name '" + mod_name + "', residue '" + residue + "', specificity '" + String(Int(term_spec)) << "' found, picking the first one of:";
-      for (set<const ResidueModification*>::const_iterator it = mods.begin();
-           it != mods.end(); ++it)
+      for (auto it = mods.begin(); it != mods.end(); ++it)
       {
         LOG_WARN << " " << (*it)->getFullId();
       }
@@ -192,8 +191,7 @@ namespace OpenMS
   {
     if (!has(mod_name))
     {
-      LOG_WARN << OPENMS_PRETTY_FUNCTION  << " Modification not found: " << mod_name << endl;
-      return numeric_limits<Size>::max();
+      throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Modification not found: " + mod_name);
     }
 
     bool one_mod(true);
@@ -201,11 +199,13 @@ namespace OpenMS
     {
       if (modification_names_[mod_name].size() > 1)
       {
-        LOG_WARN << OPENMS_PRETTY_FUNCTION  << " More than one Modification with name: " << mod_name << endl;
         one_mod = false;
       }
     }
-    if (!one_mod) return numeric_limits<Size>::max();
+    if (!one_mod) 
+    {
+      throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "More than one modification with name: " + mod_name);
+    }
 
     Size index(numeric_limits<Size>::max());
     #pragma omp critical(OpenMS_ModificationsDB)
@@ -220,9 +220,10 @@ namespace OpenMS
         }
       }
     }
+
     if (index == numeric_limits<Size>::max())
     {
-      LOG_WARN << OPENMS_PRETTY_FUNCTION  << " Modification name found but modification not found: " << mod_name << endl;
+      throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Modification name found but modification not found: " + mod_name);
     }
     return index;
   }

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -49,7 +49,6 @@ using namespace std;
 namespace OpenMS
 {
   bool ModificationsDB::is_instantiated_ = false;
-  
 
   ModificationsDB::ModificationsDB(OpenMS::String unimod_file, OpenMS::String psimod_file, OpenMS::String xlmod_file)
   {
@@ -67,40 +66,36 @@ namespace OpenMS
     {
       readFromOBOFile(xlmod_file);
     }
-
     is_instantiated_ = true;
-  }
-
-
-  bool ModificationsDB::isInstantiated()
-  {
-    return is_instantiated_;
   }
 
 
   ModificationsDB::~ModificationsDB()
   {
     modification_names_.clear();
-    for (vector<ResidueModification*>::iterator it = mods_.begin(); it != mods_.end(); ++it)
+    for (auto it = mods_.begin(); it != mods_.end(); ++it)
     {
       delete *it;
     }
   }
 
+  bool ModificationsDB::isInstantiated()
+  {
+    return is_instantiated_;
+  }
 
   Size ModificationsDB::getNumberOfModifications() const
   {
-    return mods_.size();
+    Size s;
+    s = mods_.size();
+    return s;
   }
 
 
-  const ResidueModification& ModificationsDB::getModification(Size index) const
+  const ResidueModification* ModificationsDB::getModification(Size index) const
   {
-    if (index >= mods_.size())
-    {
-      throw Exception::IndexOverflow(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, index, mods_.size());
-    }
-    return *mods_[index];
+    OPENMS_PRECONDITION(index < mods_.size(), "Index out of bounds in ModificationsDB::getModification(Size index)." );
+    return mods_[index];
   }
 
 
@@ -141,7 +136,7 @@ namespace OpenMS
   }
 
 
-  const ResidueModification& ModificationsDB::getModification(const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const
+  const ResidueModification* ModificationsDB::getModification(const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const
   {
     set<const ResidueModification*> mods;
     // if residue is specified, try residue-specific search first to avoid
@@ -156,7 +151,8 @@ namespace OpenMS
 
     if (mods.empty())
     {
-      throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Retrieving the modification failed. It is not available for the residue '" + String(residue) + "' and term specificity " + String(Int(term_spec)) + ".", mod_name);
+      LOG_WARN << "Warning ("<< OPENMS_PRETTY_FUNCTION << ") Retrieving the modification failed. It is not available for the residue '" + String(residue) + "' and term specificity " + String(Int(term_spec)) + ". " <<  mod_name << endl;
+      return nullptr;
     }
     if (mods.size() > 1)
     {
@@ -168,7 +164,7 @@ namespace OpenMS
       }
       LOG_WARN << "\n";
     }
-    return **mods.begin();
+    return *mods.begin();
   }
 
 

--- a/src/openms/source/CHEMISTRY/Residue.cpp
+++ b/src/openms/source/CHEMISTRY/Residue.cpp
@@ -506,8 +506,8 @@ namespace OpenMS
   void Residue::setModification(const String& name)
   {
     ModificationsDB* mod_db = ModificationsDB::getInstance();
-    const ResidueModification& mod = mod_db->getModification(name, one_letter_code_, ResidueModification::ANYWHERE);
-    setModification_(mod);
+    const ResidueModification* mod = mod_db->getModification(name, one_letter_code_, ResidueModification::ANYWHERE);
+    setModification_(*mod);
   }
 
   const String& Residue::getModificationName() const

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -249,7 +249,7 @@ namespace OpenMS
           residues_.insert(res_ptr);
           const_residues_.insert(res_ptr);
           prefix = split[0] + split[1];
-          residue_by_one_letter_code_[res_ptr->getOneLetterCode()[0]] = res_ptr;
+          residue_by_one_letter_code_[static_cast<unsigned char>(res_ptr->getOneLetterCode()[0])] = res_ptr;
         }
 
         String value = it->value;
@@ -261,7 +261,7 @@ namespace OpenMS
       res_ptr = parseResidue_(values);
       residues_.insert(res_ptr);
       const_residues_.insert(res_ptr);
-      residue_by_one_letter_code_[res_ptr->getOneLetterCode()[0]] = res_ptr;
+      residue_by_one_letter_code_[static_cast<unsigned char>(res_ptr->getOneLetterCode()[0])] = res_ptr;
     }
     catch (Exception::BaseException& e)
     {

--- a/src/openms/source/CHEMISTRY/ResidueDB.cpp
+++ b/src/openms/source/CHEMISTRY/ResidueDB.cpp
@@ -128,7 +128,7 @@ namespace OpenMS
       buildResidueNames_();
     }     
   }
-
+/*
   void ResidueDB::addResidue(const Residue& residue)
   {
     #pragma omp critical (ResidueDB)
@@ -137,7 +137,7 @@ namespace OpenMS
       addResidue_(r);
     }
   }
-
+*/
   void ResidueDB::addResidue_(Residue* r)
   {
     vector<String> names;

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -2432,55 +2432,71 @@ namespace OpenMS
                     }
                     else if (index == static_cast<SignedSize>(aas.size() + 1))
                     {
-                      try // does not work for cross-links yet, but the information is finally stored as MetaValues of the PeptideHit
+                      // TODO: does not work for cross-links yet, but the information is finally stored as MetaValues of the PeptideHit
+                      if (cvname == "unknown modification")
                       {
-                        if (cvname == "unknown modification")
+                        const String & cvvalue = cv.getValue();
+                        if (ModificationsDB::getInstance()->has(cvvalue) && !cvvalue.empty())
                         {
-                          const String & cvvalue = cv.getValue();
-                          if (ModificationsDB::getInstance()->has(cvvalue) && !cvvalue.empty())
-                          {
-                            aas.setCTerminalModification(cvvalue);
-                          }
+                          aas.setCTerminalModification(cvvalue);
                         }
                         else
+                        {
+                          LOG_WARN << "Modification: " << cvvalue << " not found in ModificationsDB." << endl;
+                          // TODO? @enetz look it up in XLDB?
+                        }
+                      }
+                      else
+                      {
+                        if (ModificationsDB::getInstance()->has(cvname))
                         {
                           aas.setCTerminalModification(cvname);
                         }
-                        cvp = cvp->getNextElementSibling();
-                        continue;
+                        else
+                        {
+                          LOG_WARN << "Modification: " << cvname << " not found in ModificationsDB." << endl;
+                          // TODO? @enetz look it up in XLDB?
+                        }
                       }
-                      catch (...)
-                      {
-                        // TODO Residue and AASequence should use CrossLinksDB as well
-                      }
+                      cvp = cvp->getNextElementSibling();
+                      continue;
                     }
                     else
                     {
-                      try
+                      if (cvname == "unknown modification")
                       {
-                        if (cvname == "unknown modification")
+                        const String & cvvalue = cv.getValue();
+                        if (ModificationsDB::getInstance()->has(cvvalue) && !cvvalue.empty())
                         {
-                          const String & cvvalue = cv.getValue();
-                          if (ModificationsDB::getInstance()->has(cvvalue) && !cvvalue.empty())
-                          {
-                            aas.setModification(index - 1, cvvalue); //TODO @mths,Timo : do this via UNIMOD accessions
-                          }
+                          aas.setModification(index - 1, cvvalue); 
                         }
                         else
                         {
-                          aas.setModification(index - 1, cv.getName()); //TODO @mths,Timo : do this via UNIMOD accessions
+                          LOG_WARN << "Modification: " << cvvalue << " not found in ModificationsDB." << endl;
+                          // TODO? @enetz look it up in XLDB?
                         }
-                        cvp = cvp->getNextElementSibling();
-                        continue;
                       }
-                      catch (Exception::BaseException& e)
+                      else
                       {
+                        if (ModificationsDB::getInstance()->has(cvname))
+                        {
+                          aas.setModification(index - 1, cvname);
+                        }
+                        else
+                        {
+                          LOG_WARN << "Modification: " << cvname << " not found in ModificationsDB." << endl;
+                          // TODO? @enetz look it up in XLDB?
+                        }
+                      }
+                      cvp = cvp->getNextElementSibling();
+                      continue;
+/* TODO enetz: look up in XLDB and remvoe this ha
                         // this is a bad hack to avoid a long list of warnings in the case of XL-MS data
                         if ( !(String(e.getMessage()).hasSubstring("'DSG'") || String(e.getMessage()).hasSubstring("'DSS'") || String(e.getMessage()).hasSubstring("'EDC'")) || String(e.getMessage()).hasSubstring("'BS3'") || String(e.getMessage()).hasSubstring("'BS2G'") )
                         {
                           LOG_WARN << e.getName() << ": " << e.getMessage() << " Sequence: " << aas.toUnmodifiedString() << ", residue " << aas.getResidue(index - 1).getName() << "@" << String(index) << endl;
                         }
-                      }
+*/
                     }
                   }
                 }

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -970,34 +970,34 @@ namespace OpenMS
                     {
                       if (spci->second.front().getAccession() == "MS:1001189")  // nterm
                       {
-                        ResidueModification m = ModificationsDB::getInstance()->getModification(mname, r, ResidueModification::N_TERM);
-                        mod = m.getFullId();
+                        const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r, ResidueModification::N_TERM);
+                        mod = m->getFullId();
                       }
                       else if (spci->second.front().getAccession() == "MS:1001190")  // cterm
                       {
-                        ResidueModification m = ModificationsDB::getInstance()->getModification(mname, r, ResidueModification::C_TERM);
-                        mod = m.getFullId();
+                        const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r, ResidueModification::C_TERM);
+                        mod = m->getFullId();
                       }
                       else if (spci->second.front().getAccession() == "MS:1002057")  // pro nterm
                       {
                         // TODO: add support for protein N-terminal modifications in unimod
-                        // ResidueModification m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::PROTEIN_N_TERM);
-                        ResidueModification m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::N_TERM);
-                        mod = m.getFullId();
+                        // ResidueModification* m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::PROTEIN_N_TERM);
+                        const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::N_TERM);
+                        mod = m->getFullId();
                       }
                       else if (spci->second.front().getAccession() == "MS:1002058")  // pro cterm
                       {
                         // TODO: add support for protein C-terminal modifications in unimod
-                        // ResidueModification m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::PROTEIN_C_TERM);
-                        ResidueModification m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::C_TERM);
-                        mod = m.getFullId();
+                        // ResidueModification* m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::PROTEIN_C_TERM);
+                        const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname,  r, ResidueModification::C_TERM);
+                        mod = m->getFullId();
                       }
                     }
                   }
                   else  // anywhere
                   {
-                    ResidueModification m = ModificationsDB::getInstance()->getModification(mname, r);
-                    mod = m.getFullId();
+                    const ResidueModification* m = ModificationsDB::getInstance()->getModification(mname, r);
+                    mod = m->getFullId();
                   }
 
                   if (fixedMod)
@@ -2617,7 +2617,7 @@ namespace OpenMS
 
                       // now use the new modification
                       Size mod_idx = mod_db->findModificationIndex(residue_name);
-                      const ResidueModification* res_mod = &mod_db->getModification(mod_idx);
+                      const ResidueModification* res_mod = mod_db->getModification(mod_idx);
 
                       // Set a modification on the given AA
                       // Note: this calls setModification_ on a new Residue which changes its
@@ -2752,34 +2752,34 @@ namespace OpenMS
         current_pep->appendChild(current_seq);
         if (peps->second.hasNTerminalModification())
         {
-          const ResidueModification& mod = *(peps->second.getNTerminalModification());
+          const ResidueModification* mod = peps->second.getNTerminalModification();
           DOMElement* current_mod = current_pep->getOwnerDocument()->createElement(XMLString::transcode("Modification"));
           DOMElement* current_cv = current_pep->getOwnerDocument()->createElement(XMLString::transcode("cvParam"));
           current_mod->setAttribute(XMLString::transcode("location"), XMLString::transcode("0"));
-          current_mod->setAttribute(XMLString::transcode("monoisotopicMassDelta"), XMLString::transcode(String(mod.getDiffMonoMass()).c_str()));
-          String origin = mod.getOrigin();
+          current_mod->setAttribute(XMLString::transcode("monoisotopicMassDelta"), XMLString::transcode(String(mod->getDiffMonoMass()).c_str()));
+          String origin = mod->getOrigin();
           if (origin == "X") origin = ".";
           current_mod->setAttribute(XMLString::transcode("residues"), XMLString::transcode(origin.c_str()));
-          current_cv->setAttribute(XMLString::transcode("name"), XMLString::transcode(mod.getName().c_str()));
+          current_cv->setAttribute(XMLString::transcode("name"), XMLString::transcode(mod->getName().c_str()));
           current_cv->setAttribute(XMLString::transcode("cvRef"), XMLString::transcode("UNIMOD"));
-          current_cv->setAttribute(XMLString::transcode("accession"), XMLString::transcode(mod.getUniModAccession().c_str()));
+          current_cv->setAttribute(XMLString::transcode("accession"), XMLString::transcode(mod->getUniModAccession().c_str()));
 
           current_mod->appendChild(current_cv);
           current_pep->appendChild(current_mod);
         }
         if (peps->second.hasCTerminalModification())
         {
-          const ResidueModification& mod = *(peps->second.getCTerminalModification());
+          const ResidueModification* mod = peps->second.getCTerminalModification();
           DOMElement* current_mod = current_pep->getOwnerDocument()->createElement(XMLString::transcode("Modification"));
           DOMElement* current_cv = current_mod->getOwnerDocument()->createElement(XMLString::transcode("cvParam"));
           current_mod->setAttribute(XMLString::transcode("location"), XMLString::transcode(String(peps->second.size() + 1).c_str()));
-          current_mod->setAttribute(XMLString::transcode("monoisotopicMassDelta"), XMLString::transcode(String(mod.getDiffMonoMass()).c_str()));
-          String origin = mod.getOrigin();
+          current_mod->setAttribute(XMLString::transcode("monoisotopicMassDelta"), XMLString::transcode(String(mod->getDiffMonoMass()).c_str()));
+          String origin = mod->getOrigin();
           if (origin == "X") origin = ".";
           current_mod->setAttribute(XMLString::transcode("residues"), XMLString::transcode(origin.c_str()));
-          current_cv->setAttribute(XMLString::transcode("name"), XMLString::transcode(mod.getName().c_str()));
+          current_cv->setAttribute(XMLString::transcode("name"), XMLString::transcode(mod->getName().c_str()));
           current_cv->setAttribute(XMLString::transcode("cvRef"), XMLString::transcode("UNIMOD"));
-          current_cv->setAttribute(XMLString::transcode("accession"), XMLString::transcode(mod.getUniModAccession().c_str()));
+          current_cv->setAttribute(XMLString::transcode("accession"), XMLString::transcode(mod->getUniModAccession().c_str()));
 
           current_mod->appendChild(current_cv);
           current_pep->appendChild(current_mod);

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -986,12 +986,9 @@ namespace OpenMS
                 {
                   if (mods[s].hasSubstring(jt->getMetaValue("xl_mod")))
                   {
-                    ResidueModification mod;
-                    try
-                    {
-                      mod = xl_db->getModification(mods[s], jt->getSequence()[i].getOneLetterCode(), ResidueModification::ANYWHERE);
-                    }
-                    catch (...)
+                    const ResidueModification* mod = xl_db->getModification(mods[s], jt->getSequence()[i].getOneLetterCode(), ResidueModification::ANYWHERE);
+                    
+                    if (mod == nullptr)
                     {
                       if (jt->metaValueExists("xl_term_spec") && jt->getMetaValue("xl_term_spec") == "N_TERM")
                       {
@@ -1002,8 +999,8 @@ namespace OpenMS
                         mod = xl_db->getModification(mods[s], "", ResidueModification::C_TERM);
                       }
                     }
-                    acc = mod.getPSIMODAccession();
-                    name = mod.getId();
+                    acc = mod->getPSIMODAccession();
+                    name = mod->getId();
                   }
                   if (!acc.empty())
                   {
@@ -1012,9 +1009,9 @@ namespace OpenMS
                 }
                 if ( acc.empty() && (mods.size() > 0) ) // If ambiguity can not be resolved by xl_mod, just take one with the same mass diff from the database
                 {
-                  ResidueModification mod = xl_db->getModification( String(jt->getSequence()[i].getOneLetterCode()), mods[0], ResidueModification::ANYWHERE);
-                  acc = mod.getPSIMODAccession();
-                  name = mod.getId();
+                  const ResidueModification* mod = xl_db->getModification( String(jt->getSequence()[i].getOneLetterCode()), mods[0], ResidueModification::ANYWHERE);
+                  acc = mod->getPSIMODAccession();
+                  name = mod->getId();
                 }
 
                 if (!acc.empty())

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -1007,7 +1007,8 @@ namespace OpenMS
                         mod = xl_db->getModification(mods[s], "", ResidueModification::C_TERM);
                       }
                     }
-                    acc = mod->getPSIMODAccession();
+                    // mod should never be null, but gcc complains (-Werror=maybe-uninitialized)
+                    if (mod != nullptr) acc = mod->getPSIMODAccession();
                     if (mod != nullptr) name = mod->getId();
                   }
                   if (!acc.empty())

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -991,7 +991,7 @@ namespace OpenMS
                 {
                   if (mods[s].hasSubstring(jt->getMetaValue("xl_mod")))
                   {
-                    const ResidueModification* mod;
+                    const ResidueModification* mod = nullptr;
                     try
                     {
                       mod = xl_db->getModification(mods[s], jt->getSequence()[i].getOneLetterCode(), ResidueModification::ANYWHERE);

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -1008,7 +1008,7 @@ namespace OpenMS
                       }
                     }
                     acc = mod->getPSIMODAccession();
-                    name = mod->getId();
+                    if (mod != nullptr) name = mod->getId();
                   }
                   if (!acc.empty())
                   {

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -373,6 +373,11 @@ namespace OpenMS
           {
             warning(LOAD, "location of modification not defined!");
           }
+          if (mods.empty()) 
+          {
+            String message = String("Modification '") + accession + "' is unknown.";
+            throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, message);
+          }
         }
       }
     }
@@ -986,9 +991,12 @@ namespace OpenMS
                 {
                   if (mods[s].hasSubstring(jt->getMetaValue("xl_mod")))
                   {
-                    const ResidueModification* mod = xl_db->getModification(mods[s], jt->getSequence()[i].getOneLetterCode(), ResidueModification::ANYWHERE);
-                    
-                    if (mod == nullptr)
+                    const ResidueModification* mod;
+                    try
+                    {
+                      mod = xl_db->getModification(mods[s], jt->getSequence()[i].getOneLetterCode(), ResidueModification::ANYWHERE);
+                    }
+                    catch (...)
                     {
                       if (jt->metaValueExists("xl_term_spec") && jt->getMetaValue("xl_term_spec") == "N_TERM")
                       {
@@ -1653,7 +1661,8 @@ namespace OpenMS
         }
         else
         {
-          LOG_WARN << String("Registered ") + (fixed ? "fixed" : "variable") + " modification '" << *it << "' is unknown and will be ignored." << std::endl;
+          String message = String("Registered ") + (fixed ? "fixed" : "variable") + " modification '" + *it + "' is unknown and will be ignored.";
+          throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, message);
         }
       }
     }

--- a/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/TraMLHandler.cpp
@@ -680,8 +680,8 @@ namespace OpenMS
                 {
                   residue = it->sequence[mit->location];
                 }
-                const ResidueModification& rmod = mod_db->getModification("UniMod:" + String(mit->unimod_id), residue, term_spec);
-                String modname = rmod.getId();
+                const ResidueModification* rmod = mod_db->getModification("UniMod:" + String(mit->unimod_id), residue, term_spec);
+                String modname = rmod->getId();
                 os << "        <cvParam cvRef=\"UNIMOD\" accession=\"UNIMOD:" << mit->unimod_id
                   << "\" name=\"" << modname << "\"/>\n";
               }

--- a/src/openms/source/FORMAT/OMSSAXMLFile.cpp
+++ b/src/openms/source/FORMAT/OMSSAXMLFile.cpp
@@ -162,17 +162,18 @@ namespace OpenMS
           warning(LOAD, String("Cannot determine exact type of modification of position ") + actual_mod_site_ + " in sequence " + actual_peptide_hit_.getSequence().toString() + " using modification " + actual_mod_type_ + " - using first possibility!");
         }
         AASequence pep = actual_peptide_hit_.getSequence();
-        if (mods_map_[actual_mod_type_.toInt()].begin()->getTermSpecificity() == ResidueModification::N_TERM)
+        auto mod = *(mods_map_[actual_mod_type_.toInt()].begin());
+        if (mod->getTermSpecificity() == ResidueModification::N_TERM)
         {
-          pep.setNTerminalModification(mods_map_[actual_mod_type_.toInt()].begin()->getFullId());
+          pep.setNTerminalModification(mod->getFullId());
         }
-        else if (mods_map_[actual_mod_type_.toInt()].begin()->getTermSpecificity() == ResidueModification::C_TERM)
+        else if (mod->getTermSpecificity() == ResidueModification::C_TERM)
         {
-          pep.setCTerminalModification(mods_map_[actual_mod_type_.toInt()].begin()->getFullId());
+          pep.setCTerminalModification(mod->getFullId());
         }
         else
         {
-          pep.setModification(actual_mod_site_, mods_map_[actual_mod_type_.toInt()].begin()->getFullId());
+          pep.setModification(actual_mod_site_, mod->getFullId());
         }
         actual_peptide_hit_.setSequence(pep);
       }
@@ -282,7 +283,7 @@ namespace OpenMS
         set<String> fixed_mod_names = mod_def_set_.getFixedModificationNames();
         for (set<String>::const_iterator it = fixed_mod_names.begin(); it != fixed_mod_names.end(); ++it)
         {
-          String origin = ModificationsDB::getInstance()->getModification(*it).getOrigin();
+          String origin = ModificationsDB::getInstance()->getModification(*it)->getOrigin();
           UInt position(0);
           for (AASequence::Iterator ait = seq.begin(); ait != seq.end(); ++ait, ++position)
           {
@@ -391,15 +392,15 @@ namespace OpenMS
         {
           fatalError(LOAD, String("Invalid mapping file line: '") + *it + "'");
         }
-        vector<ResidueModification> mods;
+        vector<const ResidueModification*> mods;
         for (Size i = 2; i != split.size(); ++i)
         {
           String tmp(split[i].trim());
           if (!tmp.empty())
           {
-            ResidueModification mod = ModificationsDB::getInstance()->getModification(tmp);
+            const ResidueModification* mod = ModificationsDB::getInstance()->getModification(tmp);
             mods.push_back(mod);
-            mods_to_num_[mod.getFullId()] = omssa_mod_num;
+            mods_to_num_[mod->getFullId()] = omssa_mod_num;
           }
         }
         mods_map_[omssa_mod_num] = mods;

--- a/src/openms/source/FORMAT/PepNovoInfile.cpp
+++ b/src/openms/source/FORMAT/PepNovoInfile.cpp
@@ -83,11 +83,11 @@ namespace OpenMS
   {
     String locations, key, type;
 
-    ResidueModification::TermSpecificity ts = ModificationsDB::getInstance()->getModification(modification).getTermSpecificity();
-    String origin = ModificationsDB::getInstance()->getModification(modification).getOrigin();
-    double mass = ModificationsDB::getInstance()->getModification(modification).getDiffMonoMass();
-    String full_name = ModificationsDB::getInstance()->getModification(modification).getFullName();
-    String full_id = ModificationsDB::getInstance()->getModification(modification).getFullId();
+    ResidueModification::TermSpecificity ts = ModificationsDB::getInstance()->getModification(modification)->getTermSpecificity();
+    String origin = ModificationsDB::getInstance()->getModification(modification)->getOrigin();
+    double mass = ModificationsDB::getInstance()->getModification(modification)->getDiffMonoMass();
+    String full_name = ModificationsDB::getInstance()->getModification(modification)->getFullName();
+    String full_id = ModificationsDB::getInstance()->getModification(modification)->getFullId();
 
 
     if (variable)

--- a/src/openms/source/FORMAT/PepNovoOutfile.cpp
+++ b/src/openms/source/FORMAT/PepNovoOutfile.cpp
@@ -127,14 +127,14 @@ namespace OpenMS
       if (pnovo_modkey_to_mod_id.find(*mod_it) != pnovo_modkey_to_mod_id.end())
       {
         //cout<<keys_to_id.find(*mod_it)->second<<endl;
-        ResidueModification tmp_mod = ModificationsDB::getInstance()->getModification(pnovo_modkey_to_mod_id.find(*mod_it)->second);
+        const ResidueModification* tmp_mod = ModificationsDB::getInstance()->getModification(pnovo_modkey_to_mod_id.find(*mod_it)->second);
         if (mod_it->prefix(1) == "^" || mod_it->prefix(1) == "$")
         {
-          mod_mask_map[*mod_it] = "(" + tmp_mod.getId() + ")";
+          mod_mask_map[*mod_it] = "(" + tmp_mod->getId() + ")";
         }
         else
         {
-          mod_mask_map[*mod_it] = String(tmp_mod.getOrigin()) + "(" + tmp_mod.getId() + ")";
+          mod_mask_map[*mod_it] = String(tmp_mod->getOrigin()) + "(" + tmp_mod->getId() + ")";
         }
       }
       else

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -219,15 +219,15 @@ namespace OpenMS
     for (set<String>::const_iterator it = aa_mods.begin();
          it != aa_mods.end(); ++it)
     {
-      const ResidueModification& mod = ModificationsDB::getInstance()->getModification(*it, "", ResidueModification::ANYWHERE);
+      const ResidueModification* mod = ModificationsDB::getInstance()->getModification(*it, "", ResidueModification::ANYWHERE);
 
       // compute mass of modified residue
-      EmpiricalFormula ef = ResidueDB::getInstance()->getResidue(mod.getOrigin())->getFormula(Residue::Internal);
-      ef += mod.getDiffFormula();
+      EmpiricalFormula ef = ResidueDB::getInstance()->getResidue(mod->getOrigin())->getFormula(Residue::Internal);
+      ef += mod->getDiffFormula();
 
       f << "\t\t"
-        << "<aminoacid_modification aminoacid=\"" << mod.getOrigin()
-        << "\" massdiff=\"" << precisionWrapper(mod.getDiffMonoMass()) << "\" mass=\""
+        << "<aminoacid_modification aminoacid=\"" << mod->getOrigin()
+        << "\" massdiff=\"" << precisionWrapper(mod->getDiffMonoMass()) << "\" mass=\""
         << precisionWrapper(ef.getMonoWeight())
         << "\" variable=\"Y\" binary=\"N\" description=\"" << *it << "\"/>"
         << "\n";
@@ -235,20 +235,20 @@ namespace OpenMS
 
     for (set<String>::const_iterator it = n_term_mods.begin(); it != n_term_mods.end(); ++it)
     {
-      const ResidueModification& mod = ModificationsDB::getInstance()->getModification(*it, "", ResidueModification::N_TERM);
+      const ResidueModification* mod = ModificationsDB::getInstance()->getModification(*it, "", ResidueModification::N_TERM);
       f << "\t\t"
         << "<terminal_modification terminus=\"n\" massdiff=\""
-        << precisionWrapper(mod.getDiffMonoMass()) << "\" mass=\"" << precisionWrapper(mod.getMonoMass())
+        << precisionWrapper(mod->getDiffMonoMass()) << "\" mass=\"" << precisionWrapper(mod->getMonoMass())
         << "\" variable=\"Y\" description=\"" << *it
         << "\" protein_terminus=\"\"/>" << "\n";
     }
 
     for (set<String>::const_iterator it = c_term_mods.begin(); it != c_term_mods.end(); ++it)
     {
-      const ResidueModification& mod = ModificationsDB::getInstance()->getModification(*it, "", ResidueModification::C_TERM);
+      const ResidueModification* mod = ModificationsDB::getInstance()->getModification(*it, "", ResidueModification::C_TERM);
       f << "\t\t"
         << "<terminal_modification terminus=\"c\" massdiff=\""
-        << precisionWrapper(mod.getDiffMonoMass()) << "\" mass=\"" << precisionWrapper(mod.getMonoMass())
+        << precisionWrapper(mod->getDiffMonoMass()) << "\" mass=\"" << precisionWrapper(mod->getMonoMass())
         << "\" variable=\"Y\" description=\"" << *it
         << "\" protein_terminus=\"\"/>" << "\n";
     }
@@ -403,15 +403,15 @@ namespace OpenMS
 
           if (seq.hasNTerminalModification())
           {
-            const ResidueModification& mod = *(seq.getNTerminalModification());
-            const double mod_nterm_mass = Residue::getInternalToNTerm().getMonoWeight() + mod.getDiffMonoMass();
+            const ResidueModification* mod = seq.getNTerminalModification();
+            const double mod_nterm_mass = Residue::getInternalToNTerm().getMonoWeight() + mod->getDiffMonoMass();
             f << " mod_nterm_mass=\"" << precisionWrapper(mod_nterm_mass) << "\"";
           }
 
           if (seq.hasCTerminalModification())
           {
-            const ResidueModification& mod = *(seq.getCTerminalModification());
-            const double mod_cterm_mass = Residue::getInternalToCTerm().getMonoWeight() + mod.getDiffMonoMass();
+            const ResidueModification* mod = seq.getCTerminalModification();
+            const double mod_cterm_mass = Residue::getInternalToCTerm().getMonoWeight() + mod->getDiffMonoMass();
             f << " mod_cterm_mass=\"" << precisionWrapper(mod_cterm_mass) << "\"";
           }
 
@@ -421,11 +421,11 @@ namespace OpenMS
           {
             if (seq[i].isModified())
             {
-              const ResidueModification& mod = *(seq[i].getModification());
+              const ResidueModification* mod = seq[i].getModification();
               // the modification position is 1-based
               f << "\t\t\t\t<mod_aminoacid_mass position=\"" << (i + 1)
                 << "\" mass=\"" <<
-                precisionWrapper(mod.getMonoMass() + seq[i].getMonoWeight(Residue::Internal)) << "\"/>" << "\n";
+                precisionWrapper(mod->getMonoMass() + seq[i].getMonoWeight(Residue::Internal)) << "\"/>" << "\n";
             }
           }
 
@@ -1215,11 +1215,12 @@ namespace OpenMS
       // check if the modification is uniquely defined:
       if (!aa_mod.description.empty())
       {
-        try
+        const ResidueModification* r = ModificationsDB::getInstance()->getModification(aa_mod.description, aa_mod.aminoacid, term_spec);
+        if (r)
         {
-          desc = ModificationsDB::getInstance()->getModification(aa_mod.description, aa_mod.aminoacid, term_spec).getFullId();
+          desc = r->getFullId();
         }
-        catch (Exception::BaseException)
+        else
         {
           error(LOAD, "Modification '" + aa_mod.description + "' of residue '" + aa_mod.aminoacid + "' could not be matched. Trying by modification mass.");
         }

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -1215,12 +1215,12 @@ namespace OpenMS
       // check if the modification is uniquely defined:
       if (!aa_mod.description.empty())
       {
-        const ResidueModification* r = ModificationsDB::getInstance()->getModification(aa_mod.description, aa_mod.aminoacid, term_spec);
-        if (r)
-        {
+	try
+	{
+          const ResidueModification* r = ModificationsDB::getInstance()->getModification(aa_mod.description, aa_mod.aminoacid, term_spec);
           desc = r->getFullId();
-        }
-        else
+	}
+        catch (Exception::BaseException)
         {
           error(LOAD, "Modification '" + aa_mod.description + "' of residue '" + aa_mod.aminoacid + "' could not be matched. Trying by modification mass.");
         }
@@ -1469,12 +1469,12 @@ namespace OpenMS
       // fixed modifications
       for (vector<AminoAcidModification>::const_iterator it = fixed_modifications_.begin(); it != fixed_modifications_.end(); ++it)
       {
-        const Residue* residue = ResidueDB::getInstance()->getResidue(it->aminoacid);
+        bool mass_only = it->aminoacid == "" ? true : false;
 
-        if (residue == nullptr)
+        if (mass_only)
         {
           double new_mass = it->massdiff.toDouble();
-          if (it->aminoacid == "" && it->terminus =="n")
+          if (it->terminus == "n")
           {
             vector<String> mods;
             ModificationsDB::getInstance()->searchModificationsByDiffMonoMass(mods, new_mass, mod_tol_, "", ResidueModification::N_TERM);
@@ -1496,7 +1496,7 @@ namespace OpenMS
                     it->massdiff + " mass: " + String(it->mass) + " variable: " + String(it->variable) + " terminus: " + it->terminus + " description: " + it->description);
             }
           }
-          else if (it->aminoacid == "" && it->terminus =="c")
+          else if (it->terminus == "c")
           {
             vector<String> mods;
             ModificationsDB::getInstance()->searchModificationsByDiffMonoMass(mods, new_mass, mod_tol_, "", ResidueModification::C_TERM);
@@ -1526,6 +1526,8 @@ namespace OpenMS
         }
         else
         {
+          const Residue* residue = ResidueDB::getInstance()->getResidue(it->aminoacid);
+
           double new_mass = it->mass - residue->getMonoWeight(Residue::Internal);
           vector<String> mods;
           ModificationsDB::getInstance()->searchModificationsByDiffMonoMass(mods, new_mass, mod_tol_, it->aminoacid, ResidueModification::ANYWHERE);

--- a/src/openms/source/FORMAT/PepXMLFile.cpp
+++ b/src/openms/source/FORMAT/PepXMLFile.cpp
@@ -1216,10 +1216,10 @@ namespace OpenMS
       if (!aa_mod.description.empty())
       {
 	try
-	{
+        {
           const ResidueModification* r = ModificationsDB::getInstance()->getModification(aa_mod.description, aa_mod.aminoacid, term_spec);
           desc = r->getFullId();
-	}
+        }
         catch (Exception::BaseException)
         {
           error(LOAD, "Modification '" + aa_mod.description + "' of residue '" + aa_mod.aminoacid + "' could not be matched. Trying by modification mass.");

--- a/src/openms/source/FORMAT/ProtXMLFile.cpp
+++ b/src/openms/source/FORMAT/ProtXMLFile.cpp
@@ -211,13 +211,13 @@ namespace OpenMS
         temp_description.split(' ', mod_split);
         if (mod_split.size() == 2)
         {
-          if (mod_split[1] == "(C-term)" || ModificationsDB::getInstance()->getModification(temp_description).getTermSpecificity() == ResidueModification::C_TERM)
+          if (mod_split[1] == "(C-term)" || ModificationsDB::getInstance()->getModification(temp_description)->getTermSpecificity() == ResidueModification::C_TERM)
           {
             temp_aa_sequence.setCTerminalModification(mod_split[0]);
           }
           else
           {
-            if (mod_split[1] == "(N-term)" || ModificationsDB::getInstance()->getModification(temp_description).getTermSpecificity() == ResidueModification::N_TERM)
+            if (mod_split[1] == "(N-term)" || ModificationsDB::getInstance()->getModification(temp_description)->getTermSpecificity() == ResidueModification::N_TERM)
             {
               temp_aa_sequence.setNTerminalModification(mod_split[0]);
             }

--- a/src/openms/source/SIMULATION/LABELING/SILACLabeler.cpp
+++ b/src/openms/source/SIMULATION/LABELING/SILACLabeler.cpp
@@ -76,14 +76,12 @@ namespace OpenMS
   bool SILACLabeler::canModificationBeApplied_(const String& modification_id, const String& aa) const
   {
     std::set<const ResidueModification*> modifications;
-    try
+    ModificationsDB::getInstance()->searchModifications(modifications, modification_id, aa);
+    
+    if (modifications.empty())
     {
-      ModificationsDB::getInstance()->searchModifications(modifications, modification_id, aa);
-    }
-    catch (Exception::ElementNotFound& ex)
-    {
-      ex.setMessage("The modification \"" + modification_id + "\" could not be found in the local UniMod DB! Please check if you used the correct format (e.g. UniMod:Accession#)");
-      throw;
+      String message = String("The modification '") + modification_id + "' could not be found in the local UniMod DB! Please check if you used the correct format (e.g. UniMod:Accession#)";
+      throw Exception::ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, message);
     }
 
     return !modifications.empty();

--- a/src/pyOpenMS/pxds/CrossLinksDB.pxd
+++ b/src/pyOpenMS/pxds/CrossLinksDB.pxd
@@ -15,13 +15,18 @@ cdef extern from "<OpenMS/CHEMISTRY/CrossLinksDB.h>" namespace "OpenMS":
 
         Size getNumberOfModifications() nogil except +
 
-        ResidueModification getModification(Size index) nogil except +
-
         void searchModifications(libcpp_set[ const ResidueModification * ] & mods,
-                                 String mod_name, String residue,
+                                 const String& mod_name,
+                                 const String& residue,
                                  TermSpecificity term_spec) nogil except +
 
-        ResidueModification getModification(const String & mod_name, const String & residue, TermSpecificity term_spec) nogil except +
+        const ResidueModification * getModification(Size index) nogil except +
+
+        const ResidueModification * getModification(const String & mod_name) nogil except +
+
+        const ResidueModification * getModification(const String & mod_name,
+                                            const String & residue,
+                                            TermSpecificity term_spec) nogil except +
 
         bool has(String modification) nogil except +
 
@@ -32,16 +37,13 @@ cdef extern from "<OpenMS/CHEMISTRY/CrossLinksDB.h>" namespace "OpenMS":
         void searchModificationsByDiffMonoMass(libcpp_vector[ String ] & mods, double mass, double max_error,
                                                const String & residue, TermSpecificity term_spec) nogil except +
 
-        const ResidueModification* getBestModificationByMonoMass(double mass, double max_error,
-                                                                 const String residue,
-                                                                 TermSpecificity term_spec) nogil except +
-
         const ResidueModification* getBestModificationByDiffMonoMass(double mass, double max_error,
-                                                                     const String residue, TermSpecificity term_spec) nogil except +
-
+                                                              const String residue, TermSpecificity term_spec) nogil except +
         void getAllSearchModifications(libcpp_vector[ String ] & modifications) nogil except +
 
         void readFromOBOFile(const String & filename) nogil except +
+
+        bool isInstantiated() nogil except +
 
 ## wrap static methods
 cdef extern from "<OpenMS/CHEMISTRY/CrossLinksDB.h>" namespace "OpenMS::CrossLinksDB":

--- a/src/pyOpenMS/pxds/ModificationsDB.pxd
+++ b/src/pyOpenMS/pxds/ModificationsDB.pxd
@@ -13,16 +13,17 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationsDB.h>" namespace "OpenMS":
         ModificationsDB(ModificationsDB) nogil except + #wrap-ignore
 
         Size getNumberOfModifications() nogil except +
-        ResidueModification getModification(Size index) nogil except +
 
         void searchModifications(libcpp_set[ const ResidueModification * ] & mods,
                                  const String& mod_name,
                                  const String& residue,
                                  TermSpecificity term_spec) nogil except +
 
-        ResidueModification getModification(const String & mod_name) nogil except +
+        ResidueModification * getModification(Size index) nogil except +
 
-        ResidueModification getModification(const String & mod_name,
+        ResidueModification * getModification(const String & mod_name) nogil except +
+
+        ResidueModification * getModification(const String & mod_name,
                                             const String & residue,
                                             TermSpecificity term_spec) nogil except +
 

--- a/src/pyOpenMS/pxds/ModificationsDB.pxd
+++ b/src/pyOpenMS/pxds/ModificationsDB.pxd
@@ -19,11 +19,11 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationsDB.h>" namespace "OpenMS":
                                  const String& residue,
                                  TermSpecificity term_spec) nogil except +
 
-        ResidueModification * getModification(Size index) nogil except +
+        const ResidueModification * getModification(Size index) nogil except +
 
-        ResidueModification * getModification(const String & mod_name) nogil except +
+        const ResidueModification * getModification(const String & mod_name) nogil except +
 
-        ResidueModification * getModification(const String & mod_name,
+        const ResidueModification * getModification(const String & mod_name,
                                             const String & residue,
                                             TermSpecificity term_spec) nogil except +
 
@@ -36,9 +36,6 @@ cdef extern from "<OpenMS/CHEMISTRY/ModificationsDB.h>" namespace "OpenMS":
         void searchModificationsByDiffMonoMass(libcpp_vector[ String ] & mods, double mass, double max_error,
                                                const String & residue, TermSpecificity term_spec) nogil except +
 
-        const ResidueModification* getBestModificationByMonoMass(double mass, double max_error,
-                                                                 const String& residue,
-                                                                 TermSpecificity term_spec) nogil except +
 
         const ResidueModification* getBestModificationByDiffMonoMass(double mass, double max_error,
                                                                      const String& residue, TermSpecificity term_spec) nogil except +

--- a/src/pyOpenMS/pxds/ResidueDB.pxd
+++ b/src/pyOpenMS/pxds/ResidueDB.pxd
@@ -17,7 +17,6 @@ cdef extern from "<OpenMS/CHEMISTRY/ResidueDB.h>" namespace "OpenMS":
         const Residue * getModifiedResidue(Residue * residue, const String & name) nogil except +
         libcpp_set[ const Residue * ] getResidues(const String & residue_set) nogil except +
         libcpp_set[ String ] getResidueSets() nogil except +
-        void setResidues(const String & filename) nogil except +
         void addResidue(Residue & residue) nogil except +
         bool hasResidue(const String & name) nogil except +
         # bool hasResidue(Residue * residue) nogil except + # does not really work as the ptr is different

--- a/src/pyOpenMS/pxds/ResidueDB.pxd
+++ b/src/pyOpenMS/pxds/ResidueDB.pxd
@@ -17,7 +17,6 @@ cdef extern from "<OpenMS/CHEMISTRY/ResidueDB.h>" namespace "OpenMS":
         const Residue * getModifiedResidue(Residue * residue, const String & name) nogil except +
         libcpp_set[ const Residue * ] getResidues(const String & residue_set) nogil except +
         libcpp_set[ String ] getResidueSets() nogil except +
-        void addResidue(Residue & residue) nogil except +
         bool hasResidue(const String & name) nogil except +
         # bool hasResidue(Residue * residue) nogil except + # does not really work as the ptr is different
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -5084,12 +5084,6 @@ def testModificationsDB():
 
     ###
 
-    m = mdb.getBestModificationByMonoMass(80, 20, "T", pyopenms.ResidueModification.TermSpecificity.ANYWHERE)
-    assert m is not None
-    assert m.getId() == "MOD:00439"
-    assert m.getFullName() == "O-phospho-L-threonine with neutral loss of phosphate", m.getFullName() # something crazy
-    assert m.getUniModAccession() == "" # no unimod for crazyness ...
-
     m = mdb.getBestModificationByMonoMass(147, 20, "M", pyopenms.ResidueModification.TermSpecificity.ANYWHERE)
     assert m is not None
     assert m.getUniModAccession() == "", m.getUniModAccession()

--- a/src/tests/class_tests/openms/source/CrossLinksDB_test.cpp
+++ b/src/tests/class_tests/openms/source/CrossLinksDB_test.cpp
@@ -75,7 +75,7 @@ START_SECTION(Size getNumberOfModifications() const)
 END_SECTION
 
 START_SECTION(const ResidueModification& getModification(Size index) const)
-        TEST_EQUAL(ptr->getModification(0).getId().size() > 0, true)
+        TEST_EQUAL(ptr->getModification(0)->getId().size() > 0, true)
 END_SECTION
 
 START_SECTION((void searchModifications(std::set<const ResidueModification*>& mods, const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const))
@@ -219,16 +219,16 @@ END_SECTION
 
 START_SECTION((const ResidueModification& getModification(const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const))
 {
-  TEST_EQUAL(ptr->getModification("EDC (E)").getFullId(), "EDC (E)");
-  TEST_EQUAL(ptr->getModification("EDC (E)").getId(), "EDC");
+  TEST_EQUAL(ptr->getModification("EDC (E)")->getFullId(), "EDC (E)");
+  TEST_EQUAL(ptr->getModification("EDC (E)")->getId(), "EDC");
 
-  TEST_EQUAL(ptr->getModification("DSS", "S", ResidueModification::ANYWHERE).getId(), "DSS");
-  TEST_EQUAL(ptr->getModification("DSS", "S", ResidueModification::ANYWHERE).getFullId(), "DSS (S)");
+  TEST_EQUAL(ptr->getModification("DSS", "S", ResidueModification::ANYWHERE)->getId(), "DSS");
+  TEST_EQUAL(ptr->getModification("DSS", "S", ResidueModification::ANYWHERE)->getFullId(), "DSS (S)");
 
   // terminal mod:
-  TEST_EQUAL(ptr->getModification("DSS", "", ResidueModification::N_TERM).getId(), "DSS");
-  TEST_EQUAL(ptr->getModification("BS3", "", ResidueModification::N_TERM).getFullId(), "BS3 (N-term)");
-  TEST_EQUAL(ptr->getModification("EDC", "", ResidueModification::N_TERM).getFullId(), "EDC (N-term)");
+  TEST_EQUAL(ptr->getModification("DSS", "", ResidueModification::N_TERM)->getId(), "DSS");
+  TEST_EQUAL(ptr->getModification("BS3", "", ResidueModification::N_TERM)->getFullId(), "BS3 (N-term)");
+  TEST_EQUAL(ptr->getModification("EDC", "", ResidueModification::N_TERM)->getFullId(), "EDC (N-term)");
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ElementDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ElementDB_test.cpp
@@ -38,6 +38,7 @@
 
 ///////////////////////////
 
+#include <OpenMS/CHEMISTRY/Element.h>
 #include <OpenMS/CHEMISTRY/ElementDB.h>
 #include <OpenMS/DATASTRUCTURES/Map.h>
 
@@ -53,6 +54,21 @@ START_TEST(ElementDB, "$Id$")
 const ElementDB* e_ptr = nullptr;
 const ElementDB* e_nullPointer = nullptr;
 const Element * elem_nullPointer = nullptr;
+
+START_SECTION([EXTRA] multithreaded example)
+{
+  int nr_iterations (100);
+  int test = 0;
+#pragma omp parallel for reduction(+: test)
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    auto edb = ElementDB::getInstance();
+    const Element * e1 = edb->getElement("Carbon");
+    test += e1->getAtomicNumber();
+  }
+  TEST_EQUAL(test, 6 * 100)
+}
+END_SECTION
 
 START_SECTION(static const ElementDB* getInstance())
 	e_ptr = ElementDB::getInstance();

--- a/src/tests/class_tests/openms/source/FASTAFile_test.cpp
+++ b/src/tests/class_tests/openms/source/FASTAFile_test.cpp
@@ -138,7 +138,7 @@ START_SECTION((void load(const String& filename, std::vector< FASTAEntry > &data
     + String("AGEGEN"))
 
   TEST_EQUAL(aa.isModified(), true)
-  String expectedModification = ModificationsDB::getInstance()->getModification("ICPL:13C(6)", "", ResidueModification::N_TERM).getId();
+  String expectedModification = ModificationsDB::getInstance()->getModification("ICPL:13C(6)", "", ResidueModification::N_TERM)->getId();
   TEST_EQUAL(aa.getNTerminalModificationName(), expectedModification)
 
   sequences_iterator++;

--- a/src/tests/class_tests/openms/source/FactoryBase_test.cpp
+++ b/src/tests/class_tests/openms/source/FactoryBase_test.cpp
@@ -51,14 +51,14 @@ FactoryBase* ptr = nullptr;
 FactoryBase* nullPointer = nullptr;
 START_SECTION(FactoryBase())
 {
-        ptr = new FactoryBase();
-	TEST_NOT_EQUAL(ptr, nullPointer)
+  ptr = new FactoryBase();
+  TEST_NOT_EQUAL(ptr, nullPointer)
 }
 END_SECTION
 
 START_SECTION(~FactoryBase())
 {
-        delete ptr;
+  delete ptr;
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/Factory_test.cpp
+++ b/src/tests/class_tests/openms/source/Factory_test.cpp
@@ -51,29 +51,6 @@ START_TEST(<Factory>, "$Id$")
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
-START_SECTION([EXTRA] multithreaded example)
-{
-
-  int nr_iterations (1e2), test (0);
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
-  for (int k = 1; k < nr_iterations + 1; k++)
-  {
-    FilterFunctor* p = Factory<FilterFunctor>::create("TICFilter");
-    TICFilter reducer;
-
-#ifdef _OPENMP
-#pragma omp critical (add_test)
-#endif
-    {
-      test += (*p==reducer);
-    }
-  }
-  TEST_EQUAL(test, nr_iterations)
-}
-END_SECTION
-
 // Factory is singleton, therefore we don't test the constructor
 START_SECTION(static FactoryProduct* create(const String& name))
 	FilterFunctor* p = Factory<FilterFunctor>::create("TICFilter");
@@ -96,6 +73,22 @@ END_SECTION
 START_SECTION(static std::vector<String> registeredProducts())
 	vector<String> list = Factory<FilterFunctor>::registeredProducts();
 	TEST_EQUAL(list.size(),6)
+END_SECTION
+
+START_SECTION([EXTRA] multithreaded example)
+{
+
+   int nr_iterations (1e2);
+   int test = 0;
+#pragma omp parallel for reduction (+: test)
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    FilterFunctor* p = Factory<FilterFunctor>::create("TICFilter");
+    TICFilter reducer;
+    test += (*p == reducer);
+  }
+  TEST_EQUAL(test, nr_iterations)
+}
 END_SECTION
 
 /////////////////////////////////////////////////////////////

--- a/src/tests/class_tests/openms/source/ModificationDefinition_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationDefinition_test.cpp
@@ -95,12 +95,12 @@ END_SECTION
 
 START_SECTION((ModificationDefinition(const ResidueModification& mod, bool fixed = true, UInt max_occur = 0)))
 {
-  const ResidueModification res_mod1 = ModificationsDB::getInstance()->getModification("Acetyl (N-term)");
+  const ResidueModification res_mod1 = *ModificationsDB::getInstance()->getModification("Acetyl (N-term)");
   ModificationDefinition mod1(res_mod1);
   TEST_EQUAL(mod1.getModificationName(), "Acetyl (N-term)");
   TEST_EQUAL(mod1.isFixedModification(), true);
   TEST_EQUAL(mod1.getMaxOccurrences(), 0);
-  const ResidueModification res_mod2 = ModificationsDB::getInstance()->getModification("Oxidation (M)");
+  const ResidueModification res_mod2 = *ModificationsDB::getInstance()->getModification("Oxidation (M)");
   ModificationDefinition mod2(res_mod2, false, 2);
   TEST_EQUAL(mod2.isFixedModification(), false);
   TEST_EQUAL(mod2.getMaxOccurrences(), 2);
@@ -151,10 +151,10 @@ END_SECTION
 
 START_SECTION((String getModification() const))
 {
-  const ResidueModification& rm = ModificationsDB::getInstance()->getModification("Acetyl (N-term)");
+  const ResidueModification* rm = ModificationsDB::getInstance()->getModification("Acetyl (N-term)");
   ModificationDefinition mod1;
-  mod1.setModification(rm.getFullId());
-  TEST_EQUAL(&rm, &(mod1.getModification()));
+  mod1.setModification(rm->getFullId());
+  TEST_EQUAL(rm, &(mod1.getModification()));
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -244,10 +244,10 @@ START_SECTION((const ResidueModification& getModification(const String& mod_name
   TEST_EQUAL(ptr->getModification("NIC", "", ResidueModification::N_TERM)->getFullId(), "NIC (N-term)");
   TEST_EQUAL(ptr->getModification("Acetyl", "", ResidueModification::N_TERM)->getFullId(), "Acetyl (N-term)");
 
-  // missing modification (returns nullptr)
-  TEST_EQUAL(ptr->getModification("MISSING"), nullPointer);
-  TEST_EQUAL(ptr->getModification("MISSING", "", ResidueModification::N_TERM), nullPointer);
-  TEST_EQUAL(ptr->getModification("MISSING", "", ResidueModification::C_TERM), nullPointer);	
+  // missing modification (exception)
+  TEST_EXCEPTION(Exception::InvalidValue, ptr->getModification("MISSING"));
+  TEST_EXCEPTION(Exception::InvalidValue, ptr->getModification("MISSING", "", ResidueModification::N_TERM));
+  TEST_EXCEPTION(Exception::InvalidValue, ptr->getModification("MISSING", "", ResidueModification::C_TERM));	
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -245,9 +245,9 @@ START_SECTION((const ResidueModification& getModification(const String& mod_name
   TEST_EQUAL(ptr->getModification("Acetyl", "", ResidueModification::N_TERM)->getFullId(), "Acetyl (N-term)");
 
   // missing modification (returns nullptr)
-  TEST_EQUAL(ptr->getModification("MISSING"), nullptr);
-  TEST_EQUAL(ptr->getModification("MISSING", "", ResidueModification::N_TERM), nullptr);
-  TEST_EQUAL(ptr->getModification("MISSING", "", ResidueModification::C_TERM), nullptr);	
+  TEST_EQUAL(ptr->getModification("MISSING"), nullPointer);
+  TEST_EQUAL(ptr->getModification("MISSING", "", ResidueModification::N_TERM), nullPointer);
+  TEST_EQUAL(ptr->getModification("MISSING", "", ResidueModification::C_TERM), nullPointer);	
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -290,6 +290,61 @@ START_SECTION((bool addModification(ResidueModification* modification)))
   TEST_EQUAL(ptr->has("Phospho (E)"), true);
 }
 END_SECTION
+
+START_SECTION([EXTRA] multithreaded example)
+{
+  // All measurements are best of three (wall time, Linux, 8 threads)
+  //
+  // Serial execution of code:
+  // 1e6 iterations -> 6.36 seconds
+  // Parallel execution of code:
+  // 1e6 iterations -> 9.79 seconds with boost::shared_mutex
+  // 1e6 iterations -> 6.28 seconds with std::mutex
+  // 1e6 iterations -> 4.64 seconds with pragma critical
+
+   static ModificationsDB* mdb = ModificationsDB::getInstance();
+
+   int nr_iterations (1e4), test (0);
+#pragma omp parallel for reduction (+: test)
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    int mod_id = k;
+    String modname = "mod" + String(mod_id);
+    ResidueModification * new_mod = new ResidueModification();
+    new_mod->setFullId(modname);
+    new_mod->setMonoMass( 0.11 * mod_id);
+    new_mod->setAverageMass(1.0);
+    new_mod->setDiffMonoMass( 0.05 * mod_id);
+    mdb->addModification(new_mod);
+    int tmp = (int)mdb->getModification(modname)->getAverageMass();
+    test += tmp;
+  }
+  TEST_EQUAL(test, nr_iterations*1.0)
+
+   // Every modification is the same
+  test = 0;
+  #pragma omp parallel for reduction (+: test)
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    int mod_id = 42;
+    String modname = "mod" + String(mod_id);
+    if (!mdb->has(modname)) 
+    {
+      ResidueModification * new_mod = new ResidueModification();
+      new_mod->setFullId(modname);
+      new_mod->setMonoMass( 0.11 * mod_id);
+      new_mod->setAverageMass(1.0);
+      new_mod->setDiffMonoMass( 0.05 * mod_id);
+      mdb->addModification(new_mod);
+    }
+    int tmp = (int)mdb->getModification(modname)->getAverageMass();
+    test += tmp;
+  }
+  TEST_EQUAL(test, nr_iterations*1.0)
+
+ }
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -243,6 +243,11 @@ START_SECTION((const ResidueModification& getModification(const String& mod_name
   TEST_EQUAL(ptr->getModification("NIC", "", ResidueModification::N_TERM)->getId(), "NIC");
   TEST_EQUAL(ptr->getModification("NIC", "", ResidueModification::N_TERM)->getFullId(), "NIC (N-term)");
   TEST_EQUAL(ptr->getModification("Acetyl", "", ResidueModification::N_TERM)->getFullId(), "Acetyl (N-term)");
+
+  // missing modification (returns nullptr)
+  TEST_EQUAL(ptr->getModification("MISSING"), nullptr);
+  TEST_EQUAL(ptr->getModification("MISSING", "", ResidueModification::N_TERM), nullptr);
+  TEST_EQUAL(ptr->getModification("MISSING", "", ResidueModification::C_TERM), nullptr);	
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ModificationsDB_test.cpp
@@ -57,13 +57,6 @@ START_TEST(ModificationsDB, "$Id$")
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 
-START_SECTION(bool ModificationsDB::isInstantiated())
-{
-  bool instantiated = ModificationsDB::isInstantiated();
-  TEST_EQUAL(instantiated, false);
-}
-END_SECTION
-
 ModificationsDB* ptr = nullptr;
 ModificationsDB* nullPointer = nullptr;
 
@@ -74,20 +67,13 @@ START_SECTION(ModificationsDB* getInstance())
 }
 END_SECTION
 
-START_SECTION(bool ModificationsDB::isInstantiated())
-{
-  bool instantiated = ModificationsDB::isInstantiated();
-  TEST_EQUAL(instantiated, true);
-}
-END_SECTION
-
 START_SECTION(Size getNumberOfModifications() const)
 	// range because data may change over time
 	TEST_EQUAL(ptr->getNumberOfModifications() > 100, true);
 END_SECTION
 
 START_SECTION(const ResidueModification& getModification(Size index) const)
-	TEST_EQUAL(ptr->getModification(0).getId().size() > 0, true)
+	TEST_EQUAL(ptr->getModification(0)->getId().size() > 0, true)
 END_SECTION
 
   START_SECTION((void searchModifications(std::set<const ResidueModification*>& mods, const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const))
@@ -233,16 +219,16 @@ END_SECTION
 
 START_SECTION((const ResidueModification& getModification(const String& mod_name, const String& residue, ResidueModification::TermSpecificity term_spec) const))
 {
-  TEST_EQUAL(ptr->getModification("Carboxymethyl (C)").getFullId(), "Carboxymethyl (C)");
-  TEST_EQUAL(ptr->getModification("Carboxymethyl (C)").getId(), "Carboxymethyl");
+  TEST_EQUAL(ptr->getModification("Carboxymethyl (C)")->getFullId(), "Carboxymethyl (C)");
+  TEST_EQUAL(ptr->getModification("Carboxymethyl (C)")->getId(), "Carboxymethyl");
 
-  TEST_EQUAL(ptr->getModification("Phosphorylation", "S", ResidueModification::ANYWHERE).getId(), "Phospho");
-  TEST_EQUAL(ptr->getModification("Phosphorylation", "S", ResidueModification::ANYWHERE).getFullId(), "Phospho (S)");
+  TEST_EQUAL(ptr->getModification("Phosphorylation", "S", ResidueModification::ANYWHERE)->getId(), "Phospho");
+  TEST_EQUAL(ptr->getModification("Phosphorylation", "S", ResidueModification::ANYWHERE)->getFullId(), "Phospho (S)");
 
   // terminal mod:
-  TEST_EQUAL(ptr->getModification("NIC", "", ResidueModification::N_TERM).getId(), "NIC");
-  TEST_EQUAL(ptr->getModification("NIC", "", ResidueModification::N_TERM).getFullId(), "NIC (N-term)");
-  TEST_EQUAL(ptr->getModification("Acetyl", "", ResidueModification::N_TERM).getFullId(), "Acetyl (N-term)");
+  TEST_EQUAL(ptr->getModification("NIC", "", ResidueModification::N_TERM)->getId(), "NIC");
+  TEST_EQUAL(ptr->getModification("NIC", "", ResidueModification::N_TERM)->getFullId(), "NIC (N-term)");
+  TEST_EQUAL(ptr->getModification("Acetyl", "", ResidueModification::N_TERM)->getFullId(), "Acetyl (N-term)");
 }
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/ModifiedPeptideGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/ModifiedPeptideGenerator_test.cpp
@@ -76,7 +76,7 @@ START_SECTION((static void applyFixedModifications(const std::vector< ResidueMod
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back( ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
   }
 
   AASequence seq0 = AASequence::fromString("AAAACAAAA"); // exactly one target site
@@ -104,7 +104,7 @@ START_SECTION((static void applyFixedModifications(const std::vector< ResidueMod
    for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
    {
      String modification(*mod_it);
-     fixed_mods.push_back(ModificationsDB::getInstance()->getModification(modification));
+     fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
    }
   seq0 = AASequence::fromString("KAAAAAAAA"); // exactly one target site
   seq1 = AASequence::fromString("K(Carbamyl)AAAAAAAA"); // ambigous case: is mod Carbamyl (K) or (N-Term)?
@@ -125,7 +125,7 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back( ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
   }
 
   vector<AASequence> modified_peptides;
@@ -203,7 +203,7 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back( ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
   }
 
   seq = AASequence::fromString("ACAACAACA"); // three target sites
@@ -237,7 +237,7 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back( ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
   }
   modified_peptides.clear();
 
@@ -256,7 +256,7 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back(ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
   }
 
   modified_peptides.clear();

--- a/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
+++ b/src/tests/class_tests/openms/source/MzIdentMLFile_test.cpp
@@ -478,7 +478,7 @@ START_SECTION(([EXTRA] XLMS data unlabeled cross-linker))
   vector<ProteinIdentification> protein_ids2;
   vector<PeptideIdentification> peptide_ids2;
 
-  String input_file= OPENMS_GET_TEST_DATA_PATH("MzIdentML_XLMS_unlabelled.mzid");
+  String input_file = OPENMS_GET_TEST_DATA_PATH("MzIdentML_XLMS_unlabelled.mzid");
   MzIdentMLFile().load(input_file, protein_ids, peptide_ids);
 
   // Reading and writing

--- a/src/tests/class_tests/openms/source/ProteaseDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ProteaseDB_test.cpp
@@ -162,4 +162,23 @@ START_SECTION((void getAllOMSSANames(std::vector<String>& all_names) const))
     TEST_EQUAL(names.size(), old_size)
 END_SECTION
 
+START_SECTION([EXTRA] multithreaded example)
+{
+
+   int nr_iterations (1e2), test (0);
+#pragma omp parallel for reduction (+: test)
+  for (int k = 1; k < nr_iterations + 1; k++)
+  {
+    auto p = ProteaseDB::getInstance();
+    int tmp (0);
+    if (p->hasEnzyme("Trypsin"), true)
+    {
+      tmp++;
+    }
+    test += tmp;
+  }
+  TEST_EQUAL(test, nr_iterations)
+}
+END_SECTION
+
 END_TEST

--- a/src/tests/class_tests/openms/source/ResidueDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueDB_test.cpp
@@ -76,7 +76,7 @@ START_SECTION((bool hasResidue(const String& name) const))
 END_SECTION
 
 START_SECTION(bool hasResidue(const Residue* residue) const)
-	TEST_EQUAL(ptr->hasResidue(ptr->getResidue("BLUBB")), false)
+	TEST_EXCEPTION(Exception::InvalidValue, ptr->hasResidue(ptr->getResidue("BLUBB")))
 	TEST_EQUAL(ptr->hasResidue(ptr->getResidue("LYS")), true)
 	TEST_EQUAL(ptr->hasResidue(ptr->getResidue("K")), true)
 END_SECTION

--- a/src/tests/class_tests/openms/source/ResidueDB_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueDB_test.cpp
@@ -119,24 +119,6 @@ START_SECTION(void setResidues(const String& filename))
 	NOT_TESTABLE // this method is hard to test, just provided for convenience
 END_SECTION
 
-START_SECTION(void addResidue(const Residue& residue))
-	TEST_EQUAL(ptr->hasResidue("UGU"), false)
-	TEST_EQUAL(ptr->hasResidue("$"), false)
-	TEST_EQUAL(ptr->hasResidue("$hortName"), false)
-	TEST_EQUAL(ptr->hasResidue("MyLittleUGUResidue"), false)
-	Residue res;
-	res.setShortName("$hortName");
-	res.setOneLetterCode("$");
-	res.setThreeLetterCode("UGU");
-	res.setName("MyLittleUGUResidue");
-	res.setFormula(EmpiricalFormula("C3H4O4"));
-	ptr->addResidue(res);
-	TEST_EQUAL(ptr->hasResidue("UGU"), true)
-	TEST_EQUAL(ptr->hasResidue("$"), true)
-	TEST_EQUAL(ptr->hasResidue("$hortName"), true)
-	TEST_EQUAL(ptr->hasResidue("MyLittleUGUResidue"), true)
-END_SECTION
-
 START_SECTION(ResidueIterator beginResidue())
 	ResidueDB::ResidueIterator it = ptr->beginResidue();
 	Size count(0);

--- a/src/tests/class_tests/openms/source/ResidueModification_test.cpp
+++ b/src/tests/class_tests/openms/source/ResidueModification_test.cpp
@@ -79,7 +79,9 @@ END_SECTION
 
 START_SECTION(bool ResidueModification::operator<(const ResidueModification& rhs) const)
   ModificationsDB* ptr = ModificationsDB::getInstance();
-  TEST_EQUAL(ptr->getModification("Carboxymethyl (C)") < ptr->getModification("Phospho (S)"), true);
+  const ResidueModification* cm = ptr->getModification("Carboxymethyl (C)");
+  const ResidueModification* pm = ptr->getModification("Phospho (S)");
+  TEST_EQUAL(*cm < *pm, true);
 END_SECTION
 
 START_SECTION(void setId(const String& id))

--- a/src/tests/class_tests/openms/source/Residue_test.cpp
+++ b/src/tests/class_tests/openms/source/Residue_test.cpp
@@ -310,12 +310,12 @@ END_SECTION
 
 
 START_SECTION(void setModification(const String& name))
-    e_ptr->setOneLetterCode("M"); // we need M for this mod
-    TEST_EQUAL(e_ptr->getModificationName(), "")
-    TEST_EQUAL(e_ptr->getModification(), 0)
-    e_ptr->setModification("Oxidation");
-    TEST_EQUAL(e_ptr->getModificationName(), "Oxidation")
-    TEST_EQUAL(e_ptr->getModification()->getFullId(), "Oxidation (M)")
+	e_ptr->setOneLetterCode("M"); // we need M for this mod
+	TEST_EQUAL(e_ptr->getModificationName(), "")
+	TEST_EQUAL(e_ptr->getModification(), 0)
+	e_ptr->setModification("Oxidation");
+	TEST_EQUAL(e_ptr->getModificationName(), "Oxidation")
+	TEST_EQUAL(e_ptr->getModification()->getFullId(), "Oxidation (M)")
 	e_ptr->setOneLetterCode("B");
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
@@ -145,6 +145,29 @@ START_SECTION((static void setSeed(UInt seed)))
 }
 END_SECTION
 
+START_SECTION([EXTRA] multithreaded example)
+{
+
+   /* test for collisions, test will be different for every test execution */
+  OpenMS::UniqueIdGenerator::setSeed(std::time(nullptr));
+  std::vector<OpenMS::UInt64> ids;
+  ids.reserve(nofIdsToGenerate);
+#pragma omp parallel for
+  for (unsigned int i = 0; i < nofIdsToGenerate; ++i)
+  {
+    OpenMS::UInt64 tmp = OpenMS::UniqueIdGenerator::getUniqueId();
+#pragma omp critical (add_test)
+    {
+      ids.push_back(tmp);
+    }
+  }
+  std::sort(ids.begin(), ids.end());
+  // check if the generated ids contain (at least) two equal ones
+  std::vector<OpenMS::UInt64>::iterator iter = std::adjacent_find(ids.begin(), ids.end());
+  TEST_EQUAL(iter == ids.end(), true);
+}
+END_SECTION
+
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST

--- a/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/UniqueIdGenerator_test.cpp
@@ -153,7 +153,7 @@ START_SECTION([EXTRA] multithreaded example)
   std::vector<OpenMS::UInt64> ids;
   ids.reserve(nofIdsToGenerate);
 #pragma omp parallel for
-  for (unsigned int i = 0; i < nofIdsToGenerate; ++i)
+  for (int i = 0; i < nofIdsToGenerate; ++i)
   {
     OpenMS::UInt64 tmp = OpenMS::UniqueIdGenerator::getUniqueId();
 #pragma omp critical (add_test)

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -240,7 +240,7 @@ protected:
         continue;
       }
       String modification(*mod_it);
-      modifications.push_back(ModificationsDB::getInstance()->getModification(modification));
+      modifications.push_back(*ModificationsDB::getInstance()->getModification(modification));
     }
 
     return modifications;

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -193,10 +193,9 @@ protected:
   
   String makeModString_(const String& mod_name)
   {
-    ResidueModification mod = ModificationsDB::getInstance()->getModification(mod_name);
-    String residue = mod.getOrigin();
-    
-    return String(residue +  " " + mod.getDiffMonoMass());    
+    const ResidueModification* mod = ModificationsDB::getInstance()->getModification(mod_name);
+    const String& residue = mod->getOrigin();
+    return String(residue +  " " + mod->getDiffMonoMass());    
   }
  
   ExitCodes parseParameters_(map<String, vector<String> >& config_map, const String& id, const String& in,

--- a/src/topp/MSGFPlusAdapter.cpp
+++ b/src/topp/MSGFPlusAdapter.cpp
@@ -335,12 +335,12 @@ protected:
 
   String makeModString_(const String& mod_name, bool fixed=true)
   {
-    ResidueModification mod = ModificationsDB::getInstance()->getModification(mod_name);
-    char residue = mod.getOrigin();
+    const ResidueModification* mod = ModificationsDB::getInstance()->getModification(mod_name);
+    char residue = mod->getOrigin();
     if (residue == 'X') residue = '*'; // terminal mod. without residue specificity
-    String position = mod.getTermSpecificityName(); // "Prot-N-term", "Prot-C-term" not supported by OpenMS
+    String position = mod->getTermSpecificityName(); // "Prot-N-term", "Prot-C-term" not supported by OpenMS
     if (position == "none") position = "any";
-    return String(mod.getDiffMonoMass()) + ", " + residue + (fixed ? ", fix, " : ", opt, ") + position + ", " + mod.getId() + "    # " + mod_name;
+    return String(mod->getDiffMonoMass()) + ", " + residue + (fixed ? ", fix, " : ", opt, ") + position + ", " + mod->getId() + "    # " + mod_name;
   }
 
   void writeModificationsFile_(const String& out_path, const vector<String>& fixed_mods, const vector<String>& variable_mods, Size max_mods)

--- a/src/topp/MyriMatchAdapter.cpp
+++ b/src/topp/MyriMatchAdapter.cpp
@@ -162,9 +162,9 @@ protected:
       set<String> mod_names = mod_set.getFixedModificationNames();
       for (set<String>::const_iterator it = mod_names.begin(); it != mod_names.end(); ++it)
       {
-        ResidueModification mod = ModificationsDB::getInstance()->getModification(*it);
-        String origin = String(mod.getOrigin());
-        String mass_diff = String(mod.getDiffMonoMass());
+        const ResidueModification* mod = ModificationsDB::getInstance()->getModification(*it);
+        String origin = mod->getOrigin();
+        String mass_diff = String(mod->getDiffMonoMass());
         if (origin == "N-term")
         {
           origin = "(";
@@ -173,15 +173,15 @@ protected:
         {
           origin = ")";
         }
-        else if (mod.getTermSpecificityName(mod.getTermSpecificity()) == "N-term")
+        else if (mod->getTermSpecificityName(mod->getTermSpecificity()) == "N-term")
         {
           origin = "(" + origin;
         }
-        else if (mod.getTermSpecificityName(mod.getTermSpecificity()) == "C-term")
+        else if (mod->getTermSpecificityName(mod->getTermSpecificity()) == "C-term")
         {
           origin = ")" + origin;
         }
-        static_mod_list.push_back(origin + " " + mod.getDiffMonoMass());
+        static_mod_list.push_back(origin + " " + mod->getDiffMonoMass());
       }
     }
 
@@ -191,9 +191,9 @@ protected:
 
       for (set<String>::const_iterator it = mod_names.begin(); it != mod_names.end(); ++it)
       {
-        ResidueModification mod = ModificationsDB::getInstance()->getModification(*it);
-        String origin = String(mod.getOrigin());
-        String mass_diff = String(mod.getDiffMonoMass());
+        const ResidueModification* mod = ModificationsDB::getInstance()->getModification(*it);
+        String origin = mod->getOrigin();
+        String mass_diff = String(mod->getDiffMonoMass());
         if (origin == "N-term")
         {
           origin = "(";
@@ -202,11 +202,11 @@ protected:
         {
           origin = ")";
         }
-        else if (mod.getTermSpecificityName(mod.getTermSpecificity()) == "N-term")
+        else if (mod->getTermSpecificityName(mod->getTermSpecificity()) == "N-term")
         {
           origin = "(" + origin;
         }
-        else if (mod.getTermSpecificityName(mod.getTermSpecificity()) == "C-term")
+        else if (mod->getTermSpecificityName(mod->getTermSpecificity()) == "C-term")
         {
           origin = ")" + origin;
         }

--- a/src/topp/MzTabExporter.cpp
+++ b/src/topp/MzTabExporter.cpp
@@ -234,34 +234,34 @@ protected:
         mp.setCVLabel("UNIMOD");
         ModificationsDB* mod_db = ModificationsDB::getInstance();
         // MzTab standard is to just report Unimod accession.
-        ResidueModification m = mod_db->getModification(*sit);
-        String unimod_accession = m.getUniModAccession();
+        const ResidueModification* m = mod_db->getModification(*sit);
+        String unimod_accession = m->getUniModAccession();
         mp.setAccession(unimod_accession.toUpper());
-        mp.setName(m.getId());
+        mp.setName(m->getId());
         mod.modification = mp;
 
-        if (m.getTermSpecificity() == ResidueModification::C_TERM)
+        if (m->getTermSpecificity() == ResidueModification::C_TERM)
         {
           mod.position = MzTabString("Any C-term");
         }
-        else if (m.getTermSpecificity() == ResidueModification::N_TERM)
+        else if (m->getTermSpecificity() == ResidueModification::N_TERM)
         {
           mod.position = MzTabString("Any N-term");
         }
-        else if (m.getTermSpecificity() == ResidueModification::ANYWHERE)
+        else if (m->getTermSpecificity() == ResidueModification::ANYWHERE)
         {
           mod.position = MzTabString("Anywhere");
         }
-        else if (m.getTermSpecificity() == ResidueModification::PROTEIN_C_TERM)
+        else if (m->getTermSpecificity() == ResidueModification::PROTEIN_C_TERM)
         {
           mod.position = MzTabString("Protein C-term");
         }
-        else if (m.getTermSpecificity() == ResidueModification::PROTEIN_N_TERM)
+        else if (m->getTermSpecificity() == ResidueModification::PROTEIN_N_TERM)
         {
           mod.position = MzTabString("Protein N-term");
         }
 
-        mod.site = MzTabString(m.getOrigin());
+        mod.site = MzTabString(m->getOrigin());
         mods_mztab[index] = mod;
       }
       return mods_mztab;

--- a/src/topp/OMSSAAdapter.cpp
+++ b/src/topp/OMSSAAdapter.cpp
@@ -673,8 +673,9 @@ protected:
             9 modmax	-  the max number of modification types
         */
 
-        ResidueModification::TermSpecificity ts = ModificationsDB::getInstance()->getModification(it->second).getTermSpecificity();
-        String origin = ModificationsDB::getInstance()->getModification(it->second).getOrigin();
+	const ResidueModification* mod = ModificationsDB::getInstance()->getModification(it->second);
+        ResidueModification::TermSpecificity ts = mod->getTermSpecificity();
+        const String& origin = mod->getOrigin();
         if (ts == ResidueModification::ANYWHERE)
         {
           out << "\t\t<MSModType value=\"modaa\">0</MSModType>" << "\n";
@@ -704,8 +705,8 @@ protected:
         out << "\t</MSModSpec_type>" << "\n";
 
         out << "\t<MSModSpec_name>" << it->second << "</MSModSpec_name>" << "\n";
-        out << "\t<MSModSpec_monomass>" << ModificationsDB::getInstance()->getModification(it->second).getDiffMonoMass()  << "</MSModSpec_monomass>" << "\n";
-        out << "\t<MSModSpec_averagemass>" << ModificationsDB::getInstance()->getModification(it->second).getDiffAverageMass() << "</MSModSpec_averagemass>" << "\n";
+        out << "\t<MSModSpec_monomass>" << ModificationsDB::getInstance()->getModification(it->second)->getDiffMonoMass()  << "</MSModSpec_monomass>" << "\n";
+        out << "\t<MSModSpec_averagemass>" << ModificationsDB::getInstance()->getModification(it->second)->getDiffAverageMass() << "</MSModSpec_averagemass>" << "\n";
         out << "\t<MSModSpec_n15mass>0</MSModSpec_n15mass>" << "\n";
 
         if (origin != "")
@@ -718,8 +719,8 @@ protected:
           double neutral_loss_mono = ModificationsDB::getInstance()->getModification(it->second).getNeutralLossMonoMass();
           double neutral_loss_avg = ModificationsDB::getInstance()->getModification(it->second).getNeutralLossAverageMass();
           */
-          double neutral_loss_mono = ModificationsDB::getInstance()->getModification(it->second).getNeutralLossDiffFormula().getMonoWeight();
-          double neutral_loss_avg = ModificationsDB::getInstance()->getModification(it->second).getNeutralLossDiffFormula().getAverageWeight();
+          double neutral_loss_mono = ModificationsDB::getInstance()->getModification(it->second)->getNeutralLossDiffFormula().getMonoWeight();
+          double neutral_loss_avg = ModificationsDB::getInstance()->getModification(it->second)->getNeutralLossDiffFormula().getAverageWeight();
 
           if (fabs(neutral_loss_mono) > 0.00001)
           {
@@ -748,10 +749,10 @@ protected:
     writeDebug_("Splitting modification into N-Term, C-Term and anywhere specificity", 1);
     for (set<String>::const_iterator it = fixed_mod_names.begin(); it != fixed_mod_names.end(); ++it)
     {
-      ResidueModification::TermSpecificity ts = ModificationsDB::getInstance()->getModification(*it).getTermSpecificity();
+      ResidueModification::TermSpecificity ts = ModificationsDB::getInstance()->getModification(*it)->getTermSpecificity();
       if (ts == ResidueModification::ANYWHERE)
       {
-        fixed_residue_mods[ModificationsDB::getInstance()->getModification(*it).getOrigin()] = *it;
+        fixed_residue_mods[ModificationsDB::getInstance()->getModification(*it)->getOrigin()] = *it;
       }
       if (ts == ResidueModification::C_TERM)
       {

--- a/src/topp/SpecLibSearcher.cpp
+++ b/src/topp/SpecLibSearcher.cpp
@@ -195,7 +195,7 @@ protected:
            const Residue& mod = aaseq.getResidue(j);
            for (Size k = 0; k < fixed_modifications.size(); ++k)
            {
-             if (mod.getOneLetterCode()[0] == mdb->getModification(fixed_modifications[k]).getOrigin() && fixed_modifications[k] != mod.getModificationName())
+             if (mod.getOneLetterCode()[0] == mdb->getModification(fixed_modifications[k])->getOrigin() && fixed_modifications[k] != mod.getModificationName())
              {
                fixed_modifications_ok = false;
                break;
@@ -215,7 +215,7 @@ protected:
            const Residue& mod = aaseq.getResidue(j);
            for (Size k = 0; k < variable_modifications.size(); ++k)
            {
-             if (mod.getOneLetterCode()[0] == mdb->getModification(variable_modifications[k]).getOrigin() && variable_modifications[k] != mod.getModificationName())
+             if (mod.getOneLetterCode()[0] == mdb->getModification(variable_modifications[k])->getOrigin() && variable_modifications[k] != mod.getModificationName())
              {
                variable_modifications_ok = false;
                break;

--- a/src/utils/RNPxlSearch.cpp
+++ b/src/utils/RNPxlSearch.cpp
@@ -2506,16 +2506,16 @@ vector<ResidueModification> RNPxlSearch::RNPxlParameterParsing::getModifications
     if (modification.hasSubstring(" (N-term)"))
     {
       modification.substitute(" (N-term)", "");
-      rm = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::N_TERM);
+      rm = *ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::N_TERM);
     }
     else if (modification.hasSubstring(" (C-term)"))
     {
       modification.substitute(" (C-term)", "");
-      rm = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::C_TERM);
+      rm = *ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::C_TERM);
     }
     else
     {
-      rm = ModificationsDB::getInstance()->getModification(modification);
+      rm = *ModificationsDB::getInstance()->getModification(modification);
     }
     modifications.push_back(rm);
   }

--- a/src/utils/SimpleSearchEngine.cpp
+++ b/src/utils/SimpleSearchEngine.cpp
@@ -176,7 +176,7 @@ class SimpleSearchEngine :
       for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
       {
         String modification(*mod_it);
-        modifications.push_back(ModificationsDB::getInstance()->getModification(modification));
+        modifications.push_back(*ModificationsDB::getInstance()->getModification(modification));
       }
 
       return modifications;


### PR DESCRIPTION
Currently only implements on lock for reading and writing (=one common critical section).
Main work was in removing exceptions in critical section (or moving them to the caller).
Should be easy to promote to a readers-writer-lock.
I did not do that as the XL search engine (which I consider one of the heaviest use cases) did not show a significant speed drop (~10% on 20 threads).
All tests are passing.
 