### PR TITLE
[PYOPENMS] fix inheritance for MetaInfoInterface / CVTermList

### DIFF
--- a/src/pyOpenMS/pxds/Acquisition.pxd
+++ b/src/pyOpenMS/pxds/Acquisition.pxd
@@ -3,9 +3,13 @@ from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/Acquisition.h>" namespace "OpenMS":
     
-    cdef cppclass Acquisition "OpenMS::Acquisition":
+    cdef cppclass Acquisition(MetaInfoInterface):
+        # wrap-inherits:
+        #    MetaInfoInterface
+
         Acquisition() nogil except +
         Acquisition(Acquisition) nogil except +
+
         bool operator==(Acquisition &rhs) nogil except +
         bool operator!=(Acquisition &rhs) nogil except +
         String getIdentifier() nogil except +

--- a/src/pyOpenMS/pxds/AcquisitionInfo.pxd
+++ b/src/pyOpenMS/pxds/AcquisitionInfo.pxd
@@ -1,10 +1,13 @@
 from Types cimport *
 from libcpp cimport bool
 from String cimport *
+from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/AcquisitionInfo.h>" namespace "OpenMS":
 
-    cdef cppclass AcquisitionInfo:
+    cdef cppclass AcquisitionInfo(MetaInfoInterface):
+        # wrap-inherits:
+        #    MetaInfoInterface
         
         AcquisitionInfo()    nogil except +
         AcquisitionInfo(AcquisitionInfo)    nogil except +

--- a/src/pyOpenMS/pxds/CVMappingRule.pxd
+++ b/src/pyOpenMS/pxds/CVMappingRule.pxd
@@ -1,7 +1,6 @@
 from libcpp cimport bool
 from String cimport *
 from CVTerm cimport *
-from MetaInfoInterface cimport *
 from CVMappingTerm cimport *
 
 cdef extern from "<OpenMS/DATASTRUCTURES/CVMappingRule.h>" namespace "OpenMS":

--- a/src/pyOpenMS/pxds/CVTermList.pxd
+++ b/src/pyOpenMS/pxds/CVTermList.pxd
@@ -11,8 +11,10 @@ cdef extern from "<OpenMS/METADATA/CVTermList.h>" namespace "OpenMS":
     cdef cppclass CVTermList(MetaInfoInterface):
         # wrap-inherits:
         #    MetaInfoInterface
+
         ######################################################################
-        # cython has a problem with inheritance of overloaded methods,
+        # Cython has a problem with inheritance of overloaded methods, so we
+        # can only declare one of the two methods here.
         # see eg Precursor.pxd 
 
         CVTermList()            nogil except +
@@ -21,8 +23,9 @@ cdef extern from "<OpenMS/METADATA/CVTermList.h>" namespace "OpenMS":
         void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
         void replaceCVTerm(CVTerm & term)               nogil except +
 
+        # will not wrap due to Cython inheritance issue
         void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
+        # void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
 
         void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
 

--- a/src/pyOpenMS/pxds/CVTermListInterface.pxd
+++ b/src/pyOpenMS/pxds/CVTermListInterface.pxd
@@ -10,17 +10,27 @@ cdef extern from "<OpenMS/METADATA/CVTermListInterface.h>" namespace "OpenMS":
     cdef cppclass CVTermListInterface(MetaInfoInterface) :
         # wrap-inherits:
         #  MetaInfoInterface
+
         CVTermListInterface() nogil except +
         CVTermListInterface(CVTermListInterface) nogil except +
+
         bool operator==(CVTermListInterface & rhs) nogil except +
         bool operator!=(CVTermListInterface & rhs) nogil except +
+
         void replaceCVTerms(Map[ String, libcpp_vector[ CVTerm ] ] & cv_terms) nogil except +
         void setCVTerms(libcpp_vector[ CVTerm ] & terms) nogil except +
+
+        ######################################################################
+        # Cython has a problem with inheritance of overloaded methods, so we
+        # can only declare one of the two methods here.
         void replaceCVTerm(CVTerm & cv_term) nogil except +
         void replaceCVTerms(libcpp_vector[ CVTerm ] & cv_terms, const String & accession) nogil except +
         # void replaceCVTerms(Map[ String, libcpp_vector[ CVTerm ] ] & cv_term_map) nogil except +
+
         void consumeCVTerms(Map[ String, libcpp_vector[ CVTerm ] ] & cv_term_map) nogil except +
         Map[ String, libcpp_vector[ CVTerm ] ]  getCVTerms() nogil except +
+
+
         void addCVTerm(CVTerm & term) nogil except +
         bool hasCVTerm(const String & accession) nogil except +
         bool empty() nogil except +

--- a/src/pyOpenMS/pxds/ChromatogramSettings.pxd
+++ b/src/pyOpenMS/pxds/ChromatogramSettings.pxd
@@ -7,10 +7,14 @@ from DataProcessing cimport *
 from Product cimport *
 from AcquisitionInfo cimport *
 from Precursor cimport *
+from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/ChromatogramSettings.h>" namespace "OpenMS":
 
-    cdef cppclass ChromatogramSettings:
+    cdef cppclass ChromatogramSettings(MetaInfoInterface):
+        # wrap-inherits:
+        #    MetaInfoInterface
+        #
         # wrap-doc:
         #   Description of the chromatogram settings, provides meta-information
         #   about a single chromatogram.

--- a/src/pyOpenMS/pxds/ConsensusMap.pxd
+++ b/src/pyOpenMS/pxds/ConsensusMap.pxd
@@ -12,12 +12,16 @@ from DataProcessing cimport *
 from Types cimport *
 from DocumentIdentifier cimport *
 from RangeManager cimport *
+from MetaInfoInterface cimport *
 
 # this class has addons, see the ./addons folder
 
 cdef extern from "<OpenMS/KERNEL/ConsensusMap.h>" namespace "OpenMS::ConsensusMap":
 
-    cdef cppclass ColumnHeader:
+    cdef cppclass ColumnHeader(MetaInfoInterface):
+        # wrap-inherits:
+        #   MetaInfoInterface
+
         String filename
         String label
         Size size
@@ -33,12 +37,13 @@ cdef extern from "<OpenMS/KERNEL/ConsensusMap.h>" namespace "OpenMS::ConsensusMa
 
 cdef extern from "<OpenMS/KERNEL/ConsensusMap.h>" namespace "OpenMS":
 
