### PR TITLE
[DOC] topp/utils docu

### DIFF
--- a/doc/doxygen/public/TOPP.doxygen
+++ b/doc/doxygen/public/TOPP.doxygen
@@ -38,8 +38,6 @@
   'TOPP - The %OpenMS Proteomics Pipeline' is a pipeline for the analysis of HPLC-MS data. It consists of several small applications that
   can be chained to create analysis pipelines tailored for a specific problem.
 
-  <BR>
-
  	The TOPP tools are divided into several subgroups:
 
   <b>Graphical Tools</b>
@@ -57,8 +55,9 @@
   - @subpage TOPP_IDRipper - Splits protein/peptide identifications according their file-origin.
   - @subpage TOPP_IDFileConverter - Converts identification engine file formats.
   - @subpage TOPP_MapStatistics - Extract extended statistics on the features of a map for quality control.
+  - @subpage UTILS_TargetedFileConverter - Converts targeted files (such as tsv or TraML files).
   - @subpage TOPP_TextExporter - Exports various XML formats to a text file.
-  - @subpage TOPP_MzTabExporter - Exports various XML formats to an mzTab file
+  - @subpage TOPP_MzTabExporter - Exports various XML formats to an mzTab file.
 
   <b>Signal Processing and Preprocessing</b>
   - @subpage TOPP_BaselineFilter - Removes the baseline from profile spectra using a top-hat filter.
@@ -82,7 +81,7 @@
   - @subpage TOPP_SpectraFilterSqrtMower - Applies a filter to peak spectra.
   - @subpage TOPP_SpectraFilterThresholdMower - Applies a filter to peak spectra.
   - @subpage TOPP_SpectraFilterWindowMower - Applies a filter to peak spectra.
-  - @subpage TOPP_SpectraMerger - Merges spectra from an LC-MS map, either by precursor or by RT blocks
+  - @subpage TOPP_SpectraMerger - Merges spectra from an LC-MS map, either by precursor or by RT blocks.
   - @subpage TOPP_TOFCalibration - Applies time of flight mass calibration.
 
   <b>Quantitation</b>
@@ -108,12 +107,13 @@
   - @subpage TOPP_FeatureLinkerLabeled - Groups corresponding isotope-labeled features in a feature map.
   - @subpage TOPP_FeatureLinkerUnlabeled - Groups corresponding features from multiple maps.
   - @subpage TOPP_FeatureLinkerUnlabeledQT - Groups corresponding features from multiple maps using a QT clustering approach.
-  - @subpage TOPP_FeatureLinkerUnlabeledKD - Groups corresponding features from multiple maps using a KD tree
+  - @subpage TOPP_FeatureLinkerUnlabeledKD - Groups corresponding features from multiple maps using a KD tree.
 
   <b>Protein/Peptide Identification</b>
   - @subpage TOPP_CometAdapter - Identifies MS/MS spectra using Comet (external).
   - @subpage TOPP_CompNovo - Performs a peptide/protein identification with the CompNovo engine.
   - @subpage TOPP_CompNovoCID - Performs a peptide/protein identification with the CompNovo engine in CID mode.
+  - @subpage TOPP_CruxAdapter - Identifies peptides in MS/MS spectra via Crux and tide-search (external).
   - @subpage TOPP_InspectAdapter - Identifies MS/MS spectra using Inspect (external).
   - @subpage TOPP_MascotAdapter - Identifies MS/MS spectra using Mascot (external).
   - @subpage TOPP_MascotAdapterOnline - Identifies MS/MS spectra using Mascot (external).
@@ -121,9 +121,9 @@
   - @subpage TOPP_MyriMatchAdapter - Identifies MS/MS spectra using MyriMatch (external).
   - @subpage TOPP_OMSSAAdapter - Identifies MS/MS spectra using OMSSA (external).
   - @subpage TOPP_PepNovoAdapter - Identifies MS/MS spectra using PepNovo (external).
-  - @subpage TOPP_XTandemAdapter - Identifies MS/MS spectra using XTandem (external).
   - @subpage TOPP_SpecLibSearcher - Identifies peptide MS/MS spectra by spectral matching with a searchable spectral library.
