### PR TITLE
[FIX] always keep order: spectra, features, consensusfeatures, ids in…

### DIFF
--- a/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
+++ b/src/openms_gui/include/OpenMS/VISUAL/LayerData.h
@@ -87,13 +87,14 @@ namespace OpenMS
 public:
     /** @name Type definitions */
     //@{
-    /// Dataset types
+    /// Dataset types.
+    /// Order in the enum determines the order in which layer types are drawn.
     enum DataType
     {
       DT_PEAK,            ///< Spectrum profile or centroided data
+      DT_CHROMATOGRAM,    ///< Chromatogram data
       DT_FEATURE,         ///< Feature data
       DT_CONSENSUS,       ///< Consensus feature data
-      DT_CHROMATOGRAM,    ///< Chromatogram data
       DT_IDENT,           ///< Peptide identification data
       DT_UNKNOWN          ///< Undefined data type indicating an error
     };

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/TOPPViewBase.cpp
@@ -1314,14 +1314,26 @@ namespace OpenMS
     // try to add the data
     if (caption == "")
     {
-      caption = File::basename(abs_filename);
+      caption = File::removeExtension(File::basename(abs_filename));
     }
     else
     {
       abs_filename = "";
     }
 
-    addData(feature_map_sptr, consensus_map_sptr, peptides, peak_map_sptr, on_disc_peaks, data_type, false, show_options, true, abs_filename, caption, window_id, spectrum_id);
+    addData(feature_map_sptr, 
+      consensus_map_sptr, 
+      peptides, 
+      peak_map_sptr, 
+      on_disc_peaks, 
+      data_type, 
+      false, 
+      show_options, 
+      true, 
+      abs_filename, 
+      caption, 
+      window_id, 
+      spectrum_id);
 
     // add to recent file
     if (add_to_recent)
@@ -1519,9 +1531,6 @@ namespace OpenMS
           open_1d_window->canvas()->activateSpectrum(spectrum_id);
         }
       }
-
-      //set caption
-      target_window->canvas()->setLayerName(target_window->canvas()->activeLayerIndex(), caption);
     }
     else //merge feature/ID data into feature layer
     {

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -398,15 +398,17 @@ namespace OpenMS
     new_layer.setPeakData(map);
     new_layer.setOnDiscPeakData(od_map);
 
-    if (new_layer.getPeakData()->getChromatograms().size() != 0 
-        && new_layer.getPeakData()->size() != 0)
+    // both empty
+    if (!new_layer.getPeakData()->getChromatograms().empty() 
+     && !new_layer.getPeakData()->empty())
     {
       // TODO : handle this case better
       OPENMS_LOG_WARN << "Your input data contains chromatograms and spectra, falling back to display spectra only." << std::endl;
     }
 
-    if (new_layer.getPeakData()->getChromatograms().size() != 0 
-        && new_layer.getPeakData()->size() == 0)
+    // check which one is empty
+    if (!new_layer.getPeakData()->getChromatograms().empty() 
+      && new_layer.getPeakData()->empty())
     {
       new_layer.type = LayerData::DT_CHROMATOGRAM;
     }
@@ -415,19 +417,14 @@ namespace OpenMS
       new_layer.type = LayerData::DT_PEAK;
     }
 
-    // insert after last peak or chomatogram layer
-    for (auto it = layers_.rbegin(); it != layers_.rend(); ++it)
-    {
-      if (it->type == LayerData::DT_PEAK 
-        || it->type == LayerData::DT_CHROMATOGRAM)
-      {
-        layers_.insert(it.base(), new_layer);
-        return finishAdding_();
-      }
-    }
+    // insert after last layer of same type, 
+    // if there is no such layer after last layer of previous types, 
+    // if there are no layers at all put at front
+    auto it = std::find_if(layers_.rbegin(), layers_.rend(), [](const LayerData& l) 
+      { return l.type <= LayerData::DT_PEAK; });
+      
+    layers_.insert(it.base(), std::move(new_layer));
 
-    // insert at front
-    layers_.insert(layers_.begin(), new_layer);
     return finishAdding_();
   }
 
@@ -440,18 +437,13 @@ namespace OpenMS
     new_layer.getFeatureMap() = map;
     new_layer.type = LayerData::DT_FEATURE;
 
-    // draw features after last feature map (or if not present, after last peak map)
-    for (auto it = layers_.rbegin(); it != layers_.rend(); ++it)
-    {
-      if (it->type == LayerData::DT_PEAK 
-        || it->type == LayerData::DT_FEATURE)
-      {
-        layers_.insert(it.base(), new_layer);
-        return finishAdding_();
-      }
-    }
-    // insert at front
-    layers_.insert(layers_.begin(), new_layer);
+    // insert after last layer of same type, 
+    // if there is no such layer after last layer of previous types, 
+    // if there are no layers at all put at front
+    auto it = std::find_if(layers_.rbegin(), layers_.rend(), [](const LayerData& l) 
+      { return l.type <= LayerData::DT_FEATURE; });
+      
+    layers_.insert(it.base(), std::move(new_layer));
     return finishAdding_();
   }
 