-    cdef cppclass ConsensusMap(UniqueIdInterface, DocumentIdentifier, RangeManager2):
+    cdef cppclass ConsensusMap(UniqueIdInterface, DocumentIdentifier, RangeManager2, MetaInfoInterface):
 
         # wrap-inherits:
         #   UniqueIdInterface
         #   DocumentIdentifier
         #   RangeManager2
+        #   MetaInfoInterface
         #
         # wrap-doc:
         #   A container for consensus elements.

--- a/src/pyOpenMS/pxds/ContactPerson.pxd
+++ b/src/pyOpenMS/pxds/ContactPerson.pxd
@@ -1,8 +1,8 @@
 from SourceFile cimport *
 from DateTime cimport *
 from DocumentIdentifier cimport *
-from MetaInfoInterface cimport *
 from libcpp.vector cimport vector as libcpp_vector
+from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/ContactPerson.h>" namespace "OpenMS":
 

--- a/src/pyOpenMS/pxds/DataProcessing.pxd
+++ b/src/pyOpenMS/pxds/DataProcessing.pxd
@@ -4,6 +4,7 @@ from Peak1D cimport *
 from String cimport *
 from Software cimport *
 from DateTime cimport *
+from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/DataProcessing.h>" namespace "OpenMS":
 
@@ -22,21 +23,6 @@ cdef extern from "<OpenMS/METADATA/DataProcessing.h>" namespace "OpenMS":
 
         DateTime getCompletionTime()  nogil except +
         void setCompletionTime(DateTime t) nogil except +
-
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 
     ctypedef shared_ptr[DataProcessing] DataProcessingPtr
 

--- a/src/pyOpenMS/pxds/ExperimentalSettings.pxd
+++ b/src/pyOpenMS/pxds/ExperimentalSettings.pxd
@@ -12,7 +12,7 @@ from libcpp.vector cimport vector as libcpp_vector
 
 cdef extern from "<OpenMS/METADATA/ExperimentalSettings.h>" namespace "OpenMS":
 
-    cdef cppclass ExperimentalSettings(MetaInfoInterface,DocumentIdentifier):
+    cdef cppclass ExperimentalSettings(MetaInfoInterface, DocumentIdentifier):
         # wrap-inherits:
         #    DocumentIdentifier
         #    MetaInfoInterface
@@ -68,7 +68,4 @@ cdef extern from "<OpenMS/METADATA/ExperimentalSettings.h>" namespace "OpenMS":
         String getFractionIdentifier() nogil except +
         # sets the fraction identifier
         void setFractionIdentifier(String fraction_identifier) nogil except +
-
-        # since this class can be derived again, we will not declare
-        # the MetaInfoInterface methods here
 

--- a/src/pyOpenMS/pxds/FeatureMap.pxd
+++ b/src/pyOpenMS/pxds/FeatureMap.pxd
@@ -5,6 +5,7 @@ from UniqueIdInterface cimport *
 from ProteinIdentification cimport *
 from PeptideIdentification cimport *
 from DataProcessing cimport *
+from MetaInfoInterface cimport *
 from DocumentIdentifier cimport *
 from RangeManager cimport *
 
@@ -12,12 +13,13 @@ from RangeManager cimport *
 
 cdef extern from "<OpenMS/KERNEL/FeatureMap.h>" namespace "OpenMS":
 
-    cdef cppclass FeatureMap(UniqueIdInterface, DocumentIdentifier, RangeManager2):
+    cdef cppclass FeatureMap(UniqueIdInterface, DocumentIdentifier, RangeManager2, MetaInfoInterface):
 
         # wrap-inherits:
         #   UniqueIdInterface
         #   DocumentIdentifier
         #   RangeManager2
+        #   MetaInfoInterface
         #
         # wrap-instances:
         #   FeatureMap := FeatureMap

--- a/src/pyOpenMS/pxds/FloatDataArray.pxd
+++ b/src/pyOpenMS/pxds/FloatDataArray.pxd
@@ -31,14 +31,4 @@ cdef extern from "<OpenMS/METADATA/DataArrays.h>" namespace "OpenMS::DataArrays"
         libcpp_vector[float].iterator end()   nogil # wrap-ignore
         void assign(float*, float*) # wrap-ignore
 
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 

--- a/src/pyOpenMS/pxds/Gradient.pxd
+++ b/src/pyOpenMS/pxds/Gradient.pxd
@@ -1,5 +1,5 @@
+from Types cimport *
 from String cimport *
-from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/Gradient.h>" namespace "OpenMS":
 
@@ -35,7 +35,7 @@ cdef extern from "<OpenMS/METADATA/Gradient.h>" namespace "OpenMS":
         # TODO 
         # libcpp_vector[ libcpp_vector[unsigned int] ] getPercentages() nogil except +
 
-        # sets all precentage values to 0
+        # sets all percentage values to 0
         void clearPercentages() nogil except +
         # checks if the percentages of all timepoints add up to 100%
         bool isValid() nogil except +

--- a/src/pyOpenMS/pxds/Identification.pxd
+++ b/src/pyOpenMS/pxds/Identification.pxd
@@ -28,14 +28,3 @@ cdef extern from "<OpenMS/METADATA/Identification.h>" namespace "OpenMS":
         # /// returns the spectrum identifications stored
         libcpp_vector[SpectrumIdentification] getSpectrumIdentifications()  nogil except +
 
-        # COPY-PASTE from MetaInfoInterface
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +

--- a/src/pyOpenMS/pxds/IdentificationData.pxd
+++ b/src/pyOpenMS/pxds/IdentificationData.pxd
@@ -9,4 +9,5 @@ cdef extern from "<OpenMS/METADATA/ID/IdentificationData.h>" namespace "OpenMS":
     cdef cppclass IdentificationData(MetaInfoInterface) :
         # wrap-inherits:
         #  MetaInfoInterface
+
         IdentificationData() nogil except +

--- a/src/pyOpenMS/pxds/IdentificationHit.pxd
+++ b/src/pyOpenMS/pxds/IdentificationHit.pxd
@@ -55,14 +55,3 @@ cdef extern from "<OpenMS/METADATA/IdentificationHit.h>" namespace "OpenMS":
         # /// returns the rank of the peptide
         Int getRank() nogil except +
 
