### PR TITLE
feat: MRMFeatureFilter failure messages as StringList

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
@@ -53,7 +53,7 @@ namespace OpenMS
   /**
 
     @brief The MRMFeatureFilter either flags components and/or transitions that do not pass the QC criteria or filters out
-      components and/or transitions that do not pass the QC criteria. 
+      components and/or transitions that do not pass the QC criteria.
 
     @htmlinclude OpenMS_MRMFeatureFilter.parameters
 
@@ -89,10 +89,10 @@ public:
       @param filter_criteria MRMFeatureQC class defining QC parameters
       @param transitions transitions from a TargetedExperiment
 
-    */    
+    */
     void FilterFeatureMap(FeatureMap& features, const MRMFeatureQC& filter_criteria,
       const TargetedExperiment & transitions);
-    
+
     /**
       @brief Converts a FeatureMap to a qcMLFile::Attachment
 
@@ -101,7 +101,7 @@ public:
 
     */
     void FeatureMapToAttachment(FeatureMap& features, QcMLFile::Attachment& attachment);
-    
+
     /**
       @brief Calculates the ion ratio between two transitions
 
@@ -111,9 +111,9 @@ public:
        e.g., peak_apex, peak_area
 
       @return The ratio.
-    */ 
+    */
     double calculateIonRatio(const Feature & component_1, const Feature & component_2, const String & feature_name);
-    
+
     /**
       @brief Calculates the retention time difference between two features
 
@@ -121,9 +121,9 @@ public:
       @param component_2 Second eluting component
 
       @return The difference.
-    */ 
+    */
     double calculateRTDifference(Feature & component_1, Feature & component_2);
-    
+
     /**
       @brief Calculates the resolution between two features
 
@@ -131,7 +131,7 @@ public:
       @param component_2 component 2
 
       @return The difference.
-    */ 
+    */
     double calculateResolution(Feature & component_1, Feature & component_2);
 
     /**
@@ -160,17 +160,17 @@ public:
       @param transitions transitions from a TargetedExperiment
 
       @return Map of labels/transition types and their corresponding number.
-    */ 
+    */
     std::map<String,int> countLabelsAndTransitionTypes(const Feature & component_group,
       const TargetedExperiment & transitions);
-    
+
     /**
       @brief Sorts the messages and returns a copy without duplicates
 
       @param[in] messages A StringList containing the failure messages
 
       @return A copy of the input, without duplicates
-    */ 
+    */
     StringList getUniqueSorted(const StringList& messages) const;
 
 private:

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMFeatureFilter.h
@@ -165,14 +165,13 @@ public:
       const TargetedExperiment & transitions);
     
     /**
-      @brief Sorts, removes duplicates, and concatenates a list of Strings
+      @brief Sorts the messages and returns a copy without duplicates
 
-      @param str_vec vector of Strings
-      @param delim token to separate Strings in the list
+      @param[in] messages A StringList containing the failure messages
 
-      @return A concatenated string.
+      @return A copy of the input, without duplicates
     */ 
-    String uniqueJoin(std::vector<String>& str_vec, String& delim);
+    StringList getUniqueSorted(const StringList& messages) const;
 
 private:
     template <typename T>

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
@@ -85,19 +85,19 @@ namespace OpenMS
     report_tic_ = param_.getValue("report_tic").toBool();
   }
 