@@ -464,19 +456,13 @@ namespace OpenMS
     new_layer.getConsensusMap() = map;
     new_layer.type = LayerData::DT_CONSENSUS;
 
-    // insert as last consensus layer (of after the other layer types if missing)
-    for (auto it = layers_.rbegin(); it != layers_.rend(); ++it)
-    {
-      if (it->type == LayerData::DT_PEAK 
-        || it->type == LayerData::DT_FEATURE 
-        || it->type == LayerData::DT_CONSENSUS)
-      {
-        layers_.insert(it.base(), new_layer);
-        return finishAdding_();
-      }
-    }
-    // insert at front
-    layers_.insert(layers_.begin(), new_layer);
+    // insert after last layer of same type, 
+    // if there is no such layer after last layer of previous types, 
+    // if there are no layers at all put at front
+    auto it = std::find_if(layers_.rbegin(), layers_.rend(), [](const LayerData& l) 
+      { return l.type <= LayerData::DT_CONSENSUS; });
+      
+    layers_.insert(it.base(), std::move(new_layer));
     return finishAdding_();
   }
 
@@ -490,20 +476,13 @@ namespace OpenMS
     new_layer.peptides.swap(peptides);
     new_layer.type = LayerData::DT_IDENT;
 
-    // insert as last ID layer (of after the other layer types if missing)
-    for (auto it = layers_.rbegin(); it != layers_.rend(); ++it)
-    {
-      if (it->type == LayerData::DT_PEAK 
-        || it->type == LayerData::DT_FEATURE 
-        || it->type == LayerData::DT_CONSENSUS
-        || it->type == LayerData::DT_IDENT)
-      {
-        layers_.insert(it.base(), new_layer);
-        return finishAdding_();
-      }
-    }
-    // insert at front
-    layers_.insert(layers_.begin(), new_layer);
+    // insert after last layer of same type, 
+    // if there is no such layer after last layer of previous types, 
+    // if there are no layers at all put at front
+    auto it = std::find_if(layers_.rbegin(), layers_.rend(), [](const LayerData& l) 
+      { return l.type <= LayerData::DT_IDENT; });
+      
+    layers_.insert(it.base(), std::move(new_layer));
     return finishAdding_(); 
   }
 