-  - @subpage TOPP_CruxAdapter - Identifies peptides in MS/MS spectra via Crux and tide-search.
+  - @subpage TOPP_SimpleSearchEngine - A simple database search engine for annotating MS/MS spectra.
+  - @subpage TOPP_XTandemAdapter - Identifies MS/MS spectra using XTandem (external).
 
   <b>Protein/Peptide Processing</b>
   - @subpage TOPP_ConsensusID - Computes a consensus identification from peptide identifications of several identification engines.
@@ -140,17 +140,20 @@
   - @subpage TOPP_ProteinInference - Infer proteins from a list of (high-confidence) peptides.
   - @subpage TOPP_PercolatorAdapter - Applies the percolator algorithm to protein/peptide identifications.
 
-  <b>Targeted Experiments</b>
+  <b>Targeted Experiments and OpenSWATH</b>
+  - @subpage UTILS_OpenSwathWorkflow - Complete workflow to run OpenSWATH.
+  - @subpage UTILS_AssayGeneratorMetabo - Generates an assay library using DDA data (Metabolomics).
   - @subpage TOPP_InclusionExclusionListCreator - Creates inclusion and/or exclusion lists for LC-MS/MS experiments.
+  - @subpage TOPP_MRMMapper - MRMMapper maps measured chromatograms (mzML) and the transitions used (TraML).
+  - @subpage UTILS_MRMTransitionGroupPicker - Picks peaks in MRM chromatograms.
   - @subpage TOPP_PrecursorIonSelector - A tool for precursor ion selection based on identification results.
-  - @subpage TOPP_MRMMapper - MRMMapper maps measured chromatograms (mzML) and the transitions used (TraML)
-  - @subpage TOPP_OpenSwathDecoyGenerator - Generates decoys according to different models for a specific TraML
+  - @subpage TOPP_OpenSwathAnalyzer - Picks peaks and finds features in an SRM experiment.
   - @subpage TOPP_OpenSwathAssayGenerator - Generates filtered and optimized assays using TraML files.
   - @subpage TOPP_OpenSwathChromatogramExtractor - Extract chromatograms (XIC) from a MS2 map file.
-  - @subpage TOPP_OpenSwathAnalyzer - Picks peaks and finds features in an SRM experiment.
-  - @subpage TOPP_OpenSwathRTNormalizer - This tool will align an SRM / SWATH run to a normalized retention time space.
-  - @subpage TOPP_OpenSwathFeatureXMLToTSV - Converts a featureXML to a tsv.
   - @subpage TOPP_OpenSwathConfidenceScoring - Computes confidence scores for OpenSwath results.
+  - @subpage TOPP_OpenSwathDecoyGenerator - Generates decoys according to different models for a specific TraML.
+  - @subpage TOPP_OpenSwathFeatureXMLToTSV - Converts a featureXML to a tsv.
+  - @subpage TOPP_OpenSwathRTNormalizer - This tool will align an SRM / SWATH run to a normalized retention time space.
 
   <b>Peptide Property Prediction</b>
   - @subpage TOPP_PTModel - Trains a model for the prediction of proteotypic peptides from a training set.
@@ -161,4 +164,7 @@
   <b>Misc</b>
   - @subpage TOPP_GenericWrapper - Allows the generic wrapping of external tools.
   - @subpage TOPP_ExecutePipeline - Executes workflows created by TOPPAS.
+  - @subpage TOPP_GNPSExport - Export MS/MS data in .MGF format for GNPS.
+  - @subpage TOPP_MaRaClusterAdapter - Run the spectral clustering implemented in MaRaCluster.
+
 */

--- a/doc/doxygen/public/UTILS.doxygen
+++ b/doc/doxygen/public/UTILS.doxygen
@@ -39,7 +39,7 @@
   They are not included in TOPP as they are not part of typical analysis pipelines,
   but they still might be very helpful to you.
 
-  Just as the TOPP tools, they can be found in the %OpenMS/bin folder.
+  Just as the TOPP tools, they can be found in the <tt>%OpenMS/bin</tt> folder.
 
   The UTILS tools are divided into several subgroups:
 