-  void MRMFeatureFilter::FilterFeatureMap(FeatureMap& features, 
+  void MRMFeatureFilter::FilterFeatureMap(FeatureMap& features,
     const MRMFeatureQC& filter_criteria,
     const TargetedExperiment & transitions
   )
-  {     
+  {
     // initialize QC variables
     FeatureMap features_filtered;
 
     // bool qc_pass;
-    String concentration_units;// iterate through each component_group/feature     
+    String concentration_units;// iterate through each component_group/feature
 
     for (size_t feature_it = 0; feature_it < features.size(); ++feature_it)
-    {      
+    {
       String component_group_name = (String)features[feature_it].getMetaValue("PeptideRef");
       // std::cout << "component_group_name" << component_group_name << std::endl; //debugging
 
@@ -112,7 +112,7 @@ namespace OpenMS
       // iterate through each component/sub-feature
       for (size_t sub_it = 0; sub_it < features[feature_it].getSubordinates().size(); ++sub_it)
       {
-        String component_name = (String)features[feature_it].getSubordinates()[sub_it].getMetaValue("native_id"); 
+        String component_name = (String)features[feature_it].getSubordinates()[sub_it].getMetaValue("native_id");
         // std::cout << "component_name" << component_name << std::endl; //debugging
         bool c_qc_pass = true;
         StringList c_qc_fail_message_vec;
@@ -204,7 +204,7 @@ namespace OpenMS
             // ion ratio QC
             for (size_t sub_it2 = 0; sub_it2 < features[feature_it].getSubordinates().size(); ++sub_it2)
             {
-              String component_name2 = (String)features[feature_it].getSubordinates()[sub_it2].getMetaValue("native_id"); 
+              String component_name2 = (String)features[feature_it].getSubordinates()[sub_it2].getMetaValue("native_id");
               // find the ion ratio pair
               if (filter_criteria.component_group_qcs[cg_qc_it].ion_ratio_pair_name_1 != ""
                 && filter_criteria.component_group_qcs[cg_qc_it].ion_ratio_pair_name_2 != ""
@@ -237,9 +237,9 @@ namespace OpenMS
             }
           }
         }
-        
+
         UInt c_tests_count{0};
-        // iterate through feature/sub-feature QCs/filters        
+        // iterate through feature/sub-feature QCs/filters
         for (size_t c_qc_it = 0; c_qc_it < filter_criteria.component_qcs.size(); ++c_qc_it)
         {
           if (filter_criteria.component_qcs[c_qc_it].component_name == component_name)
@@ -330,12 +330,12 @@ namespace OpenMS
         Feature feature_filtered(features[feature_it]);
         feature_filtered.setSubordinates(subordinates_filtered);
         features_filtered.push_back(feature_filtered);
-      }   
+      }
       else if (cg_qc_pass && flag_or_filter_ == "filter" && subordinates_filtered.size() == 0)
       {
         // do nothing
         // std::cout << "omitted failing feature" << std::endl; //debugging
-      }   
+      }
       else if (cg_qc_pass && flag_or_filter_ == "flag")
       {
         features[feature_it].setMetaValue("QC_transition_group_pass", true);
@@ -345,7 +345,7 @@ namespace OpenMS
       {
         // do nothing
         // std::cout << "omitted failing feature" << std::endl; //debugging
-      }   
+      }
       else if (!cg_qc_pass && flag_or_filter_ == "flag")
       {
         features[feature_it].setMetaValue("QC_transition_group_pass", false);
@@ -359,7 +359,7 @@ namespace OpenMS
       features = features_filtered;
     }
   }
-  
+
   std::map<String,int> MRMFeatureFilter::countLabelsAndTransitionTypes(
     const Feature & component_group,
     const TargetedExperiment & transitions)
@@ -384,7 +384,7 @@ namespace OpenMS
       // count labels and transition types
       String label_type = (String)component_group.getSubordinates()[cg_it].getMetaValue("LabelType");
       if (label_type == "Heavy")
-      { 
+      {
         ++n_heavy;
       }
       else if (label_type == "Light")
@@ -416,7 +416,7 @@ namespace OpenMS
 
     return output;
   }
-  
+
   double MRMFeatureFilter::calculateIonRatio(const Feature & component_1, const Feature & component_2, const String & feature_name)
   {
     double ratio = 0.0;
@@ -497,7 +497,7 @@ namespace OpenMS
     // std::cout << "value: " << (String)value << " lb: " << (String)value_l << " ub: " << (String)value_u << std::endl; //debugging
     return value >= value_l && value <= value_u;
   }
-  
+
   //TODO: Future addition to allow for generating a QcML attachment for QC reporting
   // void MRMFeatureFilter::FeatureMapToAttachment(FeatureMap& features, QcMLFile::Attachment& attachment)
   // {

--- a/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
@@ -441,11 +441,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "metaValue[peak_apex_int]");
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
   TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "peak_apex_int");
   TEST_EQUAL(components[1].getMetaValue("QC_transition_group_pass"), false);
