### PR TITLE
style: rename LogStream macros to avoid name clashes

### DIFF
--- a/doc/OpenMS_tutorial/OpenMS_Tutorial.doxygen
+++ b/doc/OpenMS_tutorial/OpenMS_Tutorial.doxygen
@@ -450,15 +450,15 @@ http://www.psidev.info/
 @subsection tutorial_logging Logging
 To make direct output to std::out and std::err more consistent, %OpenMS provides several low-level macros:
 <br>
-LOG_FATAL_ERROR, 
+OPENMS_LOG_FATAL_ERROR, 
 <br>
-LOG_ERROR
+OPENMS_LOG_ERROR
 <br>
-LOG_WARN,
+OPENMS_LOG_WARN,
 <br>
-LOG_INFO and
-<br
->LOG_DEBUG
+OPENMS_LOG_INFO and
+<br>
+OPENMS_LOG_DEBUG
 <br>
 which should be used instead of the less descriptive std::out and std::err streams. 
 

--- a/doc/code_examples/Tutorial_Final.cpp
+++ b/doc/code_examples/Tutorial_Final.cpp
@@ -122,7 +122,7 @@ protected:
 
  //! [Functionality_1]
 
-   LOG_INFO << "Protein IDs: " << id_accessions.size() << endl;
+   OPENMS_LOG_INFO << "Protein IDs: " << id_accessions.size() << endl;
 
  //! [Functionality_2]
 
@@ -197,7 +197,7 @@ protected:
        return ILLEGAL_PARAMETERS;
      }
 
-     LOG_INFO << "Identifications: " << ids.size() << endl;
+     OPENMS_LOG_INFO << "Identifications: " << ids.size() << endl;
 
      // run filter
      filterByProteinIDs_(db, peptide_identifications, whitelist, db_new);
@@ -207,7 +207,7 @@ protected:
    // writing output
    //-------------------------------------------------------------
 
-   LOG_INFO << "Database entries (before / after): " << db.size() << " / " << db_new.size() << endl;
+   OPENMS_LOG_INFO << "Database entries (before / after): " << db.size() << " / " << db_new.size() << endl;
    //! [output]  
 
    FASTAFile().store(out, db_new);

--- a/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/AccurateMassSearchEngine.h
@@ -310,7 +310,7 @@ private:
             if (pols[0] == "positive" || pols[0] == "negative")
             {
               ion_mode_internal = pols[0];
-              LOG_INFO << "Setting auto ion-mode to '" << ion_mode_internal << "' for file " << File::basename(map.getLoadedFilePath()) << std::endl;
+              OPENMS_LOG_INFO << "Setting auto ion-mode to '" << ion_mode_internal << "' for file " << File::basename(map.getLoadedFilePath()) << std::endl;
             }
             else ion_mode_detect_msg = String("Meta value 'scan_polarity' does not contain unknown ion mode") + String(map[0].getMetaValue("scan_polarity"));
           }
@@ -326,7 +326,7 @@ private:
       }
       else
       { // do nothing, since map is
-        LOG_INFO << "Meta value 'scan_polarity' cannot be determined since (Consensus-)Feature map is empty!" << std::endl;
+        OPENMS_LOG_INFO << "Meta value 'scan_polarity' cannot be determined since (Consensus-)Feature map is empty!" << std::endl;
       }
 
       if (ion_mode_detect_msg.size() > 0)

--- a/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/PeptideIndexing.h
@@ -200,13 +200,13 @@ public:
         }
         else if (!is_decoy_string_auto_successful && !contains_decoys_)
         {
-          LOG_WARN << "Unable to determine decoy string automatically, not enough decoys were detected! Using default " << (prefix_ ? "prefix" : "suffix") << " decoy string '" << decoy_string_ << "\n"
+          OPENMS_LOG_WARN << "Unable to determine decoy string automatically, not enough decoys were detected! Using default " << (prefix_ ? "prefix" : "suffix") << " decoy string '" << decoy_string_ << "\n"
                    << "If you think that this is false, please provide a decoy_string and its position manually!" << std::endl;
         }
         else
         {
           // decoy string and position was extracted successfully
-          LOG_INFO << "Using " << (prefix_ ? "prefix" : "suffix") << " decoy string '" << decoy_string_ << "'" << std::endl;
+          OPENMS_LOG_INFO << "Using " << (prefix_ ? "prefix" : "suffix") << " decoy string '" << decoy_string_ << "'" << std::endl;
         }
 
         proteins.reset();
@@ -244,7 +244,7 @@ public:
       // solely MSGFPlus -> Trypsin P as enzyme
       if (msgfplus_fix_parameters && enzyme.getEnzymeName() == "Trypsin")
       {
-        LOG_WARN << "MSGFPlus detected but enzyme cutting rules were set to Trypsin. Correcting to Trypsin/P to copy with special cutting rule in MSGFPlus." << std::endl;
+        OPENMS_LOG_WARN << "MSGFPlus detected but enzyme cutting rules were set to Trypsin. Correcting to Trypsin/P to copy with special cutting rule in MSGFPlus." << std::endl;
         enzyme.setEnzyme("Trypsin/P");
       }
 
@@ -260,13 +260,13 @@ public:
 
       if (proteins.empty()) // we do not allow an empty database
       {
-        LOG_ERROR << "Error: An empty database was provided. Mapping makes no sense. Aborting..." << std::endl;
+        OPENMS_LOG_ERROR << "Error: An empty database was provided. Mapping makes no sense. Aborting..." << std::endl;
         return DATABASE_EMPTY;
       }
 
       if (pep_ids.empty()) // Aho-Corasick requires non-empty input; but we allow this case, since the TOPP tool should not crash when encountering a bad raw file (with no PSMs)
       {
-        LOG_WARN << "Warning: An empty set of peptide identifications was provided. Output will be empty as well." << std::endl;
+        OPENMS_LOG_WARN << "Warning: An empty set of peptide identifications was provided. Output will be empty as well." << std::endl;
         if (!keep_unreferenced_proteins_)
         {
           // delete only protein hits, not whole ID runs incl. meta data:
@@ -306,7 +306,7 @@ public:
             String seq = it2->getSequence().toUnmodifiedString().remove('*'); // make a copy, i.e. do NOT change the peptide sequence!
             if (seqan::isAmbiguous(seqan::AAString(seq.c_str())))
             { // do not quit here, to show the user all sequences .. only quit after loop
-              LOG_ERROR << "Peptide sequence '" << it2->getSequence() << "' contains one or more ambiguous amino acids (B|J|Z|X).\n";
+              OPENMS_LOG_ERROR << "Peptide sequence '" << it2->getSequence() << "' contains one or more ambiguous amino acids (B|J|Z|X).\n";
               has_illegal_AAs = true;
             }
             if (IL_equivalent_) // convert L to I;
@@ -318,30 +318,30 @@ public:
         }
         if (has_illegal_AAs)
         {
-          LOG_ERROR << "One or more peptides contained illegal amino acids. This is not allowed!"
+          OPENMS_LOG_ERROR << "One or more peptides contained illegal amino acids. This is not allowed!"
                     << "\nPlease either remove the peptide or replace it with one of the unambiguous ones (while allowing for ambiguous AA's to match the protein)." << std::endl;;
         }
 
-        LOG_INFO << "Mapping " << length(pep_DB) << " peptides to " << (proteins.size() == PROTEIN_CACHE_SIZE ? "? (unknown number of)" : String(proteins.size()))  << " proteins." << std::endl;
+        OPENMS_LOG_INFO << "Mapping " << length(pep_DB) << " peptides to " << (proteins.size() == PROTEIN_CACHE_SIZE ? "? (unknown number of)" : String(proteins.size()))  << " proteins." << std::endl;
 
         if (length(pep_DB) == 0)
         { // Aho-Corasick will crash if given empty needles as input
-          LOG_WARN << "Warning: Peptide identifications have no hits inside! Output will be empty as well." << std::endl;
+          OPENMS_LOG_WARN << "Warning: Peptide identifications have no hits inside! Output will be empty as well." << std::endl;
           return PEPTIDE_IDS_EMPTY;
         }
 
         /*
            Aho Corasick (fast)
         */
-        LOG_INFO << "Searching with up to " << aaa_max_ << " ambiguous amino acid(s) and " << mm_max_ << " mismatch(es)!" << std::endl;
+        OPENMS_LOG_INFO << "Searching with up to " << aaa_max_ << " ambiguous amino acid(s) and " << mm_max_ << " mismatch(es)!" << std::endl;
         SysInfo::MemUsage mu;
-        LOG_INFO << "Building trie ...";
+        OPENMS_LOG_INFO << "Building trie ...";
         StopWatch s;
         s.start();
         AhoCorasickAmbiguous::FuzzyACPattern pattern;
         AhoCorasickAmbiguous::initPattern(pep_DB, aaa_max_, mm_max_, pattern);
         s.stop();
-        LOG_INFO << " done (" << int(s.getClockTime()) << "s)" << std::endl;
+        OPENMS_LOG_INFO << " done (" << int(s.getClockTime()) << "s)" << std::endl;
         s.reset();
 
         uint16_t count_j_proteins(0);
@@ -478,15 +478,15 @@ public:
         mu.after();
         std::cout << mu.delta("Aho-Corasick") << "\n\n";
 
-        LOG_INFO << "\nAho-Corasick done:\n  found " << func.filter_passed << " hits for " << func.pep_to_prot.size() << " of " << length(pep_DB) << " peptides.\n";
+        OPENMS_LOG_INFO << "\nAho-Corasick done:\n  found " << func.filter_passed << " hits for " << func.pep_to_prot.size() << " of " << length(pep_DB) << " peptides.\n";
 
         // write some stats
-        LOG_INFO << "Peptide hits passing enzyme filter: " << func.filter_passed << "\n"
+        OPENMS_LOG_INFO << "Peptide hits passing enzyme filter: " << func.filter_passed << "\n"
                  << "     ... rejected by enzyme filter: " << func.filter_rejected << std::endl;
 
         if (count_j_proteins)
         {
-          LOG_WARN << "PeptideIndexer found " << count_j_proteins << " protein sequences in your database containing the amino acid 'J'."
+          OPENMS_LOG_WARN << "PeptideIndexer found " << count_j_proteins << " protein sequences in your database containing the amino acid 'J'."
             << "To match 'J' in a protein, an ambiguous amino acid placeholder for I/L will be used.\n"
             << "This costs runtime and eats into the 'aaa_max' limit, leaving less opportunity for B/Z/X matches.\n"
             << "If you want 'J' to be treated as unambiguous, enable '-IL_equivalent'!" << std::endl;
@@ -586,8 +586,8 @@ public:
           {
             it2->setMetaValue("protein_references", "unmatched");
             ++stats_unmatched;
-            if (stats_unmatched < 15) LOG_INFO << "Unmatched peptide: " << it2->getSequence() << "\n";
-            else if (stats_unmatched == 15) LOG_INFO << "Unmatched peptide: ...\n";
+            if (stats_unmatched < 15) OPENMS_LOG_INFO << "Unmatched peptide: " << it2->getSequence() << "\n";
+            else if (stats_unmatched == 15) OPENMS_LOG_INFO << "Unmatched peptide: ...\n";
           }
 
           ++pep_idx; // next hit
@@ -596,19 +596,19 @@ public:
       }
 
       Size total_peptides = stats_count_m_t + stats_count_m_d + stats_count_m_td + stats_unmatched;
-      LOG_INFO << "-----------------------------------\n";
-      LOG_INFO << "Peptide statistics\n";
-      LOG_INFO << "\n";
-      LOG_INFO << "  unmatched                : " << stats_unmatched << " (" << stats_unmatched * 100 / total_peptides << " %)\n";
-      LOG_INFO << "  target/decoy:\n";
-      LOG_INFO << "    match to target DB only: " << stats_count_m_t << " (" << stats_count_m_t * 100 / total_peptides << " %)\n";
-      LOG_INFO << "    match to decoy DB only : " << stats_count_m_d << " (" << stats_count_m_d * 100 / total_peptides << " %)\n";
-      LOG_INFO << "    match to both          : " << stats_count_m_td << " (" << stats_count_m_td * 100 / total_peptides << " %)\n";
-      LOG_INFO << "\n";
-      LOG_INFO << "  mapping to proteins:\n";
-      LOG_INFO << "    no match (to 0 protein)         : " << stats_unmatched << "\n";
-      LOG_INFO << "    unique match (to 1 protein)     : " << stats_matched_unique << "\n";
-      LOG_INFO << "    non-unique match (to >1 protein): " << stats_matched_multi << std::endl;
+      OPENMS_LOG_INFO << "-----------------------------------\n";
+      OPENMS_LOG_INFO << "Peptide statistics\n";
+      OPENMS_LOG_INFO << "\n";
+      OPENMS_LOG_INFO << "  unmatched                : " << stats_unmatched << " (" << stats_unmatched * 100 / total_peptides << " %)\n";
+      OPENMS_LOG_INFO << "  target/decoy:\n";
+      OPENMS_LOG_INFO << "    match to target DB only: " << stats_count_m_t << " (" << stats_count_m_t * 100 / total_peptides << " %)\n";
+      OPENMS_LOG_INFO << "    match to decoy DB only : " << stats_count_m_d << " (" << stats_count_m_d * 100 / total_peptides << " %)\n";
+      OPENMS_LOG_INFO << "    match to both          : " << stats_count_m_td << " (" << stats_count_m_td * 100 / total_peptides << " %)\n";
+      OPENMS_LOG_INFO << "\n";
+      OPENMS_LOG_INFO << "  mapping to proteins:\n";
+      OPENMS_LOG_INFO << "    no match (to 0 protein)         : " << stats_unmatched << "\n";
+      OPENMS_LOG_INFO << "    unique match (to 1 protein)     : " << stats_matched_unique << "\n";
+      OPENMS_LOG_INFO << "    non-unique match (to >1 protein): " << stats_matched_multi << std::endl;
 
       /// for proteins --> peptides
       Size stats_matched_proteins(0), stats_matched_new_proteins(0), stats_orphaned_proteins(0), stats_proteins_target(0), stats_proteins_decoy(0);
@@ -676,18 +676,18 @@ public:
       }
 
 
-      LOG_INFO << "-----------------------------------\n";
-      LOG_INFO << "Protein statistics\n";
-      LOG_INFO << "\n";
-      LOG_INFO << "  total proteins searched: " << proteins.size() << "\n";
-      LOG_INFO << "  matched proteins       : " << stats_matched_proteins << " (" << stats_matched_new_proteins << " new)\n";
+      OPENMS_LOG_INFO << "-----------------------------------\n";
+      OPENMS_LOG_INFO << "Protein statistics\n";
+      OPENMS_LOG_INFO << "\n";
+      OPENMS_LOG_INFO << "  total proteins searched: " << proteins.size() << "\n";
+      OPENMS_LOG_INFO << "  matched proteins       : " << stats_matched_proteins << " (" << stats_matched_new_proteins << " new)\n";
       if (stats_matched_proteins)
       { // prevent Division-by-0 Exception
-        LOG_INFO << "  matched target proteins: " << stats_proteins_target << " (" << stats_proteins_target * 100 / stats_matched_proteins << " %)\n";
-        LOG_INFO << "  matched decoy proteins : " << stats_proteins_decoy << " (" << stats_proteins_decoy * 100 / stats_matched_proteins << " %)\n";
+        OPENMS_LOG_INFO << "  matched target proteins: " << stats_proteins_target << " (" << stats_proteins_target * 100 / stats_matched_proteins << " %)\n";
+        OPENMS_LOG_INFO << "  matched decoy proteins : " << stats_proteins_decoy << " (" << stats_proteins_decoy * 100 / stats_matched_proteins << " %)\n";
       }
-      LOG_INFO << "  orphaned proteins      : " << stats_orphaned_proteins << (keep_unreferenced_proteins_ ? " (all kept)" : " (all removed)\n");
-      LOG_INFO << "-----------------------------------" << std::endl;
+      OPENMS_LOG_INFO << "  orphaned proteins      : " << stats_orphaned_proteins << (keep_unreferenced_proteins_ ? " (all kept)" : " (all removed)\n");
+      OPENMS_LOG_INFO << "-----------------------------------" << std::endl;
 
 
       /// exit if no peptides were matched to decoy
@@ -695,7 +695,7 @@ public:
 
       if (invalid_protein_sequence)
       {
-        LOG_ERROR << "Error: One or more protein sequences contained the characters '[' or '(', which are illegal in protein sequences."
+        OPENMS_LOG_ERROR << "Error: One or more protein sequences contained the characters '[' or '(', which are illegal in protein sequences."
                  << "\nPeptide hits might be masked by these characters (which usually indicate presence of modifications).\n";
         has_error = true;
       }
@@ -705,12 +705,12 @@ public:
         String msg("No peptides were matched to the decoy portion of the database! Did you provide the correct concatenated database? Are your 'decoy_string' (=" + String(decoy_string_) + ") and 'decoy_string_position' (=" + String(param_.getValue("decoy_string_position")) + ") settings correct?");
         if (missing_decoy_action_ == "error")
         {
-          LOG_ERROR << "Error: " << msg << "\nSet 'missing_decoy_action' to 'warn' if you are sure this is ok!\nAborting ..." << std::endl;
+          OPENMS_LOG_ERROR << "Error: " << msg << "\nSet 'missing_decoy_action' to 'warn' if you are sure this is ok!\nAborting ..." << std::endl;
           has_error = true;
         }
         else if (missing_decoy_action_ == "warn")
         {
-          LOG_WARN << "Warn: " << msg << "\nSet 'missing_decoy_action' to 'error' if you want to elevate this to an error!" << std::endl;
+          OPENMS_LOG_WARN << "Warn: " << msg << "\nSet 'missing_decoy_action' to 'error' if you want to elevate this to an error!" << std::endl;
         }
         else // silent
         {
@@ -719,7 +719,7 @@ public:
 
       if ((!allow_unmatched_) && (stats_unmatched > 0))
       {
-        LOG_ERROR << "PeptideIndexer found unmatched peptides, which could not be associated to a protein.\n"
+        OPENMS_LOG_ERROR << "PeptideIndexer found unmatched peptides, which could not be associated to a protein.\n"
                   << "Potential solutions:\n"
                   << "   - check your FASTA database for completeness\n"
                   << "   - set 'enzyme:specificity' to match the identification parameters of the search engine\n"
@@ -733,7 +733,7 @@ public:
 
       if (has_error)
       {
-        LOG_ERROR << "Result files will be written, but PeptideIndexer will exit with an error code." << std::endl;
+        OPENMS_LOG_ERROR << "Result files will be written, but PeptideIndexer will exit with an error code." << std::endl;
         return UNEXPECTED_RESULT;
       }
       return EXECUTION_OK;
@@ -826,7 +826,7 @@ public:
        }
 
        // DEBUG ONLY: print counts of found decoys
-       for (auto &a : decoy_count) LOG_DEBUG << a.first << "\t" << a.second.first << "\t" << a.second.second << std::endl;
+       for (auto &a : decoy_count) OPENMS_LOG_DEBUG << a.first << "\t" << a.second.first << "\t" << a.second.second << std::endl;
 
        // less than 40% of proteins are decoys -> won't be able to determine a decoy string and its position
        // return default values
@@ -840,7 +840,7 @@ public:
 
        if (all_prefix_occur == all_suffix_occur)
        {
-         LOG_ERROR << "Unable to determine decoy string!" << std::endl;
+         OPENMS_LOG_ERROR << "Unable to determine decoy string!" << std::endl;
          return false;
        }
 
@@ -859,8 +859,8 @@ public:
 
            if (prefix_suffix_counts.first != all_prefix_occur)
            {
-             LOG_WARN << "More than one decoy prefix observed!" << std::endl;
-             LOG_WARN << "Using most frequent decoy prefix (" << (int) (freq_prefix * 100) <<"%)" << std::endl;
+             OPENMS_LOG_WARN << "More than one decoy prefix observed!" << std::endl;
+             OPENMS_LOG_WARN << "Using most frequent decoy prefix (" << (int) (freq_prefix * 100) <<"%)" << std::endl;
            }
 
            return true;
@@ -882,15 +882,15 @@ public:
 
            if (prefix_suffix_counts.second != all_suffix_occur)
            {
-             LOG_WARN << "More than one decoy suffix observed!" << std::endl;
-             LOG_WARN << "Using most frequent decoy suffix (" << (int) (freq_suffix * 100) <<"%)" << std::endl;
+             OPENMS_LOG_WARN << "More than one decoy suffix observed!" << std::endl;
+             OPENMS_LOG_WARN << "Using most frequent decoy suffix (" << (int) (freq_suffix * 100) <<"%)" << std::endl;
            }
 
            return true;
          }
        }
 
-       LOG_ERROR << "Unable to determine decoy string and its position. Please provide a decoy string and its position as parameters." << std::endl;
+       OPENMS_LOG_ERROR << "Unable to determine decoy string and its position. Please provide a decoy string and its position as parameters." << std::endl;
        return false;
      }
 

--- a/src/openms/include/OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h
+++ b/src/openms/include/OpenMS/ANALYSIS/ID/SiriusAdapterAlgorithm.h
@@ -101,7 +101,7 @@ namespace OpenMS
       /**
       @brief logs number of features and spectra used
 
-      Prints the number of features and spectra used (LOG_INFO)
+      Prints the number of features and spectra used (OPENMS_LOG_INFO)
 
       @param featureinfo: Path to featureXML
       @param feature_mapping: FeatureToMs2Indices with feature mapping

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ConfidenceScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/ConfidenceScoring.h
@@ -185,7 +185,7 @@ namespace OpenMS
         }
         if (n_assays - 1 < n_decoys_)
         {
-          LOG_WARN << "Warning: Parameter 'decoys' (" << n_decoys_ 
+          OPENMS_LOG_WARN << "Warning: Parameter 'decoys' (" << n_decoys_ 
                    << ") is higher than the number of unrelated assays in the "
                    << "library (" << n_assays - 1 << "). "
                    << "Using all unrelated assays as decoys." << std::endl;
@@ -196,14 +196,14 @@ namespace OpenMS
         for (Size i = 0; i < n_assays; ++i) decoy_index_[i] = boost::numeric_cast<Int>(i);
 
         // build mapping between assays and transitions:
-        LOG_DEBUG << "Building transition map..." << std::endl;
+        OPENMS_LOG_DEBUG << "Building transition map..." << std::endl;
         for (Size i = 0; i < library_.getTransitions().size(); ++i)
         {
           const String& ref = library_.getTransitions()[i].getPeptideRef();
           transition_map_[ref].push_back(boost::numeric_cast<Int>(i));
         }
         // find min./max. RT in the library:
-        LOG_DEBUG << "Determining retention time range..." << std::endl;
+        OPENMS_LOG_DEBUG << "Determining retention time range..." << std::endl;
         rt_norm_.min_rt = std::numeric_limits<double>::infinity();
         rt_norm_.max_rt = -std::numeric_limits<double>::infinity();
         for (std::vector<TargetedExperiment::Peptide>::const_iterator it = 
@@ -217,13 +217,13 @@ namespace OpenMS
         }
 
         // log scoring progress:
-        LOG_DEBUG << "Scoring features..." << std::endl;
+        OPENMS_LOG_DEBUG << "Scoring features..." << std::endl;
         startProgress(0, features.size(), "scoring features");
 
         for (FeatureMap::Iterator feat_it = features.begin(); 
              feat_it != features.end(); ++feat_it)
         {
-          LOG_DEBUG << "Feature " << feat_it - features.begin() + 1 
+          OPENMS_LOG_DEBUG << "Feature " << feat_it - features.begin() + 1 
                     << " (ID '" << feat_it->getUniqueId() << "')"<< std::endl;
           scoreFeature_(*feat_it);
           setProgress(feat_it - features.begin());

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.h
@@ -226,7 +226,7 @@ public:
       double best_left = picked_chroms[chr_idx].getFloatDataArrays()[PeakPickerMRM::IDX_LEFTBORDER][peak_idx];
       double best_right = picked_chroms[chr_idx].getFloatDataArrays()[PeakPickerMRM::IDX_RIGHTBORDER][peak_idx];
       double peak_apex = picked_chroms[chr_idx][peak_idx].getRT();
-      LOG_DEBUG << "**** Creating MRMFeature for peak " << chr_idx << " " << peak_idx << " " <<
+      OPENMS_LOG_DEBUG << "**** Creating MRMFeature for peak " << chr_idx << " " << peak_idx << " " <<
         picked_chroms[chr_idx][peak_idx] << " with borders " << best_left << " " <<
         best_right << " (" << best_right - best_left << ")" << std::endl;
 
@@ -851,7 +851,7 @@ protected:
 
       // Check how many chromatograms had exactly one peak picked between our
       // current left/right borders -> this would be a sign of consistency.
-      LOG_DEBUG << " Overall found missing : " << missing_peaks << " and multiple : " << multiple_peaks << std::endl;
+      OPENMS_LOG_DEBUG << " Overall found missing : " << missing_peaks << " and multiple : " << multiple_peaks << std::endl;
 
       /// left_borders / right_borders might not have the same length since we might have peaks missing!!
 
@@ -859,7 +859,7 @@ protected:
       // the same element has a bad shape and a bad coelution score) -> potential outlier
       if (min_index_shape == max_index_coel)
       {
-        LOG_DEBUG << " element " << min_index_shape << " is a candidate for removal ... " << std::endl;
+        OPENMS_LOG_DEBUG << " element " << min_index_shape << " is a candidate for removal ... " << std::endl;
         outlier = String(picked_chroms[min_index_shape].getNativeID());
       }
       else
@@ -878,7 +878,7 @@ protected:
 
       double score = shape_score - coel_score - 1.0 * missing_peaks / picked_chroms.size();
 
-      LOG_DEBUG << " computed score  " << score << " (from " <<  shape_score << 
+      OPENMS_LOG_DEBUG << " computed score  " << score << " (from " <<  shape_score << 
         " - " << coel_score << " - " << 1.0 * missing_peaks / picked_chroms.size() << ")" << std::endl;
 
       return score;
@@ -923,8 +923,8 @@ protected:
         {
           left_borders.push_back(left);
           right_borders.push_back(right);
-          LOG_DEBUG << " * " << k << " left boundary " << left_borders.back()   <<  " with int " << max_int << std::endl;
-          LOG_DEBUG << " * " << k << " right boundary " << right_borders.back() <<  " with int " << max_int << std::endl;
+          OPENMS_LOG_DEBUG << " * " << k << " left boundary " << left_borders.back()   <<  " with int " << max_int << std::endl;
+          OPENMS_LOG_DEBUG << " * " << k << " right boundary " << right_borders.back() <<  " with int " << max_int << std::endl;
         }
       }
 
@@ -952,7 +952,7 @@ protected:
                                / right_borders.size() - mean * mean);
       std::sort(right_borders.begin(), right_borders.end());
 
-      LOG_DEBUG << " - Recalculating right peak boundaries " << mean << " mean / best " 
+      OPENMS_LOG_DEBUG << " - Recalculating right peak boundaries " << mean << " mean / best " 
                 << best_right << " std " << stdev << " : "  << std::fabs(best_right - mean) / stdev 
                 << " coefficient of variation" << std::endl;
 
@@ -960,7 +960,7 @@ protected:
       if (std::fabs(best_right - mean) / stdev > max_z)
       {
         best_right = right_borders[right_borders.size() / 2]; // pseudo median
-        LOG_DEBUG << " - Setting right boundary to  " << best_right << std::endl;
+        OPENMS_LOG_DEBUG << " - Setting right boundary to  " << best_right << std::endl;
       }
 
       // Left borders
@@ -969,7 +969,7 @@ protected:
                         / left_borders.size() - mean * mean);
       std::sort(left_borders.begin(), left_borders.end());
 
-      LOG_DEBUG << " - Recalculating left peak boundaries " << mean << " mean / best " 
+      OPENMS_LOG_DEBUG << " - Recalculating left peak boundaries " << mean << " mean / best " 
                 << best_left << " std " << stdev << " : "  << std::fabs(best_left - mean) / stdev 
                 << " coefficient of variation" << std::endl;
 
@@ -977,7 +977,7 @@ protected:
       if (std::fabs(best_left - mean)  / stdev > max_z)
       {
         best_left = left_borders[left_borders.size() / 2]; // pseudo median
-        LOG_DEBUG << " - Setting left boundary to  " << best_left << std::endl;
+        OPENMS_LOG_DEBUG << " - Setting left boundary to  " << best_left << std::endl;
       }
 
     }

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/PeakIntegrator.h
@@ -560,7 +560,7 @@ protected:
       std::function<double(const double, const double)>
       compute_peak_area_intensity_sum = [&p](const double left, const double right)
       {
-        // LOG_WARN << "WARNING: intensity_sum method is being used." << std::endl;
+        // OPENMS_LOG_WARN << "WARNING: intensity_sum method is being used." << std::endl;
         double peak_area { 0.0 };
         for (typename PeakContainerT::ConstIterator it = p.PosBegin(left); it != p.PosEnd(right); ++it)
         {
@@ -593,7 +593,7 @@ protected:
       {
         if (n_points == 2)
         {
-          LOG_WARN << std::endl << "PeakIntegrator::integratePeak:"
+          OPENMS_LOG_WARN << std::endl << "PeakIntegrator::integratePeak:"
             "number of points is 2, falling back to `trapezoid`." << std::endl;
           pa.area = compute_peak_area_trapezoid(left, right);
         }

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.h
@@ -149,7 +149,7 @@ public:
         {
           bs_library_.emplace_back(s, bin_size_, false, peak_spread_, bin_offset_);
         }
-        LOG_INFO << "The library contains " << bs_library_.size() << " spectra." << std::endl;
+        OPENMS_LOG_INFO << "The library contains " << bs_library_.size() << " spectra." << std::endl;
       }
     private:
       BinnedSpectralContrastAngle cmp_bs_;

--- a/src/openms/include/OpenMS/APPLICATIONS/OpenSwathBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/OpenSwathBase.h
@@ -186,7 +186,7 @@ protected:
 
     for (Size i = 0; i < swath_maps.size(); i++)
     {
-      LOG_DEBUG << "Found swath map " << i
+      OPENMS_LOG_DEBUG << "Found swath map " << i
         << " with lower " << swath_maps[i].lower
         << " and upper " << swath_maps[i].upper
         << " and " << swath_maps[i].sptr->getNrSpectra()
@@ -209,14 +209,14 @@ protected:
     {
       double lower_map_end = sw_windows[i-1].second - min_upper_edge_dist;
       double upper_map_start = sw_windows[i].first;
-      LOG_DEBUG << "Extraction will go up to " << lower_map_end << " and continue at " << upper_map_start << std::endl;
+      OPENMS_LOG_DEBUG << "Extraction will go up to " << lower_map_end << " and continue at " << upper_map_start << std::endl;
 
       if (upper_map_start - lower_map_end > 0.01)
       {
-        LOG_WARN << "Extraction will have a gap between " << lower_map_end << " and " << upper_map_start << std::endl;
+        OPENMS_LOG_WARN << "Extraction will have a gap between " << lower_map_end << " and " << upper_map_start << std::endl;
         if (!force)
         {
-          LOG_ERROR << "Extraction windows have a gap. Will abort (override with -force)" << std::endl;
+          OPENMS_LOG_ERROR << "Extraction windows have a gap. Will abort (override with -force)" << std::endl;
           return false;
         }
       }
@@ -225,13 +225,13 @@ protected:
 
       if (lower_map_end - upper_map_start > 0.01)
       {
-        LOG_WARN << "Extraction will overlap between " << lower_map_end << " and " << upper_map_start << "!\n"
+        OPENMS_LOG_WARN << "Extraction will overlap between " << lower_map_end << " and " << upper_map_start << "!\n"
                  << "This will lead to multiple extraction of the transitions in the overlapping region "
                  << "which will lead to duplicated output. It is very unlikely that you want this." << "\n"
                  << "Please fix this by providing an appropriate extraction file with -swath_windows_file" << std::endl;
         if (!force)
         {
-          LOG_ERROR << "Extraction windows overlap. Will abort (override with -force)" << std::endl;
+          OPENMS_LOG_ERROR << "Extraction windows overlap. Will abort (override with -force)" << std::endl;
           return false;
         }
       }
@@ -338,7 +338,7 @@ protected:
     }
     else
     {
-      LOG_ERROR << "Provide valid TraML, TSV or PQP transition file." << std::endl;
+      OPENMS_LOG_ERROR << "Provide valid TraML, TSV or PQP transition file." << std::endl;
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Need to provide valid input file.");
     }
     return transition_exp;

--- a/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeDB.h
+++ b/src/openms/include/OpenMS/CHEMISTRY/DigestionEnzymeDB.h
@@ -232,7 +232,7 @@ namespace OpenMS
         const String& value = it->second;
         if (!enzy_ptr->setValueFromFile(key, value))
         {
-          LOG_ERROR << "Error while parsing enzymes file: unknown key '" << key << "' with value '" << value << "'" << std::endl;
+          OPENMS_LOG_ERROR << "Error while parsing enzymes file: unknown key '" << key << "' with value '" << value << "'" << std::endl;
         }
       }
       return enzy_ptr;

--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -290,14 +290,14 @@ protected:
       appropriate stream:
 
       Macros:
-        - LOG_FATAL_ERROR
-        - LOG_ERROR (non-fatal error are reported (processing continues))
-        - LOG_WARN  (warning, a piece of information which should be read by the user, should be logged)
-        - LOG_INFO (information, e.g. a status should be reported)
-        - LOG_DEBUG (general debugging information -  output be written to cout if debug_level > 0)
+        - OPENMS_LOG_FATAL_ERROR
+        - OPENMS_LOG_ERROR (non-fatal error are reported (processing continues))
+        - OPENMS_LOG_WARN  (warning, a piece of information which should be read by the user, should be logged)
+        - OPENMS_LOG_INFO (information, e.g. a status should be reported)
+        - OPENMS_LOG_DEBUG (general debugging information -  output be written to cout if debug_level > 0)
 
       To use a specific logger of a log level simply use it as cerr or cout: <br>
-      <code> LOG_ERROR << " A bad error occurred ..."  </code>
+      <code> OPENMS_LOG_ERROR << " A bad error occurred ..."  </code>
       <br>
       Which produces an error message in the log.
     */
@@ -441,23 +441,23 @@ private:
 
 
   /// Macro to be used if fatal error are reported (processing stops)
-#define LOG_FATAL_ERROR \
+#define OPENMS_LOG_FATAL_ERROR \
   Log_fatal << __FILE__ << "(" << __LINE__ << "): "
 
   /// Macro to be used if non-fatal error are reported (processing continues)
-#define LOG_ERROR \
+#define OPENMS_LOG_ERROR \
   Log_error
 
   /// Macro if a warning, a piece of information which should be read by the user, should be logged
-#define LOG_WARN \
+#define OPENMS_LOG_WARN \
   Log_warn
 
   /// Macro if a information, e.g. a status should be reported
-#define LOG_INFO \
+#define OPENMS_LOG_INFO \
   Log_info
 
   /// Macro for general debugging information
-#define LOG_DEBUG \
+#define OPENMS_LOG_DEBUG \
   Log_debug << __FILE__ << "(" << __LINE__ << "): "
 
   OPENMS_DLLAPI extern Logger::LogStream Log_fatal; ///< Global static instance of a LogStream to capture messages classified as fatal errors. By default it is bound to @b cerr.

--- a/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
+++ b/src/openms/include/OpenMS/DATASTRUCTURES/Param.h
@@ -463,7 +463,7 @@ protected:
     /**
       @brief Rescue parameter <b>values</b> from @p p_outdated to current param
 
-      Calls ::update(p_outdated, true, add_unknown, false, false, LOG_WARN) and returns its value.
+      Calls ::update(p_outdated, true, add_unknown, false, false, OPENMS_LOG_WARN) and returns its value.
     */
     bool update(const Param& p_outdated, const bool add_unknown = false);
 
@@ -535,7 +535,7 @@ protected:
       @param defaults The default values.
       @param prefix The prefix where to check for the defaults.
 
-      Warnings etc. will be send to LOG_WARN.
+      Warnings etc. will be send to OPENMS_LOG_WARN.
 
       @exception Exception::InvalidParameter is thrown if errors occur during the check
     */

--- a/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/ID/IDFilter.h
@@ -413,7 +413,7 @@ public:
       {
         if(!evidence.hasValidLimits())
         {
-          LOG_WARN << "Invalid limits! Peptide '" << evidence.getProteinAccession() << "' not filtered" << std::endl;
+          OPENMS_LOG_WARN << "Invalid limits! Peptide '" << evidence.getProteinAccession() << "' not filtered" << std::endl;
           return true;
         }
 
@@ -427,11 +427,11 @@ public:
         {
           if (evidence.getProteinAccession().empty())
           {
-            LOG_WARN << "Peptide accession not available! Skipping Evidence." << std::endl;
+            OPENMS_LOG_WARN << "Peptide accession not available! Skipping Evidence." << std::endl;
           }
           else
           {
-            LOG_WARN << "Peptide accession '" << evidence.getProteinAccession()
+            OPENMS_LOG_WARN << "Peptide accession '" << evidence.getProteinAccession()
                      << "' not found in fasta file!" << std::endl;
           }
           return true;

--- a/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h
+++ b/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h
@@ -66,8 +66,8 @@ namespace OpenMS
 
     Changing any of the parameters will invalidate the S/N values (which will invoke a recomputation on the next request).
 
-    @note If more than 20 percent of windows have less than <i>min_required_elements</i> of elements, a warning is issued to <i>LOG_WARN</i> and noise estimates in those windows are set to the constant <i>noise_for_empty_window</i>.
-    @note If more than 1 percent of median estimations had to rely on the last(=rightmost) bin (which gives an unreliable result), a warning is issued to <i>LOG_WARN</i>.  In this case you should increase <i>max_intensity</i> (and optionally the <i>bin_count</i>). 
+    @note If more than 20 percent of windows have less than <i>min_required_elements</i> of elements, a warning is issued to <i>OPENMS_LOG_WARN</i> and noise estimates in those windows are set to the constant <i>noise_for_empty_window</i>.
+    @note If more than 1 percent of median estimations had to rely on the last(=rightmost) bin (which gives an unreliable result), a warning is issued to <i>OPENMS_LOG_WARN</i>.  In this case you should increase <i>max_intensity</i> (and optionally the <i>bin_count</i>). 
     @note You can disable logging this error by setting <i>write_log_messages</i> and read out the values 
 
 
@@ -388,7 +388,7 @@ protected:
       // warn if percentage of sparse windows is above 20%
       if (sparse_window_percent_ > 20 && write_log_messages_)
       {
-        LOG_WARN << "WARNING in SignalToNoiseEstimatorMedian: "
+        OPENMS_LOG_WARN << "WARNING in SignalToNoiseEstimatorMedian: "
                  << sparse_window_percent_
                  << "% of all windows were sparse. You should consider increasing 'win_len' or decreasing 'min_required_elements'"
                  << std::endl;
@@ -397,7 +397,7 @@ protected:
       // warn if percentage of possibly wrong median estimates is above 1%
       if (histogram_oob_percent_ > 1 && write_log_messages_)
       {
-        LOG_WARN << "WARNING in SignalToNoiseEstimatorMedian: "
+        OPENMS_LOG_WARN << "WARNING in SignalToNoiseEstimatorMedian: "
                  << histogram_oob_percent_
                  << "% of all Signal-to-Noise estimates are too high, because the median was found in the rightmost histogram-bin. "
                  << "You should consider increasing 'max_intensity' (and maybe 'bin_count' with it, to keep bin width reasonable)"

--- a/src/openms/include/OpenMS/FILTERING/SMOOTHING/GaussFilter.h
+++ b/src/openms/include/OpenMS/FILTERING/SMOOTHING/GaussFilter.h
@@ -120,7 +120,7 @@ public:
         {
           error_message += String(" The error occurred in the spectrum with retention time ") + spectrum.getRT() + ".";
         }
-        LOG_ERROR << error_message << std::endl;
+        OPENMS_LOG_ERROR << error_message << std::endl;
       }
       else
       {
@@ -170,7 +170,7 @@ public:
         {
           error_message += String(" The error occurred in the chromatogram with m/z time ") + chromatogram.getMZ() + ".";
         }
-        LOG_ERROR << error_message << std::endl;
+        OPENMS_LOG_ERROR << error_message << std::endl;
       }
       else
       {

--- a/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/SpectraMerger.h
+++ b/src/openms/include/OpenMS/FILTERING/TRANSFORMERS/SpectraMerger.h
@@ -236,7 +236,7 @@ public:
           }
           if (pcs.size() > 1)
           {
-            LOG_WARN << "More than one precursor found. Using first one!" << std::endl;
+            OPENMS_LOG_WARN << "More than one precursor found. Using first one!" << std::endl;
           }
           bf.setMZ(pcs[0].getMZ());
           data.push_back(bf);
@@ -608,7 +608,7 @@ protected:
           consensus_spec.sortByPosition(); // sort, otherwise next alignment will fail
           if (spec_a + spec_b - align_size != consensus_spec.size())
           {
-            LOG_WARN << "wrong number of features after merge. Expected: " << spec_a + spec_b - align_size << " got: " << consensus_spec.size() << "\n";
+            OPENMS_LOG_WARN << "wrong number of features after merge. Expected: " << spec_a + spec_b - align_size << " got: " << consensus_spec.size() << "\n";
           }
         }
         rt_average /= it->second.size() + 1;
@@ -621,7 +621,7 @@ protected:
             precursor_mz_average /= precursor_count;
           }
           std::vector<Precursor> pcs = consensus_spec.getPrecursors();
-          //if (pcs.size()>1) LOG_WARN << "Removing excessive precursors - leaving only one per MS2 spectrum.\n";
+          //if (pcs.size()>1) OPENMS_LOG_WARN << "Removing excessive precursors - leaving only one per MS2 spectrum.\n";
           pcs.resize(1);
           pcs[0].setMZ(precursor_mz_average);
           consensus_spec.setPrecursors(pcs);
@@ -637,16 +637,16 @@ protected:
         }
       }
 
-      LOG_INFO << "Cluster sizes:\n";
+      OPENMS_LOG_INFO << "Cluster sizes:\n";
       for (Map<Size, Size>::const_iterator it = cluster_sizes.begin(); it != cluster_sizes.end(); ++it)
       {
-        LOG_INFO << "  size " << it->first << ": " << it->second << "x\n";
+        OPENMS_LOG_INFO << "  size " << it->first << ": " << it->second << "x\n";
       }
 
       char buffer[200];
       sprintf(buffer, "%d/%d (%.2f %%) of blocked spectra", (int)count_peaks_aligned,
               (int)count_peaks_overall, float(count_peaks_aligned) / float(count_peaks_overall) * 100.);
-      LOG_INFO << "Number of merged peaks: " << String(buffer) << "\n";
+      OPENMS_LOG_INFO << "Number of merged peaks: " << String(buffer) << "\n";
 
       // remove all spectra that were within a cluster
       typename MapType::SpectrumType empty_spec;

--- a/src/openms/include/OpenMS/FORMAT/ConsensusXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/ConsensusXMLFile.h
@@ -54,7 +54,7 @@ namespace OpenMS
 
     A documented schema for this format can be found at https://github.com/OpenMS/OpenMS/tree/develop/share/OpenMS/SCHEMAS
 
-  @todo Take care that unique ids are assigned properly by TOPP tools before calling ConsensusXMLFile::store().  There will be a message on LOG_INFO but we will make no attempt to fix the problem in this class.  (all developers)
+  @todo Take care that unique ids are assigned properly by TOPP tools before calling ConsensusXMLFile::store().  There will be a message on OPENMS_LOG_INFO but we will make no attempt to fix the problem in this class.  (all developers)
 
     @ingroup FileIO
   */

--- a/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
+++ b/src/openms/include/OpenMS/FORMAT/DATAACCESS/SwathFileConsumer.h
@@ -269,7 +269,7 @@ public:
             boundary.center = center;
             swath_map_boundaries_.push_back(boundary);
 
-            LOG_DEBUG << "Adding Swath centered at " << center
+            OPENMS_LOG_DEBUG << "Adding Swath centered at " << center
               << " m/z with an isolation window of " << lower << " to " << upper
               << " m/z." << std::endl;
           }

--- a/src/openms/include/OpenMS/FORMAT/FeatureXMLFile.h
+++ b/src/openms/include/OpenMS/FORMAT/FeatureXMLFile.h
@@ -57,7 +57,7 @@ namespace OpenMS
     A documented schema for this format can be found at https://github.com/OpenMS/OpenMS/tree/develop/share/OpenMS/SCHEMAS
 
     @todo Take care that unique ids are assigned properly by TOPP tools before
-    calling FeatureXMLFile::store().  There will be a message on LOG_INFO but
+    calling FeatureXMLFile::store().  There will be a message on OPENMS_LOG_INFO but
     we will make no attempt to fix the problem in this class.  (all developers)
 
     @note This format will eventually be replaced by the HUPO-PSI AnalysisXML

--- a/src/openms/include/OpenMS/KERNEL/ChromatogramTools.h
+++ b/src/openms/include/OpenMS/KERNEL/ChromatogramTools.h
@@ -188,7 +188,7 @@ public:
           }
           else
           {
-            LOG_WARN << "ChromatogramTools: need exactly one precursor (given " << it->getPrecursors().size() <<
+            OPENMS_LOG_WARN << "ChromatogramTools: need exactly one precursor (given " << it->getPrecursors().size() <<
             ") and one or more product ions (" << it->size() << "), skipping conversion of this spectrum to chromatogram. If this is a MS1 chromatogram, please force conversion (e.g. with -convert_to_chromatograms)." << std::endl;
           }
         }
@@ -196,7 +196,7 @@ public:
         {
           // This does not makes sense to warn here, because it would also warn on simple mass spectra...
           // TODO think what to to here
-          //LOG_WARN << "ChromatogramTools: cannot convert other chromatogram spectra types than 'Selected Reaction Monitoring', skipping conversion." << std::endl;
+          //OPENMS_LOG_WARN << "ChromatogramTools: cannot convert other chromatogram spectra types than 'Selected Reaction Monitoring', skipping conversion." << std::endl;
           //
         }
       }

--- a/src/openms/include/OpenMS/KERNEL/RangeUtils.h
+++ b/src/openms/include/OpenMS/KERNEL/RangeUtils.h
@@ -687,7 +687,7 @@ public:
       {
         if (it->getIsolationWindowLowerOffset() == 0 || it->getIsolationWindowUpperOffset() == 0)
         {
-          LOG_WARN << "IsInIsolationWindow(): Lower/Upper Offset for Precursor Isolation Window is Zero! " << 
+          OPENMS_LOG_WARN << "IsInIsolationWindow(): Lower/Upper Offset for Precursor Isolation Window is Zero! " << 
             "Filtering will probably be too strict (unless you hit the exact precursor m/z)!" << std::endl;
         }
         const double lower_mz = it->getMZ() - it->getIsolationWindowLowerOffset();

--- a/src/openms/include/OpenMS/KERNEL/SpectrumHelper.h
+++ b/src/openms/include/OpenMS/KERNEL/SpectrumHelper.h
@@ -172,7 +172,7 @@ namespace OpenMS
   {
     if (!p.getFloatDataArrays().empty() || !p.getStringDataArrays().empty() || !p.getIntegerDataArrays().empty())
     {
-      LOG_WARN << "Warning: data arrays are being ignored in the method SpectrumHelper::makePeakPositionUnique().\n";
+      OPENMS_LOG_WARN << "Warning: data arrays are being ignored in the method SpectrumHelper::makePeakPositionUnique().\n";
     }
     
     if (p.empty()) return;

--- a/src/openms/include/OpenMS/METADATA/SpectrumLookup.h
+++ b/src/openms/include/OpenMS/METADATA/SpectrumLookup.h
@@ -118,7 +118,7 @@ namespace OpenMS
           scan_no = extractScanNumber(native_id, scan_regexp_, true);
           if (scan_no < 0)
           {
-            LOG_WARN << "Warning: Could not extract scan number from spectrum native ID '" + native_id + "' using regular expression '" + scan_regexp + "'. Look-up by scan number may not work properly." << std::endl;
+            OPENMS_LOG_WARN << "Warning: Could not extract scan number from spectrum native ID '" + native_id + "' using regular expression '" + scan_regexp + "'. Look-up by scan number may not work properly." << std::endl;
           }
         }
         addEntry_(i, spectrum.getRT(), scan_no, native_id);

--- a/src/openms/include/OpenMS/SYSTEM/File.h
+++ b/src/openms/include/OpenMS/SYSTEM/File.h
@@ -77,7 +77,7 @@ public:
        @param from Source filename
        @param to Target filename
        @param overwrite_existing Delete already existing target, before renaming
-       @param verbose Print message to LOG_ERROR if something goes wrong.
+       @param verbose Print message to OPENMS_LOG_ERROR if something goes wrong.
        @return True on success
     */
     static bool rename(const String& from, const String& to, bool overwrite_existing = true, bool verbose = true);

--- a/src/openms/include/OpenMS/SYSTEM/JavaInfo.h
+++ b/src/openms/include/OpenMS/SYSTEM/JavaInfo.h
@@ -53,7 +53,7 @@ public:
       The call fails if either Java is not installed or if a relative location is given and Java is not on the search PATH.
 
       @param java_executable Path to Java executable. Can be absolute, relative or just a filename
-      @param verbose On error, should an error message be printed to LOG_ERROR?
+      @param verbose On error, should an error message be printed to OPENMS_LOG_ERROR?
       @return Returns false if Java executable can not be called; true if Java executable can be executed
     **/
     static bool canRun(const String& java_executable, bool verbose_on_error = true);

--- a/src/openms/include/OpenMS/SYSTEM/RWrapper.h
+++ b/src/openms/include/OpenMS/SYSTEM/RWrapper.h
@@ -68,7 +68,7 @@ public:
       An exception will be thrown if the file cannot be found.
 
       @param script_file Name of the R script
-      @param verbose Print error message to LOG_ERROR upon FileNotFound
+      @param verbose Print error message to OPENMS_LOG_ERROR upon FileNotFound
       @return Full filename with absolute path
       @throw Exception::FileNotFound
     */

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerIterative.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerIterative.h
@@ -325,12 +325,12 @@ public:
       // after picking peaks, we store the closest index of the raw spectrum and the picked intensity
       std::vector<PeakCandidate> newPeakCandidates_;
       Size j = 0;
-      LOG_DEBUG << "Candidates " << picked_spectrum.size() << std::endl;
+      OPENMS_LOG_DEBUG << "Candidates " << picked_spectrum.size() << std::endl;
       for (Size k = 0; k < input.size() && j < picked_spectrum.size(); k++)
       {
         if (input[k].getMZ() > picked_spectrum[j].getMZ())
         {
-          LOG_DEBUG << "got a value " << k << " @ " << input[k] << std::endl;
+          OPENMS_LOG_DEBUG << "got a value " << k << " @ " << input[k] << std::endl;
           PeakCandidate pc = { /*.index=*/ static_cast<int>(k), /*.intensity=*/ picked_spectrum[j].getIntensity(), -1, -1, -1, -1};
           newPeakCandidates_.push_back(pc);
           j++;
@@ -364,7 +364,7 @@ public:
 
       // Go through all candidates and exclude all lower-intensity candidates
       // that are within the borders of another peak
-      LOG_DEBUG << "Will now merge candidates" << std::endl;
+      OPENMS_LOG_DEBUG << "Will now merge candidates" << std::endl;
       for (Size peak_it = 0; peak_it < PeakCandidates.size(); peak_it++)
       {
         if (PeakCandidates[peak_it].leftWidth < 0) continue;
@@ -374,7 +374,7 @@ public:
         {
           if (PeakCandidates[m].mz >= PeakCandidates[peak_it].leftWidth && PeakCandidates[m].mz <= PeakCandidates[peak_it].rightWidth)
           {
-            LOG_DEBUG << "Remove peak " << m <<  " : " << PeakCandidates[m].mz << " "  <<
+            OPENMS_LOG_DEBUG << "Remove peak " << m <<  " : " << PeakCandidates[m].mz << " "  <<
               PeakCandidates[m].peak_apex_intensity << " (too close to " << PeakCandidates[peak_it].mz <<
               " " << PeakCandidates[peak_it].peak_apex_intensity <<  ")" << std::endl;
             PeakCandidates[m].leftWidth = PeakCandidates[m].rightWidth = -1;
@@ -386,13 +386,13 @@ public:
         peak.setIntensity(PeakCandidates[peak_it].integrated_intensity);
         output.push_back(peak);
 
-        LOG_DEBUG << "Push peak " << peak_it << "  " << peak << std::endl;
+        OPENMS_LOG_DEBUG << "Push peak " << peak_it << "  " << peak << std::endl;
         output.getFloatDataArrays()[0].push_back(PeakCandidates[peak_it].integrated_intensity);
         output.getFloatDataArrays()[1].push_back(PeakCandidates[peak_it].leftWidth);
         output.getFloatDataArrays()[2].push_back(PeakCandidates[peak_it].rightWidth);
       }
 
-      LOG_DEBUG << "Found seeds: " << PeakCandidates.size() << " / Found peaks: " << output.size() << std::endl;
+      OPENMS_LOG_DEBUG << "Found seeds: " << PeakCandidates.size() << " / Found peaks: " << output.size() << std::endl;
       output.sortByPosition();
     }
 

--- a/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/FeatureDeconvolution.cpp
@@ -252,7 +252,7 @@ namespace OpenMS
     {
       if (rt_diff_max != rt_diff_max_local)
       {
-        LOG_WARN << "Parameters 'retention_max_diff' and 'retention_max_diff_local' are unequal, but no RT shift of adducts has been defined. Setting parameters to minimum of the two." << std::endl;
+        OPENMS_LOG_WARN << "Parameters 'retention_max_diff' and 'retention_max_diff_local' are unequal, but no RT shift of adducts has been defined. Setting parameters to minimum of the two." << std::endl;
         param_.setValue("retention_max_diff", std::min(rt_diff_max, rt_diff_max_local));
         param_.setValue("retention_max_diff_local", std::min(rt_diff_max, rt_diff_max_local));
       }
@@ -261,7 +261,7 @@ namespace OpenMS
     {
       if (rt_diff_max < rt_diff_max_local)
       {
-        LOG_WARN << "Parameters 'retention_max_diff' is smaller than 'retention_max_diff_local'. This does not make sense! Setting 'retention_max_diff_local' to 'retention_max_diff'." << std::endl;
+        OPENMS_LOG_WARN << "Parameters 'retention_max_diff' is smaller than 'retention_max_diff_local'. This does not make sense! Setting 'retention_max_diff_local' to 'retention_max_diff'." << std::endl;
         param_.setValue("retention_max_diff_local", rt_diff_max);
       }
     }
@@ -358,7 +358,7 @@ namespace OpenMS
 
 
     // create mass difference list
-    LOG_INFO << "Generating Masses with threshold: " << thresh_logp << " ...\n";
+    OPENMS_LOG_INFO << "Generating Masses with threshold: " << thresh_logp << " ...\n";
     
     //make it proof for charge 1..3 and charge -3..-1
     if ((q_min * q_max) < 0)
@@ -378,7 +378,7 @@ namespace OpenMS
     }
     MassExplainer me(potential_adducts_, small, large, q_span, thresh_logp, max_neutrals);
     me.compute();
-    LOG_INFO << "done\n";
+    OPENMS_LOG_INFO << "done\n";
 
     // holds query results for a mass difference
     MassExplainer::CompomerIterator md_s, md_e;
@@ -509,7 +509,7 @@ namespace OpenMS
                   if (((q1 - left_charges) % default_adduct.getCharge() != 0) ||
                       ((q2 - right_charges) % default_adduct.getCharge() != 0))
                   {
-                    LOG_WARN << "Cannot add enough default adduct (" << default_adduct.getFormula() << ") to exactly fit feature charge! Next...)\n";
+                    OPENMS_LOG_WARN << "Cannot add enough default adduct (" << default_adduct.getFormula() << ") to exactly fit feature charge! Next...)\n";
                     continue;
                   }
 
@@ -575,7 +575,7 @@ namespace OpenMS
       } // RT-window
     } // RT sweep line
 
-    LOG_INFO << no_cmp_hit << " of " << (no_cmp_hit + cmp_hit) << " valid net charge compomer results did not pass the feature charge constraints\n";
+    OPENMS_LOG_INFO << no_cmp_hit << " of " << (no_cmp_hit + cmp_hit) << " valid net charge compomer results did not pass the feature charge constraints\n";
 
     inferMoreEdges_(feature_relation, feature_adducts);
 
@@ -592,12 +592,12 @@ namespace OpenMS
 
     if (feature_relation.empty())
     {
-      LOG_INFO << "Found NO putative edges. The output generated will be trivial (only singleton clusters and no pairings). "
+      OPENMS_LOG_INFO << "Found NO putative edges. The output generated will be trivial (only singleton clusters and no pairings). "
                << "Your parameters might need revision or the input was ill-formed." << std::endl;
     }
     else
     {
-      LOG_INFO << "Found " << feature_relation.size() << " putative edges (of " << possibleEdges << ")"
+      OPENMS_LOG_INFO << "Found " << feature_relation.size() << " putative edges (of " << possibleEdges << ")"
                << " and avg hit-size of " << (1.0 * overallHits / feature_relation.size())
                << std::endl;
 
@@ -609,7 +609,7 @@ namespace OpenMS
       ILPDCWrapper lp_wrapper;
       // compute best solution (this will REORDER elements on feature_relation[] !) - do not rely on order afterwards!
       double ilp_score = lp_wrapper.compute(fm_out, feature_relation, this->verbose_level_);
-      LOG_INFO << "ILP score is: " << ilp_score << std::endl;
+      OPENMS_LOG_INFO << "ILP score is: " << ilp_score << std::endl;
     }
 
     // prepare output consensusMaps
@@ -686,7 +686,7 @@ namespace OpenMS
           double rt_diff =  fabs(fm_out[feature_relation[i].getElementIndex(0)].getRT() - fm_out[feature_relation[i].getElementIndex(1)].getRT());
           if (verbose_level_ > 2)
           {
-            LOG_WARN << "Conflict in f_Q! f_RT:" << fm_out[f_idx_v[f_idx]].getRT() << " f_MZ:" << fm_out[f_idx_v[f_idx]].getMZ() << " f_int:" << fm_out[f_idx_v[f_idx]].getIntensity()
+            OPENMS_LOG_WARN << "Conflict in f_Q! f_RT:" << fm_out[f_idx_v[f_idx]].getRT() << " f_MZ:" << fm_out[f_idx_v[f_idx]].getMZ() << " f_int:" << fm_out[f_idx_v[f_idx]].getIntensity()
                      << " Q:" << fm_out[f_idx_v[f_idx]].getCharge() << " PredictedQ:" << feature_relation[i].getCharge((UInt)f_idx)
                      << "[[ dRT: " << rt_diff << " dMZ: " << feature_relation[i].getMassDiff() << " score[" << i << "]:"
                      << feature_relation[i].getEdgeScore() << " f#:" << fm_out[f_idx_v[f_idx]].getUniqueId() << " " << feature_relation[i].getCompomer().getAdductsAsString((UInt)f_idx)
@@ -713,7 +713,7 @@ namespace OpenMS
       }
 
     }
-    LOG_INFO << "Agreeing charges: " << agreeing_fcharge << "/" << (aedges * 2) << std::endl;
+    OPENMS_LOG_INFO << "Agreeing charges: " << agreeing_fcharge << "/" << (aedges * 2) << std::endl;
 
 #ifdef DC_DEVEL
     out_dead.store("ILP_dead_edges.txt"); // TODO disable
@@ -1013,7 +1013,7 @@ namespace OpenMS
       ++singletons_count;
     }
 
-    LOG_INFO << "Single features without charge ladder: " << singletons_count << " of " << fm_out.size() << "\n";
+    OPENMS_LOG_INFO << "Single features without charge ladder: " << singletons_count << " of " << fm_out.size() << "\n";
 
 
     // fill the header
@@ -1165,7 +1165,7 @@ namespace OpenMS
       }
     } // edge for
 
-    LOG_INFO << "Inferring edges raised edge count from " << edges_size << " to " << edges.size() << "\n";
+    OPENMS_LOG_INFO << "Inferring edges raised edge count from " << edges_size << " to " << edges.size() << "\n";
   }
 
   void FeatureDeconvolution::printEdgesOfConnectedFeatures_(Size idx_1, Size idx_2, const PairsType& feature_relation)
@@ -1278,8 +1278,8 @@ namespace OpenMS
     // if more than 5% of charge ladder have only gapped, report
     if (ladders_with_odd < ladders_total * 0.95)
     {
-      LOG_WARN << ".\n..\nWarning: a significant portion of your decharged molecules have gapped, even-numbered charge ladders (" << ladders_total - ladders_with_odd << " of " << ladders_total << ")";
-      LOG_WARN <<"This might indicate a too low charge interval being tested.\n..\n.\n";
+      OPENMS_LOG_WARN << ".\n..\nWarning: a significant portion of your decharged molecules have gapped, even-numbered charge ladders (" << ladders_total - ladders_with_odd << " of " << ladders_total << ")";
+      OPENMS_LOG_WARN <<"This might indicate a too low charge interval being tested.\n..\n.\n";
     }
 
   }

--- a/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/ILPDCWrapper.cpp
@@ -55,7 +55,7 @@ namespace OpenMS
   {
     if (fm.empty())
     {
-      LOG_INFO << "ILPDC wrapper received empty feature list. Nothing to compute! Exiting..." << std::endl;
+      OPENMS_LOG_INFO << "ILPDC wrapper received empty feature list. Nothing to compute! Exiting..." << std::endl;
       return -1;
     }
 
@@ -131,11 +131,11 @@ namespace OpenMS
       }
       if (verbose_level > 1)
       {
-        LOG_INFO << "Components:\n";
-        LOG_INFO << "  Size 1 occurs ?x\n";
+        OPENMS_LOG_INFO << "Components:\n";
+        OPENMS_LOG_INFO << "  Size 1 occurs ?x\n";
         for (OpenMS::Map<Size, Size>::const_iterator it = hist_component_sum.begin(); it != hist_component_sum.end(); ++it)
         {
-          LOG_INFO << "  Size " << it->first << " occurs " << it->second << "x\n";
+          OPENMS_LOG_INFO << "  Size " << it->first << " occurs " << it->second << "x\n";
         }
       }
 
@@ -153,7 +153,7 @@ namespace OpenMS
           if (count > 0) // either bin is full or we have to close it due to big clique
           {
             if (verbose_level > 2)
-              LOG_INFO << "Overstepping border of " << pairs_per_bin << " by " << SignedSize(count - pairs_per_bin) << " elements!\n";
+              OPENMS_LOG_INFO << "Overstepping border of " << pairs_per_bin << " by " << SignedSize(count - pairs_per_bin) << " elements!\n";
             bins.push_back(std::make_pair(start, pairs_clique_ordered.size()));
             start = pairs_clique_ordered.size();
             count = 0;
@@ -165,7 +165,7 @@ namespace OpenMS
               pairs_clique_ordered.push_back(pairs[*i_p]);
             }
             if (verbose_level > 2)
-              LOG_INFO << "Extra bin for big clique (" << clique_size << ") prepended to schedule\n";
+              OPENMS_LOG_INFO << "Extra bin for big clique (" << clique_size << ") prepended to schedule\n";
             bins.insert(bins.begin(), std::make_pair(start, pairs_clique_ordered.size()));
             start = pairs_clique_ordered.size();
             continue; // next clique (this one is already processed)
@@ -203,7 +203,7 @@ namespace OpenMS
       score = computeSlice_(fm, pairs, bins[i].first, bins[i].second, verbose_level);
     }
     time1.stop();
-    LOG_INFO << " Branch and cut took " << time1.getClockTime() << " seconds, "
+    OPENMS_LOG_INFO << " Branch and cut took " << time1.getClockTime() << " seconds, "
              << " with objective value: " << score << "."
              << std::endl;
 
@@ -357,7 +357,7 @@ namespace OpenMS
       //std::cerr << "MIP: edge#"<< i << " score: " << pairs[i].getEdgeScore() << " adduct:" << pairs[i].getCompomer().getAdductsAsString() << "\n";
     }
     if (verbose_level > 2)
-      LOG_INFO << "score_min: " << score_min << " score_max: " << score_max << "\n";
+      OPENMS_LOG_INFO << "score_min: " << score_min << " score_max: " << score_max << "\n";
 
     //------------------------------------adding constraints--------------------------------------------------
 
@@ -439,18 +439,18 @@ namespace OpenMS
     }
 
     if (verbose_level > 2)
-      LOG_INFO << "node count: " << fm.size() << "\n";
+      OPENMS_LOG_INFO << "node count: " << fm.size() << "\n";
     if (verbose_level > 2)
-      LOG_INFO << "edge count: " << pairs.size() << "\n";
+      OPENMS_LOG_INFO << "edge count: " << pairs.size() << "\n";
     if (verbose_level > 2)
-      LOG_INFO << "constraint count: " << (conflict_idx[0] + conflict_idx[1] + conflict_idx[2] + conflict_idx[3]) << " = " << conflict_idx[0] << " + " << conflict_idx[1] << " + " << conflict_idx[2] << " + " << conflict_idx[3] << "(0 or inferred)" << std::endl;
+      OPENMS_LOG_INFO << "constraint count: " << (conflict_idx[0] + conflict_idx[1] + conflict_idx[2] + conflict_idx[3]) << " = " << conflict_idx[0] << " + " << conflict_idx[1] << " + " << conflict_idx[2] << " + " << conflict_idx[3] << "(0 or inferred)" << std::endl;
 
     //---------------------------------------------------------------------------------------------------------
     //----------------------------------------Solving and querying result--------------------------------------
     //---------------------------------------------------------------------------------------------------------
 
     if (verbose_level > 0)
-      LOG_INFO << "Starting to solve..." << std::endl;
+      OPENMS_LOG_INFO << "Starting to solve..." << std::endl;
     LPWrapper::SolverParam param;
     param.enable_mir_cuts = true;
     param.enable_cov_cuts = true;
@@ -464,7 +464,7 @@ namespace OpenMS
     build.solve(param);
     time1.stop();
     if (verbose_level > 0)
-      LOG_INFO << " Branch and cut took " << time1.getClockTime() << " seconds, "
+      OPENMS_LOG_INFO << " Branch and cut took " << time1.getClockTime() << " seconds, "
                << " with objective value: " << build.getObjectiveValue() << "."
                << " Status: " << (!build.getStatus() ? " Finished" : " Not finished")
                << std::endl;
@@ -491,7 +491,7 @@ namespace OpenMS
       }
     }
     if (verbose_level > 2)
-      LOG_INFO << "Active edges: " << active_edges << " of overall " << pairs.size() << std::endl;
+      OPENMS_LOG_INFO << "Active edges: " << active_edges << " of overall " << pairs.size() << std::endl;
 
     for (Map<String, Size>::const_iterator it = count_cmp.begin(); it != count_cmp.end(); ++it)
     {

--- a/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
+++ b/src/openms/source/ANALYSIS/DECHARGING/MetaboliteFeatureDeconvolution.cpp
@@ -191,7 +191,7 @@ namespace OpenMS
       }
       // determine probability
       float prob = adduct[2].toFloat();
-      //LOG_WARN << "Adduct " << *it << " prob " << String(prob) << std::endl;
+      //OPENMS_LOG_WARN << "Adduct " << *it << " prob " << String(prob) << std::endl;
       if (prob > 1.0 || prob <= 0.0)
       {
         String error = "MetaboliteFeatureDeconvolution::potential_adducts (" + (*it) + ") does not have a proper probability (" + String(prob) + ") in [0,1]!";
@@ -201,7 +201,7 @@ namespace OpenMS
       {
         summed_probs += prob;
       }
-      //LOG_WARN << "Total prob" << String(summed_probs) << std::endl;
+      //OPENMS_LOG_WARN << "Total prob" << String(summed_probs) << std::endl;
 
       // RT Shift:
       double rt_shift(0);
@@ -288,7 +288,7 @@ namespace OpenMS
     {
       if (rt_diff_max != rt_diff_max_local)
       {
-        LOG_WARN << "Parameters 'retention_max_diff' and 'retention_max_diff_local' are unequal, but no RT shift of adducts has been defined. Setting parameters to minimum of the two." << std::endl;
+        OPENMS_LOG_WARN << "Parameters 'retention_max_diff' and 'retention_max_diff_local' are unequal, but no RT shift of adducts has been defined. Setting parameters to minimum of the two." << std::endl;
         param_.setValue("retention_max_diff", std::min(rt_diff_max, rt_diff_max_local));
         param_.setValue("retention_max_diff_local", std::min(rt_diff_max, rt_diff_max_local));
       }
@@ -297,7 +297,7 @@ namespace OpenMS
     {
       if (rt_diff_max < rt_diff_max_local)
       {
-        LOG_WARN << "Parameters 'retention_max_diff' is smaller than 'retention_max_diff_local'. This does not make sense! Setting 'retention_max_diff_local' to 'retention_max_diff'." << std::endl;
+        OPENMS_LOG_WARN << "Parameters 'retention_max_diff' is smaller than 'retention_max_diff_local'. This does not make sense! Setting 'retention_max_diff_local' to 'retention_max_diff'." << std::endl;
         param_.setValue("retention_max_diff_local", rt_diff_max);
       }
     }
@@ -428,7 +428,7 @@ namespace OpenMS
     }
 
     // create mass difference list
-    LOG_INFO << "Generating Masses with threshold: " << thresh_logp << " ...\n";
+    OPENMS_LOG_INFO << "Generating Masses with threshold: " << thresh_logp << " ...\n";
 
     //make it proof for charge 1..3 and charge -3..-1
     if ((q_min * q_max) < 0)
@@ -447,7 +447,7 @@ namespace OpenMS
     }
     MassExplainer me(potential_adducts_, small, large, q_span, thresh_logp, max_neutrals);
     me.compute();
-    LOG_INFO << "done\n";
+    OPENMS_LOG_INFO << "done\n";
 
 
     // holds query results for a mass difference
@@ -600,7 +600,7 @@ namespace OpenMS
                   if (((q1 - left_charges) % default_adduct.getCharge() != 0) ||
                       ((q2 - right_charges) % default_adduct.getCharge() != 0))
                   {
-                    LOG_WARN << "Cannot add enough default adduct (" << default_adduct.getFormula() << ") to exactly fit feature charge! Next...)\n";
+                    OPENMS_LOG_WARN << "Cannot add enough default adduct (" << default_adduct.getFormula() << ") to exactly fit feature charge! Next...)\n";
                     continue;
                   }
 
@@ -667,11 +667,11 @@ namespace OpenMS
     } // RT sweep line
 
 
-    LOG_INFO << no_cmp_hit << " of " << (no_cmp_hit + cmp_hit) << " valid net charge compomer results did not pass the feature charge constraints\n";
+    OPENMS_LOG_INFO << no_cmp_hit << " of " << (no_cmp_hit + cmp_hit) << " valid net charge compomer results did not pass the feature charge constraints\n";
 
     inferMoreEdges_(feature_relation, feature_adducts);
 
-    LOG_INFO << "Found " << feature_relation.size() << " putative edges (of " << possibleEdges << ")"
+    OPENMS_LOG_INFO << "Found " << feature_relation.size() << " putative edges (of " << possibleEdges << ")"
                << " and avg hit-size of " << (1.0 * overallHits / feature_relation.size())
                << std::endl;
 
@@ -726,7 +726,7 @@ namespace OpenMS
       ILPDCWrapper lp_wrapper;
       // compute best solution (this will REORDER elements on feature_relation[] !) - do not rely on order afterwards!
       double ilp_score = lp_wrapper.compute(fm_out, feature_relation, this->verbose_level_);
-      LOG_INFO << "ILP score is: " << ilp_score << std::endl;
+      OPENMS_LOG_INFO << "ILP score is: " << ilp_score << std::endl;
     }
 
     // prepare output consensusMaps
@@ -789,7 +789,7 @@ namespace OpenMS
           double rt_diff =  fabs(fm_out[feature_relation[i].getElementIndex(0)].getRT() - fm_out[feature_relation[i].getElementIndex(1)].getRT());
           if (verbose_level_ > 2)
           {
-            LOG_WARN << "Conflict in f_Q! f_RT:" << fm_out[f_idx_v[f_idx]].getRT() << " f_MZ:" << fm_out[f_idx_v[f_idx]].getMZ() << " f_int:" << fm_out[f_idx_v[f_idx]].getIntensity()
+            OPENMS_LOG_WARN << "Conflict in f_Q! f_RT:" << fm_out[f_idx_v[f_idx]].getRT() << " f_MZ:" << fm_out[f_idx_v[f_idx]].getMZ() << " f_int:" << fm_out[f_idx_v[f_idx]].getIntensity()
                      << " Q:" << fm_out[f_idx_v[f_idx]].getCharge() << " PredictedQ:" << feature_relation[i].getCharge((UInt)f_idx)
                      << "[[ dRT: " << rt_diff << " dMZ: " << feature_relation[i].getMassDiff() << " score[" << i << "]:"
                      << feature_relation[i].getEdgeScore() << " f#:" << fm_out[f_idx_v[f_idx]].getUniqueId() << " " << feature_relation[i].getCompomer().getAdductsAsString((UInt)f_idx)
@@ -816,7 +816,7 @@ namespace OpenMS
       }
 
     }
-    LOG_INFO << "Agreeing charges: " << agreeing_fcharge << "/" << (aedges * 2) << std::endl;
+    OPENMS_LOG_INFO << "Agreeing charges: " << agreeing_fcharge << "/" << (aedges * 2) << std::endl;
 
 
     // END DEBUG
@@ -1085,7 +1085,7 @@ namespace OpenMS
     }
     if (verbose_level_ > 2)
     {
-      LOG_INFO << "Single features without charge ladder: " << singletons_count << " of " << fm_out.size() << "\n";
+      OPENMS_LOG_INFO << "Single features without charge ladder: " << singletons_count << " of " << fm_out.size() << "\n";
     }
 
 
@@ -1231,7 +1231,7 @@ namespace OpenMS
       }
     } // edge for
 
-    LOG_INFO << "Inferring edges raised edge count from " << edges_size << " to " << edges.size() << "\n";
+    OPENMS_LOG_INFO << "Inferring edges raised edge count from " << edges_size << " to " << edges.size() << "\n";
   }
 
   void MetaboliteFeatureDeconvolution::printEdgesOfConnectedFeatures_(Size idx_1, Size idx_2, const PairsType& feature_relation)
@@ -1355,8 +1355,8 @@ namespace OpenMS
     // if more than 5% of charge ladder have only gapped, report
     if (ladders_with_odd < ladders_total * 0.95)
     {
-      LOG_WARN << ".\n..\nWarning: a significant portion of your decharged molecules have gapped, even-numbered charge ladders (" << ladders_total - ladders_with_odd << " of " << ladders_total << ")";
-      LOG_WARN <<"This might indicate a too low charge interval being tested.\n..\n.\n";
+      OPENMS_LOG_WARN << ".\n..\nWarning: a significant portion of your decharged molecules have gapped, even-numbered charge ladders (" << ladders_total - ladders_with_odd << " of " << ladders_total << ")";
+      OPENMS_LOG_WARN <<"This might indicate a too low charge interval being tested.\n..\n.\n";
     }
   }
 }

--- a/src/openms/source/ANALYSIS/ID/AScore.cpp
+++ b/src/openms/source/ANALYSIS/ID/AScore.cpp
@@ -88,7 +88,7 @@ namespace OpenMS
 
     if ((max_peptide_length_ > 0) && (seq_without_phospho.toUnmodifiedString().size() > max_peptide_length_))
     {
-      LOG_DEBUG << "\tcalculation aborted: peptide too long: " << seq_without_phospho.toString() << std::endl;
+      OPENMS_LOG_DEBUG << "\tcalculation aborted: peptide too long: " << seq_without_phospho.toString() << std::endl;
       return phospho;
     }
 
@@ -107,14 +107,14 @@ namespace OpenMS
     } 
 
     vector<vector<Size>> permutations = computePermutations_(sites, (Int)number_of_phosphorylation_events);
-    LOG_DEBUG << "\tnumber of permutations: " << permutations.size() << std::endl;
+    OPENMS_LOG_DEBUG << "\tnumber of permutations: " << permutations.size() << std::endl;
 
     // TODO: using a heuristic to calculate the best phospho sites if the number of permutations are exceeding the maximum.
     // A heuristic could be to calculate the best site for the first phosphorylation and based on this the best site for the second 
     // phosphorylation and so on until every site is determined
     if ((max_permutations_ > 0) && (permutations.size() > max_permutations_))
     {
-      LOG_DEBUG << "\tcalculation aborted: number of permutations exceeded" << std::endl;
+      OPENMS_LOG_DEBUG << "\tcalculation aborted: number of permutations exceeded" << std::endl;
       return phospho;
     }
 
@@ -155,7 +155,7 @@ namespace OpenMS
       double Ascore = 0;
       if (peptide1_score == peptide2_score) // set Ascore = 0 for each phosphorylation site
       {
-        LOG_DEBUG << "\tscore of best (" << seq1 << ") and second best peptide (" << seq2 << ") are equal (" << peptide1_score << ")" << std::endl;
+        OPENMS_LOG_DEBUG << "\tscore of best (" << seq1 << ") and second best peptide (" << seq2 << ") are equal (" << peptide1_score << ")" << std::endl;
       }
       else
       {
@@ -184,11 +184,11 @@ namespace OpenMS
         double score_first = abs(-10 * log10(P_first));
         double score_second = abs(-10 * log10(P_second));
 
-        LOG_DEBUG << "\tfirst - N: " << N << ",p: " << p << ",n: " << n_first << ", score: " << score_first << std::endl;
-        LOG_DEBUG << "\tsecond - N: " << N2 << ",p: " << p << ",n: " << n_second << ", score: " << score_second << std::endl;
+        OPENMS_LOG_DEBUG << "\tfirst - N: " << N << ",p: " << p << ",n: " << n_first << ", score: " << score_first << std::endl;
+        OPENMS_LOG_DEBUG << "\tsecond - N: " << N2 << ",p: " << p << ",n: " << n_second << ", score: " << score_second << std::endl;
 
         Ascore = score_first - score_second;
-        LOG_DEBUG << "\tAscore_" << rank << ": " << Ascore << std::endl;
+        OPENMS_LOG_DEBUG << "\tAscore_" << rank << ": " << Ascore << std::endl;
       }
       if (Ascore < best_Ascore)
       {
@@ -345,8 +345,8 @@ namespace OpenMS
       spectrum_first.begin(), spectrum_first.end(),
       std::inserter(spectrum_second_diff, spectrum_second_diff.begin()));
       
-    LOG_DEBUG << spectrum_first_diff << std::endl;
-    LOG_DEBUG << spectrum_second_diff << std::endl;
+    OPENMS_LOG_DEBUG << spectrum_first_diff << std::endl;
+    OPENMS_LOG_DEBUG << spectrum_second_diff << std::endl;
       
     site_determining_ions[0] = spectrum_first_diff;
     site_determining_ions[1] = spectrum_second_diff;

--- a/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
+++ b/src/openms/source/ANALYSIS/ID/AccurateMassSearchEngine.cpp
@@ -235,7 +235,7 @@ namespace OpenMS
       }
 
       EmpiricalFormula ef_part(formula_str);
-      LOG_DEBUG << "Adducts: " << stoichio_factor << "*" << formula_str << " == " << stoichio_factor * ef_part.getMonoWeight() << std::endl;
+      OPENMS_LOG_DEBUG << "Adducts: " << stoichio_factor << "*" << formula_str << " == " << stoichio_factor * ef_part.getMonoWeight() << std::endl;
 
       if (op_plus)
       {
@@ -632,7 +632,7 @@ namespace OpenMS
         if (!it->isCompatible(EmpiricalFormula(mass_mappings_[i].formula)))
         {
           // only written if TOPP tool has --debug
-          LOG_DEBUG << "'" << mass_mappings_[i].formula << "' cannot have adduct '" << it->getName() << "'. Omitting.\n";
+          OPENMS_LOG_DEBUG << "'" << mass_mappings_[i].formula << "' cannot have adduct '" << it->getName() << "'. Omitting.\n";
           continue;
         }
 
@@ -806,7 +806,7 @@ namespace OpenMS
       {
         if (!fmap[i].metaValueExists("num_of_masstraces"))
         {
-          LOG_WARN << "Feature does not contain meta value 'num_of_masstraces'. Cannot compute isotope similarity.";
+          OPENMS_LOG_WARN << "Feature does not contain meta value 'num_of_masstraces'. Cannot compute isotope similarity.";
         }
         else if ((Size)fmap[i].getMetaValue("num_of_masstraces") > 1)
         { // compute isotope pattern similarities (do not take the best-scoring one, since it might have really bad ppm or other properties --
@@ -838,11 +838,11 @@ namespace OpenMS
 
     if (fmap.empty())
     {
-      LOG_INFO << "FeatureMap was empty! No hits found!" << std::endl;
+      OPENMS_LOG_INFO << "FeatureMap was empty! No hits found!" << std::endl;
     }
     else
     { // division by 0 if used on empty fmap
-      LOG_INFO << "\nFound " << (overall_results.size() - dummy_count) << " matched masses (with at least one hit each)\nfrom " << fmap.size() << " features\n  --> " << (overall_results.size()-dummy_count)*100/fmap.size() << "% explained" << std::endl;
+      OPENMS_LOG_INFO << "\nFound " << (overall_results.size() - dummy_count) << " matched masses (with at least one hit each)\nfrom " << fmap.size() << " features\n  --> " << (overall_results.size()-dummy_count)*100/fmap.size() << "% explained" << std::endl;
     }
 
     exportMzTab_(overall_results, 1, mztab_out);
@@ -1245,12 +1245,12 @@ namespace OpenMS
     mztab_out.setSmallMoleculeSectionRows(all_sm_rows);
 
     // print some adduct stats:
-    LOG_INFO << "Hits by adduct: #peaks explained (# matching db entries)'\n";
+    OPENMS_LOG_INFO << "Hits by adduct: #peaks explained (# matching db entries)'\n";
     for (std::map<String, UInt>::const_iterator it = adduct_stats.begin(); it != adduct_stats.end(); ++it)
     {
-      LOG_INFO << "  '" << it->first << "' : " << adduct_stats_unique[it->first].size() << " (" << it->second << ")\n";
+      OPENMS_LOG_INFO << "  '" << it->first << "' : " << adduct_stats_unique[it->first].size() << " (" << it->second << ")\n";
     }
-    LOG_INFO << std::endl;
+    OPENMS_LOG_INFO << std::endl;
 
   }
 
@@ -1302,7 +1302,7 @@ namespace OpenMS
       std::stringstream str_buf;
       std::istream_iterator<String> eol;
 
-      // LOG_DEBUG << "parsing " << fname << " file..." << std::endl;
+      // OPENMS_LOG_DEBUG << "parsing " << fname << " file..." << std::endl;
 
       std::ifstream ifs(filename.c_str());
       while (getline(ifs, line))
@@ -1351,7 +1351,7 @@ namespace OpenMS
 
         while (istr_it != eol)
         {
-          // LOG_DEBUG << *istr_it << " ";
+          // OPENMS_LOG_DEBUG << *istr_it << " ";
           if (word_count == 0)
           {
             entry.mass = istr_it->toDouble();
@@ -1373,7 +1373,7 @@ namespace OpenMS
           ++word_count;
           ++istr_it;
         }
-        // LOG_DEBUG << std::endl;
+        // OPENMS_LOG_DEBUG << std::endl;
 
         if (entry.massIDs.empty())
         {
@@ -1384,7 +1384,7 @@ namespace OpenMS
     }
     std::sort(mass_mappings_.begin(), mass_mappings_.end(), CompareEntryAndMass_());
 
-    LOG_INFO << "Read " << mass_mappings_.size() << " entries from mapping file!" << std::endl;
+    OPENMS_LOG_INFO << "Read " << mass_mappings_.size() << " entries from mapping file!" << std::endl;
 
     return;
   }
@@ -1406,7 +1406,7 @@ namespace OpenMS
 
       std::ifstream ifs(filename.c_str());
       String line;
-      // LOG_DEBUG << "parsing " << fname << " file..." << std::endl;
+      // OPENMS_LOG_DEBUG << "parsing " << fname << " file..." << std::endl;
 
       std::vector<String> parts;
       while (getline(ifs, line))
@@ -1455,14 +1455,14 @@ namespace OpenMS
       result.push_back(AdductInfo::parseAdductString(*it));
     }
 
-    LOG_INFO << "Read " << result.size() << " entries from adduct file '" << fname << "'." << std::endl;
+    OPENMS_LOG_INFO << "Read " << result.size() << " entries from adduct file '" << fname << "'." << std::endl;
 
     return;
   }
 
   void AccurateMassSearchEngine::searchMass_(double neutral_query_mass, double diff_mass, std::pair<Size, Size>& hit_indices) const
   {
-    //LOG_INFO << "searchMass: neutral_query_mass=" << neutral_query_mass << " diff_mz=" << diff_mz << " ppm allowed:" << mass_error_value_ << std::endl;
+    //OPENMS_LOG_INFO << "searchMass: neutral_query_mass=" << neutral_query_mass << " diff_mz=" << diff_mz << " ppm allowed:" << mass_error_value_ << std::endl;
 
     // binary search for formulas which are within diff_mz distance
     if (mass_mappings_.empty())

--- a/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithm.cpp
@@ -127,7 +127,7 @@ namespace OpenMS
       hit.setScore(res_it->second.second[0]);
       ids[0].insertHit(hit);
 #ifdef DEBUG_ID_CONSENSUS
-      LOG_DEBUG << " - Output hit: " << hit.getSequence() << " "
+      OPENMS_LOG_DEBUG << " - Output hit: " << hit.getSequence() << " "
                 << hit.getScore() << endl;
 #endif
     }

--- a/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithmIdentity.cpp
+++ b/src/openms/source/ANALYSIS/ID/ConsensusIDAlgorithmIdentity.cpp
@@ -72,7 +72,7 @@ namespace OpenMS
     {
       String types;
       types.concatenate(score_types.begin(), score_types.end(), "'/'");
-      LOG_WARN << "Warning: Different score types for peptide hits found ('"
+      OPENMS_LOG_WARN << "Warning: Different score types for peptide hits found ('"
                << types << "'). If the scores are not comparable, "
                << "results will be meaningless." << endl;
     }

--- a/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
+++ b/src/openms/source/ANALYSIS/ID/FalseDiscoveryRate.cpp
@@ -74,7 +74,7 @@ namespace OpenMS
 
     if (ids.empty())
     {
-      LOG_WARN << "No peptide identifications given to FalseDiscoveryRate! No calculation performed.\n";
+      OPENMS_LOG_WARN << "No peptide identifications given to FalseDiscoveryRate! No calculation performed.\n";
       return;
     }
 
@@ -152,7 +152,7 @@ namespace OpenMS
 
             if (!it->getHits()[i].metaValueExists("target_decoy"))
             {
-              LOG_FATAL_ERROR << "Meta value 'target_decoy' does not exists, reindex the idXML file with 'PeptideIndexer' first (run-id='" << it->getIdentifier() << ", rank=" << i + 1 << " of " << it->getHits().size() << ")!" << endl;
+              OPENMS_LOG_FATAL_ERROR << "Meta value 'target_decoy' does not exists, reindex the idXML file with 'PeptideIndexer' first (run-id='" << it->getIdentifier() << ", rank=" << i + 1 << " of " << it->getHits().size() << ")!" << endl;
               throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Meta value 'target_decoy' does not exist!");
             }
 
@@ -199,7 +199,7 @@ namespace OpenMS
             }
             error_string += ")";
           }
-          LOG_ERROR << error_string << std::endl;
+          OPENMS_LOG_ERROR << error_string << std::endl;
         }
 
         // check target scores
@@ -219,7 +219,7 @@ namespace OpenMS
             }
             error_string += ")";
           }
-          LOG_ERROR << error_string << std::endl;
+          OPENMS_LOG_ERROR << error_string << std::endl;
         }
 
         if (target_scores.empty() || decoy_scores.empty())
@@ -244,7 +244,7 @@ namespace OpenMS
 
               if (!hits[i].metaValueExists("target_decoy"))
               {
-                LOG_FATAL_ERROR << "Meta value 'target_decoy' does not exists, reindex the idXML file with 'PeptideIndexer' (run-id='" << it->getIdentifier() << ", rank=" << i + 1 << " of " << hits.size() << ")!" << endl;
+                OPENMS_LOG_FATAL_ERROR << "Meta value 'target_decoy' does not exists, reindex the idXML file with 'PeptideIndexer' (run-id='" << it->getIdentifier() << ", rank=" << i + 1 << " of " << hits.size() << ")!" << endl;
                 throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Meta value 'target_decoy' does not exist!");
               }
 
@@ -435,7 +435,7 @@ namespace OpenMS
 
     if (ids.empty())
     {
-      LOG_WARN << "No protein identifications given to FalseDiscoveryRate! No calculation performed.\n";
+      OPENMS_LOG_WARN << "No protein identifications given to FalseDiscoveryRate! No calculation performed.\n";
       return;
     }
 
@@ -446,7 +446,7 @@ namespace OpenMS
       {
         if (!pit->metaValueExists("target_decoy"))
         {
-          LOG_FATAL_ERROR << "Meta value 'target_decoy' does not exists, reindex the idXML file with 'PeptideIndexer' (run-id='" << it->getIdentifier() << ", accession=" << pit->getAccession() << ")!" << endl;
+          OPENMS_LOG_FATAL_ERROR << "Meta value 'target_decoy' does not exists, reindex the idXML file with 'PeptideIndexer' (run-id='" << it->getIdentifier() << ", accession=" << pit->getAccession() << ")!" << endl;
           throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Meta value 'target_decoy' does not exist!");
         }
 

--- a/src/openms/source/ANALYSIS/ID/IDMapper.cpp
+++ b/src/openms/source/ANALYSIS/ID/IDMapper.cpp
@@ -196,7 +196,7 @@ namespace OpenMS
     }
 
     // some statistics output
-    LOG_INFO << "Peptides assigned to a precursor: " << peptides_mapped.size() << "\n"
+    OPENMS_LOG_INFO << "Peptides assigned to a precursor: " << peptides_mapped.size() << "\n"
              << "             Unassigned peptides: " << peptide_ids.size() - peptides_mapped.size() << "\n"
              << "       Unmapped (empty) peptides: " << peptide_ids.size() - identifications_precursors.size() << endl;
   }
@@ -360,9 +360,9 @@ namespace OpenMS
     if (!ids.empty() && !spectra.empty())
     {
 
-      LOG_INFO << "Mapping " << ids.size() << "PeptideIdentifications to " << spectra.size() << " spectra." << endl;
+      OPENMS_LOG_INFO << "Mapping " << ids.size() << "PeptideIdentifications to " << spectra.size() << " spectra." << endl;
 
-      LOG_INFO << "Identification state of spectra: \n"
+      OPENMS_LOG_INFO << "Identification state of spectra: \n"
                << "Unidentified: " << unidentified.size() << "\n"
                << "Identified:   " << mapPrecursorsToIdentifications(spectra, ids).identified.size() << "\n"
                << "No precursor: " << mapPrecursorsToIdentifications(spectra, ids).no_precursors.size() << endl;
@@ -484,14 +484,14 @@ namespace OpenMS
     // some statistics output
     if (!ids.empty())
     {
-      LOG_INFO << "Unassigned peptides: " << id_matches_none << "\n"
+      OPENMS_LOG_INFO << "Unassigned peptides: " << id_matches_none << "\n"
                << "Peptides assigned to exactly one feature: " << id_matches_single << "\n"
                << "Peptides assigned to multiple features: " << id_matches_multiple << "\n";
     }
 
     if (!spectra.empty())
     {
-      LOG_INFO << "Unassigned precursors without identification: " << spectrum_matches_none << "\n"
+      OPENMS_LOG_INFO << "Unassigned precursors without identification: " << spectrum_matches_none << "\n"
                << "Unidentified precursor assigned to exactly one feature: " << spectrum_matches_single << "\n"
                << "Unidentified precursor assigned to multiple features: " << spectrum_matches_multiple << "\n";
     }
@@ -516,7 +516,7 @@ namespace OpenMS
         {
           use_centroid_rt = true;
           use_centroid_mz = true;
-          LOG_WARN << "IDMapper warning: at least one feature has no convex hull - using centroid coordinates for matching" << endl;
+          OPENMS_LOG_WARN << "IDMapper warning: at least one feature has no convex hull - using centroid coordinates for matching" << endl;
           break;
         }
       }
@@ -587,7 +587,7 @@ namespace OpenMS
     }
     else
     {
-      LOG_WARN << "IDMapper received an empty FeatureMap! All peptides are mapped as 'unassigned'!" << endl;
+      OPENMS_LOG_WARN << "IDMapper received an empty FeatureMap! All peptides are mapped as 'unassigned'!" << endl;
     }
 
     // for statistics:
@@ -825,15 +825,15 @@ namespace OpenMS
     }
 
     // some statistics output
-    LOG_INFO << "Unassigned peptides: " << matches_none << "\n"
+    OPENMS_LOG_INFO << "Unassigned peptides: " << matches_none << "\n"
     << "Peptides assigned to exactly one feature: " << matches_single << "\n"
     << "Peptides assigned to multiple features: " << matches_multi << "\n";
 
-    LOG_INFO << "Unassigned and unidentified precursors: " << spectrum_matches_none << "\n"
+    OPENMS_LOG_INFO << "Unassigned and unidentified precursors: " << spectrum_matches_none << "\n"
     << "Unidentified precursor assigned to exactly one feature: " << spectrum_matches_single << "\n"
     << "Unidentified precursor assigned to multiple features: " << spectrum_matches_multi << "\n";
 
-    LOG_INFO << map.getAnnotationStatistics() << endl;
+    OPENMS_LOG_INFO << map.getAnnotationStatistics() << endl;
   }
 
   double IDMapper::getAbsoluteMZTolerance_(const double mz) const
@@ -932,7 +932,7 @@ namespace OpenMS
           continue; // parameter info not available
         if (!before.empty() && (reported_mz != before))
         {
-          LOG_WARN << "The m/z values reported for features in the input seem to be of different types (e.g. monoisotopic/average). They will all be compared against monoisotopic peptide masses, but the mapping results may not be meaningful in the end." << endl;
+          OPENMS_LOG_WARN << "The m/z values reported for features in the input seem to be of different types (e.g. monoisotopic/average). They will all be compared against monoisotopic peptide masses, but the mapping results may not be meaningful in the end." << endl;
           return false;
         }
         if (reported_mz == "average")
@@ -941,7 +941,7 @@ namespace OpenMS
         }
         else if (reported_mz == "maximum")
         {
-          LOG_WARN << "For features, m/z values from the highest mass traces are reported. This type of m/z value is not available for peptides, so the comparison has to be done using average peptide masses." << endl;
+          OPENMS_LOG_WARN << "For features, m/z values from the highest mass traces are reported. This type of m/z value is not available for peptides, so the comparison has to be done using average peptide masses." << endl;
           use_avg_mass = true;
         }
         before = reported_mz;

--- a/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
+++ b/src/openms/source/ANALYSIS/ID/PeptideProteinResolution.cpp
@@ -133,7 +133,7 @@ namespace OpenMS
     {
       if (statistics_ && (old_size - indist_prot_grp_to_pep_.size() > 1))
       {
-        LOG_INFO << "resolved group of size "
+        OPENMS_LOG_INFO << "resolved group of size "
         << old_size - indist_prot_grp_to_pep_.size() << " in last step "
         << endl;
         old_size = indist_prot_grp_to_pep_.size();
@@ -171,9 +171,9 @@ namespace OpenMS
         
         if (curr_component.prot_grp_indices.size() > 1)
         {
-          LOG_INFO << "found group: " << endl;
-          LOG_INFO << curr_component;
-          LOG_INFO << endl << "Processing ..." << endl;
+          OPENMS_LOG_INFO << "found group: " << endl;
+          OPENMS_LOG_INFO << curr_component;
+          OPENMS_LOG_INFO << endl << "Processing ..." << endl;
         }
       }
       
@@ -196,12 +196,12 @@ namespace OpenMS
     //TODO maybe extend statistics of connected components!
     if (statistics_)
     {
-      LOG_INFO << endl << "Most protein groups in component:" << endl;
-      LOG_INFO << most_grps;
-      LOG_INFO << endl << "Most peptides in component:"<< endl;
-      LOG_INFO << most_peps;
-      LOG_INFO << endl << "Biggest component:" << endl;
-      LOG_INFO << most_both;
+      OPENMS_LOG_INFO << endl << "Most protein groups in component:" << endl;
+      OPENMS_LOG_INFO << most_grps;
+      OPENMS_LOG_INFO << endl << "Most peptides in component:"<< endl;
+      OPENMS_LOG_INFO << most_peps;
+      OPENMS_LOG_INFO << endl << "Biggest component:" << endl;
+      OPENMS_LOG_INFO << most_both;
     }
   }
 

--- a/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
+++ b/src/openms/source/ANALYSIS/ID/PercolatorFeatureSetHelper.cpp
@@ -105,7 +105,7 @@ namespace OpenMS
               else
               {
                 stdev_error_top7 = mean_error_top7;
-                LOG_WARN << "StdevErrorTop7 is NaN, setting as MeanErrorTop7 instead." << endl;
+                OPENMS_LOG_WARN << "StdevErrorTop7 is NaN, setting as MeanErrorTop7 instead." << endl;
               }
               
               mean_error_top7 = rescaleFragmentFeature_(mean_error_top7, num_matched_main_ions);
@@ -116,7 +116,7 @@ namespace OpenMS
               hit->setMetaValue("MSGF:StdevErrorTop7", stdev_error_top7);
             }
           }
-          else LOG_WARN << "MS-GF+ PSM with missing NumMatchedMainIons skipped." << endl;
+          else OPENMS_LOG_WARN << "MS-GF+ PSM with missing NumMatchedMainIons skipped." << endl;
         }
       }
     }
@@ -274,7 +274,7 @@ namespace OpenMS
       for (StringList::iterator it = search_engines_used.begin(); it != search_engines_used.end(); ++it) {
         feature_set.push_back("CONCAT:" + *it);
       }
-      LOG_INFO << "Using " << ListUtils::concatenate(search_engines_used, ", ") << " as source for search engine specific features." << endl;
+      OPENMS_LOG_INFO << "Using " << ListUtils::concatenate(search_engines_used, ", ") << " as source for search engine specific features." << endl;
       feature_set.push_back("CONCAT:lnEvalue");
       feature_set.push_back("CONCAT:deltaLnEvalue");
       
@@ -289,7 +289,7 @@ namespace OpenMS
 
     void PercolatorFeatureSetHelper::mergeMULTISEPeptideIds(vector<PeptideIdentification>& all_peptide_ids, vector<PeptideIdentification>& new_peptide_ids, String search_engine)
     {
-      LOG_DEBUG << "creating spectrum map" << endl;
+      OPENMS_LOG_DEBUG << "creating spectrum map" << endl;
       
       std::map<String,PeptideIdentification> unified;
       //setup map of merge characteristics per spectrum
@@ -301,11 +301,11 @@ namespace OpenMS
         String spectrum_reference = getScanMergeKey_(pit, all_peptide_ids.begin());
         unified[spectrum_reference] = ins;
       }
-      LOG_DEBUG << "filled spectrum map with previously observed PSM: " << unified.size() << endl;
+      OPENMS_LOG_DEBUG << "filled spectrum map with previously observed PSM: " << unified.size() << endl;
 
       int nc = 0;
       int mc = 0;
-      LOG_DEBUG << "About to merge in:" << new_peptide_ids.size() << "PSMs." << endl;
+      OPENMS_LOG_DEBUG << "About to merge in:" << new_peptide_ids.size() << "PSMs." << endl;
       for (vector<PeptideIdentification>::iterator pit = new_peptide_ids.begin(); pit != new_peptide_ids.end(); ++pit)
       {
         PeptideIdentification ins = *pit;
@@ -412,22 +412,22 @@ namespace OpenMS
         }
       }
       
-      LOG_DEBUG << "filled spectrum map" << endl;
+      OPENMS_LOG_DEBUG << "filled spectrum map" << endl;
       std::vector<PeptideIdentification> swip;
       swip.reserve(unified.size());
-      LOG_DEBUG << "merging spectrum map" << endl;
+      OPENMS_LOG_DEBUG << "merging spectrum map" << endl;
       for (std::map<String,PeptideIdentification>::iterator it = unified.begin(); it != unified.end(); ++it)
       {
         swip.push_back(it->second);
       }
       all_peptide_ids.swap(swip);
-      LOG_DEBUG << "Now containing " << all_peptide_ids.size() << " spectra identifications, new: " << nc << " merged in: " << mc << endl;
+      OPENMS_LOG_DEBUG << "Now containing " << all_peptide_ids.size() << " spectra identifications, new: " << nc << " merged in: " << mc << endl;
     }
     
     // references from PeptideHits to ProteinHits work with the protein accessions, so no need to update the PeptideHits
     void PercolatorFeatureSetHelper::mergeMULTISEProteinIds(vector<ProteinIdentification>& all_protein_ids, vector<ProteinIdentification>& new_protein_ids)
     {      
-      LOG_DEBUG << "merging search parameters" << endl;
+      OPENMS_LOG_DEBUG << "merging search parameters" << endl;
       
       String SE = new_protein_ids.front().getSearchEngine();  
       if (all_protein_ids.empty())
@@ -439,7 +439,7 @@ namespace OpenMS
         all_protein_ids.front().setDateTime(now);
         all_protein_ids.front().setIdentifier(identifier);
         all_protein_ids.front().setSearchEngine(SE);
-        LOG_DEBUG << "Setting search engine to " << SE << endl;
+        OPENMS_LOG_DEBUG << "Setting search engine to " << SE << endl;
         all_protein_ids.front().setSearchParameters(new_protein_ids.front().getSearchParameters());
       }
       else if (all_protein_ids.front().getSearchEngine() != SE)
@@ -449,10 +449,10 @@ namespace OpenMS
       std::vector<ProteinHit>& all_protein_hits = all_protein_ids.front().getHits();
       std::vector<ProteinHit>& new_protein_hits = new_protein_ids.front().getHits();
       
-      LOG_DEBUG << "Sorting " << new_protein_hits.size() << " new ProteinHits." << endl;
+      OPENMS_LOG_DEBUG << "Sorting " << new_protein_hits.size() << " new ProteinHits." << endl;
       std::sort(new_protein_hits.begin(), new_protein_hits.end(), PercolatorFeatureSetHelper::lq_ProteinHit());
       
-      LOG_DEBUG << "Melting with " << all_protein_hits.size() << " previous ProteinHits." << endl;
+      OPENMS_LOG_DEBUG << "Melting with " << all_protein_hits.size() << " previous ProteinHits." << endl;
       if (all_protein_hits.empty())
       {
         all_protein_hits.swap(new_protein_hits);
@@ -467,13 +467,13 @@ namespace OpenMS
         tmp_protein_hits.resize(uni - tmp_protein_hits.begin());
         all_protein_hits.swap(tmp_protein_hits);
       }
-      LOG_DEBUG << "Done with next ProteinHits." << endl;
+      OPENMS_LOG_DEBUG << "Done with next ProteinHits." << endl;
     
       StringList keys;
       all_protein_ids.front().getSearchParameters().getKeys(keys);      
       if (!ListUtils::contains(keys, "SE:" + SE)) 
       {
-        LOG_DEBUG << "Melting Parameters from " << SE << " into MetaInfo." << endl;
+        OPENMS_LOG_DEBUG << "Melting Parameters from " << SE << " into MetaInfo." << endl;
         
         //insert into MetaInfo as SE:param
         ProteinIdentification::SearchParameters sp = new_protein_ids.front().getSearchParameters();
@@ -492,10 +492,10 @@ namespace OpenMS
         all_sp.setMetaValue(SE+":precursor_mass_tolerance_ppm",sp.precursor_mass_tolerance_ppm);
         all_sp.setMetaValue(SE+":digestion_enzyme",sp.digestion_enzyme.getName());
         
-        LOG_DEBUG << "Done with next Parameters." << endl;
+        OPENMS_LOG_DEBUG << "Done with next Parameters." << endl;
         all_protein_ids.front().setSearchParameters(all_sp);
       }
-      LOG_DEBUG << "Merging primaryMSRunPaths." << endl;
+      OPENMS_LOG_DEBUG << "Merging primaryMSRunPaths." << endl;
       try
       {
         StringList all_primary_ms_run_path;
@@ -506,15 +506,15 @@ namespace OpenMS
         all_primary_ms_run_path.insert(all_primary_ms_run_path.end(), new_primary_ms_run_path.begin(), new_primary_ms_run_path.end());
         all_protein_ids.front().setPrimaryMSRunPath(all_primary_ms_run_path);
 
-        LOG_DEBUG << "New primary run paths: " << ListUtils::concatenate(new_primary_ms_run_path,",") << endl;
-        LOG_DEBUG << "All primary run paths: " << ListUtils::concatenate(all_primary_ms_run_path,",") << endl;
+        OPENMS_LOG_DEBUG << "New primary run paths: " << ListUtils::concatenate(new_primary_ms_run_path,",") << endl;
+        OPENMS_LOG_DEBUG << "All primary run paths: " << ListUtils::concatenate(all_primary_ms_run_path,",") << endl;
       }
       catch (Exception::BaseException& e)
       {
-        LOG_DEBUG << "faulty primary MS run path: " << endl;
+        OPENMS_LOG_DEBUG << "faulty primary MS run path: " << endl;
         Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, e.what(), "");
       }
-      LOG_DEBUG << "Merging for this file finished." << endl;
+      OPENMS_LOG_DEBUG << "Merging for this file finished." << endl;
     }
     
     void PercolatorFeatureSetHelper::concatMULTISEPeptideIds(vector<PeptideIdentification>& all_peptide_ids, vector<PeptideIdentification>& new_peptide_ids, String search_engine)
@@ -586,7 +586,7 @@ namespace OpenMS
       //feature_set.push_back("MULTI:ionFrac");
       //feature_set.push_back("MULTI:numHits"); // this is not informative if we only keep PSMs with hits for all search engines
       
-      LOG_INFO << "Using " << ListUtils::concatenate(search_engines_used, ", ") << " as source for search engine specific features." << endl;
+      OPENMS_LOG_INFO << "Using " << ListUtils::concatenate(search_engines_used, ", ") << " as source for search engine specific features." << endl;
 
       // get all the feature values
       if (!complete_only)
@@ -604,11 +604,11 @@ namespace OpenMS
                 {
                   String recast = hit->getMetaValue(*feats);
                   double d = boost::lexical_cast<double>(recast);
-                  LOG_DEBUG << "recast: "
+                  OPENMS_LOG_DEBUG << "recast: "
                             << recast << " "
                             << double(hit->getMetaValue(*feats)) << "* ";
                   hit->setMetaValue(*feats,d);
-                  LOG_DEBUG << hit->getMetaValue(*feats).valueType() << " "
+                  OPENMS_LOG_DEBUG << hit->getMetaValue(*feats).valueType() << " "
                             << hit->getMetaValue(*feats)
                             << endl;
                 }
@@ -652,7 +652,7 @@ namespace OpenMS
       size_t complete_spectra = 0;
       size_t incomplete_spectra = 0;
 
-      LOG_DEBUG << "Looking for minimum feature set:" << ListUtils::concatenate(feature_set, ", ") << "." << endl;
+      OPENMS_LOG_DEBUG << "Looking for minimum feature set:" << ListUtils::concatenate(feature_set, ", ") << "." << endl;
 
       for (vector<PeptideIdentification>::iterator pi = peptide_ids.begin(); pi != peptide_ids.end(); ++pi)
       {
@@ -702,15 +702,15 @@ namespace OpenMS
       }
       if (sum_removed > 0)
       {
-        LOG_WARN << "Removed " << sum_removed << " incomplete cases of PSMs." << endl;
+        OPENMS_LOG_WARN << "Removed " << sum_removed << " incomplete cases of PSMs." << endl;
       }
       if (imputed_values > 0)
       {
-        LOG_WARN << "Imputed " << imputed_values << " of " << observed_values+imputed_values
+        OPENMS_LOG_WARN << "Imputed " << imputed_values << " of " << observed_values+imputed_values
                  << " missing values. ("
                  << imputed_values*100.0/(imputed_values+observed_values)
                  << "%)" << endl;
-        LOG_WARN << "Affected " << incomplete_spectra << " of " << incomplete_spectra+complete_spectra
+        OPENMS_LOG_WARN << "Affected " << incomplete_spectra << " of " << incomplete_spectra+complete_spectra
                  << " spectra. ("
                  << incomplete_spectra*100.0/(incomplete_spectra+complete_spectra)
                  << "%)" << endl;
@@ -732,7 +732,7 @@ namespace OpenMS
       }
       for (set<StringList::iterator>::reverse_iterator rit = unavail.rbegin(); rit != unavail.rend(); ++rit)
       {
-        LOG_WARN << "A extra_feature requested (" << *(*rit) << ") was not available - removed." << endl;
+        OPENMS_LOG_WARN << "A extra_feature requested (" << *(*rit) << ") was not available - removed." << endl;
         extra_features.erase(*rit);
       }
     }
@@ -781,7 +781,7 @@ namespace OpenMS
         else
         {
           scan_identifier = "index=" + String(it - start + 1);
-          LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
+          OPENMS_LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
         }
       }
       

--- a/src/openms/source/ANALYSIS/ID/PrecursorPurity.cpp
+++ b/src/openms/source/ANALYSIS/ID/PrecursorPurity.cpp
@@ -172,7 +172,7 @@ namespace OpenMS
     // if there is no MS1 before the first MS2, the spectra datastructure is not suitable for this function
     if (spectra[0].getMSLevel() == 2)
     {
-      LOG_WARN << "Warning: Input data not suitable for Precursor Purity computation. Will be skipped!\n";
+      OPENMS_LOG_WARN << "Warning: Input data not suitable for Precursor Purity computation. Will be skipped!\n";
       return purityscores;
     }
 

--- a/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SimpleSearchEngineAlgorithm.cpp
@@ -551,9 +551,9 @@ void SimpleSearchEngineAlgorithm::postProcessHits_(const PeakMap& exp,
     }
     endProgress();
 
-    LOG_INFO << "Proteins: " << count_proteins << endl;
-    LOG_INFO << "Peptides: " << count_peptides << endl;
-    LOG_INFO << "Processed peptides: " << processed_petides.size() << endl;
+    OPENMS_LOG_INFO << "Proteins: " << count_proteins << endl;
+    OPENMS_LOG_INFO << "Peptides: " << count_peptides << endl;
+    OPENMS_LOG_INFO << "Processed peptides: " << processed_petides.size() << endl;
 
     startProgress(0, 1, "Post-processing PSMs...");
     SimpleSearchEngineAlgorithm::postProcessHits_(spectra, 

--- a/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusAdapterAlgorithm.cpp
@@ -158,7 +158,7 @@ namespace OpenMS
       QFileInfo file_info(exe);
       exe = file_info.canonicalFilePath();
   
-      LOG_WARN << "Executable is: " + String(exe) << std::endl;
+      OPENMS_LOG_WARN << "Executable is: " + String(exe) << std::endl;
       const String path_to_executable = File::path(exe);
       executable_workdir = std::make_pair(exe.toStdString(), path_to_executable);
       
@@ -202,7 +202,7 @@ namespace OpenMS
           if (num_masstrace_filter != 1 && !feature_only)
           {
             num_masstrace_filter = 1;
-            LOG_WARN << "Parameter: filter_by_num_masstraces, was set to 1 to retain the adduct information for all MS2 spectra, if available. Please use the masstrace filter in combination with feature_only." << std::endl;
+            OPENMS_LOG_WARN << "Parameter: filter_by_num_masstraces, was set to 1 to retain the adduct information for all MS2 spectra, if available. Please use the masstrace filter in combination with feature_only." << std::endl;
           }
 
           // filter feature by number of masstraces
@@ -243,12 +243,12 @@ namespace OpenMS
       // number of features to be processed 
       if (feature_only && !featureinfo.empty())
       {
-        LOG_WARN << "Number of features to be processed: " << feature_mapping.assignedMS2.size() << std::endl;
+        OPENMS_LOG_WARN << "Number of features to be processed: " << feature_mapping.assignedMS2.size() << std::endl;
       }
       else if (!featureinfo.empty())
       {
-        LOG_WARN << "Number of features to be processed: " << feature_mapping.assignedMS2.size() << std::endl;
-        LOG_WARN << "Number of additional MS2 spectra to be processed: " << feature_mapping.unassignedMS2.size() << std::endl;
+        OPENMS_LOG_WARN << "Number of features to be processed: " << feature_mapping.assignedMS2.size() << std::endl;
+        OPENMS_LOG_WARN << "Number of additional MS2 spectra to be processed: " << feature_mapping.unassignedMS2.size() << std::endl;
       } 
       else
       {
@@ -260,7 +260,7 @@ namespace OpenMS
             count_ms2++;
           }
         }
-        LOG_WARN << "Number of MS2 spectra to be processed: " << count_ms2 << std::endl;
+        OPENMS_LOG_WARN << "Number of MS2 spectra to be processed: " << count_ms2 << std::endl;
       }
     } 
 
@@ -323,19 +323,19 @@ namespace OpenMS
       {
           ss << " " << it->toStdString();
       }
-      LOG_DEBUG << ss.str() << std::endl;
-      LOG_WARN << "Executing: " + String(exe) << std::endl;
-      LOG_WARN << "Working Dir is: " + String(wd) << std::endl;
+      OPENMS_LOG_DEBUG << ss.str() << std::endl;
+      OPENMS_LOG_WARN << "Executing: " + String(exe) << std::endl;
+      OPENMS_LOG_WARN << "Working Dir is: " + String(wd) << std::endl;
       const bool success = qp.waitForFinished(-1); // wait till job is finished
   
       if (!success || qp.exitStatus() != 0 || qp.exitCode() != 0)
       {
-        LOG_WARN << "FATAL: External invocation of Sirius failed. Standard output and error were:" << std::endl;
+        OPENMS_LOG_WARN << "FATAL: External invocation of Sirius failed. Standard output and error were:" << std::endl;
         const QString sirius_stdout(qp.readAllStandardOutput());
         const QString sirius_stderr(qp.readAllStandardError());
-        LOG_WARN << String(sirius_stdout) << std::endl;
-        LOG_WARN << String(sirius_stderr) << std::endl;
-        LOG_WARN << String(qp.exitCode()) << std::endl;
+        OPENMS_LOG_WARN << String(sirius_stdout) << std::endl;
+        OPENMS_LOG_WARN << String(sirius_stderr) << std::endl;
+        OPENMS_LOG_WARN << String(qp.exitCode()) << std::endl;
         qp.close();
 
         throw Exception::InvalidValue(__FILE__,

--- a/src/openms/source/ANALYSIS/ID/SiriusMSConverter.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusMSConverter.cpp
@@ -695,10 +695,10 @@ namespace OpenMS
 
     os.close();
 
-    LOG_WARN << "No MS1 spectrum for this precursor. Occurred " << count_no_ms1 << " times." << endl;
-    LOG_WARN << count_skipped_spectra << " spectra were skipped due to precursor charge below -1 and above +1." << endl;
-    LOG_WARN << "Mono charge assumed and set to charge 1 with respect to current polarity " << count_assume_mono << " times."<< endl;
-    LOG_WARN << count_skipped_features << " features were skipped due to feature charge below -1 and above +1." << endl;
+    OPENMS_LOG_WARN << "No MS1 spectrum for this precursor. Occurred " << count_no_ms1 << " times." << endl;
+    OPENMS_LOG_WARN << count_skipped_spectra << " spectra were skipped due to precursor charge below -1 and above +1." << endl;
+    OPENMS_LOG_WARN << "Mono charge assumed and set to charge 1 with respect to current polarity " << count_assume_mono << " times."<< endl;
+    OPENMS_LOG_WARN << count_skipped_features << " features were skipped due to feature charge below -1 and above +1." << endl;
 
   }
 } // namespace OpenMS

--- a/src/openms/source/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmMedian.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmMedian.cpp
@@ -92,7 +92,7 @@ namespace OpenMS
       }
     }
 
-    LOG_INFO << endl << "Using " << pass_counter << "/" << map.size() <<  " consensus features for computing normalization coefficients" << endl << endl;
+    OPENMS_LOG_INFO << endl << "Using " << pass_counter << "/" << map.size() <<  " consensus features for computing normalization coefficients" << endl << endl;
 
     // do we have enough features passing the filters to compute the median for every map?
     bool enough_features_left = true;
@@ -110,7 +110,7 @@ namespace OpenMS
 
     if (!enough_features_left)
     {
-      LOG_WARN << endl << "Not enough features passing filters. Cannot compute normalization coefficients for all maps. Result will be unnormalized." << endl << endl;
+      OPENMS_LOG_WARN << endl << "Not enough features passing filters. Cannot compute normalization coefficients for all maps. Result will be unnormalized." << endl << endl;
       return 0;
     }
     else
@@ -130,7 +130,7 @@ namespace OpenMS
   {
     if (method == NM_SHIFT)
     {
-      LOG_WARN << endl << "WARNING: normalization using median shifting is not recommended for regular log-normal MS data. Use this only if you know exactly what you're doing!" << endl << endl;
+      OPENMS_LOG_WARN << endl << "WARNING: normalization using median shifting is not recommended for regular log-normal MS data. Use this only if you know exactly what you're doing!" << endl << endl;
     }
 
     ConsensusMap::Iterator cf_it;

--- a/src/openms/source/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmThreshold.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/ConsensusMapNormalizerAlgorithmThreshold.cpp
@@ -90,7 +90,7 @@ namespace OpenMS
       }
     }
 
-    LOG_INFO << endl << "Using " << pass_counter << "/" << map.size() <<  " consensus features for computing normalization coefficients" << endl << endl;
+    OPENMS_LOG_INFO << endl << "Using " << pass_counter << "/" << map.size() <<  " consensus features for computing normalization coefficients" << endl << endl;
 
     //determine ratio
     vector<double> ratio_vector(number_of_maps);
@@ -110,7 +110,7 @@ namespace OpenMS
       }
       if (ratios.empty())
       {
-        LOG_WARN << endl << "Not enough features passing filters. Cannot compute normalization coefficients for all maps. Result will be unnormalized." << endl << endl;
+        OPENMS_LOG_WARN << endl << "Not enough features passing filters. Cannot compute normalization coefficients for all maps. Result will be unnormalized." << endl << endl;
         return vector<double>(number_of_maps, 1.0);
       }
       ratio_vector[j] = Math::mean(ratios.begin(), ratios.end());

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithm.cpp
@@ -63,7 +63,7 @@ namespace OpenMS
 
   void FeatureGroupingAlgorithm::group(const vector<ConsensusMap>& maps, ConsensusMap& out)
   {
-    LOG_WARN << "FeatureGroupingAlgorithm::group() does not support ConsensusMaps directly. Converting to FeatureMaps." << endl;
+    OPENMS_LOG_WARN << "FeatureGroupingAlgorithm::group() does not support ConsensusMaps directly. Converting to FeatureMaps." << endl;
 
     vector<FeatureMap> maps_f;
     for (Size i = 0; i < maps.size(); ++i)

--- a/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmKD.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/FeatureGroupingAlgorithmKD.cpp
@@ -227,7 +227,7 @@ namespace OpenMS
       }
       catch (Exception::BaseException& e)
       {
-        LOG_ERROR << "Error: " << e.what() << endl;
+        OPENMS_LOG_ERROR << "Error: " << e.what() << endl;
         return;
       }
 

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmIdentification.cpp
@@ -78,7 +78,7 @@ namespace OpenMS
         String(min_run_occur_) + ") is higher than the number of runs incl. "
         "reference (here: " + String(runs) + "). Using " + String(runs) +
         " instead.";
-      LOG_WARN << msg << endl;
+      OPENMS_LOG_WARN << msg << endl;
       min_run_occur_ = runs;
     }
   }
@@ -139,7 +139,7 @@ namespace OpenMS
     // TODO
 
     // compute RT medians:
-    LOG_DEBUG << "Computing RT medians..." << endl;
+    OPENMS_LOG_DEBUG << "Computing RT medians..." << endl;
     vector<SeqToValue> medians_per_run(size);
     for (Int i = 0; i < size; ++i)
     {
@@ -162,7 +162,7 @@ namespace OpenMS
     if (reference_given)
     {
       // remove peptides that don't occur in enough runs:
-      LOG_DEBUG << "Removing peptides that occur in too few runs..." << endl;
+      OPENMS_LOG_DEBUG << "Removing peptides that occur in too few runs..." << endl;
       SeqToValue temp;
       for (SeqToValue::iterator ref_it = reference_.begin();
            ref_it != reference_.end(); ++ref_it)
@@ -174,16 +174,16 @@ namespace OpenMS
           temp.insert(temp.end(), *ref_it); // new items should go at the end
         }
       }
-      LOG_DEBUG << "Removed " << reference_.size() - temp.size() << " of "
+      OPENMS_LOG_DEBUG << "Removed " << reference_.size() - temp.size() << " of "
                 << reference_.size() << " peptides." << endl;
       temp.swap(reference_);
     }
     else // compute overall RT median per sequence (median of medians per run)
     {
-      LOG_DEBUG << "Computing overall RT medians per sequence..." << endl;
+      OPENMS_LOG_DEBUG << "Computing overall RT medians per sequence..." << endl;
 
       // remove peptides that don't occur in enough runs (at least two):
-      LOG_DEBUG << "Removing peptides that occur in too few runs..." << endl;
+      OPENMS_LOG_DEBUG << "Removing peptides that occur in too few runs..." << endl;
       SeqToList temp;
       for (SeqToList::iterator med_it = medians_per_seq.begin();
            med_it != medians_per_seq.end(); ++med_it)
@@ -193,7 +193,7 @@ namespace OpenMS
           temp.insert(temp.end(), *med_it);
         }
       }
-      LOG_DEBUG << "Removed " << medians_per_seq.size() - temp.size() << " of "
+      OPENMS_LOG_DEBUG << "Removed " << medians_per_seq.size() - temp.size() << " of "
                 << medians_per_seq.size() << " peptides." << endl;
       temp.swap(medians_per_seq);
       computeMedians_(medians_per_seq, reference_);
@@ -223,11 +223,11 @@ namespace OpenMS
     {
       max_rt_shift = numeric_limits<double>::max();
     }
-    LOG_DEBUG << "Max. allowed RT shift (in seconds): " << max_rt_shift << endl;
+    OPENMS_LOG_DEBUG << "Max. allowed RT shift (in seconds): " << max_rt_shift << endl;
 
     // generate RT transformations:
-    LOG_DEBUG << "Generating RT transformations..." << endl;
-    LOG_INFO << "\nAlignment based on:" << endl; // diagnostic output
+    OPENMS_LOG_DEBUG << "Generating RT transformations..." << endl;
+    OPENMS_LOG_INFO << "\nAlignment based on:" << endl; // diagnostic output
     Size offset = 0; // offset in case of internal reference
     for (Int i = 0; i < size + 1; ++i)
     {
@@ -238,7 +238,7 @@ namespace OpenMS
         TransformationDescription trafo;
         trafo.fitModel("identity");
         transforms.push_back(trafo);
-        LOG_INFO << "- " << reference_.size() << " data points for sample "
+        OPENMS_LOG_INFO << "- " << reference_.size() << " data points for sample "
                  << i + 1 << " (reference)\n";
         offset = 1;
       }
@@ -268,12 +268,12 @@ namespace OpenMS
         }
       }
       transforms.push_back(TransformationDescription(data));
-      LOG_INFO << "- " << data.size() << " data points for sample "
+      OPENMS_LOG_INFO << "- " << data.size() << " data points for sample "
                << i + offset + 1;
-      if (n_outliers) LOG_INFO << " (" << n_outliers << " outliers removed)";
-      LOG_INFO << "\n";
+      if (n_outliers) OPENMS_LOG_INFO << " (" << n_outliers << " outliers removed)";
+      OPENMS_LOG_INFO << "\n";
     }
-    LOG_INFO << endl;
+    OPENMS_LOG_INFO << endl;
 
     // delete temporary reference
     if (!reference_given) reference_.clear();

--- a/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmKD.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/MapAlignmentAlgorithmKD.cpp
@@ -110,7 +110,7 @@ void MapAlignmentAlgorithmKD::fitLOWESS()
     Size n = fit_data_[i].size();
     if (n < 50)
     {
-      LOG_WARN << "Warning: Only " << n << " data points for LOWESS fit of map " << i << ". Consider adjusting RT or m/z tolerance or max_pairwise_log_fc, decreasing min_rel_cc_size, or increasing max_nr_conflicts." << endl;
+      OPENMS_LOG_WARN << "Warning: Only " << n << " data points for LOWESS fit of map " << i << ". Consider adjusting RT or m/z tolerance or max_pairwise_log_fc, decreasing min_rel_cc_size, or increasing max_nr_conflicts." << endl;
     }
     const Param& lowess_param = param_.copy("LOWESS:", true);
     transformations_[i] = new TransformationModelLowess(fit_data_[i], lowess_param);

--- a/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModel.cpp
+++ b/src/openms/source/ANALYSIS/MAPMATCHING/TransformationModel.cpp
@@ -158,7 +158,7 @@ namespace OpenMS
     }
     else
     {
-      LOG_INFO << "weight " + weight + " is not supported.";
+      OPENMS_LOG_INFO << "weight " + weight + " is not supported.";
     }
     return valid;
   }
@@ -168,14 +168,14 @@ namespace OpenMS
     double datum_checked = datum;
     if (datum >= datum_max)
     {
-      LOG_INFO << "datum " << datum << " is out of range.";
-      LOG_INFO << "datum will be truncated to " << datum_max << ".";
+      OPENMS_LOG_INFO << "datum " << datum << " is out of range.";
+      OPENMS_LOG_INFO << "datum will be truncated to " << datum_max << ".";
       datum_checked = datum_max;
     }
     else if (datum <= datum_min)
     {
-      LOG_INFO << "datum " << datum << " is out of range.";
-      LOG_INFO << "datum will be truncated to " << datum_min << ".";
+      OPENMS_LOG_INFO << "datum " << datum << " is out of range.";
+      OPENMS_LOG_INFO << "datum will be truncated to " << datum_min << ".";
       datum_checked = datum_min;
     }
     return datum_checked;
@@ -237,8 +237,8 @@ namespace OpenMS
     else
     {
       datum_weighted = datum;
-      LOG_INFO << "weight " + weight + " not supported.";
-      LOG_INFO << "no weighting will be applied.";
+      OPENMS_LOG_INFO << "weight " + weight + " not supported.";
+      OPENMS_LOG_INFO << "no weighting will be applied.";
     }
     return datum_weighted;
   } 
@@ -277,8 +277,8 @@ namespace OpenMS
     else
     {
       datum_weighted = datum;
-      LOG_INFO << "weight " + weight + " not supported.";
-      LOG_INFO << "no weighting will be applied.";
+      OPENMS_LOG_INFO << "weight " + weight + " not supported.";
+      OPENMS_LOG_INFO << "no weighting will be applied.";
     }
     return datum_weighted;
   }

--- a/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ChromatogramExtractor.cpp
@@ -54,7 +54,7 @@ namespace OpenMS
     // Catch cases where a compound has no transitions
     if (pep2tr.count(pep.id) == 0)
     {
-      LOG_INFO << "Warning: no transitions found for compound " << pep.id << std::endl;
+      OPENMS_LOG_INFO << "Warning: no transitions found for compound " << pep.id << std::endl;
       coord.id = OpenSwathHelper::computePrecursorId(pep.id, 0);
       return false;
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/ConfidenceScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/ConfidenceScoring.cpp
@@ -157,7 +157,7 @@ namespace OpenMS
 
       double score = glm_(diff_rt, dist_int);
 
-      LOG_DEBUG << "\ndelta_RT:  " << fabs(diff_rt)
+      OPENMS_LOG_DEBUG << "\ndelta_RT:  " << fabs(diff_rt)
                 << "\ndist_int:  " << dist_int
                 << "\nGLM_score: " << score << endl;
 
@@ -185,7 +185,7 @@ namespace OpenMS
       extractIntensities_(intensity_map, n_transitions_, feature_intensities);
       if ((n_transitions_ > 0) && (feature_intensities.size() < n_transitions_))
       {
-        LOG_WARN << "Warning: Feature '" << feature.getUniqueId() 
+        OPENMS_LOG_WARN << "Warning: Feature '" << feature.getUniqueId() 
                  << "' contains only " << feature_intensities.size()
                  << " transitions." << endl;
       }
@@ -201,7 +201,7 @@ namespace OpenMS
 
       // compare to "true" assay:
       String true_id = feature.getMetaValue("PeptideRef");
-      LOG_DEBUG << "True assay (ID '" << true_id << "')" << endl;
+      OPENMS_LOG_DEBUG << "True assay (ID '" << true_id << "')" << endl;
       if (true_id.empty())
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
@@ -226,7 +226,7 @@ namespace OpenMS
         {
           continue;
         }
-        LOG_DEBUG << "Decoy assay " << scores.size() << " (ID '" << decoy_assay.id
+        OPENMS_LOG_DEBUG << "Decoy assay " << scores.size() << " (ID '" << decoy_assay.id
                   << "')" << endl;
 
         scores.push_back(scoreAssay_(decoy_assay, feature_rt, feature_intensities));
@@ -237,7 +237,7 @@ namespace OpenMS
       Size n_scores = scores.size();
       if (n_scores - 1 < n_decoys_)
       {
-        LOG_WARN << "Warning: Feature '" << feature.getUniqueId() 
+        OPENMS_LOG_WARN << "Warning: Feature '" << feature.getUniqueId() 
                  << "': Couldn't find enough decoy assays with at least "
                  << feature_intensities.size() << " transitions. "
                  << "Scoring based on " << n_scores - 1 << " decoys." << endl;
@@ -245,7 +245,7 @@ namespace OpenMS
       // TODO: this warning may trigger for every feature and get annoying
       if ((n_decoys_ == 0) && (n_scores < library_.getPeptides().size()))
       {
-        LOG_WARN << "Warning: Feature '" << feature.getUniqueId() 
+        OPENMS_LOG_WARN << "Warning: Feature '" << feature.getUniqueId() 
                  << "': Skipped some decoy assays with fewer than " 
                  << feature_intensities.size() << " transitions. "
                  << "Scoring based on " << n_scores - 1 << " decoys." << endl;

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMAssay.cpp
@@ -345,7 +345,7 @@ namespace OpenMS
       // Some permutations might be too complex, skip if threshold is reached
       if (alternative_peptide_sequences.size() > max_num_alternative_localizations)
       {
-        LOG_DEBUG << "[uis] Peptide skipped (too many permutations possible): " << peptide.id << std::endl;
+        OPENMS_LOG_DEBUG << "[uis] Peptide skipped (too many permutations possible): " << peptide.id << std::endl;
         continue;
       }
 
@@ -573,14 +573,14 @@ namespace OpenMS
           trn.setNativeID(String(transition_index) + "_" + String("UIS") + "_{" + ListUtils::concatenate(isoforms, "|") + "}_" + String(trn.getPrecursorMZ()) + "_" + String(trn.getProductMZ()) + "_" + String(peptide.getRetentionTime()) + "_" + tr_it->first);
           trn.setMetaValue("Peptidoforms", ListUtils::concatenate(isoforms, "|"));
 
-          LOG_DEBUG << "[uis] Transition " << trn.getNativeID() << std::endl;
+          OPENMS_LOG_DEBUG << "[uis] Transition " << trn.getNativeID() << std::endl;
 
           // Append transition
           transitions.push_back(trn);
         }
         transition_index++;
       }
-      LOG_DEBUG << "[uis] Peptide " << peptide.id << std::endl;
+      OPENMS_LOG_DEBUG << "[uis] Peptide " << peptide.id << std::endl;
     }
     endProgress();
   }
@@ -655,7 +655,7 @@ namespace OpenMS
               String(decoy_peptide.getRetentionTime()) + "_" + decoy_tr_it->first);
           trn.setMetaValue("Peptidoforms", ListUtils::concatenate(decoy_isoforms, "|"));
 
-          LOG_DEBUG << "[uis] Decoy transition " << trn.getNativeID() << std::endl;
+          OPENMS_LOG_DEBUG << "[uis] Decoy transition " << trn.getNativeID() << std::endl;
 
           // Check if decoy transition is overlapping with target transition
           std::vector<std::string> target_isoforms_overlap = getMatchingPeptidoforms_(
@@ -663,7 +663,7 @@ namespace OpenMS
 
           if (target_isoforms_overlap.size() > 0)
           {
-            LOG_DEBUG << "[uis] Skipping overlapping decoy transition " << trn.getNativeID() << std::endl;
+            OPENMS_LOG_DEBUG << "[uis] Skipping overlapping decoy transition " << trn.getNativeID() << std::endl;
             continue;
           }
           else
@@ -745,14 +745,14 @@ namespace OpenMS
         // Skip unannotated transitions from previous step
         if (targetion.first == "unannotated")
         {
-          LOG_DEBUG << "[unannotated] Skipping " << target_peptide_sequence.toString() 
+          OPENMS_LOG_DEBUG << "[unannotated] Skipping " << target_peptide_sequence.toString() 
             << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() 
             << " " << tr.getMetaValue("annotation") << std::endl;
           continue;
         }
         else
         {
-          LOG_DEBUG << "[selected] " << target_peptide_sequence.toString() << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << " " << tr.getMetaValue("annotation") << std::endl;
+          OPENMS_LOG_DEBUG << "[selected] " << target_peptide_sequence.toString() << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << " " << tr.getMetaValue("annotation") << std::endl;
         }
 
         // Set CV terms
@@ -793,7 +793,7 @@ namespace OpenMS
         // Check if transition is unannotated at primary annotation and if yes, skip
         if (tr.getProduct().getInterpretationList()[0].iontype == TargetedExperiment::IonType::NonIdentified)
         {
-          LOG_DEBUG << "[unannotated] Skipping " << target_peptide_sequence 
+          OPENMS_LOG_DEBUG << "[unannotated] Skipping " << target_peptide_sequence 
             << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() 
             << " " << tr.getMetaValue("annotation") << std::endl;
           continue;
@@ -805,7 +805,7 @@ namespace OpenMS
       {
         if (MRMAssay::isInSwath_(swathes, tr.getPrecursorMZ(), tr.getProductMZ()))
         {
-          LOG_DEBUG << "[swath] Skipping " << target_peptide_sequence << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << std::endl;
+          OPENMS_LOG_DEBUG << "[swath] Skipping " << target_peptide_sequence << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << std::endl;
           continue;
         }
       }
@@ -813,7 +813,7 @@ namespace OpenMS
       // Check if product m/z is outside of m/z boundaries and if yes, skip
       if (tr.getProductMZ() < lower_mz_limit || tr.getProductMZ() > upper_mz_limit)
       {
-        LOG_DEBUG << "[mz_limit] Skipping " << target_peptide_sequence << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << std::endl;
+        OPENMS_LOG_DEBUG << "[mz_limit] Skipping " << target_peptide_sequence << " PrecursorMZ: " << tr.getPrecursorMZ() << " ProductMZ: " << tr.getProductMZ() << std::endl;
         continue;
       }
 
@@ -916,7 +916,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_DEBUG << "[peptide] Skipping " << peptide.id << std::endl;
+        OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << std::endl;
       }
     }
 
@@ -931,7 +931,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_DEBUG << "[protein] Skipping " << protein.id << std::endl;
+        OPENMS_LOG_DEBUG << "[protein] Skipping " << protein.id << std::endl;
       }
     }
 
@@ -1073,7 +1073,7 @@ void MRMAssay::detectingTransitionsCompound(OpenMS::TargetedExperiment& exp, int
       }
       else
       {
-        LOG_DEBUG << "[compound] Skipping " << compound.id << " - not enough transistions."<< std::endl;
+        OPENMS_LOG_DEBUG << "[compound] Skipping " << compound.id << " - not enough transistions."<< std::endl;
       }
     }
     exp.setTransitions(transitions);

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMDecoy.cpp
@@ -435,7 +435,7 @@ namespace OpenMS
         // exclude peptide if it has C/N terminal modifications because we can't do a (partial) reverse
         if (MRMDecoy::hasCNterminalMods_(peptide, do_switchKR))
         {
-          LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
           exclusion_peptides.push_back(peptide.id);
         }
         else
@@ -449,7 +449,7 @@ namespace OpenMS
         // exclude peptide if it has C/N terminal modifications because we can't do a (partial) reverse
         if (MRMDecoy::hasCNterminalMods_(peptide, false))
         {
-          LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
           exclusion_peptides.push_back(peptide.id);
         }
         else
@@ -462,7 +462,7 @@ namespace OpenMS
         peptide = MRMDecoy::shufflePeptide(peptide, identity_threshold, -1, max_attempts);
         if (do_switchKR && MRMDecoy::hasCNterminalMods_(peptide, do_switchKR))
         {
-          LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to C/N-terminal modifications" << std::endl;
           exclusion_peptides.push_back(peptide.id);
         }
         else if (do_switchKR) switchKR(peptide);
@@ -555,7 +555,7 @@ namespace OpenMS
         {
           // transition could not be annotated, remove whole peptide
           exclusion_peptides.push_back(decoy_tr.getPeptideRef());
-          LOG_DEBUG << "[peptide] Skipping " << decoy_tr.getPeptideRef() << " due to missing annotation" << std::endl;
+          OPENMS_LOG_DEBUG << "[peptide] Skipping " << decoy_tr.getPeptideRef() << " due to missing annotation" << std::endl;
         }
       } // end loop over transitions
 
@@ -588,7 +588,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to missing transitions" << std::endl;
+        OPENMS_LOG_DEBUG << "[peptide] Skipping " << peptide.id << " due to missing transitions" << std::endl;
       }
     }
 
@@ -603,7 +603,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_DEBUG << "[protein] Skipping " << protein.id << " due to missing peptides" << std::endl;
+        OPENMS_LOG_DEBUG << "[protein] Skipping " << protein.id << " due to missing peptides" << std::endl;
       }
     }
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFilter.cpp
@@ -431,7 +431,7 @@ namespace OpenMS
       }
       else if (component_1.metaValueExists("native_id"))
       {
-        LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << "." << std::endl;
+        OPENMS_LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << "." << std::endl;
         const double feature_1 = component_1.getIntensity();
         ratio = feature_1;
       }
@@ -447,13 +447,13 @@ namespace OpenMS
       }
       else if (component_1.metaValueExists(feature_name))
       {
-        LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << "." << std::endl;
+        OPENMS_LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << "." << std::endl;
         const double feature_1 = component_1.getMetaValue(feature_name);
         ratio = feature_1;
       }
       else
       {
-        LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
+        OPENMS_LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
       }
     }
 
@@ -478,7 +478,7 @@ namespace OpenMS
     else
     {
       key_exists = false;
-      LOG_DEBUG << "Warning: no metaValue found for transition_id " << component.getMetaValue("native_id") << " for metaValue key " << meta_value_key << ".";
+      OPENMS_LOG_DEBUG << "Warning: no metaValue found for transition_id " << component.getMetaValue("native_id") << " for metaValue key " << meta_value_key << ".";
     }
     return check;
   }

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureFinderScoring.cpp
@@ -215,7 +215,7 @@ namespace OpenMS
     {
       if (trgroup_it->second.getChromatograms().size() > 0) {counter++; }
     }
-    LOG_INFO << "Will analyse " << counter << " peptides with a total of " << transition_exp.getTransitions().size() << " transitions " << std::endl;
+    OPENMS_LOG_INFO << "Will analyse " << counter << " peptides with a total of " << transition_exp.getTransitions().size() << " transitions " << std::endl;
 
     //
     // Step 3
@@ -546,7 +546,7 @@ namespace OpenMS
       OpenSwath::IMRMFeature* imrmfeature;
       imrmfeature = new MRMFeatureOpenMS(*mrmfeature);
 
-      LOG_DEBUG << "scoring feature " << (*mrmfeature) << " == " << mrmfeature->getMetaValue("PeptideRef") <<
+      OPENMS_LOG_DEBUG << "scoring feature " << (*mrmfeature) << " == " << mrmfeature->getMetaValue("PeptideRef") <<
         " [ expected RT " << PeptideRefMap_[mrmfeature->getMetaValue("PeptideRef")]->rt << " / " << expected_rt << " ]" <<
         " with " << transition_group_detection.size()  << " nr transitions and nr chromats " << 
         transition_group_detection.getChromatograms().size() << std::endl;

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMFeatureSelector.cpp
@@ -369,7 +369,7 @@ namespace OpenMS
       const LambdaScore lambda_score = score_weight.second;
       if (!feature.metaValueExists(metavalue_name))
       {
-        LOG_WARN << "computeScore_(): Metavalue \"" << metavalue_name << "\" not found.\n";
+        OPENMS_LOG_WARN << "computeScore_(): Metavalue \"" << metavalue_name << "\" not found.\n";
         continue;
       }
       const double value = weightScore_(feature.getMetaValue(metavalue_name), lambda_score);

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMRTNormalizer.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMRTNormalizer.cpp
@@ -34,7 +34,7 @@
 
 #include <OpenMS/ANALYSIS/OPENSWATH/MRMRTNormalizer.h>
 #include <OpenMS/MATH/STATISTICS/LinearRegression.h>
-#include <OpenMS/CONCEPT/LogStream.h> // LOG_DEBUG
+#include <OpenMS/CONCEPT/LogStream.h> // OPENMS_LOG_DEBUG
 #include <OpenMS/MATH/MISC/RANSAC.h> // RANSAC algorithm
 
 #include <numeric>
@@ -152,7 +152,7 @@ namespace OpenMS
     {
       x.push_back(it->first);
       y.push_back(it->second);
-      LOG_DEBUG << "RT Normalization pairs: " << it->first << " : " << it->second << std::endl;
+      OPENMS_LOG_DEBUG << "RT Normalization pairs: " << it->first << " : " << it->second << std::endl;
     }
 
     double rsq;
@@ -177,7 +177,7 @@ namespace OpenMS
           double intercept = lin_reg.getIntercept();
           double slope = (double)lin_reg.getSlope();
           residuals.push_back(abs(it->second - (intercept + it->first * slope)));
-          LOG_DEBUG << " RT Normalization residual is " << residuals.back() << std::endl;
+          OPENMS_LOG_DEBUG << " RT Normalization residual is " << residuals.back() << std::endl;
         }
 
         int pos;
@@ -200,7 +200,7 @@ namespace OpenMS
 
         // remove if residual is an outlier according to Chauvenet's criterion
         // or if testing is turned off
-        LOG_DEBUG << " Got outlier candidate " << pos << "(" << x[pos] << " / " << y[pos] << std::endl;
+        OPENMS_LOG_DEBUG << " Got outlier candidate " << pos << "(" << x[pos] << " / " << y[pos] << std::endl;
         if (!use_chauvenet || chauvenet(residuals, pos))
         {
           x.erase(x.begin() + pos);
@@ -249,7 +249,7 @@ namespace OpenMS
     double criterion = 1.0 / (2 * residuals.size());
     double prob = MRMRTNormalizer::chauvenet_probability(residuals, pos);
 
-    LOG_DEBUG << " Chauvinet testing " << prob << " < " << criterion << std::endl;
+    OPENMS_LOG_DEBUG << " Chauvinet testing " << prob << " < " << criterion << std::endl;
     if (prob < criterion)
     {
       return true;
@@ -297,7 +297,7 @@ namespace OpenMS
     int binsFilled = 0;
     for (Size i = 0; i < binCounter.size(); i++)
     {
-      LOG_DEBUG <<" In bin " << i << " out of " << binCounter.size() << 
+      OPENMS_LOG_DEBUG <<" In bin " << i << " out of " << binCounter.size() << 
         " we have " << binCounter[i] << " peptides " << std::endl;
       if (binCounter[i] >= minPeptidesPerBin) 
       {

--- a/src/openms/source/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/MRMTransitionGroupPicker.cpp
@@ -159,13 +159,13 @@ namespace OpenMS
         const double left_rt = picked_chroms[i].getFloatDataArrays()[PeakPickerMRM::IDX_LEFTBORDER][k];
         const double right_rt = picked_chroms[i].getFloatDataArrays()[PeakPickerMRM::IDX_RIGHTBORDER][k];
         const double local_peak_width = right_rt - left_rt;
-        LOG_DEBUG << "findWidestPeakIndices(): local_peak_width=" << local_peak_width << std::endl;
+        OPENMS_LOG_DEBUG << "findWidestPeakIndices(): local_peak_width=" << local_peak_width << std::endl;
         if (local_peak_width > max_width)
         {
           max_width = local_peak_width;
           chrom_idx = static_cast<Int>(i);
           point_idx = static_cast<Int>(k);
-          LOG_DEBUG << "findWidestPeakIndices(): max_width=" << max_width << "; chrom_idx=" << chrom_idx << "; point_idx=" << point_idx << std::endl;
+          OPENMS_LOG_DEBUG << "findWidestPeakIndices(): max_width=" << max_width << "; chrom_idx=" << chrom_idx << "; point_idx=" << point_idx << std::endl;
         }
       }
     }

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathWorkflow.cpp
@@ -54,7 +54,7 @@ namespace OpenMS
     bool sonar,
     bool load_into_memory)
   {
-    LOG_DEBUG << "performRTNormalization method starting" << std::endl;
+    OPENMS_LOG_DEBUG << "performRTNormalization method starting" << std::endl;
     std::vector< OpenMS::MSChromatogram > irt_chromatograms;
     TransformationDescription trafo; // dummy
     this->simpleExtractChromatograms_(swath_maps, irt_transitions, irt_chromatograms, trafo, cp_irt, sonar, load_into_memory);
@@ -74,14 +74,14 @@ namespace OpenMS
       }
       catch (OpenMS::Exception::UnableToCreateFile& /*e*/)
       {
-        LOG_DEBUG << "Error creating file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << std::endl;
+        OPENMS_LOG_DEBUG << "Error creating file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << std::endl;
       }
       catch (OpenMS::Exception::BaseException& /*e*/)
       {
-        LOG_DEBUG << "Error writing to file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << std::endl;
+        OPENMS_LOG_DEBUG << "Error writing to file " + irt_mzml_out + ", not writing out iRT chromatogram file"  << std::endl;
       }
     }
-    LOG_DEBUG << "Extracted number of chromatograms from iRT files: " << irt_chromatograms.size() <<  std::endl;
+    OPENMS_LOG_DEBUG << "Extracted number of chromatograms from iRT files: " << irt_chromatograms.size() <<  std::endl;
 
     // perform RT and m/z correction on the data
     TransformationDescription tr = doDataNormalization_(irt_transitions,
@@ -102,18 +102,18 @@ namespace OpenMS
     double mz_extraction_window,
     bool ppm)
   {
-    LOG_DEBUG << "Start of doDataNormalization_ method" << std::endl;
+    OPENMS_LOG_DEBUG << "Start of doDataNormalization_ method" << std::endl;
     this->startProgress(0, 1, "Retention time normalization");
 
     bool estimateBestPeptides = irt_detection_param.getValue("estimateBestPeptides").toBool();
     if (estimateBestPeptides)
     {
-      LOG_DEBUG << "Activated the 'estimateBestPeptides' option." << std::endl;
+      OPENMS_LOG_DEBUG << "Activated the 'estimateBestPeptides' option." << std::endl;
     }
 
     // 1. Estimate the retention time range of the iRT peptides over all assays
     std::pair<double,double> RTRange = OpenSwathHelper::estimateRTRange(targeted_exp);
-    LOG_DEBUG << "Detected retention time range from " << RTRange.first << " to " << RTRange.second << std::endl;
+    OPENMS_LOG_DEBUG << "Detected retention time range from " << RTRange.first << " to " << RTRange.second << std::endl;
 
     // 2. Store the peptide retention times in an intermediate map
     std::map<OpenMS::String, double> PeptideRTMap;
@@ -167,7 +167,7 @@ namespace OpenMS
     std::vector<std::pair<double, double> > pairs; // store the RT pairs to write the output trafoXML
     std::map<std::string, double> best_features = OpenSwathHelper::simpleFindBestFeature(transition_group_map,
       estimateBestPeptides, irt_detection_param.getValue("OverallQualityCutoff"));
-    LOG_DEBUG << "Extracted best features: " << best_features.size() << std::endl;
+    OPENMS_LOG_DEBUG << "Extracted best features: " << best_features.size() << std::endl;
 
     // Create pairs vector and store peaks
     std::map<String, OpenMS::MRMFeatureFinderScoring::MRMTransitionGroupType *> trgrmap_allpeaks; // store all peaks above cutoff
@@ -210,7 +210,7 @@ namespace OpenMS
         String("Illegal argument '") + outlier_method +
         "' used for outlierMethod (valid: 'iter_residual', 'iter_jackknife', 'ransac', 'none').");
     }
-    LOG_DEBUG << "Performed outlier detection, left with features: " << pairs_corrected.size() << std::endl;
+    OPENMS_LOG_DEBUG << "Performed outlier detection, left with features: " << pairs_corrected.size() << std::endl;
 
     // 6. Check whether the found peptides fulfill the binned coverage criteria
     // set by the user.
@@ -269,12 +269,12 @@ namespace OpenMS
     String model_type = irt_detection_param.getValue("alignmentMethod");
     trafo_out.fitModel(model_type, model_params);
 
-    LOG_DEBUG << "Final RT mapping:" << std::endl;
+    OPENMS_LOG_DEBUG << "Final RT mapping:" << std::endl;
     for (Size i = 0; i < pairs_corrected.size(); i++)
     {
-      LOG_DEBUG << pairs_corrected[i].first << " " <<  pairs_corrected[i].second << std::endl;
+      OPENMS_LOG_DEBUG << pairs_corrected[i].first << " " <<  pairs_corrected[i].second << std::endl;
     }
-    LOG_DEBUG << "End of doDataNormalization_ method" << std::endl;
+    OPENMS_LOG_DEBUG << "End of doDataNormalization_ method" << std::endl;
 
     this->endProgress();
     return trafo_out;
@@ -329,7 +329,7 @@ namespace OpenMS
 #pragma omp critical (osw_write_chroms)
 #endif
           {
-            LOG_DEBUG << "[simple] Extracted "  << tmp_chromatograms.size() << " chromatograms from SWATH map " <<
+            OPENMS_LOG_DEBUG << "[simple] Extracted "  << tmp_chromatograms.size() << " chromatograms from SWATH map " <<
               map_idx << " with m/z " << swath_maps[map_idx].lower << " to " << swath_maps[map_idx].upper << ":" << std::endl;
             for (Size chrom_idx = 0; chrom_idx < tmp_chromatograms.size(); chrom_idx++)
             {
@@ -338,7 +338,7 @@ namespace OpenMS
               // window).
               double tic = std::accumulate(tmp_out[chrom_idx]->getIntensityArray()->data.begin(),
                                            tmp_out[chrom_idx]->getIntensityArray()->data.end(),0.0);
-              LOG_DEBUG << "Chromatogram "  << coordinates[chrom_idx].id << " with size "
+              OPENMS_LOG_DEBUG << "Chromatogram "  << coordinates[chrom_idx].id << " with size "
                 << tmp_out[chrom_idx]->getIntensityArray()->data.size() << " and TIC " << tic  << std::endl;
               if (tic > 0.0)
               {
@@ -355,7 +355,7 @@ namespace OpenMS
         }
         else
         {
-          LOG_DEBUG << "Extracted no transitions from SWATH map " << map_idx << " with m/z " <<
+          OPENMS_LOG_DEBUG << "Extracted no transitions from SWATH map " << map_idx << " with m/z " <<
               swath_maps[map_idx].lower << " to " << swath_maps[map_idx].upper << std::endl;
         }
       }
@@ -364,7 +364,7 @@ namespace OpenMS
     if (sonar)
     {
 
-      LOG_DEBUG << " got a total of " << chromatograms.size() << " chromatograms before SONAR addition " << std::endl;
+      OPENMS_LOG_DEBUG << " got a total of " << chromatograms.size() << " chromatograms before SONAR addition " << std::endl;
 
       // for SONAR: group chromatograms together and then add them up (we will have one chromatogram for every single map)
       std::vector< OpenMS::MSChromatogram > chromatograms_new;
@@ -385,7 +385,7 @@ namespace OpenMS
       }
       chromatograms = chromatograms_new; // switch
 
-      LOG_DEBUG << " got a total of " << chromatograms.size() << " chromatograms after SONAR addition " << std::endl;
+      OPENMS_LOG_DEBUG << " got a total of " << chromatograms.size() << " chromatograms after SONAR addition " << std::endl;
     }
 
     this->endProgress();
@@ -1036,7 +1036,7 @@ namespace OpenMS
       {
         double currwin_start = sonar_start + sonar_idx * sonar_winsize;
         double currwin_end = currwin_start + sonar_winsize;
-        LOG_DEBUG << "   ====  sonar window " << sonar_idx << " from " << currwin_start << " to " << currwin_end << std::endl;
+        OPENMS_LOG_DEBUG << "   ====  sonar window " << sonar_idx << " from " << currwin_start << " to " << currwin_end << std::endl;
 
         // Step 1: select which transitions to extract with the current windows (proceed in batches)
         OpenSwath::LightTargetedExperiment transition_exp_used_all;

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMRM.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMRM.cpp
@@ -96,15 +96,15 @@ namespace OpenMS
                                        "Chromatogram must be sorted by position");
     }
 
-    LOG_DEBUG << " ====  Picking chromatogram " << chromatogram.getNativeID() << 
+    OPENMS_LOG_DEBUG << " ====  Picking chromatogram " << chromatogram.getNativeID() << 
         " with " << chromatogram.size() << " peaks ";
     if (chromatogram.empty())
     {
-        LOG_DEBUG << std::endl; 
-        LOG_DEBUG << " - Error: chromatogram is empty, abort picking."  << std::endl;
+        OPENMS_LOG_DEBUG << std::endl; 
+        OPENMS_LOG_DEBUG << " - Error: chromatogram is empty, abort picking."  << std::endl;
         return;
     }
-    LOG_DEBUG << "(start at RT " << chromatogram[0].getRT() << " to RT " << chromatogram.back().getRT() << ") "
+    OPENMS_LOG_DEBUG << "(start at RT " << chromatogram[0].getRT() << " to RT " << chromatogram.back().getRT() << ") "
         "using method \'" << method_ << "\'" << std::endl;
 
     picked_chrom.clear(true);
@@ -128,7 +128,7 @@ namespace OpenMS
 
     // Find initial seeds (peak picking)
     pp_.pick(smoothed_chrom, picked_chrom);
-    LOG_DEBUG << "Found " << picked_chrom.size() << " chromatographic peaks." << std::endl;
+    OPENMS_LOG_DEBUG << "Found " << picked_chrom.size() << " chromatographic peaks." << std::endl;
 
     if (method_ == "legacy")
     {
@@ -218,7 +218,7 @@ namespace OpenMS
       right_width_.push_back(right_idx);
       integrated_intensities_.push_back(0);
 
-      LOG_DEBUG << "Found peak at " << central_peak_rt << " and "  << picked_chrom[i].getIntensity()
+      OPENMS_LOG_DEBUG << "Found peak at " << central_peak_rt << " and "  << picked_chrom[i].getIntensity()
                 << " with borders " << chromatogram[left_width_[i]].getRT() << " " << chromatogram[right_width_[i]].getRT() <<
         " (" << chromatogram[right_width_[i]].getRT() - chromatogram[left_width_[i]].getRT() << ") "
                 << 0 << " weighted RT " << /* weighted_mz << */ std::endl;
@@ -228,7 +228,7 @@ namespace OpenMS
 #ifdef WITH_CRAWDAD
   void PeakPickerMRM::pickChromatogramCrawdad_(const MSChromatogram& chromatogram, MSChromatogram& picked_chrom)
   {
-    LOG_DEBUG << "Picking chromatogram using crawdad " << std::endl;
+    OPENMS_LOG_DEBUG << "Picking chromatogram using crawdad " << std::endl;
 
     std::vector<double> time;
     std::vector<double> intensity;
@@ -274,7 +274,7 @@ namespace OpenMS
 
       */
 
-      LOG_DEBUG << "Found peak at " << p.getRT() << " and "  << chromatogram[it->peak_rt_idx].getIntensity()
+      OPENMS_LOG_DEBUG << "Found peak at " << p.getRT() << " and "  << chromatogram[it->peak_rt_idx].getIntensity()
                 << " with borders " << chromatogram[it->start_rt_idx].getRT() << " " << chromatogram[it->stop_rt_idx].getRT()  <<  " (" << chromatogram[it->start_rt_idx].getRT() - chromatogram[it->stop_rt_idx].getRT() << ") "
                 << it->peak_area << " weighted RT " << /* weighted_mz << */ std::endl;
 
@@ -294,7 +294,7 @@ namespace OpenMS
   void PeakPickerMRM::removeOverlappingPeaks_(const MSChromatogram& chromatogram, MSChromatogram& picked_chrom)
   {
     if (picked_chrom.empty()) {return; }
-    LOG_DEBUG << "Remove overlapping peaks now (size " << picked_chrom.size() << ")" << std::endl;
+    OPENMS_LOG_DEBUG << "Remove overlapping peaks now (size " << picked_chrom.size() << ")" << std::endl;
     Size current_peak = 0;
     // Find overlapping peaks
     for (Size i = 0; i < picked_chrom.size() - 1; i++)
@@ -308,8 +308,8 @@ namespace OpenMS
         const int current_right_idx = right_width_[i];
         const int next_left_idx = left_width_[i + 1];
         const int next_right_idx = right_width_[i + 1];
-        LOG_DEBUG << " Found overlapping " << i << " : " << current_left_idx << " " << current_right_idx << std::endl;
-        LOG_DEBUG << "                   -- with  " << i + 1 << " : " << next_left_idx << " " << next_right_idx << std::endl;
+        OPENMS_LOG_DEBUG << " Found overlapping " << i << " : " << current_left_idx << " " << current_right_idx << std::endl;
+        OPENMS_LOG_DEBUG << "                   -- with  " << i + 1 << " : " << next_left_idx << " " << next_right_idx << std::endl;
 
         // Find the peak width and best RT
         double central_peak_mz = picked_chrom[i].getMZ();
@@ -342,8 +342,8 @@ namespace OpenMS
 
         }
 
-        LOG_DEBUG << "New peak l: " << chromatogram[current_left_idx].getMZ() << " " << chromatogram[new_right_border].getMZ() << " int " << integrated_intensities_[i] << std::endl;
-        LOG_DEBUG << "New peak r: " << chromatogram[new_left_border].getMZ() << " " << chromatogram[next_right_idx].getMZ() << " int " << integrated_intensities_[i + 1] << std::endl;
+        OPENMS_LOG_DEBUG << "New peak l: " << chromatogram[current_left_idx].getMZ() << " " << chromatogram[new_right_border].getMZ() << " int " << integrated_intensities_[i] << std::endl;
+        OPENMS_LOG_DEBUG << "New peak r: " << chromatogram[new_left_border].getMZ() << " " << chromatogram[next_right_idx].getMZ() << " int " << integrated_intensities_[i + 1] << std::endl;
 
 
         right_width_[i] = new_right_border;

--- a/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/SwathMapMassCorrection.cpp
@@ -55,7 +55,7 @@ namespace OpenMS
     const double mz_extr_window,
     const bool ppm)
   {
-    LOG_DEBUG << "SwathMapMassCorrection::correctMZ with type " << corr_type << " and window " << mz_extr_window << " in ppm " << ppm << std::endl;
+    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctMZ with type " << corr_type << " and window " << mz_extr_window << " in ppm " << ppm << std::endl;
 
     bool is_ppm = bool(corr_type == "quadratic_regression_delta_ppm" ||
                        corr_type == "weighted_quadratic_regression_delta_ppm" ||
@@ -157,7 +157,7 @@ namespace OpenMS
 #ifdef SWATHMAPMASSCORRECTION_DEBUG
         os << mz << "\t" << tr->product_mz << "\t" << diff_ppm << "\t" << log(intensity) / log(2.0) << "\t" << bestRT << std::endl;
 #endif
-        LOG_DEBUG << mz << "\t" << tr->product_mz << "\t" << diff_ppm << "\t" << log(intensity) / log(2.0) << "\t" << bestRT << std::endl;
+        OPENMS_LOG_DEBUG << mz << "\t" << tr->product_mz << "\t" << diff_ppm << "\t" << log(intensity) / log(2.0) << "\t" << bestRT << std::endl;
 
       }
     }
@@ -242,7 +242,7 @@ namespace OpenMS
            regression_params[1],
            regression_params[2]);
 
-    LOG_DEBUG << "# mz regression parameters: Y = " << regression_params[0] << " + " <<
+    OPENMS_LOG_DEBUG << "# mz regression parameters: Y = " << regression_params[0] << " + " <<
       regression_params[1] << " X + " << regression_params[2] << " X^2" << std::endl;
 
 #ifdef SWATHMAPMASSCORRECTION_DEBUG
@@ -273,7 +273,7 @@ namespace OpenMS
           regression_params[0], regression_params[1], regression_params[2], is_ppm));
     }
 
-    LOG_DEBUG << "SwathMapMassCorrection::correctMZ done." << std::endl;
+    OPENMS_LOG_DEBUG << "SwathMapMassCorrection::correctMZ done." << std::endl;
   }
 
 /* display debug output in R

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -168,7 +168,7 @@ namespace OpenMS
       const std::vector<Precursor>& precursors = spectrum.getPrecursors();
       if (precursors.empty())
       {
-        LOG_WARN << "annotateSpectra(): No precursor MZ found. Setting spectrum_mz to 0." << std::endl;
+        OPENMS_LOG_WARN << "annotateSpectra(): No precursor MZ found. Setting spectrum_mz to 0." << std::endl;
       }
       const double spectrum_mz = precursors.empty() ? 0.0 : precursors.front().getMZ();
       const double mz_tolerance = mz_unit_is_Da_ ? mz_tolerance_ : mz_tolerance_ / 1e6;
@@ -177,7 +177,7 @@ namespace OpenMS
       const double mz_left_lim = spectrum_mz ? spectrum_mz - mz_tolerance : std::numeric_limits<double>::min();
       const double mz_right_lim = spectrum_mz ? spectrum_mz + mz_tolerance : std::numeric_limits<double>::max();
 
-      LOG_DEBUG << "annotateSpectra(): [" << i << "] (RT: " << spectrum_rt << ") (MZ: " << spectrum_mz << ")" << std::endl;
+      OPENMS_LOG_DEBUG << "annotateSpectra(): [" << i << "] (RT: " << spectrum_rt << ") (MZ: " << spectrum_mz << ")" << std::endl;
 
       for (Size j = 0; j < transitions.size(); ++j)
       {
@@ -191,8 +191,8 @@ namespace OpenMS
         if (target_rt >= rt_left_lim && target_rt <= rt_right_lim &&
             target_mz >= mz_left_lim && target_mz <= mz_right_lim)
         {
-          LOG_DEBUG << "annotateSpectra(): [" << j << "][" << transitions[j].getPeptideRef() << "]";
-          LOG_DEBUG << " (target_rt: " << target_rt << ") (target_mz: " << target_mz << ")" << std::endl << std::endl;
+          OPENMS_LOG_DEBUG << "annotateSpectra(): [" << j << "][" << transitions[j].getPeptideRef() << "]";
+          OPENMS_LOG_DEBUG << " (target_rt: " << target_rt << ") (target_mz: " << target_mz << ")" << std::endl << std::endl;
           MSSpectrum annotated_spectrum = spectrum;
           annotated_spectrum.setName(transitions[j].getPeptideRef());
           annotated_spectra.push_back(annotated_spectrum);
@@ -207,7 +207,7 @@ namespace OpenMS
         }
       }
     }
-    LOG_DEBUG << "annotateSpectra(): (input size: " << spectra.size() << ") (annotated spectra: " << annotated_spectra.size() << ")\n" << std::endl;
+    OPENMS_LOG_DEBUG << "annotateSpectra(): (input size: " << spectra.size() << ") (annotated spectra: " << annotated_spectra.size() << ")\n" << std::endl;
   }
 
   void TargetedSpectraExtractor::annotateSpectra(
@@ -286,7 +286,7 @@ namespace OpenMS
       picked_spectrum.clear(true);
     }
 
-    LOG_DEBUG << "pickSpectrum(): " << spectrum.getName() << " (input size: " <<
+    OPENMS_LOG_DEBUG << "pickSpectrum(): " << spectrum.getName() << " (input size: " <<
       spectrum.size() << ") (picked: " << picked_spectrum.size() << ")\n" << std::endl;
   }
 
@@ -569,7 +569,7 @@ namespace OpenMS
       {
         warn_msg += std::to_string(idx) + " ";
       }
-      LOG_WARN << std:: endl << warn_msg << std::endl;
+      OPENMS_LOG_WARN << std:: endl << warn_msg << std::endl;
     }
   }
 
@@ -601,7 +601,7 @@ namespace OpenMS
       const std::vector<Precursor>& precursors = spectrum.getPrecursors();
       if (precursors.empty())
       {
-        LOG_WARN << "untargetedMatching(): No precursor MZ found. Setting spectrum_mz to 0." << std::endl;
+        OPENMS_LOG_WARN << "untargetedMatching(): No precursor MZ found. Setting spectrum_mz to 0." << std::endl;
       }
       const double spectrum_mz = precursors.empty() ? 0.0 : precursors.front().getMZ();
       Feature feature;

--- a/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVFile.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TransitionTSVFile.cpp
@@ -749,13 +749,13 @@ namespace OpenMS
           if (override_group_label_check_)
           {
             // We wont fix it but give out a warning
-            LOG_WARN << "Warning: Found multiple peptide sequences for peptide label group " << pep_it.first << 
+            OPENMS_LOG_WARN << "Warning: Found multiple peptide sequences for peptide label group " << pep_it.first << 
               ". Since 'override_group_label_check' is on, nothing will be changed." << std::endl;
           }
           else
           {
             // Lets fix it and inform the user
-            LOG_WARN << "Warning: Found multiple peptide sequences for peptide label group " << pep_it.first << 
+            OPENMS_LOG_WARN << "Warning: Found multiple peptide sequences for peptide label group " << pep_it.first << 
               ". This is most likely an error and to fix this, a new peptide label group will be inferred - " << 
               "to override this decision, please use the override_group_label_check parameter." << std::endl;
             tr_it->peptide_group_label = tr_it->group_id;
@@ -1061,12 +1061,12 @@ namespace OpenMS
     {
       if (force_invalid_mods_)
       {
-        LOG_DEBUG << "Invalid sequence when parsing '" << tr_it->FullPeptideName << "'" << std::endl;
+        OPENMS_LOG_DEBUG << "Invalid sequence when parsing '" << tr_it->FullPeptideName << "'" << std::endl;
         aa_sequence = AASequence::fromString(tr_it->PeptideSequence);
       }
       else
       {
-        LOG_DEBUG << "Invalid sequence when parsing '" << tr_it->FullPeptideName << "'" << std::endl;
+        OPENMS_LOG_DEBUG << "Invalid sequence when parsing '" << tr_it->FullPeptideName << "'" << std::endl;
         std::cerr << "Error while reading file (use 'force_invalid_mods' parameter to override): " << e.what() << std::endl;
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
             "Invalid input, cannot parse: " + tr_it->FullPeptideName);
@@ -1085,9 +1085,9 @@ namespace OpenMS
         // something is wrong, return and do not try and add any modifications
         return;
       }
-      LOG_WARN << "Warning: The peptide sequence " << peptide.sequence << " and the full peptide name " << aa_sequence << 
+      OPENMS_LOG_WARN << "Warning: The peptide sequence " << peptide.sequence << " and the full peptide name " << aa_sequence << 
         " are not equal. Please check your input." << std::endl;
-      LOG_WARN << "(use force_invalid_mods to override)" << std::endl;
+      OPENMS_LOG_WARN << "(use force_invalid_mods to override)" << std::endl;
     }
 
     // Unfortunately, we cannot store an AASequence here but have to work with
@@ -1201,7 +1201,7 @@ namespace OpenMS
       mytransition.group_id = it->getPeptideRef();
 
 #ifdef TRANSITIONTSVREADER_TESTING
-      LOG_DEBUG << "Peptide rts empty " <<
+      OPENMS_LOG_DEBUG << "Peptide rts empty " <<
       pep.rts.empty()  << " or no cv term " << pep.getRetentionTime() << std::endl;
 #endif
 

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitation.cpp
@@ -147,7 +147,7 @@ namespace OpenMS
       }
       else if (component_1.metaValueExists("native_id"))
       {
-        LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
+        OPENMS_LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
         const double feature_1 = component_1.getIntensity();
         ratio = feature_1;
       }
@@ -163,13 +163,13 @@ namespace OpenMS
       }
       else if (component_1.metaValueExists(feature_name))
       {
-        LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
+        OPENMS_LOG_DEBUG << "Warning: no IS found for component " << component_1.getMetaValue("native_id") << ".";
         const double feature_1 = component_1.getMetaValue(feature_name);
         ratio = feature_1;
       }
       else
       {
-        LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
+        OPENMS_LOG_DEBUG << "Feature metaValue " << feature_name << " not found for components " << component_1.getMetaValue("native_id") << " and " << component_2.getMetaValue("native_id") << ".";
       }
     }
 
@@ -384,8 +384,8 @@ namespace OpenMS
             }
             else
             {
-              LOG_INFO << "Component " << component_name << " IS " << quant_IS_component_name << " was not found.";
-              LOG_INFO << "No concentration will be calculated.\n";
+              OPENMS_LOG_INFO << "Component " << component_name << " IS " << quant_IS_component_name << " was not found.";
+              OPENMS_LOG_INFO << "No concentration will be calculated.\n";
             }
           }
           else
@@ -406,8 +406,8 @@ namespace OpenMS
         }
         else
         {
-          LOG_INFO << "Component " << component_name << " does not have a quantitation method.";
-          LOG_INFO << "No concentration will be calculated.\n";
+          OPENMS_LOG_INFO << "Component " << component_name << " does not have a quantitation method.";
+          OPENMS_LOG_INFO << "No concentration will be calculated.\n";
           unknowns[feature_it].getSubordinates()[sub_it].setMetaValue("calculated_concentration","");
           unknowns[feature_it].getSubordinates()[sub_it].setMetaValue("concentration_units","");
         }
@@ -454,7 +454,7 @@ namespace OpenMS
       // check if the min number of calibration points has been broken
       if (component_concentrations_sorted_indices.size() < min_points_)
       {
-        LOG_INFO << "No optimal calibration found for " << component_concentrations_sub[0].feature.getMetaValue("native_id") << " .";
+        OPENMS_LOG_INFO << "No optimal calibration found for " << component_concentrations_sub[0].feature.getMetaValue("native_id") << " .";
         return false;  //no optimal calibration found
       }
 
@@ -486,7 +486,7 @@ namespace OpenMS
       }
       if (bias_check && correlation_coefficient > min_correlation_coefficient_)
       {
-        LOG_INFO << "Valid calibration found for " << component_concentrations_sub[0].feature.getMetaValue("native_id") << " .";
+        OPENMS_LOG_INFO << "Valid calibration found for " << component_concentrations_sub[0].feature.getMetaValue("native_id") << " .";
 
         // copy over the final optimized points before exiting
         component_concentrations = component_concentrations_sub;
@@ -689,7 +689,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_DEBUG << "Warning: Standards not found for component " << component_name << ".";
+        OPENMS_LOG_DEBUG << "Warning: Standards not found for component " << component_name << ".";
       }
     }
   }

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricChannelExtractor.cpp
@@ -455,7 +455,7 @@ namespace OpenMS
   {
     if (ms_exp_data.empty())
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.\n";
       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Experiment has no scans!");
     }
@@ -471,7 +471,7 @@ namespace OpenMS
     consensus_map.setExperimentType("labeled_MS2");
 
     // create predicate for spectrum checking
-    LOG_INFO << "Selecting scans with activation mode: " << (selected_activation_ == "" ? "any" : selected_activation_) << std::endl;
+    OPENMS_LOG_INFO << "Selecting scans with activation mode: " << (selected_activation_ == "" ? "any" : selected_activation_) << std::endl;
     HasActivationMethod<PeakMap::SpectrumType> isValidActivation(ListUtils::create<String>(selected_activation_));
 
     // walk through spectra and count the number of scans with valid activation method per MS-level
@@ -489,22 +489,22 @@ namespace OpenMS
     }
     if (ms_level.empty())
     {
-      LOG_WARN << "Filtering by MS/MS(/MS) and activation mode: no spectra pass activation mode filter!\n"
+      OPENMS_LOG_WARN << "Filtering by MS/MS(/MS) and activation mode: no spectra pass activation mode filter!\n"
                << "Activation modes found:\n";
       for (std::map<String, int>::const_iterator it = activation_modes.begin(); it != activation_modes.end(); ++it)
       {
-        LOG_WARN << "  mode " << (it->first.empty() ? "<none>" : it->first) << ": " << it->second << " scans\n";
+        OPENMS_LOG_WARN << "  mode " << (it->first.empty() ? "<none>" : it->first) << ": " << it->second << " scans\n";
       }
-      LOG_WARN << "Result will be empty!" << std::endl;
+      OPENMS_LOG_WARN << "Result will be empty!" << std::endl;
       return;
     }
-    LOG_INFO << "Filtering by MS/MS(/MS) and activation mode:\n";
+    OPENMS_LOG_INFO << "Filtering by MS/MS(/MS) and activation mode:\n";
     for (std::map<UInt, UInt>::const_iterator it = ms_level.begin(); it != ms_level.end(); ++it)
     {
-      LOG_INFO << "  level " << it->first << ": " << it->second << " scans\n";
+      OPENMS_LOG_INFO << "  level " << it->first << ": " << it->second << " scans\n";
     }
     UInt quant_ms_level = ms_level.rbegin()->first;
-    LOG_INFO << "Using MS-level " << quant_ms_level << " for quantification." << std::endl;
+    OPENMS_LOG_INFO << "Using MS-level " << quant_ms_level << " for quantification." << std::endl;
 
     // now we have picked data
     // --> assign peaks to channels
@@ -560,7 +560,7 @@ namespace OpenMS
       // check precursor constraints
       if (!isValidPrecursor_(it->getPrecursors()[0]))
       {
-        LOG_DEBUG << "Skip spectrum " << it->getNativeID() << ": Precursor doesn't fulfill all constraints." << std::endl;
+        OPENMS_LOG_DEBUG << "Skip spectrum " << it->getNativeID() << ": Precursor doesn't fulfill all constraints." << std::endl;
         continue;
       }
 
@@ -572,13 +572,13 @@ namespace OpenMS
         // check if purity is high enough
         if (precursor_purity < min_precursor_purity_)
         {
-          LOG_DEBUG << "Skip spectrum " << it->getNativeID() << ": Precursor purity is below the threshold. [purity = " << precursor_purity << "]" << std::endl;
+          OPENMS_LOG_DEBUG << "Skip spectrum " << it->getNativeID() << ": Precursor purity is below the threshold. [purity = " << precursor_purity << "]" << std::endl;
           continue;
         }
       }
       else
       {
-        LOG_INFO << "No precursor available for spectrum: " << it->getNativeID() << std::endl;
+        OPENMS_LOG_INFO << "No precursor available for spectrum: " << it->getNativeID() << std::endl;
       }
 
       // store RT&MZ of MS1 parent ion as centroid of ConsensusFeature
@@ -682,13 +682,13 @@ namespace OpenMS
     } // ! Experiment iterator
 
     // print stats about m/z calibration / presence of signal
-    LOG_INFO << "Calibration stats: Median distance of observed reporter ions m/z to expected position (up to " << qc_dist_mz << " Th):\n";
+    OPENMS_LOG_INFO << "Calibration stats: Median distance of observed reporter ions m/z to expected position (up to " << qc_dist_mz << " Th):\n";
     bool impurities_found(false);
     for (IsobaricQuantitationMethod::IsobaricChannelList::const_iterator cl_it = quant_method_->getChannelInformation().begin();
       cl_it != quant_method_->getChannelInformation().end();
       ++cl_it)
     {
-      LOG_INFO << "  ch " << String(cl_it->name).fillRight(' ', 4) << " (~" << String(cl_it->center).substr(0, 7).fillRight(' ', 7) << "): ";
+      OPENMS_LOG_INFO << "  ch " << String(cl_it->name).fillRight(' ', 4) << " (~" << String(cl_it->center).substr(0, 7).fillRight(' ', 7) << "): ";
       if (channel_mz_delta.find(cl_it->name) != channel_mz_delta.end())
       {
         // sort
@@ -697,27 +697,27 @@ namespace OpenMS
             (fabs(median) > TMT_10AND11PLEX_CHANNEL_TOLERANCE) &&
             (int(cl_it->center) != 126 && int(cl_it->center) != 131)) // these two channels have ~1 Th spacing.. so they do not suffer from the tolerance problem
         { // the channel was most likely empty, and we picked up the neighbouring channel's data (~0.006 Th apart). So reporting median here is misleading.
-          LOG_INFO << "<invalid data (>" << TMT_10AND11PLEX_CHANNEL_TOLERANCE << " Th channel tolerance)>\n";
+          OPENMS_LOG_INFO << "<invalid data (>" << TMT_10AND11PLEX_CHANNEL_TOLERANCE << " Th channel tolerance)>\n";
         }
         else
         {
-          LOG_INFO << median << " Th";
+          OPENMS_LOG_INFO << median << " Th";
           if (channel_mz_delta[cl_it->name].signal_not_unique > 0) 
           {
-            LOG_INFO << " [MSn impurity (within " << reporter_mass_shift_ << " Th): " << channel_mz_delta[cl_it->name].signal_not_unique << " windows|spectra]";
+            OPENMS_LOG_INFO << " [MSn impurity (within " << reporter_mass_shift_ << " Th): " << channel_mz_delta[cl_it->name].signal_not_unique << " windows|spectra]";
             impurities_found = true;
           }
-          LOG_INFO << "\n";
+          OPENMS_LOG_INFO << "\n";
         }
       }
       else
       {
-        LOG_INFO << "<no data>\n";
+        OPENMS_LOG_INFO << "<no data>\n";
       }
     }
-    if (impurities_found) LOG_INFO << "\nImpurities within the allowed reporter mass shift " << reporter_mass_shift_ << " Th have been found." 
+    if (impurities_found) OPENMS_LOG_INFO << "\nImpurities within the allowed reporter mass shift " << reporter_mass_shift_ << " Th have been found." 
                                    << "They can be ignored if the spectra are m/z calibrated (see above), since only the peak closest to the theoretical position is used for quantification!";
-    LOG_INFO << std::endl;
+    OPENMS_LOG_INFO << std::endl;
 
 
     /// add meta information to the map

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricIsotopeCorrector.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricIsotopeCorrector.cpp
@@ -174,7 +174,7 @@ namespace OpenMS
 
     if (s_negative == 0 && s_different_count > 0) //some solutions are inconsistent, despite being positive
     {
-      LOG_WARN << "IsobaricIsotopeCorrector: Isotope correction values of alternative method differ!" << std::endl;
+      OPENMS_LOG_WARN << "IsobaricIsotopeCorrector: Isotope correction values of alternative method differ!" << std::endl;
     }
 
     // update global stats

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricNormalizer.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricNormalizer.cpp
@@ -154,7 +154,7 @@ namespace OpenMS
       peptide_intensities_[vec_idx][0] = peptide_intensities_[vec_idx][peptide_intensities_[vec_idx].size() / 2] /
                                          peptide_intensities_[ref_map_id_][peptide_intensities_[ref_map_id_].size() / 2];
 
-      LOG_INFO << "IsobaricNormalizer:  map-id " << (it_map->first) << " has factor " << (normalization_factors[vec_idx]) << " (control: " << (peptide_intensities_[vec_idx][0]) << ")" << std::endl;
+      OPENMS_LOG_INFO << "IsobaricNormalizer:  map-id " << (it_map->first) << " has factor " << (normalization_factors[vec_idx]) << " (control: " << (peptide_intensities_[vec_idx][0]) << ")" << std::endl;
 
       Peak2D::IntensityType dev = (peptide_ratios_[vec_idx][0] - peptide_intensities_[vec_idx][0]) / normalization_factors[vec_idx];
       if (fabs(max_deviation_from_control) < fabs(dev))
@@ -163,7 +163,7 @@ namespace OpenMS
       }
     }
 
-    LOG_INFO << "IsobaricNormalizer: max ratio deviation of alternative method is " << (max_deviation_from_control * 100) << "%\n";
+    OPENMS_LOG_INFO << "IsobaricNormalizer: max ratio deviation of alternative method is " << (max_deviation_from_control * 100) << "%\n";
   }
 
   void IsobaricNormalizer::normalize(ConsensusMap& consensus_map)
@@ -187,7 +187,7 @@ namespace OpenMS
       // reference channel not found in this ConsensusFeature
       if (ref_it == cm_it->end())
       {
-        LOG_WARN << "IsobaricNormalizer::normalize() WARNING: ConsensusFeature "
+        OPENMS_LOG_WARN << "IsobaricNormalizer::normalize() WARNING: ConsensusFeature "
                  << (cm_it - consensus_map.begin())
                  << " does not have a reference channel! Skipping"
                  << std::endl;

--- a/src/openms/source/ANALYSIS/QUANTITATION/IsobaricQuantifier.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/IsobaricQuantifier.cpp
@@ -92,7 +92,7 @@ namespace OpenMS
     // precheck incoming map
     if (consensus_map_in.empty())
     {
-      LOG_WARN << "Warning: Empty iTRAQ/TMT container. No quantitative information available!" << std::endl;
+      OPENMS_LOG_WARN << "Warning: Empty iTRAQ/TMT container. No quantitative information available!" << std::endl;
       return;
     }
 
@@ -110,7 +110,7 @@ namespace OpenMS
     }
     else
     {
-      LOG_WARN << "Warning: Due to deactivated isotope-correction labeling statistics will be based on raw intensities, which might give too optimistic results." << std::endl;
+      OPENMS_LOG_WARN << "Warning: Due to deactivated isotope-correction labeling statistics will be based on raw intensities, which might give too optimistic results." << std::endl;
     }
 
     // compute statistics and embed into output map
@@ -147,11 +147,11 @@ namespace OpenMS
         }
       }
     }
-    LOG_INFO << "IsobaricQuantifier: skipped " << stats_.number_ms2_empty << " of " << consensus_map_out.size() << " selected scans due to lack of reporter information:\n";
+    OPENMS_LOG_INFO << "IsobaricQuantifier: skipped " << stats_.number_ms2_empty << " of " << consensus_map_out.size() << " selected scans due to lack of reporter information:\n";
     consensus_map_out.setMetaValue("isoquant:scans_noquant", stats_.number_ms2_empty);
     consensus_map_out.setMetaValue("isoquant:scans_total", consensus_map_out.size());
 
-    LOG_INFO << "IsobaricQuantifier: channels with signal\n";
+    OPENMS_LOG_INFO << "IsobaricQuantifier: channels with signal\n";
     for (IsobaricQuantitationMethod::IsobaricChannelList::const_iterator cl_it = quant_method_->getChannelInformation().begin();
       cl_it != quant_method_->getChannelInformation().end();
       ++cl_it) // use the same iteration method for printing stats as in IsobaricChannelExtractor which have the same order, so user can make 1:1 comparison
@@ -159,10 +159,10 @@ namespace OpenMS
       std::map<String, Size>::const_iterator it_m = stats_.empty_channels.find(cl_it->name);
       if (it_m == stats_.empty_channels.end()) 
       { // should not happen
-        LOG_WARN << "Warning: no stats for channel '" << cl_it->name << "'" << std::endl;
+        OPENMS_LOG_WARN << "Warning: no stats for channel '" << cl_it->name << "'" << std::endl;
         continue;
       }
-      LOG_INFO << "  ch " << String(cl_it->name).fillRight(' ', 4) << ": " << (consensus_map_out.size() - it_m->second) << " / " << consensus_map_out.size() << " (" << ((consensus_map_out.size() - it_m->second) * 100 / consensus_map_out.size()) << "%)\n";
+      OPENMS_LOG_INFO << "  ch " << String(cl_it->name).fillRight(' ', 4) << ": " << (consensus_map_out.size() - it_m->second) << " / " << consensus_map_out.size() << " (" << ((consensus_map_out.size() - it_m->second) * 100 / consensus_map_out.size()) << "%)\n";
       consensus_map_out.setMetaValue(String("isoquant:quantifyable_ch") + it_m->first, (consensus_map_out.size() - it_m->second));
     }
   }

--- a/src/openms/source/ANALYSIS/QUANTITATION/ItraqEightPlexQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/ItraqEightPlexQuantitationMethod.cpp
@@ -140,7 +140,7 @@ namespace OpenMS
     }
     else if (ref_ch == 120)
     {
-      LOG_WARN << "Invalid channel selection." << std::endl;
+      OPENMS_LOG_WARN << "Invalid channel selection." << std::endl;
     }
     else
     {

--- a/src/openms/source/ANALYSIS/QUANTITATION/ProteinResolver.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/ProteinResolver.cpp
@@ -113,7 +113,7 @@ namespace OpenMS
 
     // building ISD Groups
     buildingISDGroups_(*protein_nodes, *peptide_nodes, *isd_groups);
-    LOG_INFO << "ISD groups done! size: " << isd_groups->size() << std::endl;
+    OPENMS_LOG_INFO << "ISD groups done! size: " << isd_groups->size() << std::endl;
 
     // Including all MSMS derived peptides into the graph
     includeMSMSPeptides_(peptide_identifications, *peptide_nodes);

--- a/src/openms/source/ANALYSIS/QUANTITATION/QuantitativeExperimentalDesign.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/QuantitativeExperimentalDesign.cpp
@@ -129,7 +129,7 @@ namespace OpenMS
       {
         mergeFeatureMaps_(features, iter->first, iter->second);
       }
-      LOG_INFO << "Number of proteinIdentifications: " << features.getProteinIdentifications().size() << endl;
+      OPENMS_LOG_INFO << "Number of proteinIdentifications: " << features.getProteinIdentifications().size() << endl;
       ProteinIdentification& proteins = features.getProteinIdentifications()[0];
 
       quantifier.readQuantData(features);
@@ -145,7 +145,7 @@ namespace OpenMS
         mergeConsensusMaps_(consensus, iter->first, iter->second);
       }
 
-      LOG_INFO << "Number of proteinIdentifications: " << consensus.getProteinIdentifications().size() << endl;
+      OPENMS_LOG_INFO << "Number of proteinIdentifications: " << consensus.getProteinIdentifications().size() << endl;
       ProteinIdentification& proteins = consensus.getProteinIdentifications()[0];
 
       quantifier.readQuantData(consensus);
@@ -158,7 +158,7 @@ namespace OpenMS
   {
     ConsensusMap map;
 
-    LOG_INFO << "Merge consensus maps: " << endl;
+    OPENMS_LOG_INFO << "Merge consensus maps: " << endl;
     UInt counter = 1;
     for (StringList::iterator file_it = file_paths.begin(); file_it != file_paths.end(); ++file_it, ++counter)
     {
@@ -170,14 +170,14 @@ namespace OpenMS
       }
       out.appendRows(map);
     }
-    LOG_INFO << endl;
+    OPENMS_LOG_INFO << endl;
   }
 
   void QuantitativeExperimentalDesign::mergeFeatureMaps_(FeatureMap& out, const String& experiment, StringList& file_paths)
   {
     FeatureMap map;
 
-    LOG_INFO << "Merge feature maps: " << endl;
+    OPENMS_LOG_INFO << "Merge feature maps: " << endl;
     UInt counter = 1;
     for (StringList::iterator file_it = file_paths.begin(); file_it != file_paths.end(); ++file_it, ++counter)
     {
@@ -197,7 +197,7 @@ namespace OpenMS
     vector<ProteinIdentification> additional_proteins;
     vector<PeptideIdentification> additional_peptides;
 
-    LOG_INFO << "Merge idXML-files:" << endl;
+    OPENMS_LOG_INFO << "Merge idXML-files:" << endl;
     for (StringList::iterator file_it = file_paths.begin(); file_it != file_paths.end(); ++file_it)
     {
       // load should clear the vectors
@@ -223,7 +223,7 @@ namespace OpenMS
         String id = prot_it->getIdentifier();
         if (used_ids.find(id) != used_ids.end()) // ID used previously
         {
-          LOG_INFO << "Warning: The identifier '" + id + "' was used before!" << endl;
+          OPENMS_LOG_INFO << "Warning: The identifier '" + id + "' was used before!" << endl;
           // generate a new ID:
           DateTime date_time = prot_it->getDateTime();
           String new_id;
@@ -235,7 +235,7 @@ namespace OpenMS
             new_id = search_engine + "_" + date_time.toString(Qt::ISODate);
           } while (used_ids.find(new_id) != used_ids.end());
 
-          LOG_INFO << "New identifier '" + new_id + "' generated as replacement." << endl;
+          OPENMS_LOG_INFO << "New identifier '" + new_id + "' generated as replacement." << endl;
           // update fields:
           prot_it->setIdentifier(new_id);
           prot_it->setDateTime(date_time);
@@ -390,10 +390,10 @@ namespace OpenMS
       }
     }
 
-    LOG_INFO << "\n Statistics: \n";
+    OPENMS_LOG_INFO << "\n Statistics: \n";
     for (it = experiments.begin(); it != experiments.end(); ++it)
     {
-      LOG_INFO << "Experiment: " << it->first << ", number datasets: " << it->second.size() << endl;
+      OPENMS_LOG_INFO << "Experiment: " << it->first << ", number datasets: " << it->second.size() << endl;
     }
   }
 

--- a/src/openms/source/ANALYSIS/RNPXL/RNPxlModificationsGenerator.cpp
+++ b/src/openms/source/ANALYSIS/RNPXL/RNPxlModificationsGenerator.cpp
@@ -165,7 +165,7 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
 
   if (!map_source_to_targets.empty() && sequence_restriction.empty())
   {
-    LOG_WARN << "WARNING: no restriction on sequence but multiple target nucleotides specified. Will generate huge amount of sequences" << endl;
+    OPENMS_LOG_WARN << "WARNING: no restriction on sequence but multiple target nucleotides specified. Will generate huge amount of sequences" << endl;
   }
 
   using NucleotideModificationSubFormula = pair<EmpiricalFormula, bool>; // e.g., "H2O", true
@@ -228,7 +228,7 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
   StringList target_sequences;
   generateTargetSequences(sequence_restriction, 0, map_source_to_targets, target_sequences);
 
-  LOG_INFO << "target sequence(s):" << target_sequences.size() << endl;
+  OPENMS_LOG_INFO << "target sequence(s):" << target_sequences.size() << endl;
 
   if (!original_sequence_restriction.empty())
   {
@@ -236,11 +236,11 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
     {
       if (target_sequences[i].size() < 60)
       {
-        LOG_INFO << target_sequences[i] << endl;
+        OPENMS_LOG_INFO << target_sequences[i] << endl;
       }
       else
       {
-        LOG_INFO << target_sequences[i].prefix(60) << "..."  << endl;
+        OPENMS_LOG_INFO << target_sequences[i].prefix(60) << "..."  << endl;
       }
     }
   }
@@ -252,7 +252,7 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
     for (map<String, EmpiricalFormula>::const_iterator mit = map_target_to_formula.begin(); mit != map_target_to_formula.end(); ++mit)
     {
       String target_nucleotide = mit->first;
-      LOG_INFO << "target nucleotide: " << target_nucleotide << endl;
+      OPENMS_LOG_INFO << "target nucleotide: " << target_nucleotide << endl;
 
       EmpiricalFormula target_nucleotide_formula = mit->second;
 
@@ -280,7 +280,7 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
         }
         actual_combinations.push_back(e);
         result.mod_combinations[actual_combinations.back().toString()].insert(s);
-        LOG_INFO << "\t" << "modifications: " << s << "\t\t" << e.toString() << endl;
+        OPENMS_LOG_INFO << "\t" << "modifications: " << s << "\t\t" << e.toString() << endl;
       }
     }
 
@@ -305,7 +305,7 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
           for (auto const & s : ambiguities)
           {
             result.mod_combinations[all_combinations.back().toString()].insert(target_nucleotide + s);
-            LOG_DEBUG << target_nucleotide + s << endl;
+            OPENMS_LOG_DEBUG << target_nucleotide + s << endl;
           }
         }
       }
@@ -385,7 +385,7 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
   {
     const String& chemical_formula = violates_restriction[i].first;
     result.mod_combinations[chemical_formula].erase(violates_restriction[i].second);
-    LOG_DEBUG << "filtered sequence: " 
+    OPENMS_LOG_DEBUG << "filtered sequence: " 
               << chemical_formula 
               << "\t" 
               << violates_restriction[i].second << endl;
@@ -421,11 +421,11 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
   {
     if (cysteine_adduct && m.first == cysteine_adduct_formula.toString())
     {
-      LOG_INFO << "Precursor adduct " << pseudo_rt++ << "\t:\t" << m.first << " " << m.second << " ( cysteine adduct )" << endl;
+      OPENMS_LOG_INFO << "Precursor adduct " << pseudo_rt++ << "\t:\t" << m.first << " " << m.second << " ( cysteine adduct )" << endl;
       continue;
     }
 
-    LOG_INFO << "Precursor adduct " << pseudo_rt++ << "\t:\t" << m.first << " " << m.second << " ( ";
+    OPENMS_LOG_INFO << "Precursor adduct " << pseudo_rt++ << "\t:\t" << m.first << " " << m.second << " ( ";
 
     const set<String>& ambiguities = result.mod_combinations[m.first];
     set<String> printed;
@@ -450,18 +450,18 @@ RNPxlModificationMassesResult RNPxlModificationsGenerator::initModificationMasse
       // only print ambiguous sequences once
       if (printed.find(nucleotide_style_formula) == printed.end())
       {
-        LOG_INFO << nucleotide_style_formula << " ";
+        OPENMS_LOG_INFO << nucleotide_style_formula << " ";
         printed.insert(nucleotide_style_formula);
       }
       else
       {
-        LOG_DEBUG << "ambigious " << nucleotide_style_formula << endl;
+        OPENMS_LOG_DEBUG << "ambigious " << nucleotide_style_formula << endl;
       }
     }
 
-    LOG_INFO << ")" << endl;
+    OPENMS_LOG_INFO << ")" << endl;
   }
-  LOG_INFO << "Finished generation of modification masses." << endl;
+  OPENMS_LOG_INFO << "Finished generation of modification masses." << endl;
   return result;
 }
 

--- a/src/openms/source/ANALYSIS/SVM/SVMWrapper.cpp
+++ b/src/openms/source/ANALYSIS/SVM/SVMWrapper.cpp
@@ -901,7 +901,7 @@ namespace OpenMS
       ++work_steps;
     //reset actual values:
     actual_values = start_values;
-    LOG_INFO << "SVM-CrossValidation -- number of grid cells:" << work_steps << "\n";
+    OPENMS_LOG_INFO << "SVM-CrossValidation -- number of grid cells:" << work_steps << "\n";
 
     work_steps *= number_of_runs * number_of_partitions;
     startProgress(0, work_steps, "SVM-CrossValidation");

--- a/src/openms/source/ANALYSIS/SVM/SimpleSVM.cpp
+++ b/src/openms/source/ANALYSIS/SVM/SimpleSVM.cpp
@@ -135,7 +135,7 @@ void SimpleSVM::setup(PredictorMap& predictors, const map<Size, Int>& labels)
     msg += "\n- '" + String(it->first) + "': " + String(it->second) +
       " observations";
   }
-  LOG_INFO << msg << endl;
+  OPENMS_LOG_INFO << msg << endl;
 
   svm_params_.svm_type = C_SVC;
   String kernel = param_.getValue("kernel");
@@ -151,7 +151,7 @@ void SimpleSVM::setup(PredictorMap& predictors, const map<Size, Int>& labels)
   // in case "setup" was called before:
   if (model_ != nullptr) svm_free_model_content(model_);
   model_ = svm_train(&data_, &svm_params_);
-  LOG_INFO << "Number of support vectors in the final model: " << model_->l
+  OPENMS_LOG_INFO << "Number of support vectors in the final model: " << model_->l
            << endl;
 }
 
@@ -243,7 +243,7 @@ void SimpleSVM::scaleData_(PredictorMap& predictors) const
     double vmax = *max_element(val_begin, val_end);
     if (vmin == vmax)
     {
-      LOG_INFO << "Predictor '" + pred_it->first + "' is uninformative." 
+      OPENMS_LOG_INFO << "Predictor '" + pred_it->first + "' is uninformative." 
                << endl;
       pred_it->second.clear();
       continue;
@@ -280,7 +280,7 @@ void SimpleSVM::convertData_(const PredictorMap& predictors)
       }
     }
   }
-  LOG_DEBUG << "Number of predictors for SVM: " << pred_index << endl;
+  OPENMS_LOG_DEBUG << "Number of predictors for SVM: " << pred_index << endl;
   svm_node final = {-1, 0.0};
   for (vector<vector<struct svm_node> >::iterator node_it = nodes_.begin();
        node_it != nodes_.end(); ++node_it)
@@ -328,7 +328,7 @@ pair<double, double> SimpleSVM::chooseBestParameters_() const
       }
     }
   }
-  LOG_INFO << "Best cross-validation performance: " 
+  OPENMS_LOG_INFO << "Best cross-validation performance: " 
            << float(best_value * 100.0) << "% correct" << endl;
   if (best_indexes.size() == 1)
   {
@@ -382,7 +382,7 @@ void SimpleSVM::optimizeParameters_()
     log2_gamma_ = vector<double>(1, 0.0);
   }
 
-  LOG_INFO << "Running cross-validation to find optimal SVM parameters..." 
+  OPENMS_LOG_INFO << "Running cross-validation to find optimal SVM parameters..." 
            << endl;
   Size prog_counter = 0;
   ProgressLogger prog_log;
@@ -408,7 +408,7 @@ void SimpleSVM::optimizeParameters_()
       double ratio = n_correct / double(data_.l);
       performance_[g_index][c_index] = ratio;
       prog_log.setProgress(++prog_counter);
-      LOG_DEBUG << "Performance (log2_C = " << log2_C_[c_index] 
+      OPENMS_LOG_DEBUG << "Performance (log2_C = " << log2_C_[c_index] 
                 << ", log2_gamma = " << log2_gamma_[g_index] << "): " 
                 << n_correct << " correct (" << float(ratio * 100.0) << "%)"
                 << endl;
@@ -417,7 +417,7 @@ void SimpleSVM::optimizeParameters_()
   prog_log.endProgress();
 
   pair<double, double> best_params = chooseBestParameters_();
-  LOG_INFO << "Best SVM parameters: log2_C = " << best_params.first
+  OPENMS_LOG_INFO << "Best SVM parameters: log2_C = " << best_params.first
            << ", log2_gamma = " << best_params.second << endl;
 
   svm_params_.C = pow(2.0, best_params.first);

--- a/src/openms/source/ANALYSIS/TARGETED/InclusionExclusionList.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/InclusionExclusionList.cpp
@@ -129,12 +129,12 @@ namespace OpenMS
       ++cluster_sizes[clusters[i_outer].size()]; // for stats
     }
 
-    LOG_INFO << "Clustered overlapping windows\nCluster sizes:\n";
+    OPENMS_LOG_INFO << "Clustered overlapping windows\nCluster sizes:\n";
     for (Map<Size, Size>::const_iterator it = cluster_sizes.begin(); it != cluster_sizes.end(); ++it)
     {
-      LOG_INFO << "  size " << it->first << ": " << it->second << "x\n";
+      OPENMS_LOG_INFO << "  size " << it->first << ": " << it->second << "x\n";
     }
-    LOG_INFO << " --> Window count before: " << list.size() << "\n"
+    OPENMS_LOG_INFO << " --> Window count before: " << list.size() << "\n"
              << "     Window count after : " << list_new.size() << "\n";
 
     // replace with clustered version
@@ -323,7 +323,7 @@ namespace OpenMS
     }
 
     if (charge_invalid_count > 0)
-      LOG_WARN << "Warning: " << charge_invalid_count << " peptides with charge=0 were found, and assumed to have charge=2.\n";
+      OPENMS_LOG_WARN << "Warning: " << charge_invalid_count << " peptides with charge=0 were found, and assumed to have charge=2.\n";
 
     mergeOverlappingWindows_(result);
     writeToFile_(out_path, result);

--- a/src/openms/source/ANALYSIS/TARGETED/MRMMapping.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/MRMMapping.cpp
@@ -90,12 +90,12 @@ namespace OpenMS
       {
         if (map_multiple_assays_)
         {
-          LOG_WARN << "Warning: Chromatogram " + 
+          OPENMS_LOG_WARN << "Warning: Chromatogram " + 
             String(chromatogram.getNativeID()) + " has no precursor or product m/z recorded, mapping may not work." << std::endl;
         }
         else
         {
-          LOG_WARN << "Skip mapping for chromatogram " + 
+          OPENMS_LOG_WARN << "Skip mapping for chromatogram " + 
             String(chromatogram.getNativeID()) + " since no precursor or product m/z was recorded." << std::endl;
           continue;
         }
@@ -107,7 +107,7 @@ namespace OpenMS
         if (fabs(chromatogram.getPrecursor().getMZ() - targeted_exp.getTransitions()[j].getPrecursorMZ()) < precursor_tol_ &&
             fabs(chromatogram.getProduct().getMZ()   - targeted_exp.getTransitions()[j].getProductMZ())   < product_tol_)
         {
-          LOG_DEBUG << "Mapping chromatogram " << i << " to transition " << j << " (" << targeted_exp.getTransitions()[j].getNativeID() << ")"
+          OPENMS_LOG_DEBUG << "Mapping chromatogram " << i << " to transition " << j << " (" << targeted_exp.getTransitions()[j].getNativeID() << ")"
              " with precursor mz " << chromatogram.getPrecursor().getMZ() << " / " <<  targeted_exp.getTransitions()[j].getPrecursorMZ() <<
              " and product mz " << chromatogram.getProduct().getMZ() << " / " <<  targeted_exp.getTransitions()[j].getProductMZ() << std::endl;
 
@@ -145,7 +145,7 @@ namespace OpenMS
       //  - else append the first mapped chromatograms (if we don't allow multiple mappings)
       if (mapped_chroms.empty())
       {
-        LOG_WARN << "Did not find a mapping for chromatogram " + String(i) + " with transition " + String(chromatogram.getPrecursor().getMZ()) + \
+        OPENMS_LOG_WARN << "Did not find a mapping for chromatogram " + String(i) + " with transition " + String(chromatogram.getPrecursor().getMZ()) + \
           " -> " + String(chromatogram.getProduct().getMZ()) +  "! Maybe try to increase your mapping tolerance." << std::endl;
         notmapped++;
         if (error_on_unmapped_)
@@ -159,7 +159,7 @@ namespace OpenMS
         for (auto & c : mapped_chroms) output.addChromatogram(c);
         if (mapped_chroms.size() > 1)
         {
-          LOG_WARN << "Chromatogram " + String(chromatogram.getNativeID()) <<
+          OPENMS_LOG_WARN << "Chromatogram " + String(chromatogram.getNativeID()) <<
             " with " + String(chromatogram.getPrecursor().getMZ()) <<
             " -> " + String(chromatogram.getProduct().getMZ()) <<
             " maps to multiple assays!" << std::endl;
@@ -180,7 +180,7 @@ namespace OpenMS
 
     if (notmapped > 0)
     {
-      LOG_WARN << "Could not find mapping for " << notmapped  << " chromatogram(s)." << std::endl;
+      OPENMS_LOG_WARN << "Could not find mapping for " << notmapped  << " chromatogram(s)." << std::endl;
       if (error_on_unmapped_)
       {
         throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Found " + String(notmapped) + \

--- a/src/openms/source/ANALYSIS/TARGETED/MetaboTargetedAssay.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/MetaboTargetedAssay.cpp
@@ -140,7 +140,7 @@ namespace OpenMS
         // check if MS2 spectrum is empty
         if (spectrum.empty())
         {
-          LOG_WARN << "Empty MS/MS spectrum was provided. Please manually investigate at index: " << *index_it << std::endl;
+          OPENMS_LOG_WARN << "Empty MS/MS spectrum was provided. Please manually investigate at index: " << *index_it << std::endl;
           continue;
         }
 
@@ -394,7 +394,7 @@ namespace OpenMS
           explanation_array = transition_spectrum.getStringDataArrays()[0];
           if (explanation_array.getName() != "explanation")
           {
-            LOG_WARN << "Fragment explanation was not found. Please check if your annotation works properly." << std::endl;
+            OPENMS_LOG_WARN << "Fragment explanation was not found. Please check if your annotation works properly." << std::endl;
           }
           else
           {
@@ -458,7 +458,7 @@ namespace OpenMS
       OpenMS::DataArrays::StringDataArray explanation_array = transition_spectrum.getStringDataArrays()[0];
 
       // check which entry is saved in the FloatDataArry (control for "use_exact_mass")
-      LOG_DEBUG << transition_spectrum.getFloatDataArrays()[0].getName() << " is not used to build the assay library."
+      OPENMS_LOG_DEBUG << transition_spectrum.getFloatDataArrays()[0].getName() << " is not used to build the assay library."
                 << std::endl;
 
       // here ms2 spectra information is used

--- a/src/openms/source/ANALYSIS/TARGETED/PSProteinInference.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/PSProteinInference.cpp
@@ -59,7 +59,7 @@ namespace OpenMS
     //     // consider only first peptide hit -> should be filtered before
     //     if(ids[i].getHits().empty() || ids[i].getHits().size() > 1)
     //       {
-    //         LOG_FATAL_ERROR << "peptide id contains more than 1 peptide hit -> filter for best hits before using PSProteinInference!";
+    //         OPENMS_LOG_FATAL_ERROR << "peptide id contains more than 1 peptide hit -> filter for best hits before using PSProteinInference!";
     //         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Peptide Id contains more than 1 peptide hit", String(ids[i].getHits().size()));
     //       }
 
@@ -126,7 +126,7 @@ namespace OpenMS
       // consider only first peptide hit -> should be filtered before
       if (peptide_ids[p].getHits().size() > 1)
       {
-        LOG_FATAL_ERROR << "peptide id contains more than 1 peptide hit -> filter for best hits before using PSProteinInference!";
+        OPENMS_LOG_FATAL_ERROR << "peptide id contains more than 1 peptide hit -> filter for best hits before using PSProteinInference!";
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Peptide Id contains more than 1 peptide hit", String(peptide_ids[p].getHits().size()));
       }
 
@@ -172,7 +172,7 @@ namespace OpenMS
       // consider only first peptide hit -> should be filtered before
       if (ids[i].getHits().empty() || ids[i].getHits().size() > 1)
       {
-        LOG_FATAL_ERROR << "peptide id contains more than 1 peptide hit -> filter for best hits before using PSProteinInference!";
+        OPENMS_LOG_FATAL_ERROR << "peptide id contains more than 1 peptide hit -> filter for best hits before using PSProteinInference!";
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Peptide Id contains more than 1 peptide hit", String(ids[i].getHits().size()));
       }
 

--- a/src/openms/source/ANALYSIS/TARGETED/PrecursorIonSelectionPreprocessing.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/PrecursorIonSelectionPreprocessing.cpp
@@ -263,7 +263,7 @@ namespace OpenMS
   {
 
 #ifdef PISP_DEBUG
-    LOG_DEBUG << "Original Entry-Identifier:" << entry.identifier << std::endl;
+    OPENMS_LOG_DEBUG << "Original Entry-Identifier:" << entry.identifier << std::endl;
 #endif
     if (entry.identifier.hasPrefix("sp|") || entry.identifier.hasPrefix("tr|") || entry.identifier.hasPrefix("gi|"))
     {
@@ -280,7 +280,7 @@ namespace OpenMS
     }
 
 #ifdef PISP_DEBUG
-    LOG_DEBUG << "Processed Entry-Identifier:" << entry.identifier << std::endl;
+    OPENMS_LOG_DEBUG << "Processed Entry-Identifier:" << entry.identifier << std::endl;
 #endif
 
   }

--- a/src/openms/source/ANALYSIS/TARGETED/TargetedExperiment.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/TargetedExperiment.cpp
@@ -464,7 +464,7 @@ namespace OpenMS
       // Create new transition group if it does not yet exist
       if (unique_protein_map.find(prot_it->id) != unique_protein_map.end())
       {
-        LOG_ERROR << "Found duplicate protein id (must be unique): " + String(prot_it->id) << std::endl;
+        OPENMS_LOG_ERROR << "Found duplicate protein id (must be unique): " + String(prot_it->id) << std::endl;
         return true;
       }
       unique_protein_map[prot_it->id] = 0;
@@ -477,7 +477,7 @@ namespace OpenMS
       // Create new transition group if it does not yet exist
       if (unique_peptide_map.find(pep_it->id) != unique_peptide_map.end())
       {
-        LOG_ERROR << "Found duplicate peptide id (must be unique): " + String(pep_it->id) << std::endl;
+        OPENMS_LOG_ERROR << "Found duplicate peptide id (must be unique): " + String(pep_it->id) << std::endl;
         return true;
       }
       unique_peptide_map[pep_it->id] = 0;
@@ -490,7 +490,7 @@ namespace OpenMS
       // Create new transition group if it does not yet exist
       if (unique_compounds_map.find(comp_it->id) != unique_compounds_map.end())
       {
-        LOG_ERROR << "Found duplicate compound id (must be unique): " + String(comp_it->id) << std::endl;
+        OPENMS_LOG_ERROR << "Found duplicate compound id (must be unique): " + String(comp_it->id) << std::endl;
         return true;
       }
       unique_compounds_map[comp_it->id] = 0;
@@ -503,7 +503,7 @@ namespace OpenMS
       // Create new transition group if it does not yet exist
       if (unique_transition_map.find(tr_it->getNativeID()) != unique_transition_map.end())
       {
-        LOG_ERROR << "Found duplicate transition id (must be unique): " + String(tr_it->getNativeID()) << std::endl;
+        OPENMS_LOG_ERROR << "Found duplicate transition id (must be unique): " + String(tr_it->getNativeID()) << std::endl;
         return true;
       }
       unique_transition_map[tr_it->getNativeID()] = 0;
@@ -516,7 +516,7 @@ namespace OpenMS
       {
         if (unique_protein_map.find(*prot_it) == unique_protein_map.end()) 
         {
-          LOG_ERROR << "Protein " << *prot_it << " is not present in the provided data structure." << std::endl;
+          OPENMS_LOG_ERROR << "Protein " << *prot_it << " is not present in the provided data structure." << std::endl;
           return true;
         }
       }
@@ -530,7 +530,7 @@ namespace OpenMS
       {
         if (unique_peptide_map.find(tr.getPeptideRef()) == unique_peptide_map.end()) 
         {
-          LOG_ERROR << "Peptide " << tr.getPeptideRef() << " is not present in the provided data structure." << std::endl;
+          OPENMS_LOG_ERROR << "Peptide " << tr.getPeptideRef() << " is not present in the provided data structure." << std::endl;
           return true;
         }
       }
@@ -538,14 +538,14 @@ namespace OpenMS
       {
         if (unique_compounds_map.find(tr.getCompoundRef()) == unique_compounds_map.end()) 
         {
-          LOG_ERROR << "Compound " << tr.getPeptideRef() << " is not present in the provided data structure." << std::endl;
+          OPENMS_LOG_ERROR << "Compound " << tr.getPeptideRef() << " is not present in the provided data structure." << std::endl;
           return true;
         }
       }
       else
       {
         // It seems that having no associated compound or peptide is valid as both attributes are optional.
-        LOG_WARN << "Transition " << tr.getNativeID() << " does not have a compound or peptide associated with it." << std::endl;
+        OPENMS_LOG_WARN << "Transition " << tr.getNativeID() << " does not have a compound or peptide associated with it." << std::endl;
         // return true;
       }
     }

--- a/src/openms/source/ANALYSIS/TARGETED/TargetedExperimentHelper.cpp
+++ b/src/openms/source/ANALYSIS/TARGETED/TargetedExperimentHelper.cpp
@@ -84,7 +84,7 @@ namespace OpenMS
           continue;
         }
 
-        LOG_WARN << "Warning: No UniMod id set for modification on peptide " << peptide.sequence << 
+        OPENMS_LOG_WARN << "Warning: No UniMod id set for modification on peptide " << peptide.sequence << 
           ". Will try to infer modification id by mass next." << std::endl;
 
         // compare with code in source/ANALYSIS/OPENSWATH/DATAACCESS/DataAccessHelper.cpp

--- a/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLHelper.cpp
@@ -692,13 +692,13 @@ namespace OpenMS
 
 #ifdef DEBUG_OPXLHELPER
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Searching mono-link for " << residue << " | " << alpha_pos << endl;
+        OPENMS_LOG_DEBUG << "Searching mono-link for " << residue << " | " << alpha_pos << endl;
 #endif
         ModificationsDB::getInstance()->searchModificationsByDiffMonoMass(mods, top_csms_spectrum[i].cross_link.cross_linker_mass, 0.001, residue, ResidueModification::ANYWHERE);
 
 #ifdef DEBUG_OPXLHELPER
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "number of modifications fitting the diff mass: " << mods.size() << endl;
+        OPENMS_LOG_DEBUG << "number of modifications fitting the diff mass: " << mods.size() << endl;
 #endif
 
         bool mod_set = false;
@@ -710,7 +710,7 @@ namespace OpenMS
             {
 #ifdef DEBUG_OPXLHELPER
 #pragma omp critical (LOG_DEBUG_access)
-              LOG_DEBUG << "applied modification: " << mods[s] << endl;
+              OPENMS_LOG_DEBUG << "applied modification: " << mods[s] << endl;
 #endif
               seq_alpha.setModification(alpha_pos, mods[s]);
               mod_set = true;
@@ -722,7 +722,7 @@ namespace OpenMS
         {
 #ifdef DEBUG_OPXLHELPER
 #pragma omp critical (LOG_DEBUG_access)
-          LOG_DEBUG << "No residue specific mono-link found, searching for terminal mods..." << endl;
+          OPENMS_LOG_DEBUG << "No residue specific mono-link found, searching for terminal mods..." << endl;
 #endif
           ModificationsDB::getInstance()->searchModificationsByDiffMonoMass(mods, top_csms_spectrum[i].cross_link.cross_linker_mass, 0.001, "", alpha_term_spec);
           if (mods.size() > 0)
@@ -739,7 +739,7 @@ namespace OpenMS
             {
 #ifdef DEBUG_OPXLHELPER
 #pragma omp critical (LOG_DEBUG_access)
-              LOG_DEBUG << "Setting N-term mono-link: " << mods[mod_index] << endl;
+              OPENMS_LOG_DEBUG << "Setting N-term mono-link: " << mods[mod_index] << endl;
 #endif
               seq_alpha.setNTerminalModification(mods[mod_index]);
             }
@@ -747,7 +747,7 @@ namespace OpenMS
             {
 #ifdef DEBUG_OPXLHELPER
 #pragma omp critical (LOG_DEBUG_access)
-              LOG_DEBUG << "Setting C-term mono-link: " << mods[mod_index] << endl;
+              OPENMS_LOG_DEBUG << "Setting C-term mono-link: " << mods[mod_index] << endl;
 #endif
               seq_alpha.setCTerminalModification(mods[mod_index]);
             }
@@ -878,7 +878,7 @@ namespace OpenMS
 
 #ifdef DEBUG_OPXLHELPER
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "Annotations of size " << ph_alpha.getPeakAnnotations().size() << endl;
+      OPENMS_LOG_DEBUG << "Annotations of size " << ph_alpha.getPeakAnnotations().size() << endl;
 #endif
 
       if (top_csms_spectrum[i].cross_link.getType() == OPXLDataStructs::CROSS)

--- a/src/openms/source/ANALYSIS/XLMS/OPXLSpectrumProcessingAlgorithms.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OPXLSpectrumProcessingAlgorithms.cpp
@@ -109,7 +109,7 @@ namespace OpenMS
 
     // sort by rt
     exp.sortSpectra(false);
-    LOG_DEBUG << "Deisotoping and filtering spectra." << endl;
+    OPENMS_LOG_DEBUG << "Deisotoping and filtering spectra." << endl;
 
     // filter settings
     WindowMower window_mower_filter;

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLAlgorithm.cpp
@@ -197,7 +197,7 @@ using namespace OpenMS;
       fragment_mass_tolerance_xlinks_ = fragment_mass_tolerance_;
     }
 #ifdef DEBUG_OPENPEPXLALGO
-    LOG_DEBUG << "XLinks Tolerance: " << fragment_mass_tolerance_xlinks_ << endl;
+    OPENMS_LOG_DEBUG << "XLinks Tolerance: " << fragment_mass_tolerance_xlinks_ << endl;
 #endif
 
     std::sort(cross_link_mass_mono_link_.begin(), cross_link_mass_mono_link_.end(), std::greater< double >());
@@ -212,7 +212,7 @@ using namespace OpenMS;
     if (fixed_unique.size() != fixedModNames_.size())
     {
 #ifdef DEBUG_OPENPEPXLALGO
-      LOG_DEBUG << "duplicate fixed modification provided." << endl;
+      OPENMS_LOG_DEBUG << "duplicate fixed modification provided." << endl;
 #endif
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
@@ -221,7 +221,7 @@ using namespace OpenMS;
     if (var_unique.size() != varModNames_.size())
     {
 #ifdef DEBUG_OPENPEPXLALGO
-      LOG_DEBUG << "duplicate variable modification provided." << endl;
+      OPENMS_LOG_DEBUG << "duplicate variable modification provided." << endl;
 #endif
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
@@ -384,7 +384,7 @@ using namespace OpenMS;
     specGen_mainscore.setParameters(specGenParams_mainscore);
 
 #ifdef DEBUG_OPENPEPXLALGO
-    LOG_DEBUG << "Peptide candidates: " << peptide_masses.size() << endl;
+    OPENMS_LOG_DEBUG << "Peptide candidates: " << peptide_masses.size() << endl;
 #endif
 
     search_params = protein_ids[0].getSearchParameters();
@@ -392,7 +392,7 @@ using namespace OpenMS;
     protein_ids[0].setSearchParameters(search_params);
 
 #ifdef DEBUG_OPENPEPXLALGO
-    LOG_DEBUG << "Number of paired precursor masses: " << spectrum_precursors.size() << endl;
+    OPENMS_LOG_DEBUG << "Number of paired precursor masses: " << spectrum_precursors.size() << endl;
 #endif
 
     sort(peptide_masses.begin(), peptide_masses.end(), OPXLDataStructs::AASeqWithMassComparator());
@@ -416,7 +416,7 @@ using namespace OpenMS;
     double max_peptide_mass = max_precursor_mass - cross_link_mass_light_ + max_peptide_allowed_error;
 
 #ifdef DEBUG_OPENPEPXLALGO
-    LOG_DEBUG << "Filtering peptides with precursors" << endl;
+    OPENMS_LOG_DEBUG << "Filtering peptides with precursors" << endl;
 #endif
 
     // search for the first mass greater than the maximum, use everything before that peptide
@@ -439,7 +439,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "New scan indices: " << scan_index << "\t" << scan_index_heavy << endl;
+      OPENMS_LOG_DEBUG << "New scan indices: " << scan_index << "\t" << scan_index_heavy << endl;
 #endif
       const PeakSpectrum& spectrum_light = spectra[scan_index];
       const double precursor_charge = spectrum_light.getPrecursors()[0].getCharge();
@@ -621,7 +621,7 @@ using namespace OpenMS;
         double candidate_mz = (alpha.getMonoWeight() + beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass+ (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
 #pragma omp critical (LOG_DEBUG_access)
         {
-          LOG_DEBUG << "Pair: " << alpha.toString() << "-" << beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index_heavy
+          OPENMS_LOG_DEBUG << "Pair: " << alpha.toString() << "-" << beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index_heavy
               << " with m/z: " << precursor_mz << "\t" << "and candidate m/z: " << candidate_mz << "\tK Positions: " << cross_link_candidate.cross_link_position.first << "\t" << cross_link_candidate.cross_link_position.second << endl;
         }
 #endif
@@ -721,9 +721,9 @@ using namespace OpenMS;
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
         {
-          LOG_DEBUG << "matched peaks: " << matched_alpha_count + matched_beta_count << endl;
-          LOG_DEBUG << "theoretical peaks: " << theor_alpha_count + theor_beta_count << endl;
-          LOG_DEBUG << "exp peaks: " << all_peaks.size() << endl;
+          OPENMS_LOG_DEBUG << "matched peaks: " << matched_alpha_count + matched_beta_count << endl;
+          OPENMS_LOG_DEBUG << "theoretical peaks: " << theor_alpha_count + theor_beta_count << endl;
+          OPENMS_LOG_DEBUG << "exp peaks: " << all_peaks.size() << endl;
         }
 #endif
 
@@ -1032,7 +1032,7 @@ using namespace OpenMS;
           // write fragment annotations
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-          LOG_DEBUG << "Start writing annotations" << endl;
+          OPENMS_LOG_DEBUG << "Start writing annotations" << endl;
 #endif
 
           vector<PeptideHit::PeakAnnotation> frag_annotations;
@@ -1044,7 +1044,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-          LOG_DEBUG << "End writing fragment annotations, size: " << frag_annotations.size() << endl;
+          OPENMS_LOG_DEBUG << "End writing fragment annotations, size: " << frag_annotations.size() << endl;
 #endif
 
           // make annotations unique
@@ -1091,14 +1091,14 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "Next Spectrum #############################################" << endl;
+      OPENMS_LOG_DEBUG << "Next Spectrum #############################################" << endl;
 #endif
     } // end of matching / scoring, end of parallel for-loop
 
     progresslogger.endProgress();
 
 #ifdef DEBUG_OPENPEPXLALGO
-    LOG_DEBUG << "# Peptide IDs: " << peptide_ids.size() << " | # all_top_csms: " << all_top_csms.size() << endl;
+    OPENMS_LOG_DEBUG << "# Peptide IDs: " << peptide_ids.size() << " | # all_top_csms: " << all_top_csms.size() << endl;
 #endif
 
     peptide_ids = OPXLHelper::combineTopRanksFromPairs(peptide_ids, number_top_hits_);
@@ -1145,7 +1145,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << " heavy_light comparison, matching peaks without shift: " << matched_fragments_without_shift.size() << endl;
+      OPENMS_LOG_DEBUG << " heavy_light comparison, matching peaks without shift: " << matched_fragments_without_shift.size() << endl;
 #endif
 
       // transform by m/z difference between unlabeled and labeled cross-link to make heavy and light comparable.
@@ -1215,7 +1215,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Spectrum heavy to light: " << spectrum_heavy_to_light.size() << endl;
+        OPENMS_LOG_DEBUG << "Spectrum heavy to light: " << spectrum_heavy_to_light.size() << endl;
 #endif
 
         // align peaks from light spectrum with shifted peaks from heavy spectrum
@@ -1230,7 +1230,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-          LOG_DEBUG << "matched with shift: " << matched_fragments_with_shift.size() << endl;
+          OPENMS_LOG_DEBUG << "matched with shift: " << matched_fragments_with_shift.size() << endl;
 #endif
 
           // fill xlink_peaks spectrum with matched peaks from the light spectrum and add the currently considered charge
@@ -1254,7 +1254,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "done shifting peaks, total xlink peaks: " << xlink_peaks.size() << endl;
+      OPENMS_LOG_DEBUG << "done shifting peaks, total xlink peaks: " << xlink_peaks.size() << endl;
 #endif
 
       // generate linear peaks spectrum, include charges determined through deisotoping in preprocessing
@@ -1285,12 +1285,12 @@ using namespace OpenMS;
       }
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "done creating linear ion spectrum, total linear peaks: " << linear_peaks.size() << endl;
+      OPENMS_LOG_DEBUG << "done creating linear ion spectrum, total linear peaks: " << linear_peaks.size() << endl;
 #endif
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "Peaks to match: " << linear_peaks.size() << endl;
+      OPENMS_LOG_DEBUG << "Peaks to match: " << linear_peaks.size() << endl;
 #endif
 
       // TODO make this a tool parameter ? Leave it out completely? Comparing Light/Heavy spectra should already be good enough filtering
@@ -1312,7 +1312,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "paired up, linear peaks: " << linear_peaks.size() << " | xlink peaks: " << xlink_peaks.size() << " | all peaks: " << all_peaks.size() << endl;
+      OPENMS_LOG_DEBUG << "paired up, linear peaks: " << linear_peaks.size() << " | xlink peaks: " << xlink_peaks.size() << " | all peaks: " << all_peaks.size() << endl;
 #endif
 
   #ifdef _OPENMP
@@ -1327,8 +1327,8 @@ using namespace OpenMS;
 #ifdef DEBUG_OPENPEPXLALGO
 #pragma omp critical (LOG_DEBUG_access)
         {
-          LOG_DEBUG << "spectrum_linear_peaks: " << preprocessed_pair_spectra.spectra_linear_peaks[pair_index].size() << endl;
-          LOG_DEBUG << "spectrum_xlink_peaks: " << preprocessed_pair_spectra.spectra_xlink_peaks[pair_index].size() << endl;
+          OPENMS_LOG_DEBUG << "spectrum_linear_peaks: " << preprocessed_pair_spectra.spectra_linear_peaks[pair_index].size() << endl;
+          OPENMS_LOG_DEBUG << "spectrum_xlink_peaks: " << preprocessed_pair_spectra.spectra_xlink_peaks[pair_index].size() << endl;
         }
 #endif
 

--- a/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
+++ b/src/openms/source/ANALYSIS/XLMS/OpenPepXLLFAlgorithm.cpp
@@ -205,14 +205,14 @@ using namespace OpenMS;
 
     if (fixed_unique.size() != fixedModNames_.size())
     {
-      LOG_DEBUG << "duplicate fixed modification provided." << endl;
+      OPENMS_LOG_DEBUG << "duplicate fixed modification provided." << endl;
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
 
     set<String> var_unique(varModNames_.begin(), varModNames_.end());
     if (var_unique.size() != varModNames_.size())
     {
-      LOG_DEBUG << "duplicate variable modification provided." << endl;
+      OPENMS_LOG_DEBUG << "duplicate variable modification provided." << endl;
       return ExitCodes::ILLEGAL_PARAMETERS;
     }
     ModifiedPeptideGenerator::MapToResidueType fixed_modifications = ModifiedPeptideGenerator::getModifications(fixedModNames_);
@@ -334,7 +334,7 @@ using namespace OpenMS;
     specGen_mainscore.setParameters(specGenParams_mainscore);
 
 #ifdef DEBUG_OPENPEPXLLFALGO
-    LOG_DEBUG << "Peptide candidates: " << peptide_masses.size() << endl;
+    OPENMS_LOG_DEBUG << "Peptide candidates: " << peptide_masses.size() << endl;
 #endif
 
     search_params = protein_ids[0].getSearchParameters();
@@ -353,7 +353,7 @@ using namespace OpenMS;
     sort(spectrum_precursors.begin(), spectrum_precursors.end());
 
 #ifdef DEBUG_OPENPEPXLLFALGO
-    LOG_DEBUG << "Number of precursor masses in the spectra: " << spectrum_precursors.size() << endl;
+    OPENMS_LOG_DEBUG << "Number of precursor masses in the spectra: " << spectrum_precursors.size() << endl;
 #endif
 
     sort(peptide_masses.begin(), peptide_masses.end(), OPXLDataStructs::AASeqWithMassComparator());
@@ -375,7 +375,7 @@ using namespace OpenMS;
     double max_peptide_mass = max_precursor_mass - cross_link_mass_ + max_peptide_allowed_error;
 
 #ifdef DEBUG_OPENPEPXLLFALGO
-    LOG_DEBUG << "Filtering peptides with precursors" << endl;
+    OPENMS_LOG_DEBUG << "Filtering peptides with precursors" << endl;
 #endif
 
     // search for the first mass greater than the maximim, cut off everything larger
@@ -389,7 +389,7 @@ using namespace OpenMS;
     Size spectrum_counter = 0;
 
 #ifdef DEBUG_OPENPEPXLLFALGO
-    LOG_DEBUG << "Spectra left after preprocessing and filtering: " << spectra.size() << " of " << unprocessed_spectra.size() << endl;
+    OPENMS_LOG_DEBUG << "Spectra left after preprocessing and filtering: " << spectra.size() << " of " << unprocessed_spectra.size() << endl;
 #endif
 
 // #ifdef _OPENMP
@@ -408,7 +408,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "Size of enumerated candidates: " << double(cross_link_candidates.size()) * sizeof(OPXLDataStructs::ProteinProteinCrossLink) / 1024.0 / 1024.0 << " mb" << endl;
+      OPENMS_LOG_DEBUG << "Size of enumerated candidates: " << double(cross_link_candidates.size()) * sizeof(OPXLDataStructs::ProteinProteinCrossLink) / 1024.0 / 1024.0 << " mb" << endl;
 #endif
 
 #ifdef _OPENMP
@@ -560,7 +560,7 @@ using namespace OpenMS;
         double candidate_mz = (alpha.getMonoWeight() + beta.getMonoWeight() +  cross_link_candidate.cross_linker_mass + (static_cast<double>(precursor_charge) * Constants::PROTON_MASS_U)) / precursor_charge;
 #pragma omp critical (LOG_DEBUG_access)
         {
-          LOG_DEBUG << "Pair: " << alpha.toString() << "-" << beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index
+          OPENMS_LOG_DEBUG << "Pair: " << alpha.toString() << "-" << beta.toString() << " matched to light spectrum " << scan_index << "\t and heavy spectrum " << scan_index
             << " with m/z: " << precursor_mz << "\t" << "and candidate m/z: " << candidate_mz << "\tK Positions: " << cross_link_candidate.cross_link_position.first << "\t" << cross_link_candidate.cross_link_position.second << endl;
         }
 #endif
@@ -636,9 +636,9 @@ using namespace OpenMS;
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
         {
-          LOG_DEBUG << "Spectrum sizes: " << spectrum.size() << " || " << theoretical_spec_linear_alpha.size() <<  " | " << theoretical_spec_linear_beta.size()
+          OPENMS_LOG_DEBUG << "Spectrum sizes: " << spectrum.size() << " || " << theoretical_spec_linear_alpha.size() <<  " | " << theoretical_spec_linear_beta.size()
                                 <<  " | " << theoretical_spec_xlinks_alpha.size() <<  " | " << theoretical_spec_xlinks_beta.size() << endl;
-          LOG_DEBUG << "Matched peaks: " << matched_spec_linear_alpha.size() << " | " << matched_spec_linear_beta.size()
+          OPENMS_LOG_DEBUG << "Matched peaks: " << matched_spec_linear_alpha.size() << " | " << matched_spec_linear_beta.size()
                                 <<  " | " << matched_spec_xlinks_alpha.size() <<  " | " << matched_spec_xlinks_beta.size() << endl;
         }
 #endif
@@ -652,7 +652,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Computing Intsum..." << endl;
+        OPENMS_LOG_DEBUG << "Computing Intsum..." << endl;
 #endif
 
         // compute intsum score
@@ -684,7 +684,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Computing TIC..." << endl;
+        OPENMS_LOG_DEBUG << "Computing TIC..." << endl;
 #endif
 
         // compute weighted TIC
@@ -697,7 +697,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Computing Match-Odds..." << endl;
+        OPENMS_LOG_DEBUG << "Computing Match-Odds..." << endl;
 #endif
 
         // compute match odds (unweighted), the 3 is the number of charge states in the theoretical spectra
@@ -794,7 +794,7 @@ using namespace OpenMS;
         {
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-          LOG_DEBUG << "Computing Iso Peak summeries..." << endl;
+          OPENMS_LOG_DEBUG << "Computing Iso Peak summeries..." << endl;
 #endif
 
           DataArrays::IntegerDataArray num_iso_peaks_array;
@@ -815,7 +815,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Computing ppm error summeries..." << endl;
+        OPENMS_LOG_DEBUG << "Computing ppm error summeries..." << endl;
 #endif
 
         // TODO find a better way to compute the absolute sum
@@ -919,7 +919,7 @@ using namespace OpenMS;
         // write fragment annotations
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "Start writing annotations" << endl;
+        OPENMS_LOG_DEBUG << "Start writing annotations" << endl;
 #endif
 
         vector<PeptideHit::PeakAnnotation> frag_annotations;
@@ -931,7 +931,7 @@ using namespace OpenMS;
 
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-        LOG_DEBUG << "End writing annotations, size: " << frag_annotations.size() << endl;
+        OPENMS_LOG_DEBUG << "End writing annotations, size: " << frag_annotations.size() << endl;
 #endif
 
         // make annotations unique
@@ -976,7 +976,7 @@ using namespace OpenMS;
       }
 #ifdef DEBUG_OPENPEPXLLFALGO
 #pragma omp critical (LOG_DEBUG_access)
-      LOG_DEBUG << "Next Spectrum ##################################" << endl;
+      OPENMS_LOG_DEBUG << "Next Spectrum ##################################" << endl;
 #endif
     }
 

--- a/src/openms/source/APPLICATIONS/ConsoleUtils.cpp
+++ b/src/openms/source/APPLICATIONS/ConsoleUtils.cpp
@@ -87,7 +87,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_DEBUG << "output shaping: COLUMNS env does not exist!" << std::endl;
+        OPENMS_LOG_DEBUG << "output shaping: COLUMNS env does not exist!" << std::endl;
 #ifdef OPENMS_WINDOWSPLATFORM
         HANDLE hOut;
         CONSOLE_SCREEN_BUFFER_INFO SBInfo;
@@ -112,13 +112,13 @@ namespace OpenMS
           else
           {
             // TODO: throw ?
-            LOG_DEBUG << "Could not read 100 characters from file." << std::endl;
+            OPENMS_LOG_DEBUG << "Could not read 100 characters from file." << std::endl;
           }
           pclose(fp); //moved pclose outside of fgets condition - cant move it out of not nullpointer condition because pclose(null pointer is undefined behaviour)
         }
         else
         {
-          LOG_DEBUG << "output shaping: stty size command failed." << std::endl;
+          OPENMS_LOG_DEBUG << "output shaping: stty size command failed." << std::endl;
         }
 #endif
       }
@@ -130,7 +130,7 @@ namespace OpenMS
     // if console_width_ is still -1, we do not use command line reshaping
     if (console_width_ < 10)
     {
-      LOG_DEBUG << "Console width could not be determined or is smaller than 10. Not using output shaping!" << std::endl;
+      OPENMS_LOG_DEBUG << "Console width could not be determined or is smaller than 10. Not using output shaping!" << std::endl;
       console_width_ = std::numeric_limits<int>::max();
     }
 

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -352,9 +352,9 @@ namespace OpenMS
       // note the copy(getIniLocation_(),..) as we want the param tree without instance
       // information
       param_ = this->getDefaultParameters_().copy(getIniLocation_(), true);
-      if (!param_.update(finalParam, false, false, true, true, LOG_WARN))
+      if (!param_.update(finalParam, false, false, true, true, OPENMS_LOG_WARN))
       {
-        LOG_ERROR << "Parameters passed to '" << this->tool_name_ << "' are invalid. To prevent usage of wrong defaults, please update/fix the parameters!" << std::endl;
+        OPENMS_LOG_ERROR << "Parameters passed to '" << this->tool_name_ << "' are invalid. To prevent usage of wrong defaults, please update/fix the parameters!" << std::endl;
         return ILLEGAL_PARAMETERS;
       }
 
@@ -423,7 +423,7 @@ namespace OpenMS
     //-------------------------------------------------------------
     debug_level_ = getParamAsInt_("debug", 0);
     writeDebug_(String("Debug level (after ini file): ") + String(debug_level_), 1);
-    if (debug_level_ > 0) Log_debug.insert(cout); // allows to use LOG_DEBUG << "something" << std::endl;
+    if (debug_level_ > 0) Log_debug.insert(cout); // allows to use OPENMS_LOG_DEBUG << "something" << std::endl;
 
     //-------------------------------------------------------------
     //progress logging
@@ -446,7 +446,7 @@ namespace OpenMS
     sw.start();
     result = main_(argc, argv);
     sw.stop();
-    LOG_INFO << this->tool_name_ << " took " << sw.toString() << "." << std::endl;
+    OPENMS_LOG_INFO << this->tool_name_ << " took " << sw.toString() << "." << std::endl;
 
     // useful for benchmarking
     if (debug_level_ >= 1)
@@ -1562,7 +1562,7 @@ namespace OpenMS
 
   void TOPPBase::writeLog_(const String& text) const
   {
-    LOG_INFO << text << endl;
+    OPENMS_LOG_INFO << text << endl;
     enableLogging_();
     log_ << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << ": " << text << endl;
   }
@@ -1579,7 +1579,7 @@ namespace OpenMS
   {
     if (debug_level_ >= (Int)min_level)
     {
-      LOG_DEBUG << " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " << endl
+      OPENMS_LOG_DEBUG << " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " << endl
                 << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss").toStdString() << ' ' << getIniLocation_() << " " << text << endl
                 << param
                 << " - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " << endl;
@@ -1642,12 +1642,12 @@ namespace OpenMS
     {
         ss << " " << it->toStdString();
     }
-    LOG_DEBUG << ss.str() << endl;
+    OPENMS_LOG_DEBUG << ss.str() << endl;
     writeLog_("Executing: " + String(executable));
     const bool success = qp.waitForFinished(-1); // wait till job is finished
     if (qp.error() == QProcess::FailedToStart)
     {
-      LOG_ERROR << "Process '" << String(executable) << "' failed to start. Does it exist? Is it executable?" << std::endl;
+      OPENMS_LOG_ERROR << "Process '" << String(executable) << "' failed to start. Does it exist? Is it executable?" << std::endl;
       return EXTERNAL_PROGRAM_ERROR;
     } 
 
@@ -1939,17 +1939,17 @@ namespace OpenMS
     // check file
     if (!File::exists(filename))
     {
-      LOG_ERROR << message;
+      OPENMS_LOG_ERROR << message;
       throw FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
     }
     if (!File::readable(filename))
     {
-      LOG_ERROR << message;
+      OPENMS_LOG_ERROR << message;
       throw FileNotReadable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
     }
     if (!File::isDirectory(filename) && File::empty(filename))
     {
-      LOG_ERROR << message;
+      OPENMS_LOG_ERROR << message;
       throw FileEmpty(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
     }
   }
@@ -1967,7 +1967,7 @@ namespace OpenMS
 
     if (!File::writable(filename))
     {
-      LOG_ERROR << message;
+      OPENMS_LOG_ERROR << message;
       throw UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename);
     }
   }
@@ -2510,7 +2510,7 @@ namespace OpenMS
             if (!queue.empty())
               queue.pop_front(); // argument was already used
           }
-          LOG_DEBUG << "Command line: setting parameter value: '" << pos->second->name << "' to '" << value << "'" << std::endl;
+          OPENMS_LOG_DEBUG << "Command line: setting parameter value: '" << pos->second->name << "' to '" << value << "'" << std::endl;
           cmd_params.setValue(pos->second->name, value);
         }
         else // unknown argument -> append to "unknown" list

--- a/src/openms/source/CHEMISTRY/AASequence.cpp
+++ b/src/openms/source/CHEMISTRY/AASequence.cpp
@@ -348,14 +348,14 @@ namespace OpenMS
           return ef + Residue::getInternalToZIon();
 
         default:
-          LOG_ERROR << "AASequence::getFormula: unknown ResidueType" << std::endl;
+          OPENMS_LOG_ERROR << "AASequence::getFormula: unknown ResidueType" << std::endl;
       }
 
       return ef;
     }
     else
     {
-      LOG_ERROR << "AASequence::getFormula: Formula for ResidueType " << type << " not defined for sequences of length 0." << std::endl;
+      OPENMS_LOG_ERROR << "AASequence::getFormula: Formula for ResidueType " << type << " not defined for sequences of length 0." << std::endl;
       return EmpiricalFormula("");
     }
   }
@@ -447,14 +447,14 @@ namespace OpenMS
           return mono_weight + Residue::getInternalToZIon().getMonoWeight();
 
         default:
-          LOG_ERROR << "AASequence::getMonoWeight: unknown ResidueType" << std::endl;
+          OPENMS_LOG_ERROR << "AASequence::getMonoWeight: unknown ResidueType" << std::endl;
       }
 
       return mono_weight;
     }
     else
     {
-      LOG_ERROR << "AASequence::getMonoWeight: Mass for ResidueType " << type << " not defined for sequences of length 0." << std::endl;
+      OPENMS_LOG_ERROR << "AASequence::getMonoWeight: Mass for ResidueType " << type << " not defined for sequences of length 0." << std::endl;
       return 0.0;
     }
 }
@@ -1018,7 +1018,7 @@ namespace OpenMS
           aas.n_term_mod_ = mod_db->getModification(term_mods[0], String(*next_aa), ResidueModification::N_TERM);
           return mod_end;
         }
-        LOG_WARN << "Warning: unknown N-terminal modification '" + mod + "' - adding it to the database" << std::endl;
+        OPENMS_LOG_WARN << "Warning: unknown N-terminal modification '" + mod + "' - adding it to the database" << std::endl;
       }
       else // N-terminal mod specified by absolute mass [123.4]
       {
@@ -1030,7 +1030,7 @@ namespace OpenMS
           aas.n_term_mod_ = mod_db->getModification(term_mods[0], String(*next_aa), ResidueModification::N_TERM);
           return mod_end;
         }
-        LOG_WARN << "Warning: unknown N-terminal modification '" + mod + "' - adding it to the database" << std::endl;
+        OPENMS_LOG_WARN << "Warning: unknown N-terminal modification '" + mod + "' - adding it to the database" << std::endl;
       }
     }
     else if (specificity == ResidueModification::ANYWHERE) // internal (not exclusively terminal) modification
@@ -1113,7 +1113,7 @@ namespace OpenMS
           }
         }
       }
-      LOG_WARN << "Warning: unknown modification '" + mod + "' of residue '" +
+      OPENMS_LOG_WARN << "Warning: unknown modification '" + mod + "' of residue '" +
         residue->getOneLetterCode() + "' - adding it to the database" << std::endl;
     }
     else if (specificity == ResidueModification::C_TERM)
@@ -1129,7 +1129,7 @@ namespace OpenMS
           aas.c_term_mod_ = mod_db->getModification(term_mods[0], residue->getOneLetterCode(), ResidueModification::C_TERM);
           return mod_end;
         }
-        LOG_WARN << "Warning: unknown C-terminal modification '" + mod + "' - adding it to the database" << std::endl;
+        OPENMS_LOG_WARN << "Warning: unknown C-terminal modification '" + mod + "' - adding it to the database" << std::endl;
       }
       else // C-terminal mod specified by absolute mass [123.4]
       {
@@ -1142,7 +1142,7 @@ namespace OpenMS
           aas.c_term_mod_ = mod_db->getModification(term_mods[0], residue->getOneLetterCode(), ResidueModification::C_TERM);
           return mod_end;
         }
-        LOG_WARN << "Warning: unknown C-terminal modification '" + mod + "' - adding it to the database" << std::endl;
+        OPENMS_LOG_WARN << "Warning: unknown C-terminal modification '" + mod + "' - adding it to the database" << std::endl;
       }
     }
 

--- a/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
+++ b/src/openms/source/CHEMISTRY/EnzymaticDigestion.cpp
@@ -153,17 +153,17 @@ namespace OpenMS
 
     if (pos >= (int)sequence.size())
     {
-      LOG_WARN << "Error: start of fragment (" << pos << ") is beyond end of sequence '" << sequence << "'!" << endl;
+      OPENMS_LOG_WARN << "Error: start of fragment (" << pos << ") is beyond end of sequence '" << sequence << "'!" << endl;
       return false;
     }
     if (pos + length > (int)sequence.size())
     {
-      LOG_WARN << "Error: end of fragment (" << (pos + length) << ") is beyond end of sequence '" << sequence << "'!" << endl;
+      OPENMS_LOG_WARN << "Error: end of fragment (" << (pos + length) << ") is beyond end of sequence '" << sequence << "'!" << endl;
       return false;
     }
     if (length == 0 || sequence.empty())
     {
-      LOG_WARN << "Error: fragment and sequence must not be empty!" << endl;
+      OPENMS_LOG_WARN << "Error: fragment and sequence must not be empty!" << endl;
       return false;
     }
 

--- a/src/openms/source/CHEMISTRY/ModificationsDB.cpp
+++ b/src/openms/source/CHEMISTRY/ModificationsDB.cpp
@@ -124,7 +124,7 @@ namespace OpenMS
 
         if (!modification_names_.has(mod_name))
         {
-          LOG_WARN << OPENMS_PRETTY_FUNCTION << "Modification not found: " << mod_name << endl;
+          OPENMS_LOG_WARN << OPENMS_PRETTY_FUNCTION << "Modification not found: " << mod_name << endl;
           found = false; 
         }
       }
@@ -166,12 +166,12 @@ namespace OpenMS
     }
     if (mods.size() > 1)
     {
-      LOG_WARN << "Warning (ModificationsDB::getModification): more than one modification with name '" + mod_name + "', residue '" + residue + "', specificity '" + String(Int(term_spec)) << "' found, picking the first one of:";
+      OPENMS_LOG_WARN << "Warning (ModificationsDB::getModification): more than one modification with name '" + mod_name + "', residue '" + residue + "', specificity '" + String(Int(term_spec)) << "' found, picking the first one of:";
       for (auto it = mods.begin(); it != mods.end(); ++it)
       {
-        LOG_WARN << " " << (*it)->getFullId();
+        OPENMS_LOG_WARN << " " << (*it)->getFullId();
       }
-      LOG_WARN << "\n";
+      OPENMS_LOG_WARN << "\n";
     }
     return *mods.begin();
   }
@@ -302,7 +302,7 @@ namespace OpenMS
   {
     if (has(new_mod->getFullId()))
     {
-      LOG_WARN << "Modification already exists in ModificationsDB. Skipping." << new_mod->getFullId() << endl;
+      OPENMS_LOG_WARN << "Modification already exists in ModificationsDB. Skipping." << new_mod->getFullId() << endl;
       return;
     }
 

--- a/src/openms/source/CHEMISTRY/NASequence.cpp
+++ b/src/openms/source/CHEMISTRY/NASequence.cpp
@@ -220,7 +220,7 @@ namespace OpenMS
       return our_form + (H_form * charge) + local_three_prime + z_ion_to_full;
 
     default:
-      LOG_ERROR << "NASequence::getFormula: unsupported NASFragmentType" << endl;
+      OPENMS_LOG_ERROR << "NASequence::getFormula: unsupported NASFragmentType" << endl;
     }
 
     return our_form;

--- a/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
+++ b/src/openms/source/CHEMISTRY/RibonucleotideDB.cpp
@@ -106,7 +106,7 @@ namespace OpenMS
       }
       catch (Exception::BaseException& e)
       {
-        LOG_ERROR << "Error: Failed to parse input line " << line_count
+        OPENMS_LOG_ERROR << "Error: Failed to parse input line " << line_count
                   << ". Reason:\n" << e.getName()
                   << " - " << e.getMessage() << "\nSkipping this line." << endl;
       }

--- a/src/openms/source/CHEMISTRY/SpectrumAnnotator.cpp
+++ b/src/openms/source/CHEMISTRY/SpectrumAnnotator.cpp
@@ -234,7 +234,7 @@ namespace OpenMS
                   }
                   catch (std::out_of_range)
                   {
-                    LOG_WARN << "Note: Ions of " << ion_type << ion_name.substr(1).remove('+').toInt()
+                    OPENMS_LOG_WARN << "Note: Ions of " << ion_type << ion_name.substr(1).remove('+').toInt()
                              << " will be ignored for max_series " << ph->getSequence().toString() << endl;
                     continue;
                   }

--- a/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/SvmTheoreticalSpectrumGenerator.cpp
@@ -586,7 +586,7 @@ namespace OpenMS
       sh_ptr_c.get()->loadModel((path_to_models + svm_filename).c_str());
 
       mp_.class_models.push_back(sh_ptr_c);
-      LOG_INFO << "SVM model file loaded: " << svm_filename << std::endl;
+      OPENMS_LOG_INFO << "SVM model file loaded: " << svm_filename << std::endl;
 
 
       left_marker = StringListUtils::searchPrefix(left_marker, info_file.end(), "<SvmModelFileReg>");
@@ -596,7 +596,7 @@ namespace OpenMS
       sh_ptr_r.get()->loadModel((path_to_models + svm_filename).c_str());
 
       mp_.reg_models.push_back(sh_ptr_r);
-      LOG_INFO << "SVM model file loaded: " << svm_filename << std::endl;
+      OPENMS_LOG_INFO << "SVM model file loaded: " << svm_filename << std::endl;
 
       left_marker = StringListUtils::searchPrefix(left_marker, info_file.end(), "<IonType>");
     }
@@ -818,7 +818,7 @@ namespace OpenMS
         }
         else
         {
-          LOG_ERROR << "Requested unsupported ion type" << std::endl;
+          OPENMS_LOG_ERROR << "Requested unsupported ion type" << std::endl;
         }
 
         DescriptorSet descriptor;

--- a/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
+++ b/src/openms/source/CHEMISTRY/TheoreticalSpectrumGenerator.cpp
@@ -321,7 +321,7 @@ namespace OpenMS
       case Residue::YIon: return 'y';
       case Residue::ZIon: return 'z';
       default:
-       LOG_ERROR << "Unknown residue type encountered. Can't map to ion letter." << endl;
+       OPENMS_LOG_ERROR << "Unknown residue type encountered. Can't map to ion letter." << endl;
     }
     return ' ';
   }

--- a/src/openms/source/COMPARISON/CLUSTERING/SingleLinkage.cpp
+++ b/src/openms/source/COMPARISON/CLUSTERING/SingleLinkage.cpp
@@ -83,7 +83,7 @@ namespace OpenMS
     cluster_tree.clear();
     if (threshold < 1)
     {
-      LOG_ERROR << "You tried to use Single Linkage clustering with a threshold. This is currently not supported!" << std::endl;
+      OPENMS_LOG_ERROR << "You tried to use Single Linkage clustering with a threshold. This is currently not supported!" << std::endl;
       throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }
 

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -377,11 +377,11 @@ namespace OpenMS
   std::ostream & operator<<(std::ostream & os, LogConfigHandler const & lch)
   {
 
-    printStreamConfig_(os, "LOG_DEBUG", lch.debug_streams_, lch.stream_type_map_);
-    printStreamConfig_(os, "LOG_INFO", lch.info_streams_, lch.stream_type_map_);
+    printStreamConfig_(os, "OPENMS_LOG_DEBUG", lch.debug_streams_, lch.stream_type_map_);
+    printStreamConfig_(os, "OPENMS_LOG_INFO", lch.info_streams_, lch.stream_type_map_);
     printStreamConfig_(os, "LOG_WARNING", lch.warn_streams_, lch.stream_type_map_);
-    printStreamConfig_(os, "LOG_ERROR", lch.error_streams_, lch.stream_type_map_);
-    printStreamConfig_(os, "LOG_FATAL_ERROR", lch.fatal_streams_, lch.stream_type_map_);
+    printStreamConfig_(os, "OPENMS_LOG_ERROR", lch.error_streams_, lch.stream_type_map_);
+    printStreamConfig_(os, "OPENMS_LOG_FATAL_ERROR", lch.fatal_streams_, lch.stream_type_map_);
 
     return os;
   }

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -569,7 +569,7 @@ namespace OpenMS
   OPENMS_DLLAPI Logger::LogStream Log_error(new Logger::LogStreamBuf("ERROR"), true, &cerr);
   OPENMS_DLLAPI Logger::LogStream Log_warn(new Logger::LogStreamBuf("WARNING"), true, &cout);
   OPENMS_DLLAPI Logger::LogStream Log_info(new Logger::LogStreamBuf("INFO"), true, &cout);
-  // LOG_DEBUG is disabled by default, but will be enabled in TOPPAS.cpp or TOPPBase.cpp if started in debug mode (--debug or -debug X)
+  // OPENMS_LOG_DEBUG is disabled by default, but will be enabled in TOPPAS.cpp or TOPPBase.cpp if started in debug mode (--debug or -debug X)
   OPENMS_DLLAPI Logger::LogStream Log_debug(new Logger::LogStreamBuf("DEBUG"), false); // last param should be 'true', but segfaults...
 
 } // namespace OpenMS

--- a/src/openms/source/DATASTRUCTURES/DefaultParamHandler.cpp
+++ b/src/openms/source/DATASTRUCTURES/DefaultParamHandler.cpp
@@ -101,7 +101,7 @@ namespace OpenMS
     {
       if (defaults_.empty() && warn_empty_defaults_)
       {
-        LOG_WARN << "Warning: No default parameters for DefaultParameterHandler '" << error_name_ << "' specified!" << endl;
+        OPENMS_LOG_WARN << "Warning: No default parameters for DefaultParameterHandler '" << error_name_ << "' specified!" << endl;
       }
 
       //remove registered subsections

--- a/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
+++ b/src/openms/source/DATASTRUCTURES/LPWrapper.cpp
@@ -425,7 +425,7 @@ namespace OpenMS
         model_->setContinuous(index);
       else if (type == 3)
       {
-        LOG_WARN << "Coin-Or only knows Integer variables, setting variable to integer type";
+        OPENMS_LOG_WARN << "Coin-Or only knows Integer variables, setting variable to integer type";
         model_->setColumnIsInteger(index, true);
       }
       else
@@ -659,7 +659,7 @@ namespace OpenMS
 #endif
                        )
   {
-    LOG_INFO << "Using solver '" << (solver_ == LPWrapper::SOLVER_GLPK ? "glpk" : "coinor") << "' ...\n";
+    OPENMS_LOG_INFO << "Using solver '" << (solver_ == LPWrapper::SOLVER_GLPK ? "glpk" : "coinor") << "' ...\n";
     if (solver_ == LPWrapper::SOLVER_GLPK)
     {
       glp_iocp solver_param_glp;
@@ -749,7 +749,7 @@ namespace OpenMS
 
       // solve
       model.branchAndBound();
-      // if (verbose_level > 0) LOG_INFO << " Branch and cut took " << CoinCpuTime()-time1 << " seconds, "
+      // if (verbose_level > 0) OPENMS_LOG_INFO << " Branch and cut took " << CoinCpuTime()-time1 << " seconds, "
       //                                        << model.getNodeCount()<<" nodes with objective "
       //                                        << model.getObjValue()
       //                                        << (!model.status() ? " Finished" : " Not finished")
@@ -758,7 +758,7 @@ namespace OpenMS
       {
         solution_.push_back(model.solver()->getColSolution()[i]);
       }
-      LOG_INFO << (model.isProvenOptimal() ? "Optimal solution found!" : "No solution found!") << "\n";
+      OPENMS_LOG_INFO << (model.isProvenOptimal() ? "Optimal solution found!" : "No solution found!") << "\n";
       return model.status();
     }
 #endif

--- a/src/openms/source/DATASTRUCTURES/MassExplainer.cpp
+++ b/src/openms/source/DATASTRUCTURES/MassExplainer.cpp
@@ -220,7 +220,7 @@ namespace OpenMS
         explanations_.push_back(cmpr);
       }
 
-      LOG_DEBUG << "valid explanations: " << explanations_.size() << " after " << it->getFormula() << std::endl;
+      OPENMS_LOG_DEBUG << "valid explanations: " << explanations_.size() << " after " << it->getFormula() << std::endl;
 
     } // END adduct add
 
@@ -369,7 +369,7 @@ namespace OpenMS
   {
 
     EmpiricalFormula ef(formula);
-    LOG_DEBUG << "createAdduct_: " << formula << " " << charge << "\n";
+    OPENMS_LOG_DEBUG << "createAdduct_: " << formula << " " << charge << "\n";
     //effectively subtract charge electron masses: (-H plus one Proton)*charge
     ef -= EmpiricalFormula("H" + String(charge)); // subtracts x hydrogen
     ef.setCharge(charge); // adds x protons

--- a/src/openms/source/DATASTRUCTURES/Param.cpp
+++ b/src/openms/source/DATASTRUCTURES/Param.cpp
@@ -1015,10 +1015,10 @@ namespace OpenMS
       //unknown parameter
       if (!defaults.exists(it.getName()))
       {
-        LOG_WARN << "Warning: " << name << " received the unknown parameter '" << it.getName() << "'";
+        OPENMS_LOG_WARN << "Warning: " << name << " received the unknown parameter '" << it.getName() << "'";
         if (!prefix2.empty())
-          LOG_WARN << " in '" << prefix2 << "'";
-        LOG_WARN << "!" << std::endl;
+          OPENMS_LOG_WARN << " in '" << prefix2 << "'";
+        OPENMS_LOG_WARN << "!" << std::endl;
       }
 
       //different types
@@ -1099,7 +1099,7 @@ namespace OpenMS
 
   bool Param::update(const Param& p_outdated, const bool add_unknown)
   {
-    return update(p_outdated, add_unknown, LOG_WARN);
+    return update(p_outdated, add_unknown, OPENMS_LOG_WARN);
   }
 
   bool Param::update(const Param& p_outdated, const bool add_unknown, Logger::LogStream& stream)
@@ -1262,7 +1262,7 @@ namespace OpenMS
       if (!this->exists(it.getName()))
       {
         Param::ParamEntry entry = *it;
-        LOG_DEBUG << "[Param::merge] merging " << it.getName() << std::endl;
+        OPENMS_LOG_DEBUG << "[Param::merge] merging " << it.getName() << std::endl;
         this->root_.insert(entry, prefix);
       }
 
@@ -1272,12 +1272,12 @@ namespace OpenMS
       {
         if (traceIt->opened)
         {
-          LOG_DEBUG << "[Param::merge] extending param trace " << traceIt->name << " (" << pathname << ")" << std::endl;
+          OPENMS_LOG_DEBUG << "[Param::merge] extending param trace " << traceIt->name << " (" << pathname << ")" << std::endl;
           pathname += traceIt->name + ":";
         }
         else
         {
-          LOG_DEBUG << "[Param::merge] reducing param trace " << traceIt->name << " (" << pathname << ")" << std::endl;
+          OPENMS_LOG_DEBUG << "[Param::merge] reducing param trace " << traceIt->name << " (" << pathname << ")" << std::endl;
           if (pathname.hasSuffix(traceIt->name + ":"))
             pathname.resize(pathname.size() - traceIt->name.size() - 1);
         }

--- a/src/openms/source/DATASTRUCTURES/ToolDescription.cpp
+++ b/src/openms/source/DATASTRUCTURES/ToolDescription.cpp
@@ -161,10 +161,10 @@ namespace OpenMS
       unique_check.insert(types.begin(), types.end());
       if (unique_check.size() != types.size())
       {
-        LOG_ERROR << "A type appears at least twice for the TOPP/UTIL '" << name << "'. Types given are '" << ListUtils::concatenate(types, ", ") << "'\n";
+        OPENMS_LOG_ERROR << "A type appears at least twice for the TOPP/UTIL '" << name << "'. Types given are '" << ListUtils::concatenate(types, ", ") << "'\n";
         if (name == "GenericWrapper")
         {
-          LOG_ERROR << "Check the .ttd files in your share/ folder and remove duplicate types!\n";
+          OPENMS_LOG_ERROR << "Check the .ttd files in your share/ folder and remove duplicate types!\n";
         }
         throw Exception::InvalidValue(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "see above!", "");
       }

--- a/src/openms/source/FILTERING/CALIBRATION/InternalCalibration.cpp
+++ b/src/openms/source/FILTERING/CALIBRATION/InternalCalibration.cpp
@@ -144,7 +144,7 @@ namespace OpenMS
             Size s_left = it->findNearest(mz_iso_left);
             if (Math::getPPMAbs(mz_iso_left, (*it)[s_left].getMZ()) < 0.5) // intra-scan ppm should be very good!
             { // peak nearby lock mass was not the monoisotopic
-              if (verbose) LOG_INFO << "peak at [RT, m/z] " << it->getRT() << ", " << (*it)[s].getMZ() << " is NOT monoisotopic. Skipping it!\n";
+              if (verbose) OPENMS_LOG_INFO << "peak at [RT, m/z] " << it->getRT() << ", " << (*it)[s].getMZ() << " is NOT monoisotopic. Skipping it!\n";
               failed_lock_masses.insertCalibrationPoint(it->getRT(), itl->mz, 1.0, itl->mz, 0.0, std::distance(ref_masses.begin(), itl));
               continue;
             }
@@ -156,7 +156,7 @@ namespace OpenMS
             Size s_right = it->findNearest(mz_iso_right);
             if (!(Math::getPPMAbs(mz_iso_right, (*it)[s_right].getMZ()) < 0.5)) // intra-scan ppm should be very good!
             { // peak has no +1iso.. weird
-              if (verbose) LOG_INFO << "peak at [RT, m/z] " << it->getRT() << ", " << (*it)[s].getMZ() << " has no +1 isotope (ppm to closest: " << Math::getPPM(mz_iso_right, (*it)[s_right].getMZ()) << ")... Skipping it!\n";
+              if (verbose) OPENMS_LOG_INFO << "peak at [RT, m/z] " << it->getRT() << ", " << (*it)[s].getMZ() << " has no +1 isotope (ppm to closest: " << Math::getPPM(mz_iso_right, (*it)[s_right].getMZ()) << ")... Skipping it!\n";
               failed_lock_masses.insertCalibrationPoint(it->getRT(), itl->mz, 2.0, itl->mz, 0.0, std::distance(ref_masses.begin(), itl));
               continue;
             }
@@ -168,12 +168,12 @@ namespace OpenMS
       ++stats_cal_per_spectrum[cal_data_.size()-cnt_cd];
     }
 
-    LOG_INFO << "Lock masses found across viable spectra:\n";
+    OPENMS_LOG_INFO << "Lock masses found across viable spectra:\n";
     for (std::map<Size, Size>::const_iterator its = stats_cal_per_spectrum.begin(); its != stats_cal_per_spectrum.end(); ++its)
     {
-      LOG_INFO << "  " << its->first << " [of " << ref_masses.size() << "] lock masses: " << its->second << "x\n";
+      OPENMS_LOG_INFO << "  " << its->first << " [of " << ref_masses.size() << "] lock masses: " << its->second << "x\n";
     }
-    LOG_INFO << std::endl;
+    OPENMS_LOG_INFO << std::endl;
 
     // sort CalData by RT
     cal_data_.sortByRT();
@@ -199,7 +199,7 @@ namespace OpenMS
     // unassigned peptide IDs
     fillIDs_(fm.getUnassignedPeptideIdentifications(), tol_ppm);
 
-    LOG_INFO << "Found " << cal_data_.size() << " calibrants (incl. unassigned) in FeatureMap." << std::endl;
+    OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants (incl. unassigned) in FeatureMap." << std::endl;
 
     // sort CalData by RT
     cal_data_.sortByRT();
@@ -235,9 +235,9 @@ namespace OpenMS
       const double intensity = 1.0;
       cal_data_.insertCalibrationPoint(it->getRT(), it->getMZ(), intensity, mz_ref, weight);
     }
-    LOG_INFO << "Found " << cal_data_.size() << " calibrants in peptide IDs." << std::endl;
-    if (cnt_nomz > 0) LOG_WARN << "Warning: " << cnt_nomz << "/" << pep_ids.size() << " were skipped, since they have no m/z value set! They cannot be used as calibration point." << std::endl;
-    if (cnt_nort > 0) LOG_WARN << "Warning: " << cnt_nort << "/" << pep_ids.size() << " were skipped, since they have no RT value set! They cannot be used as calibration point." << std::endl;
+    OPENMS_LOG_INFO << "Found " << cal_data_.size() << " calibrants in peptide IDs." << std::endl;
+    if (cnt_nomz > 0) OPENMS_LOG_WARN << "Warning: " << cnt_nomz << "/" << pep_ids.size() << " were skipped, since they have no m/z value set! They cannot be used as calibration point." << std::endl;
+    if (cnt_nort > 0) OPENMS_LOG_WARN << "Warning: " << cnt_nort << "/" << pep_ids.size() << " were skipped, since they have no RT value set! They cannot be used as calibration point." << std::endl;
   }
 
   Size InternalCalibration::fillCalibrants( const std::vector<PeptideIdentification>& pep_ids, double tol_ppm )
@@ -284,7 +284,7 @@ namespace OpenMS
     bool global_model = (rt_chunk < 0);
     if (global_model)
     { // build one global modal
-      LOG_INFO << "Building a global model..." << std::endl;
+      OPENMS_LOG_INFO << "Building a global model..." << std::endl;
       tms.push_back(MZTrafoModel());
       tms[0].train(cal_data_, model_type, use_RANSAC);
       if (MZTrafoModel::isValidModel(tms[0]))
@@ -335,7 +335,7 @@ namespace OpenMS
       {
         // 2nd attempt to calibrate spectra using neighboring models
         // (will not be entered for global model since could_not_cal is empty)
-        LOG_INFO << "\nCalibration failed on " << invalid_models.size() << "/" << tms.size() << " [" <<  invalid_models.size() * 100 / tms.size() << " %] spectra. "
+        OPENMS_LOG_INFO << "\nCalibration failed on " << invalid_models.size() << "/" << tms.size() << " [" <<  invalid_models.size() * 100 / tms.size() << " %] spectra. "
           << "Using the closest successful model on these." << std::endl;
 
         std::vector<MZTrafoModel> tms_new = tms; // will contain corrected models (this wastes a bit of memory)
@@ -374,7 +374,7 @@ namespace OpenMS
     {
       if (!RWrapper::findR(rscript_executable, true))
       {
-        LOG_ERROR << "The R interpreter is required to create PNG plot files. To avoid the error, either do not request 'quality_control:*_plot' (not recommended) or fix your R installation." << std::endl;
+        OPENMS_LOG_ERROR << "The R interpreter is required to create PNG plot files. To avoid the error, either do not request 'quality_control:*_plot' (not recommended) or fix your R installation." << std::endl;
         return false;
       }
     }
@@ -405,7 +405,7 @@ namespace OpenMS
       {
         if (!RWrapper::runScript("InternalCalibration_Models.R", QStringList() << out_table.toQString() << file_models_plot.toQString(), rscript_executable))
         {
-          LOG_ERROR << "R script failed. To avoid the error, either disable the creation of 'quality_control:models_plot' (not recommended) or fix your R installation." << std::endl;
+          OPENMS_LOG_ERROR << "R script failed. To avoid the error, either disable the creation of 'quality_control:models_plot' (not recommended) or fix your R installation." << std::endl;
           return false;
         }
       }
@@ -462,7 +462,7 @@ namespace OpenMS
     {
       if (!RWrapper::runScript("InternalCalibration_Residuals.R", QStringList() << out_table_residuals.toQString() << file_residuals_plot.toQString(), rscript_executable))
       {
-        LOG_ERROR << "R script failed. To avoid the error, either disable the creation of 'quality_control:residuals_plot' (not recommended) or fix your R installation." << std::endl;
+        OPENMS_LOG_ERROR << "R script failed. To avoid the error, either disable the creation of 'quality_control:residuals_plot' (not recommended) or fix your R installation." << std::endl;
         return false;
       }
     }
@@ -470,8 +470,8 @@ namespace OpenMS
 
     if (!hasValidModels)
     { // QC tables are done; quit
-      LOG_ERROR << "Error: Could not build a single local calibration model! Check your calibrants and/or extend the search window!" << std::endl;
-      if (use_RANSAC) LOG_ERROR << "       Since you are using RANSAC, check the parameters as well and test different setups." << std::endl;
+      OPENMS_LOG_ERROR << "Error: Could not build a single local calibration model! Check your calibrants and/or extend the search window!" << std::endl;
+      if (use_RANSAC) OPENMS_LOG_ERROR << "       Since you are using RANSAC, check the parameters as well and test different setups." << std::endl;
 
       return false;
     }
@@ -479,21 +479,21 @@ namespace OpenMS
     // use median and MAD to ignore outliers
     double median_ppm_before = Math::median(vec_ppm_before.begin(), vec_ppm_before.end());
     double MAD_ppm_before =  Math::MAD(vec_ppm_before.begin(), vec_ppm_before.end(), median_ppm_before);
-    LOG_INFO << "\n-----\n" <<
+    OPENMS_LOG_INFO << "\n-----\n" <<
       "ppm stats before calibration: median = " << median_ppm_before << "  MAD = " << MAD_ppm_before << "\n";
     double median_ppm_after = Math::median(vec_ppm_after.begin(), vec_ppm_after.end());
     double MAD_ppm_after =  Math::MAD(vec_ppm_after.begin(), vec_ppm_after.end(), median_ppm_after);
-    LOG_INFO << "ppm stats after calibration: median = " << median_ppm_after << "  MAD = " << MAD_ppm_after << "\n";
+    OPENMS_LOG_INFO << "ppm stats after calibration: median = " << median_ppm_after << "  MAD = " << MAD_ppm_after << "\n";
 
     // check desired limits
     if (post_ppm_median < fabs(median_ppm_after))
     {
-      LOG_INFO << "Post calibration median threshold (" << post_ppm_median << " ppm) not reached (median = |" << median_ppm_after << "| ppm). Failed to calibrate!" << std::endl;
+      OPENMS_LOG_INFO << "Post calibration median threshold (" << post_ppm_median << " ppm) not reached (median = |" << median_ppm_after << "| ppm). Failed to calibrate!" << std::endl;
       return false;
     }
     if (post_ppm_MAD < fabs(MAD_ppm_after))
     {
-      LOG_INFO << "Post calibration median threshold (" << post_ppm_MAD << " ppm) not reached (median = |" << MAD_ppm_after << "| ppm). Failed to calibrate!" << std::endl;
+      OPENMS_LOG_INFO << "Post calibration median threshold (" << post_ppm_MAD << " ppm) not reached (median = |" << MAD_ppm_after << "| ppm). Failed to calibrate!" << std::endl;
       return false;
     }
 

--- a/src/openms/source/FILTERING/CALIBRATION/MZTrafoModel.cpp
+++ b/src/openms/source/FILTERING/CALIBRATION/MZTrafoModel.cpp
@@ -171,7 +171,7 @@ namespace OpenMS
 
     if (obs_mz.empty())
     {
-      //LOG_ERROR << "Input to calibration model is empty!" << std::endl;
+      //OPENMS_LOG_ERROR << "Input to calibration model is empty!" << std::endl;
       return false;
     }
 
@@ -183,7 +183,7 @@ namespace OpenMS
       }
       if (!(md == LINEAR || md == QUADRATIC))
       {
-        LOG_ERROR << "RANSAC is implemented for LINEAR and QUADRATIC models only! Please disable RANSAC or choose the LINEAR or QUADRATIC model." << std::endl;
+        OPENMS_LOG_ERROR << "RANSAC is implemented for LINEAR and QUADRATIC models only! Please disable RANSAC or choose the LINEAR or QUADRATIC model." << std::endl;
         throw Exception::NotImplemented(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
       }
     }
@@ -308,7 +308,7 @@ namespace OpenMS
     }
     catch (Exception::BaseException& /*e*/)
     {
-      //LOG_ERROR << "Exception during model fitting: " << e.getMessage() << std::endl;
+      //OPENMS_LOG_ERROR << "Exception during model fitting: " << e.getMessage() << std::endl;
       return false;
     }
   }

--- a/src/openms/source/FILTERING/CALIBRATION/PrecursorCorrection.cpp
+++ b/src/openms/source/FILTERING/CALIBRATION/PrecursorCorrection.cpp
@@ -120,7 +120,7 @@ using namespace std;
         if (rt_it == exp.end() 
         || rt_it->getMSLevel() != 1)
         {
-          LOG_WARN << "Warning: no MS1 spectrum for this precursor" << endl;
+          OPENMS_LOG_WARN << "Warning: no MS1 spectrum for this precursor" << endl;
           continue;          
         }
 
@@ -141,7 +141,7 @@ using namespace std;
           // sanity check: do we really have the same precursor in the original and the picked spectrum
           if (fabs(exp[precursor_spectrum_idx].getPrecursors()[0].getMZ() - mz) > 0.0001)
           {
-            LOG_WARN << "Error: index is referencing different precursors in original and picked spectrum." << endl;
+            OPENMS_LOG_WARN << "Error: index is referencing different precursors in original and picked spectrum." << endl;
           }
 
           // cout << mz << " -> " << nearest_peak_mz << endl;
@@ -192,7 +192,7 @@ using namespace std;
         if (rt_it == exp.end() 
         || rt_it->getMSLevel() != 1)
         {
-          LOG_WARN << "Warning: no MS1 spectrum for this precursor" << endl;
+          OPENMS_LOG_WARN << "Warning: no MS1 spectrum for this precursor" << endl;
           continue;
         }
 
@@ -232,7 +232,7 @@ using namespace std;
 
       if (count_error_highest_intenstiy != 0)
       {
-        LOG_INFO << "Correction to the highest intensity peak failed " 
+        OPENMS_LOG_INFO << "Correction to the highest intensity peak failed " 
            << count_error_highest_intenstiy 
            << " times because of missing peaks in the MS1. No changes were applied in these cases." 
            << std::endl;
@@ -319,7 +319,7 @@ using namespace std;
 
       if (debug_level > 0)
       {
-        LOG_INFO << "Number of precursors with compatible features: " << scan_idx_to_feature_idx.size() << endl;
+        OPENMS_LOG_INFO << "Number of precursors with compatible features: " << scan_idx_to_feature_idx.size() << endl;
       }
 
       if (!all_matching_features)
@@ -399,7 +399,7 @@ using namespace std;
     {
       if (feature.getConvexHulls().empty())
       {
-        LOG_WARN << "HighResPrecursorMassCorrector warning: at least one feature has no convex hull - omitting feature for matching" << std::endl;
+        OPENMS_LOG_WARN << "HighResPrecursorMassCorrector warning: at least one feature has no convex hull - omitting feature for matching" << std::endl;
       }
 
       // get bounding box and extend by retention time tolerance
@@ -434,7 +434,7 @@ using namespace std;
       {
         if (debug_level > 1)
         {
-          LOG_INFO << "trace: " << (int)(trace + 0.5) << " feature_rt:" << feature.getRT() << " feature_mz:" << feature.getMZ() << " precursor_mz:" << pc_mz << endl;
+          OPENMS_LOG_INFO << "trace: " << (int)(trace + 0.5) << " feature_rt:" << feature.getRT() << " feature_mz:" << feature.getMZ() << " precursor_mz:" << pc_mz << endl;
         }
         return true;
       }

--- a/src/openms/source/FILTERING/DATAREDUCTION/FeatureFindingMetabo.cpp
+++ b/src/openms/source/FILTERING/DATAREDUCTION/FeatureFindingMetabo.cpp
@@ -780,12 +780,12 @@ namespace OpenMS
     // *********************************************************** //
     if (isotope_filtering_model_ == "metabolites (2% RMS)")
     {
-      LOG_INFO << "Loading metabolite isotope model with 2% RMS error" << std::endl;
+      OPENMS_LOG_INFO << "Loading metabolite isotope model with 2% RMS error" << std::endl;
       loadIsotopeModel_("MetaboliteIsoModelNoised2");
     }
     else if (isotope_filtering_model_ == "metabolites (5% RMS)")
     {
-      LOG_INFO << "Loading metabolite isotope model with 5% RMS error" << std::endl;
+      OPENMS_LOG_INFO << "Loading metabolite isotope model with 5% RMS error" << std::endl;
       loadIsotopeModel_("MetaboliteIsoModelNoised5");
     }
 

--- a/src/openms/source/FILTERING/ID/IDFilter.cpp
+++ b/src/openms/source/FILTERING/ID/IDFilter.cpp
@@ -499,7 +499,7 @@ namespace OpenMS
 
     if (n_metavalue < n_initial)
     {
-      LOG_WARN << "Filtering peptides by RTPredict p-value removed "
+      OPENMS_LOG_WARN << "Filtering peptides by RTPredict p-value removed "
                << (n_initial - n_metavalue) << " of " << n_initial
                << " hits (total) that were missing the required meta value ('"
                << metavalue_key << "', added by RTPredict)." << endl;
@@ -583,7 +583,7 @@ namespace OpenMS
 
     if (n_metavalue < n_initial)
     {
-      LOG_WARN << "Filtering peptides by unique match to a protein removed "
+      OPENMS_LOG_WARN << "Filtering peptides by unique match to a protein removed "
                << (n_initial - n_metavalue) << " of " << n_initial
                << " hits (total) that were missing the required meta value "
                << "('protein_references', added by PeptideIndexer)." << endl;

--- a/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
+++ b/src/openms/source/FORMAT/AbsoluteQuantitationMethodFile.cpp
@@ -63,18 +63,18 @@ namespace OpenMS
         headers.count("transformation_model")
       ))
       {
-        LOG_WARN << "One or more of the following columns are missing:\n";
-        LOG_WARN << "IS_name\n";
-        LOG_WARN << "component_name\n";
-        LOG_WARN << "feature_name\n";
-        LOG_WARN << "concentration_units\n";
-        LOG_WARN << "llod\n";
-        LOG_WARN << "ulod\n";
-        LOG_WARN << "lloq\n";
-        LOG_WARN << "uloq\n";
-        LOG_WARN << "correlation_coefficient\n";
-        LOG_WARN << "n_points\n";
-        LOG_WARN << "transformation_model\n" << std::endl;
+        OPENMS_LOG_WARN << "One or more of the following columns are missing:\n";
+        OPENMS_LOG_WARN << "IS_name\n";
+        OPENMS_LOG_WARN << "component_name\n";
+        OPENMS_LOG_WARN << "feature_name\n";
+        OPENMS_LOG_WARN << "concentration_units\n";
+        OPENMS_LOG_WARN << "llod\n";
+        OPENMS_LOG_WARN << "ulod\n";
+        OPENMS_LOG_WARN << "lloq\n";
+        OPENMS_LOG_WARN << "uloq\n";
+        OPENMS_LOG_WARN << "correlation_coefficient\n";
+        OPENMS_LOG_WARN << "n_points\n";
+        OPENMS_LOG_WARN << "transformation_model\n" << std::endl;
       }
     }
     for (Size i = 1; i < rowCount(); ++i)

--- a/src/openms/source/FORMAT/ConsensusXMLFile.cpp
+++ b/src/openms/source/FORMAT/ConsensusXMLFile.cpp
@@ -638,7 +638,7 @@ namespace OpenMS
       throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, filename, "invalid file extension, expected '" + FileTypes::typeToName(FileTypes::CONSENSUSXML) + "'");
     }
 
-    if (!consensus_map.isMapConsistent(&LOG_WARN))
+    if (!consensus_map.isMapConsistent(&OPENMS_LOG_WARN))
     {
       // Currently it is possible that FeatureLinkerUnlabeledQT triggers this exception
       // throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The ConsensusXML file contains invalid maps or references thereof. No data was written! Please fix the file or notify the maintainer of this tool if you did not provide a consensusXML file!");
@@ -655,7 +655,7 @@ namespace OpenMS
       // We can detect this here but it is too late to fix the problem;
       // there is no straightforward action to be taken in all cases.
       // Note also that we are given a const reference.
-      LOG_INFO << String("ConsensusXMLFile::store():  found ") + invalid_unique_ids + " invalid unique ids" << std::endl;
+      OPENMS_LOG_INFO << String("ConsensusXMLFile::store():  found ") + invalid_unique_ids + " invalid unique ids" << std::endl;
     }
 
     // This will throw if the unique ids are not unique,
@@ -666,7 +666,7 @@ namespace OpenMS
     }
     catch (Exception::Postcondition& e)
     {
-      LOG_FATAL_ERROR << e.getName() << ' ' << e.getMessage() << std::endl;
+      OPENMS_LOG_FATAL_ERROR << e.getName() << ' ' << e.getMessage() << std::endl;
       throw;
     }
 
@@ -912,7 +912,7 @@ namespace OpenMS
 
     parse_(filename, this);
 
-    if (!map.isMapConsistent(&LOG_WARN)) // a warning is printed to LOG_WARN during isMapConsistent()
+    if (!map.isMapConsistent(&OPENMS_LOG_WARN)) // a warning is printed to OPENMS_LOG_WARN during isMapConsistent()
     {
       // don't throw exception for now, since this would prevent us from reading old files...
       // throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The ConsensusXML file contains invalid maps or references thereof. Please fix the file!");

--- a/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
+++ b/src/openms/source/FORMAT/DATAACCESS/SiriusFragmentAnnotation.cpp
@@ -74,7 +74,7 @@ namespace OpenMS
         }
         else if (line == ">ms1peaks")
         {
-           LOG_WARN << "No native id was found - please check your input mzML. " << std::endl;
+           OPENMS_LOG_WARN << "No native id was found - please check your input mzML. " << std::endl;
            break;
         }
       }
@@ -104,7 +104,7 @@ namespace OpenMS
         }
         else if (line == ">ms1peaks")
         {
-          LOG_WARN << "No native id was found - please check your input mzML. " << std::endl;
+          OPENMS_LOG_WARN << "No native id was found - please check your input mzML. " << std::endl;
           break;
         }
       }
@@ -194,7 +194,7 @@ namespace OpenMS
     }
     else
     {
-      LOG_WARN << "Directory 'spectra' was not found for: " << sirius_spectra_dir << std::endl;
+      OPENMS_LOG_WARN << "Directory 'spectra' was not found for: " << sirius_spectra_dir << std::endl;
     }
   }
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/EDTAFile.cpp
+++ b/src/openms/source/FORMAT/EDTAFile.cpp
@@ -132,7 +132,7 @@ namespace OpenMS
     {
       offset = 1;
       ++input_it;
-      LOG_INFO << "Detected a header line.\n";
+      OPENMS_LOG_INFO << "Detected a header line.\n";
     }
 
     if (headers.size() >= 5)
@@ -171,7 +171,7 @@ namespace OpenMS
       line_trimmed.trim();
       if (line_trimmed == "")
       {
-        if ((input_it - input.begin()) < input_size - 1) LOG_WARN << "Notice: Empty line ignored (line " << ((input_it - input.begin()) + 1) << ").";
+        if ((input_it - input.begin()) < input_size - 1) OPENMS_LOG_WARN << "Notice: Empty line ignored (line " << ((input_it - input.begin()) + 1) << ").";
         continue;
       }
 

--- a/src/openms/source/FORMAT/FeatureXMLFile.cpp
+++ b/src/openms/source/FORMAT/FeatureXMLFile.cpp
@@ -154,7 +154,7 @@ namespace OpenMS
       // We can detect this here but it is too late to fix the problem;
       // there is no straightforward action to be taken in all cases.
       // Note also that we are given a const reference.
-      LOG_INFO << String("FeatureXMLFile::store():  found ") + invalid_unique_ids + " invalid unique ids" << std::endl;
+      OPENMS_LOG_INFO << String("FeatureXMLFile::store():  found ") + invalid_unique_ids + " invalid unique ids" << std::endl;
     }
 
     // This will throw if the unique ids are not unique,
@@ -165,7 +165,7 @@ namespace OpenMS
     }
     catch (Exception::Postcondition& e)
     {
-      LOG_FATAL_ERROR << e.getName() << ' ' << e.getMessage() << std::endl;
+      OPENMS_LOG_FATAL_ERROR << e.getName() << ' ' << e.getMessage() << std::endl;
       throw;
     }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLDOMHandler.cpp
@@ -73,7 +73,7 @@ namespace OpenMS
       catch (XMLException& e)
       {
         char* message = XMLString::transcode(e.getMessage());
-        LOG_ERROR << "XML toolkit initialization error: " << message << endl;
+        OPENMS_LOG_ERROR << "XML toolkit initialization error: " << message << endl;
         XMLString::release(&message);
         // throw exception here to return ERROR_XERCES_INIT
       }
@@ -107,7 +107,7 @@ namespace OpenMS
       catch (XMLException& e)
       {
         char* message = XMLString::transcode(e.getMessage());
-        LOG_ERROR << "XML toolkit initialization error: " << message << endl;
+        OPENMS_LOG_ERROR << "XML toolkit initialization error: " << message << endl;
         XMLString::release(&message);
       }
 
@@ -135,7 +135,7 @@ namespace OpenMS
       }
       catch (...)
       {
-        LOG_ERROR << "Unknown exception encountered in 'TagNames' destructor" << endl;
+        OPENMS_LOG_ERROR << "Unknown exception encountered in 'TagNames' destructor" << endl;
       }
 
       // Terminate Xerces
@@ -146,7 +146,7 @@ namespace OpenMS
       catch (xercesc::XMLException& e)
       {
         char* message = xercesc::XMLString::transcode(e.getMessage());
-        LOG_ERROR << "XML toolkit teardown error: " << message << endl;
+        OPENMS_LOG_ERROR << "XML toolkit teardown error: " << message << endl;
         XMLString::release(&message);
       }
     }
@@ -213,7 +213,7 @@ namespace OpenMS
 
         if (xl_ms_search_)
         {
-          LOG_DEBUG << "Reading a Cross-Linking MS file." << endl;
+          OPENMS_LOG_DEBUG << "Reading a Cross-Linking MS file." << endl;
         }
 
         // 0. AnalysisSoftwareList {0,1}
@@ -279,7 +279,7 @@ namespace OpenMS
         char* message = xercesc::XMLString::transcode(e.getMessage());
 //          ostringstream errBuf;
 //          errBuf << "Error parsing file: " << message << flush;
-        LOG_ERROR << "XERCES error parsing file: " << message << flush << endl;
+        OPENMS_LOG_ERROR << "XERCES error parsing file: " << message << flush << endl;
         XMLString::release(&message);
       }
     }
@@ -418,20 +418,20 @@ namespace OpenMS
           catch (const XMLException& toCatch)
           {
             char* message = XMLString::transcode(toCatch.getMessage());
-            LOG_ERROR << "Serialisation exception: \n"
+            OPENMS_LOG_ERROR << "Serialisation exception: \n"
                       << message << "\n";
             XMLString::release(&message);
           }
           catch (const DOMException& toCatch)
           {
             char* message = XMLString::transcode(toCatch.msg);
-            LOG_ERROR << "Serialisation exception: \n"
+            OPENMS_LOG_ERROR << "Serialisation exception: \n"
                       << message << "\n";
             XMLString::release(&message);
           }
           catch (...)
           {
-            LOG_ERROR << "Unexpected exception building the document tree." << endl;
+            OPENMS_LOG_ERROR << "Unexpected exception building the document tree." << endl;
           }
 
           dom_output->release();
@@ -441,21 +441,21 @@ namespace OpenMS
         }
         catch (const OutOfMemoryException&)
         {
-          LOG_ERROR << "Xerces OutOfMemoryException" << endl;
+          OPENMS_LOG_ERROR << "Xerces OutOfMemoryException" << endl;
         }
         catch (const DOMException& e)
         {
-          LOG_ERROR << "DOMException code is: " << e.code << endl;
+          OPENMS_LOG_ERROR << "DOMException code is: " << e.code << endl;
         }
         catch (const exception& e)
         {
-          LOG_ERROR << "An error occurred creating the document: " << e.what() << endl;
+          OPENMS_LOG_ERROR << "An error occurred creating the document: " << e.what() << endl;
         }
 
       } // (inpl != NULL)
       else
       {
-        LOG_ERROR << "Requested DOM implementation is not supported" << endl;
+        OPENMS_LOG_ERROR << "Requested DOM implementation is not supported" << endl;
       }
     }
 
@@ -487,7 +487,7 @@ namespace OpenMS
           }
           else
           {
-            LOG_WARN << "Misplaced elements ignored in 'ParamGroup' in " << (std::string)XMLString::transcode(element_param->getTagName()) << endl;
+            OPENMS_LOG_WARN << "Misplaced elements ignored in 'ParamGroup' in " << (std::string)XMLString::transcode(element_param->getTagName()) << endl;
           }
         }
       }
@@ -514,7 +514,7 @@ namespace OpenMS
           u = CVTerm::Unit(unitAcc, unitName, unitCvRef);
           if (unitCvRef.empty())
           {
-            LOG_WARN << "This mzid file uses a cv term with units, but without "
+            OPENMS_LOG_WARN << "This mzid file uses a cv term with units, but without "
                      << "unit cv reference (required)! Please notify the mzid "
                      << "producer of this file. \"" << name << "\" will be read as \""
                      << unitName << "\" but further actions on this unit may fail."
@@ -549,7 +549,7 @@ namespace OpenMS
           }
           catch (...)
           {
-            LOG_ERROR << "Found float parameter not convertible to float type." << endl;
+            OPENMS_LOG_ERROR << "Found float parameter not convertible to float type." << endl;
           }
         }
         else if (type == "xsd:int" || type == "xsd:unsignedInt")
@@ -560,7 +560,7 @@ namespace OpenMS
           }
           catch (...)
           {
-            LOG_ERROR << "Found integer parameter not convertible to integer type." << endl;
+            OPENMS_LOG_ERROR << "Found integer parameter not convertible to integer type." << endl;
           }
         }
         else
@@ -583,7 +583,7 @@ namespace OpenMS
           }
           else
           {
-            LOG_WARN << String("Unhandled unit '") + unitAcc + "' in tag '" + name + "'." << endl;
+            OPENMS_LOG_WARN << String("Unhandled unit '") + unitAcc + "' in tag '" + name + "'." << endl;
           }
         }
 
@@ -591,7 +591,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_ERROR << "No parameters found at given position." << endl;
+        OPENMS_LOG_ERROR << "No parameters found at given position." << endl;
         throw invalid_argument("no user param here");
       }
     }
@@ -656,7 +656,7 @@ namespace OpenMS
           }
           else
           {
-            LOG_ERROR << "No name/version found for 'AnalysisSoftware':" << id << "." << endl;
+            OPENMS_LOG_ERROR << "No name/version found for 'AnalysisSoftware':" << id << "." << endl;
           }
         }
       }
@@ -735,7 +735,7 @@ namespace OpenMS
           }
           catch (...)
           {
-            LOG_ERROR << "No amino acid sequence readable from 'Peptide'" << endl;
+            OPENMS_LOG_ERROR << "No amino acid sequence readable from 'Peptide'" << endl;
           }
 
           pep_map_.insert(make_pair(id, aas));
@@ -770,7 +770,7 @@ namespace OpenMS
           }
           catch (...)
           {
-            LOG_WARN << "'PeptideEvidence' without reference to the position in the originating sequence found." << endl;
+            OPENMS_LOG_WARN << "'PeptideEvidence' without reference to the position in the originating sequence found." << endl;
           }
           char pre = '-';
           char post = '-';
@@ -787,7 +787,7 @@ namespace OpenMS
           }
           catch (...)
           {
-            LOG_WARN << "'PeptideEvidence' without reference to the bordering amino acids in the originating sequence found." << endl;
+            OPENMS_LOG_WARN << "'PeptideEvidence' without reference to the bordering amino acids in the originating sequence found." << endl;
           }
           bool idec = false;
           try
@@ -798,7 +798,7 @@ namespace OpenMS
           }
           catch (...)
           {
-            LOG_WARN << "'PeptideEvidence' with unreadable 'isDecoy' status found." << endl;
+            OPENMS_LOG_WARN << "'PeptideEvidence' with unreadable 'isDecoy' status found." << endl;
           }
           PeptideEvidence temp_struct = {start, end, pre, post, idec};
           pe_ev_map_.insert(make_pair(id, temp_struct));
@@ -930,7 +930,7 @@ namespace OpenMS
 //                }
 //                catch (...)
 //                {
-//                    LOG_ERROR << "Could not cast ModificationParam massDelta from " << XMLString::transcode(sm->getAttribute(XMLString::transcode("massDelta")));
+//                    OPENMS_LOG_ERROR << "Could not cast ModificationParam massDelta from " << XMLString::transcode(sm->getAttribute(XMLString::transcode("massDelta")));
 //                }
 
                 String mname;
@@ -954,7 +954,7 @@ namespace OpenMS
                   }
                   else
                   {
-                    LOG_ERROR << "Misplaced information in 'ModificationParams' ignored." << endl;
+                    OPENMS_LOG_ERROR << "Misplaced information in 'ModificationParams' ignored." << endl;
                   }
                   sub = sub->getNextElementSibling();
                 }
@@ -1026,7 +1026,7 @@ namespace OpenMS
                 }
                 catch (exception& e)
                 {
-                  LOG_WARN << "Search engine enzyme settings for 'missedCleavages' unreadable: " << e.what()  << String(XMLString::transcode(enzyme->getAttribute(XMLString::transcode("missedCleavages")))) << endl;
+                  OPENMS_LOG_WARN << "Search engine enzyme settings for 'missedCleavages' unreadable: " << e.what()  << String(XMLString::transcode(enzyme->getAttribute(XMLString::transcode("missedCleavages")))) << endl;
                 }
                 sp.missed_cleavages = missedCleavages;
 
@@ -1040,7 +1040,7 @@ namespace OpenMS
 //                }
 //                catch (...)
 //                {
-//                    LOG_WARN << "Search engine settings for 'minDistance' unreadable." << endl;
+//                    OPENMS_LOG_WARN << "Search engine settings for 'minDistance' unreadable." << endl;
 //                }
                 enzymename = "UNKNOWN";
                 DOMElement* sub = enzyme->getFirstElementChild();
@@ -1060,7 +1060,7 @@ namespace OpenMS
                       }
                       else
                       {
-                        LOG_WARN << "Additional parameters for enzyme settings not readable." << endl;
+                        OPENMS_LOG_WARN << "Additional parameters for enzyme settings not readable." << endl;
                       }
                     }
                   }
@@ -1221,7 +1221,7 @@ namespace OpenMS
             }
             if (dbname.empty())
             {
-              LOG_WARN << "No DatabaseName element found, use read in results at own risk." << endl;
+              OPENMS_LOG_WARN << "No DatabaseName element found, use read in results at own risk." << endl;
               dbname = "unknown";
             }
             DatabaseInput temp_struct = {dbname, location, version, releaseDate};
@@ -1358,7 +1358,7 @@ namespace OpenMS
               }
               if (pep_id_->back().getRT() != pep_id_->back().getRT())
               {
-                LOG_WARN << "No retention time found for 'SpectrumIdentificationResult'" << endl;
+                OPENMS_LOG_WARN << "No retention time found for 'SpectrumIdentificationResult'" << endl;
               }
             }
             element_res = element_res->getNextElementSibling();
@@ -1998,7 +1998,7 @@ namespace OpenMS
       }
       catch (...)
       {
-        LOG_WARN << "Found unreadable 'chargeState'." << endl;
+        OPENMS_LOG_WARN << "Found unreadable 'chargeState'." << endl;
       }
       long double experimentalMassToCharge = String(XMLString::transcode(spectrumIdentificationItemElement->getAttribute(XMLString::transcode("experimentalMassToCharge")))).toDouble();
       int rank = 0;
@@ -2008,7 +2008,7 @@ namespace OpenMS
       }
       catch (...)
       {
-        LOG_WARN << "Found unreadable PSM rank." << endl;
+        OPENMS_LOG_WARN << "Found unreadable PSM rank." << endl;
       }
 
       String peptide_ref = XMLString::transcode(spectrumIdentificationItemElement->getAttribute(XMLString::transcode("peptide_ref")));
@@ -2023,7 +2023,7 @@ namespace OpenMS
         pass = val->fData.fValue.f_bool;
       }
       delete val;
-      LOG_DEBUG << "'passThreshold' value " << pass;
+      OPENMS_LOG_DEBUG << "'passThreshold' value " << pass;
       // TODO @all: where to store passThreshold value? set after score type eval in pass_threshold
 
       long double score = 0;
@@ -2349,7 +2349,7 @@ namespace OpenMS
             }
             catch (...)
             {
-              LOG_WARN << "Found unreadable modification location." << endl;
+              OPENMS_LOG_WARN << "Found unreadable modification location." << endl;
             }
 
             //double monoisotopicMassDelta = XMLString::transcode(element_dbs->getAttribute(XMLString::transcode("monoisotopicMassDelta")));
@@ -2442,7 +2442,7 @@ namespace OpenMS
                         }
                         else
                         {
-                          LOG_WARN << "Modification: " << cvvalue << " not found in ModificationsDB." << endl;
+                          OPENMS_LOG_WARN << "Modification: " << cvvalue << " not found in ModificationsDB." << endl;
                           // TODO? @enetz look it up in XLDB?
                         }
                       }
@@ -2454,7 +2454,7 @@ namespace OpenMS
                         }
                         else
                         {
-                          LOG_WARN << "Modification: " << cvname << " not found in ModificationsDB." << endl;
+                          OPENMS_LOG_WARN << "Modification: " << cvname << " not found in ModificationsDB." << endl;
                           // TODO? @enetz look it up in XLDB?
                         }
                       }
@@ -2472,7 +2472,7 @@ namespace OpenMS
                         }
                         else
                         {
-                          LOG_WARN << "Modification: " << cvvalue << " not found in ModificationsDB." << endl;
+                          OPENMS_LOG_WARN << "Modification: " << cvvalue << " not found in ModificationsDB." << endl;
                           // TODO? @enetz look it up in XLDB?
                         }
                       }
@@ -2484,7 +2484,7 @@ namespace OpenMS
                         }
                         else
                         {
-                          LOG_WARN << "Modification: " << cvname << " not found in ModificationsDB." << endl;
+                          OPENMS_LOG_WARN << "Modification: " << cvname << " not found in ModificationsDB." << endl;
                           // TODO? @enetz look it up in XLDB?
                         }
                       }
@@ -2494,7 +2494,7 @@ namespace OpenMS
                         // this is a bad hack to avoid a long list of warnings in the case of XL-MS data
                         if ( !(String(e.getMessage()).hasSubstring("'DSG'") || String(e.getMessage()).hasSubstring("'DSS'") || String(e.getMessage()).hasSubstring("'EDC'")) || String(e.getMessage()).hasSubstring("'BS3'") || String(e.getMessage()).hasSubstring("'BS2G'") )
                         {
-                          LOG_WARN << e.getName() << ": " << e.getMessage() << " Sequence: " << aas.toUnmodifiedString() << ", residue " << aas.getResidue(index - 1).getName() << "@" << String(index) << endl;
+                          OPENMS_LOG_WARN << e.getName() << ": " << e.getMessage() << " Sequence: " << aas.toUnmodifiedString() << ", residue " << aas.getResidue(index - 1).getName() << "@" << String(index) << endl;
                         }
 */
                     }
@@ -2555,7 +2555,7 @@ namespace OpenMS
                     }
                     catch (...)
                     {
-                      LOG_WARN << "Found unreadable modification location." << endl;
+                      OPENMS_LOG_WARN << "Found unreadable modification location." << endl;
                       throw Exception::MissingInformation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "Unknown modification");
                     }
                     if (!has_mass_delta)
@@ -2683,7 +2683,7 @@ namespace OpenMS
                   }
                   catch (Exception::BaseException& e)
                   {
-                    LOG_WARN << e.getName() << ": " << e.getMessage() << " Sequence: " << aas.toUnmodifiedString() << ", residue " << aas.getResidue(index - 1).getName() << "@" << String(index) << "\n";
+                    OPENMS_LOG_WARN << e.getName() << ": " << e.getMessage() << " Sequence: " << aas.toUnmodifiedString() << ", residue " << aas.getResidue(index - 1).getName() << "@" << String(index) << "\n";
                   }
                 }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzIdentMLHandler.cpp
@@ -709,12 +709,12 @@ namespace OpenMS
               if (it->getMZ() != it->getMZ())
             {
               emz = "nan";
-              LOG_WARN << "Found no spectrum reference and no m/z position of identified spectrum! You are probably converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
+              OPENMS_LOG_WARN << "Found no spectrum reference and no m/z position of identified spectrum! You are probably converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
             }
             if (it->getRT() != it->getRT())
             {
               ert = "nan";
-              LOG_WARN << "Found no spectrum reference and no RT position of identified spectrum! You are probably converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
+              OPENMS_LOG_WARN << "Found no spectrum reference and no RT position of identified spectrum! You are probably converting from an old format with insufficient data provision. Setting 'nan' - downstream applications might fail unless you set the references right." << std::endl;
             }
             sid = String("MZ:") + emz + String("@RT:") + ert;
           }
@@ -733,7 +733,7 @@ namespace OpenMS
         }
         else
         {
-          LOG_WARN << "Falling back to referencing first spectrum file given because file or identifier could not be mapped." << std::endl;
+          OPENMS_LOG_WARN << "Falling back to referencing first spectrum file given because file or identifier could not be mapped." << std::endl;
         }
 
         sidres += String("\t\t\t<SpectrumIdentificationResult spectraData_ref=\"")
@@ -1093,7 +1093,7 @@ namespace OpenMS
               }
               else
               {
-                LOG_ERROR << "Error: Missing or invalid protein reference for peptide '" << pepi << "': '" << pe->getProteinAccession() << "' - skipping." << endl;
+                OPENMS_LOG_ERROR << "Error: Missing or invalid protein reference for peptide '" << pepi << "': '" << pe->getProteinAccession() << "' - skipping." << endl;
                 continue;
               }
               String idec;
@@ -1124,7 +1124,7 @@ namespace OpenMS
               }
               else
               {
-                LOG_WARN << "Found no start position of peptide hit in protein sequence." << std::endl;
+                OPENMS_LOG_WARN << "Found no start position of peptide hit in protein sequence." << std::endl;
               }
               if (pe->getEnd() != PeptideEvidence::UNKNOWN_POSITION)
               {
@@ -1136,7 +1136,7 @@ namespace OpenMS
               }
               else
               {
-                LOG_WARN << "Found no end position of peptide hit in protein sequence." << std::endl;
+                OPENMS_LOG_WARN << "Found no end position of peptide hit in protein sequence." << std::endl;
               }
               if (!idec.empty())
               {
@@ -1169,7 +1169,7 @@ namespace OpenMS
           if (sc.empty())
           {
             sc = "NA";
-            LOG_WARN << "No score assigned to this PSM: " /*<< jt->getSequence().toString()*/ << std::endl;
+            OPENMS_LOG_WARN << "No score assigned to this PSM: " /*<< jt->getSequence().toString()*/ << std::endl;
           }
           String c(jt->getCharge()); //charge
 
@@ -1205,7 +1205,7 @@ namespace OpenMS
 
           if (pevid_ids.empty())
           {
-            LOG_WARN << "PSM without peptide evidence registered in the given search database found. This will cause an invalid mzIdentML file (which OpenMS can still consume)." << std::endl;
+            OPENMS_LOG_WARN << "PSM without peptide evidence registered in the given search database found. This will cause an invalid mzIdentML file (which OpenMS can still consume)." << std::endl;
           }
           for (std::vector<String>::const_iterator pevref = pevid_ids.begin(); pevref != pevid_ids.end(); ++pevref)
           {
@@ -1278,7 +1278,7 @@ namespace OpenMS
             sii_tmp += String(5, '\t') + cv_.getTermByName("PSM-level search engine specific statistic").toXMLString(cv_ns);
             sii_tmp += "\n" + String(5, '\t') + "<userParam name=\"" + score_name_placeholder
                          + "\" unitName=\"" + "xsd:double" + "\" value=\"" + sc + "\"/>";
-            LOG_WARN << "Converting unknown score type to PSM-level search engine specific statistic from PSI controlled vocabulary." << std::endl;
+            OPENMS_LOG_WARN << "Converting unknown score type to PSM-level search engine specific statistic from PSI controlled vocabulary." << std::endl;
           }
           sii_tmp += "\n";
 
@@ -1393,7 +1393,7 @@ namespace OpenMS
           else
           {
             //encountered a PeptideIdentification which is not linked to any ProteinIdentification
-            LOG_ERROR << "encountered a PeptideIdentification which is not linked to any ProteinIdentification" << std::endl;
+            OPENMS_LOG_ERROR << "encountered a PeptideIdentification which is not linked to any ProteinIdentification" << std::endl;
           }
         }
 
@@ -1421,7 +1421,7 @@ namespace OpenMS
           else
           {
             //encountered a PeptideIdentification which is not linked to any ProteinIdentification
-            LOG_ERROR << "encountered a PeptideIdentification crosslink information which is not linked to any ProteinIdentification" << std::endl;
+            OPENMS_LOG_ERROR << "encountered a PeptideIdentification crosslink information which is not linked to any ProteinIdentification" << std::endl;
           }
         }
       }
@@ -1695,8 +1695,8 @@ namespace OpenMS
           // this would happen quite often and flood the output, but we still need them for other output formats
           // TODO find ways to represent additional fragment types or filter out known incompatible types
 
-          // LOG_WARN << "Well, fudge you very much, there is no matching annotation. ";
-          // LOG_WARN << kt->annotation << std::endl;
+          // OPENMS_LOG_WARN << "Well, fudge you very much, there is no matching annotation. ";
+          // OPENMS_LOG_WARN << kt->annotation << std::endl;
           continue;
         }
         String lt = "frag: " + iontype + " ion";

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -79,7 +79,7 @@ namespace OpenMS
       // check the version number of the mzML handler
       if (VersionInfo::VersionDetails::create(version_) == VersionInfo::VersionDetails::EMPTY)
       {
-        LOG_ERROR << "MzMLHandler was initialized with an invalid version number: " << version_ << std::endl;
+        OPENMS_LOG_ERROR << "MzMLHandler was initialized with an invalid version number: " << version_ << std::endl;
       }
     }
 
@@ -1057,7 +1057,7 @@ namespace OpenMS
         }
         catch (Exception::ParseError& /*e*/)
         {
-          LOG_ERROR << "Warning: Parsing error, \"processingMethod\" is missing the required attribute \"softwareRef\".\n" <<
+          OPENMS_LOG_ERROR << "Warning: Parsing error, \"processingMethod\" is missing the required attribute \"softwareRef\".\n" <<
           "The software tool which generated this mzML should be fixed. Please notify the maintainers." << std::endl;
         }
         processing_[current_id_].push_back(dp);

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandlerHelper.cpp
@@ -57,7 +57,7 @@ namespace OpenMS
       {
         error_message_ += String("( in line ") + line + " column " + column + ")";
       }
-      LOG_WARN << error_message_ << std::endl;
+      OPENMS_LOG_WARN << error_message_ << std::endl;
     }
 
   String MzMLHandlerHelper::getCompressionTerm_(const PeakFileOptions& opt, MSNumpressCoder::NumpressConfig np, String indent, bool use_numpress)

--- a/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLSqliteHandler.cpp
@@ -307,7 +307,7 @@ namespace OpenMS
           {
             const unsigned char * native_id = sqlite3_column_text(stmt, 1);
             const unsigned char * filename = sqlite3_column_text(stmt, 2);
-            LOG_WARN << "Warning: no full meta data found for run " << native_id << " from file "<< filename << std::endl;
+            OPENMS_LOG_WARN << "Warning: no full meta data found for run " << native_id << " from file "<< filename << std::endl;
           }
           sqlite3_step( stmt );
         }
@@ -317,7 +317,7 @@ namespace OpenMS
 
         if (nr_results == 0)
         {
-          LOG_WARN << "Warning: no meta data found, fall back to inference from SQL data structures." << std::endl;
+          OPENMS_LOG_WARN << "Warning: no meta data found, fall back to inference from SQL data structures." << std::endl;
         }
       }
 

--- a/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzXMLHandler.cpp
@@ -694,7 +694,7 @@ namespace OpenMS
             (manufacturer.empty() && String(inst.getSoftware().getName()).toLower().hasSubstring("xcalibur")))
         { // MaxQuant's internal parameter defaults require either "Thermo Scientific" (MaxQuant 1.2 - 1.5), or "Thermo Finnigan" (MaxQuant 1.3 - 1.5)
           manufacturer = "Thermo Scientific";
-          LOG_INFO << "Detected software '" << inst.getSoftware().getName() << "'. Setting <msManufacturer> as '" << manufacturer << "'." << std::endl;
+          OPENMS_LOG_INFO << "Detected software '" << inst.getSoftware().getName() << "'. Setting <msManufacturer> as '" << manufacturer << "'." << std::endl;
         }
         os << "\t\t<msInstrument>\n"
           << "\t\t\t<msManufacturer category=\"msManufacturer\" value=\"" << manufacturer << "\"/>\n"
@@ -1079,7 +1079,7 @@ namespace OpenMS
       { // create scan index (does not take a lot of space and is required for MaxQuant)
         if (!options_.getWriteIndex())
         {
-          LOG_INFO << "mzXML: index was not requested, but will be written to maintain MaxQuant compatibility." << std::endl;
+          OPENMS_LOG_INFO << "mzXML: index was not requested, but will be written to maintain MaxQuant compatibility." << std::endl;
         }
         std::ostream::streampos index_offset = os.tellp();
         os << "<index name = \"scan\" >\n";

--- a/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XMLHandler.cpp
@@ -101,7 +101,7 @@ namespace OpenMS
                           + "Rename the file to fix this.";
       }
 
-      LOG_FATAL_ERROR << error_message_ << std::endl;
+      OPENMS_LOG_FATAL_ERROR << error_message_ << std::endl;
       throw Exception::ParseError(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, file_, error_message_);
     }
 
@@ -119,7 +119,7 @@ namespace OpenMS
       {
         error_message_ += String("( in line ") + line + " column " + column + ")";
       }
-      LOG_ERROR << error_message_ << std::endl;
+      OPENMS_LOG_ERROR << error_message_ << std::endl;
     }
 
     void XMLHandler::warning(ActionMode mode, const String & msg, UInt line, UInt column) const
@@ -139,9 +139,9 @@ namespace OpenMS
 
 // warn only in Debug mode but suppress warnings in release mode (more happy users)
 #ifdef OPENMS_ASSERTIONS
-      LOG_WARN << error_message_ << std::endl;
+      OPENMS_LOG_WARN << error_message_ << std::endl;
 #else
-      LOG_DEBUG << error_message_ << std::endl;
+      OPENMS_LOG_DEBUG << error_message_ << std::endl;
 #endif
 
     }

--- a/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/XQuestResultXMLHandler.cpp
@@ -90,7 +90,7 @@ namespace OpenMS
       this->enzymes_db_ = ProteaseDB::getInstance();
 
       // TODO Produce some warnings that are associated with the reading of xQuest result files
-      // LOG_WARN << "WARNING: Fixed modifications are not available in the xQuest input file and will thus be not present in the loaded data!\n" << std::endl;
+      // OPENMS_LOG_WARN << "WARNING: Fixed modifications are not available in the xQuest input file and will thus be not present in the loaded data!\n" << std::endl;
     }
 
     // writer
@@ -820,7 +820,7 @@ namespace OpenMS
         }
         else
         {
-          LOG_ERROR << "ERROR: Unsupported Cross-Link type: " << xlink_type_string << endl;
+          OPENMS_LOG_ERROR << "ERROR: Unsupported Cross-Link type: " << xlink_type_string << endl;
           throw std::exception();
         }
 

--- a/src/openms/source/FORMAT/IdXMLFile.cpp
+++ b/src/openms/source/FORMAT/IdXMLFile.cpp
@@ -393,8 +393,8 @@ namespace OpenMS
       os << "\t</IdentificationRun>\n";
 
       // on more than one protein Ids (=runs) there must be wrong mappings and the message would be useless. However, a single run should not have wrong mappings!
-      if (count_wrong_id && protein_ids.size() == 1) LOG_WARN << "Omitted writing of " << count_wrong_id << " peptide identifications due to wrong protein mapping." << std::endl;
-      if (count_empty) LOG_WARN << "Omitted writing of " << count_empty << " peptide identifications due to empty hits." << std::endl;
+      if (count_wrong_id && protein_ids.size() == 1) OPENMS_LOG_WARN << "Omitted writing of " << count_wrong_id << " peptide identifications due to wrong protein mapping." << std::endl;
+      if (count_empty) OPENMS_LOG_WARN << "Omitted writing of " << count_empty << " peptide identifications due to empty hits." << std::endl;
     }
 
     // empty protein ids  parameters

--- a/src/openms/source/FORMAT/InspectOutfile.cpp
+++ b/src/openms/source/FORMAT/InspectOutfile.cpp
@@ -158,7 +158,7 @@ namespace OpenMS
     {
       result_file.close();
       result_file.clear();
-      LOG_WARN << "ParseError (" << p_e.getMessage() << ") caught in " << __FILE__ << "\n";
+      OPENMS_LOG_WARN << "ParseError (" << p_e.getMessage() << ") caught in " << __FILE__ << "\n";
       throw;
     }
 

--- a/src/openms/source/FORMAT/KroenikFile.cpp
+++ b/src/openms/source/FORMAT/KroenikFile.cpp
@@ -123,7 +123,7 @@ namespace OpenMS
       feature_map.push_back(f);
     }
 
-    LOG_INFO << "Hint: The convex hulls are approximated in m/z dimension (Kroenik lacks this information)!\n";
+    OPENMS_LOG_INFO << "Hint: The convex hulls are approximated in m/z dimension (Kroenik lacks this information)!\n";
   }
 
 } // namespace OpenMS

--- a/src/openms/source/FORMAT/MSPGenericFile.cpp
+++ b/src/openms/source/FORMAT/MSPGenericFile.cpp
@@ -93,7 +93,7 @@ namespace OpenMS
     boost::regex re_cas_nist("^CAS#: ([\\d-]+);  NIST#: (\\d+)"); // specific to NIST db
     boost::regex re_metadatum("^(.+): (.+)", boost::regex::no_mod_s);
 
-    LOG_INFO << "\nLoading spectra from .msp file. Please wait." << std::endl;
+    OPENMS_LOG_INFO << "\nLoading spectra from .msp file. Please wait." << std::endl;
 
     while (!ifs.eof())
     {
@@ -101,11 +101,11 @@ namespace OpenMS
       // Peaks
       if (boost::regex_search(line, m, re_points_line))
       {
-        // LOG_DEBUG << "re_points_line\n";
+        // OPENMS_LOG_DEBUG << "re_points_line\n";
         boost::regex_search(line, m, re_point);
         do
         {
-          // LOG_DEBUG << "{" << m[1] << "} {" << m[2] << "}; ";
+          // OPENMS_LOG_DEBUG << "{" << m[1] << "} {" << m[2] << "}; ";
           const double position { std::stod(m[1]) };
           const double intensity { std::stod(m[2]) };
           spectrum.push_back( Peak1D(position, intensity) );
@@ -114,14 +114,14 @@ namespace OpenMS
       // Synon
       else if (boost::regex_search(line, m, re_synon))
       {
-        // LOG_DEBUG << "Synon: " << m[1] << "\n";
+        // OPENMS_LOG_DEBUG << "Synon: " << m[1] << "\n";
         synonyms_.push_back(String(m[1]));
       }
       // Name
       else if (boost::regex_search(line, m, re_name))
       {
         addSpectrumToLibrary(spectrum, library);
-        // LOG_DEBUG << "\n\nName: " << m[1] << "\n";
+        // OPENMS_LOG_DEBUG << "\n\nName: " << m[1] << "\n";
         spectrum.clear(true);
         synonyms_.clear();
         spectrum.setName( String(m[1]) );
@@ -130,22 +130,22 @@ namespace OpenMS
       // Specific case of NIST's exported msp
       else if (boost::regex_search(line, m, re_cas_nist))
       {
-        // LOG_DEBUG << "CAS#: " << m[1] << "; NIST#: " << m[2] << "\n";
+        // OPENMS_LOG_DEBUG << "CAS#: " << m[1] << "; NIST#: " << m[2] << "\n";
         spectrum.setMetaValue(String("CAS#"), String(m[1]));
         spectrum.setMetaValue(String("NIST#"), String(m[2]));
       }
       // Other metadata
       else if (boost::regex_search(line, m, re_metadatum))
       {
-        // LOG_DEBUG << m[1] << m[2] << "\n";
+        // OPENMS_LOG_DEBUG << m[1] << m[2] << "\n";
         spectrum.setMetaValue(String(m[1]), String(m[2]));
       }
     }
     // To make sure a spectrum is added even if no empty line is present before EOF
     addSpectrumToLibrary(spectrum, library);
-    ifs.close();
-    LOG_INFO << "Loading spectra from .msp file completed." << std::endl;
-    std::cout << "PARSE TIME: " << ((std::clock() - start) / (double)CLOCKS_PER_SEC) << std::endl;
+    OPENMS_LOG_INFO << "Loading spectra from .msp file completed." << std::endl;
+    // DEBUG
+    // std::cout << "PARSE TIME: " << ((std::clock() - start) / (double)CLOCKS_PER_SEC) << std::endl;
   }
 
   void MSPGenericFile::addSpectrumToLibrary(
@@ -202,12 +202,12 @@ namespace OpenMS
 
       if (loaded_spectra_names_.size() % 20000 == 0)
       {
-        LOG_INFO << "Loaded " << loaded_spectra_names_.size() << " spectra..." << std::endl;
+        OPENMS_LOG_INFO << "Loaded " << loaded_spectra_names_.size() << " spectra..." << std::endl;
       }
     }
     else
     {
-      LOG_INFO << "DUPLICATE: " << spectrum.getName() << std::endl;
+      OPENMS_LOG_INFO << "DUPLICATE: " << spectrum.getName() << std::endl;
     }
 
     spectrum.setMetaValue("is_valid", 0);

--- a/src/openms/source/FORMAT/MSPGenericFile.cpp
+++ b/src/openms/source/FORMAT/MSPGenericFile.cpp
@@ -68,10 +68,6 @@ namespace OpenMS
 
   void MSPGenericFile::load(const String& filename, MSExperiment& library)
   {
-    // TODO: Remove following "clock" code when not necessary anymore
-    std::clock_t start;
-    start = std::clock();
-
     loaded_spectra_names_.clear();
     synonyms_.clear();
     std::ifstream ifs(filename, std::ifstream::in);
@@ -144,8 +140,6 @@ namespace OpenMS
     // To make sure a spectrum is added even if no empty line is present before EOF
     addSpectrumToLibrary(spectrum, library);
     OPENMS_LOG_INFO << "Loading spectra from .msp file completed." << std::endl;
-    // DEBUG
-    // std::cout << "PARSE TIME: " << ((std::clock() - start) / (double)CLOCKS_PER_SEC) << std::endl;
   }
 
   void MSPGenericFile::addSpectrumToLibrary(

--- a/src/openms/source/FORMAT/MSstatsFile.cpp
+++ b/src/openms/source/FORMAT/MSstatsFile.cpp
@@ -154,16 +154,16 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename, const Consens
 
   if (!checkUnorderedContent_(spectra_paths, design_filenames))
   {
-    LOG_FATAL_ERROR << "The filenames (extension ignored) in the consensusXML file are not the same as in the experimental design" << endl;
-    LOG_FATAL_ERROR << "Spectra files (consensus map): \n";
+    OPENMS_LOG_FATAL_ERROR << "The filenames (extension ignored) in the consensusXML file are not the same as in the experimental design" << endl;
+    OPENMS_LOG_FATAL_ERROR << "Spectra files (consensus map): \n";
     for (auto const & s : spectra_paths)
     {
-      LOG_FATAL_ERROR << s << endl;
+      OPENMS_LOG_FATAL_ERROR << s << endl;
     }
-    LOG_FATAL_ERROR << "Spectra files (design): \n";
+    OPENMS_LOG_FATAL_ERROR << "Spectra files (design): \n";
     for (auto const & s : design_filenames)
     {
-      LOG_FATAL_ERROR << s << endl;
+      OPENMS_LOG_FATAL_ERROR << s << endl;
     }
     throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The filenames (extension ignored) in the consensusXML file are not the same as in the experimental design");
   };
@@ -349,7 +349,7 @@ void OpenMS::MSstatsFile::storeLFQ(const OpenMS::String &filename, const Consens
         {
           if (retention_times.find(p.second) != retention_times.end())
           {
-            LOG_WARN <<  "Peptide ion appears multiple times at the same retention time. This is not expected" << endl;
+            OPENMS_LOG_WARN <<  "Peptide ion appears multiple times at the same retention time. This is not expected" << endl;
           }
           else
           {
@@ -479,16 +479,16 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename, const Consens
 
   if (!checkUnorderedContent_(spectra_paths, design_filenames))
   {
-    LOG_FATAL_ERROR << "The filenames (extension ignored) in the consensusXML file are not the same as in the experimental design" << endl;
-    LOG_FATAL_ERROR << "Spectra files (consensus map): \n";
+    OPENMS_LOG_FATAL_ERROR << "The filenames (extension ignored) in the consensusXML file are not the same as in the experimental design" << endl;
+    OPENMS_LOG_FATAL_ERROR << "Spectra files (consensus map): \n";
     for (auto const & s : spectra_paths)
     {
-      LOG_FATAL_ERROR << s << endl;
+      OPENMS_LOG_FATAL_ERROR << s << endl;
     }
-    LOG_FATAL_ERROR << "Spectra files (design): \n";
+    OPENMS_LOG_FATAL_ERROR << "Spectra files (design): \n";
     for (auto const & s : design_filenames)
     {
-      LOG_FATAL_ERROR << s << endl;
+      OPENMS_LOG_FATAL_ERROR << s << endl;
     }
     throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The filenames (extension ignored) in the consensusXML file are not the same as in the experimental design");
   }
@@ -639,7 +639,7 @@ void OpenMS::MSstatsFile::storeISO(const OpenMS::String &filename, const Consens
         {
           if (retention_times.find(p.second) != retention_times.end())
           {
-            LOG_WARN <<  "Peptide ion appears multiple times at the same retention time. This is not expected" << endl;
+            OPENMS_LOG_WARN <<  "Peptide ion appears multiple times at the same retention time. This is not expected" << endl;
           }
           else
           {

--- a/src/openms/source/FORMAT/MascotGenericFile.cpp
+++ b/src/openms/source/FORMAT/MascotGenericFile.cpp
@@ -443,7 +443,7 @@ namespace OpenMS
       }
       else if (experiment[i].getMSLevel() == 0)
       {
-        LOG_WARN << "MascotGenericFile: MSLevel is set to 0, ignoring this spectrum!" << "\n";
+        OPENMS_LOG_WARN << "MascotGenericFile: MSLevel is set to 0, ignoring this spectrum!" << "\n";
       }
     }
     // close file

--- a/src/openms/source/FORMAT/MascotRemoteQuery.cpp
+++ b/src/openms/source/FORMAT/MascotRemoteQuery.cpp
@@ -98,7 +98,7 @@ namespace OpenMS
 
   void MascotRemoteQuery::timedOut()
   {
-    LOG_FATAL_ERROR << "Mascot request timed out after " << to_ << " seconds! See 'timeout' parameter for details!" << std::endl;
+    OPENMS_LOG_FATAL_ERROR << "Mascot request timed out after " << to_ << " seconds! See 'timeout' parameter for details!" << std::endl;
   }
 
   void MascotRemoteQuery::run()
@@ -536,7 +536,7 @@ namespace OpenMS
     // Successful login? fire off the search
     if (new_bytes.contains("Logged in successfu")) // Do not use the whole string. Currently Mascot writes 'successfuly', but that might change...
     {
-      LOG_INFO << "Login successful!" << std::endl;
+      OPENMS_LOG_INFO << "Login successful!" << std::endl;
       execQuery();
     }
     else if (new_bytes.contains("Error: You have entered an invalid password"))
@@ -617,16 +617,16 @@ namespace OpenMS
       QRegExp mascot_error_regex("\\[M[0-9][0-9][0-9][0-9][0-9]\\]");
       if (response_text.contains(mascot_error_regex))
       {
-        LOG_ERROR << "Received response with Mascot error message!" << std::endl;
+        OPENMS_LOG_ERROR << "Received response with Mascot error message!" << std::endl;
         if (mascot_error_regex.cap() == "[M00380]")
         {
           // we know this error, so we give a much shorter and readable error message for the user
           error_message_ = "You must enter an email address and user name when using the Matrix Science public web site [M00380].";
-          LOG_ERROR << error_message_ << std::endl;
+          OPENMS_LOG_ERROR << error_message_ << std::endl;
         }
         else
         {
-          LOG_ERROR << "Error code: " << mascot_error_regex.cap().toStdString() << std::endl;
+          OPENMS_LOG_ERROR << "Error code: " << mascot_error_regex.cap().toStdString() << std::endl;
           error_message_ = response_text;
         }
         endRun_();
@@ -738,7 +738,7 @@ namespace OpenMS
 
     if (!url.startsWith(host_name_.toQString()))
     {
-      LOG_ERROR << "Invalid location returned by mascot! Abort." << std::endl;
+      OPENMS_LOG_ERROR << "Invalid location returned by mascot! Abort." << std::endl;
       endRun_();
       return;
     }

--- a/src/openms/source/FORMAT/MascotXMLFile.cpp
+++ b/src/openms/source/FORMAT/MascotXMLFile.cpp
@@ -88,7 +88,7 @@ namespace OpenMS
     }
     if (missing_sequence) 
     {
-      LOG_WARN << "Warning: Removed " << missing_sequence 
+      OPENMS_LOG_WARN << "Warning: Removed " << missing_sequence 
                << " peptide identifications without sequence." << endl;
     }
     id_data.swap(filtered_hits);
@@ -102,7 +102,7 @@ namespace OpenMS
     }
     if (no_rt_count)
     {
-      LOG_WARN << "Warning: " << no_rt_count << " (of " << id_data.size() 
+      OPENMS_LOG_WARN << "Warning: " << no_rt_count << " (of " << id_data.size() 
                << ") peptide identifications have no retention time value."
                << endl;
     }

--- a/src/openms/source/FORMAT/MzTab.cpp
+++ b/src/openms/source/FORMAT/MzTab.cpp
@@ -515,7 +515,7 @@ namespace OpenMS
     }
     else
     {
-      LOG_WARN << "Spectrum reference not set." << endl;
+      OPENMS_LOG_WARN << "Spectrum reference not set." << endl;
     }
   }
 
@@ -1563,7 +1563,7 @@ namespace OpenMS
     const FeatureMap & feature_map, 
     const String & filename)
   {
-    LOG_INFO << "exporting feature map: \"" << filename << "\" to mzTab: " << std::endl;
+    OPENMS_LOG_INFO << "exporting feature map: \"" << filename << "\" to mzTab: " << std::endl;
     MzTab mztab;
     MzTabMetaData meta_data;
 
@@ -1754,7 +1754,7 @@ namespace OpenMS
     const String& filename,
     bool first_run_inference_only)
   {
-    LOG_INFO << "exporting identifications: \"" << filename << "\" to mzTab: " << std::endl;
+    OPENMS_LOG_INFO << "exporting identifications: \"" << filename << "\" to mzTab: " << std::endl;
     vector<PeptideIdentification> pep_ids = peptide_ids;
 
     MzTab mztab;
@@ -1802,7 +1802,7 @@ namespace OpenMS
       bool skip_first_run = prot_ids[0].hasInferenceData() && first_run_inference_only;
       if (skip_first_run)
       {
-        LOG_DEBUG << "MzTab: Inference data provided. Considering first run only for inference data." << std::endl;
+        OPENMS_LOG_DEBUG << "MzTab: Inference data provided. Considering first run only for inference data." << std::endl;
       }
 
       MzTabParameter protein_score_type;
@@ -2411,7 +2411,7 @@ Not sure how to handle these:
       row.spectra_ref.setMSFile(msfile_index);
       if (spectrum_nativeID.empty())
       {
-        LOG_WARN << "spectrum_reference not set in ID with precursor (RT, m/z) " << it->getRT() << ", " << it->getMZ() << endl;
+        OPENMS_LOG_WARN << "spectrum_reference not set in ID with precursor (RT, m/z) " << it->getRT() << ", " << it->getMZ() << endl;
       }
       else
       {
@@ -2598,7 +2598,7 @@ Not sure how to handle these:
  -        mztab_run_metadata.id_format.fromCellString("[MS,MS:1001530,mzML unique identifier,]");
  -        mztab_run_metadata.location = MzTabString(m);
  -        meta_data.ms_run[run_index] = mztab_run_metadata;
- -        LOG_DEBUG << "Adding MS run for file: " << m << endl;
+ -        OPENMS_LOG_DEBUG << "Adding MS run for file: " << m << endl;
  -        ++run_index;
  -      }
  -
@@ -2617,7 +2617,7 @@ Not sure how to handle these:
     const bool export_unassigned_ids,
     String title)
   {  
-    LOG_INFO << "exporting consensus map: \"" << filename << "\" to mzTab: " << std::endl;
+    OPENMS_LOG_INFO << "exporting consensus map: \"" << filename << "\" to mzTab: " << std::endl;
     vector<ProteinIdentification> prot_ids = consensus_map.getProteinIdentifications();
 
     // extract mapped IDs (TODO: there should be a helper function)
@@ -2704,7 +2704,7 @@ Not sure how to handle these:
 
       mztab_run_metadata.location = MzTabString(m);
       meta_data.ms_run[run_index] = mztab_run_metadata;
-      LOG_DEBUG << "Adding MS run for file: " << m << endl;
+      OPENMS_LOG_DEBUG << "Adding MS run for file: " << m << endl;
       ++run_index;
     }
 
@@ -2850,7 +2850,7 @@ Not sure how to handle these:
       row.best_search_engine_score[1] = MzTabDouble();
 
       // initialize columns
-      LOG_DEBUG << "Initializing study variables:" << n_study_variables << endl;
+      OPENMS_LOG_DEBUG << "Initializing study variables:" << n_study_variables << endl;
       for (Size study_variable = 1; study_variable <= n_study_variables; ++study_variable)
       {
         row.peptide_abundance_stdev_study_variable[study_variable] = MzTabDouble();

--- a/src/openms/source/FORMAT/PepNovoOutfile.cpp
+++ b/src/openms/source/FORMAT/PepNovoOutfile.cpp
@@ -311,7 +311,7 @@ namespace OpenMS
     result_file.close();
     result_file.clear();
 
-    LOG_INFO << "Parsed " << id_count << " ids, retained " << peptide_identifications.size() << "." << std::endl;
+    OPENMS_LOG_INFO << "Parsed " << id_count << " ids, retained " << peptide_identifications.size() << "." << std::endl;
 
   }
 

--- a/src/openms/source/FORMAT/PercolatorOutfile.cpp
+++ b/src/openms/source/FORMAT/PercolatorOutfile.cpp
@@ -169,7 +169,7 @@ namespace OpenMS
     String unknown_mod = "[unknown]";
     if (peptide.hasSubstring(unknown_mod))
     {
-      LOG_WARN << "Removing unknown modification(s) from peptide '" << peptide
+      OPENMS_LOG_WARN << "Removing unknown modification(s) from peptide '" << peptide
                << "'" << endl;
       peptide.substitute(unknown_mod, "");
     }
@@ -239,7 +239,7 @@ namespace OpenMS
       {
         String msg = "Error: Could not extract data for spectrum reference '" +
           items[0] + "' from row " + String(row);
-        LOG_ERROR << msg << endl;
+        OPENMS_LOG_ERROR << msg << endl;
       }
 
       PeptideHit hit;
@@ -335,22 +335,22 @@ namespace OpenMS
                                   params.variable_modifications);
     proteins.setSearchParameters(params);
 
-    LOG_INFO << "Created " << proteins.getHits().size() << " protein hits.\n"
+    OPENMS_LOG_INFO << "Created " << proteins.getHits().size() << " protein hits.\n"
              << "Created " << peptides.size() << " peptide hits (PSMs)."
              << endl;
     if (no_charge > 0)
     {
-      LOG_WARN << no_charge << " peptide hits without charge state information."
+      OPENMS_LOG_WARN << no_charge << " peptide hits without charge state information."
                << endl;
     }
     if (no_rt > 0)
     {
-      LOG_WARN << no_rt << " peptide hits without retention time information." 
+      OPENMS_LOG_WARN << no_rt << " peptide hits without retention time information." 
                << endl;
     }
     if (no_mz > 0)
     {
-      LOG_WARN << no_mz << " peptide hits without mass-to-charge information." 
+      OPENMS_LOG_WARN << no_mz << " peptide hits without mass-to-charge information." 
                << endl;
     }
   }

--- a/src/openms/source/FORMAT/ProtXMLFile.cpp
+++ b/src/openms/source/FORMAT/ProtXMLFile.cpp
@@ -113,7 +113,7 @@ namespace OpenMS
       if (!date.isValid())
         date = QDateTime::fromString(time.toQString(), Qt::ISODate);
       if (!date.isValid())
-        LOG_WARN << "Warning: Cannot parse 'time'='" << time << "'.\n";
+        OPENMS_LOG_WARN << "Warning: Cannot parse 'time'='" << time << "'.\n";
       prot_id_->setDateTime(date);
       prot_id_->setSearchEngine(analysis);
       prot_id_->setSearchEngineVersion(version);
@@ -148,7 +148,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_WARN << "Required attribute 'percent_coverage' missing\n";
+        OPENMS_LOG_WARN << "Required attribute 'percent_coverage' missing\n";
       }
       prot_id_->getHits().back().setScore(attributeAsDouble_(attributes, "probability"));
 
@@ -180,7 +180,7 @@ namespace OpenMS
       }
       else
       {
-        LOG_WARN << "Required attribute 'charge' missing\n";
+        OPENMS_LOG_WARN << "Required attribute 'charge' missing\n";
       }
 
       // add accessions of all indistinguishable proteins the peptide belongs to

--- a/src/openms/source/FORMAT/SwathFile.cpp
+++ b/src/openms/source/FORMAT/SwathFile.cpp
@@ -131,7 +131,7 @@ namespace OpenMS
 #pragma omp critical (OPENMS_SwathFile_loadSplit)
 #endif
       {
-        LOG_DEBUG << "Adding Swath file " << file_list[i] << " with " << swath_map.lower << " to " << swath_map.upper << std::endl;
+        OPENMS_LOG_DEBUG << "Adding Swath file " << file_list[i] << " with " << swath_map.lower << " to " << swath_map.upper << std::endl;
         swath_maps[i] = swath_map;
         setProgress(progress++);
       }
@@ -199,7 +199,7 @@ namespace OpenMS
     MSDataChainingConsumer chaining_consumer(consumer_list);
     MzMLFile().transform(file, &chaining_consumer);
 
-    LOG_DEBUG << "Finished parsing Swath file " << std::endl;
+    OPENMS_LOG_DEBUG << "Finished parsing Swath file " << std::endl;
     std::vector<OpenSwath::SwathMap> swath_maps;
     dataConsumer->retrieveSwathMaps(swath_maps);
     endProgress();
@@ -255,7 +255,7 @@ namespace OpenMS
       throw Exception::IllegalArgument(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION,
         "Unknown or unsupported option " + readoptions);
     }
-    LOG_DEBUG << "Finished parsing Swath file " << std::endl;
+    OPENMS_LOG_DEBUG << "Finished parsing Swath file " << std::endl;
     std::vector<OpenSwath::SwathMap> swath_maps;
     dataConsumer->retrieveSwathMaps(swath_maps);
     delete dataConsumer;
@@ -372,7 +372,7 @@ namespace OpenMS
             boundary.center = center;
             known_window_boundaries.push_back(boundary);
 
-            LOG_DEBUG << "Adding Swath centered at " << center
+            OPENMS_LOG_DEBUG << "Adding Swath centered at " << center
               << " m/z with an isolation window of " << lower << " to " << upper
               << " m/z." << std::endl;
           }

--- a/src/openms/source/FORMAT/XTandemInfile.cpp
+++ b/src/openms/source/FORMAT/XTandemInfile.cpp
@@ -132,7 +132,7 @@ namespace OpenMS
       ResidueModification::TermSpecificity ts = it->getModification().getTermSpecificity();
       if ((ts != ResidueModification::ANYWHERE) && !orig.empty())
       {
-        LOG_WARN << "Warning: X! Tandem doesn't support modifications with both residue and terminal specificity. Using only terminal specificity for modification '" << it->getModificationName() << "'." << endl;
+        OPENMS_LOG_WARN << "Warning: X! Tandem doesn't support modifications with both residue and terminal specificity. Using only terminal specificity for modification '" << it->getModificationName() << "'." << endl;
       }
 
       if (ts == ResidueModification::C_TERM)
@@ -146,13 +146,13 @@ namespace OpenMS
       // check double usage
       if (origin_set.find(orig) != origin_set.end())
       {
-        LOG_WARN << "X! Tandem config file: Duplicate modification assignment to origin '" << orig << "'. "
+        OPENMS_LOG_WARN << "X! Tandem config file: Duplicate modification assignment to origin '" << orig << "'. "
                  << "X! Tandem will ignore the first modification '" << origin_set.find(orig)->second << "'!\n";
       }
       // check if already used before (i.e. we are currently looking at variable mods)
       if (affected_origins.find(orig) != affected_origins.end())
       {
-        LOG_INFO << "X! Tandem config file: Fixed modification and variable modification to origin '" << orig << "' detected. "
+        OPENMS_LOG_INFO << "X! Tandem config file: Fixed modification and variable modification to origin '" << orig << "' detected. "
                  << "Using corrected mass of " << mod_mass - affected_origins.find(orig)->second << " instead of " << mod_mass << ".\n";
         mod_mass -= affected_origins.find(orig)->second;
       }
@@ -347,7 +347,7 @@ namespace OpenMS
           (var_mods.find("Glu->pyro-Glu (N-term E)") != var_mods.end()))
       {
         writeNote_(os, "protein, quick pyrolidone", true);
-        LOG_INFO << "Modifications 'Gln->pyro-Glu (N-term Q)' and 'Glu->pyro-Glu (N-term E)' are handled implicitly by the X! Tandem option 'protein, quick pyrolidone'. Set the 'force' flag in XTandemAdapter to force explicit inclusion of these modifications." << endl;
+        OPENMS_LOG_INFO << "Modifications 'Gln->pyro-Glu (N-term Q)' and 'Glu->pyro-Glu (N-term E)' are handled implicitly by the X! Tandem option 'protein, quick pyrolidone'. Set the 'force' flag in XTandemAdapter to force explicit inclusion of these modifications." << endl;
       }
 
       // special case for "Acetyl (N-term)" modification:
@@ -355,7 +355,7 @@ namespace OpenMS
           (var_mods.find("Acetyl (N-term)") != var_mods.end()))
       {
         writeNote_(os, "protein, quick acetyl", true);
-        LOG_INFO << "Modification 'Acetyl (N-term)' is handled implicitly by the X! Tandem option 'protein, quick acetyl'. Set the 'force' flag in XTandemAdapter to force explicit inclusion of this modification." << endl;
+        OPENMS_LOG_INFO << "Modification 'Acetyl (N-term)' is handled implicitly by the X! Tandem option 'protein, quick acetyl'. Set the 'force' flag in XTandemAdapter to force explicit inclusion of this modification." << endl;
       }
 
       ////////////////////////////////////////////////////////////////////////////////

--- a/src/openms/source/KERNEL/ConsensusFeature.cpp
+++ b/src/openms/source/KERNEL/ConsensusFeature.cpp
@@ -279,7 +279,7 @@ namespace OpenMS
     {
       Int q = it->getCharge();
       if (q == 0)
-        LOG_WARN << "ConsensusFeature::computeDechargeConsensus() WARNING: Feature's charge is 0! This will lead to M=0!\n";
+        OPENMS_LOG_WARN << "ConsensusFeature::computeDechargeConsensus() WARNING: Feature's charge is 0! This will lead to M=0!\n";
       double adduct_mass;
       Size index = fm.uniqueIdToIndex(it->getUniqueId());
       if (index > fm.size())

--- a/src/openms/source/KERNEL/ConsensusMap.cpp
+++ b/src/openms/source/KERNEL/ConsensusMap.cpp
@@ -139,7 +139,7 @@ namespace OpenMS
 
     if (!this->getIdentifier().empty() || !rhs.getIdentifier().empty())
     {
-      LOG_INFO << "DocumentIdentifiers are lost during merge of ConsensusMaps\n";
+      OPENMS_LOG_INFO << "DocumentIdentifiers are lost during merge of ConsensusMaps\n";
     }
 
     DocumentIdentifier::operator=(empty_map);
@@ -202,7 +202,7 @@ namespace OpenMS
     catch (Exception::Postcondition /*&e*/) // assign new UID's for conflicting entries
     {
       Size replaced_uids =  UniqueIdIndexer<ConsensusMap>::resolveUniqueIdConflicts();
-      LOG_INFO << "Replaced " << replaced_uids << " invalid uniqueID's\n";
+      OPENMS_LOG_INFO << "Replaced " << replaced_uids << " invalid uniqueID's\n";
     }
 
     return *this;
@@ -217,7 +217,7 @@ namespace OpenMS
 
     if (!this->getIdentifier().empty() || !rhs.getIdentifier().empty())
     {
-      LOG_INFO << "DocumentIdentifiers are lost during merge of ConsensusMaps\n";
+      OPENMS_LOG_INFO << "DocumentIdentifiers are lost during merge of ConsensusMaps\n";
     }
 
     DocumentIdentifier::operator=(empty_map);
@@ -311,7 +311,7 @@ namespace OpenMS
     catch (Exception::Postcondition ) // assign new UID's for conflicting entries
     {
       Size replaced_uids =  UniqueIdIndexer<ConsensusMap>::resolveUniqueIdConflicts();
-      LOG_INFO << "Replaced " << replaced_uids << " invalid uniqueID's\n";
+      OPENMS_LOG_INFO << "Replaced " << replaced_uids << " invalid uniqueID's\n";
     }
 
     return *this;
@@ -537,10 +537,10 @@ namespace OpenMS
   {
     if (s.empty())
     {
-      LOG_WARN << "Setting empty MS runs paths. Expected " + String(column_description_.size()) << std::endl;
+      OPENMS_LOG_WARN << "Setting empty MS runs paths. Expected " + String(column_description_.size()) << std::endl;
       for (auto & cd : column_description_)
       {
-        LOG_WARN << "Setting empty MS runs paths. Expected " + String(column_description_.size()) << std::endl;
+        OPENMS_LOG_WARN << "Setting empty MS runs paths. Expected " + String(column_description_.size()) << std::endl;
         cd.second.filename = "UKNOWN";
        }
     } 

--- a/src/openms/source/KERNEL/FeatureMap.cpp
+++ b/src/openms/source/KERNEL/FeatureMap.cpp
@@ -174,7 +174,7 @@ namespace OpenMS
     // reset these:
     RangeManagerType::operator=(empty_map);
 
-    if (!this->getIdentifier().empty() || !rhs.getIdentifier().empty()) LOG_INFO << "DocumentIdentifiers are lost during merge of FeatureMaps\n";
+    if (!this->getIdentifier().empty() || !rhs.getIdentifier().empty()) OPENMS_LOG_INFO << "DocumentIdentifiers are lost during merge of FeatureMaps\n";
     DocumentIdentifier::operator=(empty_map);
 
     UniqueIdInterface::operator=(empty_map);
@@ -198,7 +198,7 @@ namespace OpenMS
     catch (Exception::Postcondition /*&e*/) // assign new UID's for conflicting entries
     {
       Size replaced_uids =  UniqueIdIndexer<FeatureMap>::resolveUniqueIdConflicts();
-      LOG_INFO << "Replaced " << replaced_uids << " invalid uniqueID's\n";
+      OPENMS_LOG_INFO << "Replaced " << replaced_uids << " invalid uniqueID's\n";
     }
 
     return *this;
@@ -372,7 +372,7 @@ namespace OpenMS
      
     if (toFill.empty())
     {
-      LOG_WARN << "No MS run annotated in feature map. Setting to 'UNKNOWN' " << std::endl;
+      OPENMS_LOG_WARN << "No MS run annotated in feature map. Setting to 'UNKNOWN' " << std::endl;
       toFill.push_back("UNKNOWN");
     }
   }

--- a/src/openms/source/KERNEL/MSExperiment.cpp
+++ b/src/openms/source/KERNEL/MSExperiment.cpp
@@ -495,7 +495,7 @@ namespace OpenMS
 
       if (path.empty() || filename.empty())
       {
-        LOG_WARN << "Path or file name of primary MS run is empty. "
+        OPENMS_LOG_WARN << "Path or file name of primary MS run is empty. "
           << "This might be the result of incomplete conversion. "
           << "Not that tracing back e.g. identification results to the original file might more difficult." << std::endl;
       }

--- a/src/openms/source/MATH/STATISTICS/PosteriorErrorProbabilityModel.cpp
+++ b/src/openms/source/MATH/STATISTICS/PosteriorErrorProbabilityModel.cpp
@@ -132,12 +132,12 @@ namespace OpenMS
         QDir dir(param_.getValue("out_plot").toString().toQString());
         if (!dir.cdUp())
         {
-          LOG_ERROR << "Could not navigate to output directory for plots from '" << String(dir.dirName()) << "'." << std::endl;
+          OPENMS_LOG_ERROR << "Could not navigate to output directory for plots from '" << String(dir.dirName()) << "'." << std::endl;
           return false;
         }
         if (!dir.exists() && !dir.mkpath("."))
         {
-          LOG_ERROR << "Could not create output directory for plots '" << String(dir.dirName()) << "'." << std::endl;
+          OPENMS_LOG_ERROR << "Could not create output directory for plots '" << String(dir.dirName()) << "'." << std::endl;
           return false;
         }
         //
@@ -202,8 +202,8 @@ namespace OpenMS
         {
           if (itns >= max_itns)
           {
-            LOG_WARN << "Number of iterations exceeded. Convergence criterion not met. Last likelihood increase: " << (new_maxlike - maxlike) << endl;
-            LOG_WARN << "Algorithm returns probabilites for suboptimal fit. You might want to try raising the max. number of iterations and have a look at the distribution." << endl;
+            OPENMS_LOG_WARN << "Number of iterations exceeded. Convergence criterion not met. Last likelihood increase: " << (new_maxlike - maxlike) << endl;
+            OPENMS_LOG_WARN << "Algorithm returns probabilites for suboptimal fit. You might want to try raising the max. number of iterations and have a look at the distribution." << endl;
           }
           stop_em_init = true;
           sum_posterior = sum_post(incorrect_density, correct_density);
@@ -476,7 +476,7 @@ namespace OpenMS
         StringList empty;
         if (target.size() == 0) empty.push_back("target");
         if (decoy.size() == 0) empty.push_back("decoy");
-        LOG_WARN << "Target-Decoy plot was called, but '" << ListUtils::concatenate(empty, "' and '") << "' has no data! Unable to create a target-decoy plot." << std::endl;
+        OPENMS_LOG_WARN << "Target-Decoy plot was called, but '" << ListUtils::concatenate(empty, "' and '") << "' has no data! Unable to create a target-decoy plot." << std::endl;
         return;
       }
       Int number_of_bins = param_.getValue("number_of_bins");
@@ -572,13 +572,13 @@ namespace OpenMS
 
     void PosteriorErrorProbabilityModel::tryGnuplot(const String& gp_file)
     {
-      LOG_INFO << "Attempting to call 'gnuplot' ...";
+      OPENMS_LOG_INFO << "Attempting to call 'gnuplot' ...";
       String cmd = String("gnuplot \"") + gp_file + "\"";
       if (system(cmd.c_str()))  // 0 is success!
       {
-        LOG_WARN << "Calling 'gnuplot' on '" << gp_file << "' failed. Please create plots manually." << std::endl;
+        OPENMS_LOG_WARN << "Calling 'gnuplot' on '" << gp_file << "' failed. Please create plots manually." << std::endl;
       }
-      else LOG_INFO << " success!" << std::endl;
+      else OPENMS_LOG_INFO << " success!" << std::endl;
 
     }
 

--- a/src/openms/source/METADATA/ExperimentalDesign.cpp
+++ b/src/openms/source/METADATA/ExperimentalDesign.cpp
@@ -119,7 +119,7 @@ namespace OpenMS
         }
         else
         { // no fractions and fraction group information annotated, deduce from data
-          LOG_INFO << "No fractions annotated in consensusXML. Assuming unfractionated." << endl;
+          OPENMS_LOG_INFO << "No fractions annotated in consensusXML. Assuming unfractionated." << endl;
           r.fraction = 1;
 
           // no fractions -> one fraction group for each MS file
@@ -136,7 +136,7 @@ namespace OpenMS
         {
           if (experiment_type != "label-free")
           {
-            LOG_WARN << "No channel id annotated in consensusXML. Assuming one channel." << endl;
+            OPENMS_LOG_WARN << "No channel id annotated in consensusXML. Assuming one channel." << endl;
           }
           r.label = 1;
         }
@@ -154,7 +154,7 @@ namespace OpenMS
       }
 
       experimental_design.setMSFileSection(msfile_section);
-      LOG_DEBUG << "Experimental design (ConsensusMap derived):\n"
+      OPENMS_LOG_DEBUG << "Experimental design (ConsensusMap derived):\n"
                << "  Files: " << experimental_design.getNumberOfMSFiles()
                << "  Fractions: " << experimental_design.getNumberOfFractions()
                << "  Labels: " << experimental_design.getNumberOfLabels()
@@ -189,7 +189,7 @@ namespace OpenMS
 
       ExperimentalDesign::MSFileSection rows(1, r);
       experimental_design.setMSFileSection(rows);
-      LOG_INFO << "Experimental design (FeatureMap derived):\n"
+      OPENMS_LOG_INFO << "Experimental design (FeatureMap derived):\n"
                << "  files: " << experimental_design.getNumberOfMSFiles()
                << "  fractions: " << experimental_design.getNumberOfFractions()
                << "  labels: " << experimental_design.getNumberOfLabels()
@@ -236,7 +236,7 @@ namespace OpenMS
         ++sample;
       }
       experimental_design.setMSFileSection(rows);
-      LOG_INFO << "Experimental design (Identification derived):\n"
+      OPENMS_LOG_INFO << "Experimental design (Identification derived):\n"
                << "  files: " << experimental_design.getNumberOfMSFiles()
                << "  fractions: " << experimental_design.getNumberOfFractions()
                << "  labels: " << experimental_design.getNumberOfLabels()
@@ -454,7 +454,7 @@ namespace OpenMS
         if (fractiongroup_label_to_sample[fractiongroup_label].size() > 1)
         { 
 
-         LOG_INFO << "Please correct your experimental design if this is a label free experiment." << std::endl;
+         OPENMS_LOG_INFO << "Please correct your experimental design if this is a label free experiment." << std::endl;
          // throw Exception::MissingInformation(
          //   __FILE__,
          //   __LINE__,

--- a/src/openms/source/METADATA/ID/IdentificationData.cpp
+++ b/src/openms/source/METADATA/ID/IdentificationData.cpp
@@ -738,7 +738,7 @@ namespace OpenMS
     }
     if (warn)
     {
-      LOG_WARN << "Warning: filtering removed elements from parent molecule groups - associated scores may not be valid any more" << endl;
+      OPENMS_LOG_WARN << "Warning: filtering removed elements from parent molecule groups - associated scores may not be valid any more" << endl;
     }
 
     // remove entries from query match groups based on molecule-query matches:
@@ -768,7 +768,7 @@ namespace OpenMS
     }
     if (warn)
     {
-      LOG_WARN << "Warning: filtering removed elements from query match groups - associated scores may not be valid any more" << endl;
+      OPENMS_LOG_WARN << "Warning: filtering removed elements from query match groups - associated scores may not be valid any more" << endl;
     }
   }
 

--- a/src/openms/source/METADATA/SpectrumLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumLookup.cpp
@@ -297,7 +297,7 @@ namespace OpenMS
     }
     else
     {
-      LOG_WARN << "native_id: " << native_id << " accession: " << native_id_type_accession << " Could not extract scan number - no valid native_id_type_accession was provided" << std::endl;
+      OPENMS_LOG_WARN << "native_id: " << native_id << " accession: " << native_id_type_accession << " Could not extract scan number - no valid native_id_type_accession was provided" << std::endl;
     }
 
     if (!regexp.empty()) 
@@ -315,7 +315,7 @@ namespace OpenMS
         }
         catch (Exception::ConversionError&)
         {
-          LOG_WARN << "Value could not be converted to int" << std::endl;
+          OPENMS_LOG_WARN << "Value could not be converted to int" << std::endl;
           return -1;
         }
       }
@@ -335,7 +335,7 @@ namespace OpenMS
         }
         catch (Exception::ConversionError&)
         {
-          LOG_WARN << "Value could not be converted to int" << std::endl;
+          OPENMS_LOG_WARN << "Value could not be converted to int" << std::endl;
           return -1;
         }
       }

--- a/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
+++ b/src/openms/source/METADATA/SpectrumMetaDataLookup.cpp
@@ -62,7 +62,7 @@ namespace OpenMS
       meta.scan_number = extractScanNumber(meta.native_id, scan_regexp, true);
       if (meta.scan_number < 0)
       {
-        LOG_ERROR << "Error: Could not extract scan number from spectrum native ID '" + meta.native_id + "' using regular expression '" + scan_regexp.str() + "'." << endl;
+        OPENMS_LOG_ERROR << "Error: Could not extract scan number from spectrum native ID '" + meta.native_id + "' using regular expression '" + scan_regexp.str() + "'." << endl;
       }
     }
     if (!spectrum.getPrecursors().empty())
@@ -80,7 +80,7 @@ namespace OpenMS
         }
         else
         {
-          LOG_ERROR << "Error: Could not set precursor RT for spectrum with native ID '" + meta.native_id + "' - precursor spectrum not found." << endl;
+          OPENMS_LOG_ERROR << "Error: Could not set precursor RT for spectrum with native ID '" + meta.native_id + "' - precursor spectrum not found." << endl;
         }
       }
     } 
@@ -200,7 +200,7 @@ namespace OpenMS
         }
         catch (Exception::ElementNotFound&)
         {
-          LOG_ERROR << "Error: Failed to look up retention time for peptide identification with spectrum reference '" + spectrum_id + "' - no spectrum with corresponding native ID found." << endl;
+          OPENMS_LOG_ERROR << "Error: Failed to look up retention time for peptide identification with spectrum reference '" + spectrum_id + "' - no spectrum with corresponding native ID found." << endl;
           success = false;
           if (stop_on_error) break;
         }
@@ -253,7 +253,7 @@ namespace OpenMS
       }
       catch (Exception::ElementNotFound&)
       {
-        LOG_ERROR << "Error: Failed to look up spectrum native ID for peptide identification with retention time '" + String(it->getRT()) + "'." << endl;
+        OPENMS_LOG_ERROR << "Error: Failed to look up spectrum native ID for peptide identification with retention time '" + String(it->getRT()) + "'." << endl;
         success = false;
         if (stop_on_error) break;
       }

--- a/src/openms/source/SIMULATION/DetectabilitySimulation.cpp
+++ b/src/openms/source/SIMULATION/DetectabilitySimulation.cpp
@@ -71,7 +71,7 @@ namespace OpenMS
 
   void DetectabilitySimulation::filterDetectability(SimTypes::FeatureMapSim& features)
   {
-    LOG_INFO << "Detectability Simulation ... started" << std::endl;
+    OPENMS_LOG_INFO << "Detectability Simulation ... started" << std::endl;
     if (param_.getValue("dt_simulation_on") == "true")
     {
       svmFilter_(features);
@@ -172,7 +172,7 @@ namespace OpenMS
     }
 
 
-    LOG_INFO << "Predicting peptide detectabilities..    " << endl;
+    OPENMS_LOG_INFO << "Predicting peptide detectabilities..    " << endl;
 
     String allowed_amino_acid_characters = "ACDEFGHIKLMNPQRSTVWY";
 

--- a/src/openms/source/SIMULATION/DigestSimulation.cpp
+++ b/src/openms/source/SIMULATION/DigestSimulation.cpp
@@ -93,7 +93,7 @@ namespace OpenMS
 
   void DigestSimulation::digest(SimTypes::FeatureMapSim& feature_map)
   {
-    LOG_INFO << "Digest Simulation ... started" << std::endl;
+    OPENMS_LOG_INFO << "Digest Simulation ... started" << std::endl;
 
     if ((String)param_.getValue("enzyme") == String("no cleavage"))
     {

--- a/src/openms/source/SIMULATION/EGHFitter1D.cpp
+++ b/src/openms/source/SIMULATION/EGHFitter1D.cpp
@@ -213,11 +213,11 @@ namespace OpenMS
     tau_ = x_init[3];
 
 #ifdef DEBUG_EGHFITTER
-    LOG_DEBUG << "Fitter returned \n";
-    LOG_DEBUG << "height:       " << height_ << "\n";
-    LOG_DEBUG << "retention:    " << retention_ << "\n";
-    LOG_DEBUG << "sigma_square: " << sigma_square_ << "\n";
-    LOG_DEBUG << "tau:          " << tau_ << std::endl;
+    OPENMS_LOG_DEBUG << "Fitter returned \n";
+    OPENMS_LOG_DEBUG << "height:       " << height_ << "\n";
+    OPENMS_LOG_DEBUG << "retention:    " << retention_ << "\n";
+    OPENMS_LOG_DEBUG << "sigma_square: " << sigma_square_ << "\n";
+    OPENMS_LOG_DEBUG << "tau:          " << tau_ << std::endl;
 #endif
 
     // build model
@@ -322,13 +322,13 @@ namespace OpenMS
     sigma_square_ = (-1 / (2 * log_alpha)) * (B * A);
 
 #ifdef DEBUG_EGHFITTER
-    LOG_DEBUG << "Initial parameters\n";
-    LOG_DEBUG << "height:       " << height_ << "\n";
-    LOG_DEBUG << "retention:    " << retention_ << "\n";
-    LOG_DEBUG << "A:            " << A << "\n";
-    LOG_DEBUG << "B:            " << B << "\n";
-    LOG_DEBUG << "sigma_square: " << sigma_square_ << "\n";
-    LOG_DEBUG << "tau:          " << tau_ << std::endl;
+    OPENMS_LOG_DEBUG << "Initial parameters\n";
+    OPENMS_LOG_DEBUG << "height:       " << height_ << "\n";
+    OPENMS_LOG_DEBUG << "retention:    " << retention_ << "\n";
+    OPENMS_LOG_DEBUG << "A:            " << A << "\n";
+    OPENMS_LOG_DEBUG << "B:            " << B << "\n";
+    OPENMS_LOG_DEBUG << "sigma_square: " << sigma_square_ << "\n";
+    OPENMS_LOG_DEBUG << "tau:          " << tau_ << std::endl;
 #endif
   }
 

--- a/src/openms/source/SIMULATION/EGHModel.cpp
+++ b/src/openms/source/SIMULATION/EGHModel.cpp
@@ -222,13 +222,13 @@ namespace OpenMS
       max_ = param_.getValue("bounding_box:max");
     }
 
-//      LOG_DEBUG << "Computed EGH-Parameters:\n";
-//      LOG_DEBUG << "A:            " << A_ << "\n";
-//      LOG_DEBUG << "B:            " << B_ << "\n";
-//      LOG_DEBUG << "retention:    " << apex_rt_ << "\n";
-//      LOG_DEBUG << "sigma_square: " << sigma_square_ << "\n";
-//      LOG_DEBUG << "tau:          " << tau_ << "\n";
-//      LOG_DEBUG << "Feature bounding box is <" << min_ << "," << max_ << ">" << std::endl;
+//      OPENMS_LOG_DEBUG << "Computed EGH-Parameters:\n";
+//      OPENMS_LOG_DEBUG << "A:            " << A_ << "\n";
+//      OPENMS_LOG_DEBUG << "B:            " << B_ << "\n";
+//      OPENMS_LOG_DEBUG << "retention:    " << apex_rt_ << "\n";
+//      OPENMS_LOG_DEBUG << "sigma_square: " << sigma_square_ << "\n";
+//      OPENMS_LOG_DEBUG << "tau:          " << tau_ << "\n";
+//      OPENMS_LOG_DEBUG << "Feature bounding box is <" << min_ << "," << max_ << ">" << std::endl;
 
     setSamples();
   }
@@ -248,11 +248,11 @@ namespace OpenMS
     while (egh_value > threshold)
     {
       min_ -= A_;
-//        LOG_DEBUG << "Decreased feature (" << apex_rt_ << ") min_ to " << (min_ + apex_rt_) << "\n";
+//        OPENMS_LOG_DEBUG << "Decreased feature (" << apex_rt_ << ") min_ to " << (min_ + apex_rt_) << "\n";
 
       evaluateEGH_(min_, egh_value);
 
-//        LOG_DEBUG << "egh(" << min_ << ")=" << egh_value << " (H = " << height_ << ")" << endl;
+//        OPENMS_LOG_DEBUG << "egh(" << min_ << ")=" << egh_value << " (H = " << height_ << ")" << endl;
     }
 
     // go right .. B_ defines the step width
@@ -261,11 +261,11 @@ namespace OpenMS
     while (egh_value > threshold)
     {
       max_ += B_;
-//        LOG_DEBUG << "Increased feature (" << apex_rt_ << ") max_ to " << (max_ + apex_rt_) << "\n";
+//        OPENMS_LOG_DEBUG << "Increased feature (" << apex_rt_ << ") max_ to " << (max_ + apex_rt_) << "\n";
 
       evaluateEGH_(max_, egh_value);
 
-//        LOG_DEBUG << "egh(" << max_ << ")=" << egh_value << " (H = " << height_ << ")" << endl;
+//        OPENMS_LOG_DEBUG << "egh(" << max_ << ")=" << egh_value << " (H = " << height_ << ")" << endl;
     }
 
     // set boundaries at the correct position on the RT scale

--- a/src/openms/source/SIMULATION/IonizationSimulation.cpp
+++ b/src/openms/source/SIMULATION/IonizationSimulation.cpp
@@ -117,7 +117,7 @@ namespace OpenMS
 
   void IonizationSimulation::ionize(SimTypes::FeatureMapSim& features, ConsensusMap& charge_consensus, SimTypes::MSSimExperiment& experiment)
   {
-    LOG_INFO << "Ionization Simulation ... started" << std::endl;
+    OPENMS_LOG_INFO << "Ionization Simulation ... started" << std::endl;
 
     // clear the consensus map
     charge_consensus = ConsensusMap();
@@ -281,7 +281,7 @@ public:
     // features discarded - out of mz detection range
     Size undetected_features_count = 0;
 
-    LOG_INFO << "Simulating " << features.size() << " features" << std::endl;
+    OPENMS_LOG_INFO << "Simulating " << features.size() << " features" << std::endl;
 
     this->startProgress(0, features.size(), "Ionization");
     Size progress(0);
@@ -323,7 +323,7 @@ public:
         }
         catch (...) // overflow (e.g. intensity = 1e6); underflow can currently not occur (see DigestSimulation:204) but would be covered as well
         {
-          LOG_WARN << "Protein abundance of " << features[index].getIntensity() << " is too high!"
+          OPENMS_LOG_WARN << "Protein abundance of " << features[index].getIntensity() << " is too high!"
                     << "Please use values in [0," << std::numeric_limits<AbundanceType>::max() << +"]! This will fail!";
           abundance = 1; // keep on going for now, but fail after parallel region;
           omp_exception = true;
@@ -508,8 +508,8 @@ public:
     // swap feature maps
     features.swap(copy_map);
 
-    LOG_INFO << "#Peptides not ionized: " << uncharged_feature_count << std::endl;
-    LOG_INFO << "#Peptides outside mz range: " << undetected_features_count << std::endl;
+    OPENMS_LOG_INFO << "#Peptides not ionized: " << uncharged_feature_count << std::endl;
+    OPENMS_LOG_INFO << "#Peptides outside mz range: " << undetected_features_count << std::endl;
 
     features.applyMemberFunction(&UniqueIdInterface::ensureUniqueId);
     charge_consensus.applyMemberFunction(&UniqueIdInterface::ensureUniqueId);
@@ -608,11 +608,11 @@ public:
       // swap feature maps
       features.swap(copy_map);
 
-      LOG_INFO << "#Peptides outside mz range: " << undetected_features_count << std::endl;
+      OPENMS_LOG_INFO << "#Peptides outside mz range: " << undetected_features_count << std::endl;
     }
     catch (std::exception& e)
     {
-      LOG_WARN << "Exception (" << e.what() << ") caught in " << __FILE__ << "\n";
+      OPENMS_LOG_WARN << "Exception (" << e.what() << ") caught in " << __FILE__ << "\n";
       throw;
     }
 

--- a/src/openms/source/SIMULATION/LABELING/BaseLabeler.cpp
+++ b/src/openms/source/SIMULATION/LABELING/BaseLabeler.cpp
@@ -158,7 +158,7 @@ namespace OpenMS
     {
       if (simulated_features[i].metaValueExists("parent_feature"))
       {
-        LOG_DEBUG << "Checking [" << i << "]: " << simulated_features[i].getPeptideIdentifications()[0].getHits()[0].getSequence().toString()
+        OPENMS_LOG_DEBUG << "Checking [" << i << "]: " << simulated_features[i].getPeptideIdentifications()[0].getHits()[0].getSequence().toString()
                   << " with charge " << simulated_features[i].getCharge() << " (" << simulated_features[i].getMetaValue("charge_adducts") << ")"
                   << " parent was " << simulated_features[i].getMetaValue("parent_feature") << std::endl;
         id_map[simulated_features[i].getMetaValue("parent_feature")].push_back((Int)i);
@@ -174,7 +174,7 @@ namespace OpenMS
 
     for (Map<String, IntList>::iterator it = id_map.begin(); it != id_map.end(); ++it)
     {
-      LOG_DEBUG << it->first << " " << it->second << std::endl;
+      OPENMS_LOG_DEBUG << it->first << " " << it->second << std::endl;
     }
 
     // new consensus map
@@ -191,13 +191,13 @@ namespace OpenMS
     {
       bool complete = true;
 
-      LOG_DEBUG << "Checking consensus feature containing: " << std::endl;
+      OPENMS_LOG_DEBUG << "Checking consensus feature containing: " << std::endl;
 
       // check if we have all elements of current CF in the new feature map (simulated_features)
       for (ConsensusFeature::iterator cf_iter = (*cm_iter).begin(); cf_iter != (*cm_iter).end(); ++cf_iter)
       {
         complete &= id_map.has(String((*cf_iter).getUniqueId()));
-        LOG_DEBUG << "\t" << String((*cf_iter).getUniqueId()) << std::endl;
+        OPENMS_LOG_DEBUG << "\t" << String((*cf_iter).getUniqueId()) << std::endl;
       }
 
       if (complete)
@@ -224,7 +224,7 @@ namespace OpenMS
             }
             else
             {
-              LOG_DEBUG << "Create new set with charge composition " << simulated_features[*it].getMetaValue("charge_adducts") << std::endl;
+              OPENMS_LOG_DEBUG << "Create new set with charge composition " << simulated_features[*it].getMetaValue("charge_adducts") << std::endl;
               std::set<FeatureHandle, FeatureHandle::IndexLess> fh_set;
 
               fh_set.insert(FeatureHandle(map_index, simulated_features[*it]));

--- a/src/openms/source/SIMULATION/LABELING/ITRAQLabeler.cpp
+++ b/src/openms/source/SIMULATION/LABELING/ITRAQLabeler.cpp
@@ -352,7 +352,7 @@ namespace OpenMS
 
     if (MS2_RT_time < elution_bounds[1] || elution_bounds[3] < MS2_RT_time)
     {
-      LOG_WARN << "Warn: requesting MS2 RT for " << MS2_RT_time << ", but bounds are only from [" << elution_bounds[1] << "," << elution_bounds[3] << "]\n";
+      OPENMS_LOG_WARN << "Warn: requesting MS2 RT for " << MS2_RT_time << ", but bounds are only from [" << elution_bounds[1] << "," << elution_bounds[3] << "]\n";
       return 0;
     }
 

--- a/src/openms/source/SIMULATION/LABELING/LabelFreeLabeler.cpp
+++ b/src/openms/source/SIMULATION/LABELING/LabelFreeLabeler.cpp
@@ -64,7 +64,7 @@ namespace OpenMS
       return;
     else
     {
-      LOG_INFO << "Merging input FASTA files into one. Intensities will be summed up if duplicates occur.";
+      OPENMS_LOG_INFO << "Merging input FASTA files into one. Intensities will be summed up if duplicates occur.";
       SimTypes::FeatureMapSim final_map = mergeProteinIdentificationsMaps_(features);
       features.clear();
       features.push_back(final_map);

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -303,7 +303,7 @@ namespace OpenMS
       }
     }
 
-    LOG_INFO << "Final number of simulated features: " << feature_maps_[0].size() << "\n";
+    OPENMS_LOG_INFO << "Final number of simulated features: " << feature_maps_[0].size() << "\n";
 
     // re-index spectra to avoid naming conflicts
     Size id = 1;

--- a/src/openms/source/SIMULATION/RTSimulation.cpp
+++ b/src/openms/source/SIMULATION/RTSimulation.cpp
@@ -172,7 +172,7 @@ namespace OpenMS
     gradient_max_ = param_.getValue("scan_window:max");
     if (gradient_max_ > total_gradient_time_)
     {
-      LOG_WARN << "total_gradient_time_ smaller than scan_window:max -> invalid parameters!" << endl;
+      OPENMS_LOG_WARN << "total_gradient_time_ smaller than scan_window:max -> invalid parameters!" << endl;
     }
 
     rt_sampling_rate_    = param_.getValue("sampling_rate");
@@ -207,7 +207,7 @@ namespace OpenMS
    */
   void RTSimulation::predictRT(SimTypes::FeatureMapSim& features)
   {
-    LOG_INFO << "RT Simulation ... started" << std::endl;
+    OPENMS_LOG_INFO << "RT Simulation ... started" << std::endl;
 
     vector<double>  predicted_retention_times;
     bool is_relative = (param_.getValue("auto_scale") == "true");
@@ -304,7 +304,7 @@ namespace OpenMS
 
       if (variance <= 0 || (fabs(variance - egh_variance_location_) > 10 * egh_variance_scale_))
       {
-        LOG_ERROR << "Sigma^2 was negative, resulting in a feature with width=0. Tried to resample 10 times and then stopped. Setting it to the user defined width value of " << egh_variance_location_ << "!" << std::endl;
+        OPENMS_LOG_ERROR << "Sigma^2 was negative, resulting in a feature with width=0. Tried to resample 10 times and then stopped. Setting it to the user defined width value of " << egh_variance_location_ << "!" << std::endl;
         variance = egh_variance_location_;
       }
 
@@ -321,7 +321,7 @@ namespace OpenMS
 
       if (fabs(tau - egh_tau_location_) > 10 * egh_tau_scale_)
       {
-        LOG_ERROR << "Tau is to big for a reasonable feature. Tried to resample 10 times and then stopped. Setting it to the user defined skewness value of " << egh_tau_location_ << "!" << std::endl;
+        OPENMS_LOG_ERROR << "Tau is to big for a reasonable feature. Tried to resample 10 times and then stopped. Setting it to the user defined skewness value of " << egh_tau_location_ << "!" << std::endl;
         tau = egh_tau_location_;
       }
 
@@ -334,11 +334,11 @@ namespace OpenMS
     // print invalid features:
     if (deleted_features.size() > 0)
     {
-      LOG_WARN << "RT prediction gave 'invalid' results for " << deleted_features.size() << " peptide(s), making them unobservable.\n";
+      OPENMS_LOG_WARN << "RT prediction gave 'invalid' results for " << deleted_features.size() << " peptide(s), making them unobservable.\n";
       if (deleted_features.size() < 100)
-        LOG_WARN << "  " << ListUtils::concatenate(deleted_features, "\n  ") << std::endl;
+        OPENMS_LOG_WARN << "  " << ListUtils::concatenate(deleted_features, "\n  ") << std::endl;
       else
-        LOG_WARN << "  (List is too big to show)" << std::endl;
+        OPENMS_LOG_WARN << "  (List is too big to show)" << std::endl;
     }
     // only retain valid features:
     features.swap(fm_tmp);
@@ -496,7 +496,7 @@ namespace OpenMS
     // hard coding prediction bins; larger values only take more memory, result is not affected
     Size max_number_of_peptides(2000);
 
-    LOG_INFO << "Predicting RT ... ";
+    OPENMS_LOG_INFO << "Predicting RT ... ";
 
     svm.loadModel(rt_model_file_);
 
@@ -564,7 +564,7 @@ namespace OpenMS
     }
     LibSVMEncoder::destroyProblem(training_data);
 
-    LOG_INFO << "done" << endl;
+    OPENMS_LOG_INFO << "done" << endl;
   }
 
   void RTSimulation::predictContaminantsRT(SimTypes::FeatureMapSim& contaminants)
@@ -599,7 +599,7 @@ namespace OpenMS
 
     if (isRTColumnOn())
     {
-      LOG_INFO << "Creating experiment with #" << number_of_scans << " scans ... ";
+      OPENMS_LOG_INFO << "Creating experiment with #" << number_of_scans << " scans ... ";
 
       experiment.resize(number_of_scans);
 
@@ -627,14 +627,14 @@ namespace OpenMS
     }
     else
     {
-      LOG_INFO << "Creating experiment with a single scan ... ";
+      OPENMS_LOG_INFO << "Creating experiment with a single scan ... ";
 
       experiment.resize(1);
       experiment[0].setRT(-1);
       experiment[0].setNativeID("spectrum=1");
     }
     experiment.updateRanges();
-    LOG_INFO << "done\n";
+    OPENMS_LOG_INFO << "done\n";
   }
 
 //#define MSSIM_DEBUG_MOV_AVG_FILTER
@@ -650,7 +650,7 @@ namespace OpenMS
       double previous = (double) experiment[0].getMetaValue("distortion");
       boost::uniform_real<double> udist(1.0 - std::pow(fi + 1.0, 2) * 0.01, 1.0 + std::pow(fi + 1.0, 2) * 0.01); // distortion gets worse round by round
 #ifdef MSSIM_DEBUG_MOV_AVG_FILTER
-      LOG_WARN << "d <- c(" << previous << ", ";
+      OPENMS_LOG_WARN << "d <- c(" << previous << ", ";
       vector<double> tmp;
 #endif
       for (Size scan = 1; scan < experiment.size() - 1; ++scan)
@@ -663,21 +663,21 @@ namespace OpenMS
         previous = current;
 
 #ifdef MSSIM_DEBUG_MOV_AVG_FILTER
-        LOG_WARN << current << ", ";
+        OPENMS_LOG_WARN << current << ", ";
         tmp.push_back(smoothed);
 #endif
         experiment[scan].setMetaValue("distortion", smoothed);
       }
 
 #ifdef MSSIM_DEBUG_MOV_AVG_FILTER
-      LOG_WARN << next << ");" << endl;
-      LOG_WARN << "smoothed <- c(";
-      LOG_WARN << (double) experiment[0].getMetaValue("distortion") << ", ";
+      OPENMS_LOG_WARN << next << ");" << endl;
+      OPENMS_LOG_WARN << "smoothed <- c(";
+      OPENMS_LOG_WARN << (double) experiment[0].getMetaValue("distortion") << ", ";
       for (Size i = 0; i  < tmp.size(); ++i)
       {
-        LOG_WARN << tmp[i] << ", ";
+        OPENMS_LOG_WARN << tmp[i] << ", ";
       }
-      LOG_WARN << next << ");" << endl;
+      OPENMS_LOG_WARN << next << ");" << endl;
 #endif
     }
   }

--- a/src/openms/source/SIMULATION/RawMSSignalSimulation.cpp
+++ b/src/openms/source/SIMULATION/RawMSSignalSimulation.cpp
@@ -338,7 +338,7 @@ namespace OpenMS
 
   void RawMSSignalSimulation::generateRawSignals(SimTypes::FeatureMapSim& features, SimTypes::MSSimExperiment& experiment, SimTypes::MSSimExperiment& experiment_ct, SimTypes::FeatureMapSim& c_map)
   {
-    LOG_INFO << "Raw MS1 Simulation ... ";
+    OPENMS_LOG_INFO << "Raw MS1 Simulation ... ";
     // TODO: check if signal intensities scale linear with actual abundance, e.g. DOI: 10.1021/ac0202280 for NanoFlow-ESI
 
     // we rely on the same size of Raw and Peak Map
@@ -349,12 +349,12 @@ namespace OpenMS
 
     if (param_.getValue("enabled") == "false")
     {
-      LOG_INFO << "disabled" << std::endl;
+      OPENMS_LOG_INFO << "disabled" << std::endl;
       return;
     }
     else
     {
-      LOG_INFO << "started" << std::endl;
+      OPENMS_LOG_INFO << "started" << std::endl;
     }
 
     // retrieve mz boundary parameters from experiment:
@@ -364,7 +364,7 @@ namespace OpenMS
     // grid is constant over scans, so we compute it only once
     getSamplingGrid_(grid_, minimal_mz_measurement_limit, maximal_mz_measurement_limit, 5); // every 5 Da we adjust the sampling width by local FWHM
 
-    LOG_INFO << "  Simulating signal for " << features.size() << " features ..." << std::endl;
+    OPENMS_LOG_INFO << "  Simulating signal for " << features.size() << " features ..." << std::endl;
 
     this->startProgress(0, features.size(), "RawMSSignal");
 
@@ -647,7 +647,7 @@ namespace OpenMS
   {
     SimTypes::SimIntensityType intensity_sum = 0.0;
 
-    //LOG_DEBUG << "Sampling at [mz] " << mz_start << ":" << mz_end << std::endl;
+    //OPENMS_LOG_DEBUG << "Sampling at [mz] " << mz_start << ":" << mz_end << std::endl;
 
     SimTypes::SimPointType point;
 
@@ -752,7 +752,7 @@ namespace OpenMS
         point.setMZ(*it_grid);
         point.setIntensity(intensity);
 
-        //LOG_ERROR << "Sampling " << rt << " , " << mz << " -> " << point.getIntensity() << std::endl;
+        //OPENMS_LOG_ERROR << "Sampling " << rt << " , " << mz << " -> " << point.getIntensity() << std::endl;
 
         // add Gaussian distributed m/z error
 #ifdef _OPENMP
@@ -979,8 +979,8 @@ namespace OpenMS
     }
 
     c_map.applyMemberFunction(&UniqueIdInterface::ensureUniqueId);
-    LOG_INFO << "Contaminants out-of-RT-range: " << out_of_range_RT << " / " << contaminants_.size() << std::endl;
-    LOG_INFO << "Contaminants out-of-MZ-range: " << out_of_range_MZ << " / " << contaminants_.size() << std::endl;
+    OPENMS_LOG_INFO << "Contaminants out-of-RT-range: " << out_of_range_RT << " / " << contaminants_.size() << std::endl;
+    OPENMS_LOG_INFO << "Contaminants out-of-MZ-range: " << out_of_range_MZ << " / " << contaminants_.size() << std::endl;
 
   }
 
@@ -1009,7 +1009,7 @@ namespace OpenMS
     boost::uniform_real<SimTypes::SimCoordinateType> udist(mz_lw, mz_up);
     boost::random::exponential_distribution<SimTypes::SimCoordinateType> edist(intensity_mean);
 
-    LOG_INFO << "Adding shot noise to spectra ..." << std::endl;
+    OPENMS_LOG_INFO << "Adding shot noise to spectra ..." << std::endl;
     Size num_intervals = std::ceil((maximal_mz_measurement_limit - minimal_mz_measurement_limit) / window_size);
 
     for (SimTypes::MSSimExperiment::Iterator spectrum_it = experiment.begin(); spectrum_it != experiment.end(); ++spectrum_it)
@@ -1065,7 +1065,7 @@ namespace OpenMS
 
   void RawMSSignalSimulation::addWhiteNoise_(SimTypes::MSSimExperiment& experiment)
   {
-    LOG_INFO << "Adding white noise to spectra ..." << std::endl;
+    OPENMS_LOG_INFO << "Adding white noise to spectra ..." << std::endl;
 
     // get white noise parameters
     double white_noise_mean = param_.getValue("noise:white:mean");
@@ -1099,7 +1099,7 @@ namespace OpenMS
 
   void RawMSSignalSimulation::addDetectorNoise_(SimTypes::MSSimExperiment& experiment)
   {
-    LOG_INFO << "Adding detector noise to spectra ..." << std::endl;
+    OPENMS_LOG_INFO << "Adding detector noise to spectra ..." << std::endl;
 
     // get white noise parameters
     double detector_noise_mean = param_.getValue("noise:detector:mean");
@@ -1107,7 +1107,7 @@ namespace OpenMS
 
     if (detector_noise_mean == 0.0 && detector_noise_stddev == 0.0)
     {
-      LOG_INFO << "Detector noise was disabled." << std::endl;
+      OPENMS_LOG_INFO << "Detector noise was disabled." << std::endl;
       return;
     }
 
@@ -1185,7 +1185,7 @@ namespace OpenMS
 
     if (min_mz >= max_mz)
     {
-      LOG_WARN << "No data to compress." << std::endl;
+      OPENMS_LOG_WARN << "No data to compress." << std::endl;
       return;
     }
 
@@ -1195,7 +1195,7 @@ namespace OpenMS
 
     if (grid.size() < 3)
     {
-      LOG_WARN << "Data spacing is weird - either you selected a very small interval or a very low resolution - or both. Not compressing." << std::endl;
+      OPENMS_LOG_WARN << "Data spacing is weird - either you selected a very small interval or a very low resolution - or both. Not compressing." << std::endl;
       return;
     }
 
@@ -1275,11 +1275,11 @@ namespace OpenMS
 
     if (point_count_before != 0)
     {
-      LOG_INFO << "Compressed data to grid ... " <<  point_count_before << " --> " << point_count_after << " (" << (point_count_after * 100 / point_count_before) << "%)\n";
+      OPENMS_LOG_INFO << "Compressed data to grid ... " <<  point_count_before << " --> " << point_count_after << " (" << (point_count_after * 100 / point_count_before) << "%)\n";
     }
     else
     {
-      LOG_INFO << "Not enough points in map .. did not compress!\n";
+      OPENMS_LOG_INFO << "Not enough points in map .. did not compress!\n";
     }
 
     return;

--- a/src/openms/source/SIMULATION/RawTandemMSSignalSimulation.cpp
+++ b/src/openms/source/SIMULATION/RawTandemMSSignalSimulation.cpp
@@ -385,24 +385,24 @@ namespace OpenMS
 
   void RawTandemMSSignalSimulation::generateRawTandemSignals(const SimTypes::FeatureMapSim& features, SimTypes::MSSimExperiment& experiment, SimTypes::MSSimExperiment& experiment_ct)
   {
-    LOG_INFO << "Tandem MS Simulation ... ";
+    OPENMS_LOG_INFO << "Tandem MS Simulation ... ";
 
     // will hold the MS2 scans
     SimTypes::MSSimExperiment ms2;
 
     if (param_.getValue("status") == "disabled")
     {
-      LOG_INFO << "disabled" << std::endl;
+      OPENMS_LOG_INFO << "disabled" << std::endl;
       return;
     }
     else if (param_.getValue("status") == "precursor")
     {
-      LOG_INFO << "precursor" << std::endl;
+      OPENMS_LOG_INFO << "precursor" << std::endl;
       generatePrecursorSpectra_(features, experiment, ms2);
     }
     else // MS^E
     {
-      LOG_INFO << "MS^E" << std::endl;
+      OPENMS_LOG_INFO << "MS^E" << std::endl;
       generateMSESpectra_(features, experiment, ms2);
     }
 

--- a/src/openms/source/SYSTEM/File.cpp
+++ b/src/openms/source/SYSTEM/File.cpp
@@ -128,13 +128,13 @@ namespace OpenMS
     // existing file? Qt won't overwrite, so try to remove it:
     if (overwrite_existing && exists(to) && !remove(to))
     {
-      if (verbose) LOG_ERROR << "Error: Could not overwrite existing file '" << to << "'\n";
+      if (verbose) OPENMS_LOG_ERROR << "Error: Could not overwrite existing file '" << to << "'\n";
       return false;
     }
     // move the file to the actual destination:
     if (!QFile::rename(from.toQString(), to.toQString()))
     {
-      if (verbose) LOG_ERROR << "Error: Could not move '" << from << "' to '" << to << "'\n";
+      if (verbose) OPENMS_LOG_ERROR << "Error: Could not move '" << from << "' to '" << to << "'\n";
       return false;
     }
     return true;
@@ -152,7 +152,7 @@ namespace OpenMS
     // check canonical path  
     if (canonical_source_dir == canonical_target_dir)
     {
-      LOG_ERROR << "Error: Could not copy  " << from_dir.toStdString() << " to " << to_dir.toStdString() << ". Same path given." << std::endl;;  
+      OPENMS_LOG_ERROR << "Error: Could not copy  " << from_dir.toStdString() << " to " << to_dir.toStdString() << ". Same path given." << std::endl;;  
       return false;
     }
 
@@ -186,7 +186,7 @@ namespace OpenMS
               case CopyOptions::CANCEL: 
                 return false;
               case CopyOptions::SKIP: 
-                LOG_WARN << "The file " << entry.fileName().toStdString() << " was skipped." << std::endl; 
+                OPENMS_LOG_WARN << "The file " << entry.fileName().toStdString() << " was skipped." << std::endl; 
                 continue;
               case CopyOptions::OVERWRITE:
                 target_dir.remove(entry.fileName());
@@ -249,7 +249,7 @@ namespace OpenMS
     {
       if (!dir.remove(file_name))
       {
-        LOG_WARN << "Could not remove file " << String(file_name) << "!" << std::endl;
+        OPENMS_LOG_WARN << "Could not remove file " << String(file_name) << "!" << std::endl;
         fail = true;
       }
     }
@@ -480,7 +480,7 @@ namespace OpenMS
     path = path.substitute("\\", "/").ensureLastChar('/').chop(1);
 
     if (!path_checked) // - now we're in big trouble as './share' is not were its supposed to be...
-    { // - do NOT use LOG_ERROR or similar for the messages below! (it might not even usable at this point)
+    { // - do NOT use OPENMS_LOG_ERROR or similar for the messages below! (it might not even usable at this point)
       std::cerr << "OpenMS FATAL ERROR!\n  Cannot find shared data! OpenMS cannot function without it!\n";
       if (from_env)
       {
@@ -568,11 +568,11 @@ namespace OpenMS
     try
     {
       full_db_name = find(db_name, sys_p.getValue("id_db_dir"));
-      LOG_INFO << "Augmenting database name '" << db_name << "' with path given in 'OpenMS.ini:id_db_dir'. Full name is now: '" << full_db_name << "'" << std::endl;
+      OPENMS_LOG_INFO << "Augmenting database name '" << db_name << "' with path given in 'OpenMS.ini:id_db_dir'. Full name is now: '" << full_db_name << "'" << std::endl;
     }
     catch (Exception::FileNotFound& e)
     {
-      LOG_ERROR << "Input database '" + db_name + "' not found (" << e.getMessage() << "). Make sure it exists (and check 'OpenMS.ini:id_db_dir' if you used relative paths. Aborting!" << std::endl;
+      OPENMS_LOG_ERROR << "Input database '" + db_name + "' not found (" << e.getMessage() << "). Make sure it exists (and check 'OpenMS.ini:id_db_dir' if you used relative paths. Aborting!" << std::endl;
       throw;
     }
 
@@ -615,13 +615,13 @@ namespace OpenMS
       {
         if (!p.exists("version"))
         {
-          LOG_WARN << "Broken file '" << filename << "' discovered. The 'version' tag is missing." << std::endl;
+          OPENMS_LOG_WARN << "Broken file '" << filename << "' discovered. The 'version' tag is missing." << std::endl;
         }
         else // old version
         {
-          LOG_WARN << "File '" << filename << "' is deprecated." << std::endl;
+          OPENMS_LOG_WARN << "File '" << filename << "' is deprecated." << std::endl;
         }
-        LOG_WARN << "Updating missing/wrong entries in '" << filename << "' with defaults!" << std::endl;
+        OPENMS_LOG_WARN << "Updating missing/wrong entries in '" << filename << "' with defaults!" << std::endl;
         Param p_new = getSystemParameterDefaults_();
         p.setValue("version", VersionInfo::getVersion()); // update old version, such that p_new:version does not get overwritten during update()
         p_new.update(p);

--- a/src/openms/source/SYSTEM/JavaInfo.cpp
+++ b/src/openms/source/SYSTEM/JavaInfo.cpp
@@ -50,16 +50,16 @@ namespace OpenMS
     bool success = qp.waitForFinished();
     if (!success && verbose_on_error)
     {
-        LOG_ERROR << "Java-Check:\n";
+        OPENMS_LOG_ERROR << "Java-Check:\n";
         if (qp.error() == QProcess::Timedout)
         {
-          LOG_ERROR
+          OPENMS_LOG_ERROR
             << "  Java was found at '" << java_executable << "' but the process timed out (can happen on very busy systems).\n"
             << "  Please free some resources or if you want to run the TOPP tool nevertheless set the TOPP tools 'force' flag in order to avoid this check." << std::endl;
         }
         else if (qp.error() == QProcess::FailedToStart)
         {
-          LOG_ERROR
+          OPENMS_LOG_ERROR
             << "  Java not found at '" << java_executable << "'!\n"
             << "  Make sure Java is installed and this location is correct.\n";
           if (QDir::isRelativePath(java_executable.toQString()))
@@ -69,7 +69,7 @@ namespace OpenMS
             {
               path = getenv("PATH");
             }
-            LOG_ERROR << "  You might need to add the Java binary to your PATH variable\n"
+            OPENMS_LOG_ERROR << "  You might need to add the Java binary to your PATH variable\n"
               << "  or use an absolute path+filename pointing to Java.\n" 
               << "  The current SYSTEM PATH is: '" << path << "'.\n\n"
   #ifdef __APPLE__
@@ -79,14 +79,14 @@ namespace OpenMS
           }
           else 
           {
-            LOG_ERROR << "  You gave an absolute path to Java. Please check if it's correct.\n"
+            OPENMS_LOG_ERROR << "  You gave an absolute path to Java. Please check if it's correct.\n"
               << "  You can also try 'java' if your system path is correctly configured.\n"
               << std::endl;
           }
         }
         else
         {
-          LOG_ERROR << "  Error executing '" << java_executable << "'!\n"
+          OPENMS_LOG_ERROR << "  Error executing '" << java_executable << "'!\n"
                     << "  Error description: '" << qp.errorString().toStdString() << "'.\n";
         }
     }

--- a/src/openms/source/SYSTEM/RWrapper.cpp
+++ b/src/openms/source/SYSTEM/RWrapper.cpp
@@ -60,7 +60,7 @@ namespace OpenMS
       return false;
     }
 
-    if (verbose) LOG_INFO << "Running R script '" << fullscript << "' ...";
+    if (verbose) OPENMS_LOG_INFO << "Running R script '" << fullscript << "' ...";
 
     QStringList args;
     args << "--vanilla" << "--quiet" << fullscript.toQString();
@@ -74,23 +74,23 @@ namespace OpenMS
     {
       if (verbose)
       {
-        LOG_INFO << " failed" << std::endl;
-        LOG_ERROR << "\n--- ERROR MESSAGES ---\n";
-        LOG_ERROR << QString(p.readAllStandardError()).toStdString();
-        LOG_ERROR << "\n--- OTHER MESSAGES ---\n";
-        LOG_ERROR << QString(p.readAllStandardOutput()).toStdString();
-        LOG_ERROR << "\n\nScript failed. See above for an error description. " << std::endl;
+        OPENMS_LOG_INFO << " failed" << std::endl;
+        OPENMS_LOG_ERROR << "\n--- ERROR MESSAGES ---\n";
+        OPENMS_LOG_ERROR << QString(p.readAllStandardError()).toStdString();
+        OPENMS_LOG_ERROR << "\n--- OTHER MESSAGES ---\n";
+        OPENMS_LOG_ERROR << QString(p.readAllStandardOutput()).toStdString();
+        OPENMS_LOG_ERROR << "\n\nScript failed. See above for an error description. " << std::endl;
       }
       return false;
     }
-    if (verbose) LOG_INFO << " success" << std::endl;
+    if (verbose) OPENMS_LOG_INFO << " success" << std::endl;
 
     return true;
   }
 
   bool RWrapper::findR( const QString& executable /*= "Rscript"*/, bool verbose /*= true*/ )
   {
-    if (verbose) LOG_INFO << "Finding R interpreter 'Rscript' ...";
+    if (verbose) OPENMS_LOG_INFO << "Finding R interpreter 'Rscript' ...";
 
     QStringList args(QStringList() << "--vanilla" << "-e" << "sessionInfo()");
     QProcess p;
@@ -102,29 +102,29 @@ namespace OpenMS
     {
       if (verbose)
       {
-        LOG_INFO << " failed" << std::endl;
+        OPENMS_LOG_INFO << " failed" << std::endl;
         String out = QString(p.readAllStandardOutput()).toStdString();
-        LOG_ERROR << "Error: Could not find or run '" << executable.toStdString() << "' executable (FailedToStart).\n";
+        OPENMS_LOG_ERROR << "Error: Could not find or run '" << executable.toStdString() << "' executable (FailedToStart).\n";
         if (!out.empty())
         {
-          LOG_ERROR << "Output was:\n------>\n"
+          OPENMS_LOG_ERROR << "Output was:\n------>\n"
                     << out
                     << "\n<------\n";
         }
-        LOG_ERROR << "Please install 'Rscript', make sure it's in PATH and is flagged as executable." << std::endl;
+        OPENMS_LOG_ERROR << "Please install 'Rscript', make sure it's in PATH and is flagged as executable." << std::endl;
       }
 
       return false;
     }
-    if (verbose) LOG_INFO << " success" << std::endl;
+    if (verbose) OPENMS_LOG_INFO << " success" << std::endl;
 
-    if (verbose) LOG_INFO << "Trying to invoke 'Rscript' ...";
+    if (verbose) OPENMS_LOG_INFO << "Trying to invoke 'Rscript' ...";
     if (p.exitStatus() != QProcess::NormalExit || p.exitCode() != 0)
     {
       if (verbose)
       {
-        LOG_INFO << " failed" << std::endl;
-        LOG_ERROR << "Error: 'Rscript' executable returned with error (command: 'Rscript " << args.join(" ").toStdString() << "')\n"
+        OPENMS_LOG_INFO << " failed" << std::endl;
+        OPENMS_LOG_ERROR << "Error: 'Rscript' executable returned with error (command: 'Rscript " << args.join(" ").toStdString() << "')\n"
                   << "Output was:\n------>\n"
                   << QString(p.readAllStandardOutput()).toStdString()
                   << "\n<------\n"
@@ -132,7 +132,7 @@ namespace OpenMS
       }
       return false;
     }
-    if (verbose) LOG_INFO << " success" << std::endl;
+    if (verbose) OPENMS_LOG_INFO << " success" << std::endl;
 
     return true;
   }
@@ -146,7 +146,7 @@ namespace OpenMS
     }
     catch (...)
     {
-      if (verbose) LOG_ERROR << "\n\nCould not find R script '" << script_file << "'!\n" << std::endl;
+      if (verbose) OPENMS_LOG_ERROR << "\n\nCould not find R script '" << script_file << "'!\n" << std::endl;
       throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, script_file);
     }
     return s;

--- a/src/openms/source/SYSTEM/UpdateCheck.cpp
+++ b/src/openms/source/SYSTEM/UpdateCheck.cpp
@@ -125,9 +125,9 @@ namespace OpenMS
 
         if (debug_level > 0)
         {
-          LOG_INFO << "The OpenMS team is collecting usage statistics for quality control and funding purposes." << endl;
-          LOG_INFO << "We will never give out your personal data, but you may disable this functionality by " << endl;
-          LOG_INFO << "setting the environmental variable OPENMS_DISABLE_UPDATE_CHECK to ON." << endl;
+          OPENMS_LOG_INFO << "The OpenMS team is collecting usage statistics for quality control and funding purposes." << endl;
+          OPENMS_LOG_INFO << "We will never give out your personal data, but you may disable this functionality by " << endl;
+          OPENMS_LOG_INFO << "setting the environmental variable OPENMS_DISABLE_UPDATE_CHECK to ON." << endl;
         }
       
         // We need to use a QCoreApplication to fire up the  QEventLoop to process the signals and slots.
@@ -145,7 +145,7 @@ namespace OpenMS
         {
           if (debug_level > 0)
           {
-            LOG_INFO << "Connecting to REST server successful. " << endl;
+            OPENMS_LOG_INFO << "Connecting to REST server successful. " << endl;
           }
 
           QString response = query->getResponse();
@@ -154,7 +154,7 @@ namespace OpenMS
           {
             if (VersionInfo::getVersionStruct() < server_version)
             {
-              LOG_INFO << "Version " + version + " of " + tool_name + " is available at www.OpenMS.de" << endl;
+              OPENMS_LOG_INFO << "Version " + version + " of " + tool_name + " is available at www.OpenMS.de" << endl;
             }
           }
         }
@@ -162,8 +162,8 @@ namespace OpenMS
         {
           if (debug_level > 0)
           {
-            LOG_INFO << "Connecting to REST server failed. Skipping update check." << endl;
-            LOG_INFO << "Error: " << String(query->getErrorString()) << endl;
+            OPENMS_LOG_INFO << "Connecting to REST server failed. Skipping update check." << endl;
+            OPENMS_LOG_INFO << "Error: " << String(query->getErrorString()) << endl;
           }
         }
         delete query;

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/EGHTraceFitter.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/EGHTraceFitter.cpp
@@ -341,8 +341,8 @@ namespace OpenMS
 
   void EGHTraceFitter::setInitialParameters_(FeatureFinderAlgorithmPickedHelperStructs::MassTraces& traces)
   {
-    LOG_DEBUG << "EGHTraceFitter->setInitialParameters(...)" << std::endl;
-    LOG_DEBUG << "Number of traces: " << traces.size() << std::endl;
+    OPENMS_LOG_DEBUG << "EGHTraceFitter->setInitialParameters(...)" << std::endl;
+    OPENMS_LOG_DEBUG << "Number of traces: " << traces.size() << std::endl;
 
     // aggregate data; some peaks (where intensity is zero) can be missing!
     // mapping: RT -> total intensity over all mass traces
@@ -354,17 +354,17 @@ namespace OpenMS
     const Size LEN = 2;   // window size: 2 * LEN + 1
     std::vector<double> totals(N + 2 * LEN);   // pad with zeros at ends
     Int index = LEN;
-    // LOG_DEBUG << "Summed intensities:\n";
+    // OPENMS_LOG_DEBUG << "Summed intensities:\n";
     for (std::list<std::pair<double, double> >::iterator it =
            total_intensities.begin(); it != total_intensities.end(); ++it)
     {
       totals[index++] = it->second;
-      // LOG_DEBUG << it->second << std::endl;
+      // OPENMS_LOG_DEBUG << it->second << std::endl;
     }
 
     std::vector<double> smoothed(N);
     Size max_index = 0;   // index of max. smoothed intensity
-    // LOG_DEBUG << "Smoothed intensities:\n";
+    // OPENMS_LOG_DEBUG << "Smoothed intensities:\n";
     double sum = std::accumulate(&totals[LEN], &totals[2 * LEN], 0.0);
     for (Size i = 0; i < N; ++i)
     {
@@ -372,18 +372,18 @@ namespace OpenMS
       smoothed[i] = sum / (2 * LEN + 1);
       sum -= totals[i];
       if (smoothed[i] > smoothed[max_index]) max_index = i;
-      // LOG_DEBUG << smoothed[i] << std::endl;
+      // OPENMS_LOG_DEBUG << smoothed[i] << std::endl;
     }
-    LOG_DEBUG << "Maximum at index " << max_index << std::endl;
+    OPENMS_LOG_DEBUG << "Maximum at index " << max_index << std::endl;
     height_ = smoothed[max_index] - traces.baseline;
-    LOG_DEBUG << "height: " << height_ << std::endl;
+    OPENMS_LOG_DEBUG << "height: " << height_ << std::endl;
     std::list<std::pair<double, double> >::iterator it = total_intensities.begin();
     std::advance(it, max_index);
     apex_rt_ = it->first;
-    LOG_DEBUG << "apex_rt: " << apex_rt_ << std::endl;
+    OPENMS_LOG_DEBUG << "apex_rt: " << apex_rt_ << std::endl;
     region_rt_span_ = (total_intensities.rbegin()->first -
                        total_intensities.begin()->first);
-    LOG_DEBUG << "region_rt_span: " << region_rt_span_ << std::endl;
+    OPENMS_LOG_DEBUG << "region_rt_span: " << region_rt_span_ << std::endl;
 
     // find RT values where intensity is at half-maximum:
     index = static_cast<Int>(max_index);
@@ -393,7 +393,7 @@ namespace OpenMS
     it = total_intensities.begin();
     std::advance(it, index);
     double left_rt = it->first;
-    LOG_DEBUG << "Left half-maximum at index " << index << ", RT " << left_rt
+    OPENMS_LOG_DEBUG << "Left half-maximum at index " << index << ", RT " << left_rt
               << std::endl;
     index = static_cast<Int>(max_index);
     while ((index < Int(N - 1)) && (smoothed[index] > height_ * 0.5))
@@ -402,13 +402,13 @@ namespace OpenMS
     it = total_intensities.end();
     std::advance(it, index - Int(N));
     double right_rt = it->first;
-    LOG_DEBUG << "Right half-maximum at index " << index << ", RT "
+    OPENMS_LOG_DEBUG << "Right half-maximum at index " << index << ", RT "
               << right_rt << std::endl;
 
     double A = apex_rt_ - left_rt;
     double B = right_rt - apex_rt_;
-    //LOG_DEBUG << "A: " << A << std::endl;
-    //LOG_DEBUG << "B: " << B << std::endl;
+    //OPENMS_LOG_DEBUG << "A: " << A << std::endl;
+    //OPENMS_LOG_DEBUG << "B: " << B << std::endl;
 
     // compute estimates for tau / sigma based on A and B:
     double alpha = (left_height + right_height) * 0.5 / height_;   // ~0.5
@@ -418,9 +418,9 @@ namespace OpenMS
     //EGH function fails when tau==0
     if (tau_ == 0) tau_ = std::numeric_limits<double>::epsilon();
 
-    LOG_DEBUG << "tau: " << tau_ << std::endl;
+    OPENMS_LOG_DEBUG << "tau: " << tau_ << std::endl;
     sigma_ = sqrt(-0.5 / log_alpha * B * A);
-    LOG_DEBUG << "sigma: " << sigma_ << std::endl;
+    OPENMS_LOG_DEBUG << "sigma: " << sigma_ << std::endl;
   }
 
   void EGHTraceFitter::updateMembers_()

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/ElutionModelFitter.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/ElutionModelFitter.cpp
@@ -153,12 +153,12 @@ void ElutionModelFitter::fitElutionModels(FeatureMap& features)
   }
 
   // collect peaks that constitute mass traces:
-  LOG_DEBUG << "Fitting elution models to features:" << endl;
+  OPENMS_LOG_DEBUG << "Fitting elution models to features:" << endl;
   Size index = 0;
   for (FeatureMap::Iterator feat_it = features.begin(); 
        feat_it != features.end(); ++feat_it, ++index)
   {
-    // LOG_DEBUG << String(feat_it->getMetaValue("PeptideRef")) << endl;
+    // OPENMS_LOG_DEBUG << String(feat_it->getMetaValue("PeptideRef")) << endl;
     double region_start = double(feat_it->getMetaValue("leftWidth"));
     double region_end = double(feat_it->getMetaValue("rightWidth"));
 
@@ -243,7 +243,7 @@ void ElutionModelFitter::fitElutionModels(FeatureMap& features)
     }
     catch (Exception::UnableToFit& except)
     {
-      LOG_ERROR << "Error fitting model to feature '" << feat_it->getUniqueId()
+      OPENMS_LOG_ERROR << "Error fitting model to feature '" << feat_it->getUniqueId()
                 << "': " << except.getName() << " - " << except.getMessage()
                 << endl;
       fit_success = false;
@@ -413,7 +413,7 @@ void ElutionModelFitter::fitElutionModels(FeatureMap& features)
       if (impute)
       { // apply log-transform to weight down high outliers:
         double raw_intensity = feat_it->getIntensity();
-        LOG_DEBUG << "Successful model: x = " << raw_intensity << ", y = "
+        OPENMS_LOG_DEBUG << "Successful model: x = " << raw_intensity << ", y = "
                   << area << "; log(x) = " << log(raw_intensity) 
                   << ", log(y) = " << log(area) << endl;
         quant_values.push_back(make_pair(log(raw_intensity), log(area)));
@@ -422,7 +422,7 @@ void ElutionModelFitter::fitElutionModels(FeatureMap& features)
       model_successes++;
     }
   }
-  LOG_INFO << "Model fitting: " << model_successes << " successes, "
+  OPENMS_LOG_INFO << "Model fitting: " << model_successes << " successes, "
            << model_failures << " failures" << endl;
 
   if (impute) // impute results for cases where the model fit failed
@@ -432,7 +432,7 @@ void ElutionModelFitter::fitElutionModels(FeatureMap& features)
     String x_weight, y_weight;
     double x_datum_min, x_datum_max, y_datum_min, y_datum_max;
     lm.getParameters(slope, intercept, x_weight, y_weight, x_datum_min, x_datum_max, y_datum_min, y_datum_max);
-    LOG_DEBUG << "LM slope: " << slope << ", intercept: " << intercept << endl;
+    OPENMS_LOG_DEBUG << "LM slope: " << slope << ", intercept: " << intercept << endl;
     for (vector<FeatureMap::Iterator>::iterator it = failed_models.begin();
          it != failed_models.end(); ++it)
     {

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinder.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinder.cpp
@@ -84,7 +84,7 @@ namespace OpenMS
       //Check if the peaks are sorted according to m/z
       if (!input_map.isSorted(true))
       {
-        LOG_WARN << "Input map is not sorted by RT and m/z! This is done now, before applying the algorithm!" << std::endl;
+        OPENMS_LOG_WARN << "Input map is not sorted by RT and m/z! This is done now, before applying the algorithm!" << std::endl;
         input_map.sortSpectra(true);
         input_map.sortChromatograms(true);
       }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPicked.cpp
@@ -705,8 +705,8 @@ namespace OpenMS
             alt_fitter->setParameters(alt_p);
             alt_fitter->fit(traces);
 
-            LOG_DEBUG << "EGH:   " << fitter->getCenter() << " " << fitter->getHeight() << std::endl;
-            LOG_DEBUG << "GAUSS: " << alt_fitter->getCenter() << " " << alt_fitter->getHeight() << std::endl;
+            OPENMS_LOG_DEBUG << "EGH:   " << fitter->getCenter() << " " << fitter->getHeight() << std::endl;
+            OPENMS_LOG_DEBUG << "GAUSS: " << alt_fitter->getCenter() << " " << alt_fitter->getHeight() << std::endl;
 #endif
             // what should come out
             // left "sigma"
@@ -974,7 +974,7 @@ namespace OpenMS
         }
       }
     }
-    LOG_INFO << "Removed " << removed << " overlapping features." << std::endl;
+    OPENMS_LOG_INFO << "Removed " << removed << " overlapping features." << std::endl;
     //finally remove features with intensity 0
     FeatureMap tmp;
     tmp.reserve(features_->size());
@@ -1724,13 +1724,13 @@ namespace OpenMS
     // choose fitter
     if (param_.getValue("feature:rt_shape") == "asymmetric")
     {
-      LOG_DEBUG << "use asymmetric rt peak shape" << std::endl;
+      OPENMS_LOG_DEBUG << "use asymmetric rt peak shape" << std::endl;
       tau = -1.0;
       return new EGHTraceFitter();
     }
     else // if (param_.getValue("feature:rt_shape") == "symmetric")
     {
-      LOG_DEBUG << "use symmetric rt peak shape" << std::endl;
+      OPENMS_LOG_DEBUG << "use symmetric rt peak shape" << std::endl;
       return new GaussTraceFitter();
     }
   }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/GaussTraceFitter.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/GaussTraceFitter.cpp
@@ -76,7 +76,7 @@ namespace OpenMS
 
   void GaussTraceFitter::fit(FeatureFinderAlgorithmPickedHelperStructs::MassTraces& traces)
   {
-    LOG_DEBUG << "Traces length: " << traces.size() << "\n";
+    OPENMS_LOG_DEBUG << "Traces length: " << traces.size() << "\n";
     setInitialParameters_(traces);
 
     Eigen::VectorXd x_init(NUM_PARAMS_);
@@ -219,8 +219,8 @@ namespace OpenMS
 
   void GaussTraceFitter::setInitialParameters_(FeatureFinderAlgorithmPickedHelperStructs::MassTraces& traces)
   {
-    LOG_DEBUG << "GaussTraceFitter->setInitialParameters(...)" << std::endl;
-    LOG_DEBUG << "Number of traces: " << traces.size() << std::endl;
+    OPENMS_LOG_DEBUG << "GaussTraceFitter->setInitialParameters(...)" << std::endl;
+    OPENMS_LOG_DEBUG << "Number of traces: " << traces.size() << std::endl;
 
     // aggregate data; some peaks (where intensity is zero) can be missing!
     // mapping: RT -> total intensity over all mass traces
@@ -232,12 +232,12 @@ namespace OpenMS
 
     std::vector<double> totals(N + 2 * LEN); // pad with zeros at ends
     Int index = LEN;
-    // LOG_DEBUG << "Summed intensities:\n";
+    // OPENMS_LOG_DEBUG << "Summed intensities:\n";
     for (std::list<std::pair<double, double> >::iterator it =
            total_intensities.begin(); it != total_intensities.end(); ++it)
     {
       totals[index++] = it->second;
-      // LOG_DEBUG << it->second << std::endl;
+      // OPENMS_LOG_DEBUG << it->second << std::endl;
     }
 
     std::vector<double> smoothed(N);
@@ -253,7 +253,7 @@ namespace OpenMS
     }
     else // compute moving average for smoothing
     {
-      // LOG_DEBUG << "Smoothed intensities:\n";
+      // OPENMS_LOG_DEBUG << "Smoothed intensities:\n";
       double sum = std::accumulate(&totals[LEN], &totals[2 * LEN], 0.0);
       for (Size i = 0; i < N; ++i)
       {
@@ -261,19 +261,19 @@ namespace OpenMS
         smoothed[i] = sum / (2 * LEN + 1);
         sum -= totals[i];
         if (smoothed[i] > smoothed[max_index]) max_index = i;
-        // LOG_DEBUG << smoothed[i] << std::endl;
+        // OPENMS_LOG_DEBUG << smoothed[i] << std::endl;
       }
     }
-    LOG_DEBUG << "Maximum at index " << max_index << std::endl;
+    OPENMS_LOG_DEBUG << "Maximum at index " << max_index << std::endl;
     height_ = smoothed[max_index] - traces.baseline;
-    LOG_DEBUG << "height: " << height_ << std::endl;
+    OPENMS_LOG_DEBUG << "height: " << height_ << std::endl;
     std::list<std::pair<double, double> >::iterator it = total_intensities.begin();
     std::advance(it, max_index);
     x0_ = it->first;
-    LOG_DEBUG << "x0: " << x0_ << std::endl;
+    OPENMS_LOG_DEBUG << "x0: " << x0_ << std::endl;
     region_rt_span_ = (total_intensities.rbegin()->first -
                        total_intensities.begin()->first);
-    LOG_DEBUG << "region_rt_span: " << region_rt_span_ << std::endl;
+    OPENMS_LOG_DEBUG << "region_rt_span: " << region_rt_span_ << std::endl;
 
     // find RT values where intensity is at half-maximum:
     index = static_cast<Int>(max_index);
@@ -283,7 +283,7 @@ namespace OpenMS
     it = total_intensities.begin();
     std::advance(it, index);
     double left_rt = it->first;
-    LOG_DEBUG << "Left half-maximum at index " << index << ", RT " << left_rt
+    OPENMS_LOG_DEBUG << "Left half-maximum at index " << index << ", RT " << left_rt
               << std::endl;
     index = static_cast<Int>(max_index);
     while ((index < Int(N - 1)) && (smoothed[index] > height_ * 0.5))
@@ -292,14 +292,14 @@ namespace OpenMS
     it = total_intensities.end();
     std::advance(it, index - Int(N));
     double right_rt = it->first;
-    LOG_DEBUG << "Right half-maximum at index " << index << ", RT "
+    OPENMS_LOG_DEBUG << "Right half-maximum at index " << index << ", RT "
               << right_rt << std::endl;
 
     double delta_x = right_rt - left_rt;
     double alpha = (left_height + right_height) * 0.5 / height_; // ~0.5
     if (alpha >= 1) sigma_ = 1.0; // degenerate case, all values are the same
     else sigma_ = delta_x * 0.5 / sqrt(-2.0 * log(alpha));
-    LOG_DEBUG << "sigma: " << sigma_ << std::endl;
+    OPENMS_LOG_DEBUG << "sigma: " << sigma_ << std::endl;
   }
 
   void GaussTraceFitter::updateMembers_()

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringCentroided.cpp
@@ -139,7 +139,7 @@ namespace OpenMS
     
 #ifdef DEBUG
     // clock for monitoring run time performance
-    LOG_INFO << "\nThe filtering step of the algorithm took " << (float)(clock()-start)/CLOCKS_PER_SEC << " seconds.\n\n";
+    OPENMS_LOG_INFO << "\nThe filtering step of the algorithm took " << (float)(clock()-start)/CLOCKS_PER_SEC << " seconds.\n\n";
 #endif
 
     endProgress();

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/MultiplexFilteringProfile.cpp
@@ -267,7 +267,7 @@ namespace OpenMS
     
 #ifdef DEBUG
     // clock for monitoring run time performance
-    LOG_INFO << "\nThe filtering step of the algorithm took " << (float)(clock()-start)/CLOCKS_PER_SEC << " seconds.\n\n";
+    OPENMS_LOG_INFO << "\nThe filtering step of the algorithm took " << (float)(clock()-start)/CLOCKS_PER_SEC << " seconds.\n\n";
 #endif
 
     endProgress();

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/INIFileEditor.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/INIFileEditor.cpp
@@ -115,8 +115,8 @@ int main(int argc, const char** argv)
     }
     catch (Exception::BaseException& e)
     {
-      LOG_ERROR << "Error while parsing file '" << param.getValue("print") << "'\n";
-      LOG_ERROR << e << "\n";
+      OPENMS_LOG_ERROR << "Error while parsing file '" << param.getValue("print") << "'\n";
+      OPENMS_LOG_ERROR << e << "\n";
     }
 
     return 0;

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
@@ -136,8 +136,8 @@ int main(int argc, const char** argv)
   // '-debug' given
   if (param.exists("debug"))
   {
-    LOG_INFO << "Debug flag provided. Enabling 'LOG_DEBUG' ..." << std::endl;
-    Log_debug.insert(cout); // allows to use LOG_DEBUG << "something" << std::endl;
+    OPENMS_LOG_INFO << "Debug flag provided. Enabling 'OPENMS_LOG_DEBUG' ..." << std::endl;
+    Log_debug.insert(cout); // allows to use OPENMS_LOG_DEBUG << "something" << std::endl;
   }
 
   // test if unknown options were given
@@ -148,7 +148,7 @@ int main(int argc, const char** argv)
     // in Param.h
     if (!(param.getValue("unknown").toString().hasSubstring("-psn") && !param.getValue("unknown").toString().hasSubstring(", ")))
     {
-      LOG_ERROR << "Unknown option(s) '" << param.getValue("unknown").toString() << "' given. Aborting!" << endl;
+      OPENMS_LOG_ERROR << "Unknown option(s) '" << param.getValue("unknown").toString() << "' given. Aborting!" << endl;
       print_usage(Log_error);
       return 1;
     }
@@ -159,7 +159,7 @@ int main(int argc, const char** argv)
 
     if (param.exists("execute") || param.exists("out_dir"))
     {
-      LOG_ERROR << "The parameters '-execute' and '-out_dir' are not valid anymore. This functionality has been moved to the ExecutePipeline tool." << endl;
+      OPENMS_LOG_ERROR << "The parameters '-execute' and '-out_dir' are not valid anymore. This functionality has been moved to the ExecutePipeline tool." << endl;
       return 1;
     }
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/INIFileEditorWindow.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/INIFileEditorWindow.cpp
@@ -110,8 +110,8 @@ namespace OpenMS
         }
         catch (Exception::BaseException& e)
         {
-          LOG_ERROR << "Error while parsing file '" << filename_.toStdString() << "'\n";
-          LOG_ERROR << e << "\n";
+          OPENMS_LOG_ERROR << "Error while parsing file '" << filename_.toStdString() << "'\n";
+          OPENMS_LOG_ERROR << e << "\n";
         }
       }
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/MISC/QApplicationTOPP.cpp
@@ -106,7 +106,7 @@ namespace OpenMS
     catch (Exception::BaseException& e)
     {
       String msg = String("Caught exception: '") + e.getName() + "' with message '" + e.getMessage() + "'";
-      LOG_ERROR << msg << "\n";
+      OPENMS_LOG_ERROR << msg << "\n";
       QMessageBox::warning(nullptr, QString("Unexpected error occurred"), msg.toQString());
       return false;
       // we could also exit() here... but no for now

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPASBase.cpp
@@ -320,7 +320,7 @@ namespace OpenMS
     else
     {
       proposed_filename = "Workflow.toppas";
-      LOG_WARN << "The URL format of downloads from the TOPPAS Online-Repository has changed. Please notify developers!";
+      OPENMS_LOG_WARN << "The URL format of downloads from the TOPPAS Online-Repository has changed. Please notify developers!";
     }
     QString filename = QFileDialog::getSaveFileName(this, "Where to save the TOPPAS file?", this->current_path_.toQString() + "/" + proposed_filename, tr("TOPPAS (*.toppas)"));
 
@@ -356,7 +356,7 @@ namespace OpenMS
   {
     QNetworkReply::NetworkError ne = network_reply_->error();
     qint64 ba = network_reply_->bytesAvailable();
-    LOG_DEBUG << "Error code (QNetworkReply::NetworkError): " << ne << "  bytes available: " << ba << std::endl;
+    OPENMS_LOG_DEBUG << "Error code (QNetworkReply::NetworkError): " << ne << "  bytes available: " << ba << std::endl;
     return;
   }
 
@@ -546,7 +546,7 @@ namespace OpenMS
 
     if (!file_name.toQString().endsWith(".toppas", Qt::CaseInsensitive))
     {
-      LOG_ERROR << "The file '" << file_name << "' is not a .toppas file" << std::endl;
+      OPENMS_LOG_ERROR << "The file '" << file_name << "' is not a .toppas file" << std::endl;
       return;
     }
 

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1247,10 +1247,10 @@ namespace OpenMS
           indexed_mzml_file_.openFile(filename);
           if ( indexed_mzml_file_.getParsingSuccess() && cache_ms2_on_disc)
           {
-            LOG_INFO << "INFO: will use cached MS2 spectra" << std::endl;
+            OPENMS_LOG_INFO << "INFO: will use cached MS2 spectra" << std::endl;
             if (cache_ms1_on_disc)
             {
-              LOG_INFO << "log INFO: will use cached MS1 spectra" << std::endl;
+              OPENMS_LOG_INFO << "log INFO: will use cached MS1 spectra" << std::endl;
             }
             parsing_success = true;
 
@@ -1288,7 +1288,7 @@ namespace OpenMS
         {
           fh.loadExperiment(abs_filename, *peak_map_sptr, file_type, ProgressLogger::GUI);
         }
-        LOG_INFO << "INFO: done loading all " << std::endl;
+        OPENMS_LOG_INFO << "INFO: done loading all " << std::endl;
 
         // a mzML file may contain both, chromatogram and peak data
         // -> this is handled in SpectrumCanvas::addLayer

--- a/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
+++ b/src/openms_gui/source/VISUAL/MISC/GUIHelpers.cpp
@@ -60,8 +60,8 @@ namespace OpenMS
     {
       // execution failed
       QMessageBox::warning(0, "Open Folder Error", "The folder '" + folder + "' could not be opened!");
-      LOG_ERROR << "Failed to open folder '" << folder.toStdString() << "'" << std::endl;
-      LOG_ERROR << p->errorString().toStdString() << std::endl;
+      OPENMS_LOG_ERROR << "Failed to open folder '" << folder.toStdString() << "'" << std::endl;
+      OPENMS_LOG_ERROR << p->errorString().toStdString() << std::endl;
     }
 #else
     if (!QDir(folder).exists() || (!QDesktopServices::openUrl(QUrl("file:///" + folder, QUrl::TolerantMode))))
@@ -105,9 +105,9 @@ namespace OpenMS
     if (!p->waitForStarted())
     {
       // execution failed
-      LOG_ERROR << p->errorString().toStdString() << std::endl;
+      OPENMS_LOG_ERROR << p->errorString().toStdString() << std::endl;
   #if defined(Q_WS_MAC)
-      LOG_ERROR << "Please check if TOPPAS and TOPPView are located in the same directory" << std::endl;
+      OPENMS_LOG_ERROR << "Please check if TOPPAS and TOPPView are located in the same directory" << std::endl;
   #endif
     }
   }

--- a/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DCanvas.cpp
@@ -773,7 +773,7 @@ namespace OpenMS
               if (!layer.peak_colors_1d.empty() && 
                layer.peak_colors_1d.size() < spectrum.size())
               {
-                LOG_ERROR << "Peak color array size (" 
+                OPENMS_LOG_ERROR << "Peak color array size (" 
                   << layer.peak_colors_1d.size() 
                   << ") doesn't match number of peaks ("
                   << spectrum.size()

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -401,7 +401,7 @@ namespace OpenMS
         && layers_.back().getPeakData()->size() != 0)
     {
       // TODO : handle this case better
-      LOG_WARN << "Your input data contains chromatograms and spectra, falling back to display spectra only." << std::endl;
+      OPENMS_LOG_WARN << "Your input data contains chromatograms and spectra, falling back to display spectra only." << std::endl;
     }
 
     if (layers_.back().getPeakData()->getChromatograms().size() != 0 

--- a/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASOutputFileListVertex.cpp
@@ -201,7 +201,7 @@ namespace OpenMS
       {
         if (!dry_run && !File::exists(f))
         {
-          LOG_ERROR << "The file '" << String(f) << "' does not exist!" << std::endl;
+          OPENMS_LOG_ERROR << "The file '" << String(f) << "' does not exist!" << std::endl;
           throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, f.toStdString());
         }
         QString new_file = full_dir.toQString()
@@ -305,7 +305,7 @@ namespace OpenMS
           }
           else
           {
-            LOG_ERROR << "Could not copy tmp output file " << String(file_from) << " to " << String(file_to) << std::endl;
+            OPENMS_LOG_ERROR << "Could not copy tmp output file " << String(file_from) << " to " << String(file_to) << std::endl;
           }
         }
         update(boundingRect()); // repaint

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -178,7 +178,7 @@ namespace OpenMS
       {
         String msg = String("Could not open old INI file '") + old_ini_file + "'! File does not exist!";
         if (getScene_() && getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
-        else LOG_ERROR << msg << std::endl;
+        else OPENMS_LOG_ERROR << msg << std::endl;
         tool_ready_ = false;
         return false;
       }
@@ -196,7 +196,7 @@ namespace OpenMS
           "\noutput:\n" + String(QString(p.readAll())) +
           "\n";
       if (getScene_() && getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
-      else LOG_ERROR << msg << std::endl;
+      else OPENMS_LOG_ERROR << msg << std::endl;
       tool_ready_ = false;
       return false;
     }
@@ -204,7 +204,7 @@ namespace OpenMS
     { // it would be weird to get here, since the TOPP tool ran successfully above, so INI file should exist, but nevertheless:
       String msg = String("Could not open '") + ini_file + "'! It does not exist!";
       if (getScene_() && getScene_()->isGUIMode()) QMessageBox::critical(nullptr, "Error", msg.c_str());
-      else LOG_ERROR << msg << std::endl;
+      else OPENMS_LOG_ERROR << msg << std::endl;
       tool_ready_ = false;
       return false;
     }
@@ -540,7 +540,7 @@ namespace OpenMS
 
     if (finished_)
     {
-      LOG_ERROR << "This should not happen. Calling an already finished node '" << this->name_ << "' (#" << this->getTopoNr() << ")!" << std::endl;
+      OPENMS_LOG_ERROR << "This should not happen. Calling an already finished node '" << this->name_ << "' (#" << this->getTopoNr() << ")!" << std::endl;
       throw Exception::IllegalSelfOperation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
     }
     TOPPASScene* ts = getScene_();
@@ -559,7 +559,7 @@ namespace OpenMS
     bool success = buildRoundPackages(pkg, error_msg);
     if (!success)
     {
-      LOG_ERROR << "Could not retrieve input files from upstream nodes...\n";
+      OPENMS_LOG_ERROR << "Could not retrieve input files from upstream nodes...\n";
       emit toolFailed(error_msg.toQString());
       return;
     }
@@ -608,7 +608,7 @@ namespace OpenMS
         int param_index = incoming_edge.getTargetInParam();
         if (param_index < 0 || param_index >= in_params.size())
         {
-          LOG_ERROR << "TOPPAS: Input parameter index out of bounds!" << std::endl;
+          OPENMS_LOG_ERROR << "TOPPAS: Input parameter index out of bounds!" << std::endl;
           return;
         }
 
@@ -723,7 +723,7 @@ namespace OpenMS
       if (round == 0)
       {
         // active if TOPPAS is run with --debug; will print to console
-        LOG_DEBUG << msg_enqueue << std::endl;
+        OPENMS_LOG_DEBUG << msg_enqueue << std::endl;
         // show sys-call in logWindow of TOPPAS (or console for non-gui)
         if ((int) param_tmp.getValue("debug") > 0)
         {
@@ -772,7 +772,7 @@ namespace OpenMS
 
         if (finished_)
         {
-          LOG_ERROR << "SOMETHING is very fishy. The vertex is already set to finished, yet there was still a thread spawning..." << std::endl;
+          OPENMS_LOG_ERROR << "SOMETHING is very fishy. The vertex is already set to finished, yet there was still a thread spawning..." << std::endl;
           throw Exception::IllegalSelfOperation(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION);
         }
         if (!ts->isDryRun())
@@ -858,14 +858,14 @@ namespace OpenMS
             bool success = File::remove(new_filename);
             if (!success)
             {
-              LOG_ERROR << "Could not remove '" << new_filename << "'.\n";
+              OPENMS_LOG_ERROR << "Could not remove '" << new_filename << "'.\n";
               throw Exception::FileNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_filename);
             }
           }
           bool success = file.rename(new_filename.toQString());
           if (!success)
           {
-            LOG_ERROR << "Could not rename '" << String(it->second.filenames[fi]) << "' to '" << new_filename << "'\n";
+            OPENMS_LOG_ERROR << "Could not rename '" << String(it->second.filenames[fi]) << "' to '" << new_filename << "'\n";
             throw Exception::FileNotWritable(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, new_filename);
           }
           it->second.filenames.set(new_filename.toQString(), fi);
@@ -895,7 +895,7 @@ namespace OpenMS
     if (pkg.empty())
     {
       error_msg = "Less than one round received from upstream tools. Something is fishy!\n";
-      LOG_ERROR << error_msg;
+      OPENMS_LOG_ERROR << error_msg;
       return false;
     }
 
@@ -942,7 +942,7 @@ namespace OpenMS
     if (max_size_index == -1)
     {
       error_msg = "Did not find upstream nodes with un-recycled names. Something is fishy!\n";
-      LOG_ERROR << error_msg;
+      OPENMS_LOG_ERROR << error_msg;
       return false;
     }
 
@@ -1012,7 +1012,7 @@ namespace OpenMS
       else if (param_.exists(p_out_format))
       { // 'out_type' or alike is specified
         if (!param_.getValue(p_out_format).toString().empty()) file_suffix = "." + param_.getValue(p_out_format).toString();
-        else LOG_WARN << "TOPPAS cannot determine output file format for param '" << out_params[i].param_name
+        else OPENMS_LOG_WARN << "TOPPAS cannot determine output file format for param '" << out_params[i].param_name
                       << "' of Node " + this->name_ + "(" + String(this->getTopoNr()) + "). Format is ambiguous. Use parameter '" + p_out_format + "' to name intermediate output correctly!\n";
       }
       if (file_suffix.empty())
@@ -1044,34 +1044,34 @@ namespace OpenMS
         for (const QString &input_file : per_round_basenames[r])
         {
           QString fn = path + QFileInfo(input_file).fileName(); // out_path + filename
-          LOG_DEBUG << "Single:" << fn.toStdString() << "\n";
+          OPENMS_LOG_DEBUG << "Single:" << fn.toStdString() << "\n";
           if (list_to_single)
           {
             if (fn.contains(QRegExp(".*_to_.*_mrgd")))
             {
               fn = fn.left(fn.indexOf("_to_"));
-              LOG_DEBUG << "  first merge in merge: " << fn.toStdString() << "\n";
+              OPENMS_LOG_DEBUG << "  first merge in merge: " << fn.toStdString() << "\n";
             }
             QString fn_last = QFileInfo(per_round_basenames[r].last()).fileName();
             if (fn_last.contains(QRegExp(".*_to_.*_mrgd")))
             {
               int i_start = fn_last.indexOf("_to_") + 4;
               fn_last = fn_last.mid(i_start, fn_last.indexOf("_mrgd", i_start) - i_start);
-              LOG_DEBUG << "  last merge in merge: " << fn_last.toStdString() << "\n";
+              OPENMS_LOG_DEBUG << "  last merge in merge: " << fn_last.toStdString() << "\n";
             }
             fn += "_to_" + fn_last + "_mrgd";
-            LOG_DEBUG << "  List: ..." << "_to_" + fn_last.toStdString() + "_mrgd" << "\n";
+            OPENMS_LOG_DEBUG << "  List: ..." << "_to_" + fn_last.toStdString() + "_mrgd" << "\n";
           }
           if (!fn.endsWith(file_suffix.toQString()))
           {
             fn += file_suffix.toQString();
-            LOG_DEBUG << "  Suffix-add: " << file_suffix << "\n";
+            OPENMS_LOG_DEBUG << "  Suffix-add: " << file_suffix << "\n";
           }
           fn = QDir::toNativeSeparators(fn);
           if (filename_output_set.count(fn) > 0)
           {
             error_msg = "TOPPAS failed to build correct filenames. Please report this bug, along with your Pipeline\n!";
-            LOG_ERROR << error_msg;
+            OPENMS_LOG_ERROR << error_msg;
             return false;
           }
           output_files_[r][param_index].filenames.push_back(fn);
@@ -1228,7 +1228,7 @@ namespace OpenMS
 
     if (!ok)
     {
-      LOG_ERROR << "TOPPAS: Could not create path " << getFullOutputDirectory() << std::endl;
+      OPENMS_LOG_ERROR << "TOPPAS: Could not create path " << getFullOutputDirectory() << std::endl;
     }
 
     // subsdirectories named after the output parameter name
@@ -1240,7 +1240,7 @@ namespace OpenMS
       {
         if (!dir.mkpath(sdir))
         {
-          LOG_ERROR << "TOPPAS: Could not create path " << String(sdir) << std::endl;
+          OPENMS_LOG_ERROR << "TOPPAS: Could not create path " << String(sdir) << std::endl;
         }
       }
     }

--- a/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASVertex.cpp
@@ -205,7 +205,7 @@ namespace OpenMS
     if (inEdgesBegin() == inEdgesEnd())
     {
       error_msg = "buildRoundPackages() called on vertex with no input edges!\n";
-      LOG_ERROR << error_msg;
+      OPENMS_LOG_ERROR << error_msg;
       return false;
     }
 

--- a/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPViewIdentificationViewBehavior.cpp
@@ -146,7 +146,7 @@ namespace OpenMS
             break;
           }
           default:
-            LOG_WARN << "Annotation of MS level > 2 not supported.!" << endl;
+            OPENMS_LOG_WARN << "Annotation of MS level > 2 not supported.!" << endl;
         }
       }
 
@@ -165,7 +165,7 @@ namespace OpenMS
 
     if (current_layer.getCurrentSpectrum().empty())
     {
-      LOG_WARN << "Spectrum is empty! Nothing to annotate!" << endl;
+      OPENMS_LOG_WARN << "Spectrum is empty! Nothing to annotate!" << endl;
     }
 
     // mass precision to match a peak's m/z to a feature m/z
@@ -219,7 +219,7 @@ namespace OpenMS
           StringList msg;
           if (!ith->metaValueExists("identifier")) msg.push_back("identifier");
           if (!ith->metaValueExists("chemical_formula")) msg.push_back("chemical_formula");
-          LOG_WARN << "Missing meta-value(s): " << ListUtils::concatenate(msg, ", ") << ". Cannot annotate!\n";
+          OPENMS_LOG_WARN << "Missing meta-value(s): " << ListUtils::concatenate(msg, ", ") << ". Cannot annotate!\n";
         }
       }
 
@@ -450,7 +450,7 @@ namespace OpenMS
           break;
         }
         default:
-          LOG_WARN << "Annotation of MS level > 2 not supported." << endl;
+          OPENMS_LOG_WARN << "Annotation of MS level > 2 not supported." << endl;
       }
     } // end DT_PEAK
     // else if (current_layer.type == LayerData::DT_CHROMATOGRAM)
@@ -1147,7 +1147,7 @@ namespace OpenMS
 
     if (current_spectrum.empty())
     {
-      LOG_WARN << "Spectrum is empty! Nothing to annotate!" << endl;
+      OPENMS_LOG_WARN << "Spectrum is empty! Nothing to annotate!" << endl;
     }
     else if (!current_spectrum.isSorted())
     {
@@ -1164,7 +1164,7 @@ namespace OpenMS
       Int peak_idx = current_spectrum.findNearest(ann.mz, 1e-2);
       if (peak_idx == -1) // no match
       {
-        LOG_WARN << "Annotation present for missing peak. m/z: " << ann.mz
+        OPENMS_LOG_WARN << "Annotation present for missing peak. m/z: " << ann.mz
                   << endl;
         continue;
       }

--- a/src/tests/class_tests/openms/source/LogConfigHandler_test.cpp
+++ b/src/tests/class_tests/openms/source/LogConfigHandler_test.cpp
@@ -95,10 +95,10 @@ START_SECTION((void configure(const Param &param)))
 
   LogConfigHandler::getInstance().configure(p);
 
-  LOG_INFO << "1" << endl;
-  LOG_INFO << "2" << endl;
-  LOG_WARN << "3" << endl;
-  LOG_ERROR << "4" << endl;
+  OPENMS_LOG_INFO << "1" << endl;
+  OPENMS_LOG_INFO << "2" << endl;
+  OPENMS_LOG_WARN << "3" << endl;
+  OPENMS_LOG_ERROR << "4" << endl;
 
   settings.clear();
   settings.push_back("WARNING clear");
@@ -107,7 +107,7 @@ START_SECTION((void configure(const Param &param)))
   LogConfigHandler::getInstance().configure(p);
 
   // this should go into nowhere
-  LOG_WARN << "5" << endl;
+  OPENMS_LOG_WARN << "5" << endl;
 
   ostringstream& info_warn_stream = static_cast<ostringstream&>(LogConfigHandler::getInstance().getStream("testing_info_warn_stream"));
   String info_warn_stream_content(info_warn_stream.str());
@@ -151,7 +151,7 @@ START_SECTION((ostream& getStream(const String &stream_name)))
 
   LogConfigHandler::getInstance().configure(p);
 
-  LOG_INFO << "getStream 1" << endl;
+  OPENMS_LOG_INFO << "getStream 1" << endl;
 
   ostringstream& info_stream = static_cast<ostringstream&>(LogConfigHandler::getInstance().getStream("testing_getStream"));
   String info_content(info_stream.str());

--- a/src/tests/class_tests/openms/source/LogStream_test.cpp
+++ b/src/tests/class_tests/openms/source/LogStream_test.cpp
@@ -95,10 +95,10 @@ START_SECTION(([EXTRA] OpenMP - test))
     #endif
     for (int i=0;i<10000;++i)
     {
-      LOG_DEBUG << "1\n";
-      LOG_DEBUG << "2" << endl;
-      LOG_INFO << "1\n";
-      LOG_INFO << "2" << endl;
+      OPENMS_LOG_DEBUG << "1\n";
+      OPENMS_LOG_DEBUG << "2" << endl;
+      OPENMS_LOG_INFO << "1\n";
+      OPENMS_LOG_INFO << "2" << endl;
     }
   }
 
@@ -393,7 +393,7 @@ START_SECTION(([EXTRA]Test log caching))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] Macro test - LOG_FATAL_ERROR))
+START_SECTION(([EXTRA] Macro test - OPENMS_LOG_FATAL_ERROR))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
@@ -402,8 +402,8 @@ START_SECTION(([EXTRA] Macro test - LOG_FATAL_ERROR))
   {
     Log_fatal.insert(stream_by_logger);
 
-    LOG_FATAL_ERROR << "1\n";
-    LOG_FATAL_ERROR << "2" << endl;
+    OPENMS_LOG_FATAL_ERROR << "1\n";
+    OPENMS_LOG_FATAL_ERROR << "2" << endl;
   }
 
   StringList to_validate_list = ListUtils::create<String>(String(stream_by_logger.str()),'\n');
@@ -417,7 +417,7 @@ START_SECTION(([EXTRA] Macro test - LOG_FATAL_ERROR))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] Macro test - LOG_ERROR))
+START_SECTION(([EXTRA] Macro test - OPENMS_LOG_ERROR))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
@@ -428,14 +428,14 @@ START_SECTION(([EXTRA] Macro test - LOG_ERROR))
   {
     Log_error.insert(s);
 
-    LOG_ERROR << "1\n";
-    LOG_ERROR << "2" << endl;
+    OPENMS_LOG_ERROR << "1\n";
+    OPENMS_LOG_ERROR << "2" << endl;
   }
   TEST_FILE_EQUAL(filename.c_str(), OPENMS_GET_TEST_DATA_PATH("LogStream_test_general.txt"))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] Macro test - LOG_WARN))
+START_SECTION(([EXTRA] Macro test - OPENMS_LOG_WARN))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
@@ -446,14 +446,14 @@ START_SECTION(([EXTRA] Macro test - LOG_WARN))
   {
     Log_warn.insert(s);
 
-    LOG_WARN << "1\n";
-    LOG_WARN << "2" << endl;
+    OPENMS_LOG_WARN << "1\n";
+    OPENMS_LOG_WARN << "2" << endl;
   }
   TEST_FILE_EQUAL(filename.c_str(), OPENMS_GET_TEST_DATA_PATH("LogStream_test_general.txt"))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] Macro test - LOG_INFO))
+START_SECTION(([EXTRA] Macro test - OPENMS_LOG_INFO))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
@@ -469,14 +469,14 @@ START_SECTION(([EXTRA] Macro test - LOG_INFO))
   {
     Log_info.insert(s);
 
-    LOG_INFO << "1\n";
-    LOG_INFO << "2" << endl;
+    OPENMS_LOG_INFO << "1\n";
+    OPENMS_LOG_INFO << "2" << endl;
   }
   TEST_FILE_EQUAL(filename.c_str(), OPENMS_GET_TEST_DATA_PATH("LogStream_test_general.txt"))
 }
 END_SECTION
 
-START_SECTION(([EXTRA] Macro test - LOG_DEBUG))
+START_SECTION(([EXTRA] Macro test - OPENMS_LOG_DEBUG))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
@@ -490,8 +490,8 @@ START_SECTION(([EXTRA] Macro test - LOG_DEBUG))
   {
     Log_debug.insert(stream_by_logger);
 
-    LOG_DEBUG << "1\n";
-    LOG_DEBUG << "2" << endl;
+    OPENMS_LOG_DEBUG << "1\n";
+    OPENMS_LOG_DEBUG << "2" << endl;
   }
 
   StringList to_validate_list = ListUtils::create<String>(String(stream_by_logger.str()),'\n');

--- a/src/tests/class_tests/openms/source/Param_test.cpp
+++ b/src/tests/class_tests/openms/source/Param_test.cpp
@@ -1589,7 +1589,7 @@ END_SECTION
 // keep outside the scope of a single test to avoid destruction, leaving
 // Log_warn in an undefined state
 ostringstream os;
-// checkDefaults sends its warnings to LOG_WARN so we register our own
+// checkDefaults sends its warnings to OPENMS_LOG_WARN so we register our own
 // listener here to check the output
 Log_warn.remove(cout);
 Log_warn.insert(os);

--- a/src/topp/BaselineFilter.cpp
+++ b/src/topp/BaselineFilter.cpp
@@ -129,7 +129,7 @@ protected:
 
     if (ms_exp.empty())
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }

--- a/src/topp/CometAdapter.cpp
+++ b/src/topp/CometAdapter.cpp
@@ -369,11 +369,11 @@ protected:
     double bin_offset = getDoubleOption_("fragment_bin_offset");
     if (instrument == "low_res" && (bin_tol < 0.9 || bin_offset <= 0.2))
     {
-      LOG_WARN << "Fragment bin size or tolerance is quite low for low res instruments." << "\n";
+      OPENMS_LOG_WARN << "Fragment bin size or tolerance is quite low for low res instruments." << "\n";
     }
     else if (instrument == "high_res" && (bin_tol > 0.2 || bin_offset > 0.1))
     {
-      LOG_WARN << "Fragment bin size or tolerance is quite high for high res instruments." << "\n";
+      OPENMS_LOG_WARN << "Fragment bin size or tolerance is quite high for high res instruments." << "\n";
     };
 
     os << "fragment_bin_tol = " << bin_tol << "\n";               // binning to use on fragment ions
@@ -410,7 +410,7 @@ protected:
     int precursor_charge_min(0), precursor_charge_max(0);
     if (!parseRange_(getStringOption_("precursor_charge"), precursor_charge_min, precursor_charge_max))
     {
-      LOG_INFO << "precursor_charge range not set. Defaulting to 0:0 (disable charge filtering)." << endl;
+      OPENMS_LOG_INFO << "precursor_charge range not set. Defaulting to 0:0 (disable charge filtering)." << endl;
     }
 
     os << "scan_range = " << "0 0" << "\n";                        // start and scan scan range to search; 0 as 1st entry ignores parameter
@@ -423,7 +423,7 @@ protected:
     double digest_mass_range_min(600.0), digest_mass_range_max(5000.0);
     if (!parseRange_(getStringOption_("digest_mass_range"), digest_mass_range_min, digest_mass_range_max))
     {
-      LOG_INFO << "digest_mass_range not set. Defaulting to 600.0 5000.0." << endl;
+      OPENMS_LOG_INFO << "digest_mass_range not set. Defaulting to 600.0 5000.0." << endl;
     }
 
     os << "digest_mass_range = " << digest_mass_range_min << " " << digest_mass_range_max << "\n";        // MH+ peptide mass range to analyze
@@ -448,7 +448,7 @@ protected:
     double clear_mz_range_min(0.0), clear_mz_range_max(0.0);
     if (!parseRange_(getStringOption_("clear_mz_range"), clear_mz_range_min, clear_mz_range_max))
     {
-      LOG_INFO << "clear_mz_range not set. Defaulting to 0:0 (disable m/z filter)." << endl;
+      OPENMS_LOG_INFO << "clear_mz_range not set. Defaulting to 0:0 (disable m/z filter)." << endl;
     }
 
     os << "minimum_peaks = " << getIntOption_("minimum_peaks") << "\n";                      // required minimum number of peaks in spectrum to search (default 10)

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -346,7 +346,7 @@ protected:
         String run_id = pep_it->getIdentifier();
         if (!pep_it->hasRT() || !pep_it->hasMZ())
         {
-          LOG_FATAL_ERROR << "Peptide ID without RT and/or m/z information found in identification run '" + run_id + "'.\nMake sure that this information is included for all IDs when generating/converting search results. Aborting!" << endl;
+          OPENMS_LOG_FATAL_ERROR << "Peptide ID without RT and/or m/z information found in identification run '" + run_id + "'.\nMake sure that this information is included for all IDs when generating/converting search results. Aborting!" << endl;
           return INCOMPATIBLE_INPUT_DATA;
         }
 

--- a/src/topp/ConsensusMapNormalizer.cpp
+++ b/src/topp/ConsensusMapNormalizer.cpp
@@ -148,7 +148,7 @@ protected:
     {
       if (acc_filter != "" || desc_filter != "")
       {
-        LOG_WARN << endl << "NOTE: Accession / description filtering is not supported in quantile normalization mode. Ignoring filters." << endl << endl;
+        OPENMS_LOG_WARN << endl << "NOTE: Accession / description filtering is not supported in quantile normalization mode. Ignoring filters." << endl << endl;
       }
       ConsensusMapNormalizerAlgorithmQuantile::normalizeMaps(map);
     }

--- a/src/topp/EICExtractor.cpp
+++ b/src/topp/EICExtractor.cpp
@@ -233,20 +233,20 @@ public:
     // number of out_debug_TIC files and input files must be identical
     /*if (out_TIC_debug.size() > 0 && in.size() != out_TIC_debug.size())
     {
-        LOG_FATAL_ERROR << "Error: number of input file 'in' and auto_rt:out_debug_TIC files must be identical!" << std::endl;
+        OPENMS_LOG_FATAL_ERROR << "Error: number of input file 'in' and auto_rt:out_debug_TIC files must be identical!" << std::endl;
         return ILLEGAL_PARAMETERS;
     }*/
 
     // number of header files and input files must be identical
     if (in_header.size() > 0 && in.size() != in_header.size())
     {
-      LOG_FATAL_ERROR << "Error: number of input file 'in' and 'in_header' files must be identical!" << std::endl;
+      OPENMS_LOG_FATAL_ERROR << "Error: number of input file 'in' and 'in_header' files must be identical!" << std::endl;
       return ILLEGAL_PARAMETERS;
     }
 
     if (!getFlag_("auto_rt:enabled") && !out_TIC_debug.empty())
     {
-      LOG_FATAL_ERROR << "Error: TIC output file requested, but auto_rt is not enabled! Either do not request the file or switch on 'auto_rt:enabled'." << std::endl;
+      OPENMS_LOG_FATAL_ERROR << "Error: TIC output file requested, but auto_rt is not enabled! Either do not request the file or switch on 'auto_rt:enabled'." << std::endl;
       return ILLEGAL_PARAMETERS;
     }
 
@@ -277,7 +277,7 @@ public:
 
       if (exp.empty())
       {
-        LOG_WARN << "The given file does not contain any conventional peak data, but might"
+        OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                     " contain chromatograms. This tool currently cannot handle them, sorry." << std::endl;
         return INCOMPATIBLE_INPUT_DATA;
       }
@@ -317,14 +317,14 @@ public:
 
         if (tics_pp.size())
         {
-          LOG_INFO << "Found " << tics_pp.size() << " auto-rt peaks at: ";
-          for (Size ipp = 0; ipp != tics_pp.size(); ++ipp) LOG_INFO << " " << tics_pp[ipp].getMZ();
+          OPENMS_LOG_INFO << "Found " << tics_pp.size() << " auto-rt peaks at: ";
+          for (Size ipp = 0; ipp != tics_pp.size(); ++ipp) OPENMS_LOG_INFO << " " << tics_pp[ipp].getMZ();
         }
         else
         {
-          LOG_INFO << "Found no auto-rt peaks. Change threshold parameters!";
+          OPENMS_LOG_INFO << "Found no auto-rt peaks. Change threshold parameters!";
         }
-        LOG_INFO << std::endl;
+        OPENMS_LOG_INFO << std::endl;
 
         if (!out_TIC_debug.empty()) // if debug file was given
         { // store intermediate steps for debug
@@ -348,7 +348,7 @@ public:
           for (Size id = 0; id < out_debug.size(); ++id) out_debug[id].setNativeID(String("spectrum=") + id);
 
           mzml_file.store(out_TIC_debug, out_debug);
-          LOG_DEBUG << "Storing debug AUTO-RT: " << out_TIC_debug << std::endl;
+          OPENMS_LOG_DEBUG << "Storing debug AUTO-RT: " << out_TIC_debug << std::endl;
         }
 
         // add target EICs: for each m/z with no/negative RT, add all combinations of that m/z with auto-RTs
@@ -366,7 +366,7 @@ public:
             }
             else
             {
-              LOG_INFO << "Found duplicate m/z entry (" << cit->getMZ() << ") for auto-rt. Skipping ..." << std::endl;
+              OPENMS_LOG_INFO << "Found duplicate m/z entry (" << cit->getMZ() << ") for auto-rt. Skipping ..." << std::endl;
               continue;
             }
 
@@ -381,7 +381,7 @@ public:
           }
           else
           { // default feature with no auto-rt
-            LOG_INFO << "copying feature with RT " << cit->getRT() << std::endl;
+            OPENMS_LOG_INFO << "copying feature with RT " << cit->getRT() << std::endl;
             cm.push_back(*cit);
           }
         }
@@ -456,7 +456,7 @@ public:
             //std::cerr << "ppm: " << itt.getRT() << " " <<  itt->getMZ() << " " << itt->getIntensity() << std::endl;
           }
 
-          if ((SignedSize)mz.size() > (low + high + 1)) LOG_WARN << "Compound " << i << " has overlapping peaks [" << mz.size() << "/" << low + high + 1 << "]" << std::endl;
+          if ((SignedSize)mz.size() > (low + high + 1)) OPENMS_LOG_WARN << "Compound " << i << " has overlapping peaks [" << mz.size() << "/" << low + high + 1 << "]" << std::endl;
 
           if (!mz.empty())
           {
@@ -483,7 +483,7 @@ public:
                          String(max_peak.getIntensity());
       }
 
-      if (not_found) LOG_INFO << "Missing peaks for " << not_found << " compounds in file '" << in[fi] << "'.\n";
+      if (not_found) OPENMS_LOG_INFO << "Missing peaks for " << not_found << " compounds in file '" << in[fi] << "'.\n";
     }
 
     //-------------------------------------------------------------

--- a/src/topp/FalseDiscoveryRate.cpp
+++ b/src/topp/FalseDiscoveryRate.cpp
@@ -169,7 +169,7 @@ protected:
 
         if (protein_fdr < 1)
         {
-          LOG_INFO << "FDR control: Filtering proteins..." << endl;
+          OPENMS_LOG_INFO << "FDR control: Filtering proteins..." << endl;
           IDFilter::filterHitsByScore(prot_ids, protein_fdr);
         }
       }
@@ -181,14 +181,14 @@ protected:
 
         if (psm_fdr < 1)
         {
-          LOG_INFO << "FDR control: Filtering PSMs..." << endl;
+          OPENMS_LOG_INFO << "FDR control: Filtering PSMs..." << endl;
           IDFilter::filterHitsByScore(pep_ids, psm_fdr);
         }
       }
     }
     catch (Exception::MissingInformation)
     {
-      LOG_FATAL_ERROR << "FalseDiscoveryRate failed due to missing information (see above).\n";
+      OPENMS_LOG_FATAL_ERROR << "FalseDiscoveryRate failed due to missing information (see above).\n";
       return INCOMPATIBLE_INPUT_DATA;
     }
 
@@ -218,7 +218,7 @@ protected:
                                                  prot_it->getHits());
       if (!valid)
       {
-        LOG_WARN << "Warning: While updating protein groups, some prot_ids were removed from groups that are still present. "
+        OPENMS_LOG_WARN << "Warning: While updating protein groups, some prot_ids were removed from groups that are still present. "
                  << "The new grouping (especially the group probabilities) may not be completely valid any more." 
                  << endl;
       }
@@ -228,14 +228,14 @@ protected:
 
       if (!valid)
       {
-        LOG_WARN << "Warning: While updating indistinguishable prot_ids, some prot_ids were removed from groups that are still present. "
+        OPENMS_LOG_WARN << "Warning: While updating indistinguishable prot_ids, some prot_ids were removed from groups that are still present. "
                  << "The new grouping (especially the group probabilities) may not be completely valid any more." 
                  << endl;
       }
     }
 
     // some stats
-    LOG_INFO << "Before filtering:\n"
+    OPENMS_LOG_INFO << "Before filtering:\n"
              << n_prot_ids << " protein identification(s) with "
              << n_prot_hits << " protein hit(s),\n"
              << n_pep_ids << " peptide identification(s) with "
@@ -246,7 +246,7 @@ protected:
              << pep_ids.size() << " peptide identification(s) with "
              << IDFilter::countHits(pep_ids) << " pep_ids hit(s)." << endl;
 
-    LOG_INFO << "Writing filtered output..." << endl;
+    OPENMS_LOG_INFO << "Writing filtered output..." << endl;
     IdXMLFile().store(out, prot_ids, pep_ids);
     return EXECUTION_OK;
   }

--- a/src/topp/FeatureFinderCentroided.cpp
+++ b/src/topp/FeatureFinderCentroided.cpp
@@ -237,10 +237,10 @@ protected:
         {
           vector<String> keys;
           it->getKeys(keys);
-          LOG_INFO << "Feature " << it->getUniqueId() << endl;
+          OPENMS_LOG_INFO << "Feature " << it->getUniqueId() << endl;
           for (Size i = 0; i < keys.size(); i++)
           {
-            LOG_INFO << "  " << keys[i] << " = " << it->getMetaValue(keys[i]) << endl;
+            OPENMS_LOG_INFO << "  " << keys[i] << " = " << it->getMetaValue(keys[i]) << endl;
           }
         }
       }

--- a/src/topp/FeatureFinderIdentification.cpp
+++ b/src/topp/FeatureFinderIdentification.cpp
@@ -224,7 +224,7 @@ protected:
       //-------------------------------------------------------------
       // load input
       //-------------------------------------------------------------
-      LOG_INFO << "Loading input data..." << endl;
+      OPENMS_LOG_INFO << "Loading input data..." << endl;
       MzMLFile mzml;
       mzml.setLogType(log_type_);
       mzml.getOptions().addMSLevel(1);
@@ -280,9 +280,9 @@ protected:
       //-------------------------------------------------------------
       // load feature candidates
       //-------------------------------------------------------------
-      LOG_INFO << "Reading feature candidates from a previous run..." << endl;
+      OPENMS_LOG_INFO << "Reading feature candidates from a previous run..." << endl;
       FeatureXMLFile().load(candidates_in, features);
-      LOG_INFO << "Found " << features.size() << " feature candidates in total."
+      OPENMS_LOG_INFO << "Found " << features.size() << " feature candidates in total."
                << endl;
       ffid_algo.runOnCandidates(features);
     }
@@ -291,7 +291,7 @@ protected:
     // write output
     //-------------------------------------------------------------
 
-    LOG_INFO << "Writing final results..." << endl;
+    OPENMS_LOG_INFO << "Writing final results..." << endl;
     FeatureXMLFile().store(out, features);
 
 

--- a/src/topp/FeatureFinderIsotopeWavelet.cpp
+++ b/src/topp/FeatureFinderIsotopeWavelet.cpp
@@ -177,10 +177,10 @@ protected:
         {
           vector<String> keys;
           it->getKeys(keys);
-          LOG_INFO << "Feature " << it->getUniqueId() << endl;
+          OPENMS_LOG_INFO << "Feature " << it->getUniqueId() << endl;
           for (Size i = 0; i < keys.size(); i++)
           {
-            LOG_INFO << "  " << keys[i] << " = " << it->getMetaValue(keys[i]) << endl;
+            OPENMS_LOG_INFO << "  " << keys[i] << " = " << it->getMetaValue(keys[i]) << endl;
           }
         }
       }

--- a/src/topp/FeatureFinderMRM.cpp
+++ b/src/topp/FeatureFinderMRM.cpp
@@ -167,10 +167,10 @@ protected:
         {
           vector<String> keys;
           it->getKeys(keys);
-          LOG_INFO << "Feature " << it->getUniqueId() << endl;
+          OPENMS_LOG_INFO << "Feature " << it->getUniqueId() << endl;
           for (Size i = 0; i < keys.size(); i++)
           {
-            LOG_INFO << "  " << keys[i] << " = " << it->getMetaValue(keys[i]) << endl;
+            OPENMS_LOG_INFO << "  " << keys[i] << " = " << it->getMetaValue(keys[i]) << endl;
           }
         }
       }

--- a/src/topp/FeatureFinderMetabo.cpp
+++ b/src/topp/FeatureFinderMetabo.cpp
@@ -187,7 +187,7 @@ protected:
 
     if (ms_peakmap.empty())
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }
@@ -269,7 +269,7 @@ protected:
       }
       if (ffm_param.getValue("use_smoothed_intensities").toBool())
       {
-        LOG_WARN << "Without EPD, smoothing is not supported. Setting 'use_smoothed_intensities' to false!" << std::endl;
+        OPENMS_LOG_WARN << "Without EPD, smoothing is not supported. Setting 'use_smoothed_intensities' to false!" << std::endl;
         ffm_param.setValue("use_smoothed_intensities", "false");
       }
     }
@@ -302,16 +302,16 @@ protected:
     {
       if (ffm_param.getValue("remove_single_traces").toBool() == false)
       { 
-        LOG_ERROR << "FF-Metabo: Internal error. Not all mass traces have been assembled to features! Aborting." << std::endl;
+        OPENMS_LOG_ERROR << "FF-Metabo: Internal error. Not all mass traces have been assembled to features! Aborting." << std::endl;
         return UNEXPECTED_RESULT;
       }
       else
       {
-        LOG_INFO << "FF-Metabo: " << (m_traces_final.size() - trace_count) << " unassembled traces have been removed." << std::endl;
+        OPENMS_LOG_INFO << "FF-Metabo: " << (m_traces_final.size() - trace_count) << " unassembled traces have been removed." << std::endl;
       }     
     }
 
-    LOG_INFO << "-- FF-Metabo stats --\n"
+    OPENMS_LOG_INFO << "-- FF-Metabo stats --\n"
              << "Input traces:    " << m_traces_final.size() << "\n"
              << "Output features: " << feat_map.size() << " (total trace count: " << trace_count << ")" << std::endl;
 
@@ -332,7 +332,7 @@ protected:
         }
         else
         {
-            LOG_ERROR << "FF-Metabo: Internal error. The number of features (" << feat_chromatograms.size() << ") and chromatograms (" << feat_map.size() << ") are different! Aborting." << std::endl;
+            OPENMS_LOG_ERROR << "FF-Metabo: Internal error. The number of features (" << feat_chromatograms.size() << ") and chromatograms (" << feat_map.size() << ") are different! Aborting." << std::endl;
             return UNEXPECTED_RESULT;
         }
     }

--- a/src/topp/FeatureFinderMultiplex.cpp
+++ b/src/topp/FeatureFinderMultiplex.cpp
@@ -235,7 +235,7 @@ public:
     levels.push_back(1);
     file.getOptions().setMSLevels(levels);
     
-    LOG_DEBUG << "Loading input..." << endl;
+    OPENMS_LOG_DEBUG << "Loading input..." << endl;
     file.setLogType(log_type_);
     file.load(in_, exp);
 

--- a/src/topp/FeatureLinkerBase.cpp
+++ b/src/topp/FeatureLinkerBase.cpp
@@ -150,7 +150,7 @@ protected:
   
     if (file_type == FileTypes::FEATUREXML)
     {
-      LOG_INFO << "Linking " << ins.size() << " featureXMLs." << endl;
+      OPENMS_LOG_INFO << "Linking " << ins.size() << " featureXMLs." << endl;
   
       //-------------------------------------------------------------
       // Extract (optional) fraction identifiers and associate with featureXMLs
@@ -207,7 +207,7 @@ protected:
         // associate mzML file with map i in consensusXML
         if (ms_runs.size() > 1 || ms_runs.empty())
         {
-          LOG_WARN << "Exactly one MS runs should be associated with a FeatureMap. " 
+          OPENMS_LOG_WARN << "Exactly one MS runs should be associated with a FeatureMap. " 
             << ms_runs.size() 
             << " provided." << endl;
         }
@@ -337,14 +337,14 @@ protected:
       ++num_consfeat_of_size[cmit->size()];
     }
 
-    LOG_INFO << "Number of consensus features:" << endl;
+    OPENMS_LOG_INFO << "Number of consensus features:" << endl;
     for (map<Size, UInt>::reverse_iterator i = num_consfeat_of_size.rbegin();
          i != num_consfeat_of_size.rend(); ++i)
     {
-      LOG_INFO << "  of size " << setw(2) << i->first << ": " << setw(6) 
+      OPENMS_LOG_INFO << "  of size " << setw(2) << i->first << ": " << setw(6) 
                << i->second << endl;
     }
-    LOG_INFO << "  total:      " << setw(6) << out_map.size() << endl;
+    OPENMS_LOG_INFO << "  total:      " << setw(6) << out_map.size() << endl;
 
     return EXECUTION_OK;
   }

--- a/src/topp/FeatureLinkerUnlabeled.cpp
+++ b/src/topp/FeatureLinkerUnlabeled.cpp
@@ -325,12 +325,12 @@ protected:
       ++num_consfeat_of_size[cmit->size()];
     }
 
-    LOG_INFO << "Number of consensus features:" << endl;
+    OPENMS_LOG_INFO << "Number of consensus features:" << endl;
     for (map<Size, UInt>::reverse_iterator i = num_consfeat_of_size.rbegin(); i != num_consfeat_of_size.rend(); ++i)
     {
-      LOG_INFO << "  of size " << setw(2) << i->first << ": " << setw(6) << i->second << endl;
+      OPENMS_LOG_INFO << "  of size " << setw(2) << i->first << ": " << setw(6) << i->second << endl;
     }
-    LOG_INFO << "  total:      " << setw(6) << out_map.size() << endl;
+    OPENMS_LOG_INFO << "  total:      " << setw(6) << out_map.size() << endl;
 
     delete algorithm;
 

--- a/src/topp/FidoAdapter.cpp
+++ b/src/topp/FidoAdapter.cpp
@@ -194,7 +194,7 @@ protected:
       {
         if (!warned_once)
         {
-          LOG_WARN << "Warning: Scores of peptide hits seem to be posterior "
+          OPENMS_LOG_WARN << "Warning: Scores of peptide hits seem to be posterior "
             "error probabilities. Converting to (positive) posterior "
             "probabilities." << endl;
           warned_once = true;
@@ -223,7 +223,7 @@ protected:
           "matches detected (problem: " + error_reason + ").\nFido requires "
           "probabilities as scores, e.g. as produced by "
           "IDPosteriorErrorProbability with the 'prob_correct' option.";
-        LOG_ERROR << msg << endl;
+        OPENMS_LOG_ERROR << msg << endl;
         throw Exception::MissingInformation(__FILE__, __LINE__,
                                             OPENMS_PRETTY_FUNCTION, msg);
       }
@@ -269,7 +269,7 @@ protected:
         String msg = "Error: All protein hits must be annotated with target/"
           "decoy meta data. Run PeptideIndexer with the 'annotate_proteins' "
           "option to accomplish this.";
-        LOG_ERROR << msg << endl;
+        OPENMS_LOG_ERROR << msg << endl;
         throw Exception::MissingInformation(__FILE__, __LINE__,
                                             OPENMS_PRETTY_FUNCTION, msg);
       }
@@ -279,7 +279,7 @@ protected:
     {
       String msg = "Error: No target proteins found. Fido needs both targets "
         "and decoys.";
-      LOG_ERROR << msg << endl;
+      OPENMS_LOG_ERROR << msg << endl;
       throw Exception::MissingInformation(__FILE__, __LINE__,
                                           OPENMS_PRETTY_FUNCTION, msg);
     }
@@ -287,7 +287,7 @@ protected:
     {
       String msg = "Error: No decoy proteins found. Fido needs both targets "
         "and decoys.";
-      LOG_ERROR << msg << endl;
+      OPENMS_LOG_ERROR << msg << endl;
       throw Exception::MissingInformation(__FILE__, __LINE__,
                                           OPENMS_PRETTY_FUNCTION, msg);
     }
@@ -324,7 +324,7 @@ protected:
     // different values:
     QStringList current_fido_params = QStringList(fido_params);
 
-    LOG_INFO << "Generating temporary files for Fido..." << endl;
+    OPENMS_LOG_INFO << "Generating temporary files for Fido..." << endl;
     String num = counter ? "." + String(counter) : "";
     String input_graph = temp_dir + "fido_input_graph" + num + ".txt";
     current_fido_params.replaceInStrings("INPUT_GRAPH",
@@ -337,9 +337,9 @@ protected:
       current_fido_params.replaceInStrings("INPUT_PROTEINS",
                                            input_proteins.toQString());
       writeProteinLists_(protein, input_proteins);
-      LOG_INFO << "Running Fido with parameter estimation..." << endl;
+      OPENMS_LOG_INFO << "Running Fido with parameter estimation..." << endl;
     }
-    else LOG_INFO << "Running Fido with fixed parameters..." << endl;
+    else OPENMS_LOG_INFO << "Running Fido with fixed parameters..." << endl;
 
     QProcess fido;
     fido.start(exe.toQString(), current_fido_params);
@@ -348,7 +348,7 @@ protected:
     {
       String cmd = exe + " \"" + String(current_fido_params.join("\" \"")) +
         "\"";
-      LOG_ERROR << "Fatal error running Fido (command: '" + cmd + "').\n"
+      OPENMS_LOG_ERROR << "Fatal error running Fido (command: '" + cmd + "').\n"
                 << "Does the Fido executable exist?" << endl;
       return false;
     }
@@ -358,7 +358,7 @@ protected:
     if (choose_params) // get relevant parts of parameter search output
     {
       String params_output = QString(fido.readAllStandardError());
-      LOG_INFO << "Fido parameter search:" << endl;
+      OPENMS_LOG_INFO << "Fido parameter search:" << endl;
       if (debug_level_ > 1)
       {
         String output_status = temp_dir + "fido_status" + num + ".txt";
@@ -373,13 +373,13 @@ protected:
       {
         if (lines[0].hasPrefix("caught an exception"))
         {
-          LOG_ERROR << "Error running Fido: '" + lines[0] + "'" << endl;
+          OPENMS_LOG_ERROR << "Error running Fido: '" + lines[0] + "'" << endl;
           return false;
         }
-        if (lines[0].hasPrefix("Warning:")) LOG_WARN << lines[0] << endl;
+        if (lines[0].hasPrefix("Warning:")) OPENMS_LOG_WARN << lines[0] << endl;
         if (lines.back().hasPrefix("Using best gamma, alpha, beta ="))
         {
-          LOG_INFO << lines.back() << endl;
+          OPENMS_LOG_INFO << lines.back() << endl;
           stringstream ss;
           ss << lines.back().suffix('=');
           ss >> prob_protein >> prob_peptide >> prob_spurious;
@@ -387,7 +387,7 @@ protected:
       }
     }
 
-    LOG_INFO << "Parsing Fido results and writing output..." << endl;
+    OPENMS_LOG_INFO << "Parsing Fido results and writing output..." << endl;
     String output = QString(fido.readAllStandardOutput());
     if (debug_level_ > 1)
     {
@@ -472,7 +472,7 @@ protected:
     protein.setMetaValue("Fido_prob_protein", prob_protein);
     protein.setMetaValue("Fido_prob_peptide", prob_peptide);
     protein.setMetaValue("Fido_prob_spurious", prob_spurious);
-    LOG_INFO << "Inferred " << protein_counter << " proteins in "
+    OPENMS_LOG_INFO << "Inferred " << protein_counter << " proteins in "
              << groups.size() << " groups ("
              << ((keep_zero_group && zero_proteins) ? "including " : "")
              << zero_proteins << " proteins with probability zero"
@@ -482,7 +482,7 @@ protected:
     // Do post-processing on groups if specified
     if (greedy_flag)
     {
-      LOG_INFO << "Resolving ambiguity groups greedily on Fido output..."
+      OPENMS_LOG_INFO << "Resolving ambiguity groups greedily on Fido output..."
                << endl;
       PeptideProteinResolution graph = PeptideProteinResolution();
       graph.buildGraph(protein, peptides);
@@ -522,11 +522,11 @@ protected:
     vector<ProteinIdentification> proteins;
     vector<PeptideIdentification> peptides;
 
-    LOG_INFO << "Reading input data..." << endl;
+    OPENMS_LOG_INFO << "Reading input data..." << endl;
     IdXMLFile().load(in, proteins, peptides);
     if (proteins.empty() || peptides.empty())
     {
-      LOG_ERROR << "Error: Input file '" << in
+      OPENMS_LOG_ERROR << "Error: Input file '" << in
                 << "' should contain both protein and peptide data." << endl;
       return INPUT_FILE_EMPTY;
     }
@@ -607,7 +607,7 @@ protected:
       for (vector<ProteinIdentification>::iterator prot_it = proteins.begin();
            prot_it != proteins.end(); ++prot_it, ++counter)
       {
-        LOG_INFO << "Protein identification run " << counter << ":" << endl;
+        OPENMS_LOG_INFO << "Protein identification run " << counter << ":" << endl;
         fido_success = runFido_(*prot_it, peptides, choose_params, executable,
                                 fido_params, prob_protein, prob_peptide,
                                 prob_spurious, temp_dir, keep_zero_group,
@@ -667,18 +667,18 @@ protected:
     // clean up temporary files:
     if (debug_level_ > 1)
     {
-      LOG_DEBUG << "Keeping temporary files at '" << temp_dir
+      OPENMS_LOG_DEBUG << "Keeping temporary files at '" << temp_dir
                 << "'. Set debug level to 0 or 1 to remove them." << endl;
     }
     else
     {
-      LOG_INFO << "Removing temporary files..." << endl;
+      OPENMS_LOG_INFO << "Removing temporary files..." << endl;
       File::removeDirRecursively(temp_dir);
       if (debug_level_ == 1)
       {
         String msg = "Set debug level to 2 or higher to keep temporary files "
           "at '" + temp_dir + "'.";
-        LOG_DEBUG << msg << endl;
+        OPENMS_LOG_DEBUG << msg << endl;
       }
     }
 

--- a/src/topp/FileConverter.cpp
+++ b/src/topp/FileConverter.cpp
@@ -136,7 +136,7 @@ String extractCachedMetaFilename(const String& in)
   in.split(".cachedMzML", split_out);
   if (split_out.size() != 2)
   {
-    LOG_ERROR << "Cannot deduce base path from input '" << in 
+    OPENMS_LOG_ERROR << "Cannot deduce base path from input '" << in 
       << "' (note that '.cachedMzML' should only occur once as the final ending)" << std::endl;
     return "";
   }
@@ -492,7 +492,7 @@ protected:
       // Sanity check
       if (exp.size() != tmp_exp.size())
       {
-        LOG_ERROR << "Paired input files do not match, cannot convert: " << in_meta << " and " << in << std::endl;
+        OPENMS_LOG_ERROR << "Paired input files do not match, cannot convert: " << in_meta << " and " << in << std::endl;
         return ILLEGAL_PARAMETERS;
       }
 
@@ -803,7 +803,7 @@ protected:
     {
       if (fm.size() > 0 && cm.size() > 0)
       {
-        LOG_ERROR << "Internal error: cannot decide on container (Consensus or Feature)! This is a bug. Please report it!";
+        OPENMS_LOG_ERROR << "Internal error: cannot decide on container (Consensus or Feature)! This is a bug. Please report it!";
         return INTERNAL_ERROR;
       }
       if (fm.size() > 0) EDTAFile().store(out, fm);
@@ -828,7 +828,7 @@ protected:
       // IBSpectra selected as output type
       if (in_type != FileTypes::CONSENSUSXML)
       {
-        LOG_ERROR << "Incompatible input data: FileConverter can only convert consensusXML files to ibspectra format.";
+        OPENMS_LOG_ERROR << "Incompatible input data: FileConverter can only convert consensusXML files to ibspectra format.";
         return INCOMPATIBLE_INPUT_DATA;
       }
 

--- a/src/topp/FileFilter.cpp
+++ b/src/topp/FileFilter.cpp
@@ -818,7 +818,7 @@ protected:
         exp.sortSpectra(true);
         if (getFlag_("peak_options:sort_peaks"))
         {
-          LOG_INFO << "Info: Using 'peak_options:sort_peaks' in combination with 'sort' is redundant, since 'sort' implies 'peak_options:sort_peaks'." << std::endl;
+          OPENMS_LOG_INFO << "Info: Using 'peak_options:sort_peaks' in combination with 'sort' is redundant, since 'sort' implies 'peak_options:sort_peaks'." << std::endl;
         }
       }
       else if (getFlag_("peak_options:sort_peaks"))
@@ -850,7 +850,7 @@ protected:
       String id_blacklist = getStringOption_("id:blacklist");
       if (!id_blacklist.empty())
       {
-        LOG_INFO << "Filtering out MS2 spectra from raw file using blacklist ..." << std::endl;
+        OPENMS_LOG_INFO << "Filtering out MS2 spectra from raw file using blacklist ..." << std::endl;
         bool blacklist_imperfect = getFlag_("id:blacklist_imperfect");
 
         int ret = filterByBlackList(exp, id_blacklist, blacklist_imperfect, getDoubleOption_("id:rt"), getDoubleOption_("id:mz"));
@@ -861,7 +861,7 @@ protected:
       String consensus_blackorwhitelist = getStringOption_("consensus:blackorwhitelist:file");
       if (!consensus_blackorwhitelist.empty())
       {
-        LOG_INFO << "Filtering MS2 spectra from raw file using consensus features ..." << std::endl;
+        OPENMS_LOG_INFO << "Filtering MS2 spectra from raw file using consensus features ..." << std::endl;
         IntList il = getIntList_("consensus:blackorwhitelist:maps");
         set<UInt64> maps(il.begin(), il.end());
         double rt_tol = getDoubleOption_("consensus:blackorwhitelist:rt");
@@ -883,7 +883,7 @@ protected:
       String lib_file_name = getStringOption_("spectra:blackorwhitelist:file");
       if (!lib_file_name.empty())
       {
-        LOG_INFO << "Filtering MS2 spectra based on precursor rt, mz, and spectral similarity ..." << std::endl;
+        OPENMS_LOG_INFO << "Filtering MS2 spectra based on precursor rt, mz, and spectral similarity ..." << std::endl;
         double tol_rt = getDoubleOption_("spectra:blackorwhitelist:rt");
         double tol_mz = getDoubleOption_("spectra:blackorwhitelist:mz");
         double tol_sim = getDoubleOption_("spectra:blackorwhitelist:similarity_threshold");
@@ -1165,7 +1165,7 @@ protected:
     {
       if (!(peptide_ids[i].hasRT() && peptide_ids[i].hasMZ()))
       {
-        LOG_ERROR << "Identifications given in 'id:blacklist' are missing RT and/or MZ coordinates. Cannot do blacklisting without. Quitting." << std::endl;
+        OPENMS_LOG_ERROR << "Identifications given in 'id:blacklist' are missing RT and/or MZ coordinates. Cannot do blacklisting without. Quitting." << std::endl;
         return INCOMPATIBLE_INPUT_DATA;
       }
       Peak2D p;
@@ -1205,18 +1205,18 @@ protected:
       }
     }
 
-    LOG_INFO << "Removing " << blacklist_idx.size() << " MS2 spectra." << endl;
+    OPENMS_LOG_INFO << "Removing " << blacklist_idx.size() << " MS2 spectra." << endl;
     if (ids_covered.size() != ids.size())
     {
       if (!blacklist_imperfect)
       {
-        LOG_ERROR << "Covered only " << ids_covered.size() << "/" << ids.size() << " IDs. Check if your input files (raw + ids) match and if your tolerances ('rt' and 'mz') are set properly.\n"
+        OPENMS_LOG_ERROR << "Covered only " << ids_covered.size() << "/" << ids.size() << " IDs. Check if your input files (raw + ids) match and if your tolerances ('rt' and 'mz') are set properly.\n"
                   << "If you are sure unmatched ids are ok, set the 'id:blacklist_imperfect' flag!" << std::endl;
         return UNEXPECTED_RESULT;
       }
       else
       {
-        LOG_WARN << "Covered only " << ids_covered.size() << "/" << ids.size() << " IDs. Check if your input files (raw + ids) match and if your tolerances ('rt' and 'mz') are set properly.\n"
+        OPENMS_LOG_WARN << "Covered only " << ids_covered.size() << "/" << ids.size() << " IDs. Check if your input files (raw + ids) match and if your tolerances ('rt' and 'mz') are set properly.\n"
                  << "Remove the 'id:blacklist_imperfect' flag of you want this to be an error!" << std::endl;
       }
     }

--- a/src/topp/FileInfo.cpp
+++ b/src/topp/FileInfo.cpp
@@ -1589,7 +1589,7 @@ protected:
     else if (out == "" && out_tsv != "")
     {
       ofstream os_tsv(out_tsv.c_str());
-      ret = outputTo_(LOG_INFO, os_tsv);
+      ret = outputTo_(OPENMS_LOG_INFO, os_tsv);
       os_tsv.close();
     }
     else
@@ -1597,7 +1597,7 @@ protected:
       // Output stream with null output
       boost::iostreams::filtering_ostream os_tsv;
       os_tsv.push(boost::iostreams::null_sink());
-      ret = outputTo_(LOG_INFO, os_tsv);
+      ret = outputTo_(OPENMS_LOG_INFO, os_tsv);
     }
     return ret;
   }

--- a/src/topp/GNPSExport.cpp
+++ b/src/topp/GNPSExport.cpp
@@ -209,7 +209,7 @@ protected:
           if (map_index != -1 && spectrum_index != -1)
           {
             // TEMP: log debug map index and spectrum index values once they are found
-            LOG_DEBUG << "map index\t" << map_index << "\tspectrum index\t" << spectrum_index << endl;
+            OPENMS_LOG_DEBUG << "map index\t" << map_index << "\tspectrum index\t" << spectrum_index << endl;
 
             // retrieve spectrum for current peptide annotation
             auto ms2_scan = ms_maps[map_index][spectrum_index];
@@ -316,7 +316,7 @@ protected:
 
             BinnedSpectralContrastAngle bsca;
             double cosine_sim = bsca(binned_highest_int, binned_spectrum);
-            // LOG_DEBUG << cosine_sim << " >= " << cos_sim << endl;
+            // OPENMS_LOG_DEBUG << cosine_sim << " >= " << cos_sim << endl;
 
             // compare calculated cosine sim to binned highest int
             if (cosine_sim >= cos_sim)

--- a/src/topp/GenericWrapper.cpp
+++ b/src/topp/GenericWrapper.cpp
@@ -324,7 +324,7 @@ protected:
   {
     if (return_code != EXECUTION_OK)
     {
-      LOG_ERROR << "\n" << tde_.text_fail << "\n";
+      OPENMS_LOG_ERROR << "\n" << tde_.text_fail << "\n";
     }
     return return_code;
   }
@@ -369,7 +369,7 @@ protected:
         String in = it->value.toString().trim(); // will give '[]' for empty lists (hack, but DataValue class does not offer a convenient query)
         if (in.empty() || in == "[]") // any required parameter should have a value
         {
-          LOG_ERROR << "The INI-parameter 'ETool:" << it->name << "' is required, but was not given! Aborting ..." << std::endl;
+          OPENMS_LOG_ERROR << "The INI-parameter 'ETool:" << it->name << "' is required, but was not given! Aborting ..." << std::endl;
           return wrapExit(CANNOT_WRITE_OUTPUT_FILE);
         }
         else if ((it->tags).count("input file") > 0) // any required input file should exist
@@ -384,14 +384,14 @@ protected:
               ifs = it->value;
               break;
             default:
-              LOG_ERROR << "The INI-parameter 'ETool:" << it->name << "' is tagged as input file and thus must be a string! Aborting ...";
+              OPENMS_LOG_ERROR << "The INI-parameter 'ETool:" << it->name << "' is tagged as input file and thus must be a string! Aborting ...";
               return wrapExit(ILLEGAL_PARAMETERS);
           }
           for (StringList::const_iterator itf = ifs.begin(); itf != ifs.end(); ++itf)
           {
             if (!File::exists(*itf))
             {
-              LOG_ERROR << "Input file '" << *itf << "' does not exist! Aborting ...";
+              OPENMS_LOG_ERROR << "Input file '" << *itf << "' does not exist! Aborting ...";
               return wrapExit(INPUT_FILE_NOT_FOUND);
             }
           }
@@ -410,18 +410,18 @@ protected:
       }
     }
 
-    LOG_INFO << tde_.text_startup << "\n";
+    OPENMS_LOG_INFO << tde_.text_startup << "\n";
 
     String command_args = tde_.commandline;
     // check for double spaces and warn
     if (command_args.hasSubstring("  "))
     {
-      LOG_WARN << "Command line contains double spaces, which is not allowed. Condensing...\n";
+      OPENMS_LOG_WARN << "Command line contains double spaces, which is not allowed. Condensing...\n";
       while (command_args.hasSubstring("  "))
       {
         command_args.substitute("  ", " ");
       }
-      LOG_WARN << "result: " << command_args << std::endl;
+      OPENMS_LOG_WARN << "result: " << command_args << std::endl;
     }
 
     writeDebug_("CommandLine from ttd (unprocessed): " + command_args, 1);
@@ -447,7 +447,7 @@ protected:
       {
         if (!File::remove(tmp_location))
         {
-          LOG_ERROR << "While writing a tmp file: Cannot remove conflicting file '" + tmp_location + "'. Check permissions! Aborting ...";
+          OPENMS_LOG_ERROR << "While writing a tmp file: Cannot remove conflicting file '" + tmp_location + "'. Check permissions! Aborting ...";
           return wrapExit(CANNOT_WRITE_OUTPUT_FILE);
         }
       }
@@ -456,7 +456,7 @@ protected:
       bool move_ok = QFile::copy(target_file.toQString(), tmp_location.toQString());
       if (!move_ok)
       {
-        LOG_ERROR << "Copying the target file '" + tmp_location + "' from '" + target_file + "' failed! Aborting ...";
+        OPENMS_LOG_ERROR << "Copying the target file '" + tmp_location + "' from '" + target_file + "' failed! Aborting ...";
         return wrapExit(CANNOT_WRITE_OUTPUT_FILE);
       }
       // set the input file's value to the temp file
@@ -492,12 +492,12 @@ protected:
 
     if (!builder.waitForFinished(-1) || builder.exitStatus() != 0 || builder.exitCode() != 0)
     {
-      LOG_ERROR << ("External tool returned with exit code (" + String(builder.exitCode()) + "), exit status (" + String(builder.exitStatus()) + ") or timed out. Aborting ...\n");
-      LOG_ERROR << ("External tool output:\n" + String(QString(builder.readAll())));
+      OPENMS_LOG_ERROR << ("External tool returned with exit code (" + String(builder.exitCode()) + "), exit status (" + String(builder.exitStatus()) + ") or timed out. Aborting ...\n");
+      OPENMS_LOG_ERROR << ("External tool output:\n" + String(QString(builder.readAll())));
       return wrapExit(EXTERNAL_PROGRAM_ERROR);
     }
 
-    LOG_INFO << ("External tool output:\n" + String(QString(builder.readAll())));
+    OPENMS_LOG_INFO << ("External tool output:\n" + String(QString(builder.readAll())));
 
 
     // post processing (file moving via 'file_post' command)
@@ -516,7 +516,7 @@ protected:
 
       if (target_file.trim().empty())   // if target was not given, we skip the copying step (usually for optional parameters)
       {
-        LOG_INFO << "Parameter '" + target + "' not given. Skipping forwarding of files.\n";
+        OPENMS_LOG_INFO << "Parameter '" + target + "' not given. Skipping forwarding of files.\n";
         continue;
       }
       // check if the target exists already (should not; if yes, delete it before overwriting it)
@@ -524,7 +524,7 @@ protected:
       {
         if (!File::remove(target_file))
         {
-          LOG_ERROR << "Cannot remove conflicting file '" + target_file + "'. Check permissions! Aborting ..." << std::endl;
+          OPENMS_LOG_ERROR << "Cannot remove conflicting file '" + target_file + "'. Check permissions! Aborting ..." << std::endl;
           return wrapExit(CANNOT_WRITE_OUTPUT_FILE);
         }
       }
@@ -532,7 +532,7 @@ protected:
       writeDebug_(String("<file_post>: moving '") + source_file + "' to '" + target_file + "'", 1);
       if (!File::exists(source_file))
       {
-        LOG_ERROR << "Moving the source file '" + source_file + "' during <file_post> failed, since it does not exist!\n"
+        OPENMS_LOG_ERROR << "Moving the source file '" + source_file + "' during <file_post> failed, since it does not exist!\n"
                   << "Make sure the external program created the file and its filename is either\n"
                   << "unique or you only run one GenericWrapper at a time to avoid overwriting of files!\n"
                   << "Ideally, (if the external program allows to specify output filenames directly) avoid <file_post>\n"
@@ -542,13 +542,13 @@ protected:
       bool move_ok = QFile::rename(source_file.toQString(), target_file.toQString());
       if (!move_ok)
       {
-        LOG_ERROR << "Moving the target file '" + target_file + "' from '" + source_file + "' failed!\n"
+        OPENMS_LOG_ERROR << "Moving the target file '" + target_file + "' from '" + source_file + "' failed!\n"
                   << "This file exists, but is either currently open for writing or otherwise blocked (concurrent process?). Aborting ..." << std::endl;
         return wrapExit(CANNOT_WRITE_OUTPUT_FILE);
       }
     }
 
-    LOG_INFO << tde_.text_finish << "\n";
+    OPENMS_LOG_INFO << tde_.text_finish << "\n";
 
     return wrapExit(EXECUTION_OK);
   }

--- a/src/topp/HighResPrecursorMassCorrector.cpp
+++ b/src/topp/HighResPrecursorMassCorrector.cpp
@@ -172,7 +172,7 @@ class TOPPHiResPrecursorMassCorrector :
 
       if ((nearest_peak_mz_tolerance <= 0.0) && (highest_intensity_peak_mz_tolerance <= 0.0) && in_feature.empty())
       {
-        LOG_ERROR << "No method for PC correction requested. Either provide featureXML input files or set 'nearest_peak:mz_tolerance' > 0 or specify a 'highest_intensity_peak:mz_tolerance' > 0" << std::endl;
+        OPENMS_LOG_ERROR << "No method for PC correction requested. Either provide featureXML input files or set 'nearest_peak:mz_tolerance' > 0 or specify a 'highest_intensity_peak:mz_tolerance' > 0" << std::endl;
         return MISSING_PARAMETERS;
       }
 
@@ -206,22 +206,22 @@ class TOPPHiResPrecursorMassCorrector :
       {
         if (nearest_peak_mz_tolerance > 0.0 && highest_intensity_peak_mz_tolerance <= 0.0)
         {
-          LOG_INFO << "Corrected " << corrected_to_nearest_peak.size() << " precursor to a MS1 peak." << endl;
+          OPENMS_LOG_INFO << "Corrected " << corrected_to_nearest_peak.size() << " precursor to a MS1 peak." << endl;
         }
         else if (highest_intensity_peak_mz_tolerance > 0.0)
         {
-          LOG_INFO << "Corrected " << corrected_to_highest_intensity_peak.size() << " precursor to a MS1 peak." << endl;
+          OPENMS_LOG_INFO << "Corrected " << corrected_to_highest_intensity_peak.size() << " precursor to a MS1 peak." << endl;
         }
         else
         {
-          LOG_WARN << "Output file 'out_csv': No data collected since 'nearest_peak:mz_tolerance' was not enabled. CSV will be empty." << endl;
+          OPENMS_LOG_WARN << "Output file 'out_csv': No data collected since 'nearest_peak:mz_tolerance' was not enabled. CSV will be empty." << endl;
         }
         PrecursorCorrection::writeHist(out_csv, deltaMZs, mzs, rts);
       }
 
       if (!in_feature.empty())
       {
-        LOG_INFO << "Corrected " << corrected_to_nearest_feature.size() << " precursors to a feature." << endl;
+        OPENMS_LOG_INFO << "Corrected " << corrected_to_nearest_feature.size() << " precursors to a feature." << endl;
       }
 
       return EXECUTION_OK;

--- a/src/topp/IDFileConverter.cpp
+++ b/src/topp/IDFileConverter.cpp
@@ -195,7 +195,7 @@ private:
 #pragma omp critical (IDFileConverter_ERROR)
 #endif
           {
-            LOG_ERROR << "Error: Failed to look up spectrum - none with corresponding native ID found." << endl;
+            OPENMS_LOG_ERROR << "Error: Failed to look up spectrum - none with corresponding native ID found." << endl;
             ret = false;
           }
         }
@@ -415,7 +415,7 @@ protected:
 
       else if (in_type == FileTypes::MZIDENTML)
       {
-        LOG_WARN << "Converting from mzid: you might experience loss of information depending on the capabilities of the target format." << endl;
+        OPENMS_LOG_WARN << "Converting from mzid: you might experience loss of information depending on the capabilities of the target format." << endl;
         MzIdentMLFile().load(in, protein_identifications,
                              peptide_identifications);
 
@@ -499,7 +499,7 @@ protected:
             }
             else
             {
-              LOG_ERROR << "XTandem xml: Error: id '" << id << "' not found in peak map!" << endl;
+              OPENMS_LOG_ERROR << "XTandem xml: Error: id '" << id << "' not found in peak map!" << endl;
             }
           }
         }

--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -278,14 +278,14 @@ protected:
     double rt_high = numeric_limits<double>::infinity(), rt_low = -rt_high;
     if (parseRange_(getStringOption_("precursor:rt"), rt_low, rt_high))
     {
-      LOG_INFO << "Filtering peptide IDs by precursor RT..." << endl;
+      OPENMS_LOG_INFO << "Filtering peptide IDs by precursor RT..." << endl;
       IDFilter::filterPeptidesByRT(peptides, rt_low, rt_high);
     }
 
     double mz_high = numeric_limits<double>::infinity(), mz_low = -mz_high;
     if (parseRange_(getStringOption_("precursor:mz"), mz_low, mz_high))
     {
-      LOG_INFO << "Filtering peptide IDs by precursor m/z...";
+      OPENMS_LOG_INFO << "Filtering peptide IDs by precursor m/z...";
       IDFilter::filterPeptidesByMZ(peptides, mz_low, mz_high);
     }
 
@@ -294,27 +294,27 @@ protected:
 
     if (getFlag_("unique"))
     {
-      LOG_INFO << "Removing duplicate peptide hits..." << endl;
+      OPENMS_LOG_INFO << "Removing duplicate peptide hits..." << endl;
       IDFilter::removeDuplicatePeptideHits(peptides);
     }
 
     if (getFlag_("unique_per_protein"))
     {
-      LOG_INFO << "Filtering peptides by unique match to a protein..." << endl;
+      OPENMS_LOG_INFO << "Filtering peptides by unique match to a protein..." << endl;
       IDFilter::keepUniquePeptidesPerProtein(peptides);
     }
 
     double peptide_significance = getDoubleOption_("thresh:pep");
     if (peptide_significance > 0)
     {
-      LOG_INFO << "Filtering by peptide significance threshold..." << endl;
+      OPENMS_LOG_INFO << "Filtering by peptide significance threshold..." << endl;
       IDFilter::filterHitsBySignificance(peptides, peptide_significance);
     }
 
     double pred_rt_pv = getDoubleOption_("rt:p_value");
     if (pred_rt_pv > 0)
     {
-      LOG_INFO << "Filtering by RT prediction p-value..." << endl;
+      OPENMS_LOG_INFO << "Filtering by RT prediction p-value..." << endl;
       IDFilter::filterPeptidesByRTPredictPValue(
         peptides, "predicted_RT_p_value", pred_rt_pv);
     }
@@ -322,7 +322,7 @@ protected:
     double pred_rt_pv_1d = getDoubleOption_("rt:p_value_1st_dim");
     if (pred_rt_pv_1d > 0)
     {
-      LOG_INFO << "Filtering by RT prediction p-value (first dim.)..." << endl;
+      OPENMS_LOG_INFO << "Filtering by RT prediction p-value (first dim.)..." << endl;
       IDFilter::filterPeptidesByRTPredictPValue(
         peptides, "predicted_RT_p_value_first_dim", pred_rt_pv_1d);
     }
@@ -330,7 +330,7 @@ protected:
     String whitelist_fasta = getStringOption_("whitelist:proteins").trim();
     if (!whitelist_fasta.empty())
     {
-      LOG_INFO << "Filtering by protein whitelisting (FASTA input)..." << endl;
+      OPENMS_LOG_INFO << "Filtering by protein whitelisting (FASTA input)..." << endl;
       // load protein accessions from FASTA file:
       vector<FASTAFile::FASTAEntry> fasta;
       FASTAFile().load(whitelist_fasta, fasta);
@@ -348,7 +348,7 @@ protected:
       getStringList_("whitelist:protein_accessions");
     if (!whitelist_accessions.empty())
     {
-      LOG_INFO << "Filtering by protein whitelisting (accessions input)..."
+      OPENMS_LOG_INFO << "Filtering by protein whitelisting (accessions input)..."
                << endl;
       set<String> accessions(whitelist_accessions.begin(),
                              whitelist_accessions.end());
@@ -359,7 +359,7 @@ protected:
     String whitelist_peptides = getStringOption_("whitelist:peptides").trim();
     if (!whitelist_peptides.empty())
     {
-      LOG_INFO << "Filtering by inclusion peptide whitelisting..." << endl;
+      OPENMS_LOG_INFO << "Filtering by inclusion peptide whitelisting..." << endl;
       vector<PeptideIdentification> inclusion_peptides;
       vector<ProteinIdentification> inclusion_proteins; // ignored
       IdXMLFile().load(whitelist_peptides, inclusion_proteins,
@@ -372,7 +372,7 @@ protected:
     vector<String> whitelist_mods = getStringList_("whitelist:modifications");
     if (!whitelist_mods.empty())
     {
-      LOG_INFO << "Filtering peptide IDs by modification whitelisting..."
+      OPENMS_LOG_INFO << "Filtering peptide IDs by modification whitelisting..."
                << endl;
       set<String> good_mods(whitelist_mods.begin(), whitelist_mods.end());
       IDFilter::keepPeptidesWithMatchingModifications(peptides, good_mods);
@@ -381,7 +381,7 @@ protected:
     String blacklist_fasta = getStringOption_("blacklist:proteins").trim();
     if (!blacklist_fasta.empty())
     {
-      LOG_INFO << "Filtering by protein blacklisting (FASTA input)..." << endl;
+      OPENMS_LOG_INFO << "Filtering by protein blacklisting (FASTA input)..." << endl;
       // load protein accessions from FASTA file:
       vector<FASTAFile::FASTAEntry> fasta;
       FASTAFile().load(blacklist_fasta, fasta);
@@ -399,7 +399,7 @@ protected:
       getStringList_("blacklist:protein_accessions");
     if (!blacklist_accessions.empty())
     {
-      LOG_INFO << "Filtering by protein blacklisting (accessions input)..."
+      OPENMS_LOG_INFO << "Filtering by protein blacklisting (accessions input)..."
                << endl;
       set<String> accessions(blacklist_accessions.begin(),
                              blacklist_accessions.end());
@@ -410,7 +410,7 @@ protected:
     String blacklist_peptides = getStringOption_("blacklist:peptides").trim();
     if (!blacklist_peptides.empty())
     {
-      LOG_INFO << "Filtering by exclusion peptide blacklisting..." << endl;
+      OPENMS_LOG_INFO << "Filtering by exclusion peptide blacklisting..." << endl;
       vector<PeptideIdentification> exclusion_peptides;
       vector<ProteinIdentification> exclusion_proteins; // ignored
       IdXMLFile().load(blacklist_peptides, exclusion_proteins,
@@ -423,7 +423,7 @@ protected:
     vector<String> blacklist_mods = getStringList_("blacklist:modifications");
     if (!blacklist_mods.empty())
     {
-      LOG_INFO << "Filtering peptide IDs by modification blacklisting..."
+      OPENMS_LOG_INFO << "Filtering peptide IDs by modification blacklisting..."
                << endl;
       set<String> bad_mods(blacklist_mods.begin(), blacklist_mods.end());
       IDFilter::removePeptidesWithMatchingModifications(peptides, bad_mods);
@@ -432,7 +432,7 @@ protected:
 
     if (getFlag_("best:strict"))
     {
-      LOG_INFO << "Filtering by best peptide hits..." << endl;
+      OPENMS_LOG_INFO << "Filtering by best peptide hits..." << endl;
       IDFilter::keepBestPeptideHits(peptides, true);
     }
 
@@ -440,10 +440,10 @@ protected:
     Int min_length = 0, max_length = 0;
     if (parseRange_(getStringOption_("length"), min_length, max_length))
     {
-      LOG_INFO << "Filtering by peptide length..." << endl;
+      OPENMS_LOG_INFO << "Filtering by peptide length..." << endl;
       if ((min_length < 0) || (max_length < 0))
       {
-        LOG_ERROR << "Fatal error: negative values are not allowed for parameter 'length'" << endl;
+        OPENMS_LOG_ERROR << "Fatal error: negative values are not allowed for parameter 'length'" << endl;
         return ILLEGAL_PARAMETERS;
       }
       IDFilter::filterPeptidesByLength(peptides, Size(min_length),
@@ -455,7 +455,7 @@ protected:
     String protein_fasta = getStringOption_("in_silico_digestion:fasta").trim();
     if (!protein_fasta.empty())
     {
-      LOG_INFO << "Filtering peptides by digested protein (FASTA input)..." << endl;
+      OPENMS_LOG_INFO << "Filtering peptides by digested protein (FASTA input)..." << endl;
       // load protein accessions from FASTA file:
       vector<FASTAFile::FASTAEntry> fasta;
       FASTAFile().load(protein_fasta, fasta);
@@ -481,7 +481,7 @@ protected:
         ignore_missed_cleavages = false;
         if (digestion.getSpecificity() == EnzymaticDigestion::SPEC_FULL)
         {
-          LOG_WARN << "Specificity not full, missed_cleavages option is redundant" << endl;
+          OPENMS_LOG_WARN << "Specificity not full, missed_cleavages option is redundant" << endl;
         }
         digestion.setMissedCleavages(missed_cleavages);
       }
@@ -516,7 +516,7 @@ protected:
         digestion.setEnzyme(enzyme);
       }
 
-      LOG_INFO << "Filtering peptide hits by their missed cleavages count with enzyme " << digestion.getEnzymeName() << "..." << endl;
+      OPENMS_LOG_INFO << "Filtering peptide hits by their missed cleavages count with enzyme " << digestion.getEnzymeName() << "..." << endl;
 
       // Build the digest filter function
       IDFilter::PeptideDigestionFilter filter(digestion, min_cleavages, max_cleavages);
@@ -532,7 +532,7 @@ protected:
 
     if (getFlag_("var_mods"))
     {
-      LOG_INFO << "Filtering for variable modifications..." << endl;
+      OPENMS_LOG_INFO << "Filtering for variable modifications..." << endl;
       // gather possible variable modifications from search parameters:
       set<String> var_mods;
       for (vector<ProteinIdentification>::iterator prot_it = proteins.begin();
@@ -554,7 +554,7 @@ protected:
     // @TODO: what if 0 is a reasonable cut-off for some score?
     if (pep_score != 0)
     {
-      LOG_INFO << "Filtering by peptide score..." << endl;
+      OPENMS_LOG_INFO << "Filtering by peptide score..." << endl;
       IDFilter::filterHitsByScore(peptides, pep_score);
     }
 
@@ -562,14 +562,14 @@ protected:
       numeric_limits<Int>::max();
     if (parseRange_(getStringOption_("charge"), min_charge, max_charge))
     {
-      LOG_INFO << "Filtering by peptide charge..." << endl;
+      OPENMS_LOG_INFO << "Filtering by peptide charge..." << endl;
       IDFilter::filterPeptidesByCharge(peptides, min_charge, max_charge);
     }
 
     Size best_n_pep = getIntOption_("best:n_peptide_hits");
     if (best_n_pep > 0)
     {
-      LOG_INFO << "Filtering by best n peptide hits..." << endl;
+      OPENMS_LOG_INFO << "Filtering by best n peptide hits..." << endl;
       IDFilter::keepNBestHits(peptides, best_n_pep);
     }
 
@@ -577,10 +577,10 @@ protected:
     if (parseRange_(getStringOption_("best:n_to_m_peptide_hits"), min_rank,
                     max_rank))
     {
-      LOG_INFO << "Filtering by peptide hit ranks..." << endl;
+      OPENMS_LOG_INFO << "Filtering by peptide hit ranks..." << endl;
       if ((min_rank < 0) || (max_rank < 0))
       {
-        LOG_ERROR << "Fatal error: negative values are not allowed for parameter 'best:n_to_m_peptide_hits'" << endl;
+        OPENMS_LOG_ERROR << "Fatal error: negative values are not allowed for parameter 'best:n_to_m_peptide_hits'" << endl;
         return ILLEGAL_PARAMETERS;
       }
       IDFilter::filterHitsByRank(peptides, Size(min_rank), Size(max_rank));
@@ -589,7 +589,7 @@ protected:
     double mz_error = getDoubleOption_("mz:error");
     if (mz_error > 0)
     {
-      LOG_INFO << "Filtering by mass error..." << endl;
+      OPENMS_LOG_INFO << "Filtering by mass error..." << endl;
       bool unit_ppm = (getStringOption_("mz:unit") == "ppm");
       IDFilter::filterPeptidesByMZError(peptides, mz_error, unit_ppm);
     }
@@ -600,7 +600,7 @@ protected:
     double protein_significance = getDoubleOption_("thresh:prot");
     if (protein_significance > 0)
     {
-      LOG_INFO << "Filtering by protein significance threshold..." << endl;
+      OPENMS_LOG_INFO << "Filtering by protein significance threshold..." << endl;
       IDFilter::filterHitsBySignificance(proteins, protein_significance);
     }
 
@@ -608,20 +608,20 @@ protected:
     // @TODO: what if 0 is a reasonable cut-off for some score?
     if (prot_score != 0)
     {
-      LOG_INFO << "Filtering by protein score..." << endl;
+      OPENMS_LOG_INFO << "Filtering by protein score..." << endl;
       IDFilter::filterHitsByScore(proteins, prot_score);
     }
 
     Size best_n_prot = getIntOption_("best:n_protein_hits");
     if (best_n_prot > 0)
     {
-      LOG_INFO << "Filtering by best n protein hits..." << endl;
+      OPENMS_LOG_INFO << "Filtering by best n protein hits..." << endl;
       IDFilter::keepNBestHits(proteins, best_n_prot);
     }
 
     if (getFlag_("remove_decoys"))
     {
-      LOG_INFO << "Removing decoy hits..." << endl;
+      OPENMS_LOG_INFO << "Removing decoy hits..." << endl;
       IDFilter::removeDecoyHits(peptides);
       IDFilter::removeDecoyHits(proteins);
     }
@@ -680,7 +680,7 @@ protected:
 
     if (!getFlag_("keep_unreferenced_protein_hits"))
     {
-      LOG_INFO << "Removing unreferenced protein hits..." << endl;
+      OPENMS_LOG_INFO << "Removing unreferenced protein hits..." << endl;
       IDFilter::removeUnreferencedProteins(proteins, peptides);
     }
 
@@ -690,7 +690,7 @@ protected:
     // remove non-existant protein references from peptides (and optionally:
     // remove peptides with no proteins):
     bool rm_pep = getFlag_("delete_unreferenced_peptide_hits");
-    if (rm_pep) LOG_INFO << "Removing peptide hits without protein references..." << endl;
+    if (rm_pep) OPENMS_LOG_INFO << "Removing peptide hits without protein references..." << endl;
     IDFilter::updateProteinReferences(peptides, proteins, rm_pep);
 
     IDFilter::removeEmptyIdentifications(peptides);
@@ -704,19 +704,19 @@ protected:
                                                  prot_it->getHits());
       if (!valid)
       {
-        LOG_WARN << "Warning: While updating protein groups, some proteins were removed from groups that are still present. The new grouping (especially the group probabilities) may not be completely valid any more." << endl;
+        OPENMS_LOG_WARN << "Warning: While updating protein groups, some proteins were removed from groups that are still present. The new grouping (especially the group probabilities) may not be completely valid any more." << endl;
       }
 
       valid = IDFilter::updateProteinGroups(
         prot_it->getIndistinguishableProteins(), prot_it->getHits());
       if (!valid)
       {
-        LOG_WARN << "Warning: While updating indistinguishable proteins, some proteins were removed from groups that are still present. The new grouping (especially the group probabilities) may not be completely valid any more." << endl;
+        OPENMS_LOG_WARN << "Warning: While updating indistinguishable proteins, some proteins were removed from groups that are still present. The new grouping (especially the group probabilities) may not be completely valid any more." << endl;
       }
     }
 
     // some stats
-    LOG_INFO << "Before filtering:\n"
+    OPENMS_LOG_INFO << "Before filtering:\n"
              << n_prot_ids << " protein identification(s) with "
              << n_prot_hits << " protein hit(s),\n"
              << n_pep_ids << " peptide identification(s) with "

--- a/src/topp/IDMapper.cpp
+++ b/src/topp/IDMapper.cpp
@@ -171,12 +171,12 @@ protected:
 
   ExitCodes main_(int, const char**) override
   {
-    // LOG_DEBUG << "Starting..." << endl;
+    // OPENMS_LOG_DEBUG << "Starting..." << endl;
 
     //----------------------------------------------------------------
     // load ids
     //----------------------------------------------------------------
-    // LOG_DEBUG << "Loading idXML..." << endl;
+    // OPENMS_LOG_DEBUG << "Loading idXML..." << endl;
     String id = getStringOption_("id");
     vector<ProteinIdentification> protein_ids;
     vector<PeptideIdentification> peptide_ids;
@@ -203,7 +203,7 @@ protected:
     //----------------------------------------------------------------
     //create mapper
     //----------------------------------------------------------------
-    // LOG_DEBUG << "Creating mapper..." << endl;
+    // OPENMS_LOG_DEBUG << "Creating mapper..." << endl;
     IDMapper mapper;
     Param p = mapper.getParameters();
     p.setValue("rt_tolerance", getDoubleOption_("rt_tolerance"));
@@ -218,7 +218,7 @@ protected:
     //----------------------------------------------------------------
     if (in_type == FileTypes::CONSENSUSXML)
     {
-      // LOG_DEBUG << "Processing consensus map..." << endl;
+      // OPENMS_LOG_DEBUG << "Processing consensus map..." << endl;
       ConsensusXMLFile file;
       ConsensusMap map;
       file.load(in, map);
@@ -250,7 +250,7 @@ protected:
     //----------------------------------------------------------------
     if (in_type == FileTypes::FEATUREXML)
     {
-      // LOG_DEBUG << "Processing feature map..." << endl;
+      // OPENMS_LOG_DEBUG << "Processing feature map..." << endl;
       FeatureMap map;
       FeatureXMLFile file;
       file.load(in, map);
@@ -278,7 +278,7 @@ protected:
     //----------------------------------------------------------------
     if (in_type == FileTypes::MZQUANTML)
     {
-      // LOG_DEBUG << "Processing mzq ..." << endl;
+      // OPENMS_LOG_DEBUG << "Processing mzq ..." << endl;
       MSQuantifications msq;
       MzQuantMLFile file;
       file.load(in, msq);
@@ -297,7 +297,7 @@ protected:
       file.store(out, msq);
     }
 
-    // LOG_DEBUG << "Done." << endl;
+    // OPENMS_LOG_DEBUG << "Done." << endl;
     return EXECUTION_OK;
   }
 

--- a/src/topp/IDMerger.cpp
+++ b/src/topp/IDMerger.cpp
@@ -270,7 +270,7 @@ protected:
     //-------------------------------------------------------------
     // writing output
     //-------------------------------------------------------------
-    LOG_DEBUG << "protein IDs: " << proteins.size() << endl
+    OPENMS_LOG_DEBUG << "protein IDs: " << proteins.size() << endl
               << "peptide IDs: " << peptides.size() << endl;
     IdXMLFile().store(out, proteins, peptides);
 
@@ -375,10 +375,10 @@ protected:
             if (pep_it->getHits().empty()) continue;
             pep_it->sort();
             const PeptideHit& hit = pep_it->getHits()[0];
-            LOG_DEBUG << "peptide: " << hit.getSequence().toString() << endl;
+            OPENMS_LOG_DEBUG << "peptide: " << hit.getSequence().toString() << endl;
             // skip ahead if peptide is not new:
             if (sequences.find(hit.getSequence()) != sequences.end()) continue;
-            LOG_DEBUG << "new peptide!" << endl;
+            OPENMS_LOG_DEBUG << "new peptide!" << endl;
             pep_it->getHits().resize(1); // restrict to best hit for simplicity
             peptides.push_back(*pep_it);
 
@@ -387,13 +387,13 @@ protected:
             // copy over proteins:
             for (String const & acc : protein_accessions)
             {
-              LOG_DEBUG << "accession: " << acc << endl;
+              OPENMS_LOG_DEBUG << "accession: " << acc << endl;
               // skip ahead if accession is not new:
               if (accessions.find(acc) != accessions.end()) continue;
-              LOG_DEBUG << "new accession!" << endl;
+              OPENMS_LOG_DEBUG << "new accession!" << endl;
               // first find the right protein identification:
               const String& id = pep_it->getIdentifier();
-              LOG_DEBUG << "identifier: " << id << endl;
+              OPENMS_LOG_DEBUG << "identifier: " << id << endl;
               if (proteins_by_id.find(id) == proteins_by_id.end())
               {
                 writeLog_("Error: identifier '" + id + "' linking peptides and proteins not found. Skipping.");
@@ -411,7 +411,7 @@ protected:
               // we may need to copy protein ID meta data, if we haven't yet:
               if (selected_proteins.find(id) == selected_proteins.end())
               {
-                LOG_DEBUG << "adding protein identification" << endl;
+                OPENMS_LOG_DEBUG << "adding protein identification" << endl;
                 selected_proteins[id] = protein;
                 selected_proteins[id].getHits().clear();
                 // remove potentially invalid information:

--- a/src/topp/IDRTCalibration.cpp
+++ b/src/topp/IDRTCalibration.cpp
@@ -122,17 +122,17 @@ protected:
 
     if (rt_calibrant_1_input == rt_calibrant_2_input)
     {
-      LOG_ERROR << "rt_calibrant_1_input and rt_calibrant_2_input must not have the same value";
+      OPENMS_LOG_ERROR << "rt_calibrant_1_input and rt_calibrant_2_input must not have the same value";
       return ILLEGAL_PARAMETERS;
     }
     if (rt_calibrant_1_reference == rt_calibrant_2_reference)
     {
-      LOG_ERROR << "rt_calibrant_1_reference and rt_calibrant_2_reference must not have the same value";
+      OPENMS_LOG_ERROR << "rt_calibrant_1_reference and rt_calibrant_2_reference must not have the same value";
       return ILLEGAL_PARAMETERS;
     }
     if (rt_calibrant_1_reference == -1 || rt_calibrant_2_reference == -1)
     {
-      LOG_ERROR << "rt_calibrant_1_reference and rt_calibrant_2_reference must be set";
+      OPENMS_LOG_ERROR << "rt_calibrant_1_reference and rt_calibrant_2_reference must be set";
       return ILLEGAL_PARAMETERS;
     }
 

--- a/src/topp/IDRipper.cpp
+++ b/src/topp/IDRipper.cpp
@@ -176,14 +176,14 @@ protected:
       QString output = output_directory.toQString();
       // create full absolute path with filename
       String out = QDir::toNativeSeparators(output.append(QString("/")).append(it->first.toQString())).toStdString();
-      LOG_INFO << "Storing file: '" << out << "'." << std::endl;
+      OPENMS_LOG_INFO << "Storing file: '" << out << "'." << std::endl;
 
       QDir dir(output_directory.toQString());
       if (!dir.exists())
       {
         if (!File::writable(output_directory))
         {
-          LOG_WARN << "Warning: Cannot create folder: '" << output_directory << "'." << std::endl;
+          OPENMS_LOG_WARN << "Warning: Cannot create folder: '" << output_directory << "'." << std::endl;
           return CANNOT_WRITE_OUTPUT_FILE;
         }
         dir.mkpath(".");

--- a/src/topp/InspectAdapter.cpp
+++ b/src/topp/InspectAdapter.cpp
@@ -833,7 +833,7 @@ protected:
         {
           QString output = builder.readAll();
           // set the search engine and its version and the score type
-          if (!inspect_outfile.getSearchEngineAndVersion(output, protein_identification)) LOG_WARN << "Could not read version of InsPecT from:\n" << String(output) << "\n\n";
+          if (!inspect_outfile.getSearchEngineAndVersion(output, protein_identification)) OPENMS_LOG_WARN << "Could not read version of InsPecT from:\n" << String(output) << "\n\n";
         }
       }
       else protein_identification.setSearchEngine("InsPecT");

--- a/src/topp/InternalCalibration.cpp
+++ b/src/topp/InternalCalibration.cpp
@@ -250,7 +250,7 @@ protected:
 
     if (((int)!cal_lock.empty() + (int)!cal_id.empty()) != 1)
     {
-      LOG_ERROR << "Conflicting input given. Please provide only ONE of either 'cal:id_in' or 'cal:lock_in'!" << std::endl;
+      OPENMS_LOG_ERROR << "Conflicting input given. Please provide only ONE of either 'cal:id_in' or 'cal:lock_in'!" << std::endl;
       return ILLEGAL_PARAMETERS;
     }
 
@@ -317,14 +317,14 @@ protected:
       // write matched lock mass peaks
       if (!file_cal_lock_out.empty())
       {
-        LOG_INFO << "\nWriting matched lock masses to mzML file '" << file_cal_lock_out << "'." << std::endl;
+        OPENMS_LOG_INFO << "\nWriting matched lock masses to mzML file '" << file_cal_lock_out << "'." << std::endl;
         PeakMap exp_out;
         exp_out.set2DData(ic.getCalibrationPoints(), CalibrationData::getMetaValues());
         mz_file.store(file_cal_lock_out, exp_out);
       }
       if (!file_cal_lock_fail_out.empty())
       {
-        LOG_INFO << "\nWriting unmatched lock masses to mzML file '" << file_cal_lock_fail_out << "'." << std::endl;
+        OPENMS_LOG_INFO << "\nWriting unmatched lock masses to mzML file '" << file_cal_lock_fail_out << "'." << std::endl;
         PeakMap exp_out;
         exp_out.set2DData(failed_points, CalibrationData::getMetaValues());
         mz_file.store(file_cal_lock_fail_out, exp_out);
@@ -335,7 +335,7 @@ protected:
 
     if (ic.getCalibrationPoints().empty())
     {
-      LOG_ERROR << "No calibration points found! Check your Raw data and calibration masses. Aborting!" << std::endl;
+      OPENMS_LOG_ERROR << "No calibration points found! Check your Raw data and calibration masses. Aborting!" << std::endl;
       return UNEXPECTED_RESULT;
     }
       
@@ -359,7 +359,7 @@ protected:
                       getStringOption_("quality_control:residuals_plot"),
                       rscript_executable))
     {
-      LOG_ERROR << "\nCalibration failed. See error message above!" << std::endl;
+      OPENMS_LOG_ERROR << "\nCalibration failed. See error message above!" << std::endl;
       return UNEXPECTED_RESULT;
     }
  

--- a/src/topp/LuciphorAdapter.cpp
+++ b/src/topp/LuciphorAdapter.cpp
@@ -525,7 +525,7 @@ protected:
       }
       else
       {
-        LOG_WARN << "No PeptideIdentifications found in the IdXMLFile. Please check your previous steps.\n";
+        OPENMS_LOG_WARN << "No PeptideIdentifications found in the IdXMLFile. Please check your previous steps.\n";
       }
       // create a temporary pepXML file for LuciPHOR2 input
       String id_file_name = File::removeExtension(File::basename(id));

--- a/src/topp/MaRaClusterAdapter.cpp
+++ b/src/topp/MaRaClusterAdapter.cpp
@@ -240,7 +240,7 @@ protected:
       else
       {
         scan_identifier = "index=" + String(it - start + 1);
-        LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
+        OPENMS_LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
       }
     }
     return scan_identifier.removeWhitespaces();

--- a/src/topp/MapAlignerPoseClustering.cpp
+++ b/src/topp/MapAlignerPoseClustering.cpp
@@ -163,7 +163,7 @@ protected:
     }
     else if (reference_index == 0) // no reference given
     {
-      LOG_INFO << "Picking a reference (by size) ..." << std::flush;
+      OPENMS_LOG_INFO << "Picking a reference (by size) ..." << std::flush;
       // use map with highest number of features as reference:
       Size max_count(0);
       FeatureXMLFile f;
@@ -187,7 +187,7 @@ protected:
           reference_index = i;
         }
       }
-      LOG_INFO << " done" << std::endl;
+      OPENMS_LOG_INFO << " done" << std::endl;
       file = in_files[reference_index];
     }
 

--- a/src/topp/MassTraceExtractor.cpp
+++ b/src/topp/MassTraceExtractor.cpp
@@ -169,7 +169,7 @@ protected:
 
     if (ms_peakmap.size() == 0)
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }
@@ -227,7 +227,7 @@ protected:
         m_traces_final.clear();
         ep_det.filterByPeakWidth(split_mtraces, m_traces_final);
 
-        LOG_INFO << "Notice: " << split_mtraces.size() - m_traces_final.size()
+        OPENMS_LOG_INFO << "Notice: " << split_mtraces.size() - m_traces_final.size()
                  << " of total " << split_mtraces.size() 
                  << " were dropped because of too low peak width." << std::endl;
       }
@@ -319,7 +319,7 @@ protected:
       if (stats_sd.size() > 0)
       {
         std::sort(stats_sd.begin(), stats_sd.end());
-        LOG_INFO << "Mass trace m/z s.d.\n"
+        OPENMS_LOG_INFO << "Mass trace m/z s.d.\n"
                  << "    low quartile: " << stats_sd[stats_sd.size() * 1 / 4] << "\n"
                  << "          median: " << stats_sd[stats_sd.size() * 1 / 2] << "\n"
                  << "    upp quartile: " << stats_sd[stats_sd.size() * 3 / 4] << std::endl;

--- a/src/topp/MzTabExporter.cpp
+++ b/src/topp/MzTabExporter.cpp
@@ -163,7 +163,7 @@ protected:
         }
         catch (Exception::MissingInformation& e)
         {
-          LOG_WARN << "Non-critical exception: " << e.what() << "\n";
+          OPENMS_LOG_WARN << "Non-critical exception: " << e.what() << "\n";
         }
         feature_map.setProteinIdentifications(prot_ids);
 

--- a/src/topp/NoiseFilterGaussian.cpp
+++ b/src/topp/NoiseFilterGaussian.cpp
@@ -194,7 +194,7 @@ public:
 
     if (exp.empty() && exp.getChromatograms().size() == 0)
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }

--- a/src/topp/NoiseFilterSGolay.cpp
+++ b/src/topp/NoiseFilterSGolay.cpp
@@ -197,7 +197,7 @@ public:
 
     if (exp.empty() && exp.getChromatograms().size() == 0)
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }

--- a/src/topp/OMSSAAdapter.cpp
+++ b/src/topp/OMSSAAdapter.cpp
@@ -440,7 +440,7 @@ protected:
     //-------------------------------------------------------------
     if (getIntOption_("min_precursor_charge") > getIntOption_("max_precursor_charge"))
     {
-      LOG_ERROR << "Given charge range is invalid: max_precursor_charge needs to be >= min_precursor_charge." << std::endl;
+      OPENMS_LOG_ERROR << "Given charge range is invalid: max_precursor_charge needs to be >= min_precursor_charge." << std::endl;
       return ILLEGAL_PARAMETERS;
     }
 
@@ -458,7 +458,7 @@ protected:
       }
       catch (...)
       {
-        LOG_ERROR << "Unable to find database '" << db_name << "' (searched all folders). Did you mistype its name?" << std::endl;
+        OPENMS_LOG_ERROR << "Unable to find database '" << db_name << "' (searched all folders). Did you mistype its name?" << std::endl;
         return ILLEGAL_PARAMETERS;
       }
       db_name = full_db_name;
@@ -470,10 +470,10 @@ protected:
     bool has_phr = File::readable(db_name + ".phr");
     if (!has_pin || !has_phr)
     {
-      LOG_ERROR << "\nThe NCBI psq database '" << db_name << ".psq' was found, but the following associated index file(s) are missing:\n";
-      if (!has_pin) LOG_ERROR << "  missing: '" << db_name << ".pin'\n";
-      if (!has_phr) LOG_ERROR << "  missing: '" << db_name << ".phr'\n";
-      LOG_ERROR << "Please make sure the file(s) are present!\n" << std::endl;
+      OPENMS_LOG_ERROR << "\nThe NCBI psq database '" << db_name << ".psq' was found, but the following associated index file(s) are missing:\n";
+      if (!has_pin) OPENMS_LOG_ERROR << "  missing: '" << db_name << ".pin'\n";
+      if (!has_phr) OPENMS_LOG_ERROR << "  missing: '" << db_name << ".phr'\n";
+      OPENMS_LOG_ERROR << "Please make sure the file(s) are present!\n" << std::endl;
       return ILLEGAL_PARAMETERS;
     }
 
@@ -1040,7 +1040,7 @@ protected:
     IdXMLFile().store(outputfile_name, protein_identifications, peptide_ids);
 
     // some stats
-    LOG_INFO << "Statistics:\n"
+    OPENMS_LOG_INFO << "Statistics:\n"
              << "  identified MS2 spectra: " << peptide_ids.size() << " / " << ms2_spec_count << " = " << int(peptide_ids.size() * 100.0 / ms2_spec_count) << "% (with e-value < " << String(getDoubleOption_("he")) << ")" << std::endl;
 
 

--- a/src/topp/OpenSwathAssayGenerator.cpp
+++ b/src/topp/OpenSwathAssayGenerator.cpp
@@ -244,7 +244,7 @@ protected:
       if (!ModificationsDB::isInstantiated()) // We need to ensure that ModificationsDB was not instantiated before!
       {
         ModificationsDB* ptr = ModificationsDB::getInstance(unimod_file, String(""), String(""));
-        LOG_INFO << "Unimod XML: " << ptr->getNumberOfModifications() << " modification types and residue specificities imported from file: " << unimod_file << std::endl;
+        OPENMS_LOG_INFO << "Unimod XML: " << ptr->getNumberOfModifications() << " modification types and residue specificities imported from file: " << unimod_file << std::endl;
       }
       else
       {
@@ -256,23 +256,23 @@ protected:
     // Check swath window input
     if (!swath_windows_file.empty())
     {
-      LOG_INFO << "Validate provided Swath windows file:" << std::endl;
+      OPENMS_LOG_INFO << "Validate provided Swath windows file:" << std::endl;
       std::vector<double> swath_prec_lower;
       std::vector<double> swath_prec_upper;
       SwathWindowLoader::readSwathWindows(swath_windows_file, swath_prec_lower, swath_prec_upper);
 
-      LOG_INFO << "Read Swath maps file with " << swath_prec_lower.size() << " windows." << std::endl;
+      OPENMS_LOG_INFO << "Read Swath maps file with " << swath_prec_lower.size() << " windows." << std::endl;
       for (Size i = 0; i < swath_prec_lower.size(); i++)
       {
         swathes.push_back(std::make_pair(swath_prec_lower[i], swath_prec_upper[i]));
-        LOG_DEBUG << "Read lower swath window " << swath_prec_lower[i] << " and upper window " << swath_prec_upper[i] << std::endl;
+        OPENMS_LOG_DEBUG << "Read lower swath window " << swath_prec_lower[i] << " and upper window " << swath_prec_upper[i] << std::endl;
       }
     }
 
     TargetedExperiment targeted_exp;
 
     // Load data
-    LOG_INFO << "Loading " << in << std::endl;
+    OPENMS_LOG_INFO << "Loading " << in << std::endl;
     if (in_type == FileTypes::TSV || in_type == FileTypes::MRM)
     {
       const char* tr_file = in.c_str();
@@ -302,10 +302,10 @@ protected:
     MRMAssay assays = MRMAssay();
     assays.setLogType(ProgressLogger::CMD);
 
-    LOG_INFO << "Annotating transitions" << std::endl;
+    OPENMS_LOG_INFO << "Annotating transitions" << std::endl;
     assays.reannotateTransitions(targeted_exp, precursor_mz_threshold, product_mz_threshold, allowed_fragment_types, allowed_fragment_charges, enable_detection_specific_losses, enable_detection_unspecific_losses);
 
-    LOG_INFO << "Annotating detecting transitions" << std::endl;
+    OPENMS_LOG_INFO << "Annotating detecting transitions" << std::endl;
     assays.restrictTransitions(targeted_exp, product_lower_mz_limit, product_upper_mz_limit, swathes);
     assays.detectingTransitions(targeted_exp, min_transitions, max_transitions);
 
@@ -326,13 +326,13 @@ protected:
         uis_swathes = swathes;
       }
       
-      LOG_INFO << "Generating identifying transitions for IPF" << std::endl;
+      OPENMS_LOG_INFO << "Generating identifying transitions for IPF" << std::endl;
       assays.uisTransitions(targeted_exp, allowed_fragment_types, allowed_fragment_charges, enable_identification_specific_losses, enable_identification_unspecific_losses, enable_identification_ms2_precursors, product_mz_threshold, uis_swathes, -4, max_num_alternative_localizations, uis_seed, disable_decoy_transitions);
       std::vector<std::pair<double, double> > empty_swathes;
       assays.restrictTransitions(targeted_exp, product_lower_mz_limit, product_upper_mz_limit, empty_swathes);
     }
 
-    LOG_INFO << "Writing assays " << out << std::endl;
+    OPENMS_LOG_INFO << "Writing assays " << out << std::endl;
     if (out_type == FileTypes::TSV)
     {
       const char* tr_file = out.c_str();

--- a/src/topp/OpenSwathConfidenceScoring.cpp
+++ b/src/topp/OpenSwathConfidenceScoring.cpp
@@ -162,7 +162,7 @@ public:
     Size n_transitions_; // number of transitions to consider
     TransformationDescription rt_trafo_; /// RT transformation to map measured RTs to assay RTs
 
-    LOG_DEBUG << "Reading parameters..." << endl;
+    OPENMS_LOG_DEBUG << "Reading parameters..." << endl;
     String in = getStringOption_("in");
     String lib = getStringOption_("lib");
     String out = getStringOption_("out");
@@ -170,14 +170,14 @@ public:
     n_decoys_ = getIntOption_("decoys");
     n_transitions_ = getIntOption_("transitions");
 
-    LOG_DEBUG << "Loading input files..." << endl;
+    OPENMS_LOG_DEBUG << "Loading input files..." << endl;
     FeatureMap features;
     FeatureXMLFile().load(in, features);
     TraMLFile().load(lib, library_);
 
     if (trafo.empty())
     {
-      LOG_WARN << "Warning: You have not supplied an RT transformation file "
+      OPENMS_LOG_WARN << "Warning: You have not supplied an RT transformation file "
                << "(parameter 'trafo'). You should be sure that the retention "
                << "times of your features ('in') and library ('lib') are on "
                << "the same scale." << endl;
@@ -197,7 +197,7 @@ public:
     scoring.initializeGlm(getDoubleOption_("GLM:intercept"), getDoubleOption_("GLM:delta_rt"), getDoubleOption_("GLM:dist_int"));
     scoring.scoreMap(features);
 
-    LOG_DEBUG << "Storing results..." << endl;
+    OPENMS_LOG_DEBUG << "Storing results..." << endl;
     addDataProcessing_(features, 
                        getProcessingInfo_(DataProcessing::DATA_PROCESSING));
     FeatureXMLFile().store(out, features);

--- a/src/topp/OpenSwathDecoyGenerator.cpp
+++ b/src/topp/OpenSwathDecoyGenerator.cpp
@@ -226,7 +226,7 @@ protected:
     TargetedExperiment targeted_decoy;
 
     // Load data
-    LOG_INFO << "Loading targets from file: " << in << std::endl;
+    OPENMS_LOG_INFO << "Loading targets from file: " << in << std::endl;
     if (in_type == FileTypes::TSV || in_type == FileTypes::MRM)
     {
       const char* tr_file = in.c_str();
@@ -256,7 +256,7 @@ protected:
     MRMDecoy decoys = MRMDecoy();
     decoys.setLogType(ProgressLogger::CMD);
 
-    LOG_INFO << "Generate decoys" << std::endl;
+    OPENMS_LOG_INFO << "Generate decoys" << std::endl;
     decoys.generateDecoys(targeted_exp, targeted_decoy, method,
                           aim_decoy_fraction, switchKR, decoy_tag, max_attempts,
                           identity_threshold, precursor_mz_shift,
@@ -266,10 +266,10 @@ protected:
                           enable_detection_unspecific_losses);
 
     // Check if we have enough peptides left
-    LOG_INFO << "Number of target peptides: " << targeted_exp.getPeptides().size() << std::endl;
-    LOG_INFO << "Number of decoy peptides: " << targeted_decoy.getPeptides().size() << std::endl;
-    LOG_INFO << "Number of target proteins: " << targeted_exp.getProteins().size() << std::endl;
-    LOG_INFO << "Number of decoy proteins: " << targeted_decoy.getProteins().size() << std::endl;
+    OPENMS_LOG_INFO << "Number of target peptides: " << targeted_exp.getPeptides().size() << std::endl;
+    OPENMS_LOG_INFO << "Number of decoy peptides: " << targeted_decoy.getPeptides().size() << std::endl;
+    OPENMS_LOG_INFO << "Number of target proteins: " << targeted_exp.getProteins().size() << std::endl;
+    OPENMS_LOG_INFO << "Number of decoy proteins: " << targeted_decoy.getProteins().size() << std::endl;
 
     if ((float)targeted_decoy.getPeptides().size() / (float)targeted_exp.getPeptides().size() < min_decoy_fraction || (float)targeted_decoy.getProteins().size() / (float)targeted_exp.getProteins().size() < min_decoy_fraction)
     {
@@ -279,12 +279,12 @@ protected:
     TargetedExperiment targeted_merged;
     if (separate)
     {
-      LOG_INFO << "Writing only decoys to file: " << out << std::endl;
+      OPENMS_LOG_INFO << "Writing only decoys to file: " << out << std::endl;
       targeted_merged = targeted_decoy;
     }
     else
     {
-      LOG_INFO << "Writing targets and decoys to file: " << out << std::endl;
+      OPENMS_LOG_INFO << "Writing targets and decoys to file: " << out << std::endl;
       targeted_merged = targeted_exp + targeted_decoy;
     }
 

--- a/src/topp/PeakPickerHiRes.cpp
+++ b/src/topp/PeakPickerHiRes.cpp
@@ -229,7 +229,7 @@ protected:
 
     if (ms_exp_raw.empty() && ms_exp_raw.getChromatograms().size() == 0)
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }

--- a/src/topp/PeakPickerWavelet.cpp
+++ b/src/topp/PeakPickerWavelet.cpp
@@ -162,7 +162,7 @@ protected:
 
     if (ms_exp_raw.empty())
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }
@@ -199,7 +199,7 @@ protected:
     }
     catch (Exception::BaseException & e)
     {
-      LOG_ERROR << "Exception caught: " << e.what() << "\n";
+      OPENMS_LOG_ERROR << "Exception caught: " << e.what() << "\n";
       return INTERNAL_ERROR;
     }
     if (!write_meta_data_arrays)

--- a/src/topp/PepNovoAdapter.cpp
+++ b/src/topp/PepNovoAdapter.cpp
@@ -364,7 +364,7 @@ class TOPPPepNovoAdapter :
       catch(Exception::BaseException &exc)
       {
         writeLog_(exc.what());
-        LOG_ERROR << "Error occurred: " << exc.what() << std::endl;
+        OPENMS_LOG_ERROR << "Error occurred: " << exc.what() << std::endl;
         error = true;
       }
       

--- a/src/topp/PercolatorAdapter.cpp
+++ b/src/topp/PercolatorAdapter.cpp
@@ -294,7 +294,7 @@ protected:
       else
       {
         scan_identifier = "index=" + String(it - start + 1);
-        LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
+        OPENMS_LOG_WARN << "no known spectrum identifiers, using index [1,n] - use at own risk." << endl;
       }
     }
     return scan_identifier.removeWhitespaces();
@@ -413,7 +413,7 @@ protected:
       {
         if (jt->getPeptideEvidences().empty())
         {
-          LOG_WARN << "PSM (PeptideHit) without protein reference found. " 
+          OPENMS_LOG_WARN << "PSM (PeptideHit) without protein reference found. " 
                    << "This may indicate incomplete mapping during PeptideIndexing (e.g., wrong enzyme settings)." 
                    << "Will skip this PSM." << endl;
           continue;
@@ -571,14 +571,14 @@ protected:
       String in = *fit;
       FileHandler fh;
       FileTypes::Type in_type = fh.getType(in);
-      LOG_INFO << "Loading input file: " << in << endl;
+      OPENMS_LOG_INFO << "Loading input file: " << in << endl;
       if (in_type == FileTypes::IDXML)
       {
         IdXMLFile().load(in, protein_ids, peptide_ids);
       }
       else if (in_type == FileTypes::MZIDENTML)
       {
-        LOG_WARN << "Converting from mzid: possible loss of information depending on target format." << endl;
+        OPENMS_LOG_WARN << "Converting from mzid: possible loss of information depending on target format." << endl;
         MzIdentMLFile().load(in, protein_ids, peptide_ids);
       }
       //else catched by TOPPBase:registerInput being mandatory mzid or idxml
@@ -659,36 +659,36 @@ protected:
         
         if (protein_ids.front().getScoreType() != all_protein_ids.front().getScoreType())
         {
-          LOG_WARN << "Warning: differing ScoreType between input files" << endl;
+          OPENMS_LOG_WARN << "Warning: differing ScoreType between input files" << endl;
         }
         if (search_parameters.digestion_enzyme != all_search_parameters.digestion_enzyme)
         {
-          LOG_WARN << "Warning: differing DigestionEnzyme between input files" << endl;
+          OPENMS_LOG_WARN << "Warning: differing DigestionEnzyme between input files" << endl;
         }
         if (search_parameters.variable_modifications != all_search_parameters.variable_modifications)
         {
-          LOG_WARN << "Warning: differing VarMods between input files" << endl;
+          OPENMS_LOG_WARN << "Warning: differing VarMods between input files" << endl;
         }
         if (search_parameters.fixed_modifications != all_search_parameters.fixed_modifications)
         {
-          LOG_WARN << "Warning: differing FixMods between input files" << endl;
+          OPENMS_LOG_WARN << "Warning: differing FixMods between input files" << endl;
         }
         if (search_parameters.charges != all_search_parameters.charges)
         {
-          LOG_WARN << "Warning: differing SearchCharges between input files" << endl;
+          OPENMS_LOG_WARN << "Warning: differing SearchCharges between input files" << endl;
         }
         if (search_parameters.fragment_mass_tolerance != all_search_parameters.fragment_mass_tolerance)
         {
-          LOG_WARN << "Warning: differing FragTol between input files" << endl;
+          OPENMS_LOG_WARN << "Warning: differing FragTol between input files" << endl;
         }
         if (search_parameters.precursor_mass_tolerance != all_search_parameters.precursor_mass_tolerance)
         {
-          LOG_WARN << "Warning: differing PrecTol between input files" << endl;
+          OPENMS_LOG_WARN << "Warning: differing PrecTol between input files" << endl;
         }
       }
-      LOG_INFO << "Merging peptide ids." << endl;
+      OPENMS_LOG_INFO << "Merging peptide ids." << endl;
       all_peptide_ids.insert(all_peptide_ids.end(), peptide_ids.begin(), peptide_ids.end());
-      LOG_INFO << "Merging protein ids." << endl;
+      OPENMS_LOG_INFO << "Merging protein ids." << endl;
       PercolatorFeatureSetHelper::mergeMULTISEProteinIds(all_protein_ids, protein_ids);
     }
     return EXECUTION_OK;
@@ -707,7 +707,7 @@ protected:
     //-------------------------------------------------------------
     const StringList in_list = getStringList_("in");
     const StringList in_decoy = getStringList_("in_decoy");
-    LOG_DEBUG << "Input file (of target?): " << ListUtils::concatenate(in_list, ",") << " & " << ListUtils::concatenate(in_decoy, ",") << " (decoy)" << endl;
+    OPENMS_LOG_DEBUG << "Input file (of target?): " << ListUtils::concatenate(in_list, ",") << " & " << ListUtils::concatenate(in_decoy, ",") << " (decoy)" << endl;
     const String in_osw = getStringOption_("in_osw");
     const String osw_level = getStringOption_("osw_level");
 
@@ -843,7 +843,7 @@ protected:
           return read_exit;
         }
       }
-      LOG_DEBUG << "Using min/max charges of " << min_charge << "/" << max_charge << endl;
+      OPENMS_LOG_DEBUG << "Using min/max charges of " << min_charge << "/" << max_charge << endl;
       
       if (!found_decoys)
       {
@@ -908,7 +908,7 @@ protected:
       feature_set.push_back("Peptide");
       feature_set.push_back("Proteins");
       
-      LOG_DEBUG << "Writing percolator input file." << endl;
+      OPENMS_LOG_DEBUG << "Writing percolator input file." << endl;
       TextFile txt;  
       txt.addLine(ListUtils::concatenate(feature_set, '\t'));
       preparePin_(all_peptide_ids, feature_set, enz_str, txt, min_charge, max_charge);
@@ -917,7 +917,7 @@ protected:
     // OSW input
     else
     {
-      LOG_DEBUG << "Writing percolator input file." << endl;
+      OPENMS_LOG_DEBUG << "Writing percolator input file." << endl;
       TextFile txt;  
       std::stringstream pin_output;
       OSWFile().read(in_osw, osw_level, pin_output, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn);
@@ -1078,7 +1078,7 @@ protected:
           }
           else
           {
-            LOG_WARN << "Identifier " << psm_identifier << " not found in peptide map." << endl;
+            OPENMS_LOG_WARN << "Identifier " << psm_identifier << " not found in peptide map." << endl;
             hit->setMetaValue("MS:1001492", 0.0);  // svm score
             hit->setMetaValue("MS:1001491", 1.0);  // percolator q value
             hit->setMetaValue("MS:1001493", 1.0);  // percolator pep
@@ -1094,8 +1094,8 @@ protected:
           }
         }
       }
-      //LOG_INFO << "No suitable PeptideIdentification for " << c_debug << " out of " << all_peptide_ids.size() << endl;
-      LOG_INFO << "Suitable PeptideHits for " << cnt << " found." << endl;
+      //OPENMS_LOG_INFO << "No suitable PeptideIdentification for " << c_debug << " out of " << all_peptide_ids.size() << endl;
+      OPENMS_LOG_INFO << "Suitable PeptideHits for " << cnt << " found." << endl;
 
       // TODO: There should only be 1 ProteinIdentification element in this vector, no need for a for loop
       for (vector<ProteinIdentification>::iterator it = all_protein_ids.begin(); it != all_protein_ids.end(); ++it)

--- a/src/topp/PhosphoScoring.cpp
+++ b/src/topp/PhosphoScoring.cpp
@@ -324,7 +324,7 @@ protected:
         PeptideHit scored_hit = *hit;
         addScoreToMetaValues_(scored_hit, pep_id->getScoreType()); // backup score value
         
-        LOG_DEBUG << "starting to compute AScore RT=" << pep_id->getRT() << " SEQUENCE: " << scored_hit.getSequence().toString() << std::endl;
+        OPENMS_LOG_DEBUG << "starting to compute AScore RT=" << pep_id->getRT() << " SEQUENCE: " << scored_hit.getSequence().toString() << std::endl;
         
         PeptideHit phospho_sites = ascore.compute(scored_hit, temp);
         scored_peptides.push_back(phospho_sites);

--- a/src/topp/ProteinQuantifier.cpp
+++ b/src/topp/ProteinQuantifier.cpp
@@ -616,16 +616,16 @@ protected:
   /// Write processing statistics.
   void writeStatistics_(const Statistics& stats)
   {
-    LOG_INFO << "\nProcessing summary - number of...";
+    OPENMS_LOG_INFO << "\nProcessing summary - number of...";
     if (spectral_counting_)
     {
-      LOG_INFO << "\n...spectra: " << stats.total_features << " identified"
+      OPENMS_LOG_INFO << "\n...spectra: " << stats.total_features << " identified"
                << "\n...peptides: " << stats.quant_peptides
                << " identified and quantified (considering best hits only)";
     }
     else
     {
-      LOG_INFO << "\n...features: " << stats.quant_features
+      OPENMS_LOG_INFO << "\n...features: " << stats.quant_features
                << " used for quantification, " << stats.total_features
                << " total (" << stats.blank_features << " no annotation, "
                << stats.ambig_features << " ambiguous annotation)"
@@ -637,19 +637,19 @@ protected:
     {
       bool include_all = algo_params_.getValue("include_all") == "true";
       Size top = algo_params_.getValue("top");
-      LOG_INFO << "\n...proteins/protein groups: " << stats.quant_proteins
+      OPENMS_LOG_INFO << "\n...proteins/protein groups: " << stats.quant_proteins
                << " quantified";
       if (top > 1)
       {
-        if (include_all) LOG_INFO << " (incl. ";
-        else LOG_INFO << ", ";
-        LOG_INFO << stats.too_few_peptides << " with fewer than " << top
+        if (include_all) OPENMS_LOG_INFO << " (incl. ";
+        else OPENMS_LOG_INFO << ", ";
+        OPENMS_LOG_INFO << stats.too_few_peptides << " with fewer than " << top
                  << " peptides";
-        if (stats.n_samples > 1) LOG_INFO << " in every sample";
-        if (include_all) LOG_INFO << ")";
+        if (stats.n_samples > 1) OPENMS_LOG_INFO << " in every sample";
+        if (include_all) OPENMS_LOG_INFO << ")";
       }
     }
-    LOG_INFO << endl;
+    OPENMS_LOG_INFO << endl;
   }
 
 

--- a/src/topp/RTModel.cpp
+++ b/src/topp/RTModel.cpp
@@ -366,8 +366,8 @@ protected:
     String outputfile_name = getStringOption_("out");
     additive_cv = getFlag_("additive_cv");
     skip_cv = getFlag_("cv:skip_cv");
-    if (skip_cv) LOG_INFO << "Cross-validation disabled!\n";
-    else LOG_INFO << "Cross-validation enabled!\n";
+    if (skip_cv) OPENMS_LOG_INFO << "Cross-validation disabled!\n";
+    else OPENMS_LOG_INFO << "Cross-validation enabled!\n";
 
     float total_gradient_time = getDoubleOption_("total_gradient_time");
     max_std = getDoubleOption_("max_std");

--- a/src/topp/SpecLibSearcher.cpp
+++ b/src/topp/SpecLibSearcher.cpp
@@ -352,7 +352,7 @@ protected:
     MapLibraryPrecursorToLibrarySpectrum mslib = annotateIdentificationsToSpectra_(ids, library, variable_modifications, fixed_modifications, remove_peaks_below_threshold);
 
     time_t end_build_time = time(nullptr);
-    LOG_INFO << "Time needed for preprocessing data: " << (end_build_time - start_build_time) << "\n";
+    OPENMS_LOG_INFO << "Time needed for preprocessing data: " << (end_build_time - start_build_time) << "\n";
 
     //compare function
     PeakSpectrumCompareFunctor* comparor = Factory<PeakSpectrumCompareFunctor>::create(compare_function);
@@ -582,10 +582,10 @@ protected:
       IdXMLFile id_xml_file;
       id_xml_file.store(*out_file, protein_ids, peptide_ids);
       time_t end_time = time(nullptr);
-      LOG_INFO << "Search time: " << difftime(end_time, start_time) << " seconds for " << *in << "\n";
+      OPENMS_LOG_INFO << "Search time: " << difftime(end_time, start_time) << " seconds for " << *in << "\n";
     }
     time_t end_time = time(nullptr);
-    LOG_INFO << "Total time: " << difftime(end_time, prog_time) << " seconds\n";
+    OPENMS_LOG_INFO << "Total time: " << difftime(end_time, prog_time) << " seconds\n";
     return EXECUTION_OK;
   }
 

--- a/src/topp/XTandemAdapter.cpp
+++ b/src/topp/XTandemAdapter.cpp
@@ -349,7 +349,7 @@ protected:
       }
       else
       {
-        LOG_ERROR << "Error: spectrum with ID '" << ref << "' not found in input data! RT and precursor m/z values could not be looked up." << endl;
+        OPENMS_LOG_ERROR << "Error: spectrum with ID '" << ref << "' not found in input data! RT and precursor m/z values could not be looked up." << endl;
       }
     }
 
@@ -399,15 +399,15 @@ protected:
 
     // some stats (note that only MS2 spectra were loaded into "exp"):
     Int percent = peptide_ids.size() * 100.0 / exp.size();
-    LOG_INFO << "Statistics:\n"
+    OPENMS_LOG_INFO << "Statistics:\n"
              << "- identified MS2 spectra: " << peptide_ids.size() << " / "
              << exp.size() << " = " << percent << "%";
     if (output_results != "all")
     {
-      LOG_INFO << " (with E-value " << (output_results == "valid" ? "< " : "> ")
+      OPENMS_LOG_INFO << " (with E-value " << (output_results == "valid" ? "< " : "> ")
                << String(max_evalue) << ")";
     }
-    LOG_INFO << std::endl;
+    OPENMS_LOG_INFO << std::endl;
 
     return EXECUTION_OK;
   }

--- a/src/utils/AssayGeneratorMetabo.cpp
+++ b/src/utils/AssayGeneratorMetabo.cpp
@@ -313,7 +313,7 @@ protected:
           if (feature_map.getProteinIdentifications().empty())
           {
             use_known_unknowns = true;
-            LOG_INFO << "Due to the use of data without previous identification "
+            OPENMS_LOG_INFO << "Due to the use of data without previous identification "
                      << "use_known_unknowns will be switched on." << std::endl;
           }
         }
@@ -404,7 +404,7 @@ protected:
   
         // sort vector path list
         std::sort(subdirs.begin(), subdirs.end(), extractAndCompareScanIndexLess_);
-        LOG_DEBUG << subdirs.size() << " spectra were annotated using SIRIUS." << std::endl;
+        OPENMS_LOG_DEBUG << subdirs.size() << " spectra were annotated using SIRIUS." << std::endl;
   
         // get Sirius FragmentAnnotion from subdirs
         vector<MSSpectrum> annotated_spectra;

--- a/src/utils/DatabaseFilter.cpp
+++ b/src/utils/DatabaseFilter.cpp
@@ -107,7 +107,7 @@ protected:
       }
     }
 
-    LOG_INFO << "Protein accessions: " << id_accessions.size() << endl;
+    OPENMS_LOG_INFO << "Protein accessions: " << id_accessions.size() << endl;
 
     for (Size i = 0; i != db.size() ; ++i)
     {
@@ -169,7 +169,7 @@ protected:
         return ILLEGAL_PARAMETERS;
       }
 
-      LOG_INFO << "Identifications: " << ids.size() << endl;
+      OPENMS_LOG_INFO << "Identifications: " << ids.size() << endl;
 
       // run filter
       filterByProteinAccessions_(db, peptide_identifications, whitelist, db_new);
@@ -179,7 +179,7 @@ protected:
     // writing output
     //-------------------------------------------------------------
 
-    LOG_INFO << "Database entries (before / after): " << db.size() << " / " << db_new.size() << endl;
+    OPENMS_LOG_INFO << "Database entries (before / after): " << db.size() << " / " << db_new.size() << endl;
     FASTAFile().store(out, db_new);
 
     return EXECUTION_OK;

--- a/src/utils/DecoyDatabase.cpp
+++ b/src/utils/DecoyDatabase.cpp
@@ -177,7 +177,7 @@ protected:
 
     if (in.size() == 1)
     {
-      LOG_WARN << "Warning: Only one FASTA input file was provided, which might not contain contaminants. "
+      OPENMS_LOG_WARN << "Warning: Only one FASTA input file was provided, which might not contain contaminants. "
                << "You probably want to have them! Just add the contaminant file to the input file list 'in'." << endl;
     }
 
@@ -210,7 +210,7 @@ protected:
       {
         if (identifiers.find(entry.identifier) != identifiers.end())
         {
-          LOG_WARN << "DecoyDatabase: Warning, identifier '" << entry.identifier << "' occurs more than once!" << endl;
+          OPENMS_LOG_WARN << "DecoyDatabase: Warning, identifier '" << entry.identifier << "' occurs more than once!" << endl;
         }
         identifiers.insert(entry.identifier);
 

--- a/src/utils/Digestor.cpp
+++ b/src/utils/Digestor.cpp
@@ -155,7 +155,7 @@ protected:
 
     if (out_type == FileTypes::UNKNOWN)
     {
-      LOG_ERROR << ("Error: Could not determine output file type!") << std::endl;
+      OPENMS_LOG_ERROR << ("Error: Could not determine output file type!") << std::endl;
       return PARSE_ERROR;
     }
 
@@ -259,7 +259,7 @@ protected:
     }
 
     Size pep_remaining_count = (has_FASTA_output ? fasta_out_count : identifications.size());
-    LOG_INFO << "Statistics:\n"
+    OPENMS_LOG_INFO << "Statistics:\n"
              << "  file:                                    " << inputfile_name << "\n"
              << "  total #peptides after digestion:         " << pep_remaining_count + dropped_by_length << "\n"
              << "  removed #peptides (length restrictions): " << dropped_by_length << "\n"

--- a/src/utils/FeatureFinderMetaboIdent.cpp
+++ b/src/utils/FeatureFinderMetaboIdent.cpp
@@ -272,7 +272,7 @@ protected:
       vector<String> parts = ListUtils::create<String>(line, '\t'); // split
       if (parts.size() < 7)
       {
-        LOG_ERROR << "Error: Expected 7 tab-separated fields, found only "
+        OPENMS_LOG_ERROR << "Error: Expected 7 tab-separated fields, found only "
                   << parts.size() << " in line " << line_count
                   << " - skipping this line." << endl;
         continue;
@@ -280,13 +280,13 @@ protected:
       String name = parts[0];
       if (name.empty())
       {
-        LOG_ERROR << "Error: Empty name field in input line " << line_count
+        OPENMS_LOG_ERROR << "Error: Empty name field in input line " << line_count
                   << " - skipping this line." << endl;
         continue;
       }
       if (!names.insert(name).second) // @TODO: is this check necessary?
       {
-        LOG_ERROR << "Error: Duplicate name '" << name << "' in input line "
+        OPENMS_LOG_ERROR << "Error: Duplicate name '" << name << "' in input line "
                   << line_count << " - skipping this line." << endl;
         continue;
       }
@@ -316,13 +316,13 @@ protected:
   {
     if ((mass <= 0) && formula.empty())
     {
-      LOG_ERROR << "Error: No mass or sum formula given for target '" << name
+      OPENMS_LOG_ERROR << "Error: No mass or sum formula given for target '" << name
                 << "' - skipping this target." << endl;
       return;
     }
     if (rts.empty())
     {
-      LOG_ERROR << "Error: No retention time (RT) given for target '" << name
+      OPENMS_LOG_ERROR << "Error: No retention time (RT) given for target '" << name
                 << "' - skipping this target." << endl;
       return;
     }
@@ -343,7 +343,7 @@ protected:
     {
       if (formula.empty())
       {
-        LOG_ERROR << "Error: No sum formula given for target '" << name
+        OPENMS_LOG_ERROR << "Error: No sum formula given for target '" << name
                   << "'; cannot calculate isotope distribution"
                   << " - using estimation method for peptides." << endl;
         iso_dist = iso_gen_.estimateFromPeptideWeight(mass);
@@ -377,7 +377,7 @@ protected:
     {
       if (*z_it == 0)
       {
-        LOG_ERROR << "Error: Invalid charge 0 for target '" << name
+        OPENMS_LOG_ERROR << "Error: Invalid charge 0 for target '" << name
                   << "' - skipping this charge." << endl;
         continue;
       }
@@ -623,7 +623,7 @@ protected:
         if (it != group.begin()) msg += ", ";
         msg += String((*it)->getMetaValue("PeptideRef")) + " (RT " + String(float((*it)->getRT())) + ")";
       }
-      LOG_DEBUG << msg << endl;
+      OPENMS_LOG_DEBUG << msg << endl;
     }
 
     Feature* best_feature = 0;
@@ -664,7 +664,7 @@ protected:
           }
           else
           {
-            LOG_WARN << "Warning: cannot decide between equally good feature candidates; picking the first one of "
+            OPENMS_LOG_WARN << "Warning: cannot decide between equally good feature candidates; picking the first one of "
                      << best_feature->getMetaValue("PeptideRef") << " (RT "
                      << float(best_feature->getRT()) << ") and "
                      << (*it)->getMetaValue("PeptideRef") << " (RT "
@@ -785,7 +785,7 @@ protected:
       {
         if (best_rt_dist <= 0.0)
         {
-          LOG_WARN << "Warning: overlapping feature candidates for assay '"
+          OPENMS_LOG_WARN << "Warning: overlapping feature candidates for assay '"
                    << ref << "'" << endl;
         }
         rt_dist = 0.0;
@@ -901,17 +901,17 @@ protected:
     {
       // calculate RT window based on other parameters:
       rt_window_ = 4 * peak_width;
-      LOG_INFO << "RT window size calculated as " << rt_window_ << " seconds."
+      OPENMS_LOG_INFO << "RT window size calculated as " << rt_window_ << " seconds."
                << endl;
     }
 
     //-------------------------------------------------------------
     // load input
     //-------------------------------------------------------------
-    LOG_INFO << "Loading targets and creating assay library..." << endl;
+    OPENMS_LOG_INFO << "Loading targets and creating assay library..." << endl;
     readTargets_(id);
 
-    LOG_INFO << "Loading input LC-MS data..." << endl;
+    OPENMS_LOG_INFO << "Loading input LC-MS data..." << endl;
     MzMLFile mzml;
     mzml.setLogType(log_type_);
     mzml.getOptions().addMSLevel(1);
@@ -944,7 +944,7 @@ protected:
     keep_library_ = !lib_out.empty();
     keep_chromatograms_ = !chrom_out.empty();
 
-    LOG_INFO << "Extracting chromatograms..." << endl;
+    OPENMS_LOG_INFO << "Extracting chromatograms..." << endl;
     ChromatogramExtractor extractor;
     // extractor.setLogType(ProgressLogger::NONE);
     vector<OpenSwath::ChromatogramPtr> chrom_temp;
@@ -960,15 +960,15 @@ protected:
     extractor.return_chromatogram(chrom_temp, coords, library_, (*shared)[0],
                                   chrom_data_.getChromatograms(), false);
 
-    LOG_DEBUG << "Extracted " << chrom_data_.getNrChromatograms()
+    OPENMS_LOG_DEBUG << "Extracted " << chrom_data_.getNrChromatograms()
               << " chromatogram(s)." << endl;
 
-    LOG_INFO << "Detecting chromatographic peaks..." << endl;
+    OPENMS_LOG_INFO << "Detecting chromatographic peaks..." << endl;
     Log_info.remove(cout); // suppress status output from OpenSWATH
     feat_finder_.pickExperiment(chrom_data_, features, library_,
                                 TransformationDescription(), ms_data_);
     Log_info.insert(cout);
-    LOG_INFO << "Found " << features.size() << " feature candidates in total."
+    OPENMS_LOG_INFO << "Found " << features.size() << " feature candidates in total."
              << endl;
     ms_data_.reset(); // not needed anymore, free up the memory
 
@@ -1002,7 +1002,7 @@ protected:
     }
 
     selectFeaturesFromCandidates_(features);
-    LOG_INFO << features.size()
+    OPENMS_LOG_INFO << features.size()
              << " features left after selection of best candidates." << endl;
 
     // get bounding boxes for all mass traces in all features:
@@ -1013,7 +1013,7 @@ protected:
     findOverlappingFeatures_(features, feature_bounds, overlap_groups);
     if (overlap_groups.size() == features.size())
     {
-      LOG_INFO << "No overlaps between features found." << endl;
+      OPENMS_LOG_INFO << "No overlaps between features found." << endl;
     }
     else
     {
@@ -1030,7 +1030,7 @@ protected:
       }
       features.erase(remove_if(features.begin(), features.end(),
                              feature_filter_), features.end());
-      LOG_INFO << features.size()
+      OPENMS_LOG_INFO << features.size()
                << " features left after resolving overlaps (involving "
                << n_overlap_features << " features in " << n_overlap_groups
                << " groups)." << endl;
@@ -1065,7 +1065,7 @@ protected:
     // write output
     //-------------------------------------------------------------
 
-    LOG_INFO << "Writing final results..." << endl;
+    OPENMS_LOG_INFO << "Writing final results..." << endl;
     FeatureXMLFile().store(out, features);
 
     if (!trafo_out.empty()) // write expected vs. observed retention times
@@ -1090,7 +1090,7 @@ protected:
     //-------------------------------------------------------------
 
     Size n_missing = features.getUnassignedPeptideIdentifications().size();
-    LOG_INFO << "\nSummary statistics:\n"
+    OPENMS_LOG_INFO << "\nSummary statistics:\n"
              << library_.getCompounds().size() << " targets specified\n"
              << features.size() << " features found\n"
              << n_shared << " features with multiple target annotations\n"
@@ -1098,7 +1098,7 @@ protected:
     const Size n_examples = 5;
     if (n_missing)
     {
-      LOG_INFO << ":";
+      OPENMS_LOG_INFO << ":";
       for (Size i = 0;
            ((i < features.getUnassignedPeptideIdentifications().size()) &&
             (i < n_examples)); ++i)
@@ -1107,14 +1107,14 @@ protected:
           features.getUnassignedPeptideIdentifications()[i];
         const TargetedExperiment::Compound& compound =
           library_.getCompoundByRef(id.getMetaValue("PeptideRef"));
-        LOG_INFO << "\n- " << prettyPrintCompound_(compound);
+        OPENMS_LOG_INFO << "\n- " << prettyPrintCompound_(compound);
       }
       if (n_missing > n_examples)
       {
-        LOG_INFO << "\n- ... (" << n_missing - n_examples << " more)";
+        OPENMS_LOG_INFO << "\n- ... (" << n_missing - n_examples << " more)";
       }
     }
-    LOG_INFO << "\n" << endl;
+    OPENMS_LOG_INFO << "\n" << endl;
 
     return EXECUTION_OK;
   }

--- a/src/utils/FeatureFinderSuperHirn.cpp
+++ b/src/utils/FeatureFinderSuperHirn.cpp
@@ -113,7 +113,7 @@ protected:
 
     if (input.empty())
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }

--- a/src/utils/IDScoreSwitcher.cpp
+++ b/src/utils/IDScoreSwitcher.cpp
@@ -192,7 +192,7 @@ protected:
 
     IdXMLFile().store(out, proteins, peptides);
 
-    LOG_INFO << "Successfully switched " << counter << " "
+    OPENMS_LOG_INFO << "Successfully switched " << counter << " "
              << (do_proteins ? "protein" : "PSM") << " scores." << endl;
 
     return EXECUTION_OK;

--- a/src/utils/ImageCreator.cpp
+++ b/src/utils/ImageCreator.cpp
@@ -270,7 +270,7 @@ protected:
       StringListUtils::toUpper(out_formats_);
       if (!ListUtils::contains(out_formats_, format.toUpper()))
       {
-        LOG_ERROR << "No explicit image output format was provided via 'out_type', and the suffix ('" << format << "') does not resemble a valid type. Please fix one of them." << std::endl;
+        OPENMS_LOG_ERROR << "No explicit image output format was provided via 'out_type', and the suffix ('" << format << "') does not resemble a valid type. Please fix one of them." << std::endl;
         return ILLEGAL_PARAMETERS;
       }
     }

--- a/src/utils/LowMemPeakPickerHiRes.cpp
+++ b/src/utils/LowMemPeakPickerHiRes.cpp
@@ -181,7 +181,7 @@ protected:
     /*
     if (ms_exp_raw.empty() && ms_exp_raw.getChromatograms().size() == 0)
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }

--- a/src/utils/LowMemPeakPickerHiResRandomAccess.cpp
+++ b/src/utils/LowMemPeakPickerHiResRandomAccess.cpp
@@ -157,7 +157,7 @@ protected:
     /*
     if (ms_exp_raw.empty() && ms_exp_raw.getChromatograms().size() == 0)
     {
-      LOG_WARN << "The given file does not contain any conventional peak data, but might"
+      OPENMS_LOG_WARN << "The given file does not contain any conventional peak data, but might"
                   " contain chromatograms. This tool currently cannot handle them, sorry.";
       return INCOMPATIBLE_INPUT_DATA;
     }

--- a/src/utils/MRMTransitionGroupPicker.cpp
+++ b/src/utils/MRMTransitionGroupPicker.cpp
@@ -200,7 +200,7 @@ protected:
         const TransitionType* transition = assay_map[id][i];
         if (chromatogram_map.find(transition->getNativeID()) == chromatogram_map.end())
         {
-          LOG_DEBUG << "Found no matching chromatogram for id " << transition->getNativeID() << std::endl;
+          OPENMS_LOG_DEBUG << "Found no matching chromatogram for id " << transition->getNativeID() << std::endl;
           continue;
         }
 

--- a/src/utils/MSFraggerAdapter.cpp
+++ b/src/utils/MSFraggerAdapter.cpp
@@ -638,7 +638,7 @@ protected:
 
     if (process_msfragger.waitForFinished(-1) == false || process_msfragger.exitCode() != 0)
     {
-      LOG_FATAL_ERROR << "FATAL: Invocation of MSFraggerAdapter has failed. Error code was: " << process_msfragger.exitCode() << std::endl;
+      OPENMS_LOG_FATAL_ERROR << "FATAL: Invocation of MSFraggerAdapter has failed. Error code was: " << process_msfragger.exitCode() << std::endl;
       const QString msfragger_stdout(process_msfragger.readAllStandardOutput());
       const QString msfragger_stderr(process_msfragger.readAllStandardError());
       writeLog_(msfragger_stdout);
@@ -724,7 +724,7 @@ private:
 
   inline void _fatalError(const String & message)
   {
-    LOG_FATAL_ERROR << "FATAL: " << message << std::endl;
+    OPENMS_LOG_FATAL_ERROR << "FATAL: " << message << std::endl;
     throw 1;
   }
 
@@ -747,7 +747,7 @@ private:
   {
     if (right < left)
     {
-      LOG_ERROR << "FATAL: " << message << std::endl;
+      OPENMS_LOG_ERROR << "FATAL: " << message << std::endl;
       throw 1;
     }
   }

--- a/src/utils/MSSimulator.cpp
+++ b/src/utils/MSSimulator.cpp
@@ -251,7 +251,7 @@ protected:
         getStringOption_("out_cntm") == "" &&
         getStringOption_("out_id") == "")
     {
-      LOG_ERROR << "Error: At least one output file needs to specified!" << std::endl;
+      OPENMS_LOG_ERROR << "Error: At least one output file needs to specified!" << std::endl;
       return MISSING_PARAMETERS;
     }
 

--- a/src/utils/MSstatsConverter.cpp
+++ b/src/utils/MSstatsConverter.cpp
@@ -210,7 +210,7 @@ private:
     {
       if (error_condition)
       {
-        LOG_FATAL_ERROR << "FATAL: " << message << std::endl;
+        OPENMS_LOG_FATAL_ERROR << "FATAL: " << message << std::endl;
         throw exit_code;
       }
     }

--- a/src/utils/MassCalculator.cpp
+++ b/src/utils/MassCalculator.cpp
@@ -208,7 +208,7 @@ protected:
       } 
       catch (Exception::ParseError& /*e*/)
       {
-        LOG_WARN << "Warning: '" << item << "' is not a valid peptide sequence - skipping\n";
+        OPENMS_LOG_WARN << "Warning: '" << item << "' is not a valid peptide sequence - skipping\n";
         continue;
       }
 
@@ -228,11 +228,11 @@ protected:
       }
       if (conversion_failed_count)
       {
-        LOG_WARN << "Warning: Invalid charge state specified in line:" << line_count << ".\n";
+        OPENMS_LOG_WARN << "Warning: Invalid charge state specified in line:" << line_count << ".\n";
       }
       if (local_charges.empty())
       {
-        LOG_WARN << "Warning: No charge state specified - skipping (line:" << line_count << ")\n";
+        OPENMS_LOG_WARN << "Warning: No charge state specified - skipping (line:" << line_count << ")\n";
         continue;
       }
       writeLine_(seq, local_charges);
@@ -273,7 +273,7 @@ protected:
 
     if ((in.size() > 0) && (in_seq.size() > 0))
     {
-      LOG_ERROR << "Specifying an input file and input sequences at the same time is not allowed!";
+      OPENMS_LOG_ERROR << "Specifying an input file and input sequences at the same time is not allowed!";
       return ILLEGAL_PARAMETERS;
     }
 
@@ -285,7 +285,7 @@ protected:
     {
       if (charges.empty())
       {
-        LOG_ERROR << "Error: No charge state specified";
+        OPENMS_LOG_ERROR << "Error: No charge state specified";
         return ILLEGAL_PARAMETERS;
       }
       for (StringList::iterator it = in_seq.begin(); it != in_seq.end(); ++it)
@@ -297,7 +297,7 @@ protected:
         }
         catch (Exception::ParseError& /*e*/)
         {
-          LOG_WARN << "Warning: '" << *it << "' is not a valid peptide sequence - skipping\n";
+          OPENMS_LOG_WARN << "Warning: '" << *it << "' is not a valid peptide sequence - skipping\n";
           continue;
         }
 

--- a/src/utils/MetaProSIP.cpp
+++ b/src/utils/MetaProSIP.cpp
@@ -223,7 +223,7 @@ public:
 
     if (debug)
     {
-      LOG_DEBUG << x[0] << " " << x[n - 1] << " " << n << endl;
+      OPENMS_LOG_DEBUG << x[0] << " " << x[n - 1] << " " << n << endl;
     }
 
     double last_dxdy = 0;
@@ -249,10 +249,10 @@ public:
 
     if (debug)
     {
-      LOG_DEBUG << "Found: " << high_points.size() << " local maxima." << endl;
+      OPENMS_LOG_DEBUG << "Found: " << high_points.size() << " local maxima." << endl;
       for (Size i = 0; i != high_points.size(); ++i)
       {
-        LOG_DEBUG << high_points[i].rate << " " << high_points[i].score << endl;
+        OPENMS_LOG_DEBUG << high_points[i].rate << " " << high_points[i].score << endl;
       }
     }
 
@@ -787,16 +787,16 @@ public:
     }
 
     // heat map based on peptide RIAs
-    LOG_INFO << "Plotting peptide heat map of " << sip_peptides.size() << endl;
+    OPENMS_LOG_INFO << "Plotting peptide heat map of " << sip_peptides.size() << endl;
     vector<vector<double> > binned_peptide_ria;
     vector<String> class_labels;
     createBinnedPeptideRIAData_(n_heatmap_bins, sip_peptide_cluster, binned_peptide_ria, class_labels);
     plotHeatMap(qc_output_directory, tmp_path, "_peptide" + file_suffix, file_extension, binned_peptide_ria, class_labels, 0, executable);
 
-    LOG_INFO << "Plotting filtered spectra for quality report" << endl;
+    OPENMS_LOG_INFO << "Plotting filtered spectra for quality report" << endl;
     plotFilteredSpectra(qc_output_directory, tmp_path, file_suffix, file_extension, sip_peptides, 0, executable);
 
-    LOG_INFO << "Plotting correlation score and weight distribution" << endl;
+    OPENMS_LOG_INFO << "Plotting correlation score and weight distribution" << endl;
     plotScoresAndWeights(qc_output_directory, tmp_path, file_suffix, file_extension, sip_peptides, score_plot_y_axis_min, 0, executable);
 
     if (file_extension != "pdf") // html doesn't support pdf as image
@@ -1116,7 +1116,7 @@ public:
       }
     }
 
-    LOG_INFO << "Writing " << peptide_to_cluster_index.size() << " peptides to peptide centric csv." << endl;
+    OPENMS_LOG_INFO << "Writing " << peptide_to_cluster_index.size() << " peptides to peptide centric csv." << endl;
 
     // sort by sequence
     sort(peptide_to_cluster_index.begin(), peptide_to_cluster_index.end(), SequenceLess());
@@ -1858,7 +1858,7 @@ public:
         }
         else
         {
-          LOG_WARN << "RT: " << rt << " not contained in rt set." << endl;
+          OPENMS_LOG_WARN << "RT: " << rt << " not contained in rt set." << endl;
         }
       }
 
@@ -1941,7 +1941,7 @@ public:
     checkRInPath.addLine("q()");
     checkRInPath.store(script_filename);
 
-    LOG_INFO << "Checking R...";
+    OPENMS_LOG_INFO << "Checking R...";
     {
       QProcess p;
       p.setProcessChannelMode(QProcess::MergedChannels);
@@ -1956,14 +1956,14 @@ public:
 
       if (p.error() == QProcess::FailedToStart || p.exitStatus() == QProcess::CrashExit || p.exitCode() != 0)
       {
-        LOG_INFO << " failed" << std::endl;
-        LOG_ERROR << "Can't execute R. Do you have R installed? Check if the path to R is in your system path variable." << std::endl;
+        OPENMS_LOG_INFO << " failed" << std::endl;
+        OPENMS_LOG_ERROR << "Can't execute R. Do you have R installed? Check if the path to R is in your system path variable." << std::endl;
         return false;
       }
-      LOG_INFO << " success" << std::endl;
+      OPENMS_LOG_INFO << " success" << std::endl;
     }
     // check dependencies
-    LOG_INFO << "Checking R dependencies. If package is not found we will try to install it in your temp directory...";
+    OPENMS_LOG_INFO << "Checking R dependencies. If package is not found we will try to install it in your temp directory...";
     TextFile current_script;
     current_script.addLine("LoadOrInstallPackage <-function(x)");
     current_script.addLine("{");
@@ -2001,16 +2001,16 @@ public:
 
     if (status != 0)
     {
-      LOG_ERROR << "\nProblem finding all R dependencies. Check if R and following libraries are installed:" << std::endl;
+      OPENMS_LOG_ERROR << "\nProblem finding all R dependencies. Check if R and following libraries are installed:" << std::endl;
       for (TextFile::ConstIterator line_it = current_script.begin(); line_it != current_script.end(); ++line_it)
       {
-        LOG_ERROR << *line_it  << std::endl;
+        OPENMS_LOG_ERROR << *line_it  << std::endl;
       }
       QString s = p.readAllStandardOutput();
-      LOG_ERROR << s.toStdString() << std::endl;
+      OPENMS_LOG_ERROR << s.toStdString() << std::endl;
       return false;
     }
-    LOG_INFO << " success" << std::endl;
+    OPENMS_LOG_INFO << " success" << std::endl;
     return true;
   }
 
@@ -2123,7 +2123,7 @@ protected:
   {
     if (std::distance(pattern_begin, pattern_end) != std::distance(intensities_begin, intensities_end))
     {
-      LOG_ERROR << "Error: size of pattern and collected intensities don't match!: (pattern " << std::distance(pattern_begin, pattern_end) << ") (intensities " << std::distance(intensities_begin, intensities_end) << ")" << endl;
+      OPENMS_LOG_ERROR << "Error: size of pattern and collected intensities don't match!: (pattern " << std::distance(pattern_begin, pattern_end) << ") (intensities " << std::distance(intensities_begin, intensities_end) << ")" << endl;
     }
 
     if (pattern_begin == pattern_end)
@@ -2462,7 +2462,7 @@ protected:
 
     if (debug_level_ >= 10)
     {
-      LOG_DEBUG << "best rate + score: " << best_rate << " " << best_score << endl;
+      OPENMS_LOG_DEBUG << "best rate + score: " << best_rate << " " << best_score << endl;
     }
 
     // normalize weights to max(weights)=1
@@ -2657,16 +2657,16 @@ protected:
         {
           if (debug_level_ > 1)
           {
-            LOG_WARN << "warning: prevented adding of 0 abundance decomposition at rate " << rate << endl;
-            LOG_WARN << "decomposition: " << endl;
+            OPENMS_LOG_WARN << "warning: prevented adding of 0 abundance decomposition at rate " << rate << endl;
+            OPENMS_LOG_WARN << "decomposition: " << endl;
             for (MapRateToScoreType::const_iterator it = map_rate_to_decomposition_weight.begin(); it != map_rate_to_decomposition_weight.end(); ++it)
             {
-              LOG_WARN << it->first << " " << it->second << endl;
+              OPENMS_LOG_WARN << it->first << " " << it->second << endl;
             }
-            LOG_WARN << "correlation: " << endl;
+            OPENMS_LOG_WARN << "correlation: " << endl;
             for (MapRateToScoreType::const_iterator it = map_rate_to_correlation_score.begin(); it != map_rate_to_correlation_score.end(); ++it)
             {
-              LOG_WARN << it->first << " " << it->second << endl;
+              OPENMS_LOG_WARN << it->first << " " << it->second << endl;
             }
           }
 
@@ -2954,7 +2954,7 @@ protected:
       bool R_is_working = RIntegration::checkRDependencies(tmp_path, package_names, executable);
       if (!R_is_working)
       {
-        LOG_INFO << "There was a problem detecting R and/or of one of the required libraries. Make sure you have the directory of your R executable in your system path variable." << endl;
+        OPENMS_LOG_INFO << "There was a problem detecting R and/or of one of the required libraries. Make sure you have the directory of your R executable in your system path variable." << endl;
         return EXTERNAL_PROGRAM_ERROR;
       }
     }
@@ -2985,7 +2985,7 @@ protected:
     bool cluster_flag = getFlag_("cluster");
 
     // read descriptions from FASTA and create map for fast annotation
-    LOG_INFO << "loading sequences..." << endl;
+    OPENMS_LOG_INFO << "loading sequences..." << endl;
     String in_fasta = getStringOption_("in_fasta");
     vector<FASTAFile::FASTAEntry> fasta_entries;
     FASTAFile().load(in_fasta, fasta_entries);
@@ -2999,7 +2999,7 @@ protected:
       }
     }
 
-    LOG_INFO << "loading feature map..." << endl;
+    OPENMS_LOG_INFO << "loading feature map..." << endl;
     FeatureXMLFile fh;
     FeatureMap feature_map;
     fh.load(in_features, feature_map);
@@ -3041,7 +3041,7 @@ protected:
         }
       }
       feature_map.updateRanges();
-      LOG_INFO << "Evaluating " << unassigned_id_features << " unassigned identifications." << endl;
+      OPENMS_LOG_INFO << "Evaluating " << unassigned_id_features << " unassigned identifications." << endl;
     }
 
     // determine all spectra that have not been identified and assign an averagine peptide to it
@@ -3134,7 +3134,7 @@ protected:
       feature_map.updateRanges();
     }
 
-    LOG_INFO << "loading experiment..." << endl;
+    OPENMS_LOG_INFO << "loading experiment..." << endl;
     PeakMap peak_map;
     MzMLFile mh;
     std::vector<Int> ms_level(1, 1);
@@ -3196,7 +3196,7 @@ protected:
         }
         else
         {
-          LOG_WARN << "Empty peptide hit encountered on feature. Ignoring." << endl;
+          OPENMS_LOG_WARN << "Empty peptide hit encountered on feature. Ignoring." << endl;
         }
       }
 
@@ -3233,7 +3233,7 @@ protected:
 
       if (debug_level_ > 1)
       {
-        LOG_DEBUG << "Feature type: (" << sip_peptide.feature_type << ") Seq.: " << feature_hit_seq << " m/z: " << feature_hit_theoretical_mz << endl;
+        OPENMS_LOG_DEBUG << "Feature type: (" << sip_peptide.feature_type << ") Seq.: " << feature_hit_seq << " m/z: " << feature_hit_theoretical_mz << endl;
       }
 
       const set<String> protein_accessions = feature_hit.extractProteinAccessionsSet();
@@ -3307,7 +3307,7 @@ protected:
       // collect 13C / 15N peaks
       if (debug_level_ >= 10)
       {
-        LOG_DEBUG << "Extract XICs" << endl;
+        OPENMS_LOG_DEBUG << "Extract XICs" << endl;
       }
 
       vector<double> isotopic_intensities = MetaProSIPXICExtraction::extractXICsOfIsotopeTraces(isotopic_trace_count + ADDITIONAL_ISOTOPES, sip_peptide.mass_diff, mz_tolerance_ppm_, rt_tolerance_s, max_trace_int_rt, feature_hit_theoretical_mz, feature_hit_charge, peak_map, xic_threshold);
@@ -3357,7 +3357,7 @@ protected:
       // collect 13C / 15N peaks
       if (debug_level_ >= 10)
       {
-        LOG_DEBUG << "TIC of XICs: " << TIC << endl;
+        OPENMS_LOG_DEBUG << "TIC of XICs: " << TIC << endl;
         for (Size i = 0; i != isotopic_intensities.size(); ++i)
         {
           cout << isotopic_intensities[i] << endl;
@@ -3370,7 +3370,7 @@ protected:
         ++spectrum_with_no_isotopic_peaks;
         if (debug_level > 0)
         {
-          LOG_INFO << "no isotopic peaks in spectrum" << endl;
+          OPENMS_LOG_INFO << "no isotopic peaks in spectrum" << endl;
         }
         continue;
       }
@@ -3398,7 +3398,7 @@ protected:
         cout << "Isotopic intensities found / total: " << non_zero_isotopic_intensities << "/" << isotopic_intensities.size() << endl;
       }
 
-      LOG_INFO << feature_hit.getSequence().toString() << "\trt: " << max_trace_int_rt << endl;
+      OPENMS_LOG_INFO << feature_hit.getSequence().toString() << "\trt: " << max_trace_int_rt << endl;
 
       // correlation filtering
       MapRateToScoreType map_rate_to_correlation_score;
@@ -3518,7 +3518,7 @@ protected:
       {
         if (debug_level > 0)
         {
-          LOG_INFO << "SIP peptides: " << sip_peptide.incorporations.size() << endl;
+          OPENMS_LOG_INFO << "SIP peptides: " << sip_peptide.incorporations.size() << endl;
         }
         sip_peptides.push_back(sip_peptide);
       }
@@ -3532,17 +3532,17 @@ protected:
       correlation_maps.push_back(map_rate_to_correlation_score);
     }
 
-    LOG_INFO << "Spectra with / without isotopic peaks " << spectrum_with_isotopic_peaks << "/" << spectrum_with_no_isotopic_peaks << endl;
+    OPENMS_LOG_INFO << "Spectra with / without isotopic peaks " << spectrum_with_isotopic_peaks << "/" << spectrum_with_no_isotopic_peaks << endl;
 
     if (nPSMs == 0)
     {
-      LOG_ERROR << "No assigned identifications found in featureXML. Did you forget to run IDMapper?" << endl;
+      OPENMS_LOG_ERROR << "No assigned identifications found in featureXML. Did you forget to run IDMapper?" << endl;
       return INCOMPATIBLE_INPUT_DATA;
     }
 
     if (sip_peptides.size() == 0)
     {
-      LOG_ERROR << "No peptides passing the incorporation threshold found." << endl;
+      OPENMS_LOG_ERROR << "No peptides passing the incorporation threshold found." << endl;
       return INCOMPATIBLE_INPUT_DATA;
     }
 
@@ -3556,12 +3556,12 @@ protected:
     {
       if (debug_level > 0)
       {
-        LOG_INFO << "Determine cluster center of RIAs: " << endl;
+        OPENMS_LOG_INFO << "Determine cluster center of RIAs: " << endl;
       }
       vector<double> cluster_center(MetaProSIPClustering::getRIAClusterCenter(sip_peptides));
       if (debug_level > 0)
       {
-        LOG_INFO << "Assigning peptides to cluster: " << endl;
+        OPENMS_LOG_INFO << "Assigning peptides to cluster: " << endl;
       }
       sippeptide_clusters = MetaProSIPClustering::clusterSIPPeptides(cluster_center, sip_peptides);
 
@@ -3586,7 +3586,7 @@ protected:
       {
         for (Size i = 0; i != sippeptide_clusters.size(); ++i)
         {
-          LOG_INFO << "Cluster: " << (i + 1) << " contains " << sippeptide_clusters[i].size() << " peptides." << endl;
+          OPENMS_LOG_INFO << "Cluster: " << (i + 1) << " contains " << sippeptide_clusters[i].size() << " peptides." << endl;
         }
       }
     }
@@ -3598,14 +3598,14 @@ protected:
     // create group/cluster centric report
     if (!out_csv.empty())
     {
-      LOG_INFO << "Create CSV report." << endl;
+      OPENMS_LOG_INFO << "Create CSV report." << endl;
       MetaProSIPReporting::createCSVReport(sippeptide_clusters, out_csv_stream, proteinid_to_description);
     }
 
     // create peptide centric report
     if (!out_peptide_centric_csv.empty())
     {
-      LOG_INFO << "Creating peptide centric report: " << out_peptide_centric_csv << std::endl;
+      OPENMS_LOG_INFO << "Creating peptide centric report: " << out_peptide_centric_csv << std::endl;
 
       if (getFlag_("test")) 
       {

--- a/src/utils/MetaboliteSpectralMatcher.cpp
+++ b/src/utils/MetaboliteSpectralMatcher.cpp
@@ -148,7 +148,7 @@ protected:
 
     if (ms_peakmap.empty())
     {
-      LOG_WARN << "The input file does not contain any spectra.";
+      OPENMS_LOG_WARN << "The input file does not contain any spectra.";
       return INCOMPATIBLE_INPUT_DATA;
     }
 
@@ -171,7 +171,7 @@ protected:
 
     if (spec_db.empty())
     {
-      LOG_WARN << "The spectral library does not contain any spectra.";
+      OPENMS_LOG_WARN << "The spectral library does not contain any spectra.";
       return INCOMPATIBLE_INPUT_DATA;
     }
 

--- a/src/utils/MultiplexResolver.cpp
+++ b/src/utils/MultiplexResolver.cpp
@@ -464,7 +464,7 @@ private:
          ++it_mass_shift, ++it_delta_mass_matched)
     {
       
-      //LOG_DEBUG << "    index = " << (it_mass_shift - pattern.begin()) << "    shift = " << it_mass_shift->delta_mass;
+      //OPENMS_LOG_DEBUG << "    index = " << (it_mass_shift - pattern.begin()) << "    shift = " << it_mass_shift->delta_mass;
       if (*it_delta_mass_matched)
       {
         // copy feature from incomplete consensus
@@ -526,14 +526,14 @@ private:
     
     for (ConsensusMap::ConstIterator cit = map_in.begin(); cit != map_in.end(); ++cit)
     {
-      //LOG_DEBUG << "consensus = " << (cit - map_in.begin());
-      //LOG_DEBUG << "       RT = " << cit->getRT();
-      //LOG_DEBUG << "       mz = " << cit->getMZ();
+      //OPENMS_LOG_DEBUG << "consensus = " << (cit - map_in.begin());
+      //OPENMS_LOG_DEBUG << "       RT = " << cit->getRT();
+      //OPENMS_LOG_DEBUG << "       mz = " << cit->getMZ();
       
       // Consensus features without sequence annotations are written unchanged to the conflict output.
       if (cit->getPeptideIdentifications().empty())
       {
-        //LOG_DEBUG << "  (no ID)\n\n";
+        //OPENMS_LOG_DEBUG << "  (no ID)\n\n";
         
         ConsensusFeature consensus(*cit);
         map_conflicts.push_back(consensus);
@@ -551,7 +551,7 @@ private:
             
       if (index >= 0)
       {
-        //LOG_DEBUG << "  (Ok)\n\n";
+        //OPENMS_LOG_DEBUG << "  (Ok)\n\n";
         // ++found_pattern_count;
         
         ConsensusFeature consensus = completeConsensus_(*cit, theoretical_masses[index].getDeltaMasses(), delta_mass_matched, index_label_set);
@@ -559,7 +559,7 @@ private:
       }
       else
       {
-        //LOG_DEBUG << "  (Conflict)\n\n";
+        //OPENMS_LOG_DEBUG << "  (Conflict)\n\n";
         
         ConsensusFeature consensus(*cit);
         map_conflicts.push_back(consensus);
@@ -575,10 +575,10 @@ private:
     map_out.applyMemberFunction(&UniqueIdInterface::setUniqueId);
     map_conflicts.applyMemberFunction(&UniqueIdInterface::setUniqueId);
     
-    /*LOG_DEBUG << "\n";
-    LOG_DEBUG << "number of consensuses                   = " << map_in.size() << "\n";
-    LOG_DEBUG << "number of consensuses without conflicts = " << found_pattern_count << "\n";
-    LOG_DEBUG << "\n";*/
+    /*OPENMS_LOG_DEBUG << "\n";
+    OPENMS_LOG_DEBUG << "number of consensuses                   = " << map_in.size() << "\n";
+    OPENMS_LOG_DEBUG << "number of consensuses without conflicts = " << found_pattern_count << "\n";
+    OPENMS_LOG_DEBUG << "\n";*/
   }
   
 public:

--- a/src/utils/NucleicAcidSearchEngine.cpp
+++ b/src/utils/NucleicAcidSearchEngine.cpp
@@ -349,7 +349,7 @@ protected:
     // determine charge of adduct (by number of '+' or '-')
     Int pos_charge = parts[1].size() - parts[1].remove('+').size();
     Int neg_charge = parts[1].size() - parts[1].remove('-').size();
-    LOG_DEBUG << ": " << pos_charge - neg_charge << endl;
+    OPENMS_LOG_DEBUG << ": " << pos_charge - neg_charge << endl;
     if (pos_charge > 0 && neg_charge > 0)
     {
       String error = "entry in parameter 'precursor:potential_adducts' mixes positive and negative charges";
@@ -600,12 +600,12 @@ protected:
           }
           if (inferred_charge == 0)
           {
-            LOG_ERROR << "Error: unable to determine charge state for spectrum '" << spec.getNativeID() << "' based on precursor m/z values " << mz1 << " and " << mz2 << endl;
+            OPENMS_LOG_ERROR << "Error: unable to determine charge state for spectrum '" << spec.getNativeID() << "' based on precursor m/z values " << mz1 << " and " << mz2 << endl;
           }
           else
           {
             ++n_inferred_charge;
-            LOG_DEBUG << "Inferred charge state " << inferred_charge << " for spectrum '" << spec.getNativeID() << "'" << endl;
+            OPENMS_LOG_DEBUG << "Inferred charge state " << inferred_charge << " for spectrum '" << spec.getNativeID() << "'" << endl;
             // keep only precursor with highest charge, set inferred charge:
             Precursor prec = spec.getPrecursors()[precursors.begin()->second];
             prec.setCharge(abs(inferred_charge));
@@ -629,14 +629,14 @@ protected:
 
     if (n_zero_charge)
     {
-      LOG_WARN << "Warning: no charge state information available for " << n_zero_charge << " out of " << exp.size() << " spectra." << endl;
+      OPENMS_LOG_WARN << "Warning: no charge state information available for " << n_zero_charge << " out of " << exp.size() << " spectra." << endl;
       if (n_inferred_charge)
       {
-        LOG_INFO << "Inferred charge states for " << n_inferred_charge << " spectra." << endl;
+        OPENMS_LOG_INFO << "Inferred charge states for " << n_inferred_charge << " spectra." << endl;
       }
       if (n_zero_charge - n_inferred_charge > 0)
       {
-        LOG_INFO << "Spectra without charge information will be " << (include_unknown_charge ? "included in the processing" : "skipped") << " (see parameter 'precursor:include_unknown_charge')" << endl;
+        OPENMS_LOG_INFO << "Spectra without charge information will be " << (include_unknown_charge ? "included in the processing" : "skipped") << " (see parameter 'precursor:include_unknown_charge')" << endl;
       }
     }
   }
@@ -762,7 +762,7 @@ protected:
       {
         double score = pair.first;
         const AnnotatedHit& hit = pair.second;
-        LOG_DEBUG << "Hit sequence: " << hit.sequence.toString() << endl;
+        OPENMS_LOG_DEBUG << "Hit sequence: " << hit.sequence.toString() << endl;
 
         // transfer parent matches from unmodified oligo:
         IdentificationData::IdentifiedOligo oligo = *hit.oligo_ref;
@@ -843,7 +843,7 @@ protected:
     if (fdr_cutoff < 1.0)
     {
       IDFilter::filterQueryMatchesByScore(id_data, fdr_ref, fdr_cutoff);
-      LOG_INFO << "Search hits after FDR filtering: "
+      OPENMS_LOG_INFO << "Search hits after FDR filtering: "
                << id_data.getMoleculeQueryMatches().size() << endl;
     }
   }
@@ -913,14 +913,14 @@ protected:
     // @TODO: allow zero to mean "any charge state in the data"?
     if ((min_charge == 0) || (max_charge == 0))
     {
-      LOG_ERROR << "Error: invalid charge state 0" << endl;
+      OPENMS_LOG_ERROR << "Error: invalid charge state 0" << endl;
       return ILLEGAL_PARAMETERS;
     }
     // charges can be positive or negative, depending on data acquisition mode:
     if (((min_charge < 0) && (max_charge > 0)) ||
         ((min_charge > 0) && (max_charge < 0)))
     {
-      LOG_ERROR << "Error: mixing positive and negative charges is not allowed"
+      OPENMS_LOG_ERROR << "Error: mixing positive and negative charges is not allowed"
                 << endl;
       return ILLEGAL_PARAMETERS;
     }
@@ -973,7 +973,7 @@ protected:
         EmpiricalFormula ef = parseAdduct_(adduct);
         double mass = use_avg_mass ? ef.getAverageWeight() : ef.getMonoWeight();
         adduct_masses[mass] = adduct;
-        LOG_DEBUG << "Added adduct: " << adduct << ", mass: " << mass << endl;
+        OPENMS_LOG_DEBUG << "Added adduct: " << adduct << ", mass: " << mass << endl;
       }
     }
 
@@ -996,7 +996,7 @@ protected:
                        single_charge_spectra, negative_mode, min_charge,
                        max_charge, include_unknown_charge);
     progresslogger.endProgress();
-    LOG_DEBUG << "preprocessed spectra: " << spectra.getNrSpectra() << endl;
+    OPENMS_LOG_DEBUG << "preprocessed spectra: " << spectra.getNrSpectra() << endl;
 
     // build multimap of precursor mass to scan index (and other information):
     multimap<double, PrecursorInfo> precursor_mass_map;
@@ -1070,7 +1070,7 @@ protected:
     set<String> selected_ions(temp.begin(), temp.end());
     if (resolve_ambiguous_mods_ && !selected_ions.count("a-B"))
     {
-      LOG_WARN << "Warning: option 'modifications:resolve_ambiguities' requires a-B ions in parameter 'fragment:ions' - disabling the option." << endl;
+      OPENMS_LOG_WARN << "Warning: option 'modifications:resolve_ambiguities' requires a-B ions in parameter 'fragment:ions' - disabling the option." << endl;
       resolve_ambiguous_mods_ = false;
     }
     for (const auto& code : fragment_ion_codes_)
@@ -1116,7 +1116,7 @@ protected:
     registerIDMetaData_(id_data, in_mzml, primary_files, search_param);
     String decoy_pattern = getStringOption_("fdr:decoy_pattern");
 
-    LOG_INFO << "Performing in-silico digestion..." << endl;
+    OPENMS_LOG_INFO << "Performing in-silico digestion..." << endl;
     IdentificationDataConverter::importSequences(
       id_data, fasta_db, IdentificationData::MoleculeType::RNA, decoy_pattern);
     digestor.digest(id_data, min_oligo_length, max_oligo_length);
@@ -1191,7 +1191,7 @@ protected:
         for (const NASequence* seq_ptr : pair.second)
         {
           const NASequence& candidate = *seq_ptr;
-          LOG_DEBUG << "Candidate: " << candidate.toString() << " ("
+          OPENMS_LOG_DEBUG << "Candidate: " << candidate.toString() << " ("
                     << float(candidate_mass) << " Da)" << endl;
 
           // pre-generate spectra:
@@ -1202,7 +1202,7 @@ protected:
 
           for (auto prec_it = low_it; prec_it != up_it; ++prec_it) // OMS_CODING_TEST_EXCLUDE
           {
-            LOG_DEBUG << "Matching precursor mass: " << float(prec_it->first)
+            OPENMS_LOG_DEBUG << "Matching precursor mass: " << float(prec_it->first)
                       << endl;
 
             Size charge = prec_it->second.charge;
@@ -1235,7 +1235,7 @@ protected:
 #pragma omp atomic
             ++hit_counter;
 
-            LOG_DEBUG << "Score: " << score << endl;
+            OPENMS_LOG_DEBUG << "Score: " << score << endl;
 
 #pragma omp critical (annotated_hits_access)
             {
@@ -1280,10 +1280,10 @@ protected:
     }
     progresslogger.endProgress();
 
-    LOG_INFO << "Undigested nucleic acids: " << fasta_db.size() << endl;
-    LOG_INFO << "Oligonucleotides: " << id_data.getIdentifiedOligos().size()
+    OPENMS_LOG_INFO << "Undigested nucleic acids: " << fasta_db.size() << endl;
+    OPENMS_LOG_INFO << "Oligonucleotides: " << id_data.getIdentifiedOligos().size()
              << endl;
-    LOG_INFO << "Search hits: " << hit_counter << endl;
+    OPENMS_LOG_INFO << "Search hits: " << hit_counter << endl;
 
     if (!exp_ms2_out.empty())
     {
@@ -1301,14 +1301,14 @@ protected:
     // FDR:
     if (!decoy_pattern.empty())
     {
-      LOG_INFO << "Performing FDR calculations..." << endl;
+      OPENMS_LOG_INFO << "Performing FDR calculations..." << endl;
       calculateAndFilterFDR_(id_data, report_top_hits == 1);
     }
     id_data.calculateCoverages();
 
     // store results
     MzTab results = IdentificationDataConverter::exportMzTab(id_data);
-    LOG_DEBUG << "Nucleic acid rows: "
+    OPENMS_LOG_DEBUG << "Nucleic acid rows: "
               << results.getNucleicAcidSectionRows().size()
               << "\nOligonucleotide rows: "
               << results.getOligonucleotideSectionRows().size()

--- a/src/utils/OpenPepXL.cpp
+++ b/src/utils/OpenPepXL.cpp
@@ -182,8 +182,8 @@ protected:
     const string out_xquest_specxml = getStringOption_("out_xquest_specxml");
     const string out_mzIdentML = getStringOption_("out_mzIdentML");
 
-    LOG_INFO << "Analyzing file: " << endl;
-    LOG_INFO << in_mzml << endl;
+    OPENMS_LOG_INFO << "Analyzing file: " << endl;
+    OPENMS_LOG_INFO << in_mzml << endl;
 
     // load MS2 map
     PeakMap unprocessed_spectra;

--- a/src/utils/OpenPepXLLF.cpp
+++ b/src/utils/OpenPepXLLF.cpp
@@ -171,8 +171,8 @@ protected:
     const string out_xquest_specxml = getStringOption_("out_xquest_specxml");
     const string out_mzIdentML = getStringOption_("out_mzIdentML");
 
-    LOG_INFO << "Analyzing file: " << endl;
-    LOG_INFO << in_mzml << endl;
+    OPENMS_LOG_INFO << "Analyzing file: " << endl;
+    OPENMS_LOG_INFO << in_mzml << endl;
 
     // load MS2 map
     PeakMap unprocessed_spectra;

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -747,14 +747,14 @@ protected:
     // Check swath window input
     if (!swath_windows_file.empty())
     {
-      LOG_INFO << "Validate provided Swath windows file:" << std::endl;
+      OPENMS_LOG_INFO << "Validate provided Swath windows file:" << std::endl;
       std::vector<double> swath_prec_lower;
       std::vector<double> swath_prec_upper;
       SwathWindowLoader::readSwathWindows(swath_windows_file, swath_prec_lower, swath_prec_upper);
 
       for (Size i = 0; i < swath_prec_lower.size(); i++)
       {
-        LOG_DEBUG << "Read lower swath window " << swath_prec_lower[i] << " and upper window " << swath_prec_upper[i] << std::endl;
+        OPENMS_LOG_DEBUG << "Read lower swath window " << swath_prec_lower[i] << " and upper window " << swath_prec_upper[i] << std::endl;
       }
     }
 
@@ -805,7 +805,7 @@ protected:
     // Load the transitions
     ///////////////////////////////////
     OpenSwath::LightTargetedExperiment transition_exp = loadTransitionList(tr_type, tr_file, tsv_reader_param);
-    LOG_INFO << "Loaded " << transition_exp.getProteins().size() << " proteins, " <<
+    OPENMS_LOG_INFO << "Loaded " << transition_exp.getProteins().size() << " proteins, " <<
       transition_exp.getCompounds().size() << " compounds with " << transition_exp.getTransitions().size() << " transitions." << std::endl;
 
     if (tr_type == FileTypes::PQP)

--- a/src/utils/PSMFeatureExtractor.cpp
+++ b/src/utils/PSMFeatureExtractor.cpp
@@ -139,7 +139,7 @@ protected:
     //-------------------------------------------------------------
     const StringList in_list = getStringList_("in");
     bool multiple_search_engines = getFlag_("multiple_search_engines");
-    LOG_DEBUG << "Input file (of target?): " << ListUtils::concatenate(in_list, ",") << endl;
+    OPENMS_LOG_DEBUG << "Input file (of target?): " << ListUtils::concatenate(in_list, ",") << endl;
     if (in_list.size() > 1 && !multiple_search_engines)
     {
       writeLog_("Fatal error: multiple input files given for -in, but -multiple_search_engines flag not specified. If the same search engine was used, feed the input files into PSMFeatureExtractor one by one.");
@@ -162,14 +162,14 @@ protected:
       String in = *fit;
       FileHandler fh;
       FileTypes::Type in_type = fh.getType(in);
-      LOG_INFO << "Loading input file: " << in << endl;
+      OPENMS_LOG_INFO << "Loading input file: " << in << endl;
       if (in_type == FileTypes::IDXML)
       {
         IdXMLFile().load(in, protein_ids, peptide_ids);
       }
       else if (in_type == FileTypes::MZIDENTML)
       {
-        LOG_WARN << "Converting from mzid: possible loss of information depending on target format." << endl;
+        OPENMS_LOG_WARN << "Converting from mzid: possible loss of information depending on target format." << endl;
         MzIdentMLFile().load(in, protein_ids, peptide_ids);
       }
       //else caught by TOPPBase:registerInput being mandatory mzid or idxml
@@ -224,7 +224,7 @@ protected:
     //-------------------------------------------------------------
     String search_engine = all_protein_ids.front().getSearchEngine();
     if (multiple_search_engines) search_engine = "multiple";
-    LOG_DEBUG << "Registered search engine: " << search_engine << endl;
+    OPENMS_LOG_DEBUG << "Registered search engine: " << search_engine << endl;
     
     StringList extra_features = getStringList_("extra");
     StringList feature_set;
@@ -248,7 +248,7 @@ protected:
     else if (search_engine == "Comet") PercolatorFeatureSetHelper::addCOMETFeatures(all_peptide_ids, feature_set);
     else
     {
-      LOG_ERROR << "No known input to create PSM features from. Aborting" << std::endl;
+      OPENMS_LOG_ERROR << "No known input to create PSM features from. Aborting" << std::endl;
       return INCOMPATIBLE_INPUT_DATA;
     }
 
@@ -261,7 +261,7 @@ protected:
     
     if (all_protein_ids.size() > 1)
     {
-      LOG_ERROR << "Multiple identifications in one file are not supported. Please resume with separate input files. Quitting." << std::endl;
+      OPENMS_LOG_ERROR << "Multiple identifications in one file are not supported. Please resume with separate input files. Quitting." << std::endl;
       return INCOMPATIBLE_INPUT_DATA;
     }
     else
@@ -277,7 +277,7 @@ protected:
     // Storing the PeptideHits with calculated q-value, pep and svm score
     FileTypes::Type out_type = FileHandler::getType(out);
     
-    LOG_INFO << "writing output file: " << out << endl;
+    OPENMS_LOG_INFO << "writing output file: " << out << endl;
     
     if (out_type == FileTypes::IDXML)
     {

--- a/src/utils/RNADigestor.cpp
+++ b/src/utils/RNADigestor.cpp
@@ -164,7 +164,7 @@ protected:
 
     FASTAFile().store(out, all_fragments);
 
-    LOG_INFO << "Digested " << seq_data.size() << " sequence(s) into "
+    OPENMS_LOG_INFO << "Digested " << seq_data.size() << " sequence(s) into "
              << all_fragments.size()
              << " fragments meeting the length restrictions." << endl;
 

--- a/src/utils/RNAMassCalculator.cpp
+++ b/src/utils/RNAMassCalculator.cpp
@@ -220,7 +220,7 @@ protected:
       }
       catch (Exception::ParseError& /*e*/)
       {
-        LOG_WARN << "Warning: '" << item << "' is not a valid RNA sequence - skipping\n";
+        OPENMS_LOG_WARN << "Warning: '" << item << "' is not a valid RNA sequence - skipping\n";
         continue;
       }
 
@@ -240,11 +240,11 @@ protected:
       }
       if (conversion_failed_count)
       {
-        LOG_WARN << "Warning: Invalid charge state specified in line:" << line_count << ".\n";
+        OPENMS_LOG_WARN << "Warning: Invalid charge state specified in line:" << line_count << ".\n";
       }
       if (local_charges.empty())
       {
-        LOG_WARN << "Warning: No charge state specified - skipping (line:" << line_count << ")\n";
+        OPENMS_LOG_WARN << "Warning: No charge state specified - skipping (line:" << line_count << ")\n";
         continue;
       }
       writeLine_(seq, local_charges);
@@ -288,7 +288,7 @@ protected:
 
     if ((in.size() > 0) && (in_seq.size() > 0))
     {
-      LOG_ERROR << "Specifying an input file and input sequences at the same time is not allowed!";
+      OPENMS_LOG_ERROR << "Specifying an input file and input sequences at the same time is not allowed!";
       return ILLEGAL_PARAMETERS;
     }
 
@@ -300,7 +300,7 @@ protected:
     {
       if (charges.empty())
       {
-        LOG_ERROR << "Error: No charge state specified";
+        OPENMS_LOG_ERROR << "Error: No charge state specified";
         return ILLEGAL_PARAMETERS;
       }
       for (StringList::iterator it = in_seq.begin(); it != in_seq.end(); ++it)
@@ -312,7 +312,7 @@ protected:
         }
         catch (Exception::ParseError& /*e*/)
         {
-          LOG_WARN << "Warning: '" << *it << "' is not a valid RNA sequence - skipping\n";
+          OPENMS_LOG_WARN << "Warning: '" << *it << "' is not a valid RNA sequence - skipping\n";
           continue;
         }
 

--- a/src/utils/RNPxlSearch.cpp
+++ b/src/utils/RNPxlSearch.cpp
@@ -553,7 +553,7 @@ protected:
     assert(exp.size() == annotated_hits.size());
 
     #ifdef DEBUG_RNPXLSEARCH
-      LOG_DEBUG << exp.size() << " : " << annotated_hits.size() << endl;
+      OPENMS_LOG_DEBUG << exp.size() << " : " << annotated_hits.size() << endl;
     #endif
 
     SpectrumAlignment spectrum_aligner;
@@ -656,7 +656,7 @@ protected:
 
         // generate all partial loss spectra (excluding the complete loss spectrum) merged into one spectrum
         // 1. get all possible RNA fragment shifts in the MS2 (based on the precursor RNA/DNA)
-        LOG_DEBUG << "precursor_rna_adduct: "  << precursor_rna_adduct << endl;
+        OPENMS_LOG_DEBUG << "precursor_rna_adduct: "  << precursor_rna_adduct << endl;
         const vector<NucleotideToFeasibleFragmentAdducts>& feasible_MS2_adducts = all_feasible_adducts.at(precursor_rna_adduct).feasible_adducts;
 
         if (feasible_MS2_adducts.empty()) { continue; } // should not be the case - check case of no nucleotide but base fragment ?
@@ -735,7 +735,7 @@ protected:
 
         // first annotate total loss peaks (these give no information where the actual shift occured)
         #ifdef DEBUG_RNPXLSEARCH
-          LOG_DEBUG << "Annotating ion (total loss spectrum): " << fixed_and_variable_modified_peptide.toString()  << endl;
+          OPENMS_LOG_DEBUG << "Annotating ion (total loss spectrum): " << fixed_and_variable_modified_peptide.toString()  << endl;
         #endif
         vector<pair<Size, Size>> alignment;
         spectrum_aligner.getSpectrumAlignment(alignment, total_loss_spectrum, exp_spectrum);
@@ -781,7 +781,7 @@ protected:
             Size ion_number = (Size)ion_nr_string.toInt();
             #ifdef DEBUG_RNPXLSEARCH
               const AASequence& peptide_sequence = fixed_and_variable_modified_peptide.getSuffix(ion_number);
-              LOG_DEBUG << "Annotating ion: " << ion_name << " at position: " << fragment_mz << " " << peptide_sequence.toString() << " intensity: " << fragment_intensity << endl;
+              OPENMS_LOG_DEBUG << "Annotating ion: " << ion_name << " at position: " << fragment_mz << " " << peptide_sequence.toString() << " intensity: " << fragment_intensity << endl;
             #endif
             peak_is_annotated.insert(aligned.second);
 
@@ -794,7 +794,7 @@ protected:
             #ifdef DEBUG_RNPXLSEARCH
             else
             {
-              LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
+              OPENMS_LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
             }
             #endif
             }
@@ -824,7 +824,7 @@ protected:
               Size ion_number = (Size)ion_nr_string.toInt();
             #ifdef DEBUG_RNPXLSEARCH
               const AASequence& peptide_sequence = aas.getPrefix(ion_number);
-              LOG_DEBUG << "Annotating ion: " << ion_name << " at position: " << fragment_mz << " " << peptide_sequence.toString() << " intensity: " << fragment_intensity << endl;
+              OPENMS_LOG_DEBUG << "Annotating ion: " << ion_name << " at position: " << fragment_mz << " " << peptide_sequence.toString() << " intensity: " << fragment_intensity << endl;
             #endif
             peak_is_annotated.insert(aligned.second);
 
@@ -837,7 +837,7 @@ protected:
             #ifdef DEBUG_RNPXLSEARCH
             else
             {
-              LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
+              OPENMS_LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
             }
             #endif
             }
@@ -867,7 +867,7 @@ protected:
               auto ion_number = (Size)ion_nr_string.toInt();
             #ifdef DEBUG_RNPXLSEARCH
               const AASequence& peptide_sequence = aas.getPrefix(ion_number);
-              LOG_DEBUG << "Annotating ion: " << ion_name << " at position: " << fragment_mz << " " << peptide_sequence.toString() << " intensity: " << fragment_intensity << endl;
+              OPENMS_LOG_DEBUG << "Annotating ion: " << ion_name << " at position: " << fragment_mz << " " << peptide_sequence.toString() << " intensity: " << fragment_intensity << endl;
             #endif
             peak_is_annotated.insert(aligned.second);
 
@@ -880,7 +880,7 @@ protected:
             #ifdef DEBUG_RNPXLSEARCH
             else
             {
-              LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
+              OPENMS_LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
             }
             #endif
             }
@@ -974,7 +974,7 @@ protected:
           String fragment_ion_name = f[0]; // e.g. y3
 
           #ifdef DEBUG_RNPXLSEARCH
-            LOG_DEBUG << "Annotating ion: " << ion_name << " at position: " << fragment_mz << " " << " intensity: " << fragment_intensity << endl;
+            OPENMS_LOG_DEBUG << "Annotating ion: " << ion_name << " at position: " << fragment_mz << " " << " intensity: " << fragment_intensity << endl;
           #endif
 
           // define which ion names are annotated
@@ -994,7 +994,7 @@ protected:
             #ifdef DEBUG_RNPXLSEARCH
             else
             {
-              LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
+              OPENMS_LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
             }
             #endif
           }
@@ -1014,7 +1014,7 @@ protected:
             #ifdef DEBUG_RNPXLSEARCH
             else
             {
-              LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
+              OPENMS_LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
             }
             #endif
           }
@@ -1034,7 +1034,7 @@ protected:
             #ifdef DEBUG_RNPXLSEARCH
             else
             {
-              LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
+              OPENMS_LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << charge << endl;
             }
             #endif
           }
@@ -1052,7 +1052,7 @@ protected:
             #ifdef DEBUG_RNPXLSEARCH
             else
             {
-              LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << 1 << endl;
+              OPENMS_LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << 1 << endl;
             }
             #endif
           }
@@ -1070,7 +1070,7 @@ protected:
             #ifdef DEBUG_RNPXLSEARCH
             else
             {
-              LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << 1 << endl;
+              OPENMS_LOG_DEBUG << "Charge missmatch in alignment: " << ion_name << " at position: " << fragment_mz << " charge fragment: " << fragment_charge << " theo. charge: " << 1 << endl;
             }
             #endif
           }
@@ -1183,7 +1183,7 @@ protected:
 #endif
 
         #ifdef DEBUG_RNPXLSEARCH
-          LOG_DEBUG << "Localisation based on immonium ions: ";
+          OPENMS_LOG_DEBUG << "Localisation based on immonium ions: ";
         #endif
         String aas_unmodified = aas.toUnmodifiedString();
         for (Size i = 0; i != aas_unmodified.size(); ++i)
@@ -1216,7 +1216,7 @@ protected:
         for (Size i = 0; i != sites_sum_score.size(); ++i)
         {
           #ifdef DEBUG_RNPXLSEARCH
-            LOG_DEBUG << String::number(100.0 * sites_sum_score[i], 2);
+            OPENMS_LOG_DEBUG << String::number(100.0 * sites_sum_score[i], 2);
           #endif
 
           if (i != 0) localization_scores += ' ';
@@ -1235,7 +1235,7 @@ protected:
           }
         }
         #ifdef DEBUG_RNPXLSEARCH
-          LOG_DEBUG << endl;
+          OPENMS_LOG_DEBUG << endl;
         #endif
 
         // create annotation strings for shifted fragment ions
@@ -1254,29 +1254,29 @@ protected:
         a.fragment_annotations = fas;
 
         #ifdef DEBUG_RNPXLSEARCH
-          LOG_DEBUG << "Ion centric annotation: " << endl;
-          LOG_DEBUG << "unshifted b ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("b", unshifted_b_ions) << endl;
-          LOG_DEBUG << "unshifted y ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("y", unshifted_y_ions) << endl;
-          LOG_DEBUG << "unshifted a ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("a", unshifted_a_ions) << endl;
-          LOG_DEBUG << "shifted b ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("b", shifted_b_ions) << endl;
-          LOG_DEBUG << "shifted y ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("y", shifted_y_ions) << endl;
-          LOG_DEBUG << "shifted a ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("a", shifted_a_ions) << endl;
-          LOG_DEBUG << "shifted immonium ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::shiftedIonsToString(shifted_immonium_ions) << endl;
-          LOG_DEBUG << "shifted marker ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::shiftedIonsToString(annotated_marker_ions) << endl;
-          LOG_DEBUG << "shifted precursor ions: " << endl;
-          LOG_DEBUG << RNPxlFragmentAnnotationHelper::shiftedIonsToString(annotated_precursor_ions) << endl;
-          LOG_DEBUG << "Localization scores: ";
-          LOG_DEBUG << localization_scores << endl;
-          LOG_DEBUG << "Localisation based on ion series and immonium ions of all observed fragments: ";
-          LOG_DEBUG << best_localization << endl;
+          OPENMS_LOG_DEBUG << "Ion centric annotation: " << endl;
+          OPENMS_LOG_DEBUG << "unshifted b ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("b", unshifted_b_ions) << endl;
+          OPENMS_LOG_DEBUG << "unshifted y ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("y", unshifted_y_ions) << endl;
+          OPENMS_LOG_DEBUG << "unshifted a ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("a", unshifted_a_ions) << endl;
+          OPENMS_LOG_DEBUG << "shifted b ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("b", shifted_b_ions) << endl;
+          OPENMS_LOG_DEBUG << "shifted y ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("y", shifted_y_ions) << endl;
+          OPENMS_LOG_DEBUG << "shifted a ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::fragmentAnnotationDetailsToString("a", shifted_a_ions) << endl;
+          OPENMS_LOG_DEBUG << "shifted immonium ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::shiftedIonsToString(shifted_immonium_ions) << endl;
+          OPENMS_LOG_DEBUG << "shifted marker ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::shiftedIonsToString(annotated_marker_ions) << endl;
+          OPENMS_LOG_DEBUG << "shifted precursor ions: " << endl;
+          OPENMS_LOG_DEBUG << RNPxlFragmentAnnotationHelper::shiftedIonsToString(annotated_precursor_ions) << endl;
+          OPENMS_LOG_DEBUG << "Localization scores: ";
+          OPENMS_LOG_DEBUG << localization_scores << endl;
+          OPENMS_LOG_DEBUG << "Localisation based on ion series and immonium ions of all observed fragments: ";
+          OPENMS_LOG_DEBUG << best_localization << endl;
         #endif
       }
     }
@@ -1610,7 +1610,7 @@ protected:
 
     if (fixed_unique.size() != fixedModNames.size())
     {
-      LOG_WARN << "duplicate fixed modification provided." << endl;
+      OPENMS_LOG_WARN << "duplicate fixed modification provided." << endl;
       return ILLEGAL_PARAMETERS;
     }
 
@@ -1618,7 +1618,7 @@ protected:
     set<String> var_unique(varModNames.begin(), varModNames.end());
     if (var_unique.size() != varModNames.size())
     {
-      LOG_WARN << "duplicate variable modification provided." << endl;
+      OPENMS_LOG_WARN << "duplicate variable modification provided." << endl;
       return ILLEGAL_PARAMETERS;
     }
 
@@ -1985,7 +1985,7 @@ protected:
                   ah.score = RNPxlSearch::calculateCombinedScore(ah, false);
 
 #ifdef DEBUG_RNPXLSEARCH
-                  LOG_DEBUG << "best score in pre-score: " << score << endl;
+                  OPENMS_LOG_DEBUG << "best score in pre-score: " << score << endl;
 #endif
 
 #ifdef _OPENMP 
@@ -2139,7 +2139,7 @@ protected:
                     ah.score = RNPxlSearch::calculateCombinedScore(ah, true);
 
 #ifdef DEBUG_RNPXLSEARCH
-                    LOG_DEBUG << "best score in pre-score: " << score << endl;
+                    OPENMS_LOG_DEBUG << "best score in pre-score: " << score << endl;
 #endif
 
 #ifdef _OPENMP
@@ -2220,7 +2220,7 @@ protected:
                 ah.score = total_loss_score + ah.total_MIC; 
 
 #ifdef DEBUG_RNPXLSEARCH
-                LOG_DEBUG << "best score in pre-score: " << score << endl;
+                OPENMS_LOG_DEBUG << "best score in pre-score: " << score << endl;
 #endif
 
 #ifdef _OPENMP
@@ -2247,9 +2247,9 @@ protected:
     }
     progresslogger.endProgress();
 
-    LOG_INFO << "Proteins: " << count_proteins << endl;
-    LOG_INFO << "Peptides: " << count_peptides << endl;
-    LOG_INFO << "Processed peptides: " << processed_petides.size() << endl;
+    OPENMS_LOG_INFO << "Proteins: " << count_proteins << endl;
+    OPENMS_LOG_INFO << "Peptides: " << count_peptides << endl;
+    OPENMS_LOG_INFO << "Processed peptides: " << processed_petides.size() << endl;
 
     vector<PeptideIdentification> peptide_ids;
     vector<ProteinIdentification> protein_ids;
@@ -2484,7 +2484,7 @@ protected:
       }
     }
 #ifdef DEBUG_RNPXLSEARCH
-    LOG_DEBUG << "scan index: " << scan_index << " achieved score: " << score << endl;
+    OPENMS_LOG_DEBUG << "scan index: " << scan_index << " achieved score: " << score << endl;
 #endif
   // TODO: cap plss_err
   float ft_da = fragment_mass_tolerance_unit_ppm ? fragment_mass_tolerance * 1e-6 * 1000.0 : fragment_mass_tolerance;
@@ -2521,25 +2521,25 @@ RNPxlSearch::RNPxlParameterParsing::getAllFeasibleFragmentAdducts(
   // print feasible fragment adducts and marker ions
   for (auto const & fa : all_pc_all_feasible_adducts)
   {
-    LOG_DEBUG << "Precursor adduct: " << fa.first << "\n";
+    OPENMS_LOG_DEBUG << "Precursor adduct: " << fa.first << "\n";
 
     for (auto const & ffa : fa.second.feasible_adducts)
     {
       const char & nucleotide = ffa.first;
-      LOG_DEBUG << "  Cross-linkable nucleotide '" << nucleotide << "' and feasible fragment adducts:" << endl;
+      OPENMS_LOG_DEBUG << "  Cross-linkable nucleotide '" << nucleotide << "' and feasible fragment adducts:" << endl;
       for (auto const & a : ffa.second)
       {
-        LOG_DEBUG << "    " << a.name << "\t" << a.formula.toString() << "\t" << a.mass << "\n";
+        OPENMS_LOG_DEBUG << "    " << a.name << "\t" << a.formula.toString() << "\t" << a.mass << "\n";
       }
     }
 
-    LOG_DEBUG << "  Marker ions." << endl;
+    OPENMS_LOG_DEBUG << "  Marker ions." << endl;
     for (auto const & ffa : fa.second.marker_ions)
     {
-      LOG_DEBUG << "    "  << ffa.name << "\t" << ffa.formula.toString() << "\t" << ffa.mass << "\n";
+      OPENMS_LOG_DEBUG << "    "  << ffa.name << "\t" << ffa.formula.toString() << "\t" << ffa.mass << "\n";
     }
   }
-  LOG_DEBUG << endl;
+  OPENMS_LOG_DEBUG << endl;
 
   return all_pc_all_feasible_adducts;
 }
@@ -2559,7 +2559,7 @@ RNPxlSearch::RNPxlParameterParsing::getTargetNucleotideToFragmentAdducts(StringL
     char target_nucleotide = t[0];
     if (t[1] != ':')
     {
-      LOG_WARN << "Missing ':'. Wrong format of fragment_adduct string: " << t << endl;
+      OPENMS_LOG_WARN << "Missing ':'. Wrong format of fragment_adduct string: " << t << endl;
       return NucleotideToFragmentAdductMap();
     }
 
@@ -2581,7 +2581,7 @@ RNPxlSearch::RNPxlParameterParsing::getTargetNucleotideToFragmentAdducts(StringL
     }
     else
     {
-      LOG_WARN << "Wrong format of fragment_adduct string: " << t << endl;
+      OPENMS_LOG_WARN << "Wrong format of fragment_adduct string: " << t << endl;
       return NucleotideToFragmentAdductMap();
     }
 
@@ -2635,7 +2635,7 @@ RNPxlSearch::RNPxlParameterParsing::getFeasibleFragmentAdducts(const String &exp
                                                                const RNPxlSearch::RNPxlParameterParsing::NucleotideToFragmentAdductMap &nucleotide_to_fragment_adducts,
                                                                const set<char> &can_xl)
 {
-  LOG_DEBUG << "Generating fragment adducts for precursor adduct: '" << exp_pc_adduct << "'" << endl;
+  OPENMS_LOG_DEBUG << "Generating fragment adducts for precursor adduct: '" << exp_pc_adduct << "'" << endl;
 
   MS2AdductsOfSinglePrecursorAdduct ret;
 
@@ -2669,7 +2669,7 @@ RNPxlSearch::RNPxlParameterParsing::getFeasibleFragmentAdducts(const String &exp
   bool has_xl_nt(false);
   for (auto const & m : exp_pc_nucleotide_count) { if (can_xl.count(m.first)) { has_xl_nt = true; break; } }
 
-  LOG_DEBUG << "\t" << exp_pc_adduct << " has cross-linkable nucleotide (0 = false, 1 = true): " << has_xl_nt << endl;
+  OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " has cross-linkable nucleotide (0 = false, 1 = true): " << has_xl_nt << endl;
 
   // no cross-linkable nt contained in the precursor adduct? Return an empty fragment adduct definition set
   if (!has_xl_nt) { return ret; }
@@ -2679,7 +2679,7 @@ RNPxlSearch::RNPxlParameterParsing::getFeasibleFragmentAdducts(const String &exp
   // extract loss string from precursor adduct (e.g.: "-H2O")
   // String exp_pc_loss_string(exp_pc_it, exp_pc_adduct.end());
 
-  LOG_DEBUG << "\t" << exp_pc_adduct << " is monomer (1 = true, >1 = false): " << nt_count << endl;
+  OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " is monomer (1 = true, >1 = false): " << nt_count << endl;
 
   // Handle the cases of monomer or oligo nucleotide bound to the precursor.
   // This distinction is made because potential losses on the precursor only allows us to reduce the set of chemical feasible fragment adducts if they are on a monomer.
@@ -2695,8 +2695,8 @@ RNPxlSearch::RNPxlParameterParsing::getFeasibleFragmentAdducts(const String &exp
       // check if nucleotide is cross-linkable and part of the precursor adduct
       if (exp_pc_xl_nts.find(nucleotide) != exp_pc_xl_nts.end())
       {
-        LOG_DEBUG << "\t" << exp_pc_adduct << " found nucleotide: " << String(nucleotide) << " in precursor RNA." << endl;
-        LOG_DEBUG << "\t" << exp_pc_adduct << " nucleotide: " << String(nucleotide) << " has fragment_adducts: " << fragment_adducts.size() << endl;
+        OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " found nucleotide: " << String(nucleotide) << " in precursor RNA." << endl;
+        OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " nucleotide: " << String(nucleotide) << " has fragment_adducts: " << fragment_adducts.size() << endl;
 
         // store feasible adducts associated with a cross-link with character nucleotide
         vector<FragmentAdductDefinition_> faa;
@@ -2725,8 +2725,8 @@ RNPxlSearch::RNPxlParameterParsing::getFeasibleFragmentAdducts(const String &exp
       // check if nucleotide is cross-linkable and part of the precursor adduct
       if (exp_pc_xl_nts.find(nucleotide) != exp_pc_xl_nts.end())
       {
-        LOG_DEBUG << "\t" << exp_pc_adduct << " found nucleotide: " << String(nucleotide) << " in precursor RNA." << endl;
-        LOG_DEBUG << "\t" << exp_pc_adduct << " nucleotide: " << String(nucleotide) << " has fragment_adducts: " << fas.size() << endl;
+        OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " found nucleotide: " << String(nucleotide) << " in precursor RNA." << endl;
+        OPENMS_LOG_DEBUG << "\t" << exp_pc_adduct << " nucleotide: " << String(nucleotide) << " has fragment_adducts: " << fas.size() << endl;
 
         // check chemical feasibility by checking if subtraction of adduct would result in negative elemental composition
         for (auto it = fas.begin(); it != fas.end(); )
@@ -2778,18 +2778,18 @@ RNPxlSearch::RNPxlParameterParsing::getFeasibleFragmentAdducts(const String &exp
   for (auto const & ffa : ret.feasible_adducts)
   {
     const char & nucleotide = ffa.first;
-    LOG_DEBUG << "  Cross-linkable nucleotide '" << nucleotide << "' and feasible fragment adducts:" << endl;
+    OPENMS_LOG_DEBUG << "  Cross-linkable nucleotide '" << nucleotide << "' and feasible fragment adducts:" << endl;
     for (auto const & a : ffa.second)
     {
-      LOG_DEBUG << "\t" << a.name << "\t" << a.formula.toString() << "\t" << a.mass << "\n";
+      OPENMS_LOG_DEBUG << "\t" << a.name << "\t" << a.formula.toString() << "\t" << a.mass << "\n";
     }
   }
 
   // print marker ions
-  LOG_DEBUG << "  Marker ions:" << endl;
+  OPENMS_LOG_DEBUG << "  Marker ions:" << endl;
   for (auto const & a : ret.marker_ions)
   {
-    LOG_DEBUG << "\t" << a.name << "\t" << a.formula.toString() << "\t" << a.mass << "\n";
+    OPENMS_LOG_DEBUG << "\t" << a.name << "\t" << a.formula.toString() << "\t" << a.mass << "\n";
   }
 
   return ret;

--- a/src/utils/SequenceCoverageCalculator.cpp
+++ b/src/utils/SequenceCoverageCalculator.cpp
@@ -164,7 +164,7 @@ protected:
         {
           if (identifications[i].getHits().size() > 1)
           {
-            LOG_ERROR << "Spectrum with more than one identification found, which is not allowed.\n"
+            OPENMS_LOG_ERROR << "Spectrum with more than one identification found, which is not allowed.\n"
                       << "Use the IDFilter with the -best_hits option to filter for best hits." << endl;
             return ILLEGAL_PARAMETERS;
           }
@@ -268,7 +268,7 @@ protected:
     }
     else
     {
-      ret = outputTo_(LOG_INFO);
+      ret = outputTo_(OPENMS_LOG_INFO);
     }
 
     return ret;

--- a/src/utils/SiriusAdapter.cpp
+++ b/src/utils/SiriusAdapter.cpp
@@ -224,7 +224,7 @@ protected:
     if (!out_ms.empty() && converter_mode)
     {
       QFile::copy(tmp_ms_file.toQString(), out_ms.toQString());
-      LOG_WARN << "SiriusAdapter was used in converter mode and is terminated after openms preprocessing. \n"
+      OPENMS_LOG_WARN << "SiriusAdapter was used in converter mode and is terminated after openms preprocessing. \n"
                   "If you would like to run SIRIUS internally please disable the converter mode." << std::endl; 
       return EXECUTION_OK;
     }
@@ -272,11 +272,11 @@ protected:
       bool copy_status = File::copyDirRecursively(tmp_dir.toQString(), sirius_workspace_directory.toQString());
       if (copy_status)
       { 
-        LOG_INFO << "Sirius Workspace was successfully copied to " << sirius_workspace_directory << std::endl;
+        OPENMS_LOG_INFO << "Sirius Workspace was successfully copied to " << sirius_workspace_directory << std::endl;
       }
       else
       {
-        LOG_INFO << "Sirius Workspace could not be copied to " << sirius_workspace_directory << ". Please run SiriusAdapter with debug >= 2." << std::endl;
+        OPENMS_LOG_INFO << "Sirius Workspace could not be copied to " << sirius_workspace_directory << ". Please run SiriusAdapter with debug >= 2." << std::endl;
       }
     }
    
@@ -284,7 +284,7 @@ protected:
     if (!out_ms.empty())
     {  
       QFile::copy(tmp_ms_file.toQString(), out_ms.toQString());
-      LOG_INFO << "Preprocessed .ms files was moved to " << out_ms << std::endl; 
+      OPENMS_LOG_INFO << "Preprocessed .ms files was moved to " << out_ms << std::endl; 
     }
 
     // clean tmp directory if debug level < 2 

--- a/src/utils/SpectraSTSearchAdapter.cpp
+++ b/src/utils/SpectraSTSearchAdapter.cpp
@@ -176,7 +176,7 @@ protected:
      String index_file = File::removeExtension(library_file).append(".spidx");
      if (! File::exists(index_file))
      {
-         LOG_ERROR << "ERROR: Index file required by spectrast not found:\n" << index_file << endl;
+         OPENMS_LOG_ERROR << "ERROR: Index file required by spectrast not found:\n" << index_file << endl;
          return INPUT_FILE_NOT_FOUND;
      }
      arguments << library_file.toQString().prepend("-sL");
@@ -190,7 +190,7 @@ protected:
          // Check empty or invalid sequence database type
          if (sequence_database_type.empty())
          {
-            LOG_ERROR << "ERROR: Sequence database type invalid or not provided" << endl;
+            OPENMS_LOG_ERROR << "ERROR: Sequence database type invalid or not provided" << endl;
             return MISSING_PARAMETERS;
          }
          arguments << sequence_database_type.toQString().prepend("-sT");
@@ -224,12 +224,12 @@ protected:
      StringList output_files = getStringList_(TOPPSpectraSTSearchAdapter::param_output_files);
      if (spectra_files.size() != output_files.size())
      {
-        LOG_ERROR << "ERROR: Number of output files does not match number of input files." << endl;
+        OPENMS_LOG_ERROR << "ERROR: Number of output files does not match number of input files." << endl;
         return ILLEGAL_PARAMETERS;
      }
      if (spectra_files.size() < 1)
      {
-         LOG_ERROR << "ERROR: At least one file containing spectra to be searched must be provided." << endl;
+         OPENMS_LOG_ERROR << "ERROR: At least one file containing spectra to be searched must be provided." << endl;
          return ILLEGAL_PARAMETERS;
      }
      String first_output_file = output_files[0];
@@ -246,7 +246,7 @@ protected:
      }
      if (outputFormat.empty())
      {
-         LOG_ERROR << "ERROR: Unrecognized output format from file: " << first_output_file << endl;
+         OPENMS_LOG_ERROR << "ERROR: Unrecognized output format from file: " << first_output_file << endl;
          return ILLEGAL_PARAMETERS;
      }
      // Output files must agree on format
@@ -255,7 +255,7 @@ protected:
          String output_file = *it;
          if (! output_file.hasSuffix(outputFormat))
          {
-             LOG_ERROR << "ERROR: Output filename does not agree in format: "
+             OPENMS_LOG_ERROR << "ERROR: Output filename does not agree in format: "
                        << output_file << " is not " << outputFormat << endl;
              return ILLEGAL_PARAMETERS;
          }
@@ -283,7 +283,7 @@ protected:
      // Exit if the input file format is invalid
      if (inputFormat.empty())
      {
-         LOG_ERROR << "ERROR: Unrecognized input format from file: " << first_input_file << endl;
+         OPENMS_LOG_ERROR << "ERROR: Unrecognized input format from file: " << first_input_file << endl;
          return ILLEGAL_PARAMETERS;
      }
 
@@ -292,7 +292,7 @@ protected:
       String input_file = *it;
       if (! input_file.hasSuffix(inputFormat))
       {
-        LOG_ERROR << "ERROR: Input filename does not agree in format: "
+        OPENMS_LOG_ERROR << "ERROR: Input filename does not agree in format: "
                        << input_file << " is not " << inputFormat << endl;
         return ILLEGAL_PARAMETERS;
       }
@@ -306,7 +306,7 @@ protected:
      {
          ss << " " << it->toStdString();
      }
-     LOG_DEBUG << ss.str() << endl;
+     OPENMS_LOG_DEBUG << ss.str() << endl;
 
      // Run SpectraST
      QProcess spectrast_process;
@@ -314,7 +314,7 @@ protected:
 
      if (! spectrast_process.waitForFinished(-1))
      {
-         LOG_ERROR << "Fatal error running SpectraST\nDoes the spectrast executable exist?" << endl;
+         OPENMS_LOG_ERROR << "Fatal error running SpectraST\nDoes the spectrast executable exist?" << endl;
          return EXTERNAL_PROGRAM_ERROR;
      }
 

--- a/src/utils/TICCalculator.cpp
+++ b/src/utils/TICCalculator.cpp
@@ -327,7 +327,7 @@ protected:
       in.split(".cachedMzML", split_out);
       if (split_out.size() != 2)
       {
-        LOG_ERROR << "Cannot deduce base path from input '" << in << 
+        OPENMS_LOG_ERROR << "Cannot deduce base path from input '" << in << 
           "' (note that '.cachedMzML' should only occur once as the final ending)" << std::endl;
         return ILLEGAL_PARAMETERS;
       }
@@ -378,7 +378,7 @@ protected:
       in.split(".cachedMzML", split_out);
       if (split_out.size() != 2)
       {
-        LOG_ERROR << "Cannot deduce base path from input '" << in << 
+        OPENMS_LOG_ERROR << "Cannot deduce base path from input '" << in << 
           "' (note that '.cachedMzML' should only occur once as the final ending)" << std::endl;
         return ILLEGAL_PARAMETERS;
       }

--- a/src/utils/XFDR.cpp
+++ b/src/utils/XFDR.cpp
@@ -635,7 +635,7 @@ protected:
       }
       else
       {
-        LOG_WARN << "WARNING: Crosslink could not be identified as either interlink, intralink, or monolink, so no FDR will be available." << endl;
+        OPENMS_LOG_WARN << "WARNING: Crosslink could not be identified as either interlink, intralink, or monolink, so no FDR will be available." << endl;
       }
     }
 
@@ -698,7 +698,7 @@ private:
 
   void logFatal(const String &message) const
   {
-    LOG_ERROR << "FATAL: " << message << " Terminating now!" << std::endl;
+    OPENMS_LOG_ERROR << "FATAL: " << message << " Terminating now!" << std::endl;
   }
 
   bool validateDataStructures() const


### PR DESCRIPTION
This PR renames all occurrences of the logging macros prefixing them with `OPENMS_`.

For example: `LOG_INFO` -> `OPENMS_LOG_INFO`

I made heavy use of find/replace on multiple files (case sensitive, word-match, i.e. `MyString` does not match `ThisIsMyString`) at the same time. I did not check every single change.

This would solve clashes with libraries like plog.