@@ -58,7 +58,7 @@
   - @subpage UTILS_CVInspector - A tool for visualization and validation of PSI mapping and CV files.
   - @subpage UTILS_FuzzyDiff - Compares two files, tolerating numeric differences.
   - @subpage UTILS_IDSplitter - Splits protein/peptide identifications off of annotated data files.
-  - @subpage UTILS_MzMLSplitter - Splits an mzML file into multiple parts
+  - @subpage UTILS_MzMLSplitter - Splits an mzML file into multiple parts.
   - @subpage UTILS_SemanticValidator - SemanticValidator for analysisXML and mzML files.
   - @subpage UTILS_XMLValidator - Validates XML files against an XSD schema.
 
@@ -80,16 +80,13 @@
   - @subpage UTILS_NovorAdapter - De novo sequencing from tandem mass spectrometry data.
   - @subpage UTILS_PSMFeatureExtractor - Creates search engine specific features for PercolatorAdapter input.
   - @subpage UTILS_SequenceCoverageCalculator - Prints information about idXML files.
-  - @subpage UTILS_SimpleSearchEngine - A simple database search engine for annotating MS/MS spectra.
   - @subpage UTILS_SpecLibCreator - Creates an MSP-formatted spectral library.
   - @subpage UTILS_SpectraSTSearchAdapter - An interface to the 'SEARCH' mode of the SpectraST program (external, beta).
 
   <b>Cross-linking</b>
   - @subpage UTILS_OpenPepXL - Search for peptide pairs linked with a labeled cross-linker.
   - @subpage UTILS_OpenPepXLLF - Search for cross-linked peptide pairs in tandem MS spectra.
-<!-- Documentation missing:
   - @subpage UTILS_RNPxlSearch - Annotates RNA-to-peptide cross-links in MS/MS spectra.
--->
   - @subpage UTILS_RNPxlXICFilter - Removes MS2 spectra from treatment based on the fold change between control and treatment for RNA-to-peptide cross-linking experiments.
   - @subpage UTILS_XFDR - Calculates false discovery rate estimates on cross-link identifications.
 
@@ -97,24 +94,21 @@
   - @subpage UTILS_ERPairFinder - Evaluates pair ratios on enhanced resolution (zoom) scans.
   - @subpage UTILS_FeatureFinderMetaboIdent - Detects features in MS1 data corresponding to small molecule identifications.
   - @subpage UTILS_FeatureFinderSuperHirn - Finds features using the SuperHirn algorithm (can handle centroided or profile data, see .ini file).
-  - @subpage UTILS_MetaboliteAdductDecharger - Decharges and merges different feature charge variants of the same small molecule.  
+  - @subpage UTILS_MetaboliteAdductDecharger - Decharges and merges different feature charge variants of the same small molecule.
   - @subpage UTILS_MultiplexResolver - Resolves conflicts between identifications and quantifications in multiplex data.
 
   <b>Metabolite Identification</b>
   - @subpage UTILS_AccurateMassSearch - Finds potential HMDB IDs within the given mass error window.
-  - @subpage UTILS_MetaboliteSpectralMatcher - Identifies small molecules from tandem MS spectra.  
+  - @subpage UTILS_MetaboliteSpectralMatcher - Identifies small molecules from tandem MS spectra.
   - @subpage UTILS_SiriusAdapter - De novo metabolite identification.
 
   <b>Targeted Experiments and OpenSWATH</b>
-  - @subpage TOPP_CorrelateMassTraces - Identifies precursor mass traces and tries to correlate them with fragment ion mass traces in SWATH maps.
+  - @subpage TOPP_CorrelateMassTraces - Identifies precursor mass traces and tries to correlate them with fragment ion mass traces in SWATH maps. <!-- ClusterMassTracesByPrecursor -->
   - @subpage UTILS_MRMPairFinder - Evaluates labeled pair ratios on MRM features.
-  - @subpage UTILS_MRMTransitionGroupPicker - Picks peaks in MRM chromatograms.
   - @subpage UTILS_OpenSwathDIAPreScoring - SWATH (data-independent acquisition) pre-scoring.
   - @subpage UTILS_OpenSwathFileSplitter - A tool for splitting a single SWATH / DIA file into a set of files, each containing one SWATH window.