-  // TEST_EQUAL(components[1].getMetaValue("QC_transition_group_message"), "n_light;n_transitions");
   TEST_EQUAL(components[1].getMetaValue("QC_transition_group_message").toStringList().size(), 2);
   TEST_STRING_EQUAL(components[1].getMetaValue("QC_transition_group_message").toStringList()[0], "n_light");
   TEST_STRING_EQUAL(components[1].getMetaValue("QC_transition_group_message").toStringList()[1], "n_transitions");
@@ -643,7 +641,6 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "retention_time");
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
   TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "retention_time");
 
@@ -684,7 +681,6 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "intensity");
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
   TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "intensity");
   TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
@@ -728,7 +724,6 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "overall_quality");
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
   TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "overall_quality");
   TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
@@ -810,7 +805,6 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), false);
-  // TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_heavy");
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList().size(), 1);
   TEST_STRING_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList()[0], "n_heavy");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
@@ -854,7 +848,6 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), false);
-  // TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_light");
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList().size(), 1);
   TEST_STRING_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList()[0], "n_light");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
@@ -890,7 +883,6 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), false);
-  // TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_transitions");
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList().size(), 1);
   TEST_STRING_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList()[0], "n_transitions");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
@@ -932,7 +924,6 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), false);
-  // TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "ion_ratio_pair[component1.1.Light/component1.2.Light]");
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList().size(), 1);
   TEST_STRING_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList()[0], "ion_ratio_pair[component1.1.Light/component1.2.Light]");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);

--- a/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
@@ -1,32 +1,32 @@
 // --------------------------------------------------------------------------
-//                   OpenMS -- Open-Source Mass Spectrometry               
+//                   OpenMS -- Open-Source Mass Spectrometry
 // --------------------------------------------------------------------------
 // Copyright The OpenMS Team -- Eberhard Karls University Tuebingen,
 // ETH Zurich, and Freie Universitaet Berlin 2002-2018.
-// 
+//
 // This software is released under a three-clause BSD license:
 //  * Redistributions of source code must retain the above copyright
 //    notice, this list of conditions and the following disclaimer.
 //  * Redistributions in binary form must reproduce the above copyright
 //    notice, this list of conditions and the following disclaimer in the
 //    documentation and/or other materials provided with the distribution.
-//  * Neither the name of any author or any participating institution 
-//    may be used to endorse or promote products derived from this software 
+//  * Neither the name of any author or any participating institution
+//    may be used to endorse or promote products derived from this software
 //    without specific prior written permission.
-// For a full list of authors, refer to the file AUTHORS. 
+// For a full list of authors, refer to the file AUTHORS.
 // --------------------------------------------------------------------------
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING 
-// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; 
-// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
-// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+// ARE DISCLAIMED. IN NO EVENT SHALL ANY OF THE AUTHORS OR THE CONTRIBUTING
+// INSTITUTIONS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 // ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // --------------------------------------------------------------------------
 // $Maintainer: Douglas McCloskey, Pasquale Domenico Colaianni $
 // $Authors: Douglas McCloskey, Pasquale Domenico Colaianni $