-        # COPY-PASTE from MetaInfoInterface
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +

--- a/src/pyOpenMS/pxds/Instrument.pxd
+++ b/src/pyOpenMS/pxds/Instrument.pxd
@@ -58,21 +58,6 @@ cdef extern from "<OpenMS/METADATA/Instrument.h>" namespace "OpenMS":
         IonOpticsType getIonOptics() nogil except +
         void setIonOptics(IonOpticsType ion_optics) nogil except +
 
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
 cdef extern from "<OpenMS/METADATA/Instrument.h>" namespace "OpenMS::Instrument":
 
     cdef enum IonOpticsType:

--- a/src/pyOpenMS/pxds/Instrument.pxd
+++ b/src/pyOpenMS/pxds/Instrument.pxd
@@ -77,17 +77,17 @@ cdef extern from "<OpenMS/METADATA/Instrument.h>" namespace "OpenMS::Instrument"
 
     cdef enum IonOpticsType:
     
-        UNKNOWN,                                          #< unknown
-        MAGNETIC_DEFLECTION,                      #< magnetic deflection
-        DELAYED_EXTRACTION,                       #< delayed extraction
-        COLLISION_QUADRUPOLE,                 #< collision quadrupole
-        SELECTED_ION_FLOW_TUBE,               #< selected ion flow tube
-        TIME_LAG_FOCUSING,                        #< time lag focusing
-        REFLECTRON,                                       #< reflectron
-        EINZEL_LENS,                                      #< einzel lens
-        FIRST_STABILITY_REGION,               #< first stability region
-        FRINGING_FIELD,                               #< fringing field
-        KINETIC_ENERGY_ANALYZER,              #< kinetic energy analyzer
-        STATIC_FIELD,                                     #< static field
+        UNKNOWN,                          #< unknown
+        MAGNETIC_DEFLECTION,              #< magnetic deflection
+        DELAYED_EXTRACTION,               #< delayed extraction
+        COLLISION_QUADRUPOLE,             #< collision quadrupole
+        SELECTED_ION_FLOW_TUBE,           #< selected ion flow tube
+        TIME_LAG_FOCUSING,                #< time lag focusing
+        REFLECTRON,                       #< reflectron
+        EINZEL_LENS,                      #< einzel lens
+        FIRST_STABILITY_REGION,           #< first stability region
+        FRINGING_FIELD,                   #< fringing field
+        KINETIC_ENERGY_ANALYZER,          #< kinetic energy analyzer
+        STATIC_FIELD,                     #< static field
         SIZE_OF_IONOPTICSTYPE
 

--- a/src/pyOpenMS/pxds/InstrumentSettings.pxd
+++ b/src/pyOpenMS/pxds/InstrumentSettings.pxd
@@ -21,38 +21,24 @@ cdef extern from "<OpenMS/METADATA/InstrumentSettings.h>" namespace "OpenMS":
         libcpp_vector[ ScanWindow ]  getScanWindows() nogil except +
         void setScanWindows(libcpp_vector[ ScanWindow ] scan_windows) nogil except +
 
-        # declare again: cython complains for overloaded methods in base
-        # classes
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
-
 cdef extern from "<OpenMS/METADATA/InstrumentSettings.h>" namespace "OpenMS::InstrumentSettings":
 
     # scan mode
     cdef enum ScanMode:
-      UNKNOWN,                      #< Unknown scan method
-      MASSSPECTRUM,       #< general spectrum type
-      MS1SPECTRUM,              #< full scan mass spectrum, is a "mass spectrum" @n Synonyms: 'full spectrum', 'Q1 spectrum', 'Q3 spectrum', 'Single-Stage Mass Spectrometry'
-      MSNSPECTRUM,        #< MS2+ mass spectrum, is a "mass spectrum"
-      SIM,                              #< Selected ion monitoring scan @n Synonyms: 'Multiple ion monitoring scan', 'SIM scan', 'MIM scan'
-      SRM,                              #< Selected reaction monitoring scan @n Synonyms: 'Multiple reaction monitoring scan', 'SRM scan', 'MRM scan'
-      CRM,                              #< Consecutive reaction monitoring scan @n Synonyms: 'CRM scan'
-      CNG,                              #< Constant neutral gain scan @n Synonyms: 'CNG scan'
-      CNL,                              #< Constant neutral loss scan @n Synonyms: 'CNG scan'
-      PRECURSOR,                #< Precursor ion scan
-      EMC,                              #< Enhanced multiply charged scan
-      TDF,                              #< Time-delayed fragmentation scan
-      EMR,                              #< Electromagnetic radiation scan @n Synonyms: 'EMR spectrum'
-      EMISSION,                     #< Emission scan
-      ABSORPTION,               #< Absorption scan
+      UNKNOWN,                #< Unknown scan method
+      MASSSPECTRUM,           #< general spectrum type
+      MS1SPECTRUM,            #< full scan mass spectrum, is a "mass spectrum" @n Synonyms: 'full spectrum', 'Q1 spectrum', 'Q3 spectrum', 'Single-Stage Mass Spectrometry'
+      MSNSPECTRUM,            #< MS2+ mass spectrum, is a "mass spectrum"
+      SIM,                    #< Selected ion monitoring scan @n Synonyms: 'Multiple ion monitoring scan', 'SIM scan', 'MIM scan'
+      SRM,                    #< Selected reaction monitoring scan @n Synonyms: 'Multiple reaction monitoring scan', 'SRM scan', 'MRM scan'
+      CRM,                    #< Consecutive reaction monitoring scan @n Synonyms: 'CRM scan'
+      CNG,                    #< Constant neutral gain scan @n Synonyms: 'CNG scan'
+      CNL,                    #< Constant neutral loss scan @n Synonyms: 'CNG scan'
+      PRECURSOR,              #< Precursor ion scan
+      EMC,                    #< Enhanced multiply charged scan
+      TDF,                    #< Time-delayed fragmentation scan
+      EMR,                    #< Electromagnetic radiation scan @n Synonyms: 'EMR spectrum'
+      EMISSION,               #< Emission scan
+      ABSORPTION,             #< Absorption scan
       SIZE_OF_SCANMODE
 

