### PR TITLE
lockfree generation of modified peptides

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
@@ -121,8 +121,8 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
       std::vector<ProteinIdentification>& protein_ids, 
       std::vector<PeptideIdentification>& peptide_ids, 
       Size top_hits,
-      const std::vector<const ResidueModification*>& fixed_modifications, 
-      const std::vector<const ResidueModification*>& variable_modifications, 
+      const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications, 
+      const ModifiedPeptideGenerator::MapToResidueType& variable_modifications, 
       Size max_variable_mods_per_peptide,
       const StringList& modifications_fixed,
       const StringList& modifications_variable,
@@ -135,9 +135,6 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
       const Int precursor_max_charge,
       const String& enzyme,
       const String& database_name);
-
-    // @brief helper to retrieve modifications by name
-    static std::vector<const ResidueModification*> getModifications_(const StringList& modNames);
 
     double precursor_mass_tolerance_;
     String precursor_mass_tolerance_unit_;

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SimpleSearchEngineAlgorithm.h
@@ -121,8 +121,8 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
       std::vector<ProteinIdentification>& protein_ids, 
       std::vector<PeptideIdentification>& peptide_ids, 
       Size top_hits,
-      const std::vector<ResidueModification>& fixed_modifications, 
-      const std::vector<ResidueModification>& variable_modifications, 
+      const std::vector<const ResidueModification*>& fixed_modifications, 
+      const std::vector<const ResidueModification*>& variable_modifications, 
       Size max_variable_mods_per_peptide,
       const StringList& modifications_fixed,
       const StringList& modifications_variable,
@@ -137,7 +137,7 @@ class OPENMS_DLLAPI SimpleSearchEngineAlgorithm :
       const String& database_name);
 
     // @brief helper to retrieve modifications by name
-    static std::vector<ResidueModification> getModifications_(const StringList& modNames);
+    static std::vector<const ResidueModification*> getModifications_(const StringList& modNames);
 
     double precursor_mass_tolerance_;
     String precursor_mass_tolerance_unit_;

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
@@ -52,17 +52,21 @@ namespace OpenMS
   public
 :
     // Applies fixed modifications to a single peptide
-    static void applyFixedModifications(const std::vector<ResidueModification>::const_iterator& fixed_mods_begin, const std::vector<ResidueModification>::const_iterator& fixed_mods_end, AASequence& peptide);
+    static void applyFixedModifications(const std::vector<const ResidueModification*>& fixed_mods, AASequence& peptide);
 
     // Applies variable modifications to a single peptide. If keep_original is set the original (e.g. unmodified version) is also returned
-    static void applyVariableModifications(const std::vector<ResidueModification>::const_iterator& var_mods_begin, const std::vector<ResidueModification>::const_iterator& var_mods_end, const AASequence& peptide, Size max_variable_mods_per_peptide, std::vector<AASequence>& all_modified_peptides, bool keep_original=true);
+    static void applyVariableModifications(const std::vector<const ResidueModification*>& var_mods, 
+     const AASequence& peptide, 
+     Size max_variable_mods_per_peptide, 
+     std::vector<AASequence>& all_modified_peptides, 
+     bool keep_original=true);
 
   protected:
     // Recursively generate all combinatoric placements at compatible sites
-    static void recurseAndGenerateVariableModifiedPeptides_(const std::vector<int>& subset_indices, const std::map<int, std::vector<ResidueModification> >& map_compatibility, int depth, const AASequence& current_peptide, std::vector<AASequence>& modified_peptides);
+    static void recurseAndGenerateVariableModifiedPeptides_(const std::vector<int>& subset_indices, const std::map<int, std::vector<const ResidueModification*> >& map_compatibility, int depth, const AASequence& current_peptide, std::vector<AASequence>& modified_peptides);
 
     // Fast implementation of modification placement. No combinatoric placement is needed in this case - just every site is modified once by each compatible modification. Already modified residues are skipped
-    static void applyAtMostOneVariableModification_(const std::vector<ResidueModification>::const_iterator& var_mods_begin, const std::vector<ResidueModification>::const_iterator& var_mods_end, const AASequence& peptide, std::vector<AASequence>& all_modified_peptides, bool keep_original=true);
+    static void applyAtMostOneVariableModification_(const std::vector<const ResidueModification*>& var_mods, const AASequence& peptide, std::vector<AASequence>& all_modified_peptides, bool keep_original=true);
 
   };
 }

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
@@ -54,7 +54,8 @@ namespace OpenMS
     */
 
   public:
-    using MapToResidueType = boost::container::flat_map<const ResidueModification*, const Residue*>;
+    // struct needed to wrap the template for pyOpenMS
+    struct MapToResidueType { boost::container::flat_map<const ResidueModification*, const Residue*> val; };
 
       /**
       * @brief Retrieve modifications from strings

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
@@ -55,7 +55,8 @@ namespace OpenMS
     static void applyFixedModifications(const std::vector<const ResidueModification*>& fixed_mods, AASequence& peptide);
 
     // Applies variable modifications to a single peptide. If keep_original is set the original (e.g. unmodified version) is also returned
-    static void applyVariableModifications(const std::vector<const ResidueModification*>& var_mods, 
+    static void applyVariableModifications(
+     const std::vector<const ResidueModification*>& var_mods, 
      const AASequence& peptide, 
      Size max_variable_mods_per_peptide, 
      std::vector<AASequence>& all_modified_peptides, 

--- a/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h
@@ -35,11 +35,15 @@
 #pragma once
 
 #include <OpenMS/KERNEL/StandardTypes.h>
+#include <OpenMS/DATASTRUCTURES/StringListUtils.h>
+
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <vector>
 #include <map>
 #include <set>
+
+#include <boost/container/flat_map.hpp>
 
 namespace OpenMS
 {
@@ -49,25 +53,53 @@ namespace OpenMS
     * @brief Modifications can be generated and applied to AASequences. 
     */
 
-  public
-:
+  public:
+    using MapToResidueType = boost::container::flat_map<const ResidueModification*, const Residue*>;
+
+      /**
+      * @brief Retrieve modifications from strings
+      * 
+      * @param modNames The list of modification names
+      * @return A map of modifications and associated residue
+      * ResidueModifications are referenced by Residues in AASequence objects. Every time an AASequence object
+      * with modifications is constructed, it needs to query if the (modified) Residue is already
+      * registered in ResidueDB. This implies a lock of the whole db. To make modified peptide generation lock-free, we
+      * query and cache all modified residues once so we can directly apply them without further queries.
+      */
+    static MapToResidueType getModifications(const StringList& modNames);
+
     // Applies fixed modifications to a single peptide
-    static void applyFixedModifications(const std::vector<const ResidueModification*>& fixed_mods, AASequence& peptide);
+    static void applyFixedModifications(
+      const MapToResidueType& fixed_mods, 
+      AASequence& peptide);
 
     // Applies variable modifications to a single peptide. If keep_original is set the original (e.g. unmodified version) is also returned
     static void applyVariableModifications(
-     const std::vector<const ResidueModification*>& var_mods, 
+     const MapToResidueType& var_mods, 
      const AASequence& peptide, 
      Size max_variable_mods_per_peptide, 
      std::vector<AASequence>& all_modified_peptides, 
      bool keep_original=true);
 
   protected:
+    // Lookup datastructure to allow lock-free generation of modified peptides
+    static MapToResidueType createResidueModificationToResidueMap_(const std::vector<const ResidueModification*>& mods);
+
+
     // Recursively generate all combinatoric placements at compatible sites
-    static void recurseAndGenerateVariableModifiedPeptides_(const std::vector<int>& subset_indices, const std::map<int, std::vector<const ResidueModification*> >& map_compatibility, int depth, const AASequence& current_peptide, std::vector<AASequence>& modified_peptides);
+    static void recurseAndGenerateVariableModifiedPeptides_(
+      const std::vector<int>& subset_indices, 
+      const std::map<int, std::vector<const ResidueModification*> >& map_compatibility, 
+      int depth, 
+      const AASequence& current_peptide, 
+      std::vector<AASequence>& modified_peptides);
 
     // Fast implementation of modification placement. No combinatoric placement is needed in this case - just every site is modified once by each compatible modification. Already modified residues are skipped
-    static void applyAtMostOneVariableModification_(const std::vector<const ResidueModification*>& var_mods, const AASequence& peptide, std::vector<AASequence>& all_modified_peptides, bool keep_original=true);
+    static void applyAtMostOneVariableModification_(
+      const MapToResidueType& var_mods, 
+      const AASequence& peptide, 
+      std::vector<AASequence>& all_modified_peptides, 
+      bool keep_original=true);
 
   };
 }

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
@@ -39,6 +39,7 @@
 #include <OpenMS/CHEMISTRY/ResidueModification.h>
 #include <OpenMS/FORMAT/FASTAFile.h>
 #include <OpenMS/CHEMISTRY/EnzymaticDigestion.h>
+#include <OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h>
 #include <numeric>
 
 namespace OpenMS
