### PR TITLE
[FIX] fix AASequence string conversion

### DIFF
--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -158,7 +158,7 @@ namespace OpenMS
         if (!mod.isUserDefined()) nominal_mass += Residue::getInternalToNTerm().getMonoWeight(); 
         if (integer_mass)
         {
-          bs += "n[" + String(static_cast<int>(nominal_mass)) + "]";
+          bs += String("n[") + static_cast<int>(std::round(nominal_mass)) + "]";
         }
         else
         {
@@ -181,7 +181,7 @@ namespace OpenMS
           if (integer_mass)
           {
             const double residue_mono_mass = r.getMonoWeight(Residue::Internal);
-            bs += aa + "[" + static_cast<int>(residue_mono_mass) + "]"; 
+            bs += aa + "[" + static_cast<int>(std::round(residue_mono_mass)) + "]"; 
           }
           else
           {
@@ -212,7 +212,7 @@ namespace OpenMS
         if (!mod.isUserDefined()) nominal_mass += Residue::getInternalToCTerm().getMonoWeight();
         if (integer_mass)
         {
-          bs += "c[" + String(static_cast<int>(nominal_mass)) + "]";
+          bs += String("c[") + static_cast<int>(std::round(nominal_mass)) + "]";
         }
         else
         {


### PR DESCRIPTION
- fix bug introduced in #3969 which changes meaning of AASequence
  strings
- "PEPTID[160]E" has a different meaning from "PEPTID[160.0]E" with the latter meaning that the difference is *exactly* 160.0 while the former means a mod of 160 +/- 0.5 