### PR TITLE
[FIX] prevent TOPPAS crash on Windows when copying output files 

### DIFF
--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -979,13 +979,14 @@ namespace OpenMS
     //check if formats are known
     if (force_OpenMS_format)
     {
-      for (Size i = 0; i < formats.size(); ++i)
+      for (const auto& f : formats)
       {
-        if (formats[i] != "fid")
+        if (f != "fid")
         {
-          if (FileHandler::getTypeByFileName(String(".") + formats[i]) == FileTypes::UNKNOWN)
+          auto ft = FileHandler::getTypeByFileName(String(".") + f);
+          if (ft == FileTypes::UNKNOWN)
           {
-            throw InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The file format '" + formats[i] + "' is invalid!");
+            throw InvalidParameter(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "The file format '" + f + "' is invalid!");
           }
         }
       }

--- a/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
+++ b/src/openms_gui/source/VISUAL/TOPPASToolVertex.cpp
@@ -1007,13 +1007,22 @@ namespace OpenMS
       String p_out_format = out_params[i].param_name + "_type"; // expected parameter name which determines output format
       if (out_params[i].valid_types.size() == 1)
       { // only one format allowed
-        file_suffix = "." + out_params[i].valid_types[0];
+        auto t = FileTypes::nameToType(out_params[i].valid_types[0]);
+        if (t != FileTypes::UNKNOWN) 
+        { // only use canonical names for suffixes, i.e. exact upper/lowercase match, i.e. always use "consensusXML", not "ConsensusXML" or "cOnsensusXML"
+          // (TOPPAS requires this, to avoid errors when copying temporary files)
+          file_suffix = "." + FileTypes::typeToName(t);
+        }
+        else
+        { // unknown type... just use it as it is
+          file_suffix = "." + out_params[i].valid_types[0];
+        }
       }
       else if (param_.exists(p_out_format))
       { // 'out_type' or alike is specified
         if (!param_.getValue(p_out_format).toString().empty()) file_suffix = "." + param_.getValue(p_out_format).toString();
         else OPENMS_LOG_WARN << "TOPPAS cannot determine output file format for param '" << out_params[i].param_name
-                      << "' of Node " + this->name_ + "(" + String(this->getTopoNr()) + "). Format is ambiguous. Use parameter '" + p_out_format + "' to name intermediate output correctly!\n";
+                             << "' of Node " + this->name_ + "(" + String(this->getTopoNr()) + "). Format is ambiguous. Use parameter '" + p_out_format + "' to name intermediate output correctly!\n";
       }
       if (file_suffix.empty())
       { // tag as unknown (TOPPAS will try to rename the output file once its written - see renameOutput_())


### PR DESCRIPTION
if the upstream node of an output node only has a single allowed output type which at the same time has lower/uppercase differences to the default types in OpenMS, e.g. ConsensusXML vs. consensusXML, TOPPAS will try to rename the file, which fails, because it first deletes the target (if it exists).
Since this is the same file, we would be deleting the source file... bad...
This is only a problem on Windows since the file system is not case sensitive (and hence regards these files as equal).