@@ -171,8 +171,8 @@ START_SECTION((std::map<String,int> countLabelsAndTransitionTypes(const Feature 
   subordinate.setMetaValue("native_id","component1.2.Light");
   subordinate.setMetaValue("LabelType","Light");
   subordinates.push_back(subordinate);
-  // component_1.setPeptideRef("component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  // component_1.setPeptideRef("component_group1");
+  component_1.setSubordinates(subordinates);
   // // transition group 2
   // // transition 1
   // subordinate.setMetaValue("native_id","component2.1.Heavy")
@@ -182,7 +182,7 @@ START_SECTION((std::map<String,int> countLabelsAndTransitionTypes(const Feature 
   // subordinate.setMetaValue("native_id","component2.1.Light")
   // subordinate.setMetaValue("LabelType","Light");
   // subordinates.push_back(subordinate);
-  
+
   // make the targeted experiment
   TargetedExperiment transitions;
   ReactionMonitoringTransition transition;
@@ -239,7 +239,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   const TargetedExperiment & transitions))
 {
   /** FilterFeatureMap Test 1: basic ability to flag or filter transitions or transition groups */
-  
+
   MRMFeatureFilter mrmff;
 
   //make the FeatureMap
@@ -271,8 +271,8 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",500); //should fail
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
   // transition group 2
@@ -292,11 +292,11 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",1000);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group2"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group2");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
-  
+
   // make the targeted experiment
   TargetedExperiment transitions;
   ReactionMonitoringTransition transition;
@@ -344,7 +344,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   MRMFeatureQC::ComponentQCs cqcs;
   std::pair<double,double> lbub(501, 4e6);
   // transition group 1
-  cgqcs.component_group_name =  "component_group1";    
+  cgqcs.component_group_name =  "component_group1";
   cgqcs.n_heavy_l = 1;
   cgqcs.n_heavy_u = 1;
   cgqcs.n_light_l = 2;
@@ -363,7 +363,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cgqcs.ion_ratio_u = 10.0;
   cgqcs.ion_ratio_feature_name = "peak_apex_int";
   // transition 1
-  cqcs.component_name = "component1.1.Heavy";   
+  cqcs.component_name = "component1.1.Heavy";
   cqcs.retention_time_l = 2.0;
   cqcs.retention_time_u = 3.0;
   cqcs.intensity_l = 500;
@@ -372,7 +372,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cqcs.overall_quality_u = 500;
   cqcs.meta_value_qc["peak_apex_int"] = lbub;
   // transition 2
-  cqcs.component_name = "component1.1.Light";   
+  cqcs.component_name = "component1.1.Light";
   cqcs.retention_time_l = 2.0;
   cqcs.retention_time_u = 3.0;
   cqcs.intensity_l = 500;
@@ -381,7 +381,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cqcs.overall_quality_u = 500;
   cqcs.meta_value_qc["peak_apex_int"] = lbub;
   // transition 3
-  cqcs.component_name = "component1.2.Light";   
+  cqcs.component_name = "component1.2.Light";
   cqcs.retention_time_l = 2.0;
   cqcs.retention_time_u = 3.0;
   cqcs.intensity_l = 500;
@@ -392,7 +392,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   qc_criteria.component_group_qcs.push_back(cgqcs);
   qc_criteria.component_qcs.push_back(cqcs);
   // transition group 2
-  cgqcs.component_group_name =  "component_group2";    
+  cgqcs.component_group_name =  "component_group2";
   cgqcs.n_heavy_l = 1;
   cgqcs.n_heavy_u = 1;
   cgqcs.n_light_l = 2; //should fail
@@ -411,7 +411,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cgqcs.ion_ratio_u = 10.0;
   cgqcs.ion_ratio_feature_name = "peak_apex_int";
   // transition 1
-  cqcs.component_name = "component2.1.Heavy";   
+  cqcs.component_name = "component2.1.Heavy";
   cqcs.retention_time_l = 2.0;
   cqcs.retention_time_u = 3.0;
   cqcs.intensity_l = 500;
@@ -420,7 +420,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cqcs.overall_quality_u = 500;
   cqcs.meta_value_qc["peak_apex_int"] = lbub;
   // transition 2
-  cqcs.component_name = "component2.1.Light";   
+  cqcs.component_name = "component2.1.Light";
   cqcs.retention_time_l = 2.0;
   cqcs.retention_time_u = 3.0;
   cqcs.intensity_l = 500;
@@ -430,7 +430,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cqcs.meta_value_qc["peak_apex_int"] = lbub;
   qc_criteria.component_group_qcs.push_back(cgqcs);
   qc_criteria.component_qcs.push_back(cqcs);
-  
+
   //test flag mode
   Param params;
   params.setValue("flag_or_filter", "flag");
@@ -456,7 +456,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_REAL_SIMILAR(components[1].getMetaValue("QC_transition_group_score"), 0.777777777777778);
   TEST_REAL_SIMILAR(components[1].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[1].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
-  
+
   //test filter mode
   params.setValue("flag_or_filter", "filter");
   mrmff.setParameters(params);
@@ -503,11 +503,11 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",5000);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
-  
+
   // make the targeted experiment
   TargetedExperiment transitions;
   ReactionMonitoringTransition transition;
@@ -540,7 +540,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   MRMFeatureQC::ComponentQCs cqcs;
   std::pair<double,double> lbub(500, 4e6);
   // transition group 1
-  cgqcs.component_group_name =  "component_group1";    
+  cgqcs.component_group_name =  "component_group1";
   cgqcs.n_heavy_l = 1;
   cgqcs.n_heavy_u = 1;
   cgqcs.n_light_l = 1;
@@ -559,7 +559,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cgqcs.ion_ratio_u = 2.0;
   cgqcs.ion_ratio_feature_name = "peak_apex_int";
   // transition 1
-  cqcs.component_name = "component1.1.Heavy";   
+  cqcs.component_name = "component1.1.Heavy";
   cqcs.retention_time_l = 2.0;
   cqcs.retention_time_u = 3.0;
   cqcs.intensity_l = 500;
@@ -569,7 +569,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cqcs.meta_value_qc["peak_apex_int"] = lbub;
   cqcs.meta_value_qc["peak_area"] = lbub;
   // transition 2
-  cqcs.component_name = "component1.1.Light";   
+  cqcs.component_name = "component1.1.Light";
   cqcs.retention_time_l = 2.0;
   cqcs.retention_time_u = 3.0;
   cqcs.intensity_l = 500;
@@ -578,7 +578,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cqcs.overall_quality_u = 500;
   cqcs.meta_value_qc["peak_apex_int"] = lbub;
   // transition 3
-  cqcs.component_name = "component1.2.Light";   
+  cqcs.component_name = "component1.2.Light";
   cqcs.retention_time_l = 2.0;
   cqcs.retention_time_u = 3.0;
   cqcs.intensity_l = 500;
@@ -588,7 +588,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   cqcs.meta_value_qc["peak_apex_int"] = lbub;
   qc_criteria.component_group_qcs.push_back(cgqcs);
   qc_criteria.component_qcs.push_back(cqcs);
-  
+
   //test all possible comparisons
   Param params;
   params.setValue("flag_or_filter", "flag");
@@ -605,7 +605,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
-  
+
   // RT
   // transition group 1
   // transition 1
@@ -632,10 +632,10 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",5000);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
-  subordinates.clear();  
+  subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
@@ -645,7 +645,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "retention_time");
 
   components.clear();
-  
+
   // Intensity
   // transition group 1
   // transition 1
@@ -672,8 +672,8 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",5000);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
@@ -688,7 +688,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 0.75);
   components.clear();
-  
+
   // OverallQuality
   // transition group 1
   // transition 1
@@ -715,8 +715,8 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",5000);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
@@ -731,7 +731,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 0.75);
   components.clear();
-  
+
   // MetaValue
   // transition group 1
   // transition 1
@@ -758,8 +758,8 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",400); //should fail
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
@@ -775,7 +775,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 0.75);
   components.clear();
-  
+
   // n_heavy
   // transition group 1
   // transition 1
@@ -799,8 +799,8 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",5000);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
@@ -815,7 +815,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
-  
+
   // n_light
   // transition group 1
   // transition 1
@@ -842,8 +842,8 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","");
   subordinate.setMetaValue("peak_apex_int",5000);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
@@ -858,7 +858,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[2].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
-  
+
   // n_transitions
   // transition group 1
   // transition 1
@@ -877,8 +877,8 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",5000);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
@@ -891,7 +891,7 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
   components.clear();
-  
+
   // ion_ratio_pair
   // transition group 1
   // transition 1
@@ -918,8 +918,8 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinate.setMetaValue("LabelType","Light");
   subordinate.setMetaValue("peak_apex_int",500);
   subordinates.push_back(subordinate);
-  component_1.setMetaValue("PeptideRef", "component_group1"); 
-  component_1.setSubordinates(subordinates); 
+  component_1.setMetaValue("PeptideRef", "component_group1");
+  component_1.setSubordinates(subordinates);
   components.push_back(component_1);
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);

--- a/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
+++ b/src/tests/class_tests/openms/source/MRMFeatureFilter_test.cpp
@@ -80,21 +80,6 @@ END_SECTION
 // }
 // END_SECTION
 
-START_SECTION(String uniqueJoin(std::vector<String>& str_vec, const String& delim))
-{
-  MRMFeatureFilter mrmff;
-  const String str_vec_c[] = {"hello", "hello", "bye", "bye"};
-  std::vector<String> str_vec(str_vec_c, str_vec_c + sizeof(str_vec_c) / sizeof(str_vec_c[0]));
-
-  // tests
-  String delim = ";";
-  TEST_EQUAL(mrmff.uniqueJoin(str_vec, delim), "bye;hello");
-  delim = "||";
-  TEST_EQUAL(mrmff.uniqueJoin(str_vec, delim), "bye||hello");
-
-}
-END_SECTION
-
 START_SECTION(double calculateIonRatio(const Feature & component_1, const Feature & component_2, const String & feature_name))
 {
   MRMFeatureFilter mrmff;
@@ -456,9 +441,14 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "metaValue[peak_apex_int]");
+  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "metaValue[peak_apex_int]");
+  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "peak_apex_int");
   TEST_EQUAL(components[1].getMetaValue("QC_transition_group_pass"), false);
