### PR TITLE
[STYLE] rename `extern` logging objects i.e. Log_debug

### DIFF
--- a/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
@@ -127,7 +127,7 @@ public:
 protected:
 
     /**
-      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::Log_info, OpenMS::Log_warn, OpenMS::Log_error, OpenMS::Log_fatal)
+      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::Log_info, OpenMS::Log_warn, OpenMS::Log_error, OpenMS::OpenMS_Log_fatal)
 
       @param stream_name Name of the stream. Should be DEBUG,INFO,WARNING,ERROR,FATAL_ERROR.
 
@@ -161,7 +161,7 @@ protected:
     std::set<String> info_streams_; ///< List of all streams that were appended to OpenMS::Log_info
     std::set<String> warn_streams_; ///< List of all streams that were appended to OpenMS::Log_warn
     std::set<String> error_streams_; ///< List of all streams that were appended to OpenMS::Log_error
-    std::set<String> fatal_streams_; ///< List of all streams that were appended to OpenMS::Log_fatal
+    std::set<String> fatal_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_fatal
 
     std::map<String, StreamHandler::StreamType> stream_type_map_; ///< Maps the registered streams to a StreamHandler::StreamType
 

--- a/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
@@ -127,7 +127,7 @@ public:
 protected:
 
     /**
-      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::Log_info, OpenMS::Log_warn, OpenMS::OpenMS_Log_error, OpenMS::OpenMS_Log_fatal)
+      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::Log_info, OpenMS::OpenMS_Log_warn, OpenMS::OpenMS_Log_error, OpenMS::OpenMS_Log_fatal)
 
       @param stream_name Name of the stream. Should be DEBUG,INFO,WARNING,ERROR,FATAL_ERROR.
 
@@ -159,7 +159,7 @@ protected:
 
     std::set<String> debug_streams_; ///< List of all streams that were appended to OpenMS::Log_debug
     std::set<String> info_streams_; ///< List of all streams that were appended to OpenMS::Log_info
-    std::set<String> warn_streams_; ///< List of all streams that were appended to OpenMS::Log_warn
+    std::set<String> warn_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_warn
     std::set<String> error_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_error
     std::set<String> fatal_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_fatal
 

--- a/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
@@ -127,7 +127,7 @@ public:
 protected:
 
     /**
-      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::Log_info, OpenMS::Log_warn, OpenMS::Log_error, OpenMS::OpenMS_Log_fatal)
+      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::Log_info, OpenMS::Log_warn, OpenMS::OpenMS_Log_error, OpenMS::OpenMS_Log_fatal)
 
       @param stream_name Name of the stream. Should be DEBUG,INFO,WARNING,ERROR,FATAL_ERROR.
 
@@ -160,7 +160,7 @@ protected:
     std::set<String> debug_streams_; ///< List of all streams that were appended to OpenMS::Log_debug
     std::set<String> info_streams_; ///< List of all streams that were appended to OpenMS::Log_info
     std::set<String> warn_streams_; ///< List of all streams that were appended to OpenMS::Log_warn
-    std::set<String> error_streams_; ///< List of all streams that were appended to OpenMS::Log_error
+    std::set<String> error_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_error
     std::set<String> fatal_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_fatal
 
     std::map<String, StreamHandler::StreamType> stream_type_map_; ///< Maps the registered streams to a StreamHandler::StreamType

--- a/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
@@ -127,7 +127,7 @@ public:
 protected:
 
     /**
-      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::Log_info, OpenMS::OpenMS_Log_warn, OpenMS::OpenMS_Log_error, OpenMS::OpenMS_Log_fatal)
+      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::OpenMS_Log_info, OpenMS::OpenMS_Log_warn, OpenMS::OpenMS_Log_error, OpenMS::OpenMS_Log_fatal)
 
       @param stream_name Name of the stream. Should be DEBUG,INFO,WARNING,ERROR,FATAL_ERROR.
 
@@ -158,7 +158,7 @@ protected:
     StreamHandler::StreamType getStreamTypeByName_(const String & stream_type);
 
     std::set<String> debug_streams_; ///< List of all streams that were appended to OpenMS::Log_debug
-    std::set<String> info_streams_; ///< List of all streams that were appended to OpenMS::Log_info
+    std::set<String> info_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_info
     std::set<String> warn_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_warn
     std::set<String> error_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_error
     std::set<String> fatal_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_fatal

--- a/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogConfigHandler.h
@@ -127,7 +127,7 @@ public:
 protected:
 
     /**
-      @brief Returns the named global instance of the LogStream. (OpenMS::Log_debug, OpenMS::OpenMS_Log_info, OpenMS::OpenMS_Log_warn, OpenMS::OpenMS_Log_error, OpenMS::OpenMS_Log_fatal)
+      @brief Returns the named global instance of the LogStream. (OpenMS::OpenMS_Log_debug, OpenMS::OpenMS_Log_info, OpenMS::OpenMS_Log_warn, OpenMS::OpenMS_Log_error, OpenMS::OpenMS_Log_fatal)
 
       @param stream_name Name of the stream. Should be DEBUG,INFO,WARNING,ERROR,FATAL_ERROR.
 
@@ -157,7 +157,7 @@ protected:
      */
     StreamHandler::StreamType getStreamTypeByName_(const String & stream_type);
 
