### PR TITLE
columns for mz and rt for individual feature handles to mzTab

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MzTab.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTab.h
@@ -956,6 +956,7 @@ public:
       const String & filename,
       const bool export_unidentified_features,
       const bool export_unassigned_ids,
+      const bool export_subfeatures,
       String title = "ConsensusMap export from OpenMS");
 
   protected:

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -2655,6 +2655,7 @@ Not sure how to handle these:
       var_mods.insert(std::end(var_mods), std::begin(sp.variable_modifications), std::end(sp.variable_modifications));
       fixed_mods.insert(std::end(fixed_mods), std::begin(sp.fixed_modifications), std::end(sp.fixed_modifications));
     }
+    
     // make mods unique
     std::sort(var_mods.begin(), var_mods.end());
     auto v_it = std::unique(var_mods.begin(), var_mods.end()); 
@@ -2900,15 +2901,18 @@ Not sure how to handle these:
         row.peptide_abundance_std_error_study_variable[study_variable];
         row.peptide_abundance_study_variable[study_variable] = MzTabDouble(fit->getIntensity());
         
-        MzTabOptionalColumnEntry opt_global_mass_to_charge_study_variable;
-        opt_global_mass_to_charge_study_variable.first = "opt_global_mass_to_charge_study_variable[" + String(study_variable) + "]";
-        opt_global_mass_to_charge_study_variable.second = MzTabString(String(fit->getMZ()));
-        row.opt_.push_back(opt_global_mass_to_charge_study_variable);
+        if (export_subfeatures)
+        {
+	      MzTabOptionalColumnEntry opt_global_mass_to_charge_study_variable;
+	      opt_global_mass_to_charge_study_variable.first = "opt_global_mass_to_charge_study_variable[" + String(study_variable) + "]";
+	      opt_global_mass_to_charge_study_variable.second = MzTabString(String(fit->getMZ()));
+	      row.opt_.push_back(opt_global_mass_to_charge_study_variable);
 
-        MzTabOptionalColumnEntry opt_global_retention_time_study_variable;
-        opt_global_retention_time_study_variable.first = "opt_global_retention_time_study_variable[" + String(study_variable) + "]";
-        opt_global_retention_time_study_variable.second = MzTabString(String(fit->getRT()));
-        row.opt_.push_back(opt_global_retention_time_study_variable);
+	      MzTabOptionalColumnEntry opt_global_retention_time_study_variable;
+	      opt_global_retention_time_study_variable.first = "opt_global_retention_time_study_variable[" + String(study_variable) + "]";
+	      opt_global_retention_time_study_variable.second = MzTabString(String(fit->getRT()));
+	      row.opt_.push_back(opt_global_retention_time_study_variable);
+		}
       }
 
       vector<PeptideIdentification> pep_ids = c.getPeptideIdentifications();

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -2615,6 +2615,7 @@ Not sure how to handle these:
     const String& filename, 
     const bool export_unidentified_features,
     const bool export_unassigned_ids,
+    const bool export_subfeatures,
     String title)
   {  
     LOG_INFO << "exporting consensus map: \"" << filename << "\" to mzTab: " << std::endl;
@@ -2898,6 +2899,16 @@ Not sure how to handle these:
         row.peptide_abundance_stdev_study_variable[study_variable];
         row.peptide_abundance_std_error_study_variable[study_variable];
         row.peptide_abundance_study_variable[study_variable] = MzTabDouble(fit->getIntensity());
+        
+        MzTabOptionalColumnEntry opt_global_mass_to_charge_study_variable;
+        opt_global_mass_to_charge_study_variable.first = "opt_global_mass_to_charge_study_variable[" + String(study_variable) + "]";
+        opt_global_mass_to_charge_study_variable.second = MzTabString(String(fit->getMZ()));
+        row.opt_.push_back(opt_global_mass_to_charge_study_variable);
+
+        MzTabOptionalColumnEntry opt_global_retention_time_study_variable;
+        opt_global_retention_time_study_variable.first = "opt_global_retention_time_study_variable[" + String(study_variable) + "]";
+        opt_global_retention_time_study_variable.second = MzTabString(String(fit->getRT()));
+        row.opt_.push_back(opt_global_retention_time_study_variable);
       }
 
       vector<PeptideIdentification> pep_ids = c.getPeptideIdentifications();

--- a/src/openms/source/FORMAT/MzTabFile.cpp
+++ b/src/openms/source/FORMAT/MzTabFile.cpp
@@ -2888,7 +2888,7 @@ namespace OpenMS
       if (has_ms_run_level_scores) { search_ms_runs = ms_runs; }
     }
     Size n_search_engine_score = peptide_section[0].search_engine_score_ms_run.size();
-    Size n_best_search_engine_score = mz_tab.getMetaData().peptide_search_engine_score.size();
+    Size n_best_search_engine_score = peptide_section[0].best_search_engine_score.size();
 
     out.push_back(generateMzTabPeptideHeader_(search_ms_runs, n_best_search_engine_score, n_search_engine_score, assays, study_variables, mz_tab.getPeptideOptionalColumnNames()));
       generateMzTabSection_(mz_tab.getPeptideSectionRows(), mz_tab.getPeptideOptionalColumnNames(), out);

--- a/src/topp/MzTabExporter.cpp
+++ b/src/topp/MzTabExporter.cpp
@@ -120,7 +120,9 @@ protected:
       registerFlag_("first_run_inference_only", "(idXML/mzid only): Does the first IdentificationRun in the file "
                                                 "only represent inference results? Read peptide information only "
                                                 "from second to last runs.");
-          }
+      registerStringList_("opt_columns", "<mods>", {"subfeatures"}, "Add optional columns which are not part of the mzTab standard.", false);
+      setValidStrings_("opt_columns", {"subfeatures"});
+    }
 
     ExitCodes main_(int, const char**) override
     {
@@ -129,6 +131,9 @@ protected:
       FileTypes::Type in_type = FileHandler().getType(in);
 
       String out = getStringOption_("out");
+      
+      StringList optional_columns = getStringList_("opt_columns");
+      bool export_subfeatures = ListUtils::contains(optional_columns, "subfeatures");
 
       MzTab mztab;
 
@@ -148,7 +153,7 @@ protected:
 
         for (Size i = 0; i < feature_map.size(); ++i) // collect all (assigned and unassigned to a feature) peptide ids
         {
-          vector<PeptideIdentification> pep_ids_bf = feature_map[i].getPeptideIdentifications();
+          const vector<PeptideIdentification>& pep_ids_bf = feature_map[i].getPeptideIdentifications();
           pep_ids.insert(pep_ids.end(), pep_ids_bf.begin(), pep_ids_bf.end());
         }
 
@@ -196,7 +201,7 @@ protected:
         ConsensusMap consensus_map;
         ConsensusXMLFile c;
         c.load(in, consensus_map);
-        mztab = MzTab::exportConsensusMapToMzTab(consensus_map, in, true, true);
+        mztab = MzTab::exportConsensusMapToMzTab(consensus_map, in, true, true, export_subfeatures);
       }
 
       MzTabFile().store(out, mztab);


### PR DESCRIPTION
When exporting `consensusXML` to `mzTab`, the *individual peptide intensities* for each study variable i.e. map are exported but not their position. With this PR, the individual `m/z` and `RT` are now exported as well. In addition, a missing column header for *best search engine scores* is fixed.

Resubmits #4047.
Resolves #3705. 