-  - @subpage UTILS_OpenSwathMzMLFileCacher - Caching of large mzML files
+  - @subpage UTILS_OpenSwathMzMLFileCacher - Caching of large mzML files.
   - @subpage UTILS_OpenSwathRewriteToFeatureXML - Rewrites results from mProphet back into featureXML.
-  - @subpage UTILS_OpenSwathWorkflow - Complete workflow to run OpenSWATH.
-  - @subpage UTILS_TargetedFileConverter - Converts targeted files (such as tsv or TraML files)
 
   <b>RNA</b>
   - @subpage UTILS_NucleicAcidSearchEngine - Search MzML files for oligonucleotides and their modifications.
@@ -135,12 +129,11 @@
   - @subpage UTILS_DeMeanderize - Orders the spectra of MALDI spotting plates correctly.
   - @subpage UTILS_ImageCreator - Creates images from MS1 data (with MS2 data points indicated as dots).
   - @subpage UTILS_MassCalculator - Calculates masses and mass-to-charge ratios of peptide sequences.
-<!-- Documentation missing:
   - @subpage UTILS_MetaProSIP - Performs proteinSIP on peptide features for elemental flux analysis.
--->
   - @subpage UTILS_MSSimulator - A highly configurable simulator for mass spectrometry experiments.
   - @subpage UTILS_SvmTheoreticalSpectrumGeneratorTrainer - A trainer for SVM models as input for SvmTheoreticalSpectrumGenerator.
-  - @subpage UTILS_TICCalculator - Calculates the TIC of a raw mass spectrometric file. 
+  - @subpage UTILS_TICCalculator - Calculates the TIC of a raw mass spectrometric file.
+  - @subpage UTILS_MSstatsConverter - Converter to input for MSstats.
 
   <b>Deprecated</b>
   - @subpage UTILS_IDDecoyProbability - Estimates peptide probabilities using a decoy search strategy. WARNING: This utility is deprecated.

--- a/src/topp/GNPSExport.cpp
+++ b/src/topp/GNPSExport.cpp
@@ -36,8 +36,10 @@
 // Doxygen docu
 //----------------------------------------------------------
 /**
-  @page UTILS_GNPSExport GNPSExport
+  @page TOPP_GNPSExport GNPSExport
+
   @brief Export MS/MS data in .MGF format for GNPS (http://gnps.ucsd.edu).
+
 GNPS (Global Natural Products Social Molecular Networking, http://gnps.ucsd.edu) is an open-access knowledge base for community-wide organisation and sharing of raw, processed or identified tandem mass (MS/MS) spectrometry data. The GNPS web-platform makes possible to perform spectral library search against public MS/MS spectral libraries, as well as to perform various data analysis such as MS/MS molecular networking, network annotation propagation (http://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1006089), and the Dereplicator-based annotation (https://www.nature.com/articles/nchembio.2219). The GNPS manuscript is available here: https://www.nature.com/articles/nbt.3597
 
 This tool was developed for the OpenMS-GNPS workflow. It can be accessed on GNPS (https://gnps.ucsd.edu/ProteoSAFe/static/gnps-experimental.jsp). The steps used by that workflow are as following:
@@ -53,9 +55,9 @@ This tool was developed for the OpenMS-GNPS workflow. It can be accessed on GNPS
 https://ccms-ucsd.github.io/GNPSDocumentation/featurebasedmolecularnetworking/
 
   <B>The command line parameters of this tool are:</B>
-  @verbinclude UTILS_SiriusAdapter.cli
+  @verbinclude TOPP_GNPSExport.cli
   <B>INI file documentation of this tool:</B>
-  @htmlinclude UTILS_SiriusAdapter.html
+  @htmlinclude TOPP_GNPSExport.html
  */
 
 #include <OpenMS/APPLICATIONS/TOPPBase.h>