-    std::set<String> debug_streams_; ///< List of all streams that were appended to OpenMS::Log_debug
+    std::set<String> debug_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_debug
     std::set<String> info_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_info
     std::set<String> warn_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_warn
     std::set<String> error_streams_; ///< List of all streams that were appended to OpenMS::OpenMS_Log_error

--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -458,13 +458,13 @@ private:
 
   /// Macro for general debugging information
 #define OPENMS_LOG_DEBUG \
-  Log_debug << __FILE__ << "(" << __LINE__ << "): "
+  OpenMS_Log_debug << __FILE__ << "(" << __LINE__ << "): "
 
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_fatal; ///< Global static instance of a LogStream to capture messages classified as fatal errors. By default it is bound to @b cerr.
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_error; ///< Global static instance of a LogStream to capture messages classified as errors. By default it is bound to @b cerr.
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_warn;  ///< Global static instance of a LogStream to capture messages classified as warnings. By default it is bound to @b cout.
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_info;  ///< Global static instance of a LogStream to capture messages classified as information. By default it is bound to @b cout.
-  OPENMS_DLLAPI extern Logger::LogStream Log_debug; ///< Global static instance of a LogStream to capture messages classified as debug output. By default it is not bound to any output stream. TOPP(AS)Base will connect cout, iff 0 < debug-level
+  OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_debug; ///< Global static instance of a LogStream to capture messages classified as debug output. By default it is not bound to any output stream. TOPP(AS)Base will connect cout, iff 0 < debug-level
 
 } // namespace OpenMS
 

--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -450,7 +450,7 @@ private:
 
   /// Macro if a warning, a piece of information which should be read by the user, should be logged
 #define OPENMS_LOG_WARN \
-  Log_warn
+  OpenMS_Log_warn
 
   /// Macro if a information, e.g. a status should be reported
 #define OPENMS_LOG_INFO \
@@ -462,7 +462,7 @@ private:
 
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_fatal; ///< Global static instance of a LogStream to capture messages classified as fatal errors. By default it is bound to @b cerr.
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_error; ///< Global static instance of a LogStream to capture messages classified as errors. By default it is bound to @b cerr.
-  OPENMS_DLLAPI extern Logger::LogStream Log_warn;  ///< Global static instance of a LogStream to capture messages classified as warnings. By default it is bound to @b cout.
+  OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_warn;  ///< Global static instance of a LogStream to capture messages classified as warnings. By default it is bound to @b cout.
   OPENMS_DLLAPI extern Logger::LogStream Log_info;  ///< Global static instance of a LogStream to capture messages classified as information. By default it is bound to @b cout.
   OPENMS_DLLAPI extern Logger::LogStream Log_debug; ///< Global static instance of a LogStream to capture messages classified as debug output. By default it is not bound to any output stream. TOPP(AS)Base will connect cout, iff 0 < debug-level
 

--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -454,7 +454,7 @@ private:
 
   /// Macro if a information, e.g. a status should be reported
 #define OPENMS_LOG_INFO \
-  Log_info
+  OpenMS_Log_info
 
   /// Macro for general debugging information
 #define OPENMS_LOG_DEBUG \
