### PR TITLE
[FIX] move DPosition

### DIFF
--- a/src/openms/include/OpenMS/DATASTRUCTURES/DPosition.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DPosition.h
@@ -109,7 +109,10 @@ public:
     }
 
     /// Move constructor
-    DPosition(DPosition&& rhs) noexcept = default;
+	DPosition(DPosition&& rhs) noexcept
+	{
+		std::move(std::begin(rhs.coordinate_), std::end(rhs.coordinate_), &coordinate_[0]);
+	}
 
     /// Constructor only for DPosition<2> that takes two Coordinates.
     DPosition(CoordinateType x, CoordinateType y)

--- a/src/openms/include/OpenMS/DATASTRUCTURES/DPosition.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/DPosition.h
@@ -111,6 +111,7 @@ public:
     /// Move constructor
 	DPosition(DPosition&& rhs) noexcept
 	{
+		// NOTE: do not change this before testing with nightly Windows builds ( = default causes segfault)
 		std::move(std::begin(rhs.coordinate_), std::end(rhs.coordinate_), &coordinate_[0]);
 	}
 

--- a/src/tests/class_tests/openms/source/AveragePosition_test.cpp
+++ b/src/tests/class_tests/openms/source/AveragePosition_test.cpp
@@ -129,7 +129,7 @@ END_SECTION
 START_SECTION((CoordinateType const& getWeight() const))
 {
 	AveragePosition<1> avg;
-	avg.add(DPosition<1>(9),2);
+	avg.add(DPosition<1>{ 9.0 }, 2);
 	TEST_REAL_SIMILAR(avg.getWeight(),2);
 	TEST_REAL_SIMILAR(avg.getPosition()[0],9);
 	avg.add(DPosition<1>(9),3);


### PR DESCRIPTION
Fixes segfault on windows nightlies (tested on the machine itself).
Change in test unrelated. will change back.

Not sure if this is the best solution and why it occurred at all. Shouldn't this be what the
default move is doing?
I'll have another look at it later.