### PR TITLE
[STYLE/TEST] AbsoluteQuantitationMethod: rule of zero, more tests

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
@@ -127,18 +127,18 @@ public:
     Param getTransformationModelParams() const; ///< Transformation model parameters getter
 
 private:
+    Param transformation_model_params_; ///< transformation model parameters
     String component_name_; ///< id of the component
     String feature_name_; ///< name of the feature (i.e., peak_apex_int or peak_area)
     String IS_name_; ///< the internal standard (IS) name for the transition
+    String concentration_units_; ///< concentration units of the component's concentration
+    String transformation_model_; ///< transformation model
     double llod_ { 0.0 }; ///< lower limit of detection (LLOD) of the transition
     double ulod_ { 0.0 }; ///< upper limit of detection (ULOD) of the transition
     double lloq_ { 0.0 }; ///< lower limit of quantitation (LLOQ) of the transition
     double uloq_ { 0.0 }; ///< upper limit of quantitation (ULOQ) of the transition
-    Int n_points_ { 0 }; ///< number of points used in a calibration curve
     double correlation_coefficient_ { 0.0 }; ///< the Pearson R value for the correlation coefficient of the calibration curve
-    String concentration_units_; ///< concentration units of the component's concentration
-    String transformation_model_; ///< transformation model
-    Param transformation_model_params_; ///< transformation model parameters
+    Int n_points_ { 0 }; ///< number of points used in a calibration curve
   };
 }
 