--- a/src/pyOpenMS/pxds/IntegerDataArray.pxd
+++ b/src/pyOpenMS/pxds/IntegerDataArray.pxd
@@ -30,14 +30,4 @@ cdef extern from "<OpenMS/METADATA/DataArrays.h>" namespace "OpenMS::DataArrays"
         libcpp_vector[int].iterator begin() nogil except +  # wrap-ignore
         libcpp_vector[int].iterator end()   nogil except +  # wrap-ignore
 
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 

--- a/src/pyOpenMS/pxds/IonSource.pxd
+++ b/src/pyOpenMS/pxds/IonSource.pxd
@@ -32,7 +32,7 @@ cdef extern from "<OpenMS/METADATA/IonSource.h>" namespace "OpenMS":
         #     - one ion source
         #     - one or many mass analyzers
         #     - one ion detector
-        #     For more complex instuments, the order should be defined.
+        #     For more complex instruments, the order should be defined.
         Int getOrder() nogil except +
         # sets the order
         void setOrder(Int order) nogil except +

--- a/src/pyOpenMS/pxds/MSChromatogram.pxd
+++ b/src/pyOpenMS/pxds/MSChromatogram.pxd
@@ -1,6 +1,5 @@
 from Types cimport *
 from ChromatogramSettings cimport *
-from MetaInfoInterface cimport *
 from ChromatogramPeak cimport *
 from String cimport *
 from RangeManager cimport *
@@ -11,10 +10,9 @@ from DataArrays cimport *
 
 cdef extern from "<OpenMS/KERNEL/MSChromatogram.h>" namespace "OpenMS":
 
-    cdef cppclass MSChromatogram (ChromatogramSettings, MetaInfoInterface, RangeManager1):
+    cdef cppclass MSChromatogram (ChromatogramSettings, RangeManager1):
         # wrap-inherits:
         #  ChromatogramSettings
-        #  MetaInfoInterface
         #  RangeManager1
         #
         # wrap-doc:
@@ -59,15 +57,4 @@ cdef extern from "<OpenMS/KERNEL/MSChromatogram.h>" namespace "OpenMS":
         void setFloatDataArrays(libcpp_vector[FloatDataArray] fda) nogil except +
         void setIntegerDataArrays(libcpp_vector[IntegerDataArray] ida) nogil except +
         void setStringDataArrays(libcpp_vector[StringDataArray] sda) nogil except +
-
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 

--- a/src/pyOpenMS/pxds/MSExperiment.pxd
+++ b/src/pyOpenMS/pxds/MSExperiment.pxd
@@ -5,7 +5,6 @@ from DataValue cimport *
 from String cimport *
 from Peak1D cimport *
 from ChromatogramPeak cimport *
-from MetaInfoInterface cimport *
 from ExperimentalSettings cimport *
 from DateTime cimport *
 from RangeManager cimport *
@@ -96,16 +95,4 @@ cdef extern from "<OpenMS/KERNEL/MSExperiment.h>" namespace "OpenMS":
         bool operator==(MSExperiment) nogil except +
         void reset() nogil except +
         bool clearMetaDataArrays() nogil except +
-
-        # from MetaInfoInterface:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 

--- a/src/pyOpenMS/pxds/MSSpectrum.pxd
+++ b/src/pyOpenMS/pxds/MSSpectrum.pxd
@@ -1,7 +1,6 @@
 from libcpp.vector cimport vector as libcpp_vector
 from libcpp.string cimport string as libcpp_string
 from SpectrumSettings cimport *
-from MetaInfoInterface cimport *
 from Peak1D cimport *
 from String cimport *
 from RangeManager cimport *
@@ -11,10 +10,9 @@ from DataArrays cimport *
 
 cdef extern from "<OpenMS/KERNEL/MSSpectrum.h>" namespace "OpenMS":
 
-    cdef cppclass MSSpectrum(SpectrumSettings, MetaInfoInterface, RangeManager1):
+    cdef cppclass MSSpectrum(SpectrumSettings, RangeManager1):
         # wrap-inherits:
         #  SpectrumSettings
-        #  MetaInfoInterface
         #  RangeManager1
         #
         # wrap-doc:
@@ -70,15 +68,4 @@ cdef extern from "<OpenMS/KERNEL/MSSpectrum.h>" namespace "OpenMS":
         void setFloatDataArrays(libcpp_vector[FloatDataArray] fda) nogil except +
         void setIntegerDataArrays(libcpp_vector[IntegerDataArray] ida) nogil except +
         void setStringDataArrays(libcpp_vector[StringDataArray] sda) nogil except +
-
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 

--- a/src/pyOpenMS/pxds/MassAnalyzer.pxd
+++ b/src/pyOpenMS/pxds/MassAnalyzer.pxd
@@ -90,7 +90,7 @@ cdef extern from "<OpenMS/METADATA/MassAnalyzer.h>" namespace "OpenMS":
         #   - one or many mass analyzers
         #   - one ion detector
         #
-        #   For more complex instuments, the order should be defined.
+        #   For more complex instruments the order should be defined.
         Int getOrder() nogil except +
         # sets the order
         void setOrder(Int order) nogil except +
@@ -101,21 +101,21 @@ cdef extern from "<OpenMS/METADATA/MassAnalyzer.h>" namespace "OpenMS::MassAnaly
     cdef enum AnalyzerType:
       # wrap-attach:
       #     MassAnalyzer
-      ANALYZERNULL,                                         #< Unknown
-      QUADRUPOLE,                                           #< Quadrupole
-      PAULIONTRAP,                                          #< Quadrupole ion trap / Paul ion trap
+      ANALYZERNULL,                         #< Unknown
+      QUADRUPOLE,                           #< Quadrupole
+      PAULIONTRAP,                          #< Quadrupole ion trap / Paul ion trap
       RADIALEJECTIONLINEARIONTRAP,          #< Radial ejection linear ion trap
       AXIALEJECTIONLINEARIONTRAP,           #< Axial ejection linear ion trap