-  TEST_EQUAL(components[1].getMetaValue("QC_transition_group_message"), "n_light;n_transitions");
+  // TEST_EQUAL(components[1].getMetaValue("QC_transition_group_message"), "n_light;n_transitions");
+  TEST_EQUAL(components[1].getMetaValue("QC_transition_group_message").toStringList().size(), 2);
+  TEST_STRING_EQUAL(components[1].getMetaValue("QC_transition_group_message").toStringList()[0], "n_light");
+  TEST_STRING_EQUAL(components[1].getMetaValue("QC_transition_group_message").toStringList()[1], "n_transitions");
   TEST_EQUAL(components[1].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[1].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
@@ -653,7 +643,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "retention_time");
+  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "retention_time");
+  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "retention_time");
 
   components.clear();
   
@@ -692,7 +684,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "intensity");
+  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "intensity");
+  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "intensity");
   TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
@@ -734,7 +728,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "overall_quality");
+  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "overall_quality");
+  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "overall_quality");
   TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
@@ -776,7 +772,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), false);
-  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "metaValue[peak_apex_int]");
+  // TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message"), "metaValue[peak_apex_int]");
+  TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_message").toStringList()[0], "peak_apex_int");
   TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[0].getMetaValue("QC_transition_score"), 1.0);
   TEST_REAL_SIMILAR(components[0].getSubordinates()[1].getMetaValue("QC_transition_score"), 1.0);
