### PR TITLE
[FIX] fix unintended copy of loop variables

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -617,7 +617,7 @@ protected:
               areas[3] = simpson_(p.PosBegin(left), p.PosEnd(right) + 1); // with one more point on the right
             }
             UInt valids = 0;
-            for (auto area : areas)
+            for (const auto& area : areas)
             {
               if (area != -1.0)
               {

--- a/src/openms/include/OpenMS/FORMAT/PeakTypeEstimator.h
+++ b/src/openms/include/OpenMS/FORMAT/PeakTypeEstimator.h
@@ -254,7 +254,7 @@ public:
 
       double q1 = Math::quantile1st(distances.begin(), distances.end(), false);
       double q3 = Math::quantile3rd(distances.begin(), distances.end(), true);
-      for (auto i : distances) std::cerr << i << ";";
+      for (const auto& i : distances) std::cerr << i << ";";
       std::cerr <<"\t";
 
       if ((q3-q1) < q1*5) // q1 and q3 are roughly equal

--- a/src/openms/include/OpenMS/METADATA/ID/AppliedProcessingStep.h
+++ b/src/openms/include/OpenMS/METADATA/ID/AppliedProcessingStep.h
@@ -94,7 +94,7 @@ namespace OpenMS
             }
           }
         }
-        for (auto pair: scores)
+        for (const auto& pair: scores)
         {
           if (!scores_done.count(pair.first))
           {

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -359,15 +359,15 @@ namespace OpenMS
 
       //need elements sorted canonically (by string)
       map<String, String> sorted_elem_map;
-      for (auto element_count : ef_)
+      for (const auto& element_count : ef_)
       {
         String e_symbol(element_count.first->getSymbol());
         String tmp = element_count.second > 0 ? "+" : "-";
         tmp += abs(element_count.second) > 1 ? String(abs(element_count.second)) : "";
         tmp += e_symbol;
-        sorted_elem_map[e_symbol] = tmp;
+        sorted_elem_map[e_symbol] = std::move(tmp);
       }
-      for (auto sorted_e_cnt : sorted_elem_map)
+      for (const auto& sorted_e_cnt : sorted_elem_map)
       {
         s += sorted_e_cnt.second;
       }

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -33,6 +33,7 @@
 // --------------------------------------------------------------------------
 
 #include <OpenMS/ANALYSIS/ID/FalseDiscoveryRate.h>
+
 #include <OpenMS/CONCEPT/LogStream.h>
 
 // #define FALSE_DISCOVERY_RATE_DEBUG
@@ -485,17 +486,17 @@ namespace OpenMS
       it->setHigherScoreBetter(false);
       const vector<ProteinHit>& old_hits = it->getHits();
       vector<ProteinHit> new_hits;
-      for (auto hit : old_hits)
+      for (auto hit : old_hits) // NOTE: performs copy
       {
         // Add decoy proteins only if add_decoy_proteins is set
         if (add_decoy_proteins || hit.getMetaValue("target_decoy") != "decoy")
         {
           hit.setMetaValue(score_type, hit.getScore());
           hit.setScore(score_to_fdr[hit.getScore()]);
-          new_hits.push_back(hit);
+          new_hits.push_back(std::move(hit));
         }
       }
-      it->setHits(new_hits);
+      it->setHits(std::move(new_hits));
     }
 
     return;
@@ -625,7 +626,7 @@ namespace OpenMS
     {
       vector<IdentificationData::QueryMatchRef> best_matches =
         id_data.getBestMatchPerQuery(score_ref);
-      for (auto match_ref : best_matches)
+      for (auto match_ref : best_matches) // NOTE: performs copy, should not be necessary?
       {
         handleQueryMatch_(match_ref, score_ref, target_scores, decoy_scores,
                           molecule_to_decoy, match_to_score);

--- a/src/openms/source/ANALYSIS/ID/PrecursorPurity.cpp
+++ b/src/openms/source/ANALYSIS/ID/PrecursorPurity.cpp
@@ -64,7 +64,7 @@ namespace OpenMS
     }
 
     // std::cout << "Isolation window peaks: " << isolated_window.size();
-    // for (auto peak : isolated_window)
+    // for (const auto& peak : isolated_window)
     // {
     //   std::cout << " | " << peak.getMZ();
     // }
@@ -74,7 +74,7 @@ namespace OpenMS
     double total_intensity(0);
     double target_intensity(0);
     Size target_peak_count(0);
-    for (auto peak : isolated_window)
+    for (const auto& peak : isolated_window)
     {
       total_intensity += peak.getIntensity();
     }
@@ -124,7 +124,7 @@ namespace OpenMS
 
     // // std::cout << "noise peaks: ";
     // double noise_intensity(0);
-    // for (auto peak : isolated_window)
+    // for (const auto& peak : isolated_window)
     // {
     //   noise_intensity += peak.getIntensity();
     //   // std::cout << peak.getMZ() << " | ";

--- a/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
@@ -254,7 +254,7 @@ namespace OpenMS
       else
       {
         int count_ms2 = 0;
-        for (auto spec_it : spectra)
+        for (const auto& spec_it : spectra)
         {
           if (spec_it.getMSLevel() == 2)
           {

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -417,7 +417,7 @@ namespace OpenMS
     // experiment.
     Size progress = 0;
     startProgress(0, selection_list.size(), "Generating decoy peptides");
-    for (auto pep_idx : selection_list)
+    for (const auto& pep_idx : selection_list)
     {
       setProgress(++progress);
 

--- a/src/openms/source/ANALYSIS/RNPXL/RNPxlFragmentAnnotationHelper.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/RNPxlFragmentAnnotationHelper.cpp
@@ -58,9 +58,9 @@ namespace OpenMS
     std::map<Size, std::vector<FragmentAnnotationDetail_> > ion_annotation_details)
   {
     std::vector<PeptideHit::PeakAnnotation> fas;
-    for (auto ait : ion_annotation_details)
+    for (const auto& ait : ion_annotation_details)
     {
-      for (auto sit : ait.second)
+      for (const auto& sit : ait.second)
       {
         PeptideHit::PeakAnnotation fa;
         fa.charge = sit.charge;
@@ -75,7 +75,7 @@ namespace OpenMS
           const String annotation_text = ion_type + String(ait.first) + "+" + sit.shift; 
           fa.annotation = annotation_text;
         }
-        fas.push_back(fa);
+        fas.push_back(std::move(fa));
       }
     }
     return fas;
@@ -86,9 +86,9 @@ namespace OpenMS
     std::set<std::pair<String, double> > >& shifted_ions)
   {
     std::vector<PeptideHit::PeakAnnotation> fas;
-    for (auto ait : shifted_ions)
+    for (const auto& ait : shifted_ions)
     {
-      for (auto sit : ait.second)
+      for (const auto& sit : ait.second)
       {
         PeptideHit::PeakAnnotation fa;
         fa.charge = 1;
@@ -96,7 +96,7 @@ namespace OpenMS
         fa.intensity = 1;
         const String annotation_text = sit.first;
         fa.annotation = annotation_text;
-        fas.push_back(fa); 
+        fas.push_back(std::move(fa)); 
       }
     }
     return fas;
@@ -108,7 +108,7 @@ namespace OpenMS
     std::vector<PeptideHit::PeakAnnotation> sorted(as);
     stable_sort(sorted.begin(), sorted.end());
     String fas;
-    for (auto & a : sorted)
+    for (const auto & a : sorted)
     {
       fas += String("(") + String::number(a.mz, 3) + "," + String::number(100.0 * a.intensity, 1) + ",\"" + a.annotation + "\")";    
       if (&a != &sorted.back()) { fas += "|"; }     

--- a/src/openms/source/ANALYSIS/RNPXL/RNPxlReport.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/RNPxlReport.cpp
@@ -126,7 +126,7 @@ namespace OpenMS
     for (PeakMap::ConstIterator s_it = spectra.begin(); s_it != spectra.end(); ++s_it)
     {
       int scan_index = s_it - spectra.begin();
-     std::vector<Precursor> precursor = s_it->getPrecursors();
+      std::vector<Precursor> precursor = s_it->getPrecursors();
 
       // there should only one precursor and MS2 should contain at least a few peaks to be considered (e.g. at least for every AA in the peptide)
       if (s_it->getMSLevel() == 2 && precursor.size() == 1)
@@ -270,7 +270,7 @@ namespace OpenMS
             }
             else // place it anywhere
             {
-              for (auto a : aa)
+              for (auto a : aa) // NOTE: performs copy, this cannot possibly work!
               {
                 if (!a.isModified())
                 {

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -1193,7 +1193,7 @@ namespace OpenMS
 
     if (!matched_spec_linear_alpha.empty())
     {
-      for (auto match : matched_spec_linear_alpha)
+      for (const auto& match : matched_spec_linear_alpha)
       {
         iso_peaks_linear_alpha.push_back(num_iso_peaks_array[match.second]);
       }
@@ -1202,7 +1202,7 @@ namespace OpenMS
 
     if (!matched_spec_linear_beta.empty())
     {
-      for (auto match : matched_spec_linear_beta)
+      for (const auto& match : matched_spec_linear_beta)
       {
         iso_peaks_linear_beta.push_back(num_iso_peaks_array[match.second]);
       }
@@ -1211,7 +1211,7 @@ namespace OpenMS
 
     if (!matched_spec_xlinks_alpha.empty())
     {
-      for (auto match : matched_spec_xlinks_alpha)
+      for (const auto& match : matched_spec_xlinks_alpha)
       {
         iso_peaks_xlinks_alpha.push_back(num_iso_peaks_array[match.second]);
       }
@@ -1220,7 +1220,7 @@ namespace OpenMS
 
     if (!matched_spec_xlinks_beta.empty())
     {
-      for (auto match : matched_spec_xlinks_beta)
+      for (const auto& match : matched_spec_xlinks_beta)
       {
         iso_peaks_xlinks_beta.push_back(num_iso_peaks_array[match.second]);
       }

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -891,7 +891,7 @@ using namespace OpenMS;
 
             if (!matched_spec_linear_alpha.empty())
             {
-              for (auto match : matched_spec_linear_alpha)
+              for (const auto& match : matched_spec_linear_alpha)
               {
                 iso_peaks_linear_alpha.push_back(num_iso_peaks_array_linear[match.second]);
               }
@@ -900,7 +900,7 @@ using namespace OpenMS;
 
             if (!matched_spec_linear_beta.empty())
             {
-              for (auto match : matched_spec_linear_beta)
+              for (const auto& match : matched_spec_linear_beta)
               {
                 iso_peaks_linear_beta.push_back(num_iso_peaks_array_linear[match.second]);
               }
@@ -909,7 +909,7 @@ using namespace OpenMS;
 
             if (!matched_spec_xlinks_alpha.empty())
             {
-              for (auto match : matched_spec_xlinks_alpha)
+              for (const auto& match : matched_spec_xlinks_alpha)
               {
                 iso_peaks_xlinks_alpha.push_back(num_iso_peaks_array_xlinks[match.second]);
               }
@@ -921,7 +921,7 @@ using namespace OpenMS;
 
             if (!matched_spec_xlinks_beta.empty())
             {
-              for (auto match : matched_spec_xlinks_beta)
+              for (const auto& match : matched_spec_xlinks_beta)
               {
                 iso_peaks_xlinks_beta.push_back(num_iso_peaks_array_xlinks[match.second]);
               }

--- a/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
+++ b/src/openms/source/CHEMISTRY/EmpiricalFormula.cpp
@@ -98,7 +98,7 @@ namespace OpenMS
     {
       UInt non_trace_isotopes = 0;
       const auto& distr = element.first->getIsotopeDistribution();
-      for (auto isotope : distr)
+      for (const auto& isotope : distr)
       {
         if (isotope.getIntensity() != 0)
         {

--- a/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
+++ b/src/openms/source/CHEMISTRY/ISOTOPEDISTRIBUTION/IsoSpecWrapper.cpp
@@ -101,13 +101,13 @@ namespace OpenMS
     std::vector<std::vector<double> > isotopeMasses, isotopeProbabilities;
 
     // Iterate through all elements in the molecular formula
-    for (auto elem : formula)
+    for (const auto& elem : formula)
     {
       atomCounts.push_back(elem.second);
 
       std::vector<double> masses;
       std::vector<double> probs;
-      for (auto iso : elem.first->getIsotopeDistribution())
+      for (const auto& iso : elem.first->getIsotopeDistribution())
       {
         if (iso.getIntensity() <= 0.0) continue; // Note: there will be a segfault if one of the intensities is zero!
         masses.push_back(iso.getMZ());

--- a/src/openms/source/CHEMISTRY/NASequence.cpp
+++ b/src/openms/source/CHEMISTRY/NASequence.cpp
@@ -166,7 +166,7 @@ namespace OpenMS
 
     EmpiricalFormula our_form;
     // Add all the ribonucleotide masses
-    for (auto i : seq_)
+    for (const auto& i : seq_)
     {
       our_form += i->getFormula();
     }

--- a/src/openms/source/CHEMISTRY/NucleicAcidSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/NucleicAcidSpectrumGenerator.cpp
@@ -224,7 +224,7 @@ namespace OpenMS
 
     vector<double> ribo_masses(oligo.size());
     Size index = 0;
-    for (auto ribo : oligo)
+    for (const auto& ribo : oligo)
     {
       ribo_masses[index] = ribo.getMonoMass();
       ++index;

--- a/src/openms/source/COMPARISON/SPECTRA/SpectrumAlignmentScore.cpp
+++ b/src/openms/source/COMPARISON/SPECTRA/SpectrumAlignmentScore.cpp
@@ -102,7 +102,7 @@ namespace OpenMS
     double sum2(0);
     for (auto const & p : s2) { sum2 += pow(p.getIntensity(), 2); }
 
-    for (auto const ap : alignment)
+    for (auto const & ap : alignment)
     {
       const double mz_tolerance = is_relative_tolerance ? tolerance * s1[ap.first].getMZ() * 1e-6 : tolerance;
       const double mz_difference(fabs(s1[ap.first].getMZ() - s2[ap.second].getMZ()));

--- a/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/CsiFingerIdMzTabWriter.cpp
@@ -54,7 +54,7 @@ void CsiFingerIdMzTabWriter::read(const std::vector<String> & sirius_output_path
 
   CsiFingerIdMzTabWriter::CsiAdapterRun csi_result;
 
-  for (auto it : sirius_output_paths)
+  for (const auto& it : sirius_output_paths)
   {
    
     // extract mz, rt and nativeID of the corresponding precursor spectrum in the spectrum.ms file

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusMzTabWriter.cpp
@@ -57,7 +57,7 @@ void SiriusMzTabWriter::read(const std::vector<String> & sirius_output_paths,
 
   SiriusMzTabWriter::SiriusAdapterRun sirius_result;
 
-  for (auto it : sirius_output_paths)
+  for (const auto& it : sirius_output_paths)
   {
     // extract mz, rt and nativeID of the corresponding precursor spectrum in the spectrum.ms file
     String ext_nid;

--- a/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
@@ -962,7 +962,7 @@ namespace OpenMS
       String current_spectrum_light("");
       String current_spectrum_heavy("");
 
-      for (auto current_pep_id : *cpep_id_)
+      for (const auto& current_pep_id : *cpep_id_)
       {
         std::vector< PeptideHit > pep_hits = current_pep_id.getHits();
         if (pep_hits.size() < 1)

--- a/src/openms/source/FORMAT/MSstatsFile.cpp
+++ b/src/openms/source/FORMAT/MSstatsFile.cpp
@@ -265,7 +265,7 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename, ConsensusMap 
             frag_ions.insert(sm.begin(), sm.end());
             if (frag_ions.size() == 1)
             {
-              for (auto frag_ions_elem : frag_ions)
+              for (const auto& frag_ions_elem : frag_ions)
               {
                 fragment_ion = frag_ions_elem;
               }

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -644,7 +644,7 @@ namespace OpenMS
         s.substitute("ms_run[","").substitute("]","");
         vector<String> ms_run;
         s.split(',', ms_run);
-        for (auto a : ms_run)
+        for (auto& a : ms_run)
         {
           a.trim();
           mz_tab_metadata.assay[n].ms_run_ref.push_back(a.toInt());
@@ -657,7 +657,7 @@ namespace OpenMS
         s.substitute("assay[","").substitute("]","");
         vector<String> assays;
         s.split(',', assays);
-        for (auto a : assays)
+        for (auto& a : assays)
         {
           a.trim();
           mz_tab_metadata.study_variable[n].assay_refs.push_back(a.toInt());
@@ -671,7 +671,7 @@ namespace OpenMS
 
         vector<String> assays;
         s.split(',', assays);
-        for (auto a : assays)
+        for (auto& a : assays)
         {
           a.trim();
           mz_tab_metadata.study_variable[n].sample_refs.push_back(a.toInt());

--- a/src/openms/source/METADATA/ID/IdentificationData.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationData.cpp
@@ -282,7 +282,7 @@ namespace OpenMS
     {
       checkScoreTypes_(group.scores);
 
-      for (auto ref : group.parent_molecule_refs)
+      for (const auto& ref : group.parent_molecule_refs)
       {
         if (!isValidHashedReference_(ref, parent_molecule_lookup_))
         {
@@ -355,7 +355,7 @@ namespace OpenMS
   IdentificationData::MatchGroupRef
   IdentificationData::registerQueryMatchGroup(const QueryMatchGroup& group)
   {
-    for (auto ref : group.query_match_refs)
+    for (const auto& ref : group.query_match_refs)
     {
       if (!isValidHashedReference_(ref, query_match_lookup_))
       {

--- a/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationDataConverter.cpp
@@ -550,7 +550,7 @@ namespace OpenMS
               // @TODO: what if there are several scores?
               new_group.probability = group.scores.begin()->second;
             }
-            for (auto parent_ref : group.parent_molecule_refs)
+            for (const auto& parent_ref : group.parent_molecule_refs)
             {
               new_group.accessions.push_back(parent_ref->accession);
             }

--- a/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
@@ -235,9 +235,7 @@ namespace OpenMS
         it->setMetaValue("spectra_data", spectra_data);
       }
     }
-    for (auto it =
-          peptides.begin(); it !=
-          peptides.end(); ++it)
+    for (auto it = peptides.begin(); it != peptides.end(); ++it)
     {
       // spectrum reference already set? skip if we don't want to overwrite
       if (!override_spectra_references 

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -425,7 +425,7 @@ namespace OpenMS
     // same peptide sequence may be quantified based on internal and external
     // IDs if charge states differ!
     set<AASequence> quantified_internal, quantified_all;
-    for (auto const f : features)
+    for (const auto& f : features)
     {
       const PeptideIdentification& pep_id = f.getPeptideIdentifications()[0];
       const AASequence& seq = pep_id.getHits()[0].getSequence();

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -3557,7 +3557,7 @@ namespace OpenMS
 
     // Add spectra into a MSExperiment, sort and prepare it for display
     ExperimentSharedPtrType tmpe(new OpenMS::MSExperiment() );
-    for (auto s : im_map)
+    for (const auto& s : im_map)
     {
       tmpe->addSpectrum( *(s.second) );
     }

--- a/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewSpectraViewBehavior.cpp
@@ -204,7 +204,7 @@ namespace OpenMS
     // fix legend if its a chromatogram
     w->xAxis()->setLegend("Time [sec]");
 
-    for (auto index : indices)
+    for (const auto& index : indices)
     {
       if (layer.type == LayerData::DT_CHROMATOGRAM)
       {
@@ -340,7 +340,7 @@ namespace OpenMS
         widget_1d->canvas()->removeLayer(0); // remove layer 0 until there are no more layers
       }
 
-      for (auto index : indices)
+      for (const auto& index : indices)
       {
         ExperimentSharedPtrType chrom_exp_sptr = prepareChromatogram(index, exp_sptr, ondisc_sptr);
 

--- a/src/topp/CruxAdapter.cpp
+++ b/src/topp/CruxAdapter.cpp
@@ -305,7 +305,7 @@ protected:
       QStringList process_params;
       process_params << tool.toQString();
       params.split(' ', substrings);
-      for (auto s : substrings)
+      for (const auto& s : substrings)
       {
         process_params << s.toQString();
       }
@@ -355,7 +355,7 @@ protected:
       QStringList process_params;
       process_params << tool.toQString();
       params.split(' ', substrings);
-      for (auto s : substrings)
+      for (const auto& s : substrings)
       {
         process_params << s.toQString();
       }
@@ -401,7 +401,7 @@ protected:
       QStringList process_params;
       process_params << tool.toQString();
       params.split(' ', substrings);
-      for (auto s : substrings)
+      for (const auto& s : substrings)
       {
         process_params << s.toQString();
       }

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -194,7 +194,7 @@ void processDriftTimeStack(const std::vector<MSSpectrum>& stack, std::vector<MSS
       name += " (MS:1002815)";
     }
     fda.setName(name);
-    for (auto s : stack)
+    for (const auto& s : stack)
     {
       new_spec.insert(new_spec.end(), s.begin(), s.end());
       fda.insert(fda.end(), s.size(), s.getDriftTime());
@@ -261,7 +261,7 @@ void expandIMSpectrum(const MSSpectrum& tmps, std::vector<MSSpectrum>& result)
 
   // Add spectra to result, note that this is guaranteed to be
   // sorted by ion mobility (through std::map).
-  for (auto s : im_map)
+  for (const auto& s : im_map)
   {
     result.push_back(s.second);
   }

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -812,7 +812,7 @@ protected:
 
       // write peak types (centroided / profile mode)
       os << "Peak type metadata (estimated)\n";
-      for (auto const l : levels)
+      for (const auto& l : levels)
       {
         os << "  level " << l << ": "
            << SpectrumSettings::NamesOfSpectrumType[level_annotated_picked[l]] << " ("

--- a/src/topp/GNPSExport.cpp
+++ b/src/topp/GNPSExport.cpp
@@ -141,7 +141,7 @@ protected:
 
     // MSExperiment
     vector<MSExperiment> ms_maps;
-    for (auto mzml_file_path : mzml_file_paths)
+    for (const auto& mzml_file_path : mzml_file_paths)
     {
       MzMLFile mzml_file;
       MSExperiment map;
@@ -260,7 +260,7 @@ protected:
         // full spectra
         if (output_type == "full_spectra")
         {
-          for (auto peptide : peptides)
+          for (const auto& peptide : peptides)
           {
             feature_stream << "BEGIN IONS" << endl;
 

--- a/src/topp/IDMerger.cpp
+++ b/src/topp/IDMerger.cpp
@@ -339,8 +339,7 @@ protected:
         {
           peptides.insert(peptides.end(), peps.begin(), peps.end());
         }
-        for (auto map_it =
-               proteins_by_id.begin(); map_it != proteins_by_id.end(); ++map_it)
+        for (auto map_it = proteins_by_id.begin(); map_it != proteins_by_id.end(); ++map_it)
         {
           proteins.push_back(map_it->second);
         }

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -213,7 +213,7 @@ protected:
 
     // add modified ribos from database
     vector<String> all_mods;
-    for (auto r : *RibonucleotideDB::getInstance())
+    for (const auto& r : *RibonucleotideDB::getInstance())
     {
       if (r->isModified())
       {

--- a/src/utils/RNPxlSearch.cpp
+++ b/src/utils/RNPxlSearch.cpp
@@ -1639,7 +1639,7 @@ protected:
     // read list of nucleotides that can directly cross-link
     // these are responsible for shifted fragment ions. Their fragment adducts thus determine which shifts will be observed on b-,a-,y-ions
     String can_cross_link = getStringOption_("RNPxl:can_cross_link");
-    for (auto c : can_cross_link) { can_xl_.insert(c); }
+    for (const auto& c : can_cross_link) { can_xl_.insert(c); }
 
     StringList modifications = getStringList_("RNPxl:modifications");
 


### PR DESCRIPTION
fixes several instances of 

```
for (auto var : arr)
```

instead of the intended

```
for (const auto& var : arr)
```

as discussed in #4049 but only for now. Basically replacing the copy with a const-ref should have no side effects since it ensures that the const-ref is not modified. 

Found with
```
$ grep -R for src/openms | grep auto | grep -v begin | grep ":" | grep -v '&' | grep -v '//' | grep "for[ ]*(" 
```