@@ -463,7 +463,7 @@ private:
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_fatal; ///< Global static instance of a LogStream to capture messages classified as fatal errors. By default it is bound to @b cerr.
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_error; ///< Global static instance of a LogStream to capture messages classified as errors. By default it is bound to @b cerr.
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_warn;  ///< Global static instance of a LogStream to capture messages classified as warnings. By default it is bound to @b cout.
-  OPENMS_DLLAPI extern Logger::LogStream Log_info;  ///< Global static instance of a LogStream to capture messages classified as information. By default it is bound to @b cout.
+  OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_info;  ///< Global static instance of a LogStream to capture messages classified as information. By default it is bound to @b cout.
   OPENMS_DLLAPI extern Logger::LogStream Log_debug; ///< Global static instance of a LogStream to capture messages classified as debug output. By default it is not bound to any output stream. TOPP(AS)Base will connect cout, iff 0 < debug-level
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -446,7 +446,7 @@ private:
 
   /// Macro to be used if non-fatal error are reported (processing continues)
 #define OPENMS_LOG_ERROR \
-  Log_error
+  OpenMS_Log_error
 
   /// Macro if a warning, a piece of information which should be read by the user, should be logged
 #define OPENMS_LOG_WARN \
@@ -461,7 +461,7 @@ private:
   Log_debug << __FILE__ << "(" << __LINE__ << "): "
 
   OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_fatal; ///< Global static instance of a LogStream to capture messages classified as fatal errors. By default it is bound to @b cerr.
-  OPENMS_DLLAPI extern Logger::LogStream Log_error; ///< Global static instance of a LogStream to capture messages classified as errors. By default it is bound to @b cerr.
+  OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_error; ///< Global static instance of a LogStream to capture messages classified as errors. By default it is bound to @b cerr.
   OPENMS_DLLAPI extern Logger::LogStream Log_warn;  ///< Global static instance of a LogStream to capture messages classified as warnings. By default it is bound to @b cout.
   OPENMS_DLLAPI extern Logger::LogStream Log_info;  ///< Global static instance of a LogStream to capture messages classified as information. By default it is bound to @b cout.
   OPENMS_DLLAPI extern Logger::LogStream Log_debug; ///< Global static instance of a LogStream to capture messages classified as debug output. By default it is not bound to any output stream. TOPP(AS)Base will connect cout, iff 0 < debug-level

--- a/src/openms/include/OpenMS/CONCEPT/LogStream.h
+++ b/src/openms/include/OpenMS/CONCEPT/LogStream.h
@@ -442,7 +442,7 @@ private:
 
   /// Macro to be used if fatal error are reported (processing stops)
 #define OPENMS_LOG_FATAL_ERROR \
-  Log_fatal << __FILE__ << "(" << __LINE__ << "): "
+  OpenMS_Log_fatal << __FILE__ << "(" << __LINE__ << "): "
 
   /// Macro to be used if non-fatal error are reported (processing continues)
 #define OPENMS_LOG_ERROR \
@@ -460,7 +460,7 @@ private:
 #define OPENMS_LOG_DEBUG \
   Log_debug << __FILE__ << "(" << __LINE__ << "): "
 
-  OPENMS_DLLAPI extern Logger::LogStream Log_fatal; ///< Global static instance of a LogStream to capture messages classified as fatal errors. By default it is bound to @b cerr.
+  OPENMS_DLLAPI extern Logger::LogStream OpenMS_Log_fatal; ///< Global static instance of a LogStream to capture messages classified as fatal errors. By default it is bound to @b cerr.
   OPENMS_DLLAPI extern Logger::LogStream Log_error; ///< Global static instance of a LogStream to capture messages classified as errors. By default it is bound to @b cerr.
   OPENMS_DLLAPI extern Logger::LogStream Log_warn;  ///< Global static instance of a LogStream to capture messages classified as warnings. By default it is bound to @b cout.
   OPENMS_DLLAPI extern Logger::LogStream Log_info;  ///< Global static instance of a LogStream to capture messages classified as information. By default it is bound to @b cout.

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -423,7 +423,7 @@ namespace OpenMS
     //-------------------------------------------------------------
     debug_level_ = getParamAsInt_("debug", 0);
     writeDebug_(String("Debug level (after ini file): ") + String(debug_level_), 1);