-      TOF,                                                          #< Time-of-flight
-      SECTOR,                                                   #< Magnetic sector
-      FOURIERTRANSFORM,                                 #< Fourier transform ion cyclotron resonance mass spectrometer
-      IONSTORAGE,                                           #< Ion storage
-      ESA,                                                          #< Electrostatic energy analyzer
-      IT,                                                           #< Ion trap
-      SWIFT,                                                    #< Stored waveform inverse fourier transform
-      CYCLOTRON,                                            #< Cyclotron
-      ORBITRAP,                                                 #< Orbitrap
-      LIT,                                                          #< Linear ion trap
+      TOF,                                  #< Time-of-flight
+      SECTOR,                               #< Magnetic sector
+      FOURIERTRANSFORM,                     #< Fourier transform ion cyclotron resonance mass spectrometer
+      IONSTORAGE,                           #< Ion storage
+      ESA,                                  #< Electrostatic energy analyzer
+      IT,                                   #< Ion trap
+      SWIFT,                                #< Stored waveform inverse fourier transform
+      CYCLOTRON,                            #< Cyclotron
+      ORBITRAP,                             #< Orbitrap
+      LIT,                                  #< Linear ion trap
       SIZE_OF_ANALYZERTYPE
 
 
@@ -123,10 +123,10 @@ cdef extern from "<OpenMS/METADATA/MassAnalyzer.h>" namespace "OpenMS::MassAnaly
     cdef enum ResolutionMethod:
       # wrap-attach:
       #     MassAnalyzer
-      RESMETHNULL,                      #< Unknown
-      FWHM,                                     #< Full width at half max
+      RESMETHNULL,                  #< Unknown
+      FWHM,                         #< Full width at half max
       TENPERCENTVALLEY,             #< Ten percent valley
-      BASELINE,                             #< Baseline
+      BASELINE,                     #< Baseline
       SIZE_OF_RESOLUTIONMETHOD
 
     # Resolution type
@@ -134,7 +134,7 @@ cdef extern from "<OpenMS/METADATA/MassAnalyzer.h>" namespace "OpenMS::MassAnaly
       # wrap-attach:
       #     MassAnalyzer
       RESTYPENULL,              #< Unknown
-      CONSTANT,                     #< Constant
+      CONSTANT,                 #< Constant
       PROPORTIONAL,             #< Proportional
       SIZE_OF_RESOLUTIONTYPE
 
@@ -143,8 +143,8 @@ cdef extern from "<OpenMS/METADATA/MassAnalyzer.h>" namespace "OpenMS::MassAnaly
       # wrap-attach:
       #     MassAnalyzer
       SCANDIRNULL,              #< Unknown
-      UP,                               #< Up
-      DOWN,                             #< Down
+      UP,                       #< Up
+      DOWN,                     #< Down
       SIZE_OF_SCANDIRECTION
 
     #Scan law
@@ -153,7 +153,7 @@ cdef extern from "<OpenMS/METADATA/MassAnalyzer.h>" namespace "OpenMS::MassAnaly
       #     MassAnalyzer
       SCANLAWNULL,              #< Unknown
       EXPONENTIAL,              #< Unknown
-      LINEAR,                       #< Linear
+      LINEAR,                   #< Linear
       QUADRATIC,                #< Quadratic
       SIZE_OF_SCANLAW
 
@@ -162,8 +162,8 @@ cdef extern from "<OpenMS/METADATA/MassAnalyzer.h>" namespace "OpenMS::MassAnaly
       # wrap-attach:
       #     MassAnalyzer
       REFLSTATENULL,            #< Unknown
-      ON,                                   #< On
-      OFF,                                  #< Off
-      NONE,                                 #< None
+      ON,                       #< On
+      OFF,                      #< Off
+      NONE,                     #< None
       SIZE_OF_REFLECTRONSTATE
 

--- a/src/pyOpenMS/pxds/MetaInfoDescription.pxd
+++ b/src/pyOpenMS/pxds/MetaInfoDescription.pxd
@@ -25,17 +25,3 @@ cdef extern from "<OpenMS/METADATA/MetaInfoDescription.h>" namespace "OpenMS":
         libcpp_vector[ shared_ptr[DataProcessing] ] getDataProcessing() nogil except +
         void setDataProcessing(libcpp_vector[ shared_ptr[DataProcessing] ]) nogil except +
 
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        #
-        #void getKeys(libcpp_vector[String] & keys)
-        #void getKeys(libcpp_vector[unsigned int] & keys)
-        #DataValue getMetaValue(unsigned int) nogil except +
-        #DataValue getMetaValue(String) nogil except +
-        #void setMetaValue(unsigned int, DataValue) nogil except +
-        #void setMetaValue(String, DataValue) nogil except +
-        #bool metaValueExists(String) nogil except +
-        #bool metaValueExists(unsigned int) nogil except +
-        #void removeMetaValue(String) nogil except +
-        #void removeMetaValue(unsigned int) nogil except +

--- a/src/pyOpenMS/pxds/MetaInfoInterface.pxd
+++ b/src/pyOpenMS/pxds/MetaInfoInterface.pxd
@@ -17,17 +17,17 @@ cdef extern from "<OpenMS/METADATA/MetaInfoInterface.h>" namespace "OpenMS":
 
         MetaInfoRegistry metaRegistry() nogil except +
 
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
+        # Cython has a problem with inheritance of overloaded methods, so we
+        # can only declare one of the two methods here (most people will want
+        # to use the String-based methods).
         #
-        #void getKeys(libcpp_vector[String] & keys)
+        void getKeys(libcpp_vector[String] & keys)
         #void getKeys(libcpp_vector[unsigned int] & keys)
+        DataValue getMetaValue(String) nogil except +
         #DataValue getMetaValue(unsigned int) nogil except +
-        #DataValue getMetaValue(String) nogil except +
+        void setMetaValue(String, DataValue) nogil except +
         #void setMetaValue(unsigned int, DataValue) nogil except +
-        #void setMetaValue(String, DataValue) nogil except +
-        #bool metaValueExists(String) nogil except +
+        bool metaValueExists(String) nogil except +
         #bool metaValueExists(unsigned int) nogil except +
-        #void removeMetaValue(String) nogil except +
+        void removeMetaValue(String) nogil except +
         #void removeMetaValue(unsigned int) nogil except +

--- a/src/pyOpenMS/pxds/PeptideHit.pxd
+++ b/src/pyOpenMS/pxds/PeptideHit.pxd
@@ -4,11 +4,13 @@ from Feature cimport *
 from ProteinIdentification cimport *
 from AASequence cimport *
 from PeptideEvidence cimport *
+from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/PeptideHit.h>" namespace "OpenMS":
 
