### PR TITLE
[FIX] OpenSWATHOSWWriter: Separate score fix

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathTSVWriter.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/OpenSwathTSVWriter.h
@@ -60,15 +60,13 @@ namespace OpenMS
     bool doWrite_;
     bool use_ms1_traces_;
     bool sonar_;
-    bool enable_uis_scoring_;
 
   public:
 
     OpenSwathTSVWriter(const String& output_filename, 
                        const String& input_filename = "inputfile",
                        bool ms1_scores = false, 
-                       bool sonar = false, 
-                       bool uis_scores = false);
+                       bool sonar = false);
 
     bool isActive() const;
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathOSWWriter.cpp
@@ -178,7 +178,25 @@ namespace OpenMS
 
     if (!feature.getMetaValue(score_name).isEmpty())
     {
-      separated_scores = feature.getMetaValue(score_name).toStringList();
+      if (feature.getMetaValue(score_name).valueType() == DataValue::STRING_LIST)
+      {
+        separated_scores = feature.getMetaValue(score_name).toStringList();
+      }
+      else if (feature.getMetaValue(score_name).valueType() == DataValue::INT_LIST)
+      {
+        std::vector<int> int_separated_scores = feature.getMetaValue(score_name).toIntList();
+        std::transform(int_separated_scores.begin(), int_separated_scores.end(), std::back_inserter(separated_scores), [](const int& num) { return String(num); });
+
+      }
+      else if (feature.getMetaValue(score_name).valueType() == DataValue::DOUBLE_LIST)
+      {
+        std::vector<double> double_separated_scores = feature.getMetaValue(score_name).toDoubleList();
+        std::transform(double_separated_scores.begin(), double_separated_scores.end(), std::back_inserter(separated_scores), [](const double& num) { return String(num); });
+      }
+      else
+      {
+        separated_scores.push_back(feature.getMetaValue(score_name).toString());
+      }
     }
 
     return separated_scores;

--- a/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathTSVWriter.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/OpenSwathTSVWriter.cpp
@@ -41,14 +41,12 @@ namespace OpenMS
   OpenSwathTSVWriter::OpenSwathTSVWriter(const String& output_filename, 
                                          const String& input_filename,
                                          bool ms1_scores, 
-                                         bool sonar, 
-                                         bool uis_scores) :
+                                         bool sonar) :
     ofs(output_filename.c_str()),
     input_filename_(input_filename),
     doWrite_(!output_filename.empty()),
     use_ms1_traces_(ms1_scores),
-    sonar_(sonar),
-    enable_uis_scoring_(uis_scores)
+    sonar_(sonar)
     {
     }
 
@@ -101,27 +99,6 @@ namespace OpenMS
         ofs << "\taggr_prec_Peak_Area\taggr_prec_Peak_Apex\taggr_prec_Fragment_Annotation";
       }
       ofs << "\taggr_Peak_Area\taggr_Peak_Apex\taggr_Fragment_Annotation";
-      if (enable_uis_scoring_)
-      {
-        ofs << "\t" << "uis_target_transition_names"
-            << "\t" << "uis_target_var_ind_log_intensity"
-            << "\t" << "uis_target_num_transitions"
-            << "\t" << "uis_target_var_ind_xcorr_coelution"
-            << "\t" << "uis_target_main_var_ind_xcorr_shape"
-            << "\t" << "uis_target_var_ind_log_sn_score"
-            << "\t" << "uis_target_var_ind_massdev_score"
-            << "\t" << "uis_target_var_ind_isotope_correlation"
-            << "\t" << "uis_target_var_ind_isotope_overlap"
-            << "\t" << "uis_decoy_transition_names"
-            << "\t" << "uis_decoy_var_ind_log_intensity"
-            << "\t" << "uis_decoy_num_transitions"
-            << "\t" << "uis_decoy_var_ind_xcorr_coelution"
-            << "\t" << "uis_decoy_main_var_ind_xcorr_shape"
-            << "\t" << "uis_decoy_var_ind_log_sn_score"
-            << "\t" << "uis_decoy_var_ind_massdev_score"
-            << "\t" << "uis_decoy_var_ind_isotope_correlation"
-            << "\t" << "uis_decoy_var_ind_isotope_overlap";
-      }
       ofs << "\n";
     }
 
@@ -287,27 +264,6 @@ namespace OpenMS
               line += "\t" + ListUtils::concatenate(aggr_prec_Peak_Area, ";") + "\t" + ListUtils::concatenate(aggr_prec_Peak_Apex, ";") + "\t" + ListUtils::concatenate(aggr_prec_Fragment_Annotation, ";");
             }
             line += "\t" + ListUtils::concatenate(aggr_Peak_Area, ";") + "\t" + ListUtils::concatenate(aggr_Peak_Apex, ";") + "\t" + ListUtils::concatenate(aggr_Fragment_Annotation, ";");
-            if (enable_uis_scoring_)
-            {
-              line += "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_transition_names").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_ind_log_intensity").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_num_transitions").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_ind_xcorr_coelution").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_ind_xcorr_shape").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_ind_log_sn_score").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_ind_massdev_score").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_ind_isotope_correlation").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_target_ind_isotope_overlap").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_transition_names").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_ind_log_intensity").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_num_transitions").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_ind_xcorr_coelution").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_ind_xcorr_shape").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_ind_log_sn_score").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_ind_massdev_score").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_ind_isotope_correlation").toStringList(), ";")
-              + "\t" + ListUtils::concatenate(feature_it->getMetaValue("id_decoy_ind_isotope_overlap").toStringList(), ";");
-            }
             line += "\n";
             result += line;
         } // end of iteration

--- a/src/utils/OpenSwathWorkflow.cpp
+++ b/src/utils/OpenSwathWorkflow.cpp
@@ -914,7 +914,7 @@ protected:
     // Set up peakgroup file output
     ///////////////////////////////////
     FeatureMap out_featureFile;
-    OpenSwathTSVWriter tsvwriter(out_tsv, file_list[0], use_ms1_traces, sonar, enable_uis_scoring); // only active if filename not empty
+    OpenSwathTSVWriter tsvwriter(out_tsv, file_list[0], use_ms1_traces, sonar); // only active if filename not empty
     OpenSwathOSWWriter oswwriter(out_osw, file_list[0], use_ms1_traces, sonar, enable_uis_scoring); // only active if filename not empty
 
     ///////////////////////////////////


### PR DESCRIPTION
This PR fixes an issue in OpenSwathOSWWriter, where some types of ``MetaValue`` were not correctly converted.

This PR further removes support for UIS scores from OpenSWATHTSVWriter, as the downstream tools (PyProphet & Percolator) now only support OSW and parsing of concatenated scores with different length was always suboptimal.