### PR TITLE
[FIX] fix overflow on Windows

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -487,8 +487,8 @@ protected:
        * <chromatogram> tag is stored and will then be stored at the end of the file.
        **/
       //@{
-      std::vector<std::pair<std::string, long> > spectra_offsets_; ///< Stores binary offsets for each <spectrum> tag
-      std::vector<std::pair<std::string, long> > chromatograms_offsets_; ///< Stores binary offsets for each <chromatogram> tag
+      std::vector<std::pair<std::string, Int64> > spectra_offsets_; ///< Stores binary offsets for each <spectrum> tag
+      std::vector<std::pair<std::string, Int64> > chromatograms_offsets_; ///< Stores binary offsets for each <chromatogram> tag
       //@}
 
       /// Progress logger

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandlerHelper.h
@@ -141,8 +141,8 @@ namespace OpenMS
       */
       static void writeFooter_(std::ostream& os,
                                const PeakFileOptions& options,
-                               const std::vector< std::pair<std::string, long> > & spectra_offsets,
-                               const std::vector< std::pair<std::string, long> > & chromatograms_offsets);
+                               const std::vector< std::pair<std::string, Int64> > & spectra_offsets,
+                               const std::vector< std::pair<std::string, Int64> > & chromatograms_offsets);
 
       /**
         @brief Decode Base64 arrays and write into data_ array

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -4882,7 +4882,7 @@ namespace OpenMS
         native_id = String("spectrum=") + s;
       }
 
-      long offset = os.tellp();
+      Int64 offset = os.tellp();
       spectra_offsets_.push_back(make_pair(native_id, offset + 3));
 
       // IMPORTANT make sure the offset (above) corresponds to the start of the <spectrum tag
@@ -5439,7 +5439,7 @@ namespace OpenMS
                                          Size c,
                                          const Internal::MzMLValidator& validator)
     {
-      long offset = os.tellp();
+      Int64 offset = os.tellp();
       chromatograms_offsets_.push_back(make_pair(chromatogram.getNativeID(), offset + 3));
 
       // TODO native id with chromatogram=?? prefix?

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -107,8 +107,8 @@ namespace OpenMS
 
   void MzMLHandlerHelper::writeFooter_(std::ostream& os,
                                        const PeakFileOptions& options_, 
-                                       const std::vector< std::pair<std::string, long> > & spectra_offsets,
-                                       const std::vector< std::pair<std::string, long> > & chromatograms_offsets)
+                                       const std::vector< std::pair<std::string, Int64> > & spectra_offsets,
+                                       const std::vector< std::pair<std::string, Int64> > & chromatograms_offsets)
   {
     os << "\t</run>\n";
     os << "</mzML>";

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -117,7 +117,7 @@ namespace OpenMS
     {
       int indexlists = (int) !spectra_offsets.empty() + (int) !chromatograms_offsets.empty();
 
-      long indexlistoffset = os.tellp();
+      Int64 indexlistoffset = os.tellp();
       os << "\n";
       // NOTE: indexList is required, so we need to write one 
       // NOTE: the spectra and chromatogram ids are user-supplied, so better XML-escape them!


### PR DESCRIPTION
Ensure that we actually use 64 bit integers to store spectra / chromatogram offsets on all platforms

I have confirmed this on Windows that it fixes #4009 

There is currently no test for it as it would require to write a 2+ GB file to disk which we probably dont want to do routinely