-    cdef cppclass PeptideHit:
-
+    cdef cppclass PeptideHit(MetaInfoInterface):
+        # wrap-inherits:
+        #    MetaInfoInterface
 
         PeptideHit() nogil except +
 
@@ -43,23 +45,6 @@ cdef extern from "<OpenMS/METADATA/PeptideHit.h>" namespace "OpenMS":
 
         bool operator==(PeptideHit) nogil except +
         bool operator!=(PeptideHit) nogil except +
-        bool isMetaEmpty() nogil except +
-        void clearMetaInfo() nogil except +
-
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
 
     cdef cppclass PeptideHit_AnalysisResult "OpenMS::PeptideHit::PepXMLAnalysisResult":
 

--- a/src/pyOpenMS/pxds/PeptideIdentification.pxd
+++ b/src/pyOpenMS/pxds/PeptideIdentification.pxd
@@ -55,16 +55,3 @@ cdef extern from "<OpenMS/METADATA/PeptideIdentification.h>" namespace "OpenMS":
 
         libcpp_vector[PeptideHit] getReferencingHits(libcpp_vector[PeptideHit], libcpp_set[String] &) nogil except +
 
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +

--- a/src/pyOpenMS/pxds/Precursor.pxd
+++ b/src/pyOpenMS/pxds/Precursor.pxd
@@ -5,9 +5,10 @@ from Map cimport *
 
 cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS":
 
-    cdef cppclass Precursor(Peak1D):
+    cdef cppclass Precursor(Peak1D, CVTermList):
         # wrap-inherits:
         #    Peak1D
+        #    CVTermList
 
         Precursor() nogil except +
         Precursor(Precursor) nogil except +
@@ -48,60 +49,20 @@ cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS":
         bool operator==(Precursor)  nogil except +
         bool operator!=(Precursor)  nogil except +
 
-        #####################################################################
-        # we do not declare inheritance from CVTermList, because cython
-        # has problems inheriting overloaded methods (in this case
-        # replaceCVTerms).
-        # Instead we declare the derived methods manually:
-
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms,
-                             String accession
-                            ) nogil except +
-
-
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map
-                            ) nogil except +
-
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
-
-        #####################################################################
-        # we do not declare inheritance from MetaInfoInterface, because cython
-        # has problems inheriting overloaded methods (in this case
-        # e.g. getKeys and getMetaValue).
-        # Instead we declare the derived methods manually:
-
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
 cdef extern from "<OpenMS/METADATA/Precursor.h>" namespace "OpenMS::Precursor":
     cdef enum ActivationMethod:
       CID,                      #< Collision-induced dissociation
       PSD,                      #< Post-source decay
       PD,                       #< Plasma desorption
       SID,                      #< Surface-induced dissociation
-      BIRD,                             #< Blackbody infrared radiative dissociation
-      ECD,                              #< Electron capture dissociation
-      IMD,                              #< Infrared multiphoton dissociation
-      SORI,                             #< Sustained off-resonance irradiation
-      HCID,                             #< High-energy collision-induced dissociation
-      LCID,                             #< Low-energy collision-induced dissociation
-      PHD,                              #< Photodissociation
-      ETD,                              #< Electron transfer dissociation
-      PQD,                              #< Pulsed q dissociation
+      BIRD,                     #< Blackbody infrared radiative dissociation
+      ECD,                      #< Electron capture dissociation
+      IMD,                      #< Infrared multiphoton dissociation
+      SORI,                     #< Sustained off-resonance irradiation
+      HCID,                     #< High-energy collision-induced dissociation
+      LCID,                     #< Low-energy collision-induced dissociation
+      PHD,                      #< Photodissociation
+      ETD,                      #< Electron transfer dissociation
+      PQD,                      #< Pulsed q dissociation
       SIZE_OF_ACTIVATIONMETHOD
 

--- a/src/pyOpenMS/pxds/ProteinHit.pxd
+++ b/src/pyOpenMS/pxds/ProteinHit.pxd
@@ -4,10 +4,13 @@ from DataValue cimport *
 from Feature cimport *
 from UniqueIdInterface cimport *
 from ProteinIdentification cimport *
+from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/ProteinHit.h>" namespace "OpenMS":
 
-    cdef cppclass ProteinHit:
+    cdef cppclass ProteinHit(MetaInfoInterface):
+        # wrap-inherits:
+        #    MetaInfoInterface
 
         ProteinHit() nogil except +
         ProteinHit(double score, UInt rank, String accession, String sequence) nogil except +
@@ -32,21 +35,6 @@ cdef extern from "<OpenMS/METADATA/ProteinHit.h>" namespace "OpenMS":
 
         bool operator==(ProteinHit) nogil except +
         bool operator!=(ProteinHit) nogil except +
-        bool isMetaEmpty() nogil except +
-        void clearMetaInfo() nogil except +
 
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 
 

--- a/src/pyOpenMS/pxds/ProteinIdentification.pxd
+++ b/src/pyOpenMS/pxds/ProteinIdentification.pxd
@@ -21,20 +21,6 @@ cdef extern from "<OpenMS/METADATA/ProteinIdentification.h>" namespace "OpenMS":
         bool operator==(ProteinIdentification) nogil except +
         bool operator!=(ProteinIdentification) nogil except +
 
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
         # Returns the protein hits (mutable)
         libcpp_vector[ProteinHit] getHits() nogil except +
         # Appends a protein hit
@@ -137,3 +123,4 @@ cdef extern from "<OpenMS/METADATA/ProteinIdentification.h>" namespace "OpenMS::
       double precursor_mass_tolerance            #< Mass tolerance of precursor ions (Dalton)
       bool precursor_mass_tolerance_ppm
       DigestionEnzymeProtein digestion_enzyme            #< The enzyme for cleavage
+

--- a/src/pyOpenMS/pxds/RichPeak2D.pxd
+++ b/src/pyOpenMS/pxds/RichPeak2D.pxd
@@ -20,15 +20,3 @@ cdef extern from "<OpenMS/KERNEL/RichPeak2D.h>" namespace "OpenMS":
         bool operator==(RichPeak2D) nogil except +
         bool operator!=(RichPeak2D) nogil except +
 
-        # declare again: cython complains for overloaded methods in base
-        # classes
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +

