### PR TITLE
 [FIX] IDFilter: fixed 'not equal' option in MetaValue filtering 

### DIFF
--- a/src/tests/topp/CMakeLists.txt
+++ b/src/tests/topp/CMakeLists.txt
@@ -1022,6 +1022,11 @@ set_tests_properties("TOPP_IDFilter_20_out1" PROPERTIES DEPENDS "TOPP_IDFilter_2
 add_test("TOPP_IDFilter_21" ${TOPP_BIN_PATH}/IDFilter -test -in ${DATA_DIR_TOPP}/IDFilter_16_input.idXML -out IDFilter_21_output.tmp -remove_peptide_hits_by_metavalue "calcMZ" "gt" "750.0")
 add_test("TOPP_IDFilter_21_out1" ${DIFF} -in1 IDFilter_21_output.tmp -in2 ${DATA_DIR_TOPP}/IDFilter_21_output.idXML)
 set_tests_properties("TOPP_IDFilter_21_out1" PROPERTIES DEPENDS "TOPP_IDFilter_21")
+
+add_test("TOPP_IDFilter_22" ${TOPP_BIN_PATH}/IDFilter -test -in ${DATA_DIR_TOPP}/IDFilter_16_input.idXML -out IDFilter_22_output.tmp -remove_peptide_hits_by_metavalue "end" "ne" "23")
+add_test("TOPP_IDFilter_22_out1" ${DIFF} -in1 IDFilter_22_output.tmp -in2 ${DATA_DIR_TOPP}/IDFilter_22_output.idXML)
+set_tests_properties("TOPP_IDFilter_22_out1" PROPERTIES DEPENDS "TOPP_IDFilter_22")
+
 #------------------------------------------------------------------------------
 # MapAlignerPoseClustering tests
 # featureXML input:

--- a/src/tests/topp/IDFilter_22_output.idXML
+++ b/src/tests/topp/IDFilter_22_output.idXML
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="https://www.openms.de/xml-stylesheet/IdXML.xsl" ?>
+<IdXML version="1.5" xsi:noNamespaceSchemaLocation="https://www.openms.de/xml-schema/IdXML_1_5.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<SearchParameters id="SP_0" db="/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/proteins.fasta" db_version="" taxonomy="" mass_type="monoisotopic" charges="" enzyme="trypsin" missed_cleavages="1000" precursor_peak_tolerance="10" precursor_peak_tolerance_ppm="false" peak_mass_tolerance="0" peak_mass_tolerance_ppm="false" >
+		<VariableModification name="Oxidation (M)" />
+				<UserParam type="string" name="MS:1001211" value=""/>
+				<UserParam type="string" name="MS:1001256" value=""/>
+				<UserParam type="string" name="ChargeCarrierMass" value="1.00727649"/>
+				<UserParam type="string" name="FragmentMethod" value="As written in the spectrum or CID if no info"/>
+				<UserParam type="string" name="Instrument" value="HighRes"/>
+				<UserParam type="string" name="MaxCharge" value="3"/>
+				<UserParam type="string" name="MaxIsotopeError" value="1"/>
+				<UserParam type="string" name="MaxNumModifications" value="2"/>
+				<UserParam type="string" name="MaxPepLength" value="40"/>
+				<UserParam type="string" name="MinCharge" value="1"/>
+				<UserParam type="string" name="MinIsotopeError" value="0"/>
+				<UserParam type="string" name="MinPepLength" value="6"/>
+				<UserParam type="string" name="NumMatchesPerSpec" value="1"/>
+				<UserParam type="string" name="NumTolerableTermini" value="2"/>
+				<UserParam type="string" name="Protocol" value="Standard"/>
+				<UserParam type="string" name="TargetDecoyApproach" value="false"/>
+	</SearchParameters>
+	<IdentificationRun date="2016-10-17T18:33:11" search_engine="MS-GF+" search_engine_version="Release (v2016.10.14)" search_parameters_ref="SP_0" >
+		<ProteinIdentification score_type="" higher_score_better="true" significance_threshold="0" >
+			<ProteinHit id="PH_0" accession="BSA2" score="0.0" sequence="" >
+				<UserParam type="string" name="isDecoy" value="false"/>
+			</ProteinHit>
+			<UserParam type="stringList" name="spectra_data" value="[/Users/timosachsenberg/oms210/src/tests/topp/THIRDPARTY/spectra.mzML]"/>
+		</ProteinIdentification>
+		<PeptideIdentification score_type="SpecEValue" higher_score_better="false" significance_threshold="0.0" MZ="1063.209838867190001" RT="4587.668999999999869" spectrum_reference="spectrum=1" >
+			<PeptideHit score="3.864406e-26" sequence="IALSRPNVEVVALNDPFITNDYAAYM(Oxidation)FK" charge="3" aa_before="-" aa_after="E" start="1" end="28" protein_refs="PH_0" >
+				<UserParam type="float" name="MS:1002049" value="163.0"/>
+				<UserParam type="float" name="MS:1002050" value="199.0"/>
+				<UserParam type="float" name="MS:1002052" value="3.864406e-26"/>
+				<UserParam type="float" name="MS:1002053" value="1.5921352e-23"/>
+				<UserParam type="string" name="AssumedDissociationMethod" value="HCD"/>
+				<UserParam type="string" name="IsotopeError" value="0"/>
+				<UserParam type="float" name="calcMZ" value="1063.209350585940001"/>
+				<UserParam type="int" name="pass_threshold" value="1"/>
+				<UserParam type="int" name="start" value="1"/>
+				<UserParam type="int" name="end" value="28"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+		<PeptideIdentification score_type="SpecEValue" higher_score_better="false" significance_threshold="0.0" MZ="520.262817382812045" RT="2655.095699999999852" spectrum_reference="spectrum=0" >
+			<PeptideHit score="4.652130499999999e-19" sequence="DFASSGGYVLHLHR" charge="3" >
+				<UserParam type="float" name="MS:1002049" value="123.0"/>
+				<UserParam type="float" name="MS:1002050" value="125.0"/>
+				<UserParam type="float" name="MS:1002052" value="4.652130499999999e-19"/>
+				<UserParam type="float" name="MS:1002053" value="1.63755e-16"/>
+				<UserParam type="string" name="AssumedDissociationMethod" value="HCD"/>
+				<UserParam type="string" name="IsotopeError" value="0"/>
+				<UserParam type="float" name="calcMZ" value="520.263549804687955"/>
+				<UserParam type="int" name="pass_threshold" value="1"/>
+				<UserParam type="int" name="start" value="1"/>
+				<UserParam type="int" name="end" value="14"/>
+				<UserParam type="string" name="target_decoy" value="target"/>
+			</PeptideHit>
+		</PeptideIdentification>
+	</IdentificationRun>
+</IdXML>

--- a/src/topp/IDFilter.cpp
+++ b/src/topp/IDFilter.cpp
@@ -191,7 +191,7 @@ protected:
     setValidStrings_("in_silico_digestion:enzyme", all_enzymes);
     registerStringOption_("in_silico_digestion:specificity", "<specificity>", specificity[EnzymaticDigestion::SPEC_FULL], "Specificity of the filter", false);
     setValidStrings_("in_silico_digestion:specificity", specificity);
-    registerIntOption_("in_silico_digestion:missed_cleavages", "<integer>", -1, 
+    registerIntOption_("in_silico_digestion:missed_cleavages", "<integer>", -1,
                        "range of allowed missed cleavages in the peptide sequences\n"
                        "By default missed cleavages are ignored", false);
     setMinInt_("in_silico_digestion:missed_cleavages", -1);
@@ -266,9 +266,9 @@ protected:
       printUsage_();
       return ILLEGAL_PARAMETERS;
     }
-    if (remove_meta_enabled && !(meta_info[1] == "lt" || meta_info[1] == "eq" || meta_info[1] == "gt"))
+    if (remove_meta_enabled && !(meta_info[1] == "lt" || meta_info[1] == "eq" || meta_info[1] == "gt" || meta_info[1] == "ne"))
     {
-      writeLog_("Param 'remove_peptide_hits_by_metavalue' has invalid second argument. Expected one of 'lt', 'eq' or 'gt'. Got '" + meta_info[1] + "'. Aborting!");
+      writeLog_("Param 'remove_peptide_hits_by_metavalue' has invalid second argument. Expected one of 'lt', 'eq', 'gt' or 'ne'. Got '" + meta_info[1] + "'. Aborting!");
       printUsage_();
       return ILLEGAL_PARAMETERS;
     }
@@ -632,7 +632,7 @@ protected:
     {
       auto checkMVs = [this, &meta_info](PeptideHit& ph)->bool
       {
-        if (!ph.metaValueExists(meta_info[0])) return true; // not having the meta value means passing the test 
+        if (!ph.metaValueExists(meta_info[0])) return true; // not having the meta value means passing the test
         DataValue v_data = ph.getMetaValue(meta_info[0]);
         DataValue v_user;
         switch (v_data.valueType())
@@ -653,7 +653,7 @@ protected:
         else if (meta_info[1] == "eq")
         {
           return !(v_data == v_user);
-        } 
+        }
         else if (meta_info[1] == "gt")
         {
           return !(v_data > v_user);
@@ -661,7 +661,7 @@ protected:
         else if (meta_info[1] == "ne")
         {
           return (v_data == v_user);
-        }         
+        }
         else
         {
           writeLog_("Internal Error. Meta value filtering got invalid comparison operator ('" + meta_info[1] + "'), which should have been caught before! Aborting!");


### PR DESCRIPTION
The 'not equal' or `'ne'` option in the IDFilter MetaValue filtering was missing in a check for illegal parameters and did not actually work.
Added a regression test as well.