### PR TITLE
Fix/tv minor

### DIFF
--- a/src/openms_gui/source/VISUAL/Spectrum1DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum1DWidget.cpp
@@ -57,7 +57,7 @@ namespace OpenMS
     //set the label mode for the axes  - side effect
     setCanvas_(new Spectrum1DCanvas(preferences, this));
 
-    x_axis_->setLegend(String(Peak2D::shortDimensionName(Peak2D::MZ)) + " [" + String(Peak2D::shortDimensionUnit(Peak2D::MZ)) + "]");
+    x_axis_->setLegend("m/z");
     x_axis_->setAllowShortNumbers(false);
     y_axis_->setLegend("Intensity");
     y_axis_->setAllowShortNumbers(true);

--- a/src/openms_gui/source/VISUAL/Spectrum2DWidget.cpp
+++ b/src/openms_gui/source/VISUAL/Spectrum2DWidget.cpp
@@ -59,8 +59,8 @@ namespace OpenMS
     setCanvas_(new Spectrum2DCanvas(preferences, this), 1, 2);
 
     // add axes
-    x_axis_->setLegend(String(Peak2D::shortDimensionName(Peak2D::MZ)) + " [" + String(Peak2D::shortDimensionUnit(Peak2D::MZ)) + "]");
-    y_axis_->setLegend(String(Peak2D::shortDimensionName(Peak2D::RT)) + " [" + String(Peak2D::shortDimensionUnit(Peak2D::RT)) + "]");
+    x_axis_->setLegend("m/z");
+    y_axis_->setLegend("retention time [s]");
     y_axis_->setMinimumWidth(50);
 
     // add projections


### PR DESCRIPTION
- using m/z instead of M/Z with unit Th
- using retention time [s] instead of RT [sec]
as axis labels