--- a/src/pyOpenMS/pxds/Sample.pxd
+++ b/src/pyOpenMS/pxds/Sample.pxd
@@ -67,9 +67,6 @@ cdef extern from "<OpenMS/METADATA/Sample.h>" namespace "OpenMS":
         # returns the number of sample treatments
         Int countTreatments() nogil except +
 
-        # since this class can be derived again, we will not declare the
-        # MetaInfoInterface methods here
-
 cdef extern from "<OpenMS/METADATA/Sample.h>" namespace "OpenMS::Sample":
 
     cdef enum SampleState:

--- a/src/pyOpenMS/pxds/SampleTreatment.pxd
+++ b/src/pyOpenMS/pxds/SampleTreatment.pxd
@@ -9,9 +9,10 @@ cdef extern from "<OpenMS/METADATA/SampleTreatment.h>" namespace "OpenMS":
         # wrap-ignore
         # no-pxd-import
         # ABSTRACT class
-
+        #
         # wrap-inherits:
         #  MetaInfoInterface
+
         SampleTreatment(SampleTreatment) nogil except +
         SampleTreatment(const String & type_) nogil except +
 

--- a/src/pyOpenMS/pxds/ScanWindow.pxd
+++ b/src/pyOpenMS/pxds/ScanWindow.pxd
@@ -4,9 +4,13 @@ from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/ScanWindow.h>" namespace "OpenMS":
     
-    cdef cppclass ScanWindow "OpenMS::ScanWindow":
+    cdef cppclass ScanWindow(MetaInfoInterface) :
+        # wrap-inherits:
+        #  MetaInfoInterface
+
         ScanWindow() nogil except +
         ScanWindow(ScanWindow) nogil except +
+
         double begin
         double end
 

--- a/src/pyOpenMS/pxds/SpectrumIdentification.pxd
+++ b/src/pyOpenMS/pxds/SpectrumIdentification.pxd
@@ -19,17 +19,6 @@ cdef extern from "<OpenMS/METADATA/SpectrumIdentification.h>" namespace "OpenMS"
         # /// adds a single identification hit to the hits
         void addHit(IdentificationHit & hit) nogil except +
 
-        # /// returns the identificatio hits of this spectrum identification
+        # /// returns the identification hits of this spectrum identification
         libcpp_vector[IdentificationHit] getHits() nogil except +
 
-        # COPY-PASTE from MetaInfoInterface
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +

--- a/src/pyOpenMS/pxds/SpectrumSettings.pxd
+++ b/src/pyOpenMS/pxds/SpectrumSettings.pxd
@@ -8,10 +8,13 @@ from Precursor cimport *
 from DataProcessing cimport *
 from Product cimport *
 from AcquisitionInfo cimport *
+from MetaInfoInterface cimport *
 
 cdef extern from "<OpenMS/METADATA/SpectrumSettings.h>" namespace "OpenMS":
 
-    cdef cppclass SpectrumSettings:
+    cdef cppclass SpectrumSettings(MetaInfoInterface):
+        # wrap-inherits:
+        #   MetaInfoInterface
 
         SpectrumSettings()    nogil except +
         void unify(SpectrumSettings)    nogil except +

--- a/src/pyOpenMS/pxds/StringDataArray.pxd
+++ b/src/pyOpenMS/pxds/StringDataArray.pxd
@@ -25,14 +25,4 @@ cdef extern from "<OpenMS/METADATA/DataArrays.h>" namespace "OpenMS::DataArrays"
         void clear() nogil except +
         void push_back(String) nogil except +
 
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 

--- a/src/pyOpenMS/pxds/TargetedExperimentHelper.pxd
+++ b/src/pyOpenMS/pxds/TargetedExperimentHelper.pxd
@@ -31,37 +31,15 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
 
 cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespace "OpenMS::TargetedExperimentHelper":
 
