### PR TITLE
Feature/isospec

### DIFF
--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h
@@ -38,6 +38,7 @@
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopePatternGenerator.h>
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 
+#include <set>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h
@@ -35,7 +35,6 @@
 #pragma once
 
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopePatternGenerator.h>
-#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h
@@ -158,7 +158,7 @@ namespace OpenMS
     }
 
     /// Get probability stop condition (lower values generate fewer results)
-    double getThreshold()
+    double getThreshold() const
     {
       return stop_condition_;
     }
@@ -170,7 +170,7 @@ namespace OpenMS
     }
 
     /// Returns whether threshold is absolute or relative probability (ignored if use_total_prob is true, see class docu)
-    bool getAbsolute()
+    bool getAbsolute() const
     {
       return absolute_;
     }
@@ -182,7 +182,7 @@ namespace OpenMS
     }
 
     /// Returns whether total probability should be computed
-    bool getTotalProbability()
+    bool getTotalProbability() const
     {
       return use_total_prob_;
     }

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h
@@ -37,59 +37,65 @@
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopePatternGenerator.h>
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 
-
 namespace OpenMS
 {
 
   /**
     * @ingroup Chemistry
+    *
     * @brief Isotope pattern generator for fine isotope distributions.
     *
-    * NOTE: This interface is DEPRECATED, and kept for backward compatibility
-    * only. Please use the classes defined in IsoSpecWrapper.h directly instead.
-    *
     * This algorithm generates theoretical pattern distributions for empirical
-    * formulas with high resolution. The output is a list of pairs containing
-    * isotope probabilities paired with the accurate m/z for the analyte
-    * isotopic composition.
+    * formulas with high resolution (while the CoarseIsotopePatternGenerator
+    * will generate low-resolution patterns). The output is a list of pairs
+    * containing isotope probabilities paired with the accurate m/z for the
+    * analyte isotopic composition.
     *
-    * For example, for a C100 molecule, you will get:
+    * For example, for a C100H202 molecule (at 0.01 threshold), you will get:
     *
     * @code
-    *     1200            : 0.338014274835587
-    *     1201.0033548352 : 0.368628561496735
-    *     1202.0067096704 : 0.198997721076012
-    *     1203.0100645056 : 0.0708935707807541
+    *     m/z 1403.5806564438 : INT 0.333207070827484
+    *     m/z 1404.5840114438 : INT 0.360387712717056
+    *     m/z 1404.5869331919 : INT 0.00774129061028361
+    *     m/z 1405.5873664438 : INT 0.19294385612011
+    *     m/z 1405.5902881919 : INT 0.00837276969105005
+    *     m/z 1406.5907214438 : INT 0.0681697279214859
+    *     m/z 1406.5936431919 : INT 0.00448260130360723
+    *     m/z 1407.5940764438 : INT 0.0178796537220478
+    *     m/z 1407.5969981919 : INT 0.00158376491162926
+    *     ...
+    * @endcode
+    *
+    * For comparison, the CoarseIsotopePatternGenerator will produce the
+    * following result for a C100H202 molecule:
+    *
+    * @code
+    *     m/z 1403.58 INT: 0.333489
+    *     m/z 1404.58 INT: 0.36844
+    *     m/z 1405.59 INT: 0.201576
+    *     m/z 1406.59 INT: 0.0728113
+    *     m/z 1407.59 INT: 0.0195325
+    *     ...
     * @endcode
     *
     * One important value to set is the threshold with tells the algorithm when
-    * to stop calculating isotopic peaks to calculate. Here, a threshold of
-    * 0.01 would mean that the algorithm either stops calculating when any new
-    * peak would be less than 0.01 in height (absolute) or when it would be
-    * less than 0.01 of the highest isotopic peak (relative). This is how the
-    * stop_condition parameter is interpreted when use_total_prob is set to false.
+    * to stop calculating isotopic peaks to calculate. The default stop
+    * condition is to stop when only a small portion (such as 0.01) of the
+    * total probability is unexplained and the reported values cover most of
+    * the probability (e.g. 0.99).
     *
-    * Another way to parametrise the search is to cover a certain portion
-    * of total probability, such as 0.99. This is what most users will want to use;
-    * see the documentation on IsoSpecTotalProbWrapper and IsoSpecThresholdWrapper
-    * for the details (also, you should use those classes directly for increased
-    * performance). This is how the stop_condition parameter is interpreted when
-    * use_total_prob is set to true.
-    *
-    * @note Although use_total_prob is set to false by default for backward
-    *       compatibility, most users should set it to true and parametrise by
-    *       total probability needed.
-    *
-    * @note absolute parameter is ignored when use_total_prob is set to true
-    *
-    * @note When use_total_prob is set to false, common sensible values of
-    *       stop_condition will be close to 0.0 (like 0.01), when it's set
-    *       to true - close to 1.0, like 0.99.
+    * Another way to stop the search is when any new peak would be less than
+    * 0.01 in height (absolute) or when it would be less than 0.01 of the
+    * highest isotopic peak (relative). This is how the stop_condition
+    * parameter is interpreted when use_total_prob is set to false.
     *
     * @note Computation of fine isotope patterns can be slow for large
-    * molecules, if you don't need fine isotope distributions consider using
-    * CoarseIsotopePatternGenerator.
-    * @note Consider using IsoSpec directly for increased performance.
+    *       molecules, if you don't need fine isotope distributions consider using
+    *       CoarseIsotopePatternGenerator.
+    *
+    * @note Consider using IsoSpec directly or the OpenMS IsoSpecWrapper /
+    *       IsoSpecGeneratorWrapper classes defined in IsoSpecWrapper.h for
+    *       increased performance.
     *
     * The computation is based on the IsoSpec algorithm
     *
@@ -118,14 +124,16 @@ namespace OpenMS
       *
       * @param stop_condition The total probability (if use_total_prob == true) or
       *        threshold (if use_total_prob is false) (see class docu)
-      * @param absolute Whether threshold is absolute or relative (see class docu)
+      *
       * @param use_total_prob Whether the stop_condition should be interpreted as a
       *        probability threshold (only configurations with intensity above this
       *        threshold will be returned) or as a total probability that the distribution
       *        should cover.
       *
+      * @param absolute Whether threshold is absolute or relative (ignored if use_total_prob is true, see class docu)
+      *
       **/
-    FineIsotopePatternGenerator(double stop_condition, bool absolute = false, bool use_total_prob = false) :
+    FineIsotopePatternGenerator(double stop_condition, bool use_total_prob = true, bool absolute = false) :
       stop_condition_(stop_condition),
       absolute_(absolute),
       use_total_prob_(use_total_prob)
@@ -138,40 +146,52 @@ namespace OpenMS
       * of atoms from that element and sums up the result.
       *
       * @note The constructed isotope distribution is sorted by m/z which slows
-      * down processing, consider using IsoSpec directly for increased
-      * performance.
+      * down processing, consider using IsoSpec (IsoSpecWrapper /
+      * IsoSpecGeneratorWrapper) directly for increased performance.
       *
       **/
     IsotopeDistribution run(const EmpiricalFormula&) const;
 
-    /// Set probability stop condition
+    /// Set probability stop condition (lower values generate fewer results)
     void setThreshold(double stop_condition)
     {
       stop_condition_ = stop_condition;
     }
 
-    /// Get probability stop condition
+    /// Get probability stop condition (lower values generate fewer results)
     double getThreshold()
     {
       return stop_condition_;
     }
 
-    /// Set whether threshold is absolute or relative probability
+    /// Set whether threshold is absolute or relative probability (ignored if use_total_prob is true, see class docu)
     void setAbsolute(bool absolute)
     {
       absolute_ = absolute;
     }
 
-    /// Returns whether threshold is absolute or relative probability
+    /// Returns whether threshold is absolute or relative probability (ignored if use_total_prob is true, see class docu)
     bool getAbsolute()
     {
       return absolute_;
     }
 
+    /// Set whether total probability should be computed
+    void setTotalProbability(bool total)
+    {
+      use_total_prob_ = total;
+    }
+
+    /// Returns whether total probability should be computed
+    bool getTotalProbability()
+    {
+      return use_total_prob_;
+    }
+
  protected:
     double stop_condition_ = 0.01;
     bool absolute_ = false;
-    bool use_total_prob_ = false;
+    bool use_total_prob_ = true;
 
   };
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
@@ -57,9 +57,25 @@ namespace OpenMS
 {
 
   /**
-    * @brief Interface to the IsoSpec algorithm.
+    * @brief Interface for the IsoSpec algorithm - a generator of infinitely-resolved theoretical spectra.
     *
-    * Provides an interface to the IsoSpec algorithm.
+    * Provides an interface to the IsoSpec algorithm. See IsoSpecWrapper for a
+    * more convenient wrapper. Implements a generator pattern using the
+    * nextConf function, which can be used to iterate through all
+    * configurations:
+    *
+    * @code
+    * IsoSpecGeneratorWrapperSubclass iso(...);
+    *
+    * while(iso.nextConf())
+    * {
+    *     Peak1D conf = iso.getConf(); // and/or getMass, getIntensity, etc.
+    *     // do some computations on that conf;
+    * }
+    * @endcode
+    *
+    *
+    * The computation is based on the IsoSpec algorithm
     *
     * @code
     * Łącki MK, Startek M, Valkenborg D, Gambin A.
@@ -70,9 +86,6 @@ namespace OpenMS
     **/
   class OPENMS_DLLAPI IsoSpecGeneratorWrapper
   {
-  /**
-   * @brief Interface for the IsoSpec algorithm - a generator of infinitely-resolved theoretical spectra.
-   */
 
 public:
 
@@ -83,16 +96,6 @@ public:
      * generator has been exhausted (that is, all eligible configurations have already been visited).
      * It is invalid to call any other generator methods before the first call to nextConf(), as well as
      * after this method returns false.
-     *
-     * Thus, a common, correct usage pattern would be:
-     *
-     * IsoSpecGeneratorWrapperSubclass iso(...);
-     *
-     * while(iso.nextConf())
-     * {
-     *     Peak1D conf = iso.getConf(); // and/or getMass, getIntensity, etc.
-     *     do some computations on that conf;
-     * }
      *
      * @returns A boolean value stating whether the generator has been exhausted.
      */
@@ -143,31 +146,65 @@ public:
     virtual inline ~IsoSpecGeneratorWrapper() {};
   };
 
+  /** @brief A convenience class for the IsoSpec algorithm - easier to use than the IsoSpecGeneratorWrapper classes.
+   *
+   */
+  class OPENMS_DLLAPI IsoSpecWrapper
+  {
+public:
+    /**
+      * @brief Run the algorithm
+      *
+      * This method will run the algorithm with parameters as set up by the constructor. It will return an
+      * IsotopeDistribution containing the observed configurations. The configurations are explicitly stored
+      * in memory, which may become a problem when considering some especially large distributions. If this,
+      * or (a rather small) performance overhead is a concern, then the
+      * generator methods (see IsoSpecGeneratorWrapper) should be used instead.
+      *
+      * This method is provided for convenience. As calling that method invalidates the object (the method should
+      * not be called again, nor anything other than destroying the object should be done with it), the most common
+      * usage pattern of IsoSpecGeneratorWrapper classes with the run method is:
+      *
+      * @code
+      * IsotopeDistribution dist = IsoSpecGeneratorWrapperSubclass(...).run();
+      * // do something with dist;
+      * @endcode
+      *
+      * @note Calling this method invalidates the object! In future versions this limitation might be removed.
+      *
+      **/
+    virtual IsotopeDistribution run() = 0;
 
+    virtual inline ~IsoSpecWrapper() {};
+  };
 
+  //-------------------------------------------------------------------------- 
+  // IsoSpecGeneratorWrapper classes
+  //-------------------------------------------------------------------------- 
+
+  /**
+   * @brief Generate a p-set of configurations for a given p (that is, a set of configurations such that
+   *        their probabilities sum up to p). The p in normal usage will usually be close to 1 (e.g. 0.99).
+   *
+   * An optimal p-set of isotopologues is the smallest set of isotopologues that, taken together, cover at
+   * least p of the probability space (that is, their probabilities sum up to at least p). This means that
+   * the computed spectrum is accurate to at least degree p, and that the L1 distance between the computed
+   * spectrum and the true spectrum is less than 1-p. The optimlity of the p-set means that it contains
+   * the most probable configurations - any isotopologues outside of the returned p-set have lower intensity
+   * than the configurations in the p-set.
+   *
+   * This is the method most users will want: the p parameter directly controls the accuracy of results.
+   *
+   * Advanced usage note: The algorithm works by computing an optimal p'-set for a p' slightly larger than
+   * the requested p. By default these extra isotopologues are returned too (as they have to be computed
+   * anyway). It is possible to request that the extra configurations be discarded, using the do_p_trim
+   * parameter. This will *increase* the runtime and especially the memory usage of the algorithm, and
+   * should not be done unless there is a good reason to.
+   *
+   * @note The eligible configurations are NOT guaranteed to be returned in any particular order.
+   */
   class OPENMS_DLLAPI IsoSpecTotalProbGeneratorWrapper : public IsoSpecGeneratorWrapper
   {
-    /**
-     * @brief Generate a p-set of configurations for a given p (that is, a set of configurations such that
-     *        their probabilities sum up to p). The p in normal usage will usually be close to 1 (e.g. 0.99).
-     *
-     * An optimal p-set of isotopologues is the smallest set of isotopologues that, taken together, cover at
-     * least p of the probability space (that is, their probabilities sum up to at least p). This means that
-     * the computed spectrum is accurate to at least degree p, and that the L1 distance between the computed
-     * spectrum and the true spectrum is less than 1-p. The optimlity of the p-set means that it contains
-     * the most probable configurations - any isotopologues outside of the returned p-set have lower intensity
-     * than the configurations in the p-set.
-     *
-     * This is the method most users will want: the p parameter directly controls the accuracy of results.
-     *
-     * Advanced usage note: The algorithm works by computing an optimal p'-set for a p' slightly larger than
-     * the requested p. By default these extra isotopologues are returned too (as they have to be computed
-     * anyway). It is possible to request that the extra configurations be discarded, using the do_p_trim
-     * parameter. This will *increase* the runtime and especially the memory usage of the algorithm, and
-     * should not be done unless there is a good reason to.
-     *
-     * @note The eligible configurations are NOT guaranteed to be returned in any particular order.
-     */
 public:
     /**
       * @brief Constructor
@@ -206,32 +243,29 @@ protected:
     IsoSpec::IsoLayeredGenerator ILG;
   };
 
-
-
-
+  /**
+   * @brief Provides a threshold-based generator of isotopologues: generates all isotopologues
+   *        more probable than a given probability threshold.
+   *
+   * This is the simplest generator - most users will however want to use IsoSpecTotalProbGeneratorWrapper.
+   * The reason for it is that when thresholding by peak intensity one has no idea how far the obtained
+   * spectrum is from a real spectrum. For example, consider human insulin: if the threshold is set at
+   * 0.1 of the most intense peak, then the peaks above the treshhold account for 99.7% of total probability
+   * for water, 82% for substance P, only 60% for human insulin, and 23% for titin.
+   * For a threshold of 0.01, the numbers will be: still 99.7% for water, 96% for substance P, 88% for human insulin
+   * and 72% for titin (it also took 5 minutes on an average notebook computer to process the 17 billion configurations
+   * involved).
+   *
+   * As you can see the threshold does not have a straightforward correlation to the accuracy of the final spectrum
+   * obtained - and accuracy of final spectrum is often what the user is interested in. The IsoSpeTotalcProbGeneratorWrapper
+   * provides a way to directly parametrise based on the desired accuracy of the final spectrum - and should be used
+   * instead in most cases. The tradeoff is that it's (slightly) slower than Threshold algorithm. This speed gap will
+   * be dramatically improved with IsoSpec 2.0.
+   *
+   * @note The eligible isotopologues are NOT guaranteed to be generated in any particular order.
+   */
   class OPENMS_DLLAPI IsoSpecThresholdGeneratorWrapper : public IsoSpecGeneratorWrapper
   {
-    /**
-     * @brief Provides a threshold-based generator of isotopologues: generates all isotopologues
-     *        more probable than a given probability threshold.
-     *
-     * This is the simplest generator - most users will however want to use IsoSpecTotalProbGeneratorWrapper.
-     * The reason for it is that when thresholding by peak intensity one has no idea how far the obtained
-     * spectrum is from a real spectrum. For example, consider human insulin: if the threshold is set at
-     * 0.1 of the most intense peak, then the peaks above the treshhold account for 99.7% of total probability
-     * for water, 82% for substance P, only 60% for human insulin, and 23% for titin.
-     * For a threshold of 0.01, the numbers will be: still 99.7% for water, 96% for substance P, 88% for human insulin
-     * and 72% for titin (it also took 5 minutes on an average notebook computer to process the 17 billion configurations
-     * involved).
-     *
-     * As you can see the threshold does not have a straightforward correlation to the accuracy of the final spectrum
-     * obtained - and accuracy of final spectrum is often what the user is interested in. The IsoSpeTotalcProbGeneratorWrapper
-     * provides a way to directly parametrise based on the desired accuracy of the final spectrum - and should be used
-     * instead in most cases. The tradeoff is that it's (slightly) slower than Threshold algorithm. This speed gap will
-     * be dramatically improved with IsoSpec 2.0.
-     *
-     * @note The eligible isotopologues are NOT guaranteed to be generated in any particular order.
-     */
 
 public:
     /**
@@ -272,26 +306,24 @@ protected:
   IsoSpec::IsoThresholdGenerator ITG;
   };
 
-
-
+  /**
+   * @brief Generate the stream of configurations, ordered from most likely to least likely.
+   *
+   * This generator walks through the entire set of isotopologues of a given molecule, allowing
+   * the user to terminate the search on the fly. The returned isotopologues are guaranteed to
+   * be generated in order of descending probability (unlike the previous two generators which
+   * make no such guarantees).
+   *
+   * This causes the algorithm to run in O(n*log(n)) and means that is it much slower than the
+   * previous two.
+   *
+   * You should only use this generator if you don't know up-front when to stop the walk through
+   * the configuration space, and need to make the decision on the fly. If you know the threshold
+   * or the total probability needed, and only need the configurations sorted, it will be much
+   * faster to generate them using one of the previous algorithms and sort them afterwards.
+   */
   class OPENMS_DLLAPI IsoSpecOrderedGeneratorWrapper : public IsoSpecGeneratorWrapper
   {
-    /**
-     * @brief Generate the stream of configurations, ordered from most likely to least likely.
-     *
-     * This generator walks through the entire set of isotopologues of a given molecule, allowing
-     * the user to terminate the search on the fly. The returned isotopologues are guaranteed to
-     * be generated in order of descending probability (unlike the previous two generators which
-     * make no such guarantees).
-     *
-     * This causes the algorithm to run in O(n*log(n)) and means that is it much slower than the
-     * previous two.
-     *
-     * You should only use this generator if you don't know up-front when to stop the walk through
-     * the configuration space, and need to make the decision on the fly. If you know the threshold
-     * or the total probability needed, and only need the configurations sorted, it will be much
-     * faster to generate them using one of the previous algorithms and sort them afterwards.
-     */
 public:
     /**
       * @brief Constructor
@@ -323,60 +355,33 @@ protected:
   IsoSpec::IsoOrderedGenerator IOG;
   };
 
+  //-------------------------------------------------------------------------- 
+  // IsoSpecWrapper classes
+  //-------------------------------------------------------------------------- 
 
-  class OPENMS_DLLAPI IsoSpecWrapper
-  {
-    /** @brief A convenience class for the IsoSpec algorithm - easier to use than the generator classes.
-     */
-public:
-    /**
-      * @brief Run the algorithm
-      *
-      * This method will run the algorithm with parameters as set up by the constructor. It will return an
-      * IsotopeDistribution containing the observed configurations. The configurations are explicitly stored
-      * in memory, which may become a problem when considering some especially large distributions. If this,
-      * or (a rather small) performance overhead is a concern, then the generator methods (below) should be
-      * used instead.
-      *
-      * This method is provided for convience. As calling that method invalidates the object (the method should
-      * not be called again, nor anything other than destroying the object should be done with it), the most common
-      * usage pattern of IsoSpecGeneratorWrapper classes with the run method is:
-      *
-      * IsotopeDistribution dist = IsoSpecGeneratorWrapperSubclass(...).run();
-      * do something with dist;
-      *
-      * @note Calling this method invalidates the object! In future versions this limitation might be removed.
-      *
-      **/
-    virtual IsotopeDistribution run() = 0;
-
-    virtual inline ~IsoSpecWrapper() {};
-  };
-
-
+/**
+  * @brief Create a p-set of configurations for a given p (that is, a set of configurations such that
+  *        their probabilities sum up to p). The p in normal usage will usually be close to 1 (e.g. 0.99).
+  *
+  * An optimal p-set of isotopologues is the smallest set of isotopologues that, taken together, cover at
+  * least p of the probability space (that is, their probabilities sum up to at least p). This means that
+  * the computed spectrum is accurate to at least degree p, and that the L1 distance between the computed
+  * spectrum and the true spectrum is less than 1-p. The optimlity of the p-set means that it contains
+  * the most probable configurations - any isotopologues outside of the returned p-set have lower intensity
+  * than the configurations in the p-set.
+  *
+  * This is the method most users will want: the p parameter directly controls the accuracy of results.
+  *
+  * Advanced usage note: The algorithm works by computing an optimal p'-set for a p' slightly larger than
+  * the requested p. By default these extra isotopologues are returned too (as they have to be computed
+  * anyway). It is possible to request that the extra configurations be discarded, using the do_p_trim
+  * parameter. This will *increase* the runtime and especially the memory usage of the algorithm, and
+  * should not be done unless there is a good reason to.
+  *
+  * @note The eligible configurations are NOT guaranteed to be returned in any particular order.
+  */
   class OPENMS_DLLAPI IsoSpecTotalProbWrapper : public IsoSpecWrapper
   {
-  /**
-    * @brief Create a p-set of configurations for a given p (that is, a set of configurations such that
-    *        their probabilities sum up to p). The p in normal usage will usually be close to 1 (e.g. 0.99).
-    *
-    * An optimal p-set of isotopologues is the smallest set of isotopologues that, taken together, cover at
-    * least p of the probability space (that is, their probabilities sum up to at least p). This means that
-    * the computed spectrum is accurate to at least degree p, and that the L1 distance between the computed
-    * spectrum and the true spectrum is less than 1-p. The optimlity of the p-set means that it contains
-    * the most probable configurations - any isotopologues outside of the returned p-set have lower intensity
-    * than the configurations in the p-set.
-    *
-    * This is the method most users will want: the p parameter directly controls the accuracy of results.
-    *
-    * Advanced usage note: The algorithm works by computing an optimal p'-set for a p' slightly larger than
-    * the requested p. By default these extra isotopologues are returned too (as they have to be computed
-    * anyway). It is possible to request that the extra configurations be discarded, using the do_p_trim
-    * parameter. This will *increase* the runtime and especially the memory usage of the algorithm, and
-    * should not be done unless there is a good reason to.
-    *
-    * @note The eligible configurations are NOT guaranteed to be returned in any particular order.
-    */
 public:
     /**
       * @brief Constructor
@@ -412,28 +417,28 @@ protected:
 
   };
 
+  /**
+    * @brief A non-generator version of IsoSpecThresholdGeneratorWrapper
+    *
+    * This is the simplest algorithm - most users will however want to use IsoSpecTotalProbWrapper.
+    * The reason for it is that when thresholding by peak intensity one has no idea how far the obtained
+    * spectrum is from a real spectrum. For example, consider human insulin: if the threshold is set at
+    * 0.1 of the most intense peak, then the peaks above the treshhold account for 99.7% of total probability
+    * for water, 82% for substance P, only 60% for human insulin, and 23% for titin.
+    * For a threshold of 0.01, the numbers will be: still 99.7% for water, 96% for substance P, 88% for human insulin
+    * and 72% for titin (it also took 5 minutes on an average notebook computer to process the 17 billion configurations
+    * involved).
+    *
+    * As you can see the threshold does not have a straightforward correlation to the accuracy of the final spectrum
+    * obtained - and accuracy of final spectrum is often what the user is interested in. The IsoSpeTotalcProbGeneratorWrapper
+    * provides a way to directly parametrise based on the desired accuracy of the final spectrum - and should be used
+    * instead in most cases. The tradeoff is that it's (slightly) slower than Threshold algorithm. This speed gap will
+    * be dramatically improved with IsoSpec 2.0.
+    *
+    * @note The eligible isotopologues are NOT guaranteed to be generated in any particular order.
+    */
   class OPENMS_DLLAPI IsoSpecThresholdWrapper : public IsoSpecWrapper
   {
-    /**
-      * @brief A non-generator version of IsoSpecThresholdGeneratorWrapper
-      *
-      * This is the simplest algorithm - most users will however want to use IsoSpecTotalProbWrapper.
-      * The reason for it is that when thresholding by peak intensity one has no idea how far the obtained
-      * spectrum is from a real spectrum. For example, consider human insulin: if the threshold is set at
-      * 0.1 of the most intense peak, then the peaks above the treshhold account for 99.7% of total probability
-      * for water, 82% for substance P, only 60% for human insulin, and 23% for titin.
-      * For a threshold of 0.01, the numbers will be: still 99.7% for water, 96% for substance P, 88% for human insulin
-      * and 72% for titin (it also took 5 minutes on an average notebook computer to process the 17 billion configurations
-      * involved).
-      *
-      * As you can see the threshold does not have a straightforward correlation to the accuracy of the final spectrum
-      * obtained - and accuracy of final spectrum is often what the user is interested in. The IsoSpeTotalcProbGeneratorWrapper
-      * provides a way to directly parametrise based on the desired accuracy of the final spectrum - and should be used
-      * instead in most cases. The tradeoff is that it's (slightly) slower than Threshold algorithm. This speed gap will
-      * be dramatically improved with IsoSpec 2.0.
-      *
-      * @note The eligible isotopologues are NOT guaranteed to be generated in any particular order.
-      */
 
 public:
     /**
@@ -469,7 +474,6 @@ protected:
     IsoSpec::IsoThresholdGenerator ITG;
 
   };
-
 
 }
 

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h
@@ -189,7 +189,7 @@ public:
    * An optimal p-set of isotopologues is the smallest set of isotopologues that, taken together, cover at
    * least p of the probability space (that is, their probabilities sum up to at least p). This means that
    * the computed spectrum is accurate to at least degree p, and that the L1 distance between the computed
-   * spectrum and the true spectrum is less than 1-p. The optimlity of the p-set means that it contains
+   * spectrum and the true spectrum is less than 1-p. The optimality of the p-set means that it contains
    * the most probable configurations - any isotopologues outside of the returned p-set have lower intensity
    * than the configurations in the p-set.
    *
@@ -250,7 +250,7 @@ protected:
    * This is the simplest generator - most users will however want to use IsoSpecTotalProbGeneratorWrapper.
    * The reason for it is that when thresholding by peak intensity one has no idea how far the obtained
    * spectrum is from a real spectrum. For example, consider human insulin: if the threshold is set at
-   * 0.1 of the most intense peak, then the peaks above the treshhold account for 99.7% of total probability
+   * 0.1 of the most intense peak, then the peaks above the threshold account for 99.7% of total probability
    * for water, 82% for substance P, only 60% for human insulin, and 23% for titin.
    * For a threshold of 0.01, the numbers will be: still 99.7% for water, 96% for substance P, 88% for human insulin
    * and 72% for titin (it also took 5 minutes on an average notebook computer to process the 17 billion configurations
@@ -259,7 +259,7 @@ protected:
    * As you can see the threshold does not have a straightforward correlation to the accuracy of the final spectrum
    * obtained - and accuracy of final spectrum is often what the user is interested in. The IsoSpeTotalcProbGeneratorWrapper
    * provides a way to directly parametrise based on the desired accuracy of the final spectrum - and should be used
-   * instead in most cases. The tradeoff is that it's (slightly) slower than Threshold algorithm. This speed gap will
+   * instead in most cases. The trade-off is that it's (slightly) slower than Threshold algorithm. This speed gap will
    * be dramatically improved with IsoSpec 2.0.
    *
    * @note The eligible isotopologues are NOT guaranteed to be generated in any particular order.
@@ -366,7 +366,7 @@ protected:
   * An optimal p-set of isotopologues is the smallest set of isotopologues that, taken together, cover at
   * least p of the probability space (that is, their probabilities sum up to at least p). This means that
   * the computed spectrum is accurate to at least degree p, and that the L1 distance between the computed
-  * spectrum and the true spectrum is less than 1-p. The optimlity of the p-set means that it contains
+  * spectrum and the true spectrum is less than 1-p. The optimality of the p-set means that it contains
   * the most probable configurations - any isotopologues outside of the returned p-set have lower intensity
   * than the configurations in the p-set.
   *
@@ -423,7 +423,7 @@ protected:
     * This is the simplest algorithm - most users will however want to use IsoSpecTotalProbWrapper.
     * The reason for it is that when thresholding by peak intensity one has no idea how far the obtained
     * spectrum is from a real spectrum. For example, consider human insulin: if the threshold is set at
-    * 0.1 of the most intense peak, then the peaks above the treshhold account for 99.7% of total probability
+    * 0.1 of the most intense peak, then the peaks above the threshold account for 99.7% of total probability
     * for water, 82% for substance P, only 60% for human insulin, and 23% for titin.
     * For a threshold of 0.01, the numbers will be: still 99.7% for water, 96% for substance P, 88% for human insulin
     * and 72% for titin (it also took 5 minutes on an average notebook computer to process the 17 billion configurations
@@ -432,7 +432,7 @@ protected:
     * As you can see the threshold does not have a straightforward correlation to the accuracy of the final spectrum
     * obtained - and accuracy of final spectrum is often what the user is interested in. The IsoSpeTotalcProbGeneratorWrapper
     * provides a way to directly parametrise based on the desired accuracy of the final spectrum - and should be used
-    * instead in most cases. The tradeoff is that it's (slightly) slower than Threshold algorithm. This speed gap will
+    * instead in most cases. The trade-off is that it's (slightly) slower than Threshold algorithm. This speed gap will
     * be dramatically improved with IsoSpec 2.0.
     *
     * @note The eligible isotopologues are NOT guaranteed to be generated in any particular order.

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h
@@ -35,17 +35,9 @@
 #ifndef OPENMS_CHEMISTRY_ISOTOPEDISTRIBUTION_ISOTOPEDISTRIBUTION_H
 #define OPENMS_CHEMISTRY_ISOTOPEDISTRIBUTION_ISOTOPEDISTRIBUTION_H
 
-
-#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 #include <OpenMS/KERNEL/Peak1D.h>
 
-#include <utility>
-#include <functional>
-
 #include <vector>
-#include <set>
-#include <map>
-
 
 namespace OpenMS
 {

--- a/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopePatternGenerator.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopePatternGenerator.h
@@ -36,12 +36,12 @@
 #ifndef OPENMS_CHEMISTRY_ISOTOPEDISTRIBUTION_ISOTOPEPATTERNGENERATOR_H
 #define OPENMS_CHEMISTRY_ISOTOPEDISTRIBUTION_ISOTOPEPATTERNGENERATOR_H
 
-
-#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
+#include <OpenMS/config.h>
 
 namespace OpenMS
 {
   class EmpiricalFormula;
+  class IsotopeDistribution;
 
   /** 
       @brief Provides an interface for different isotope pattern generator methods.

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.cpp
@@ -32,6 +32,13 @@
 // $Authors: Clemens Groepl, Andreas Bertsch, Chris Bielow $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
+
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
+#include <OpenMS/CHEMISTRY/Element.h>
+#include <include/OpenMS/CONCEPT/Constants.h>
+
 #include <cmath>
 #include <iostream>
 #include <cstdlib>
@@ -39,11 +46,6 @@
 #include <limits>
 #include <functional>
 #include <numeric>
-
-#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/CoarseIsotopePatternGenerator.h>
-#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
-#include <OpenMS/CHEMISTRY/Element.h>
-#include <include/OpenMS/CONCEPT/Constants.h>
 
 using namespace std;
 

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.cpp
@@ -34,9 +34,8 @@
 
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h>
 
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h>
-#include <OpenMS/DATASTRUCTURES/String.h>
-#include <OpenMS/CHEMISTRY/Element.h>
 
 namespace OpenMS
 {

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.cpp
@@ -46,7 +46,7 @@ namespace OpenMS
 
     if (use_total_prob_)
     {
-        IsotopeDistribution result(IsoSpecTotalProbWrapper(formula, stop_condition_).run());
+        IsotopeDistribution result(IsoSpecTotalProbWrapper(formula, 1.0-stop_condition_).run());
         result.sortByMass();
         return result;
     }
@@ -59,3 +59,4 @@ namespace OpenMS
   }
 
 }
+

--- a/src/openms/thirdparty/IsoSpec/IsoSpec/isoMath.h
+++ b/src/openms/thirdparty/IsoSpec/IsoSpec/isoMath.h
@@ -23,7 +23,7 @@
 // 10M should be enough for anyone, right?
 // Actually, yes. If anyone tries to input a molecule that has more than 10M atoms, 
 // he deserves to get an exception thrown in his face.
-#define ISOSPEC_G_FACT_TABLE_SIZE 1024*1024*10
+#define ISOSPEC_G_FACT_TABLE_SIZE 1024 // *1024*10
 #endif
 
 namespace IsoSpec
@@ -33,8 +33,12 @@ extern double* g_lfact_table;
 
 static inline double minuslogFactorial(int n) 
 { 
+    // check if value is too small or too large to be found in the lookup table
     if (n < 2) 
         return 0.0;
+    if (n >= ISOSPEC_G_FACT_TABLE_SIZE) return -lgamma(n+1);
+
+    // store in lookup table if not present yet
     if (g_lfact_table[n] == 0.0)
         g_lfact_table[n] = -lgamma(n+1);
 

--- a/src/openms/thirdparty/IsoSpec/IsoSpec/marginalTrek++.cpp
+++ b/src/openms/thirdparty/IsoSpec/IsoSpec/marginalTrek++.cpp
@@ -204,8 +204,8 @@ smallest_lprob(atomCnt * *std::min_element(atom_lProbs, atom_lProbs+isotopeNo))
 {
     try
     {
-        if(ISOSPEC_G_FACT_TABLE_SIZE-1 <= atomCnt)
-            throw std::length_error("Subisotopologue too large, size limit (that is, the maximum number of atoms of a single element in a molecule) is: " + std::to_string(ISOSPEC_G_FACT_TABLE_SIZE-1));
+        // if(ISOSPEC_G_FACT_TABLE_SIZE-1 <= atomCnt)
+        //     throw std::length_error("Subisotopologue too large, size limit (that is, the maximum number of atoms of a single element in a molecule) is: " + std::to_string(ISOSPEC_G_FACT_TABLE_SIZE-1));
         for(size_t ii = 0; ii < isotopeNo; ii++)
             if(_probs[ii] <= 0.0 || _probs[ii] > 1.0)
                 throw std::invalid_argument("All isotope probabilities p must fulfill: 0.0 < p <= 1.0");

--- a/src/pyOpenMS/pxds/IsotopeDistribution.pxd
+++ b/src/pyOpenMS/pxds/IsotopeDistribution.pxd
@@ -69,13 +69,17 @@ cdef extern from "<OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenera
 
         FineIsotopePatternGenerator() nogil except + 
         FineIsotopePatternGenerator(double threshold) nogil except +
-        FineIsotopePatternGenerator(double threshold, bool absolute) nogil except +
+        FineIsotopePatternGenerator(double threshold, bool use_total_prob) nogil except +
+        FineIsotopePatternGenerator(double threshold, bool use_total_prob, bool absolute) nogil except +
 
         void setThreshold(double threshold) nogil except +
         double getThreshold() nogil except +
 
         void setAbsolute(bool absolute) nogil except +
         bool getAbsolute() nogil except +
+
+        void setTotalProbability(bool total) nogil except +
+        bool getTotalProbability() nogil except +
 
         IsotopeDistribution run(EmpiricalFormula) nogil except +
 

--- a/src/pyOpenMS/tests/unittests/test000.py
+++ b/src/pyOpenMS/tests/unittests/test000.py
@@ -365,18 +365,25 @@ def testFineIsotopePatternGenerator():
     methanol = pyopenms.EmpiricalFormula("CH3OH")
     water = pyopenms.EmpiricalFormula("H2O")
     mw = methanol + water
-    iso_dist = mw.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-20))
+    iso_dist = mw.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-20, False, False))
     assert len(iso_dist.getContainer()) == 56
-    iso_dist = mw.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-200))
+    iso_dist = mw.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-200, False, False))
     assert len(iso_dist.getContainer()) == 84
 
     c100 = pyopenms.EmpiricalFormula("C100")
-    iso_dist = c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-200))
+    iso_dist = c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-200, False, False))
     assert len(iso_dist.getContainer()) == 101
-    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-2, False)).size() == 6
-    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-2, True)).size() == 5
+    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-2, False, False)).size() == 6
+    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-2, False, True)).size() == 5
+    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-2, True, False)).size() == 5
+    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-2, True, True)).size() == 5
 
-    iso = pyopenms.FineIsotopePatternGenerator(1e-5)
+    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-10, False, False)).size() == 14
+    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-10, False, True)).size() == 13
+    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-10, True, False)).size() == 10
+    assert c100.getIsotopeDistribution(pyopenms.FineIsotopePatternGenerator(1e-10, True, True)).size() == 10
+
+    iso = pyopenms.FineIsotopePatternGenerator(1e-5, False, False)
     isod = iso.run(methanol)
     assert len(isod.getContainer()) == 6
     assert abs(isod.getContainer()[0].getMZ() - 32.0262151276) < 1e-5

--- a/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
@@ -39,7 +39,10 @@
 #include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/FineIsotopePatternGenerator.h>
 ///////////////////////////
 
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.h>
 #include <OpenMS/CHEMISTRY/Element.h>
+#include <OpenMS/CHEMISTRY/EmpiricalFormula.h>
 
 using namespace OpenMS;
 using namespace std;

--- a/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
@@ -129,8 +129,8 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
     IsotopeDistribution id = gen.run(EmpiricalFormula("C100"));
     TEST_EQUAL(id.size(), 6)
 
-    for (auto i : id.getContainer())
-      std::cout << i << std::endl;
+    // for (auto i : id.getContainer())
+    //   std::cout << i << std::endl;
 
     gen.setThreshold(1e-5);
     TEST_EQUAL(gen.run(EmpiricalFormula("C100")).size(), 9)

--- a/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
@@ -65,11 +65,19 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
   EmpiricalFormula ef ("C6H12O6");
 
   // simple way of getting an IsotopeDistribution
-  IsotopeDistribution test_id = ef.getIsotopeDistribution(FineIsotopePatternGenerator());
+  IsotopeDistribution test_id = ef.getIsotopeDistribution(FineIsotopePatternGenerator(0.01, false, false));
   TEST_EQUAL(test_id.size(), 3)
 
+  // simple way of getting an IsotopeDistribution using absolute tol
+  test_id = ef.getIsotopeDistribution(FineIsotopePatternGenerator(0.01, false, true));
+  TEST_EQUAL(test_id.size(), 3)
+
+  // simple way of getting an IsotopeDistribution using total probability
+  test_id = ef.getIsotopeDistribution(FineIsotopePatternGenerator(0.01, true, false));
+  TEST_EQUAL(test_id.size(), 6)
+
   {
-    FineIsotopePatternGenerator gen;
+    FineIsotopePatternGenerator gen(0.01, false, false);
     IsotopeDistribution id = gen.run(ef);
     TEST_EQUAL(id.size(), 3)
 
@@ -82,7 +90,7 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
 
   {
     const double threshold = 1e-5;
-    FineIsotopePatternGenerator gen(threshold);
+    FineIsotopePatternGenerator gen(threshold, false, false);
     IsotopeDistribution id = gen.run(ef);
     TEST_EQUAL(id.size(), 14)
 
@@ -97,7 +105,7 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
   }
 
   {
-    FineIsotopePatternGenerator gen(1e-12);
+    FineIsotopePatternGenerator gen(1e-12, false, false);
     IsotopeDistribution id = gen.run(ef);
     TEST_EQUAL(id.size(), 104)
 
@@ -116,10 +124,13 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
 
   // For a C100 molecule
   {
-    FineIsotopePatternGenerator gen;
+    FineIsotopePatternGenerator gen(0.01, false, false);
     gen.setThreshold(1e-2);
     IsotopeDistribution id = gen.run(EmpiricalFormula("C100"));
     TEST_EQUAL(id.size(), 6)
+
+    for (auto i : id.getContainer())
+      std::cout << i << std::endl;
 
     gen.setThreshold(1e-5);
     TEST_EQUAL(gen.run(EmpiricalFormula("C100")).size(), 9)
@@ -158,15 +169,26 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
     TEST_REAL_SIMILAR(gen.run(EmpiricalFormula("C100"))[100].getMZ(), 1300.3355000000001)
   }
 
+  // {
+  //   std::string formula = "C100H202"; // add 202 hydrogen
+  //   FineIsotopePatternGenerator gen(0.99, true, true);
+  //   IsotopeDistribution id = gen.run(EmpiricalFormula(formula));
+  //   TEST_EQUAL(id.size(), 9)
+
+  //   for (auto i : id.getContainer())
+  //     std::cout << i << std::endl;
+  // }
+
   {
-    std::string formula = "C100H202";
-    FineIsotopePatternGenerator gen;
+    std::string formula = "C100H202"; // add 202 hydrogen
+    FineIsotopePatternGenerator gen(0.01, false, false);
     gen.setThreshold(1e-2);
     IsotopeDistribution id = gen.run(EmpiricalFormula(formula));
     TEST_EQUAL(id.size(), 9)
 
     gen.setThreshold(1e-5);
     TEST_EQUAL(gen.run(EmpiricalFormula(formula)).size(), 21)
+    id = gen.run(EmpiricalFormula(formula));
 
     gen.setThreshold(1e-10);
     TEST_EQUAL(gen.run(EmpiricalFormula(formula)).size(), 50)
@@ -204,7 +226,7 @@ START_SECTION(( [EXTRA]IsotopeDistribution run(const EmpiricalFormula&) const ))
     // human insulin
     EmpiricalFormula ef ("C520H817N139O147S8");
 
-    FineIsotopePatternGenerator gen;
+    FineIsotopePatternGenerator gen(0.01, false, false);
     IsotopeDistribution id = gen.run(ef);
     TEST_EQUAL(id.size(), 267)
 
@@ -212,16 +234,16 @@ START_SECTION(( [EXTRA]IsotopeDistribution run(const EmpiricalFormula&) const ))
     IsotopeDistribution id2 = gen.run(ef);
     TEST_EQUAL(id2.size(), 5513)
 
-    IsotopeDistribution id3 = ef.getIsotopeDistribution(FineIsotopePatternGenerator());
+    IsotopeDistribution id3 = ef.getIsotopeDistribution(FineIsotopePatternGenerator(0.01, false, false));
     TEST_EQUAL(id3.size(), 267)
 
-    IsotopeDistribution id4 = ef.getIsotopeDistribution(FineIsotopePatternGenerator(1e-5));
+    IsotopeDistribution id4 = ef.getIsotopeDistribution(FineIsotopePatternGenerator(1e-5, false, false));
     TEST_EQUAL(id4.size(), 5513)
   }
 
   {
     EmpiricalFormula ef("C222N190O110");
-    FineIsotopePatternGenerator gen;
+    FineIsotopePatternGenerator gen(0.01, false, false);
     gen.setThreshold(1e-3);
     IsotopeDistribution id = gen.run(ef);
 
@@ -279,7 +301,7 @@ START_SECTION(( [EXTRA]IsotopeDistribution run(const EmpiricalFormula&) const ))
     // test gapped isotope distributions, e.g. bromide 79,81 (missing 80)
 
     EmpiricalFormula ef("CBr2");
-    FineIsotopePatternGenerator gen;
+    FineIsotopePatternGenerator gen(0.01, false, false);
     gen.setThreshold(1e-3);
     IsotopeDistribution id = gen.run(ef);
 
@@ -310,7 +332,7 @@ START_SECTION(( [EXTRA]IsotopeDistribution run(const EmpiricalFormula&) const ))
   for (Size k = 0; k < 2e5; k++)
   {
     EmpiricalFormula ef ("C520H817N139O147");
-    FineIsotopePatternGenerator gen(1e-2, false);
+    FineIsotopePatternGenerator gen(1e-2, false, false);
     IsotopeDistribution id = gen.run(ef);
     sum += id.size();
   }
@@ -329,7 +351,7 @@ START_SECTION(( [EXTRA]IsotopeDistribution run(const EmpiricalFormula&) const ))
     std::cout << " Working on stress test " << k << " " << ef.toString() << std::endl;
 
     {
-      FineIsotopePatternGenerator gen;
+      FineIsotopePatternGenerator gen(0.01, false, false);
       IsotopeDistribution id = gen.run(ef);
       calculated_masses += id.size();
 
@@ -351,7 +373,7 @@ START_SECTION(( [EXTRA]IsotopeDistribution run(const EmpiricalFormula&) const ))
     std::cout << " Working on stress test " << k << " " << ef.toString() << std::endl;
 
     {
-      FineIsotopePatternGenerator gen;
+      FineIsotopePatternGenerator gen(0.01, false, false);
       IsotopeDistribution id = gen.run(ef);
       calculated_masses += id.size();
 
@@ -368,7 +390,7 @@ END_SECTION
 START_SECTION(( void setAbsolute(bool absolute) ))
 {
   {
-    FineIsotopePatternGenerator gen;
+    FineIsotopePatternGenerator gen(0.01, false, false);
     gen.setAbsolute(true);
     TEST_EQUAL(gen.getAbsolute(), true);
     gen.setAbsolute(false);
@@ -378,7 +400,7 @@ START_SECTION(( void setAbsolute(bool absolute) ))
   EmpiricalFormula ef ("C520H817N139O147S8");
 
   {
-    FineIsotopePatternGenerator gen;
+    FineIsotopePatternGenerator gen(0.01, false, false);
     IsotopeDistribution id = gen.run(ef);
     TEST_EQUAL(id.size(), 267)
 

--- a/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
+++ b/src/tests/class_tests/openms/source/FineIsotopeDistribution_test.cpp
@@ -217,6 +217,18 @@ START_SECTION(( IsotopeDistribution run(const EmpiricalFormula&) const ))
     gen.setThreshold(0.0);
     TEST_EQUAL(gen.run(EmpiricalFormula(formula)).size(), 101* 203)
   }
+
+  // Also test a molecule with 2048 atoms (a value that does not fit into the
+  // lookup table any more, it should still work).
+  {
+    FineIsotopePatternGenerator gen(0.01, false, false);
+    gen.setThreshold(1e-2);
+    IsotopeDistribution id = gen.run(EmpiricalFormula("C2048"));
+    TEST_EQUAL(id.size(), 28)
+
+    gen.setThreshold(1e-5);
+    TEST_EQUAL(gen.run(EmpiricalFormula("C2048")).size(), 44)
+  }
 }
 END_SECTION
 


### PR DESCRIPTION
fixes #4030

- reduces lookup table from 10 MB to 1 KB
- some additional fixes in the docu
- change the interface of FineIsotopePatternGenerator to use recommended default params