-    if (debug_level_ > 0) Log_debug.insert(cout); // allows to use OPENMS_LOG_DEBUG << "something" << std::endl;
+    if (debug_level_ > 0) OpenMS_Log_debug.insert(cout); // allows to use OPENMS_LOG_DEBUG << "something" << std::endl;
 
     //-------------------------------------------------------------
     //progress logging

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -275,7 +275,7 @@ namespace OpenMS
     }
     else if (stream_name == "FATAL_ERROR")
     {
-      log = &Log_fatal;
+      log = &OpenMS_Log_fatal;
     }
     else
     {

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -255,11 +255,11 @@ namespace OpenMS
 
   Logger::LogStream & LogConfigHandler::getLogStreamByName_(const String & stream_name)
   {
-    Logger::LogStream * log = &Log_debug; // default
+    Logger::LogStream * log = &OpenMS_Log_debug; // default
 
     if (stream_name == "DEBUG")
     {
-      log = &Log_debug;
+      log = &OpenMS_Log_debug;
     }
     else if (stream_name == "INFO")
     {

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -271,7 +271,7 @@ namespace OpenMS
     }
     else if (stream_name == "ERROR")
     {
-      log = &Log_error;
+      log = &OpenMS_Log_error;
     }
     else if (stream_name == "FATAL_ERROR")
     {

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -267,7 +267,7 @@ namespace OpenMS
     }
     else if (stream_name == "WARNING")
     {
-      log = &Log_warn;
+      log = &OpenMS_Log_warn;
     }
     else if (stream_name == "ERROR")
     {

--- a/src/openms/source/CONCEPT/LogConfigHandler.cpp
+++ b/src/openms/source/CONCEPT/LogConfigHandler.cpp
@@ -263,7 +263,7 @@ namespace OpenMS
     }
     else if (stream_name == "INFO")
     {
-      log = &Log_info;
+      log = &OpenMS_Log_info;
     }
     else if (stream_name == "WARNING")
     {

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -570,6 +570,6 @@ namespace OpenMS
   OPENMS_DLLAPI Logger::LogStream OpenMS_Log_warn(new Logger::LogStreamBuf("WARNING"), true, &cout);
   OPENMS_DLLAPI Logger::LogStream OpenMS_Log_info(new Logger::LogStreamBuf("INFO"), true, &cout);
   // OPENMS_LOG_DEBUG is disabled by default, but will be enabled in TOPPAS.cpp or TOPPBase.cpp if started in debug mode (--debug or -debug X)
-  OPENMS_DLLAPI Logger::LogStream Log_debug(new Logger::LogStreamBuf("DEBUG"), false); // last param should be 'true', but segfaults...
+  OPENMS_DLLAPI Logger::LogStream OpenMS_Log_debug(new Logger::LogStreamBuf("DEBUG"), false); // last param should be 'true', but segfaults...
 
 } // namespace OpenMS

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -566,7 +566,7 @@ namespace OpenMS
 
   // global default logstream
   OPENMS_DLLAPI Logger::LogStream OpenMS_Log_fatal(new Logger::LogStreamBuf("FATAL_ERROR"), true, &cerr);
-  OPENMS_DLLAPI Logger::LogStream Log_error(new Logger::LogStreamBuf("ERROR"), true, &cerr);
+  OPENMS_DLLAPI Logger::LogStream OpenMS_Log_error(new Logger::LogStreamBuf("ERROR"), true, &cerr);
   OPENMS_DLLAPI Logger::LogStream Log_warn(new Logger::LogStreamBuf("WARNING"), true, &cout);
   OPENMS_DLLAPI Logger::LogStream Log_info(new Logger::LogStreamBuf("INFO"), true, &cout);
   // OPENMS_LOG_DEBUG is disabled by default, but will be enabled in TOPPAS.cpp or TOPPBase.cpp if started in debug mode (--debug or -debug X)

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -567,7 +567,7 @@ namespace OpenMS
   // global default logstream
   OPENMS_DLLAPI Logger::LogStream OpenMS_Log_fatal(new Logger::LogStreamBuf("FATAL_ERROR"), true, &cerr);
   OPENMS_DLLAPI Logger::LogStream OpenMS_Log_error(new Logger::LogStreamBuf("ERROR"), true, &cerr);
-  OPENMS_DLLAPI Logger::LogStream Log_warn(new Logger::LogStreamBuf("WARNING"), true, &cout);
+  OPENMS_DLLAPI Logger::LogStream OpenMS_Log_warn(new Logger::LogStreamBuf("WARNING"), true, &cout);
   OPENMS_DLLAPI Logger::LogStream Log_info(new Logger::LogStreamBuf("INFO"), true, &cout);
   // OPENMS_LOG_DEBUG is disabled by default, but will be enabled in TOPPAS.cpp or TOPPBase.cpp if started in debug mode (--debug or -debug X)
   OPENMS_DLLAPI Logger::LogStream Log_debug(new Logger::LogStreamBuf("DEBUG"), false); // last param should be 'true', but segfaults...

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -568,7 +568,7 @@ namespace OpenMS
   OPENMS_DLLAPI Logger::LogStream OpenMS_Log_fatal(new Logger::LogStreamBuf("FATAL_ERROR"), true, &cerr);
   OPENMS_DLLAPI Logger::LogStream OpenMS_Log_error(new Logger::LogStreamBuf("ERROR"), true, &cerr);
   OPENMS_DLLAPI Logger::LogStream OpenMS_Log_warn(new Logger::LogStreamBuf("WARNING"), true, &cout);
-  OPENMS_DLLAPI Logger::LogStream Log_info(new Logger::LogStreamBuf("INFO"), true, &cout);
+  OPENMS_DLLAPI Logger::LogStream OpenMS_Log_info(new Logger::LogStreamBuf("INFO"), true, &cout);
   // OPENMS_LOG_DEBUG is disabled by default, but will be enabled in TOPPAS.cpp or TOPPBase.cpp if started in debug mode (--debug or -debug X)
   OPENMS_DLLAPI Logger::LogStream Log_debug(new Logger::LogStreamBuf("DEBUG"), false); // last param should be 'true', but segfaults...
 

--- a/src/openms/source/CONCEPT/LogStream.cpp
+++ b/src/openms/source/CONCEPT/LogStream.cpp
@@ -565,7 +565,7 @@ namespace OpenMS
   OPENMS_DLLAPI StreamHandler STREAM_HANDLER;
 
   // global default logstream
-  OPENMS_DLLAPI Logger::LogStream Log_fatal(new Logger::LogStreamBuf("FATAL_ERROR"), true, &cerr);
+  OPENMS_DLLAPI Logger::LogStream OpenMS_Log_fatal(new Logger::LogStreamBuf("FATAL_ERROR"), true, &cerr);
   OPENMS_DLLAPI Logger::LogStream Log_error(new Logger::LogStreamBuf("ERROR"), true, &cerr);
   OPENMS_DLLAPI Logger::LogStream Log_warn(new Logger::LogStreamBuf("WARNING"), true, &cout);
   OPENMS_DLLAPI Logger::LogStream Log_info(new Logger::LogStreamBuf("INFO"), true, &cout);

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -166,7 +166,7 @@ namespace OpenMS
   {
     /*todo: move to a global config file or into INI file */
     OpenMS_Log_fatal.setPrefix("%S: ");
-    Log_error.setPrefix("%S: ");
+    OpenMS_Log_error.setPrefix("%S: ");
     Log_warn.setPrefix("%S: ");
     Log_info.setPrefix("%S: ");
     Log_debug.setPrefix("%S: ");

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -165,7 +165,7 @@ namespace OpenMS
   void MSSim::simulate(SimTypes::MutableSimRandomNumberGeneratorPtr rnd_gen, SimTypes::SampleChannels& channels)
   {
     /*todo: move to a global config file or into INI file */
-    Log_fatal.setPrefix("%S: ");
+    OpenMS_Log_fatal.setPrefix("%S: ");
     Log_error.setPrefix("%S: ");
     Log_warn.setPrefix("%S: ");
     Log_info.setPrefix("%S: ");

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -167,7 +167,7 @@ namespace OpenMS
     /*todo: move to a global config file or into INI file */
     OpenMS_Log_fatal.setPrefix("%S: ");
     OpenMS_Log_error.setPrefix("%S: ");
-    Log_warn.setPrefix("%S: ");
+    OpenMS_Log_warn.setPrefix("%S: ");
     Log_info.setPrefix("%S: ");
     Log_debug.setPrefix("%S: ");
 

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -168,7 +168,7 @@ namespace OpenMS
     OpenMS_Log_fatal.setPrefix("%S: ");
     OpenMS_Log_error.setPrefix("%S: ");
     OpenMS_Log_warn.setPrefix("%S: ");
-    Log_info.setPrefix("%S: ");
+    OpenMS_Log_info.setPrefix("%S: ");
     Log_debug.setPrefix("%S: ");
 
     /*

--- a/src/openms/source/SIMULATION/MSSim.cpp
+++ b/src/openms/source/SIMULATION/MSSim.cpp
@@ -169,7 +169,7 @@ namespace OpenMS
     OpenMS_Log_error.setPrefix("%S: ");
     OpenMS_Log_warn.setPrefix("%S: ");
     OpenMS_Log_info.setPrefix("%S: ");
-    Log_debug.setPrefix("%S: ");
+    OpenMS_Log_debug.setPrefix("%S: ");
 
     /*
       General progress should be

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderIdentificationAlgorithm.cpp
@@ -289,10 +289,10 @@ namespace OpenMS
 
     OPENMS_LOG_INFO << "Detecting chromatographic peaks..." << endl;
     // suppress status output from OpenSWATH, unless in debug mode:
-    if (debug_level_ < 1) Log_info.remove(cout);
+    if (debug_level_ < 1) OpenMS_Log_info.remove(cout);
     feat_finder_.pickExperiment(chrom_data_, features, library_,
                                 TransformationDescription(), ms_data_);
-    if (debug_level_ < 1) Log_info.insert(cout); // revert logging change
+    if (debug_level_ < 1) OpenMS_Log_info.insert(cout); // revert logging change
     OPENMS_LOG_INFO << "Found " << features.size() << " feature candidates in total."
              << endl;
     ms_data_.reset(); // not needed anymore, free up the memory

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
@@ -137,7 +137,7 @@ int main(int argc, const char** argv)
   if (param.exists("debug"))
   {
     OPENMS_LOG_INFO << "Debug flag provided. Enabling 'OPENMS_LOG_DEBUG' ..." << std::endl;
-    Log_debug.insert(cout); // allows to use OPENMS_LOG_DEBUG << "something" << std::endl;
+    OpenMS_Log_debug.insert(cout); // allows to use OPENMS_LOG_DEBUG << "something" << std::endl;
   }
 
   // test if unknown options were given

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
@@ -149,7 +149,7 @@ int main(int argc, const char** argv)
     if (!(param.getValue("unknown").toString().hasSubstring("-psn") && !param.getValue("unknown").toString().hasSubstring(", ")))
     {
       OPENMS_LOG_ERROR << "Unknown option(s) '" << param.getValue("unknown").toString() << "' given. Aborting!" << endl;
-      print_usage(Log_error);
+      print_usage(OpenMS_Log_error);
       return 1;
     }
   }

--- a/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
+++ b/src/openms_gui/source/VISUAL/APPLICATIONS/GUITOOLS/TOPPAS.cpp
@@ -97,7 +97,7 @@ const char* tool_name = "TOPPAS";
 // description of the usage of this TOPP tool
 //-------------------------------------------------------------
 
-void print_usage(Logger::LogStream& stream = Log_info)
+void print_usage(Logger::LogStream& stream = OpenMS_Log_info)
 {
   stream << "\n"
          << tool_name << " -- An assistant for GUI-driven TOPP workflow design." << "\n"

--- a/src/tests/class_tests/openms/source/LogStream_test.cpp
+++ b/src/tests/class_tests/openms/source/LogStream_test.cpp
@@ -397,10 +397,10 @@ START_SECTION(([EXTRA] Macro test - OPENMS_LOG_FATAL_ERROR))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
-  Log_fatal.remove(cerr);
+  OpenMS_Log_fatal.remove(cerr);
   ostringstream stream_by_logger;
   {
-    Log_fatal.insert(stream_by_logger);
+    OpenMS_Log_fatal.insert(stream_by_logger);
 
     OPENMS_LOG_FATAL_ERROR << "1\n";
     OPENMS_LOG_FATAL_ERROR << "2" << endl;

--- a/src/tests/class_tests/openms/source/LogStream_test.cpp
+++ b/src/tests/class_tests/openms/source/LogStream_test.cpp
@@ -84,8 +84,8 @@ START_SECTION(([EXTRA] OpenMP - test))
   ostringstream stream_by_logger;
   Log_debug.insert(stream_by_logger);
   Log_debug.remove(cout);
-  Log_info.insert(stream_by_logger);
-  Log_info.remove(cout);
+  OpenMS_Log_info.insert(stream_by_logger);
+  OpenMS_Log_info.remove(cout);
 
 
   {
@@ -104,7 +104,7 @@ START_SECTION(([EXTRA] OpenMP - test))
 
   // remove logger after testing
   Log_debug.remove(stream_by_logger);
-  Log_info.remove(stream_by_logger);
+  OpenMS_Log_info.remove(stream_by_logger);
 
   NOT_TESTABLE;
 }
@@ -457,17 +457,17 @@ START_SECTION(([EXTRA] Macro test - OPENMS_LOG_INFO))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
-  Log_info.remove(cout);
+  OpenMS_Log_info.remove(cout);
 
   // clear cache to avoid pollution of the test output
   // by previous tests
-  Log_info.rdbuf()->clearCache();
+  OpenMS_Log_info.rdbuf()->clearCache();
 
   String filename;
   NEW_TMP_FILE(filename)
   ofstream s(filename.c_str(), std::ios::out);
   {
-    Log_info.insert(s);
+    OpenMS_Log_info.insert(s);
 
     OPENMS_LOG_INFO << "1\n";
     OPENMS_LOG_INFO << "2" << endl;

--- a/src/tests/class_tests/openms/source/LogStream_test.cpp
+++ b/src/tests/class_tests/openms/source/LogStream_test.cpp
@@ -82,8 +82,8 @@ START_SECTION(([EXTRA] OpenMP - test))
 {
   // just see if this crashes with OpenMP
   ostringstream stream_by_logger;
-  Log_debug.insert(stream_by_logger);
-  Log_debug.remove(cout);
+  OpenMS_Log_debug.insert(stream_by_logger);
+  OpenMS_Log_debug.remove(cout);
   OpenMS_Log_info.insert(stream_by_logger);
   OpenMS_Log_info.remove(cout);
 
@@ -103,7 +103,7 @@ START_SECTION(([EXTRA] OpenMP - test))
   }
 
   // remove logger after testing
-  Log_debug.remove(stream_by_logger);
+  OpenMS_Log_debug.remove(stream_by_logger);
   OpenMS_Log_info.remove(stream_by_logger);
 
   NOT_TESTABLE;
@@ -480,15 +480,15 @@ START_SECTION(([EXTRA] Macro test - OPENMS_LOG_DEBUG))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
-  Log_debug.remove(cout);
+  OpenMS_Log_debug.remove(cout);
 
   // clear cache to avoid pollution of the test output
   // by previous tests
-  Log_debug.rdbuf()->clearCache();
+  OpenMS_Log_debug.rdbuf()->clearCache();
 
   ostringstream stream_by_logger;
   {
-    Log_debug.insert(stream_by_logger);
+    OpenMS_Log_debug.insert(stream_by_logger);
 
     OPENMS_LOG_DEBUG << "1\n";
     OPENMS_LOG_DEBUG << "2" << endl;

--- a/src/tests/class_tests/openms/source/LogStream_test.cpp
+++ b/src/tests/class_tests/openms/source/LogStream_test.cpp
@@ -421,12 +421,12 @@ START_SECTION(([EXTRA] Macro test - OPENMS_LOG_ERROR))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
-  Log_error.remove(cerr);
+  OpenMS_Log_error.remove(cerr);
   String filename;
   NEW_TMP_FILE(filename)
   ofstream s(filename.c_str(), std::ios::out);
   {
-    Log_error.insert(s);
+    OpenMS_Log_error.insert(s);
 
     OPENMS_LOG_ERROR << "1\n";
     OPENMS_LOG_ERROR << "2" << endl;

--- a/src/tests/class_tests/openms/source/LogStream_test.cpp
+++ b/src/tests/class_tests/openms/source/LogStream_test.cpp
@@ -439,12 +439,12 @@ START_SECTION(([EXTRA] Macro test - OPENMS_LOG_WARN))
 {
   // remove cout/cerr streams from global instances
   // and append trackable ones
-  Log_warn.remove(cout);
+  OpenMS_Log_warn.remove(cout);
   String filename;
   NEW_TMP_FILE(filename)
   ofstream s(filename.c_str(), std::ios::out);
   {
-    Log_warn.insert(s);
+    OpenMS_Log_warn.insert(s);
 
     OPENMS_LOG_WARN << "1\n";
     OPENMS_LOG_WARN << "2" << endl;

--- a/src/tests/class_tests/openms/source/Param_test.cpp
+++ b/src/tests/class_tests/openms/source/Param_test.cpp
@@ -1587,12 +1587,12 @@ END_SECTION
 
 // warnings for unknown parameters
 // keep outside the scope of a single test to avoid destruction, leaving
-// Log_warn in an undefined state
+// OpenMS_Log_warn in an undefined state
 ostringstream os;
 // checkDefaults sends its warnings to OPENMS_LOG_WARN so we register our own
 // listener here to check the output
-Log_warn.remove(cout);
-Log_warn.insert(os);
+OpenMS_Log_warn.remove(cout);
+OpenMS_Log_warn.insert(os);
 
 START_SECTION((void checkDefaults(const String &name, const Param &defaults, const String& prefix="") const))
     Param p,d;

--- a/src/topp/ConsensusID.cpp
+++ b/src/topp/ConsensusID.cpp
@@ -316,7 +316,7 @@ protected:
     {
       consensus = new ConsensusIDAlgorithmRanks();
     }
-    algo_params.update(getParam_(), false, Log_debug); // update general params.
+    algo_params.update(getParam_(), false, OpenMS_Log_debug); // update general params.
     consensus->setParameters(algo_params);
 
     //----------------------------------------------------------------

--- a/src/topp/PeptideIndexer.cpp
+++ b/src/topp/PeptideIndexer.cpp
@@ -140,7 +140,7 @@ protected:
     PeptideIndexing indexer;
     Param param = getParam_().copy("", true);
     Param param_pi = indexer.getParameters();
-    param_pi.update(param, false, Log_debug); // suppress param. update message
+    param_pi.update(param, false, OpenMS_Log_debug); // suppress param. update message
     indexer.setParameters(param_pi);
     indexer.setLogType(this->log_type_);
     String db_name = getStringOption_("fasta");

--- a/src/topp/PhosphoScoring.cpp
+++ b/src/topp/PhosphoScoring.cpp
@@ -287,7 +287,7 @@ protected:
 
     AScore ascore;
     Param ascore_params = ascore.getDefaults();
-    ascore_params.update(getParam_(), false, false, false, false, Log_debug);
+    ascore_params.update(getParam_(), false, false, false, false, OpenMS_Log_debug);
     ascore.setParameters(ascore_params);
 
     //-------------------------------------------------------------

--- a/src/utils/FeatureFinderMetaboIdent.cpp
+++ b/src/utils/FeatureFinderMetaboIdent.cpp
@@ -964,10 +964,10 @@ protected:
               << " chromatogram(s)." << endl;
 
     OPENMS_LOG_INFO << "Detecting chromatographic peaks..." << endl;
-    Log_info.remove(cout); // suppress status output from OpenSWATH
+    OpenMS_Log_info.remove(cout); // suppress status output from OpenSWATH
     feat_finder_.pickExperiment(chrom_data_, features, library_,
                                 TransformationDescription(), ms_data_);
-    Log_info.insert(cout);
+    OpenMS_Log_info.insert(cout);
     OPENMS_LOG_INFO << "Found " << features.size() << " feature candidates in total."
              << endl;
     ms_data_.reset(); // not needed anymore, free up the memory

--- a/src/utils/OpenPepXL.cpp
+++ b/src/utils/OpenPepXL.cpp
@@ -230,7 +230,7 @@ protected:
     OpenPepXLAlgorithm search_algorithm;
     Param this_param = getParam_().copy("", true);
     Param algo_param = search_algorithm.getParameters();
-    algo_param.update(this_param, false, Log_debug); // suppress param. update message
+    algo_param.update(this_param, false, OpenMS_Log_debug); // suppress param. update message
     search_algorithm.setParameters(algo_param);
     search_algorithm.setLogType(this->log_type_);
 

--- a/src/utils/OpenPepXLLF.cpp
+++ b/src/utils/OpenPepXLLF.cpp
@@ -217,7 +217,7 @@ protected:
     OpenPepXLLFAlgorithm search_algorithm;
     Param this_param = getParam_().copy("", true);
     Param algo_param = search_algorithm.getParameters();
-    algo_param.update(this_param, false, Log_debug); // suppress param. update message
+    algo_param.update(this_param, false, OpenMS_Log_debug); // suppress param. update message
     search_algorithm.setParameters(algo_param);
     search_algorithm.setLogType(this->log_type_);
 


### PR DESCRIPTION
This PR completes https://github.com/OpenMS/OpenMS/pull/4082

For some reason, I am experiencing name clashes in my codebase when it comes to those `extern` identifiers.

I might be proposing another PR soon, which would remove all the loggers' buffer logic and just redirect all streams to `std::cout`, as proposed by @hroest . Hopefully those changes will help in multi-threading scenarios.