--- a/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
+++ b/src/openms_gui/source/VISUAL/SpectrumCanvas.cpp
@@ -391,60 +391,120 @@ namespace OpenMS
 
   bool SpectrumCanvas::addLayer(ExperimentSharedPtrType map, ODExperimentSharedPtrType od_map, const String & filename)
   {
-    layers_.resize(layers_.size() + 1);
-    layers_.back().param = param_;
-    layers_.back().filename = filename;
-    layers_.back().setPeakData(map);
-    layers_.back().setOnDiscPeakData(od_map);
+    LayerData new_layer;
+    new_layer.param = param_;
+    new_layer.filename = filename;
+    new_layer.name = QFileInfo(filename.toQString()).baseName();
+    new_layer.setPeakData(map);
+    new_layer.setOnDiscPeakData(od_map);
 
-    if (layers_.back().getPeakData()->getChromatograms().size() != 0 
-        && layers_.back().getPeakData()->size() != 0)
+    if (new_layer.getPeakData()->getChromatograms().size() != 0 
+        && new_layer.getPeakData()->size() != 0)
     {
       // TODO : handle this case better
       OPENMS_LOG_WARN << "Your input data contains chromatograms and spectra, falling back to display spectra only." << std::endl;
     }
 
-    if (layers_.back().getPeakData()->getChromatograms().size() != 0 
-        && layers_.back().getPeakData()->size() == 0)
+    if (new_layer.getPeakData()->getChromatograms().size() != 0 
+        && new_layer.getPeakData()->size() == 0)
     {
-      layers_.back().type = LayerData::DT_CHROMATOGRAM;
+      new_layer.type = LayerData::DT_CHROMATOGRAM;
     }
     else
     {
-      layers_.back().type = LayerData::DT_PEAK;
+      new_layer.type = LayerData::DT_PEAK;
     }
+
+    // insert after last peak or chomatogram layer
+    for (auto it = layers_.rbegin(); it != layers_.rend(); ++it)
+    {
+      if (it->type == LayerData::DT_PEAK 
+        || it->type == LayerData::DT_CHROMATOGRAM)
+      {
+        layers_.insert(it.base(), new_layer);
+        return finishAdding_();
+      }
+    }
+
+    // insert at front
+    layers_.insert(layers_.begin(), new_layer);
     return finishAdding_();
   }
 
   bool SpectrumCanvas::addLayer(FeatureMapSharedPtrType map, const String & filename)
   {
-    layers_.resize(layers_.size() + 1);
-    layers_.back().param = param_;
-    layers_.back().filename = filename;
-    layers_.back().getFeatureMap() = map;
-    layers_.back().type = LayerData::DT_FEATURE;
+    LayerData new_layer;
+    new_layer.param = param_;
+    new_layer.filename = filename;
+    new_layer.name = QFileInfo(filename.toQString()).baseName();
+    new_layer.getFeatureMap() = map;
+    new_layer.type = LayerData::DT_FEATURE;
+
+    // draw features after last feature map (or if not present, after last peak map)
+    for (auto it = layers_.rbegin(); it != layers_.rend(); ++it)
+    {
+      if (it->type == LayerData::DT_PEAK 
+        || it->type == LayerData::DT_FEATURE)
+      {
+        layers_.insert(it.base(), new_layer);
+        return finishAdding_();
+      }
+    }
+    // insert at front
+    layers_.insert(layers_.begin(), new_layer);
     return finishAdding_();
   }
 
   bool SpectrumCanvas::addLayer(ConsensusMapSharedPtrType map, const String & filename)
   {
-    layers_.resize(layers_.size() + 1);
-    layers_.back().param = param_;
-    layers_.back().filename = filename;
-    layers_.back().getConsensusMap() = map;
-    layers_.back().type = LayerData::DT_CONSENSUS;
+    LayerData new_layer;
+    new_layer.param = param_;
+    new_layer.filename = filename;
+    new_layer.name = QFileInfo(filename.toQString()).baseName();
+    new_layer.getConsensusMap() = map;
+    new_layer.type = LayerData::DT_CONSENSUS;
+
+    // insert as last consensus layer (of after the other layer types if missing)
+    for (auto it = layers_.rbegin(); it != layers_.rend(); ++it)
+    {
+      if (it->type == LayerData::DT_PEAK 
+        || it->type == LayerData::DT_FEATURE 
+        || it->type == LayerData::DT_CONSENSUS)
+      {
+        layers_.insert(it.base(), new_layer);
+        return finishAdding_();
+      }
+    }
+    // insert at front
+    layers_.insert(layers_.begin(), new_layer);
     return finishAdding_();
   }
 
   bool SpectrumCanvas::addLayer(vector<PeptideIdentification> & peptides,
                                 const String & filename)
   {
-    layers_.resize(layers_.size() + 1);
-    layers_.back().param = param_;
-    layers_.back().filename = filename;
-    layers_.back().peptides.swap(peptides);
-    layers_.back().type = LayerData::DT_IDENT;
-    return finishAdding_();
+    LayerData new_layer;
+    new_layer.param = param_;
+    new_layer.filename = filename;
+    new_layer.name = QFileInfo(filename.toQString()).baseName();
+    new_layer.peptides.swap(peptides);
+    new_layer.type = LayerData::DT_IDENT;
+
+    // insert as last ID layer (of after the other layer types if missing)
+    for (auto it = layers_.rbegin(); it != layers_.rend(); ++it)
+    {
+      if (it->type == LayerData::DT_PEAK 
+        || it->type == LayerData::DT_FEATURE 
+        || it->type == LayerData::DT_CONSENSUS
+        || it->type == LayerData::DT_IDENT)
+      {
+        layers_.insert(it.base(), new_layer);
+        return finishAdding_();
+      }
+    }
+    // insert at front
+    layers_.insert(layers_.begin(), new_layer);
+    return finishAdding_(); 
   }
 
   void SpectrumCanvas::setLayerName(Size i, const String & name)

--- a/src/tests/class_tests/openms_gui/source/GUI/TOPPView_test.cpp
+++ b/src/tests/class_tests/openms_gui/source/GUI/TOPPView_test.cpp
@@ -132,7 +132,7 @@ void TestTOPPView::testGui()
 
 #if 1 //def __APPLE__ // MAC OS does not support entering a filename via keyboard in the file-open menu
     tv.addDataFile(File::getOpenMSDataPath() + "/examples/peakpicker_tutorial_1.mzML", false, false);
-    QCOMPARE(tv.tab_bar_->tabText(tv.tab_bar_->currentIndex()), QString("peakpicker_tutorial_1.mzML"));
+    QCOMPARE(tv.tab_bar_->tabText(tv.tab_bar_->currentIndex()), QString("peakpicker_tutorial_1"));
 #else
     scheduleModalWidget_("peakpicker_tutorial_1.mzML", "Open file(s)",1000);                 // Open File dialog
     scheduleModalWidget_("", "Open data options for peakpicker_tutorial_1.mzML",1000); // layer data options dialog
@@ -148,7 +148,7 @@ void TestTOPPView::testGui()
 #endif
 
   // compare the name of the opened tab
-  QCOMPARE(tv.tab_bar_->tabText(tv.tab_bar_->currentIndex()), QString("peakpicker_tutorial_1.mzML"));
+  QCOMPARE(tv.tab_bar_->tabText(tv.tab_bar_->currentIndex()), QString("peakpicker_tutorial_1"));
 }
 
 // expands to a simple main() method that runs all the test functions


### PR DESCRIPTION
… layer manager

It doesn't make sense to draw features e.g., below spectra so we keep a fixed order:
spectra, features, consensus features, ids

@hroest or @oliveralka I did not test it on chromatograms. Would be cool is someone could give it a try