-    cdef cppclass Configuration "OpenMS::TargetedExperimentHelper::Configuration":
+    cdef cppclass Configuration(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
+
         Configuration(Configuration) nogil except + #wrap-ignore
         String contact_ref
         String instrument_ref
         libcpp_vector[ CVTermList ] validations
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
-
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 
     cdef cppclass CV:
         CV(CV) nogil except +
@@ -72,40 +50,21 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
         String version
         String URI
 
-    cdef cppclass Protein "OpenMS::TargetedExperimentHelper::Protein":
+    cdef cppclass Protein(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
+
         Protein() nogil except +
         Protein(Protein) nogil except +
 
         String id
         String sequence
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
 
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
+    cdef cppclass RetentionTime(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
 
-    cdef cppclass RetentionTime "OpenMS::TargetedExperimentHelper::RetentionTime":
         RetentionTime() nogil except +
         RetentionTime(RetentionTime) nogil except +
 
@@ -117,33 +76,10 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
         void setRT(double rt) nogil except +
         double getRT() nogil except +
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
+    cdef cppclass Compound(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
 
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
-    cdef cppclass Compound "OpenMS::TargetedExperimentHelper::Compound":
         Compound() nogil except +
         Compound(Compound) nogil except +
         bool operator==(Compound & rhs) nogil except +
@@ -162,33 +98,10 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
         RTType getRetentionTimeType() nogil except +
         RTUnit getRetentionTimeUnit() nogil except +
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
+    cdef cppclass Peptide(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
 
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
-    cdef cppclass Peptide "OpenMS::TargetedExperimentHelper::Peptide":
         Peptide() nogil except +
         Peptide(Peptide) nogil except +
 
@@ -211,95 +124,24 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
         RTType getRetentionTimeType() nogil except +
         RTUnit getRetentionTimeUnit() nogil except +
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
+    cdef cppclass Contact(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
 
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
-    cdef cppclass Contact "OpenMS::TargetedExperimentHelper::Contact":
         Contact() nogil except +
         Contact(Contact) nogil except + #wrap-ignore
         String id
         bool operator==(Contact & rhs) nogil except +
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
+    cdef cppclass Publication(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
 
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
-
-    cdef cppclass Publication "OpenMS::TargetedExperimentHelper::Publication":
         Publication() nogil except +
         Publication(Publication) nogil except + #wrap-ignore
         String id
         bool operator==(Publication & rhs) nogil except +
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
-
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 
     cdef cppclass TargetedExperiment_Instrument "OpenMS::TargetedExperimentHelper::Instrument":
         TargetedExperiment_Instrument() nogil except +
@@ -333,7 +175,10 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
         void removeMetaValue(String) nogil except +
         void removeMetaValue(unsigned int) nogil except +
 
-    cdef cppclass Prediction "OpenMS::TargetedExperimentHelper::Prediction":
+    cdef cppclass Prediction(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
+
         Prediction() nogil except +
         Prediction(Prediction) nogil except + #wrap-ignore
         bool operator==(Prediction & rhs) nogil except +
@@ -341,31 +186,6 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
         String software_ref
         String contact_ref
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
-
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 
     cdef cppclass TargetedExperiment_Interpretation "OpenMS::TargetedExperimentHelper::Interpretation":
         TargetedExperiment_Interpretation() nogil except +
@@ -401,7 +221,10 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
         void removeMetaValue(String) nogil except +
         void removeMetaValue(unsigned int) nogil except +
 
-    cdef cppclass TraMLProduct "OpenMS::TargetedExperimentHelper::TraMLProduct":
+    cdef cppclass TraMLProduct(CVTermList):
+        # wrap-inherits:
+        #    CVTermList
+
         TraMLProduct() nogil except +
         TraMLProduct(TraMLProduct) nogil except + #wrap-ignore
         bool operator==(TraMLProduct & rhs) nogil except +
@@ -418,31 +241,6 @@ cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespa
         void addInterpretation(TargetedExperiment_Interpretation interpretation) nogil except +
         void resetInterpretations() nogil except +
 
-        # CVTermList:
-        void setCVTerms(libcpp_vector[CVTerm] & terms)  nogil except +
-        void replaceCVTerm(CVTerm & term)               nogil except +
-        void replaceCVTerms(libcpp_vector[CVTerm] cv_terms, String accession) nogil except +
-        void replaceCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        void consumeCVTerms(Map[String, libcpp_vector[CVTerm] ] cv_term_map) nogil except +
-        Map[String, libcpp_vector[CVTerm] ] getCVTerms() nogil except +
-        void addCVTerm(CVTerm & term)                   nogil except +
-        bool hasCVTerm(String accession)  nogil except +
-        bool empty()                      nogil except +
-
-        # MetaInfoInterface:
-        # cython has a problem with inheritance of overloaded methods,
-        # so we do not declare them here, but separately in each derived
-        # class which we want to be wrapped:
-        void getKeys(libcpp_vector[String] & keys) nogil except +
-        void getKeys(libcpp_vector[unsigned int] & keys) nogil except + # wrap-as:getKeysAsIntegers
-        DataValue getMetaValue(unsigned int) nogil except +
-        DataValue getMetaValue(String) nogil except +
-        void setMetaValue(unsigned int, DataValue) nogil except +
-        void setMetaValue(String, DataValue) nogil except +
-        bool metaValueExists(String) nogil except +
-        bool metaValueExists(unsigned int) nogil except +
-        void removeMetaValue(String) nogil except +
-        void removeMetaValue(unsigned int) nogil except +
 
 # no support for nested classes yet in Cython
 cdef extern from "<OpenMS/ANALYSIS/TARGETED/TargetedExperimentHelper.h>" namespace "OpenMS::TargetedExperimentHelper::Peptide":

--- a/src/pyOpenMS/pxds/XMLHandler.pxd
+++ b/src/pyOpenMS/pxds/XMLHandler.pxd
@@ -1,7 +1,7 @@
 from Types cimport *
 from Types cimport *
 from DateTime cimport *
-from MetaInfoInterface cimport *
+from String cimport *
 
 cdef extern from "<OpenMS/FORMAT/HANDLERS/XMLHandler.h>" namespace "OpenMS::Internal":
     

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -53,28 +53,17 @@ def _testMetaInfoInterface(what):
     what.getKeys(keys)
     assert len(keys) and all(isinstance(k, bytes) for k in keys)
     assert what.getMetaValue(keys[0]) == 42
-    keys = []
-    what.getKeysAsIntegers(keys)
-    assert len(keys) and all(isinstance(k, (long, int)) for k in keys)
 
     assert what.metaValueExists("key")
     what.removeMetaValue("key")
 
-    what.setMetaValue(1024, 42)
-    assert what.getMetaValue(1024) == 42
-
     keys = []
     what.getKeys(keys)
     assert what.getMetaValue(keys[0]) == 42
-    keys = []
-    what.getKeysAsIntegers(keys)
-    assert len(keys) and all(isinstance(k, (long, int)) for k in keys)
 
     what.clearMetaInfo()
     keys = []
     what.getKeys(keys)
-    assert len(keys) == 0
-    what.getKeysAsIntegers(keys)
     assert len(keys) == 0
 
 

--- a/src/pyOpenMS/tests/unittests/testCVTermList.py
+++ b/src/pyOpenMS/tests/unittests/testCVTermList.py
@@ -49,18 +49,18 @@ def testCVTermList():
     assert term.getCVIdentifierRef() == "CVREF"
     assert term.getValue() == 123
 
-    li.replaceCVTerms(li.getCVTerms())
-    dd =  li.getCVTerms()
-    assert len(dd) == 2
-    assert b"ACC" in dd and b"ACC2" in dd
-    term, = dd[b"ACC"]
-    assert term.getName() == "NAME"
-    assert term.getCVIdentifierRef() == "CVREF"
-    assert term.getValue() == 123
-    term, = dd[b"ACC2"]
-    assert term.getName() == "NAME"
-    assert term.getCVIdentifierRef() == "CVREF"
-    assert term.getValue() == 123
+    # li.replaceCVTerms(li.getCVTerms())
+    # dd =  li.getCVTerms()
+    # assert len(dd) == 2
+    # assert b"ACC" in dd and b"ACC2" in dd
+    # term, = dd[b"ACC"]
+    # assert term.getName() == "NAME"
+    # assert term.getCVIdentifierRef() == "CVREF"
+    # assert term.getValue() == 123
+    # term, = dd[b"ACC2"]
+    # assert term.getName() == "NAME"
+    # assert term.getCVIdentifierRef() == "CVREF"
+    # assert term.getValue() == 123
 
     li.addCVTerm(term)
     dd = li.getCVTerms()


### PR DESCRIPTION
[TEST] fix test

- remove overloaded methods from parent class (we anyways wont use some of these)
- allow proper inheritance through Cython of all affected classes
- do this for MetaInfoInterface / CVTermList