--- a/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
+++ b/src/openms/include/OpenMS/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.h
@@ -52,9 +52,6 @@ namespace OpenMS
   class OPENMS_DLLAPI AbsoluteQuantitationMethod
   {
 public:
-    AbsoluteQuantitationMethod(); ///< Constructor
-    ~AbsoluteQuantitationMethod() = default; ///< Destructor
-
     inline bool operator==(const AbsoluteQuantitationMethod& other) const
     {
       return
@@ -133,12 +130,12 @@ private:
     String component_name_; ///< id of the component
     String feature_name_; ///< name of the feature (i.e., peak_apex_int or peak_area)
     String IS_name_; ///< the internal standard (IS) name for the transition
-    double llod_; ///< lower limit of detection (LLOD) of the transition
-    double ulod_; ///< upper limit of detection (ULOD) of the transition
-    double lloq_; ///< lower limit of quantitation (LLOQ) of the transition
-    double uloq_; ///< upper limit of quantitation (ULOQ) of the transition
-    Int n_points_; ///< number of points used in a calibration curve
-    double correlation_coefficient_; ///< the Pearson R value for the correlation coefficient of the calibration curve
+    double llod_ { 0.0 }; ///< lower limit of detection (LLOD) of the transition
+    double ulod_ { 0.0 }; ///< upper limit of detection (ULOD) of the transition
+    double lloq_ { 0.0 }; ///< lower limit of quantitation (LLOQ) of the transition
+    double uloq_ { 0.0 }; ///< upper limit of quantitation (ULOQ) of the transition
+    Int n_points_ { 0 }; ///< number of points used in a calibration curve
+    double correlation_coefficient_ { 0.0 }; ///< the Pearson R value for the correlation coefficient of the calibration curve
     String concentration_units_; ///< concentration units of the component's concentration
     String transformation_model_; ///< transformation model
     Param transformation_model_params_; ///< transformation model parameters

--- a/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
+++ b/src/openms/source/ANALYSIS/QUANTITATION/AbsoluteQuantitationMethod.cpp
@@ -36,21 +36,6 @@
 
 namespace OpenMS
 {
-  AbsoluteQuantitationMethod::AbsoluteQuantitationMethod() :
-    component_name_(""),
-    feature_name_(""),
-    IS_name_(""),
-    llod_(0),
-    ulod_(0),
-    lloq_(0),
-    uloq_(0),
-    n_points_(0),
-    correlation_coefficient_(0),
-    concentration_units_(""),
-    transformation_model_("")
-  {
-  }
-
   void AbsoluteQuantitationMethod::setLLOD(const double llod)
   {
     llod_ = llod;

--- a/src/tests/class_tests/openms/source/AbsoluteQuantitationMethod_test.cpp
+++ b/src/tests/class_tests/openms/source/AbsoluteQuantitationMethod_test.cpp
@@ -56,6 +56,19 @@ START_SECTION(AbsoluteQuantitationMethod())
 {
   ptr = new AbsoluteQuantitationMethod();
   TEST_NOT_EQUAL(ptr, nullPointer);
+
+  TEST_EQUAL(ptr->getComponentName().size(), 0)
+  TEST_EQUAL(ptr->getFeatureName().size(), 0)
+  TEST_EQUAL(ptr->getISName().size(), 0)
+  TEST_REAL_SIMILAR(ptr->getLLOD(), 0.0)
+  TEST_REAL_SIMILAR(ptr->getULOD(), 0.0)
+  TEST_REAL_SIMILAR(ptr->getLLOQ(), 0.0)
+  TEST_REAL_SIMILAR(ptr->getULOQ(), 0.0)
+  TEST_EQUAL(ptr->getNPoints(), 0)
+  TEST_REAL_SIMILAR(ptr->getCorrelationCoefficient(), 0.0)
+  TEST_EQUAL(ptr->getConcentrationUnits().size(), 0)
+  TEST_EQUAL(ptr->getTransformationModel().size(), 0)
+  TEST_EQUAL(ptr->getTransformationModelParams().size(), 0)
 }
 END_SECTION
 
@@ -151,6 +164,80 @@ START_SECTION(inline bool operator!=(const AbsoluteQuantitationMethod& other) co
   TEST_EQUAL(aqm1 != aqm2, false);
   aqm2.setLLOD(2.0);
   TEST_EQUAL(aqm1 != aqm2, true);
+}
+END_SECTION
+
+START_SECTION(copyConstructor)
+{
+  AbsoluteQuantitationMethod aqm;
+
+  aqm.setComponentName("component");
+  aqm.setFeatureName("feature");
+  aqm.setISName("IS");
+  aqm.setLLOD(1.2);
+  aqm.setULOD(3.4);
+  aqm.setLLOQ(5.6);
+  aqm.setULOQ(7.8);
+  aqm.setNPoints(9);
+  aqm.setCorrelationCoefficient(0.44);
+  aqm.setConcentrationUnits("uM");
+  aqm.setTransformationModel("TransformationModelLinear");
+  Param params1;
+  params1.setValue("slope", 1);
+  aqm.setTransformationModelParams(params1);
+
+  const AbsoluteQuantitationMethod aqm2(aqm);
+
+  TEST_EQUAL(aqm2.getComponentName(), "component")
+  TEST_EQUAL(aqm2.getFeatureName(), "feature")
+  TEST_EQUAL(aqm2.getISName(), "IS")
+  TEST_REAL_SIMILAR(aqm2.getLLOD(), 1.2)
+  TEST_REAL_SIMILAR(aqm2.getULOD(), 3.4)
+  TEST_REAL_SIMILAR(aqm2.getLLOQ(), 5.6)
+  TEST_REAL_SIMILAR(aqm2.getULOQ(), 7.8)
+  TEST_EQUAL(aqm2.getNPoints(), 9)
+  TEST_REAL_SIMILAR(aqm2.getCorrelationCoefficient(), 0.44)
+  TEST_EQUAL(aqm2.getConcentrationUnits(), "uM")
+  TEST_EQUAL(aqm2.getTransformationModel(), "TransformationModelLinear")
+  Param params2 = aqm2.getTransformationModelParams();
+  TEST_EQUAL(params2.getValue("slope"), 1)
+}
+END_SECTION
+
+START_SECTION(copyAssignmentOperator)
+{
+  AbsoluteQuantitationMethod aqm;
+
+  aqm.setComponentName("component");
+  aqm.setFeatureName("feature");
+  aqm.setISName("IS");
+  aqm.setLLOD(1.2);
+  aqm.setULOD(3.4);
+  aqm.setLLOQ(5.6);
+  aqm.setULOQ(7.8);
+  aqm.setNPoints(9);
+  aqm.setCorrelationCoefficient(0.44);
+  aqm.setConcentrationUnits("uM");
+  aqm.setTransformationModel("TransformationModelLinear");
+  Param params1;
+  params1.setValue("slope", 1);
+  aqm.setTransformationModelParams(params1);
+
+  const AbsoluteQuantitationMethod aqm2 = aqm;
+
+  TEST_EQUAL(aqm2.getComponentName(), "component")
+  TEST_EQUAL(aqm2.getFeatureName(), "feature")
+  TEST_EQUAL(aqm2.getISName(), "IS")
+  TEST_REAL_SIMILAR(aqm2.getLLOD(), 1.2)
+  TEST_REAL_SIMILAR(aqm2.getULOD(), 3.4)
+  TEST_REAL_SIMILAR(aqm2.getLLOQ(), 5.6)
+  TEST_REAL_SIMILAR(aqm2.getULOQ(), 7.8)
+  TEST_EQUAL(aqm2.getNPoints(), 9)
+  TEST_REAL_SIMILAR(aqm2.getCorrelationCoefficient(), 0.44)
+  TEST_EQUAL(aqm2.getConcentrationUnits(), "uM")
+  TEST_EQUAL(aqm2.getTransformationModel(), "TransformationModelLinear")
+  Param params2 = aqm2.getTransformationModelParams();
+  TEST_EQUAL(params2.getValue("slope"), 1)
 }
 END_SECTION
 


### PR DESCRIPTION
### Changes
In class `AbsoluteQuantitationMethod`:
- remove unnecessary code by applying the rule of zero and in-class initializers
- add tests for: default constructor, copy constructor and copy assignment operator