--- a/src/utils/ClusterMassTraces.cpp
+++ b/src/utils/ClusterMassTraces.cpp
@@ -45,13 +45,13 @@ using namespace OpenMS;
 /**
   @page TOPP_ClusterMassTraces ClusterMassTraces
 
-  @brief Cluster mass traces occuring in the same map together
+  @brief Cluster mass traces occurring in the same map together
 
   Cluster mass traces together found in a mass spectrometric map (MS1 or MS2).
   Input is a consensus map containing individual mass traces, the output may be
   spectra containing all clustered features.
 
-  Mass traces are clustered independend of precursor traces in another map
+  Mass traces are clustered independent of precursor traces in another map
   (this is the more simple approach)  and pseudo spectra are created without
   any precursors assigned. This is useful for 
 
@@ -62,6 +62,11 @@ using namespace OpenMS;
 
    - de novo searches 
    - calculate the most likely precursor(s) and DB-search
+
+  <B>The command line parameters of this tool are:</B>
+  @verbinclude TOPP_ClusterMassTraces.cli
+  <B>INI file documentation of this tool:</B>
+  @htmlinclude TOPP_ClusterMassTraces.html
 
 */
 

--- a/src/utils/ClusterMassTracesByPrecursor.cpp
+++ b/src/utils/ClusterMassTracesByPrecursor.cpp
@@ -71,6 +71,10 @@
     they use FFT to correlate and then use lag of at least 1 scan and pearson correlation of 0.7 to assign precursors to product ions
     If one fragment matches to multiple precursors, it is assigned to all of them. If it doesnt match any, it is assigned to all
   
+  <B>The command line parameters of this tool are:</B>
+  @verbinclude TOPP_CorrelateMassTraces.cli
+  <B>INI file documentation of this tool:</B>
+  @htmlinclude TOPP_CorrelateMassTraces.html
 
 */
 

--- a/src/utils/MSstatsConverter.cpp
+++ b/src/utils/MSstatsConverter.cpp
@@ -56,7 +56,7 @@ using namespace std;
 //-------------------------------------------------------------
 
 /**
-    @page UTILS_MSstatsConverter
+    @page UTILS_MSstatsConverter MSstatsConverter
 
     @brief Converter to input for MSstats
 

--- a/src/utils/MetaProSIP.cpp
+++ b/src/utils/MetaProSIP.cpp
@@ -2016,6 +2016,23 @@ public:
 
 };
 
+//-------------------------------------------------------------
+// Doxygen docu
+//-------------------------------------------------------------
+
+/**
+    @page UTILS_MetaProSIP MetaProSIP 
+
+    @brief Performs proteinSIP on peptide features for elemental flux analysis.
+
+    <B>The command line parameters of this tool are:</B>
+    @verbinclude UTILS_MetaProSIP.cli
+    <B>INI file documentation of this tool:</B>
+    @htmlinclude UTILS_MetaProSIP.html
+ */
+
+// We do not want this class to show up in the docu:
+/// @cond TOPPCLASSES
 class TOPPMetaProSIP :
   public TOPPBase
 {

--- a/src/utils/RNPxlSearch.cpp
+++ b/src/utils/RNPxlSearch.cpp
@@ -92,6 +92,25 @@ using namespace OpenMS;
 using namespace OpenMS::Internal;
 using namespace std;
 
+
+//-------------------------------------------------------------
+// Doxygen docu
+//-------------------------------------------------------------
+
+/**
+    @page UTILS_RNPxlSearch RNPxlSearch 
+
+    @brief Annotate RNA to peptide crosslinks in MS/MS spectra.
+
+    <B>The command line parameters of this tool are:</B>
+    @verbinclude UTILS_RNPxlSearch.cli
+    <B>INI file documentation of this tool:</B>
+    @htmlinclude UTILS_RNPxlSearch.html
+ */
+
+// We do not want this class to show up in the docu:
+/// @cond TOPPCLASSES
+
 class RNPxlSearch :
   public TOPPBase
 {


### PR DESCRIPTION
fix some issues in the TOPP / UTILS documentation - this is to find tools that are not listed in the documentation anywhere:

```
cat doc/doxygen/public/TOPP.doxygen doc/doxygen/public/UTILS.doxygen  > /tmp/both
for f in src/topp/*.cpp src/utils/*.cpp; do 
  bn=`basename $f .cpp`; cnt=`grep -c $bn /tmp/both`; 
  if [ "$cnt" -eq 0 ];then echo $f;fi ;
done 
```