@@ -108,13 +109,6 @@ namespace OpenMS
       static std::vector<OPXLDataStructs::XLPrecursor> enumerateCrossLinksAndMasses(const std::vector<OPXLDataStructs::AASeqWithMass>&  peptides, double cross_link_mass_light, const DoubleList& cross_link_mass_mono_link, const StringList& cross_link_residue1, const StringList& cross_link_residue2, const std::vector< double >& spectrum_precursors, std::vector< int >& precursor_correction_positions, double precursor_mass_tolerance, bool precursor_mass_tolerance_unit_ppm);
 
       /**
-       * @brief A helper function, that turns a StringList with modification names into a vector of ResidueModifications
-       * @param modNames The list of modification names
-       * @return A vector of modifications
-       */
-      static std::vector<const ResidueModification*> getModificationsFromStringList(StringList modNames);
-
-      /**
        * @brief Digests a database with the given EnzymaticDigestion settings and precomputes masses for all peptides
 
           Also keeps track of the peptides at protein terminals and builds peptide candidates with all possible modification patterns
@@ -134,7 +128,11 @@ namespace OpenMS
        * @param c_term_linker True, if the cross-linker can react with the C-terminal of a protein
        * @return A vector of AASeqWithMass containing the peptides, their masses and information about terminal peptides
        */
-      static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(std::vector<FASTAFile::FASTAEntry> fasta_db, EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2, const std::vector<const ResidueModification*>& fixed_modifications, const std::vector<const ResidueModification*>& variable_modifications, Size max_variable_mods_per_peptide);
+      static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(std::vector<FASTAFile::FASTAEntry> fasta_db, 
+        EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2,
+        const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications, 
+        const ModifiedPeptideGenerator::MapToResidueType& variable_modifications, 
+        Size max_variable_mods_per_peptide);
 
       /**
        * @brief Builds specific cross-link candidates with all possible combinations of linked positions from peptide pairs. Used to build candidates for the precursor mass window of a single MS2 spectrum.

--- a/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/XLMS/OPXLHelper.h
@@ -112,7 +112,7 @@ namespace OpenMS
        * @param modNames The list of modification names
        * @return A vector of modifications
        */
-      static std::vector<ResidueModification> getModificationsFromStringList(StringList modNames);
+      static std::vector<const ResidueModification*> getModificationsFromStringList(StringList modNames);
 
       /**
        * @brief Digests a database with the given EnzymaticDigestion settings and precomputes masses for all peptides
@@ -134,7 +134,7 @@ namespace OpenMS
        * @param c_term_linker True, if the cross-linker can react with the C-terminal of a protein
        * @return A vector of AASeqWithMass containing the peptides, their masses and information about terminal peptides
        */
