### PR TITLE
[FEATURE] add link to online docu

### DIFF
--- a/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
+++ b/src/openms/include/OpenMS/APPLICATIONS/TOPPBase.h
@@ -374,6 +374,8 @@ private:
     */
     String getSubsection_(const String& name) const;
 
+    String getDocumentationURL() const;
+
     /// Returns the default parameters
     Param getDefaultParameters_() const;
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -353,7 +353,7 @@ namespace OpenMS
       if (compute_features)
       {
         // The intensity of a feature is (proportional to) its total ion count
-        // http://ftp.mi.fu-berlin.de/pub/OpenMS/develop-documentation/html/classOpenMS_1_1Feature.html
+        // http://www.openms.de/documentation/classOpenMS_1_1Feature.html
         features[i].setIntensity(score);
         features[i].setMetaValue("log10_total_tic", log10_total_tic);
         features[i].setMetaValue("inverse_avgFWHM", inverse_avgFWHM);

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -539,10 +539,12 @@ namespace OpenMS
   {
     // show advanced options?
     bool verbose = getFlag_("-helphelp");
+    String docurl = getDocumentationURL();
 
     // common output
     cerr << "\n"
          << ConsoleUtils::breakString(tool_name_ + " -- " + tool_description_, 0, 10) << "\n"
+         << ConsoleUtils::breakString(String("Full documentation: ") + docurl, 0, 10) << "\n"
          << "Version: " << verboseVersion_ << "\n"
          << "To cite OpenMS:\n  " << cite_openms_.toString() << "\n";
     if (!citations_.empty())
@@ -756,7 +758,8 @@ namespace OpenMS
       cerr << "\n"
            << ConsoleUtils::breakString("You can write an example INI file using the '-write_ini' option.", 0, 10) << "\n"
            << ConsoleUtils::breakString("Documentation of subsection parameters can be found in the doxygen documentation or the INIFileEditor.", 0, 10) << "\n"
-           << ConsoleUtils::breakString("Have a look at the OpenMS documentation for more information.", 0, 10) << "\n";
+           << ConsoleUtils::breakString("For more information, please consult the online documentation for this tool:", 0, 10) << "\n"
+           << ConsoleUtils::breakString("  - " + docurl, 0, 10) << "\n";
     }
     cerr << endl;
   }
@@ -2305,6 +2308,22 @@ namespace OpenMS
     map.getDataProcessing().push_back(dp);
   }
 
+  String TOPPBase::getDocumentationURL() const
+  {
+    if (official_) // we use a different URL for the TOPP (official) and UTILS (unofficial) tools
+    {
+      return String("http://www.openms.de/documentation/TOPP_") + tool_name_ + ".html";
+    }
+    else if (ToolHandler::getUtilList().count(tool_name_))
+    {
+      return String("http://www.openms.de/documentation/UTILS_") + tool_name_ + ".html";
+    }
+    else
+    {
+      throw ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "A tool either needs to be an official tool or registered as util (TOPP tool not registered)");
+    }
+  }
+
   bool TOPPBase::writeCTD_()
   {
     //store ini-file content in ini_file_str
@@ -2337,15 +2356,14 @@ namespace OpenMS
       String ini_file_str(ss->str());
 
       //
-      QString docurl = "", category = "";
+      QString docurl = getDocumentationURL().toQString();
+      QString category = "";
       if (official_) // we can only get the docurl/category from registered/official tools
       {
-        docurl = "http://ftp.mi.fu-berlin.de/OpenMS/release-documentation/html/TOPP_" + tool_name_.toQString() + ".html";
         category = ToolHandler::getCategory(tool_name_).toQString();
       }
       else if (ToolHandler::getUtilList().count(tool_name_))
       {
-        docurl = "http://ftp.mi.fu-berlin.de/OpenMS/release-documentation/html/UTILS_" + tool_name_.toQString() + ".html";
         category = ToolHandler::getCategory(tool_name_).toQString();
       }
 

--- a/src/openms/source/APPLICATIONS/TOPPBase.cpp
+++ b/src/openms/source/APPLICATIONS/TOPPBase.cpp
@@ -2320,7 +2320,9 @@ namespace OpenMS
     }
     else
     {
-      throw ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "A tool either needs to be an official tool or registered as util (TOPP tool not registered)");
+      // TODO: Fix tests first
+      // throw ElementNotFound(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, "A tool either needs to be an official tool or registered as util (TOPP tool not registered)");
+      return "";
     }
   }
 


### PR DESCRIPTION
add a link to the online documentation from the tool output

- for completeness, add it to the top and the bottom :-) 
- fix the URL in the CTD XML

New output:

```
$ ./bin/OpenSwathWorkflow 
No options given. Aborting!

OpenSwathWorkflow -- Complete workflow to run OpenSWATH
Full documentation: http://www.openms.de/documentation/UTILS_OpenSwathWorkflow.html
Version: 2.4.0-feature-osw-params-2019-06-18 Jun 18 2019, 22:57:54, Revision: ff146b4
To cite OpenMS:
  Rost HL, Sachsenberg T, Aiche S, Bielow C et al.. OpenMS: a flexible open-source software platform for mass spectrometry data analysis. Nat Meth. 2016; 13, 9: 741-748. doi:10.1038/nmeth.3959.

Usage:
  OpenSwathWorkflow <options>

This tool has algorithm parameters that are not shown here! Please check the ini file for a detailed description or use the --helphelp option.

Options (mandatory options marked with '*'):
  -in <files>*                        Input files separated by blank (valid formats: 'mzML', 'mzXML', 'sqMass')
  -tr <file>*                         Transition file ('TraML','tsv','pqp') (valid formats: 'traML', 'tsv', 'pqp')

[ ... ]

 - Scoring           Scoring parameters section

You can write an example INI file using the '-write_ini' option.
Documentation of subsection parameters can be found in the doxygen documentation or the INIFileEditor.
For more information, please consult the online documentation for this tool:
  - http://www.openms.de/documentation/UTILS_OpenSwathWorkflow.html
```