@@ -812,7 +810,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), false);
-  TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_heavy");
+  // TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_heavy");
+  TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList()[0], "n_heavy");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), true);
@@ -854,7 +854,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), false);
-  TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_light");
+  // TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_light");
+  TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList()[0], "n_light");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), true);
@@ -888,7 +890,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), false);
-  TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_transitions");
+  // TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "n_transitions");
+  TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList()[0], "n_transitions");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_REAL_SIMILAR(components[0].getMetaValue("QC_transition_group_score"), 0.888888888888889);
@@ -928,7 +932,9 @@ START_SECTION(void FilterFeatureMap(FeatureMap& features, MRMFeatureQC& filter_c
   subordinates.clear();
   mrmff.FilterFeatureMap(components, qc_criteria, transitions);
   TEST_EQUAL(components[0].getMetaValue("QC_transition_group_pass"), false);
-  TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "ion_ratio_pair[component1.1.Light/component1.2.Light]");
+  // TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message"), "ion_ratio_pair[component1.1.Light/component1.2.Light]");
+  TEST_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList().size(), 1);
+  TEST_STRING_EQUAL(components[0].getMetaValue("QC_transition_group_message").toStringList()[0], "ion_ratio_pair[component1.1.Light/component1.2.Light]");
   TEST_EQUAL(components[0].getSubordinates()[0].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[1].getMetaValue("QC_transition_pass"), true);
   TEST_EQUAL(components[0].getSubordinates()[2].getMetaValue("QC_transition_pass"), true);


### PR DESCRIPTION
The code would output the failure messages as a contatenation of all messages, delimited by a character.
In this PR I am replacing that logic with `StringList`, so that the end-user can decide how to separate/deal with the messages.