-      static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(std::vector<FASTAFile::FASTAEntry> fasta_db, EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2, std::vector<ResidueModification> fixed_modifications, std::vector<ResidueModification> variable_modifications, Size max_variable_mods_per_peptide);
+      static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(std::vector<FASTAFile::FASTAEntry> fasta_db, EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2, const std::vector<const ResidueModification*>& fixed_modifications, const std::vector<const ResidueModification*>& variable_modifications, Size max_variable_mods_per_peptide);
 
       /**
        * @brief Builds specific cross-link candidates with all possible combinations of linked positions from peptide pairs. Used to build candidates for the precursor mass window of a single MS2 spectrum.

--- a/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/AASequence.h
@@ -442,6 +442,9 @@ protected:
     /// if an empty string is passed replaces the residue with its unmodified version 
     void setModification(Size index, const String& modification);
 
+    // sets the (potentially modified) residue
+    void setModification(Size index, const Residue* modification) { peptide_[index] = modification; }
+
     /// sets the N-terminal modification
     void setNTerminalModification(const String& modification);
 

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -173,18 +173,6 @@ namespace OpenMS
   }
 
   // static
-  vector<const ResidueModification*> SimpleSearchEngineAlgorithm::getModifications_(const StringList& modNames)
-  {
-    vector<const ResidueModification*> modifications;
-    // iterate over modification names and add to vector
-    for (const String& m : modNames)
-    {
-      modifications.push_back(ModificationsDB::getInstance()->getModification(m));
-    }
-    return modifications;
-  }
-
-  // static
   void SimpleSearchEngineAlgorithm::preprocessSpectra_(PeakMap& exp, double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm)
   {
     // filter MS2 map
@@ -239,8 +227,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
       std::vector<ProteinIdentification>& protein_ids, 
       std::vector<PeptideIdentification>& peptide_ids, 
       Size top_hits,
-      const std::vector<const ResidueModification*>& fixed_modifications, 
-      const std::vector<const ResidueModification*>& variable_modifications, 
+      const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications, 
+      const ModifiedPeptideGenerator::MapToResidueType& variable_modifications, 
       Size max_variable_mods_per_peptide,
       const StringList& modifications_fixed,
       const StringList& modifications_variable,
@@ -361,8 +349,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
 
-    vector<const ResidueModification*> fixed_modifications = getModifications_(modifications_fixed_);
-    vector<const ResidueModification*> variable_modifications = getModifications_(modifications_variable_);
+    ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(modifications_fixed_);
+    ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(modifications_variable_);
 
     // load MS2 map
     PeakMap spectra;

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -173,13 +173,13 @@ namespace OpenMS
   }
 
   // static
-  vector<ResidueModification> SimpleSearchEngineAlgorithm::getModifications_(const StringList& modNames)
+  vector<const ResidueModification*> SimpleSearchEngineAlgorithm::getModifications_(const StringList& modNames)
   {
-    vector<ResidueModification> modifications;
+    vector<const ResidueModification*> modifications;
     // iterate over modification names and add to vector
     for (const String& m : modNames)
     {
-      modifications.push_back(*ModificationsDB::getInstance()->getModification(m));
+      modifications.push_back(ModificationsDB::getInstance()->getModification(m));
     }
     return modifications;
   }
@@ -239,8 +239,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
       std::vector<ProteinIdentification>& protein_ids, 
       std::vector<PeptideIdentification>& peptide_ids, 
       Size top_hits,
-      const std::vector<ResidueModification>& fixed_modifications, 
-      const std::vector<ResidueModification>& variable_modifications, 
+      const std::vector<const ResidueModification*>& fixed_modifications, 
+      const std::vector<const ResidueModification*>& variable_modifications, 
       Size max_variable_mods_per_peptide,
       const StringList& modifications_fixed,
       const StringList& modifications_variable,
@@ -295,8 +295,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
 
           // reapply modifications (because for memory reasons we only stored the index and recreation is fast)
           vector<AASequence> all_modified_peptides;
-          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications.begin(), fixed_modifications.end(), aas);
-          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications.begin(), variable_modifications.end(), aas, max_variable_mods_per_peptide, all_modified_peptides);
+          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, aas);
+          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, max_variable_mods_per_peptide, all_modified_peptides);
 
           // reannotate much more memory heavy AASequence object
           AASequence fixed_and_variable_modified_peptide = all_modified_peptides[a_it->peptide_mod_index]; 
@@ -361,8 +361,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
 
-    vector<ResidueModification> fixed_modifications = getModifications_(modifications_fixed_);
-    vector<ResidueModification> variable_modifications = getModifications_(modifications_variable_);
+    vector<const ResidueModification*> fixed_modifications = getModifications_(modifications_fixed_);
+    vector<const ResidueModification*> variable_modifications = getModifications_(modifications_variable_);
 
     // load MS2 map
     PeakMap spectra;
@@ -505,8 +505,8 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
 #endif
         {
           AASequence aas = AASequence::fromString(current_peptide);
-          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications.begin(), fixed_modifications.end(), aas);
-          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications.begin(), variable_modifications.end(), aas, modifications_max_variable_mods_per_peptide_, all_modified_peptides);
+          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, aas);
+          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, modifications_max_variable_mods_per_peptide_, all_modified_peptides);
         }
 
         for (SignedSize mod_pep_idx = 0; mod_pep_idx < (SignedSize)all_modified_peptides.size(); ++mod_pep_idx)

--- a/src/openms/source/ANALYSIS/RNPXL/ModifiedPeptideGenerator.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/ModifiedPeptideGenerator.cpp
@@ -51,6 +51,7 @@ namespace OpenMS
      const ResidueModification* rm = ModificationsDB::getInstance()->getModification(modification);
      modifications.push_back(rm);
    }
+   std::sort(modifications.begin(), modifications.end());
    return createResidueModificationToResidueMap_(modifications);
  }
 

--- a/src/openms/source/ANALYSIS/RNPXL/ModifiedPeptideGenerator.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/ModifiedPeptideGenerator.cpp
@@ -248,7 +248,10 @@ namespace OpenMS
       } while (next_permutation(subset_mask.begin(), subset_mask.end()));
     }
     // add modified version of the current peptide to the list of all peptides
-    all_modified_peptides.insert(all_modified_peptides.end(), modified_peptides.begin(), modified_peptides.end());
+    all_modified_peptides.insert(
+      all_modified_peptides.end(), 
+      make_move_iterator(modified_peptides.begin()), 
+      make_move_iterator(modified_peptides.end()));
   }
 
 
@@ -323,18 +326,15 @@ namespace OpenMS
 
       Size residue_index = residue_it - peptide.begin();
 
-      //determine compatibility of variable modifications
+      // determine compatibility of variable modifications
       for (auto const & v : var_mods)
       {
         // check if amino acid match between modification and current residue
-        if (residue_it->getOneLetterCode()[0] != v->getOrigin())
-        {
-          continue;
-        }
-        bool is_compatible = false;
+        if (residue_it->getOneLetterCode()[0] != v->getOrigin()) { continue; }
 
         // Term specificity is ANYWHERE on the peptide, C_TERM or N_TERM (currently no explicit support in OpenMS for protein C-term and protein N-term)
         const ResidueModification::TermSpecificity& term_spec = v->getTermSpecificity();
+        bool is_compatible(false);
         if (term_spec == ResidueModification::ANYWHERE)
         {
           is_compatible = true;

--- a/src/openms/source/ANALYSIS/RNPXL/ModifiedPeptideGenerator.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/ModifiedPeptideGenerator.cpp
@@ -364,7 +364,7 @@ namespace OpenMS
 
   // static
   void ModifiedPeptideGenerator::applyAtMostOneVariableModification_(
-    const boost::container::flat_map<const ResidueModification*, const Residue*>& var_mods, 
+    const MapToResidueType& var_mods, 
     const AASequence& peptide, 
     vector<AASequence>& all_modified_peptides, 
     bool keep_unmodified)

--- a/src/openms/source/ANALYSIS/RNPXL/ModifiedPeptideGenerator.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/ModifiedPeptideGenerator.cpp
@@ -41,29 +41,30 @@ namespace OpenMS
 {
 
   // static
-  void ModifiedPeptideGenerator::applyFixedModifications(const vector<ResidueModification>::const_iterator& fixed_mods_begin, const vector<ResidueModification>::const_iterator& fixed_mods_end, AASequence& peptide)
+  void ModifiedPeptideGenerator::applyFixedModifications(const vector<const ResidueModification*>& fixed_mods, 
+    AASequence& peptide)
   {
     // set terminal modifications for modifications without amino acid preference
-    for (vector<ResidueModification>::const_iterator fixed_it = fixed_mods_begin; fixed_it != fixed_mods_end; ++fixed_it)
+    for (auto const&f : fixed_mods)
     {
-      if (fixed_it->getTermSpecificity() == ResidueModification::N_TERM)
+      if (f->getTermSpecificity() == ResidueModification::N_TERM)
       {
         if (!peptide.hasNTerminalModification())
         {
-          peptide.setNTerminalModification(fixed_it->getFullName());
+          peptide.setNTerminalModification(f->getFullName());
         }
       }
-      else if (fixed_it->getTermSpecificity() == ResidueModification::C_TERM)
+      else if (f->getTermSpecificity() == ResidueModification::C_TERM)
       {
         if (!peptide.hasCTerminalModification())
         {
-          peptide.setCTerminalModification(fixed_it->getFullName());
+          peptide.setCTerminalModification(f->getFullName());
         }
       }
     }
 
     //iterate over each residue
-    for (AASequence::ConstIterator residue_it = peptide.begin(); residue_it != peptide.end(); ++residue_it)
+    for (auto residue_it = peptide.begin(); residue_it != peptide.end(); ++residue_it)
     {
       // skip already modified residue
       if (residue_it->isModified())
@@ -72,34 +73,39 @@ namespace OpenMS
       }
       Size residue_index = residue_it - peptide.begin();
       //set fixed modifications
-      for (vector<ResidueModification>::const_iterator fixed_it = fixed_mods_begin; fixed_it != fixed_mods_end; ++fixed_it)
+      for (auto const& f : fixed_mods)
       {
         // check if amino acid match between modification and current residue
-        if (residue_it->getOneLetterCode()[0] != fixed_it->getOrigin()) { continue; }
+        if (residue_it->getOneLetterCode()[0] != f->getOrigin()) { continue; }
 
         // Term specificity is ANYWHERE on the peptide, C_TERM or N_TERM (currently no explicit support in OpenMS for protein C-term and protein N-term)
-        const ResidueModification::TermSpecificity& term_spec = fixed_it->getTermSpecificity();
+        const ResidueModification::TermSpecificity& term_spec = f->getTermSpecificity();
         if (term_spec == ResidueModification::ANYWHERE)
         {
-          peptide.setModification(residue_index, fixed_it->getFullName());
+          peptide.setModification(residue_index, f->getFullName());
         }
         else if (term_spec == ResidueModification::C_TERM && residue_index == (peptide.size() - 1))
         {
-          peptide.setCTerminalModification(fixed_it->getFullName());
+          peptide.setCTerminalModification(f->getFullName());
         }
         else if (term_spec == ResidueModification::N_TERM && residue_index == 0)
         {
-          peptide.setNTerminalModification(fixed_it->getFullName());
+          peptide.setNTerminalModification(f->getFullName());
         }
       }
     }
   }
 
   // static
-  void ModifiedPeptideGenerator::applyVariableModifications(const vector<ResidueModification>::const_iterator& var_mods_begin, const vector<ResidueModification>::const_iterator& var_mods_end, const AASequence& peptide, Size max_variable_mods_per_peptide, vector<AASequence>& all_modified_peptides, bool keep_unmodified)
+  void ModifiedPeptideGenerator::applyVariableModifications(
+    const vector<const ResidueModification*>& var_mods, 
+    const AASequence& peptide, 
+    Size max_variable_mods_per_peptide, 
+    vector<AASequence>& all_modified_peptides, 
+    bool keep_unmodified)
   {
     // no variable modifications specified or no variable mods allowed? no compatibility map needs to be build
-    if (var_mods_begin == var_mods_end || max_variable_mods_per_peptide == 0)
+    if (var_mods.empty() || max_variable_mods_per_peptide == 0)
     {
       // if unmodified peptides should be kept return the original list of digested peptides
       if (keep_unmodified) { all_modified_peptides.push_back(peptide); }
@@ -110,8 +116,7 @@ namespace OpenMS
     if (max_variable_mods_per_peptide == 1)
     {
       applyAtMostOneVariableModification_(
-        var_mods_begin,
-        var_mods_end,
+        var_mods,
         peptide,
         all_modified_peptides,
         keep_unmodified);
@@ -130,30 +135,30 @@ namespace OpenMS
       modified_peptides.push_back(peptide);
     }
 
-    //iterate over each residue and build compatibility mapping describing
-    //which amino acid (peptide index) is compatible with which modification
-    map<int, vector<ResidueModification> > map_compatibility;
+    // iterate over each residue and build compatibility mapping describing
+    // which amino acid (peptide index) is compatible with which modification
+    map<int, vector<const ResidueModification*> > map_compatibility;
 
     // set terminal modifications for modifications without amino acid preference
-    for (vector<ResidueModification>::const_iterator variable_it = var_mods_begin; variable_it != var_mods_end; ++variable_it)
+    for (auto const& v : var_mods)
     {
-      if (variable_it->getTermSpecificity() == ResidueModification::N_TERM)
+      if (v->getTermSpecificity() == ResidueModification::N_TERM)
       {
         if (!peptide.hasNTerminalModification())
         {
-          map_compatibility[N_TERM_MODIFICATION_INDEX].push_back(*variable_it);
+          map_compatibility[N_TERM_MODIFICATION_INDEX].push_back(v);
         }
       }
-      else if (variable_it->getTermSpecificity() == ResidueModification::C_TERM)
+      else if (v->getTermSpecificity() == ResidueModification::C_TERM)
       {
         if (!peptide.hasCTerminalModification())
         {
-          map_compatibility[C_TERM_MODIFICATION_INDEX].push_back(*variable_it);
+          map_compatibility[C_TERM_MODIFICATION_INDEX].push_back(v);
         }
       }
     }
 
-    for (AASequence::ConstIterator residue_it = peptide.begin(); residue_it != peptide.end(); ++residue_it)
+    for (auto residue_it = peptide.begin(); residue_it != peptide.end(); ++residue_it)
     {
       // skip already modified residues
       if (residue_it->isModified())
@@ -164,10 +169,10 @@ namespace OpenMS
       Size residue_index = residue_it - peptide.begin();
 
       //determine compatibility of variable modifications
-      for (vector<ResidueModification>::const_iterator variable_it = var_mods_begin; variable_it != var_mods_end; ++variable_it)
+      for (auto const& v : var_mods)
       {
         // check if amino acid match between modification and current residue
-        if (residue_it->getOneLetterCode()[0] != variable_it->getOrigin())
+        if (residue_it->getOneLetterCode()[0] != v->getOrigin())
         {
           continue;
         }
@@ -175,18 +180,18 @@ namespace OpenMS
         // Term specificity is ANYWHERE on the peptide, C_TERM or N_TERM
         // (currently no explicit support in OpenMS for protein C-term and
         // protein N-term)
-        const ResidueModification::TermSpecificity& term_spec = variable_it->getTermSpecificity();
+        const ResidueModification::TermSpecificity& term_spec = v->getTermSpecificity();
         if (term_spec == ResidueModification::ANYWHERE)
         {
-          map_compatibility[static_cast<int>(residue_index)].push_back(*variable_it);
+          map_compatibility[static_cast<int>(residue_index)].push_back(v);
         }
         else if (term_spec == ResidueModification::C_TERM && residue_index == (peptide.size() - 1))
         {
-          map_compatibility[C_TERM_MODIFICATION_INDEX].push_back(*variable_it);
+          map_compatibility[C_TERM_MODIFICATION_INDEX].push_back(v);
         }
         else if (term_spec == ResidueModification::N_TERM && residue_index == 0)
         {
-          map_compatibility[N_TERM_MODIFICATION_INDEX].push_back(*variable_it);
+          map_compatibility[N_TERM_MODIFICATION_INDEX].push_back(v);
         }
       }
     }
@@ -229,7 +234,7 @@ namespace OpenMS
       {
         // create subset indices e.g.{4,12} from subset mask e.g. 1010000 corresponding to the positions in the peptide sequence
         vector<int> subset_indices;
-        map<int, vector<ResidueModification> >::const_iterator mit = map_compatibility.begin();
+        map<int, vector<const ResidueModification*> >::const_iterator mit = map_compatibility.begin();
         for (Size i = 0; i != compatible_mod_sites; ++i, ++mit)
         {
           if (subset_mask[i])
@@ -248,7 +253,12 @@ namespace OpenMS
 
 
   // static
-  void ModifiedPeptideGenerator::recurseAndGenerateVariableModifiedPeptides_(const vector<int>& subset_indices, const map<int, vector<ResidueModification> >& map_compatibility, int depth, const AASequence& current_peptide, vector<AASequence>& modified_peptides)
+  void ModifiedPeptideGenerator::recurseAndGenerateVariableModifiedPeptides_(
+    const vector<int>& subset_indices, 
+    const map<int, vector<const ResidueModification*> >& map_compatibility, 
+    int depth, 
+    const AASequence& current_peptide, 
+    vector<AASequence>& modified_peptides)
   {
     const int N_TERM_MODIFICATION_INDEX = -1; // magic constant to distinguish N_TERM only modifications from ANYWHERE modifications placed at N-term residue
     const int C_TERM_MODIFICATION_INDEX = -2; // magic constant to distinguish C_TERM only modifications from ANYWHERE modifications placed at C-term residue
@@ -265,24 +275,24 @@ namespace OpenMS
     // get modifications compatible to residue at current peptide position
     const int current_index = subset_indices[depth];
 
-    map<int, vector<ResidueModification> >::const_iterator pos_mod_it = map_compatibility.find(current_index);
-    const vector<ResidueModification>& mods = pos_mod_it->second; // we don't need to check for .end as entry is guaranteed to exist
+    map<int, vector<const ResidueModification*> >::const_iterator pos_mod_it = map_compatibility.find(current_index);
+    const vector<const ResidueModification*>& mods = pos_mod_it->second; // we don't need to check for .end as entry is guaranteed to exist
 
-    for (vector<ResidueModification>::const_iterator mod_it = mods.begin(); mod_it != mods.end(); ++mod_it)
+    for (auto m : mods)
     {
       // copy peptide and apply modification
       AASequence new_peptide = current_peptide;
       if (current_index == C_TERM_MODIFICATION_INDEX)
       {
-        new_peptide.setCTerminalModification(mod_it->getFullName());
+        new_peptide.setCTerminalModification(m->getFullName());
       }
       else if (current_index == N_TERM_MODIFICATION_INDEX)
       {
-        new_peptide.setNTerminalModification(mod_it->getFullName());
+        new_peptide.setNTerminalModification(m->getFullName());
       }
       else
       {
-        new_peptide.setModification(current_index, mod_it->getFullName());
+        new_peptide.setModification(current_index, m->getFullName());
       }
 
       // recurse with modified peptide
@@ -291,7 +301,11 @@ namespace OpenMS
   }
 
   // static
-  void ModifiedPeptideGenerator::applyAtMostOneVariableModification_(const vector<ResidueModification>::const_iterator& var_mods_begin, const vector<ResidueModification>::const_iterator& var_mods_end, const AASequence& peptide, vector<AASequence>& all_modified_peptides, bool keep_unmodified)
+  void ModifiedPeptideGenerator::applyAtMostOneVariableModification_(
+    const vector<const ResidueModification*>& var_mods, 
+    const AASequence& peptide, 
+    vector<AASequence>& all_modified_peptides, 
+    bool keep_unmodified)
   {
     if (keep_unmodified)
     {
@@ -299,7 +313,7 @@ namespace OpenMS
     }
 
     // we want the same behavior as for the slower function... we would need a reverse iterator here that AASequence doesn't provide
-    for (AASequence::ConstIterator residue_it = peptide.end() - 1; residue_it != peptide.begin() - 1; --residue_it)
+    for (auto residue_it = peptide.end() - 1; residue_it != peptide.begin() - 1; --residue_it)
     {
       // skip already modified residues
       if (residue_it->isModified())
@@ -310,17 +324,17 @@ namespace OpenMS
       Size residue_index = residue_it - peptide.begin();
 
       //determine compatibility of variable modifications
-      for (vector<ResidueModification>::const_iterator variable_it = var_mods_begin; variable_it != var_mods_end; ++variable_it)
+      for (auto const & v : var_mods)
       {
         // check if amino acid match between modification and current residue
-        if (residue_it->getOneLetterCode()[0] != variable_it->getOrigin())
+        if (residue_it->getOneLetterCode()[0] != v->getOrigin())
         {
           continue;
         }
         bool is_compatible = false;
 
         // Term specificity is ANYWHERE on the peptide, C_TERM or N_TERM (currently no explicit support in OpenMS for protein C-term and protein N-term)
-        const ResidueModification::TermSpecificity& term_spec = variable_it->getTermSpecificity();
+        const ResidueModification::TermSpecificity& term_spec = v->getTermSpecificity();
         if (term_spec == ResidueModification::ANYWHERE)
         {
           is_compatible = true;
@@ -338,8 +352,8 @@ namespace OpenMS
         if (is_compatible)
         {
           AASequence new_peptide = peptide;
-          new_peptide.setModification(residue_index, variable_it->getFullName());
-          all_modified_peptides.push_back(new_peptide);
+          new_peptide.setModification(residue_index, v->getFullName());
+          all_modified_peptides.push_back(std::move(new_peptide));
         }
       }
     }

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -209,20 +209,20 @@ namespace OpenMS
     }
   }
 
-  vector<ResidueModification> OPXLHelper::getModificationsFromStringList(StringList modNames)
+  vector<const ResidueModification*> OPXLHelper::getModificationsFromStringList(StringList modNames)
   {
-    vector<ResidueModification> modifications;
+    vector<const ResidueModification*> modifications;
 
     // iterate over modification names and add to vector
     for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
     {
-      modifications.push_back(*ModificationsDB::getInstance()->getModification(*mod_it));
+      modifications.push_back(ModificationsDB::getInstance()->getModification(*mod_it));
     }
 
     return modifications;
   }
 
-  std::vector<OPXLDataStructs::AASeqWithMass> OPXLHelper::digestDatabase(vector<FASTAFile::FASTAEntry> fasta_db, EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2, std::vector<ResidueModification> fixed_modifications, std::vector<ResidueModification> variable_modifications, Size max_variable_mods_per_peptide)
+  std::vector<OPXLDataStructs::AASeqWithMass> OPXLHelper::digestDatabase(vector<FASTAFile::FASTAEntry> fasta_db, EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2, const std::vector<const ResidueModification*>& fixed_modifications, const std::vector<const ResidueModification*>& variable_modifications, Size max_variable_mods_per_peptide)
   {
     multimap<StringView, AASequence> processed_peptides;
     vector<OPXLDataStructs::AASeqWithMass> peptide_masses;
@@ -317,8 +317,8 @@ namespace OpenMS
 
         // generate all modified variants of a peptide
         AASequence aas = AASequence::fromString(cit->getString());
-        ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications.begin(), fixed_modifications.end(), aas);
-        ModifiedPeptideGenerator::applyVariableModifications(variable_modifications.begin(), variable_modifications.end(), aas, max_variable_mods_per_peptide, all_modified_peptides);
+        ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, aas);
+        ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, max_variable_mods_per_peptide, all_modified_peptides);
 
         for (SignedSize mod_pep_idx = 0; mod_pep_idx < static_cast<SignedSize>(all_modified_peptides.size()); ++mod_pep_idx)
         {

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -209,20 +209,15 @@ namespace OpenMS
     }
   }
 
-  vector<const ResidueModification*> OPXLHelper::getModificationsFromStringList(StringList modNames)
-  {
-    vector<const ResidueModification*> modifications;
-
-    // iterate over modification names and add to vector
-    for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
-    {
-      modifications.push_back(ModificationsDB::getInstance()->getModification(*mod_it));
-    }
-
-    return modifications;
-  }
-
-  std::vector<OPXLDataStructs::AASeqWithMass> OPXLHelper::digestDatabase(vector<FASTAFile::FASTAEntry> fasta_db, EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2, const std::vector<const ResidueModification*>& fixed_modifications, const std::vector<const ResidueModification*>& variable_modifications, Size max_variable_mods_per_peptide)
+  std::vector<OPXLDataStructs::AASeqWithMass> OPXLHelper::digestDatabase(
+    vector<FASTAFile::FASTAEntry> fasta_db, 
+    EnzymaticDigestion digestor, 
+    Size min_peptide_length, 
+    StringList cross_link_residue1, 
+    StringList cross_link_residue2, 
+    const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications, 
+    const ModifiedPeptideGenerator::MapToResidueType& variable_modifications, 
+    Size max_variable_mods_per_peptide)
   {
     multimap<StringView, AASequence> processed_peptides;
     vector<OPXLDataStructs::AASeqWithMass> peptide_masses;

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -225,8 +225,8 @@ using namespace OpenMS;
 #endif
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
-    vector<const ResidueModification*> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames_);
-    vector<const ResidueModification*> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames_);
+    ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(fixedModNames_);
+    ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(varModNames_);
 
     // Precursor Purity precalculation
     progresslogger.startProgress(0, 1, "Computing precursor purities...");

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -225,8 +225,8 @@ using namespace OpenMS;
 #endif
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
-    vector<ResidueModification> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames_);
-    vector<ResidueModification> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames_);
+    vector<const ResidueModification*> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames_);
+    vector<const ResidueModification*> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames_);
 
     // Precursor Purity precalculation
     progresslogger.startProgress(0, 1, "Computing precursor purities...");

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
@@ -215,8 +215,8 @@ using namespace OpenMS;
       LOG_DEBUG << "duplicate variable modification provided." << endl;
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
-    vector<const ResidueModification*> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames_);
-    vector<const ResidueModification*> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames_);
+    ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(fixedModNames_);
+    ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(varModNames_);
 
     // Precursor Purity precalculation
     progresslogger.startProgress(0, 1, "Computing precursor purities...");

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
@@ -215,8 +215,8 @@ using namespace OpenMS;
       LOG_DEBUG << "duplicate variable modification provided." << endl;
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
-    vector<ResidueModification> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames_);
-    vector<ResidueModification> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames_);
+    vector<const ResidueModification*> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames_);
+    vector<const ResidueModification*> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames_);
 
     // Precursor Purity precalculation
     progresslogger.startProgress(0, 1, "Computing precursor purities...");

--- a/src/pyOpenMS/pxds/ModifiedPeptideGenerator.pxd
+++ b/src/pyOpenMS/pxds/ModifiedPeptideGenerator.pxd
@@ -1,5 +1,8 @@
 from ProgressLogger cimport *
 from libcpp cimport bool
+from libcpp.vector cimport vector as libcpp_vector
+from AASequence cimport *
+from ResidueModification cimport *
 
 cdef extern from "<OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h>" namespace "OpenMS":
 
@@ -8,8 +11,13 @@ cdef extern from "<OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h>" namespace 
         ModifiedPeptideGenerator() nogil except +
         ModifiedPeptideGenerator(ModifiedPeptideGenerator) nogil except + 
 
-        # TODO : iterator as arg
-        # applyFixedModifications
+    ## wrap static methods
+    cdef extern from "<OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h>" namespace "OpenMS::ModifiedPeptideGenerator":
+        void applyFixedModifications(const libcpp_vector[const ResidueModification*]& fixed_mods, AASequence& peptide);
 
-        # TODO : iterator as arg
-        # applyVariableModifications
+        void applyVariableModifications(const libcpp_vector[const ResidueModification*]& var_mods, 
+          const AASequence& peptide, 
+          Size max_variable_mods_per_peptide, 
+          libcpp_vector[AASequence]& all_modified_peptides, 
+          bool keep_original) nogil except +
+

--- a/src/pyOpenMS/pxds/ModifiedPeptideGenerator.pxd
+++ b/src/pyOpenMS/pxds/ModifiedPeptideGenerator.pxd
@@ -13,9 +13,11 @@ cdef extern from "<OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h>" namespace 
 
     ## wrap static methods
     cdef extern from "<OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h>" namespace "OpenMS::ModifiedPeptideGenerator":
-        void applyFixedModifications(const libcpp_vector[const ResidueModification*]& fixed_mods, AASequence& peptide);
+        MapToResidueType getModifications(const StringList& modNames) nogil except +
 
-        void applyVariableModifications(const libcpp_vector[const ResidueModification*]& var_mods, 
+        void applyFixedModifications(const MapToResidueType& fixed_mods, AASequence& peptide) nogil except +
+
+        void applyVariableModifications(const MapToResidueType& var_mods, 
           const AASequence& peptide, 
           Size max_variable_mods_per_peptide, 
           libcpp_vector[AASequence]& all_modified_peptides, 

--- a/src/pyOpenMS/pxds/ModifiedPeptideGenerator.pxd
+++ b/src/pyOpenMS/pxds/ModifiedPeptideGenerator.pxd
@@ -11,6 +11,12 @@ cdef extern from "<OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h>" namespace 
         ModifiedPeptideGenerator() nogil except +
         ModifiedPeptideGenerator(ModifiedPeptideGenerator) nogil except + 
 
+    cdef cppclass ModifiedPeptideGenerator_MapToResidueType "OpenMS::ModifiedPeptideGenerator::MapToResidueType":
+
+        ModifiedPeptideGenerator_MapToResidueType() nogil except +
+        ModifiedPeptideGenerator_MapToResidueType(ModifiedPeptideGenerator_MapToResidueType) nogil except + #wrap-ignore
+
+
     ## wrap static methods
     cdef extern from "<OpenMS/ANALYSIS/RNPXL/ModifiedPeptideGenerator.h>" namespace "OpenMS::ModifiedPeptideGenerator":
         MapToResidueType getModifications(const StringList& modNames) nogil except +

--- a/src/pyOpenMS/pxds/OPXLHelper.pxd
+++ b/src/pyOpenMS/pxds/OPXLHelper.pxd
@@ -18,6 +18,7 @@ from MSSpectrum cimport *
 from MSExperiment cimport *
 from EnzymaticDigestion cimport *
 from DataArrays cimport *
+from ModifiedPeptideGenerator cimport *
 
 
 cdef extern from "<OpenMS/ANALYSIS/XLMS/OPXLHelper.h>" namespace "OpenMS":
@@ -44,8 +45,8 @@ cdef extern from "<OpenMS/ANALYSIS/XLMS/OPXLHelper.h>" namespace "OpenMS":
                                                       Size min_peptide_length,
                                                       StringList cross_link_residue1,
                                                       StringList cross_link_residue2,
-                                                      libcpp_vector[ const ResidueModification * ] fixed_modifications,
-                                                      libcpp_vector[ const ResidueModification * ] variable_modifications,
+                                                      ModifiedPeptideGenerator_MapToResidueType fixed_modifications,
+                                                      ModifiedPeptideGenerator_MapToResidueType variable_modifications,
                                                       Size max_variable_mods_per_peptide) nogil except +
 
         libcpp_vector[ ProteinProteinCrossLink ] buildCandidates(libcpp_vector[ XLPrecursor ]& candidates,

--- a/src/pyOpenMS/pxds/OPXLHelper.pxd
+++ b/src/pyOpenMS/pxds/OPXLHelper.pxd
@@ -38,15 +38,13 @@ cdef extern from "<OpenMS/ANALYSIS/XLMS/OPXLHelper.h>" namespace "OpenMS":
                                                                   double precursor_mass_tolerance,
                                                                   bool precursor_mass_tolerance_unit_ppm)  nogil except +
 
-        libcpp_vector[ const ResidueModification * ] getModificationsFromStringList(StringList modNames)  nogil except +
-
         libcpp_vector[ AASeqWithMass ] digestDatabase(libcpp_vector[ FASTAEntry ] fasta_db,
                                                       EnzymaticDigestion digestor,
                                                       Size min_peptide_length,
                                                       StringList cross_link_residue1,
                                                       StringList cross_link_residue2,
-                                                      ModifiedPeptideGenerator_MapToResidueType fixed_modifications,
-                                                      ModifiedPeptideGenerator_MapToResidueType variable_modifications,
+                                                      ModifiedPeptideGenerator_MapToResidueType& fixed_modifications,
+                                                      ModifiedPeptideGenerator_MapToResidueType& variable_modifications,
                                                       Size max_variable_mods_per_peptide) nogil except +
 
         libcpp_vector[ ProteinProteinCrossLink ] buildCandidates(libcpp_vector[ XLPrecursor ]& candidates,

--- a/src/pyOpenMS/pxds/OPXLHelper.pxd
+++ b/src/pyOpenMS/pxds/OPXLHelper.pxd
@@ -37,15 +37,15 @@ cdef extern from "<OpenMS/ANALYSIS/XLMS/OPXLHelper.h>" namespace "OpenMS":
                                                                   double precursor_mass_tolerance,
                                                                   bool precursor_mass_tolerance_unit_ppm)  nogil except +
 
-        libcpp_vector[ ResidueModification ] getModificationsFromStringList(StringList modNames)  nogil except +
+        libcpp_vector[ const ResidueModification * ] getModificationsFromStringList(StringList modNames)  nogil except +
 
         libcpp_vector[ AASeqWithMass ] digestDatabase(libcpp_vector[ FASTAEntry ] fasta_db,
                                                       EnzymaticDigestion digestor,
                                                       Size min_peptide_length,
                                                       StringList cross_link_residue1,
                                                       StringList cross_link_residue2,
-                                                      libcpp_vector[ ResidueModification ] fixed_modifications,
-                                                      libcpp_vector[ ResidueModification ] variable_modifications,
+                                                      libcpp_vector[ const ResidueModification * ] fixed_modifications,
+                                                      libcpp_vector[ const ResidueModification * ] variable_modifications,
                                                       Size max_variable_mods_per_peptide) nogil except +
 
         libcpp_vector[ ProteinProteinCrossLink ] buildCandidates(libcpp_vector[ XLPrecursor ]& candidates,

--- a/src/tests/class_tests/openms/source/ModifiedPeptideGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/ModifiedPeptideGenerator_test.cpp
@@ -99,7 +99,7 @@ START_SECTION((static void applyFixedModifications(const ModifiedPeptideGenerato
   modNames.clear();
   modNames << "Carbamyl (N-term)";
 
-  fixed_mods.clear();
+  fixed_mods.val.clear();
   fixed_mods = ModifiedPeptideGenerator::getModifications(modNames);
 
   seq0 = AASequence::fromString("KAAAAAAAA"); // exactly one target site
@@ -191,7 +191,7 @@ START_SECTION((static void applyVariableModifications(const ModifiedPeptideGener
   // two different modifications with same target site
   modNames.clear();
   modNames << "Glutathione (C)" << "Carbamidomethyl (C)";
-  variable_mods.clear();
+  variable_mods.val.clear();
   variable_mods = ModifiedPeptideGenerator::getModifications(modNames);
 
   seq = AASequence::fromString("ACAACAACA"); // three target sites
@@ -221,7 +221,7 @@ START_SECTION((static void applyVariableModifications(const ModifiedPeptideGener
   // three different modifications
   modNames.clear();
   modNames << "Glutathione (C)" << "Carbamidomethyl (C)" << "Oxidation (M)";
-  variable_mods.clear();
+  variable_mods.val.clear();
   variable_mods = ModifiedPeptideGenerator::getModifications(modNames);
 
   modified_peptides.clear();
@@ -238,7 +238,7 @@ START_SECTION((static void applyVariableModifications(const ModifiedPeptideGener
   modNames.clear();
   modNames << "Carbamyl (N-term)" << "Oxidation (M)";
   
-  variable_mods.clear();
+  variable_mods.val.clear();
   variable_mods = ModifiedPeptideGenerator::getModifications(modNames);
 
   modified_peptides.clear();

--- a/src/tests/class_tests/openms/source/ModifiedPeptideGenerator_test.cpp
+++ b/src/tests/class_tests/openms/source/ModifiedPeptideGenerator_test.cpp
@@ -65,18 +65,17 @@ START_SECTION(~ModifiedPeptideGenerator())
 }
 END_SECTION
 
-START_SECTION((static void applyFixedModifications(const std::vector< ResidueModification >::const_iterator &fixed_mods_begin,
-                const std::vector< ResidueModification >::const_iterator& fixed_mods_end,
+START_SECTION((static void applyFixedModifications(const std::vector<const ResidueModification* >& fixed_mods,
                 AASequence& peptide)))
 {
   // query modification of interest from ModificationsDB
   StringList modNames;
   modNames << "Carbamidomethyl (C)";
-  vector<ResidueModification> fixed_mods;
+  vector<const ResidueModification*> fixed_mods;
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(ModificationsDB::getInstance()->getModification(modification));
   }
 
   AASequence seq0 = AASequence::fromString("AAAACAAAA"); // exactly one target site
@@ -85,11 +84,11 @@ START_SECTION((static void applyFixedModifications(const std::vector< ResidueMod
   AASequence seq3 = AASequence::fromString("AAAACAAC(Carbamidomethyl)AAA"); // one of two target sites already modified
   AASequence seq4 = AASequence::fromString("AAAACAAC(Oxidation)AAA"); // one of two target sites already modified
 
-  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods.begin(), fixed_mods.end(), seq0);
-  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods.begin(), fixed_mods.end(), seq1);
-  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods.begin(), fixed_mods.end(), seq2);
-  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods.begin(), fixed_mods.end(), seq3);
-  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods.begin(), fixed_mods.end(), seq4);
+  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, seq0);
+  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, seq1);
+  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, seq2);
+  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, seq3);
+  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, seq4);
 
   TEST_EQUAL(seq0.toString(), "AAAAC(Carbamidomethyl)AAAA");
   TEST_EQUAL(seq1.toString(), "AAAAAAAAA");
@@ -104,76 +103,76 @@ START_SECTION((static void applyFixedModifications(const std::vector< ResidueMod
    for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
    {
      String modification(*mod_it);
-     fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
+     fixed_mods.push_back(ModificationsDB::getInstance()->getModification(modification));
    }
   seq0 = AASequence::fromString("KAAAAAAAA"); // exactly one target site
   seq1 = AASequence::fromString("K(Carbamyl)AAAAAAAA"); // ambigous case: is mod Carbamyl (K) or (N-Term)?
-  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods.begin(), fixed_mods.end(), seq0);
-  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods.begin(), fixed_mods.end(), seq1);
+  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, seq0);
+  ModifiedPeptideGenerator::applyFixedModifications(fixed_mods, seq1);
   TEST_EQUAL(seq0.toString(), ".(Carbamyl)KAAAAAAAA");
   TEST_EQUAL(seq1.toString(), ".(Carbamyl)K(Carbamyl)AAAAAAAA");
  
 }
 END_SECTION
 
-START_SECTION((static void applyVariableModifications(const std::vector< ResidueModification >::const_iterator &var_mods_begin, const std::vector< ResidueModification >::const_iterator &var_mods_end, const AASequence& peptide, Size max_variable_mods_per_peptide, std::vector< AASequence > &all_modified_peptides, bool keep_unmodified=true)))
+START_SECTION((static void applyVariableModifications(const std::vector<const ResidueModification* >& var_mods, const AASequence& peptide, Size max_variable_mods_per_peptide, std::vector< AASequence > &all_modified_peptides, bool keep_unmodified=true)))
 {
   // query modification of interest from ModificationsDB
   StringList modNames;
   modNames << "Oxidation (M)";
-  vector<ResidueModification> fixed_mods;
+  vector<const ResidueModification*> fixed_mods;
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(ModificationsDB::getInstance()->getModification(modification));
   }
 
   vector<AASequence> modified_peptides;
 
   // test behavior if sequence empty
   AASequence seq;
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 0); // no generated peptide
   modified_peptides.clear();
 
   // test behavior if peptide empty
   seq = AASequence::fromString("");
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 0, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 0, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 0); // no generated peptide
   modified_peptides.clear();
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 0); // no generated peptide
   modified_peptides.clear();
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 2, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 2, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 0); // no generated peptide
   modified_peptides.clear();
 
   // test behavior if no target site in sequence
   seq = AASequence::fromString("AAAAAAAAA");
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 0); // no generated peptide
   modified_peptides.clear();
 
   // test flag to preserve passed peptide
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, true);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, true);
   TEST_EQUAL(modified_peptides[0], AASequence::fromString("AAAAAAAAA")); // only the original peptide
   modified_peptides.clear();
 
   // test behavior if one target site in sequence and different number of maximum variable modifications are choosen
   seq = AASequence::fromString("AAAAMAAAA"); // exactly one target site
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 0, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 0, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 0); // no generated peptide
   modified_peptides.clear();
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 1); // one generated peptide
   TEST_EQUAL(modified_peptides[0].toString(), "AAAAM(Oxidation)AAAA");
   modified_peptides.clear();
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 2, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 2, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 1); // also only one generated peptide as there is only one target site
   TEST_EQUAL(modified_peptides[0].toString(), "AAAAM(Oxidation)AAAA");
   modified_peptides.clear();
   // test again keeping of the original peptides
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, true);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, true);
   TEST_EQUAL(modified_peptides.size(), 2); // original and modified peptide
   TEST_EQUAL(modified_peptides[0].toString(), "AAAAMAAAA");
   TEST_EQUAL(modified_peptides[1].toString(), "AAAAM(Oxidation)AAAA");
@@ -182,14 +181,14 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   // test behavior if two target sites are in peptide and we need some combinatorics
   // only one additional variable modification
   seq = AASequence::fromString("AAMAAAMAA"); // two target site
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 2); // two modified peptides each modified at a different site
   TEST_EQUAL(modified_peptides[0].toString(), "AAMAAAM(Oxidation)AA");
   TEST_EQUAL(modified_peptides[1].toString(), "AAM(Oxidation)AAAMAA");
   modified_peptides.clear();
 
   // up to two variable modifications per petide
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 2, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 2, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 3); // three modified peptides, 1 modifed at first M, 1 modifed at second M and both M modified
   TEST_EQUAL(modified_peptides[0].toString(), "AAMAAAM(Oxidation)AA");
   TEST_EQUAL(modified_peptides[1].toString(), "AAM(Oxidation)AAAMAA");
@@ -203,11 +202,11 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(ModificationsDB::getInstance()->getModification(modification));
   }
 
   seq = AASequence::fromString("ACAACAACA"); // three target sites
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 6); // six modified peptides, as both C modifications can occur at all 3 sites
   TEST_EQUAL(modified_peptides[0].toString(), "ACAACAAC(Glutathione)A");
   TEST_EQUAL(modified_peptides[1].toString(), "ACAACAAC(Carbamidomethyl)A");
@@ -216,18 +215,18 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   TEST_EQUAL(modified_peptides[4].toString(), "AC(Glutathione)AACAACA");
   TEST_EQUAL(modified_peptides[5].toString(), "AC(Carbamidomethyl)AACAACA");
   modified_peptides.clear();
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 1, modified_peptides, true);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 1, modified_peptides, true);
   TEST_EQUAL(modified_peptides.size(), 7); // same as above but +1 unmodified peptide
 
   modified_peptides.clear();
 
   seq = AASequence::fromString("ACAACAACA"); // three target sites and maximum of three occurances of the two modifications Glutathione and Carbamidomethyl
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 3, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 3, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 3*3*3-1); // three sites with 3 possibilities (none, Glut., Carb.) each - but we need to subtract (none, none, none). The unmodified peptide
 
   modified_peptides.clear();
   seq = AASequence::fromString("AAAAC(Carbamidomethyl)AAAA"); // target site already occupied
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 3, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 3, modified_peptides, false);
   TEST_EQUAL(modified_peptides.size(), 0); // no generated peptide as target site was already occupied
 
   // three different modifications
@@ -237,12 +236,12 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(ModificationsDB::getInstance()->getModification(modification));
   }
   modified_peptides.clear();
 
   seq = AASequence::fromString("ACMACMACA"); // three target sites (C) and two target sites (M)
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 3, modified_peptides, false);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 3, modified_peptides, false);
 
   // for exactly one mod: 2*3 + 2 = 8 (two possibilities each for each C sites and 1 for each of the two M sites)
   // for exactly two mods: 1 (iff two Ox) + 6 * 2 (iff one Ox at two pos.) + (3 choose 2) * 4 (iff no Ox) = 25
@@ -256,12 +255,12 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   for (StringList::iterator mod_it = modNames.begin(); mod_it != modNames.end(); ++mod_it)
   {
     String modification(*mod_it);
-    fixed_mods.push_back(*ModificationsDB::getInstance()->getModification(modification));
+    fixed_mods.push_back(ModificationsDB::getInstance()->getModification(modification));
   }
 
   modified_peptides.clear();
   seq = AASequence::fromString("KAAAAAAAMA"); // exactly one target site
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 2, modified_peptides, true);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 2, modified_peptides, true);
   TEST_EQUAL(modified_peptides.size(), 4);
   TEST_EQUAL(modified_peptides[0].toString(), "KAAAAAAAMA");
   TEST_EQUAL(modified_peptides[1].toString(), "KAAAAAAAM(Oxidation)A");
@@ -270,7 +269,7 @@ START_SECTION((static void applyVariableModifications(const std::vector< Residue
   
   modified_peptides.clear();
   seq = AASequence::fromString("K(Carbamyl)AAAAAAAMA"); 
-  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods.begin(), fixed_mods.end(), seq, 2, modified_peptides, true);
+  ModifiedPeptideGenerator::applyVariableModifications(fixed_mods, seq, 2, modified_peptides, true);
   TEST_EQUAL(modified_peptides.size(), 4);
   TEST_EQUAL(modified_peptides[0].toString(), "K(Carbamyl)AAAAAAAMA");
   TEST_EQUAL(modified_peptides[1].toString(), "K(Carbamyl)AAAAAAAM(Oxidation)A");
@@ -284,6 +283,5 @@ END_SECTION
 /////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////
 END_TEST
-
 
 

--- a/src/tests/class_tests/openms/source/OPXLHelper_test.cpp
+++ b/src/tests/class_tests/openms/source/OPXLHelper_test.cpp
@@ -52,20 +52,20 @@ using namespace OpenMS;
 START_TEST(OPXLHelper, "$Id$")
 
 
-START_SECTION(static std::vector<ResidueModification> getModificationsFromStringList(StringList modNames))
+START_SECTION(static std::vector<const ResidueModification*> getModificationsFromStringList(StringList modNames))
   QStringList q_str_list1;
   QStringList q_str_list2;
   q_str_list1 << "Carbamidomethyl (C)" << "Carbamidomethyl (T)";
   q_str_list2 << "Oxidation (M)" << "Oxidation (Y)";
   StringList fixedModNames = StringListUtils::fromQStringList(q_str_list1);
   StringList varModNames = StringListUtils::fromQStringList(q_str_list2);
-  std::vector<ResidueModification> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames);
-  std::vector<ResidueModification> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames);
+  std::vector<const ResidueModification*> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames);
+  std::vector<const ResidueModification*> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames);
 
-  TEST_EQUAL(fixed_modifications[0].getFullId(), "Carbamidomethyl (C)")
-  TEST_EQUAL(fixed_modifications[1].getFullId(), "Carbamidomethyl (T)")
-  TEST_EQUAL(variable_modifications[0].getFullId(), "Oxidation (M)")
-  TEST_EQUAL(variable_modifications[1].getFullId(), "Oxidation (Y)")
+  TEST_EQUAL(fixed_modifications[0]->getFullId(), "Carbamidomethyl (C)")
+  TEST_EQUAL(fixed_modifications[1]->getFullId(), "Carbamidomethyl (T)")
+  TEST_EQUAL(variable_modifications[0]->getFullId(), "Oxidation (M)")
+  TEST_EQUAL(variable_modifications[1]->getFullId(), "Oxidation (Y)")
 END_SECTION
 
 // loading and building data structures required in several following tests
@@ -87,8 +87,8 @@ q_str_list1 << "Carbamidomethyl (C)" << "Carbamidomethyl (T)";
 q_str_list2 << "Oxidation (M)" << "Oxidation (Y)";
 StringList fixedModNames = StringListUtils::fromQStringList(q_str_list1);
 StringList varModNames = StringListUtils::fromQStringList(q_str_list2);
-std::vector<ResidueModification> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames);
-std::vector<ResidueModification> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames);
+std::vector<const ResidueModification*> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames);
+std::vector<const ResidueModification*> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames);
 
 
 QStringList q_str_list3;
@@ -100,7 +100,7 @@ StringList cross_link_residue2 = StringListUtils::fromQStringList(q_str_list4);
 
 Size max_variable_mods_per_peptide = 5;
 
-START_SECTION(static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(std::vector<FASTAFile::FASTAEntry> fasta_db, EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2, std::vector<ResidueModification> fixed_modifications, std::vector<ResidueModification> variable_modifications, Size max_variable_mods_per_peptide))
+START_SECTION(static std::vector<OPXLDataStructs::AASeqWithMass> digestDatabase(std::vector<FASTAFile::FASTAEntry> fasta_db, EnzymaticDigestion digestor, Size min_peptide_length, StringList cross_link_residue1, StringList cross_link_residue2, std::vector<const ResidueModification*> fixed_modifications, std::vector<const ResidueModification*> variable_modifications, Size max_variable_mods_per_peptide))
 
   std::vector<OPXLDataStructs::AASeqWithMass> peptides = OPXLHelper::digestDatabase(fasta_db, digestor, min_peptide_length, cross_link_residue1, cross_link_residue2, fixed_modifications, variable_modifications, max_variable_mods_per_peptide);
 

--- a/src/tests/class_tests/openms/source/OPXLHelper_test.cpp
+++ b/src/tests/class_tests/openms/source/OPXLHelper_test.cpp
@@ -51,23 +51,6 @@ using namespace OpenMS;
 
 START_TEST(OPXLHelper, "$Id$")
 
-
-START_SECTION(static std::vector<const ResidueModification*> getModificationsFromStringList(StringList modNames))
-  QStringList q_str_list1;
-  QStringList q_str_list2;
-  q_str_list1 << "Carbamidomethyl (C)" << "Carbamidomethyl (T)";
-  q_str_list2 << "Oxidation (M)" << "Oxidation (Y)";
-  StringList fixedModNames = StringListUtils::fromQStringList(q_str_list1);
-  StringList varModNames = StringListUtils::fromQStringList(q_str_list2);
-  std::vector<const ResidueModification*> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames);
-  std::vector<const ResidueModification*> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames);
-
-  TEST_EQUAL(fixed_modifications[0]->getFullId(), "Carbamidomethyl (C)")
-  TEST_EQUAL(fixed_modifications[1]->getFullId(), "Carbamidomethyl (T)")
-  TEST_EQUAL(variable_modifications[0]->getFullId(), "Oxidation (M)")
-  TEST_EQUAL(variable_modifications[1]->getFullId(), "Oxidation (Y)")
-END_SECTION
-
 // loading and building data structures required in several following tests
 std::vector<FASTAFile::FASTAEntry> fasta_db;
 FASTAFile file;
@@ -87,9 +70,8 @@ q_str_list1 << "Carbamidomethyl (C)" << "Carbamidomethyl (T)";
 q_str_list2 << "Oxidation (M)" << "Oxidation (Y)";
 StringList fixedModNames = StringListUtils::fromQStringList(q_str_list1);
 StringList varModNames = StringListUtils::fromQStringList(q_str_list2);
-std::vector<const ResidueModification*> fixed_modifications = OPXLHelper::getModificationsFromStringList(fixedModNames);
-std::vector<const ResidueModification*> variable_modifications = OPXLHelper::getModificationsFromStringList(varModNames);
-
+const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications = ModifiedPeptideGenerator::getModifications(fixedModNames);
+const ModifiedPeptideGenerator::MapToResidueType& variable_modifications = ModifiedPeptideGenerator::getModifications(varModNames);
 
 QStringList q_str_list3;
 QStringList q_str_list4;

--- a/src/utils/RNPxlSearch.cpp
+++ b/src/utils/RNPxlSearch.cpp
@@ -285,9 +285,6 @@ protected:
   // helper struct to facilitate parsing of parameters (modifications, nucleotide adducts, ...)
   struct RNPxlParameterParsing
   {
-    /// Query ResidueModifications (given as strings) from ModificationsDB
-    static vector<const ResidueModification*> getModifications(StringList modNames);
-
     // Map a nucleotide (e.g. U to all possible fragment adducts)
     using NucleotideToFragmentAdductMap = map<char, set<FragmentAdductDefinition_> >;
     // @brief Parse tool parameter to create map from target nucleotide to all its fragment adducts
@@ -546,8 +543,8 @@ protected:
                       vector<vector<AnnotatedHit> >& annotated_hits, 
                       Size top_hits, 
                       const RNPxlModificationMassesResult& mm, 
-                      const vector<const ResidueModification*>& fixed_modifications, 
-                      const vector<const ResidueModification*>& variable_modifications, 
+                      const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications, 
+                      const ModifiedPeptideGenerator::MapToResidueType& variable_modifications, 
                       Size max_variable_mods_per_peptide, 
                       const TheoreticalSpectrumGenerator& partial_loss_spectrum_generator, 
                       double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, 
@@ -1292,8 +1289,8 @@ protected:
     vector<PeptideIdentification>& peptide_ids, 
     Size top_hits, 
     const RNPxlModificationMassesResult& mm, 
-    const vector<const ResidueModification*>& fixed_modifications, 
-    const vector<const ResidueModification*>& variable_modifications, 
+    const ModifiedPeptideGenerator::MapToResidueType& fixed_modifications, 
+    const ModifiedPeptideGenerator::MapToResidueType& variable_modifications, 
     Size max_variable_mods_per_peptide,
     const vector<PrecursorPurity::PurityScores>& purities)
   {
@@ -1625,8 +1622,8 @@ protected:
       return ILLEGAL_PARAMETERS;
     }
 
-    vector<const ResidueModification*> fixed_modifications = RNPxlParameterParsing::getModifications(fixedModNames);
-    vector<const ResidueModification*> variable_modifications = RNPxlParameterParsing::getModifications(varModNames);
+    ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(fixedModNames);
+    ModifiedPeptideGenerator::MapToResidueType variable_modifications = ModifiedPeptideGenerator::getModifications(varModNames);
     Size max_variable_mods_per_peptide = getIntOption_("modifications:variable_max_per_peptide");
 
     size_t report_top_hits = (size_t)getIntOption_("report:top_hits");
@@ -2495,34 +2492,6 @@ protected:
   }
 
 };
-
-vector<const ResidueModification*> RNPxlSearch::RNPxlParameterParsing::getModifications(StringList modNames) 
-{
-  vector<const ResidueModification*> modifications;
-
-  // iterate over modification names and add to vector
-  for (String modification : modNames)
-  {
-    const ResidueModification* rm;
-    if (modification.hasSubstring(" (N-term)"))
-    {
-      modification.substitute(" (N-term)", "");
-      rm = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::N_TERM);
-    }
-    else if (modification.hasSubstring(" (C-term)"))
-    {
-      modification.substitute(" (C-term)", "");
-      rm = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::C_TERM);
-    }
-    else
-    {
-      rm = ModificationsDB::getInstance()->getModification(modification);
-    }
-    modifications.push_back(rm);
-  }
-
-  return modifications;
-}
 
 RNPxlSearch::RNPxlParameterParsing::PrecursorsToMS2Adducts
 RNPxlSearch::RNPxlParameterParsing::getAllFeasibleFragmentAdducts(

--- a/src/utils/RNPxlSearch.cpp
+++ b/src/utils/RNPxlSearch.cpp
@@ -286,7 +286,7 @@ protected:
   struct RNPxlParameterParsing
   {
     /// Query ResidueModifications (given as strings) from ModificationsDB
-    static vector<ResidueModification> getModifications(StringList modNames);
+    static vector<const ResidueModification*> getModifications(StringList modNames);
 
     // Map a nucleotide (e.g. U to all possible fragment adducts)
     using NucleotideToFragmentAdductMap = map<char, set<FragmentAdductDefinition_> >;
@@ -546,8 +546,8 @@ protected:
                       vector<vector<AnnotatedHit> >& annotated_hits, 
                       Size top_hits, 
                       const RNPxlModificationMassesResult& mm, 
-                      const vector<ResidueModification>& fixed_modifications, 
-                      const vector<ResidueModification>& variable_modifications, 
+                      const vector<const ResidueModification*>& fixed_modifications, 
+                      const vector<const ResidueModification*>& variable_modifications, 
                       Size max_variable_mods_per_peptide, 
                       const TheoreticalSpectrumGenerator& partial_loss_spectrum_generator, 
                       double fragment_mass_tolerance, bool fragment_mass_tolerance_unit_ppm, 
@@ -641,8 +641,8 @@ protected:
 
         // reapply modifications (because for memory reasons we only stored the index and recreation is fast)
         vector<AASequence> all_modified_peptides;
-        ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications.begin(), fixed_modifications.end(), aas);
-        ModifiedPeptideGenerator::applyVariableModifications(variable_modifications.begin(), variable_modifications.end(), aas, max_variable_mods_per_peptide, all_modified_peptides);
+        ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, aas);
+        ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, max_variable_mods_per_peptide, all_modified_peptides);
 
         // sequence with modifications - note: reannotated version requires much more memory heavy AASequence object
         const AASequence& fixed_and_variable_modified_peptide = all_modified_peptides[a.peptide_mod_index];
@@ -1292,8 +1292,8 @@ protected:
     vector<PeptideIdentification>& peptide_ids, 
     Size top_hits, 
     const RNPxlModificationMassesResult& mm, 
-    const vector<ResidueModification>& fixed_modifications, 
-    const vector<ResidueModification>& variable_modifications, 
+    const vector<const ResidueModification*>& fixed_modifications, 
+    const vector<const ResidueModification*>& variable_modifications, 
     Size max_variable_mods_per_peptide,
     const vector<PrecursorPurity::PurityScores>& purities)
   {
@@ -1343,8 +1343,8 @@ protected:
 
           // reapply modifications (because for memory reasons we only stored the index and recreation is fast)
           vector<AASequence> all_modified_peptides;
-          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications.begin(), fixed_modifications.end(), aas);
-          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications.begin(), variable_modifications.end(), aas, max_variable_mods_per_peptide, all_modified_peptides);
+          ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, aas);
+          ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, max_variable_mods_per_peptide, all_modified_peptides);
 
           // reannotate much more memory heavy AASequence object
           AASequence fixed_and_variable_modified_peptide = all_modified_peptides[ah.peptide_mod_index]; 
@@ -1625,8 +1625,8 @@ protected:
       return ILLEGAL_PARAMETERS;
     }
 
-    vector<ResidueModification> fixed_modifications = RNPxlParameterParsing::getModifications(fixedModNames);
-    vector<ResidueModification> variable_modifications = RNPxlParameterParsing::getModifications(varModNames);
+    vector<const ResidueModification*> fixed_modifications = RNPxlParameterParsing::getModifications(fixedModNames);
+    vector<const ResidueModification*> variable_modifications = RNPxlParameterParsing::getModifications(varModNames);
     Size max_variable_mods_per_peptide = getIntOption_("modifications:variable_max_per_peptide");
 
     size_t report_top_hits = (size_t)getIntOption_("report:top_hits");
@@ -1855,8 +1855,8 @@ protected:
           if (unmodified_sequence.find_first_of("XBZ") == std::string::npos)
           {
             AASequence aas = AASequence::fromString(unmodified_sequence);
-            ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications.begin(), fixed_modifications.end(), aas);
-            ModifiedPeptideGenerator::applyVariableModifications(variable_modifications.begin(), variable_modifications.end(), aas, max_variable_mods_per_peptide, all_modified_peptides);
+            ModifiedPeptideGenerator::applyFixedModifications(fixed_modifications, aas);
+            ModifiedPeptideGenerator::applyVariableModifications(variable_modifications, aas, max_variable_mods_per_peptide, all_modified_peptides);
           }
         }
 
@@ -2496,26 +2496,27 @@ protected:
 
 };
 
-vector<ResidueModification> RNPxlSearch::RNPxlParameterParsing::getModifications(StringList modNames) {
-  vector<ResidueModification> modifications;
+vector<const ResidueModification*> RNPxlSearch::RNPxlParameterParsing::getModifications(StringList modNames) 
+{
+  vector<const ResidueModification*> modifications;
 
   // iterate over modification names and add to vector
   for (String modification : modNames)
   {
-    ResidueModification rm;
+    const ResidueModification* rm;
     if (modification.hasSubstring(" (N-term)"))
     {
       modification.substitute(" (N-term)", "");
-      rm = *ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::N_TERM);
+      rm = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::N_TERM);
     }
     else if (modification.hasSubstring(" (C-term)"))
     {
       modification.substitute(" (C-term)", "");
-      rm = *ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::C_TERM);
+      rm = ModificationsDB::getInstance()->getModification(modification, "", ResidueModification::C_TERM);
     }
     else
     {
-      rm = *ModificationsDB::getInstance()->getModification(modification);
+      rm = ModificationsDB::getInstance()->getModification(modification);
     }
     modifications.push_back(rm);
   }
@@ -2625,7 +2626,7 @@ RNPxlSearch::RNPxlParameterParsing::getTargetNucleotideToFragmentAdducts(StringL
     // register all fragment adducts as N- and C-terminal modification (if not already registered)
     if (!ModificationsDB::getInstance()->has(name))
     {
-      ResidueModification * c_term = new ResidueModification();
+      ResidueModification* c_term = new ResidueModification();
       c_term->setId(name);
       c_term->setName(name);
       c_term->setFullId(name + " (C-term)");
@@ -2633,7 +2634,7 @@ RNPxlSearch::RNPxlParameterParsing::getTargetNucleotideToFragmentAdducts(StringL
       c_term->setDiffMonoMass(fad.mass);
       ModificationsDB::getInstance()->addModification(c_term);
 
-      ResidueModification * n_term = new ResidueModification();
+      ResidueModification* n_term = new ResidueModification();
       n_term->setId(name);
       n_term->setName(name);
       n_term->setFullId(name + " (N-term)");


### PR DESCRIPTION
Before:
Generating 29 * 1e5 peptides took:
1 thread: 16s
20 threads: 17s
After:
1 thread 15s
20 threads 0.6s
